### PR TITLE
Modified deprecated BaseModel.schema to BaseModel.model_json_schema

### DIFF
--- a/browser_use/controller/registry/views.py
+++ b/browser_use/controller/registry/views.py
@@ -22,7 +22,7 @@ class RegisteredAction(BaseModel):
 		s += str(
 			{
 				k: {sub_k: sub_v for sub_k, sub_v in v.items() if sub_k not in skip_keys}
-				for k, v in self.param_model.schema()['properties'].items()
+				for k, v in self.param_model.model_json_schema()['properties'].items()
 			}
 		)
 		s += '}'


### PR DESCRIPTION
This is a starter PR. 

I have made a small change to modify the deprecated `schema` method use on Pydantic BaseModel to the newer `model_json_schema`.