### PR TITLE
[BUG] `on_page` is called not being called for the first `new_page()` in `_initialize_session`

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -172,7 +172,7 @@ class BrowserContext:
 		playwright_browser = await self.browser.get_playwright_browser()
 
 		context = await self._create_context(playwright_browser)
-		await self._add_new_page_listener(context)
+		self._add_new_page_listener(context)
 		page = await context.new_page()
 
 		# Instead of calling _update_state(), create an empty initial state
@@ -199,7 +199,7 @@ class BrowserContext:
 		)
 		return self.session
 
-	async def _add_new_page_listener(self, context: PlaywrightBrowserContext):
+	def _add_new_page_listener(self, context: PlaywrightBrowserContext):
 		async def on_page(page: Page):
 			await page.wait_for_load_state()
 			logger.debug(f'New page opened: {page.url}')

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -172,6 +172,7 @@ class BrowserContext:
 		playwright_browser = await self.browser.get_playwright_browser()
 
 		context = await self._create_context(playwright_browser)
+		await self._add_new_page_listener(context)
 		page = await context.new_page()
 
 		# Instead of calling _update_state(), create an empty initial state
@@ -196,9 +197,6 @@ class BrowserContext:
 			current_page=page,
 			cached_state=initial_state,
 		)
-
-		await self._add_new_page_listener(context)
-
 		return self.session
 
 	async def _add_new_page_listener(self, context: PlaywrightBrowserContext):


### PR DESCRIPTION
# Summary
Addressing issue https://github.com/browser-use/browser-use/issues/114/
When running `async def _initialize_session(self)` in `browser_use/browser/context.py` the method: `self._add_new_page_listener(context)` is called at the end, after page was already created.
Therefore, the `on_page` in `_add_new_page_listener` is not triggered for that page, only for later pages.

Also, I noticed that `_add_new_page_listener` does not have to be async.

To fix that, I moved the call for `_add_new_page_listener` above the page creation.

# Testing and Reproduction:

To reproduce, put a breakpoint inside `on_page` inside `_add_new_page_listener`, and another breakpoint after the line `page = await context.new_page()` in `_initialize_session`.
You will see that `on_page` is not triggered.

Then apply the fix I made, and retry, to see that the `on_page` not correctly triggers.

I used the example from issue https://github.com/browser-use/browser-use/issues/114/ and now I can see my `print()`:


```python
import asyncio

from langchain_openai import ChatOpenAI
from playwright.async_api import (
	BrowserContext as PlaywrightBrowserContext,
)
from playwright.async_api import Page

from browser_use import Agent, Browser, BrowserConfig
from browser_use.browser.context import BrowserContext


class MyBrowserContext(BrowserContext):
	def _add_new_page_listener(self, context: PlaywrightBrowserContext):
		async def on_page(page: Page):
			# My implementation for on_page to allow for custom logic
			print(page.url)

		context.on('page', on_page)


async def main():
	browser = Browser(config=BrowserConfig(headless=True))
	browser_context = MyBrowserContext(browser=browser)
	agent = Agent(
		task='Find a one-way flight from Bali to Oman on 12 January 2025 on Google Flights. Return me the cheapest option.',
		llm=ChatOpenAI(model='gpt-4o-mini'),
		browser=browser,
		browser_context=browser_context,
	)
	await agent.run()

asyncio.run(main())
```