### PR TITLE
Fix tool call message formatting and add example tool call

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -18,6 +18,8 @@ from browser_use.agent.prompts import AgentMessagePrompt, SystemPrompt
 from browser_use.agent.views import ActionResult, AgentOutput, AgentStepInfo
 from browser_use.browser.views import BrowserState
 
+import json
+
 logger = logging.getLogger(__name__)
 
 
@@ -97,8 +99,17 @@ class MessageManager:
 	def add_model_output(self, model_output: AgentOutput) -> None:
 		"""Add model output as AI message"""
 
-		content = model_output.model_dump_json(exclude_unset=True)
-		msg = AIMessage(content=content)
+		msg = AIMessage(
+			content="",
+			tool_calls=[
+				{
+					"name": "AgentOutput",
+					"args": model_output.model_dump(mode="json", exclude_unset=True),
+					"id": "",
+					"type": "tool_call",
+				}
+			],
+		)
 		self._add_message_with_tokens(msg)
 
 	def get_messages(self) -> List[BaseMessage]:

--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -56,6 +56,28 @@ class MessageManager:
 
 		self._add_message_with_tokens(system_message)
 		self.system_prompt = system_message
+		wait_for_human = AIMessage(
+			content="",
+			additional_kwargs={},
+			response_metadata={},
+			tool_calls=[
+				{
+					"name": "AgentOutput",
+					"args": {
+						"current_state": {
+							"evaluation_previous_goal": "Unknown - No previous actions to evaluate.",
+							"memory": "",
+							"next_goal": "Obtain task from user",
+						},
+						"action": [],
+					},
+					"id": "",
+					"type": "tool_call",
+				}
+			],
+		)
+		self._add_message_with_tokens(wait_for_human)
+
 		task_message = HumanMessage(content=f'Your task is: {task}')
 		self._add_message_with_tokens(task_message)
 


### PR DESCRIPTION
Resolves browser-use/browser-use#158 by fixing the message format of messages added to the model's history and adding an example tool call at the start to increase the likelyhood of proper formatting on the first tool call, which helps especially on  small models (i.e. 7B)