### PR TITLE
feature: Support CDP_URL in BrowserConfig

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -36,6 +36,9 @@ class BrowserConfig:
 		wss_url: None
 			Connect to a browser instance via WebSocket
 
+		cdp_url: None
+			Connect to a browser instance via CDP
+
 		chrome_instance_path: None
 			Path to a Chrome instance to use to connect to your normal browser
 			e.g. '/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome'
@@ -46,6 +49,7 @@ class BrowserConfig:
 	extra_chromium_args: list[str] = field(default_factory=list)
 	chrome_instance_path: str | None = None
 	wss_url: str | None = None
+	cdp_url: str | None = None
 
 	proxy: ProxySettings | None = field(default=None)
 	new_context_config: BrowserContextConfig = field(default_factory=BrowserContextConfig)
@@ -95,6 +99,11 @@ class Browser:
 
 	async def _setup_browser(self, playwright: Playwright) -> PlaywrightBrowser:
 		"""Sets up and returns a Playwright Browser instance with anti-detection measures."""
+		if self.config.cdp_url:
+			# Loggin : Connecting to remote browser via CDP
+			logger.info(f"Connecting to remote browser via CDP {self.config.cdp_url}")
+			browser = await playwright.chromium.connect_over_cdp(self.config.cdp_url)
+			return browser
 		if self.config.wss_url:
 			browser = await playwright.chromium.connect(self.config.wss_url)
 			return browser

--- a/examples/using_cdp.py
+++ b/examples/using_cdp.py
@@ -1,0 +1,65 @@
+"""
+Simple demonstration of the CDP feature.
+
+To test this locally, follow these steps:
+1. Create a shortcut for the executable Chrome file.
+2. Add the following argument to the shortcut:
+   - On Windows: `--remote-debugging-port=9222`
+3. Open a web browser and navigate to `http://localhost:9222/json/version` to verify that the Remote Debugging Protocol (CDP) is running.
+4. Launch this example.
+
+@dev You need to set the `GEMINI_API_KEY` environment variable before proceeding.
+"""
+
+
+
+import os
+import sys
+from pathlib import Path
+from dotenv import load_dotenv
+from pydantic import SecretStr
+
+from browser_use.agent.views import ActionResult
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import asyncio
+
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+from browser_use import Agent, Controller
+from browser_use.browser.browser import Browser, BrowserConfig
+from browser_use.browser.context import BrowserContext
+
+load_dotenv()
+api_key = os.getenv('GEMINI_API_KEY')
+if not api_key:
+	raise ValueError('GEMINI_API_KEY is not set')
+
+browser = Browser(
+	config=BrowserConfig(
+		headless=False,
+		cdp_url="http://localhost:9222",
+	)
+)
+controller = Controller()
+
+
+async def main():
+	task = f'In docs.google.com write my Papa a quick thank you for everything letter \n - Magnus'
+	task += f' and save the document as pdf'
+	model = ChatGoogleGenerativeAI(model='gemini-2.0-flash-exp',api_key=SecretStr(api_key))
+	agent = Agent(
+		task=task,
+		llm=model,
+		controller=controller,
+		browser=browser,
+	)
+
+	await agent.run()
+	await browser.close()
+
+	input('Press Enter to close...')
+
+
+if __name__ == '__main__':
+	asyncio.run(main())


### PR DESCRIPTION
This pull request introduces support for connecting to remote browsers using the Chrome DevTools Protocol (CDP). 
A new `cdp_url` parameter has been added to the `BrowserConfig` class, enabling users to specify a custom CDP endpoint for use with tools like `headless-shell` or `browserless`.

### **Key Changes**
- Added `cdp_url` as an optional parameter to the `BrowserConfig` class.
- Updated the `Browser._setup_browser` method to handle CDP connections via the `cdp_url` parameter.
- Added a new example script, `using_cdp.py`, to demonstrate how to connect to a CDP-enabled browser instance.

### **How to Test**
1. **Set up Chrome for CDP**:
   - Start Chrome with the `--remote-debugging-port=9222` flag.
   - Verify that the endpoint is active by visiting `http://localhost:9222/json/version` in your browser.
2. **Run the Example Script**:
   - Use the provided `using_cdp.py` script.
   - Ensure the `GEMINI_API_KEY` environment variable is set (if applicable).
   - Observe successful connection to the browser instance via CDP.

### **Why**
#189 

