### PR TITLE
Feature: Disallow Google AI Overview on search

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -42,7 +42,7 @@ class Controller:
 		)
 		async def search_google(params: SearchGoogleAction, browser: BrowserContext):
 			page = await browser.get_current_page()
-			await page.goto(f'https://www.google.com/search?q={params.query}')
+			await page.goto(f'https://www.google.com/search?q={params.query}&udm=14')
 			await page.wait_for_load_state()
 			msg = f'🔍  Searched for "{params.query}" in Google'
 			logger.info(msg)


### PR DESCRIPTION
- Added Google param that turns off the Google AI overview feature
Removed the overview since browser use agents have a tendency to always use the data from them, thus defeating the purpose of digging deeper into multiple pages. This is especially useful when trying to get data within a certain time period, ie: 2025 where the Google AI overview will cite pages from far before 2020