### PR TITLE
fix: OS error of create_history_gif on Windows

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -608,7 +608,7 @@ class Agent:
 
 			for font_name in font_options:
 				try:
-					if platform.platform() == "Windows":
+					if platform.system() == "Windows":
 						# Need to specify the abs font path on Windows
 						font_name = os.path.join(os.getenv("WIN_FONT_DIR", "C:\\Windows\\Fonts"), font_name + ".ttf")
 					regular_font = ImageFont.truetype(font_name, font_size)

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -12,6 +12,7 @@ import uuid
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Optional, Type, TypeVar
+import platform
 
 from dotenv import load_dotenv
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -607,6 +608,9 @@ class Agent:
 
 			for font_name in font_options:
 				try:
+					if platform.platform() == "Windows":
+						# Need to specify the abs font path on Windows
+						font_name = os.path.join(os.getenv("WIN_FONT_DIR", "C:\\Windows\\Fonts"), font_name + ".ttf")
 					regular_font = ImageFont.truetype(font_name, font_size)
 					title_font = ImageFont.truetype(font_name, title_font_size)
 					goal_font = ImageFont.truetype(font_name, goal_font_size)


### PR DESCRIPTION
I encountered a bug while running the final step to generate a GIF on Windows: OSError: cannot open resource. This error prevents the GIF from being generated and causes the browser to not close properly.

Upon investigation, I found that on Windows, directly loading the font name does not work; it requires an absolute path instead. Could you please check into this?An error occurs when running on Windows. OSError: cannot open resource