### PR TITLE
fix: highlight elements arg in build-dom-tree script

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -31,7 +31,7 @@ class DomService:
 		js_code = resources.read_text('browser_use.dom', 'buildDomTree.js')
 
 		eval_page = await self.page.evaluate(
-			js_code, [highlight_elements]
+			js_code, (highlight_elements)
 		)  # This is quite big, so be careful
 		html_to_dict = self._parse_node(eval_page)
 


### PR DESCRIPTION
Currently the flag passed in the javascript evaluation does not work because the argument expected in javascript function is a `boolean` but the value passed while evaluating is a `list`.