### PR TITLE
feat: allow specifying path for gif file

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -72,7 +72,7 @@ class Agent:
 		system_prompt_class: Type[SystemPrompt] = SystemPrompt,
 		max_input_tokens: int = 128000,
 		validate_output: bool = False,
-		generate_gif: bool = True,
+		generate_gif: bool | str = True,
 		include_attributes: list[str] = [
 			'title',
 			'type',
@@ -389,7 +389,11 @@ class Agent:
 				await self.browser.close()
 
 			if self.generate_gif:
-				self.create_history_gif()
+				output_path: str = 'agent_history.gif'
+				if isinstance(self.generate_gif, str): 
+					output_path = self.generate_gif
+
+				self.create_history_gif(output_path=output_path)
 
 	def _too_many_failures(self) -> bool:
 		"""Check if we should stop due to too many failures"""

--- a/tests/test_gif_path.py
+++ b/tests/test_gif_path.py
@@ -1,0 +1,43 @@
+"""
+Simple try of the agent.
+
+@dev You need to add OPENAI_API_KEY to your environment variables.
+"""
+
+import os
+import sys
+
+from browser_use.browser.browser import Browser, BrowserConfig
+from browser_use.browser.context import BrowserContext, BrowserContextConfig
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from langchain_openai import ChatOpenAI
+
+from browser_use import Agent, AgentHistoryList, Controller
+
+llm = ChatOpenAI(model='gpt-4o')
+
+agent = Agent(
+	task=(
+		'go to google.com and search for text "hi there"'
+	),
+	llm=llm,
+	browser_context=BrowserContext(
+		browser=Browser(config=BrowserConfig(headless=False, disable_security=True)),
+	),
+	generate_gif="./google.gif"
+)
+
+
+async def test_gif_path():
+	if os.path.exists("./google.gif"):
+		os.unlink("./google.gif")
+
+	history: AgentHistoryList = await agent.run(20)
+
+	result = history.final_result()
+	assert result is not None
+
+	assert os.path.exists("./google.gif"), "google.gif was not created"
+


### PR DESCRIPTION
Multiple runs overwrite the gif, this way the developer has an option to specify a specific path to store the gif file.