### PR TITLE
Fix response format issue in agent service

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -15,7 +15,7 @@ from langchain_openai import ChatOpenAI
 
 from browser_use.agent.message_manager.views import MessageHistory, MessageMetadata
 from browser_use.agent.prompts import AgentMessagePrompt, SystemPrompt
-from browser_use.agent.views import ActionResult, AgentOutput, AgentStepInfo
+from browser_use.agent.views import ActionResult, AgentStepInfo
 from browser_use.browser.views import BrowserState
 
 logger = logging.getLogger(__name__)
@@ -132,12 +132,12 @@ class MessageManager:
 		):
 			self.history.remove_message()
 
-	def add_model_output(self, model_output: AgentOutput) -> None:
+	def add_model_output(self, model_output: dict) -> None:
 		"""Add model output as AI message"""
 		tool_calls = [
 			{
 				'name': 'AgentOutput',
-				'args': model_output.model_dump(mode='json', exclude_unset=True),
+				'args': model_output,
 				'id': '',
 				'type': 'tool_call',
 			}


### PR DESCRIPTION
Fixes #250

Update `browser_use/agent/message_manager/service.py` to handle unsupported 'json_schema' response format.

* **Import Changes**
  - Remove `AgentOutput` import from `browser_use.agent.views`.

* **Method Changes**
  - Modify `add_model_output` method to accept a dictionary instead of `AgentOutput` model.
  - Update `add_model_output` method to use the dictionary directly for tool calls.

