### PR TITLE
Re-using existing context when using CDP connection

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -73,6 +73,7 @@ class Agent:
 		max_input_tokens: int = 128000,
 		validate_output: bool = False,
 		generate_gif: bool = True,
+		gif_filename: str = 'agent_history.gif',
 		include_attributes: list[str] = [
 			'title',
 			'type',
@@ -99,6 +100,7 @@ class Agent:
 		self.include_attributes = include_attributes
 		self.max_error_length = max_error_length
 		self.generate_gif = generate_gif
+		self.gif_filename = gif_filename
 		# Controller setup
 		self.controller = controller
 		self.max_actions_per_step = max_actions_per_step
@@ -432,7 +434,7 @@ class Agent:
 				await self.browser.close()
 
 			if self.generate_gif:
-				self.create_history_gif()
+				self.create_history_gif(output_path=self.gif_filename)
 
 	def _too_many_failures(self) -> bool:
 		"""Check if we should stop due to too many failures"""

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -221,7 +221,9 @@ class BrowserContext:
 
 	async def _create_context(self, browser: PlaywrightBrowser):
 		"""Creates a new browser context with anti-detection measures and loads cookies if available."""
-		if self.browser.config.chrome_instance_path and len(browser.contexts) > 0:
+		if self.browser.config.cdp_url:
+			context = browser.contexts[0]
+		elif self.browser.config.chrome_instance_path and len(browser.contexts) > 0:
 			# Connect to existing Chrome instance instead of creating new one
 			context = browser.contexts[0]
 		else:


### PR DESCRIPTION
When using browser-use with hosted browsers, e.g. steel.dev or browserbase the streaming/live view does not work because browser-use does not re-use the existing context.

This PR re-uses the existing browser context when using a cdp connection.