### PR TITLE
Fix 'cp932' codec can't encode character when using the option to sav…

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -67,6 +67,7 @@ class Agent:
 		controller: Controller = Controller(),
 		use_vision: bool = True,
 		save_conversation_path: Optional[str] = None,
+		save_conversation_path_encoding: Optional[str] = "utf-8",
 		max_failures: int = 3,
 		retry_delay: int = 10,
 		system_prompt_class: Type[SystemPrompt] = SystemPrompt,
@@ -95,6 +96,7 @@ class Agent:
 		self.use_vision = use_vision
 		self.llm = llm
 		self.save_conversation_path = save_conversation_path
+		self.save_conversation_path_encoding = save_conversation_path_encoding
 		self._last_result = None
 		self.include_attributes = include_attributes
 		self.max_error_length = max_error_length
@@ -322,7 +324,7 @@ class Agent:
 		# create folders if not exists
 		os.makedirs(os.path.dirname(self.save_conversation_path), exist_ok=True)
 
-		with open(self.save_conversation_path + f'_{self.n_steps}.txt', 'w') as f:
+		with open(self.save_conversation_path + f'_{self.n_steps}.txt', 'w', encoding=self.save_conversation_path_encoding) as f:
 			self._write_messages_to_file(f, input_messages)
 			self._write_response_to_file(f, response)
 


### PR DESCRIPTION


Fix 'cp932' codec can't encode character when using the option to save conversation to a file.

I used it in a Japanese environment on Windows. When I tried to use the option to save the conversation to a text file, an error occurred, so I am sending the corrected version. Thank you.