### PR TITLE
Fix for nested iframes

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -677,7 +677,7 @@ class BrowserContext:
 						# Handle numeric indices
 						if idx.isdigit():
 							index = int(idx) - 1
-							base_part += f':nth-of-type({index+1})'
+							base_part += f':nth-of-type({index + 1})'
 						# Handle last() function
 						elif idx == 'last()':
 							base_part += ':last-of-type'
@@ -803,13 +803,13 @@ class BrowserContext:
 			parent = current.parent
 			parents.append(parent)
 			current = parent
-			if parent.tag_name == 'iframe':
-				break
 
-		# There can be only one iframe parent (by design of the loop above)
-		iframe_parent = [item for item in parents if item.tag_name == 'iframe']
-		if iframe_parent:
-			parent = iframe_parent[0]
+		# Reverse the parents list to process from top to bottom
+		parents.reverse()
+
+		# Process all iframe parents in sequence
+		iframes = [item for item in parents if item.tag_name == 'iframe']
+		for parent in iframes:
 			css_selector = self._enhanced_css_selector_for_element(parent)
 			current_frame = current_frame.frame_locator(css_selector)
 


### PR DESCRIPTION
Fixes #295, needs to be tested.

**The solution:**

1. Removed the break condition when finding an iframe parent. This allows us to collect all iframe parents in the hierarchy.
2. Reversed the parents list to process them from top to bottom (outermost to innermost iframe).
3. Changed the logic to process all iframe parents in sequence, rather than just the first one.
4. Renamed variables for better clarity (iframe_parent → iframes).

**Changes:**

- Previously, we were breaking after finding the first iframe parent and only processing that one
- Now we collect all iframe parents and process them in sequence from outermost to innermost
- Each iframe parent creates a new frame locator that we chain together to reach the target element

This should now properly handle multiple levels of iframe nesting.