### PR TITLE
Added support for custom user agent and an example to demonstrate it

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -38,9 +38,9 @@ class BrowserContextWindowSize(TypedDict):
 	width: int
 	height: int
 
-
 @dataclass
 class BrowserContextConfig:
+
 	"""
 	Configuration for the BrowserContext.
 
@@ -80,6 +80,9 @@ class BrowserContextConfig:
 
      		locale: None
        			Specify user locale, for example en-GB, de-DE, etc. Locale will affect navigator.language value, Accept-Language request header value as well as number and date formatting rules. If not provided, defaults to the system default locale.
+		
+		user_agent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36'
+			custom user agent to use.
 	"""
 
 	cookies_file: str | None = None
@@ -98,7 +101,8 @@ class BrowserContextConfig:
 	save_recording_path: str | None = None
 	trace_path: str | None = None
 	locale: str | None = None
-
+	user_agent: str = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36  (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36'
+		
 
 @dataclass
 class BrowserSession:
@@ -233,10 +237,7 @@ class BrowserContext:
 			context = await browser.new_context(
 				viewport=self.config.browser_window_size,
 				no_viewport=False,
-				user_agent=(
-					'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-					'(KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36'
-				),
+				user_agent=self.config.user_agent,
 				java_script_enabled=True,
 				bypass_csp=self.config.disable_security,
 				ignore_https_errors=self.config.disable_security,

--- a/examples/custom_user_agent.py
+++ b/examples/custom_user_agent.py
@@ -1,0 +1,82 @@
+import os
+import sys
+
+from langchain_anthropic import ChatAnthropic
+from langchain_openai import ChatOpenAI
+
+from browser_use.browser.context import BrowserContext, BrowserContextConfig
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import argparse
+import asyncio
+
+from browser_use import Agent
+from browser_use.browser.browser import Browser, BrowserConfig
+from browser_use.controller.service import Controller
+
+
+def get_llm(provider: str):
+	if provider == 'anthropic':
+		return ChatAnthropic(
+			model_name='claude-3-5-sonnet-20240620', timeout=25, stop=None, temperature=0.0
+		)
+	elif provider == 'openai':
+		return ChatOpenAI(model='gpt-4o', temperature=0.0)
+
+	else:
+		raise ValueError(f'Unsupported provider: {provider}')
+
+
+task = 'go to https://whatismyuseragent.com and find the current user agent string '
+
+
+controller = Controller()
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--query', type=str, help='The query to process', default=task)
+parser.add_argument(
+	'--provider',
+	type=str,
+	choices=['openai', 'anthropic'],
+	default='openai',
+	help='The model provider to use (default: openai)',
+)
+
+args = parser.parse_args()
+
+llm = get_llm(args.provider)
+
+
+browser = Browser(
+	config=BrowserConfig(
+		# chrome_instance_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+	)
+)
+
+browser_context = BrowserContext(
+	config=BrowserContextConfig(
+		user_agent="foobarfoo"
+	),
+	browser=browser
+)
+
+agent = Agent(
+	task=args.query,
+	llm=llm,
+	controller=controller,
+#	browser=browser,
+	browser_context=browser_context,
+	use_vision=True,
+	max_actions_per_step=1,
+)
+
+
+async def main():
+	await agent.run(max_steps=25)
+
+	input('Press Enter to close the browser...')
+	await browser_context.close()
+
+
+asyncio.run(main())


### PR DESCRIPTION
Added support for custom user agent:

- created a user_agent member on BrowserContextConfig, defaulting to the former code in _create_context
- changed BrowserContext._create_context to take the user agent from the Config
- created an example of how to create a browser context with the user agent `foobarfoo`