### PR TITLE
added Laminar instrumentation to trace execution steps

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -20,6 +20,7 @@ from langchain_core.messages import (
 	BaseMessage,
 	SystemMessage,
 )
+from lmnr import observe
 from openai import RateLimitError
 from PIL import Image, ImageDraw, ImageFont
 from pydantic import BaseModel, ValidationError
@@ -338,7 +339,7 @@ class Agent:
 
 		parsed: AgentOutput = response['parsed']
 		if parsed is None:
-			raise ValueError(f'Could not parse response.')
+			raise ValueError('Could not parse response.')
 
 		# cut the number of actions to max_actions_per_step
 		parsed.action = parsed.action[: self.max_actions_per_step]
@@ -420,6 +421,7 @@ class Agent:
 			)
 		)
 
+	@observe(name='agent.run')
 	async def run(self, max_steps: int = 100) -> AgentHistoryList:
 		"""Execute the task with maximum number of steps"""
 		try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "requests>=2.32.3",
     "posthog>=3.7.0",
     "playwright>=1.49.0",
-    "setuptools>=75.8.0"
+    "setuptools>=75.8.0",
+    "lmnr[langchain]>=0.4.53"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Added Laminar instrumentation (https://lmnr.ai) to trace execution steps. Traces look like this.

<img width="1512" alt="Screenshot 2025-01-19 at 11 21 39 PM" src="https://github.com/user-attachments/assets/68d33722-15b8-4b1d-9d41-dbe9ab97f662" />

Example of how to run 
```python
from langchain_openai import ChatOpenAI
from browser_use import Agent
import asyncio

from lmnr import Laminar

# this line auto-instruments LangChain
Laminar.initialize(project_api_key="...")

async def main():
    agent = Agent(
        task="open google, search Laminar AI",
        llm=ChatOpenAI(model="gpt-4o-mini"),
    )
    result = await agent.run()
    print(result)

asyncio.run(main())
```
