### PR TITLE
Let user define initial action to take

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -49,9 +49,7 @@ class Controller:
 			logger.info(msg)
 			return ActionResult(extracted_content=msg, include_in_memory=True)
 
-		@self.registry.action(
-			'Navigate to URL in the current tab', param_model=GoToUrlAction, requires_browser=True
-		)
+		@self.registry.action('Navigate to URL in the current tab', param_model=GoToUrlAction, requires_browser=True)
 		async def go_to_url(params: GoToUrlAction, browser: BrowserContext):
 			page = await browser.get_current_page()
 			await page.goto(params.url)
@@ -70,17 +68,13 @@ class Controller:
 			return ActionResult(extracted_content=msg, include_in_memory=True)
 
 		# Element Interaction Actions
-		@self.registry.action(
-			'Click element', param_model=ClickElementAction, requires_browser=True
-		)
+		@self.registry.action('Click element', param_model=ClickElementAction, requires_browser=True)
 		async def click_element(params: ClickElementAction, browser: BrowserContext):
 			session = await browser.get_session()
 			state = session.cached_state
 
 			if params.index not in state.selector_map:
-				raise Exception(
-					f'Element with index {params.index} does not exist - retry or use alternative actions'
-				)
+				raise Exception(f'Element with index {params.index} does not exist - retry or use alternative actions')
 
 			element_node = state.selector_map[params.index]
 			initial_pages = len(session.context.pages)
@@ -106,9 +100,7 @@ class Controller:
 					await browser.switch_to_tab(-1)
 				return ActionResult(extracted_content=msg, include_in_memory=True)
 			except Exception as e:
-				logger.warning(
-					f'Element no longer available with index {params.index} - most likely the page changed'
-				)
+				logger.warning(f'Element no longer available with index {params.index} - most likely the page changed')
 				return ActionResult(error=str(e))
 
 		@self.registry.action(
@@ -121,9 +113,7 @@ class Controller:
 			state = session.cached_state
 
 			if params.index not in state.selector_map:
-				raise Exception(
-					f'Element index {params.index} does not exist - retry or use alternative actions'
-				)
+				raise Exception(f'Element index {params.index} does not exist - retry or use alternative actions')
 
 			element_node = state.selector_map[params.index]
 			await browser._input_text_element_node(element_node, params.text)
@@ -143,9 +133,7 @@ class Controller:
 			logger.info(msg)
 			return ActionResult(extracted_content=msg, include_in_memory=True)
 
-		@self.registry.action(
-			'Open url in new tab', param_model=OpenTabAction, requires_browser=True
-		)
+		@self.registry.action('Open url in new tab', param_model=OpenTabAction, requires_browser=True)
 		async def open_tab(params: OpenTabAction, browser: BrowserContext):
 			await browser.create_new_tab(params.url)
 			msg = f'🔗  Opened new tab with {params.url}'
@@ -351,9 +339,7 @@ class Controller:
 
 			# Validate that we're working with a select element
 			if dom_element.tag_name != 'select':
-				logger.error(
-					f'Element is not a select! Tag: {dom_element.tag_name}, Attributes: {dom_element.attributes}'
-				)
+				logger.error(f'Element is not a select! Tag: {dom_element.tag_name}, Attributes: {dom_element.attributes}')
 				msg = f'Cannot select option: Element with index {index} is a {dom_element.tag_name}, not a select'
 				return ActionResult(extracted_content=msg, include_in_memory=True)
 
@@ -401,9 +387,7 @@ class Controller:
 
 						if dropdown_info:
 							if not dropdown_info.get('found'):
-								logger.error(
-									f'Frame {frame_index} error: {dropdown_info.get("error")}'
-								)
+								logger.error(f'Frame {frame_index} error: {dropdown_info.get("error")}')
 								continue
 
 							logger.debug(f'Found dropdown in frame {frame_index}: {dropdown_info}')
@@ -412,9 +396,7 @@ class Controller:
 							# nth(0) to disable error thrown by strict mode
 							# timeout=1000 because we are already waiting for all network events, therefore ideally we don't need to wait a lot here (default 30s)
 							selected_option_values = (
-								await frame.locator('//' + dom_element.xpath)
-								.nth(0)
-								.select_option(label=text, timeout=1000)
+								await frame.locator('//' + dom_element.xpath).nth(0).select_option(label=text, timeout=1000)
 							)
 
 							msg = f'selected option {text} with value {selected_option_values}'
@@ -447,7 +429,7 @@ class Controller:
 
 	@time_execution_async('--multi-act')
 	async def multi_act(
-		self, actions: list[ActionModel], browser_context: BrowserContext
+		self, actions: list[ActionModel], browser_context: BrowserContext, check_for_new_elements: bool = True
 	) -> list[ActionResult]:
 		"""Execute multiple actions"""
 		results = []
@@ -460,10 +442,8 @@ class Controller:
 		for i, action in enumerate(actions):
 			if action.get_index() is not None and i != 0:
 				new_state = await browser_context.get_state()
-				new_path_hashes = set(
-					e.hash.branch_path_hash for e in new_state.selector_map.values()
-				)
-				if not new_path_hashes.issubset(cached_path_hashes):
+				new_path_hashes = set(e.hash.branch_path_hash for e in new_state.selector_map.values())
+				if check_for_new_elements and not new_path_hashes.issubset(cached_path_hashes):
 					# next action requires index but there are new elements on the page
 					logger.info(f'Something new appeared after action {i} / {len(actions)}')
 					break
@@ -486,9 +466,7 @@ class Controller:
 			for action_name, params in action.model_dump(exclude_unset=True).items():
 				if params is not None:
 					# remove highlights
-					result = await self.registry.execute_action(
-						action_name, params, browser=browser_context
-					)
+					result = await self.registry.execute_action(action_name, params, browser=browser_context)
 					if isinstance(result, str):
 						return ActionResult(extracted_content=result)
 					elif isinstance(result, ActionResult):

--- a/examples/initial_actions.py
+++ b/examples/initial_actions.py
@@ -1,0 +1,29 @@
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+from browser_use import Agent
+
+load_dotenv()
+llm = ChatOpenAI(model='gpt-4o')
+
+initial_actions = [
+	{'open_tab': {'url': 'https://www.amazon.com'}},
+	{'scroll_down': {'amount': 1000}},
+	{'scroll_down': {'amount': 1000}},
+	{'click_element': {'index': 5}},
+	{'click_element': {'index': 1}},
+	{'open_tab': {'url': 'https://www.google.com'}},
+	{'click_element': {'index': 1}},
+]
+
+agent = Agent(task='Your task description', llm=llm, initial_actions=initial_actions)
+
+
+async def main():
+	await agent.run(max_steps=10)
+
+
+if __name__ == '__main__':
+	import asyncio
+
+	asyncio.run(main())

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,4 +1,9 @@
+import os
+import sys
+from unittest.mock import MagicMock, Mock
+
 import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
 
 from browser_use.agent.service import Agent
 from browser_use.browser.browser import Browser
@@ -6,494 +11,68 @@ from browser_use.browser.context import BrowserContext
 from browser_use.controller.registry.service import Registry
 from browser_use.controller.registry.views import ActionModel
 from browser_use.controller.service import Controller
-from langchain_core.language_models.chat_models import BaseChatModel
-from unittest.mock import MagicMock, Mock
 
+
+# run test with:
+# python -m pytest tests/test_service.py
 class TestAgent:
-    @pytest.fixture
-    def mock_controller(self):
-        controller = Mock(spec=Controller)
-        registry_mock = MagicMock()
-        registry_mock.registry.actions = {
-            'test_action': MagicMock(param_model=MagicMock())
-        }
-        controller.registry = registry_mock
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(task="Test task", llm=mock_llm, controller=mock_controller)
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel
-        mock_action_model = Mock(spec=ActionModel)
-        agent.ActionModel = mock_action_model
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_action_model.assert_called_once()
-        mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(param1="value1", param2="value2")
-
-        # Check that the result is a list of ActionModel instances
-        assert isinstance(result[0], Mock)
-        assert result[0] == mock_action_model.return_value
-
-    @pytest.fixture
-    def mock_controller(self):
-        controller = Mock(spec=Controller)
-        controller.registry = MagicMock()
-        controller.registry.get_prompt_description.return_value = "Test prompt description"
-        controller.registry.create_action_model.return_value = MagicMock()
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    @pytest.fixture
-    def mock_browser(self):
-        return Mock(spec=Browser)
-
-    @pytest.fixture
-    def mock_browser_context(self):
-        return Mock(spec=BrowserContext)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm, mock_browser, mock_browser_context):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(
-            task="Test task",
-            llm=mock_llm,
-            controller=mock_controller,
-            browser=mock_browser,
-            browser_context=mock_browser_context
-        )
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel and its instance
-        mock_action_model_class = MagicMock()
-        mock_action_model_instance = MagicMock()
-        mock_action_model_class.return_value = mock_action_model_instance
-        agent.ActionModel = mock_action_model_class
-
-        # Mock the param_model
-        mock_param_model = MagicMock()
-        mock_controller.registry.registry.actions = {
-            'test_action': MagicMock(param_model=mock_param_model)
-        }
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_param_model.assert_called_once_with(param1="value1", param2="value2")
-        mock_action_model_class.assert_called_once_with(test_action=mock_param_model.return_value)
-        assert result[0] == mock_action_model_instance
-
-    @pytest.fixture
-    def mock_controller(self):
-        controller = Mock(spec=Controller)
-        registry_mock = MagicMock()
-        registry_mock.registry.actions = {
-            'test_action': MagicMock(param_model=MagicMock())
-        }
-        controller.registry = registry_mock
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(task="Test task", llm=mock_llm, controller=mock_controller)
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel
-        mock_action_model = Mock(spec=ActionModel)
-        agent.ActionModel = mock_action_model
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_action_model.assert_called_once()
-        mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(param1="value1", param2="value2")
-
-        # Check that the result is a list of ActionModel instances
-        assert isinstance(result[0], Mock)
-        assert result[0] == mock_action_model.return_value
-
-    @pytest.fixture
-    def mock_controller(self):
-        controller = Mock(spec=Controller)
-        registry_mock = MagicMock()
-        registry_mock.registry.actions = {
-            'test_action': MagicMock(param_model=MagicMock())
-        }
-        controller.registry = registry_mock
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(task="Test task", llm=mock_llm, controller=mock_controller)
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel
-        mock_action_model = Mock()
-        agent.ActionModel = mock_action_model
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_action_model.assert_called_once()
-        mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(param1="value1", param2="value2")
-
-        # Check that the result is a list of ActionModel instances
-        assert isinstance(result[0], Mock)
-        assert result[0] == mock_action_model.return_value
-
-    @pytest.fixture
-    def mock_controller(self):
-        controller = Mock(spec=Controller)
-        registry_mock = MagicMock()
-        param_model_mock = MagicMock()
-        param_model_mock.return_value = MagicMock(name="ValidatedParams")
-        action_info_mock = MagicMock(param_model=param_model_mock)
-        registry_mock.registry.actions = {
-            'test_action': action_info_mock
-        }
-        controller.registry = registry_mock
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(task="Test task", llm=mock_llm, controller=mock_controller)
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel
-        mock_action_model = MagicMock(name="ActionModel")
-        mock_action_model_instance = MagicMock(name="ActionModelInstance")
-        mock_action_model.return_value = mock_action_model_instance
-        agent.ActionModel = mock_action_model
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(param1="value1", param2="value2")
-        mock_action_model.assert_called_once()
-        assert isinstance(result[0], MagicMock)
-        assert result[0] == mock_action_model_instance
-
-        # Check that the ActionModel was called with the correct parameters
-        call_args = mock_action_model.call_args[1]
-        assert 'test_action' in call_args
-        assert call_args['test_action'] == mock_controller.registry.registry.actions['test_action'].param_model.return_value
-
-    @pytest.fixture
-    def mock_controller(self):
-        controller = MagicMock(spec=Controller)
-        registry_mock = MagicMock()
-        param_model_mock = MagicMock()
-        param_model_mock.return_value = MagicMock(name="ValidatedParams")
-        action_info_mock = MagicMock(param_model=param_model_mock)
-        registry_mock.registry.actions = {
-            'test_action': action_info_mock
-        }
-        controller.registry = registry_mock
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(task="Test task", llm=mock_llm, controller=mock_controller)
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel
-        mock_action_model = MagicMock(name="ActionModel")
-        mock_action_model_instance = MagicMock(name="ActionModelInstance")
-        mock_action_model.return_value = mock_action_model_instance
-        agent.ActionModel = mock_action_model
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(param1="value1", param2="value2")
-        mock_action_model.assert_called_once()
-        assert isinstance(result[0], MagicMock)
-        assert result[0] == mock_action_model_instance
-
-        # Check that the ActionModel was called with the correct parameters
-        call_args = mock_action_model.call_args[1]
-        assert 'test_action' in call_args
-        assert call_args['test_action'] == mock_controller.registry.registry.actions['test_action'].param_model.return_value
-
-    @pytest.fixture
-    def mock_controller(self):
-        controller = MagicMock(spec=Controller)
-        registry_mock = MagicMock()
-        param_model_mock = MagicMock()
-        param_model_mock.return_value = MagicMock(name="ValidatedParams")
-        action_info_mock = MagicMock(param_model=param_model_mock)
-        registry_mock.registry.actions = {
-            'test_action': action_info_mock
-        }
-        controller.registry = registry_mock
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(task="Test task", llm=mock_llm, controller=mock_controller)
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel
-        mock_action_model = MagicMock(name="ActionModel")
-        mock_action_model_instance = MagicMock(name="ActionModelInstance")
-        mock_action_model.return_value = mock_action_model_instance
-        agent.ActionModel = mock_action_model
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(param1="value1", param2="value2")
-        mock_action_model.assert_called_once()
-        assert isinstance(result[0], MagicMock)
-        assert result[0] == mock_action_model_instance
-
-        # Check that the ActionModel was called with the correct parameters
-        call_args = mock_action_model.call_args[1]
-        assert 'test_action' in call_args
-        assert call_args['test_action'] == mock_controller.registry.registry.actions['test_action'].param_model.return_value
-
-    @pytest.fixture
-    def mock_controller(self):
-        controller = Mock(spec=Controller)
-        registry = Mock(spec=Registry)
-        registry.registry = MagicMock()
-        registry.registry.actions = {
-            'test_action': MagicMock(param_model=MagicMock())
-        }
-        controller.registry = registry
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-
-        This test ensures that:
-        1. The method processes the initial actions correctly.
-        2. The correct param_model is called with the right parameters.
-        3. The ActionModel is created with the validated parameters.
-        4. The method returns a list of ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(task="Test task", llm=mock_llm, controller=mock_controller)
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel
-        mock_action_model = MagicMock(spec=ActionModel)
-        mock_action_model_instance = MagicMock()
-        mock_action_model.return_value = mock_action_model_instance
-        agent.ActionModel = mock_action_model
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(param1="value1", param2="value2")
-        mock_action_model.assert_called_once()
-        assert isinstance(result[0], MagicMock)
-        assert result[0] == mock_action_model_instance
-
-        # Check that the ActionModel was called with the correct parameters
-        call_args = mock_action_model.call_args[1]
-        assert 'test_action' in call_args
-        assert call_args['test_action'] == mock_controller.registry.registry.actions['test_action'].param_model.return_value
-
-    @pytest.fixture
-    def mock_controller(self):
-        controller = Mock(spec=Controller)
-        registry_mock = MagicMock()
-        param_model_mock = MagicMock()
-        param_model_mock.return_value = MagicMock(name="ValidatedParams")
-        action_info_mock = MagicMock(param_model=param_model_mock)
-        registry_mock.registry.actions = {
-            'test_action': action_info_mock
-        }
-        controller.registry = registry_mock
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-
-        This test ensures that:
-        1. The method processes the initial actions correctly.
-        2. The correct param_model is called with the right parameters.
-        3. The ActionModel is created with the validated parameters.
-        4. The method returns a list of ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(task="Test task", llm=mock_llm, controller=mock_controller)
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel
-        mock_action_model = MagicMock(name="ActionModel")
-        mock_action_model_instance = MagicMock(name="ActionModelInstance")
-        mock_action_model.return_value = mock_action_model_instance
-        agent.ActionModel = mock_action_model
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(param1="value1", param2="value2")
-        mock_action_model.assert_called_once()
-        assert isinstance(result[0], MagicMock)
-        assert result[0] == mock_action_model_instance
-
-        # Check that the ActionModel was called with the correct parameters
-        call_args = mock_action_model.call_args[1]
-        assert 'test_action' in call_args
-        assert call_args['test_action'] == mock_controller.registry.registry.actions['test_action'].param_model.return_value
-
-    @pytest.fixture
-    def mock_controller(self):
-        controller = Mock(spec=Controller)
-        registry_mock = MagicMock()
-        registry_mock.registry.actions = {
-            'test_action': MagicMock(param_model=MagicMock())
-        }
-        controller.registry = registry_mock
-        return controller
-
-    @pytest.fixture
-    def mock_llm(self):
-        return Mock(spec=BaseChatModel)
-
-    def test_convert_initial_actions(self, mock_controller, mock_llm):
-        """
-        Test that the _convert_initial_actions method correctly converts
-        dictionary-based actions to ActionModel instances.
-
-        This test ensures that:
-        1. The method processes the initial actions correctly.
-        2. The correct param_model is called with the right parameters.
-        3. The ActionModel is created with the validated parameters.
-        4. The method returns a list of ActionModel instances.
-        """
-        # Arrange
-        agent = Agent(task="Test task", llm=mock_llm, controller=mock_controller)
-        initial_actions = [
-            {"test_action": {"param1": "value1", "param2": "value2"}}
-        ]
-
-        # Mock the ActionModel
-        mock_action_model = MagicMock(name="ActionModel")
-        mock_action_model_instance = MagicMock(name="ActionModelInstance")
-        mock_action_model.return_value = mock_action_model_instance
-        agent.ActionModel = mock_action_model
-
-        # Act
-        result = agent._convert_initial_actions(initial_actions)
-
-        # Assert
-        assert len(result) == 1
-        mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(param1="value1", param2="value2")
-        mock_action_model.assert_called_once()
-        assert isinstance(result[0], MagicMock)
-        assert result[0] == mock_action_model_instance
-
-        # Check that the ActionModel was called with the correct parameters
-        call_args = mock_action_model.call_args[1]
-        assert 'test_action' in call_args
-        assert call_args['test_action'] == mock_controller.registry.registry.actions['test_action'].param_model.return_value
+	@pytest.fixture
+	def mock_controller(self):
+		controller = Mock(spec=Controller)
+		registry = Mock(spec=Registry)
+		registry.registry = MagicMock()
+		registry.registry.actions = {'test_action': MagicMock(param_model=MagicMock())}  # type: ignore
+		controller.registry = registry
+		return controller
+
+	@pytest.fixture
+	def mock_llm(self):
+		return Mock(spec=BaseChatModel)
+
+	@pytest.fixture
+	def mock_browser(self):
+		return Mock(spec=Browser)
+
+	@pytest.fixture
+	def mock_browser_context(self):
+		return Mock(spec=BrowserContext)
+
+	def test_convert_initial_actions(self, mock_controller, mock_llm, mock_browser, mock_browser_context):  # type: ignore
+		"""
+		Test that the _convert_initial_actions method correctly converts
+		dictionary-based actions to ActionModel instances.
+
+		This test ensures that:
+		1. The method processes the initial actions correctly.
+		2. The correct param_model is called with the right parameters.
+		3. The ActionModel is created with the validated parameters.
+		4. The method returns a list of ActionModel instances.
+		"""
+		# Arrange
+		agent = Agent(
+			task='Test task', llm=mock_llm, controller=mock_controller, browser=mock_browser, browser_context=mock_browser_context
+		)
+		initial_actions = [{'test_action': {'param1': 'value1', 'param2': 'value2'}}]
+
+		# Mock the ActionModel
+		mock_action_model = MagicMock(spec=ActionModel)
+		mock_action_model_instance = MagicMock()
+		mock_action_model.return_value = mock_action_model_instance
+		agent.ActionModel = mock_action_model  # type: ignore
+
+		# Act
+		result = agent._convert_initial_actions(initial_actions)
+
+		# Assert
+		assert len(result) == 1
+		mock_controller.registry.registry.actions['test_action'].param_model.assert_called_once_with(  # type: ignore
+			param1='value1', param2='value2'
+		)
+		mock_action_model.assert_called_once()
+		assert isinstance(result[0], MagicMock)
+		assert result[0] == mock_action_model_instance
+
+		# Check that the ActionModel was called with the correct parameters
+		call_args = mock_action_model.call_args[1]
+		assert 'test_action' in call_args
+		assert call_args['test_action'] == mock_controller.registry.registry.actions['test_action'].param_model.return_value  # type: ignore


### PR DESCRIPTION
This pull request introduces the ability to execute initial actions when running an agent in the `browser_use` module. It also includes various code cleanups and improvements for better readability and maintainability.

### New Feature: Initial Actions

* Added support for specifying `initial_actions` in the `Agent` class, allowing predefined actions to be executed at the start of the agent's run. (`browser_use/agent/service.py`) [[1]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R93) [[2]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92L159-R160) [[3]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R414-R418)
* Implemented a method `_convert_initial_actions` to convert dictionary-based actions to `ActionModel` instances. (`browser_use/agent/service.py`)

### Code Cleanup and Improvements

* Consolidated import statements and added missing imports for `Dict` and `List`. (`browser_use/agent/service.py`)
* Removed unnecessary line breaks and improved exception messages for better readability. (`browser_use/controller/service.py`) [[1]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L52-R52) [[2]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L73-R77) [[3]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L109-R103) [[4]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L124-R116) [[5]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L146-R136) [[6]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L354-R342) [[7]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L404-R390) [[8]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L415-R399)
* Added an optional parameter `check_for_new_elements` to the `multi_act` method to control whether new elements should be checked during action execution. (`browser_use/controller/service.py`) [[1]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L450-R432) [[2]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L463-R446)

### Example Usage

* Provided an example script `initial_actions.py` demonstrating how to initialize an agent with predefined actions and run it. (`examples/initial_actions.py`)