### PR TITLE
Enhancement/exclude actions

### DIFF
--- a/browser_use/controller/registry/service.py
+++ b/browser_use/controller/registry/service.py
@@ -20,9 +20,10 @@ from browser_use.telemetry.views import (
 class Registry:
 	"""Service for registering and managing actions"""
 
-	def __init__(self):
+	def __init__(self, exclude_actions: list[str] = []):
 		self.registry = ActionRegistry()
 		self.telemetry = ProductTelemetry()
+		self.exclude_actions = exclude_actions
 
 	def _create_param_model(self, function: Callable) -> Type[BaseModel]:
 		"""Creates a Pydantic model from function signature"""
@@ -48,6 +49,10 @@ class Registry:
 		"""Decorator for registering actions"""
 
 		def decorator(func: Callable):
+			# Skip registration if action is in exclude_actions
+			if func.__name__ in self.exclude_actions:
+				return func
+
 			# Create param model from function if not provided
 			actual_param_model = param_model or self._create_param_model(func)
 

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -28,8 +28,10 @@ logger = logging.getLogger(__name__)
 class Controller:
 	def __init__(
 		self,
+		exclude_actions: list[str] = [],
 	):
-		self.registry = Registry()
+		self.exclude_actions = exclude_actions
+		self.registry = Registry(exclude_actions)
 		self._register_default_actions()
 
 	def _register_default_actions(self):

--- a/tests/test_excluded_actions.py
+++ b/tests/test_excluded_actions.py
@@ -1,0 +1,98 @@
+import asyncio
+import os
+
+import pytest
+from langchain_openai import AzureChatOpenAI
+from pydantic import SecretStr
+
+from browser_use.agent.service import Agent
+from browser_use.agent.views import AgentHistoryList
+from browser_use.browser.browser import Browser, BrowserConfig
+from browser_use.controller.service import Controller
+
+# run with:
+# python -m pytest tests/test_excluded_actions.py -v -k "test_only_open_tab_allowed" --capture=no
+
+
+@pytest.fixture(scope='session')
+def event_loop():
+	"""Create an instance of the default event loop for each test case."""
+	loop = asyncio.get_event_loop_policy().new_event_loop()
+	yield loop
+	loop.close()
+
+
+@pytest.fixture(scope='session')
+async def browser(event_loop):
+	browser_instance = Browser(
+		config=BrowserConfig(
+			headless=True,
+		)
+	)
+	yield browser_instance
+	await browser_instance.close()
+
+
+@pytest.fixture
+async def context(browser):
+	async with await browser.new_context() as context:
+		yield context
+
+
+@pytest.fixture
+def llm():
+	"""Initialize language model for testing"""
+	return AzureChatOpenAI(
+		model='gpt-4o',
+		api_version='2024-10-21',
+		azure_endpoint=os.getenv('AZURE_OPENAI_ENDPOINT', ''),
+		api_key=SecretStr(os.getenv('AZURE_OPENAI_KEY', '')),
+	)
+
+
+# pytest tests/test_excluded_actions.py -v -k "test_only_open_tab_allowed" --capture=no
+@pytest.mark.asyncio
+async def test_only_open_tab_allowed(llm, context):
+	"""Test that only open_tab action is available while others are excluded"""
+
+	# Create list of all default actions except open_tab
+	excluded_actions = [
+		'search_google',
+		'go_to_url',
+		'go_back',
+		'click_element',
+		'input_text',
+		'switch_tab',
+		'extract_content',
+		'done',
+		'scroll_down',
+		'scroll_up',
+		'send_keys',
+		'scroll_to_text',
+		'get_dropdown_options',
+		'select_dropdown_option',
+	]
+
+	# Initialize controller with excluded actions
+	controller = Controller(exclude_actions=excluded_actions)
+
+	# Create agent with a task that would normally use other actions
+	agent = Agent(
+		task="Go to google.com and search for 'python programming'",
+		llm=llm,
+		browser_context=context,
+		controller=controller,
+	)
+
+	history: AgentHistoryList = await agent.run(max_steps=2)
+
+	# Verify that only open_tab was used
+	action_names = history.action_names()
+
+	# Only open_tab should be in the actions
+	assert all(action == 'open_tab' for action in action_names), (
+		f'Found unexpected actions: {[a for a in action_names if a != "open_tab"]}'
+	)
+
+	# open_tab should be used at least once
+	assert 'open_tab' in action_names, 'open_tab action was not used'

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,9 +1,6 @@
 import os
-import sys
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
-
 import pytest
-from langchain_core.language_models.chat_models import BaseChatModel
+import sys
 
 from browser_use.agent.message_manager.service import MessageManager
 from browser_use.agent.service import Agent
@@ -14,9 +11,11 @@ from browser_use.browser.views import BrowserState
 from browser_use.controller.registry.service import Registry
 from browser_use.controller.registry.views import ActionModel
 from browser_use.controller.service import Controller
+from langchain_core.language_models.chat_models import BaseChatModel
+from pydantic import BaseModel
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 # run with python -m pytest tests/test_service.py
-
 
 # run test with:
 # python -m pytest tests/test_service.py
@@ -125,3 +124,94 @@ class TestAgent:
 			assert isinstance(agent._last_result[0], ActionResult)
 			assert 'Test error' in agent._last_result[0].error
 			assert agent._last_result[0].include_in_memory == True
+
+class TestRegistry:
+    @pytest.fixture
+    def registry_with_excludes(self):
+        return Registry(exclude_actions=['excluded_action'])
+
+    def test_action_decorator_with_excluded_action(self, registry_with_excludes):
+        """
+        Test that the action decorator does not register an action
+        if it's in the exclude_actions list.
+        """
+        # Define a function to be decorated
+        def excluded_action():
+            pass
+
+        # Apply the action decorator
+        decorated_func = registry_with_excludes.action(description="This should be excluded")(excluded_action)
+
+        # Assert that the decorated function is the same as the original
+        assert decorated_func == excluded_action
+
+        # Assert that the action was not added to the registry
+        assert 'excluded_action' not in registry_with_excludes.registry.actions
+
+        # Define another function that should be included
+        def included_action():
+            pass
+
+        # Apply the action decorator to an included action
+        registry_with_excludes.action(description="This should be included")(included_action)
+
+        # Assert that the included action was added to the registry
+        assert 'included_action' in registry_with_excludes.registry.actions
+
+    @pytest.mark.asyncio
+    async def test_execute_action_with_and_without_browser_context(self):
+        """
+        Test that the execute_action method correctly handles actions with and without a browser context.
+        This test ensures that:
+        1. An action requiring a browser context is executed correctly.
+        2. An action not requiring a browser context is executed correctly.
+        3. The browser context is passed to the action function when required.
+        4. The action function receives the correct parameters.
+        5. The method raises an error when a browser context is required but not provided.
+        """
+        registry = Registry()
+
+        # Define a mock action model
+        class TestActionModel(BaseModel):
+            param1: str
+
+        # Define mock action functions
+        async def test_action_with_browser(param1: str, browser):
+            return f"Action executed with {param1} and browser"
+
+        async def test_action_without_browser(param1: str):
+            return f"Action executed with {param1}"
+
+        # Register the actions
+        registry.registry.actions['test_action_with_browser'] = MagicMock(
+            requires_browser=True,
+            function=AsyncMock(side_effect=test_action_with_browser),
+            param_model=TestActionModel,
+            description="Test action with browser"
+        )
+
+        registry.registry.actions['test_action_without_browser'] = MagicMock(
+            requires_browser=False,
+            function=AsyncMock(side_effect=test_action_without_browser),
+            param_model=TestActionModel,
+            description="Test action without browser"
+        )
+
+        # Mock BrowserContext
+        mock_browser = MagicMock()
+
+        # Execute the action with a browser context
+        result_with_browser = await registry.execute_action('test_action_with_browser', {'param1': 'test_value'}, browser=mock_browser)
+        assert result_with_browser == "Action executed with test_value and browser"
+
+        # Execute the action without a browser context
+        result_without_browser = await registry.execute_action('test_action_without_browser', {'param1': 'test_value'})
+        assert result_without_browser == "Action executed with test_value"
+
+        # Test error when browser is required but not provided
+        with pytest.raises(RuntimeError, match="Action test_action_with_browser requires browser but none provided"):
+            await registry.execute_action('test_action_with_browser', {'param1': 'test_value'})
+
+        # Verify that the action functions were called with correct parameters
+        registry.registry.actions['test_action_with_browser'].function.assert_called_once_with(param1='test_value', browser=mock_browser)
+        registry.registry.actions['test_action_without_browser'].function.assert_called_once_with(param1='test_value')


### PR DESCRIPTION
This pull request introduces a feature to exclude specific actions from being registered and executed within the `Registry` and `Controller` classes. Additionally, it includes a new test to verify this functionality.

Key changes include:

### Exclusion of Actions:

* [`browser_use/controller/registry/service.py`](diffhunk://#diff-f23cfe7aacb36db612abb2e331a69378362a65cd7eaec17d85a0979f7b3d0578L23-R26): Added an `exclude_actions` parameter to the `Registry` class constructor and modified the `action` decorator to skip registration for excluded actions. [[1]](diffhunk://#diff-f23cfe7aacb36db612abb2e331a69378362a65cd7eaec17d85a0979f7b3d0578L23-R26) [[2]](diffhunk://#diff-f23cfe7aacb36db612abb2e331a69378362a65cd7eaec17d85a0979f7b3d0578R52-R55)
* [`browser_use/controller/service.py`](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225R31-R34): Updated the `Controller` class to accept an `exclude_actions` parameter and pass it to the `Registry`.

### Testing:

* [`tests/test_excluded_actions.py`](diffhunk://#diff-3d4c08bb55357c7d1f5af7272d7725272f0e64391194193790ac1e95c5385857R1-R98): Added a new test file to verify that only the `open_tab` action is allowed while others are excluded. This includes the setup of necessary fixtures and a test case `test_only_open_tab_allowed`.