### PR TITLE
changed the 'navigator.langagues' to return only 'en-US'

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -276,7 +276,7 @@ class BrowserContext:
 
 			// Languages
 			Object.defineProperty(navigator, 'languages', {
-				get: () => ['en-US', 'en']
+				get: () => ['en-US']
 			});
 
 			// Plugins


### PR DESCRIPTION
this prevents inconsistencies between the webworker and navigator, which, when present, are an indicator of bot activity. A more correct solution would be to set both to self.config.locale, but that could be null.