### PR TITLE
Fix: ollama.py example with AgentHistoryList type

### DIFF
--- a/examples/ollama.py
+++ b/examples/ollama.py
@@ -1,4 +1,4 @@
-import os
+# import os
 
 # Optional: Disable telemetry
 # os.environ["ANONYMIZED_TELEMETRY"] = "false"
@@ -8,10 +8,11 @@ import os
 
 import asyncio
 from browser_use import Agent
+from browser_use.agent.views import AgentHistoryList
 from langchain_ollama import ChatOllama
 
 
-async def run_search() -> str:
+async def run_search() -> AgentHistoryList:
     agent = Agent(
         task="Search for a 'browser use' post on the r/LocalLLaMA subreddit and open it.",
         llm=ChatOllama(


### PR DESCRIPTION
**Fixes this issue**: https://github.com/browser-use/browser-use/issues/238

**Problem**: running the ollama example as is leads to an error:
```
ERROR    [agent] ❌ Result failed 1/3 times:
 Could not parse response.
```

**Solution**: Simply converting from a `str` type to the `AgentHistoryList` type gets it working.

**Clarifying Question & Proposed Future Work**: I'm not a python expert, and assumed types were optional, but is the reason this was failing due to some type checking? If so, perhaps a better error message regarding a type error could help in future cases.

**Shoutout**: Huge shoutout to @arsen3d for opening the issue and supplying working code!