### PR TITLE
Make telemetry opt-in.

### DIFF
--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -36,11 +36,14 @@ class ProductTelemetry:
 	_curr_user_id = None
 
 	def __init__(self) -> None:
-		telemetry_disabled = os.getenv('ANONYMIZED_TELEMETRY', 'true').lower() == 'false'
+		telemetry_disabled = os.getenv('ANONYMIZED_TELEMETRY', 'false').lower() == 'false'
 		self.debug_logging = os.getenv('BROWSER_USE_LOGGING_LEVEL', 'info').lower() == 'debug'
 
 		if telemetry_disabled:
 			self._posthog_client = None
+			logging.info('Anonymized telemetry is disabled by default. To enable it, set the environment variable '
+						'`ANONYMIZED_TELEMETRY=true`. See https://github.com/browser-use/browser-use for more information.'
+			)
 		else:
 			logging.info(
 				'Anonymized telemetry enabled. See https://github.com/browser-use/browser-use for more information.'


### PR DESCRIPTION
I was very disappointed to encounter this line in the console while trying out demo code:

`INFO     [root] Anonymized telemetry enabled. See https://github.com/browser-use/browser-use for more information.`

Yet there's not really any information in the description of the repo that would describe this; I had to search the files for "telemetry" and work backwards from there.

I don't have a relationship with `https://eu.i.posthog.com` and I don't want my software communicating with this service by default. Please accept this PR and make the default behavior to not collect telemetry.