### PR TITLE
fix:windows connect browser error

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -151,6 +151,16 @@ class Browser:
 			stdout=subprocess.DEVNULL,
 			stderr=subprocess.DEVNULL,
 		)
+    
+		# Attempt to connect again after starting a new instance
+		for _ in range(10):
+			try:
+				response = requests.get('http://localhost:9222/json/version', timeout=2)
+				if response.status_code == 200:
+					break
+			except requests.ConnectionError:
+				pass
+			await asyncio.sleep(1)
 
 		# Attempt to connect again after starting a new instance
 		try:


### PR DESCRIPTION
On Windows, I'm encountering an issue where the browser, launched using subprocess and chrome_instance_path, sometimes hasn't fully started up before attempting to connect via connect_over_cdp. This results in an error, so I've added a trying and waiting mechanism.