### PR TITLE
feat: make use of the `tool_calling_method` param on Agent constructor

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -219,6 +219,8 @@ class Agent:
 				return 'function_calling'
 			else:
 				return None
+		else:
+			return tool_calling_method
 
 	def add_new_task(self, new_task: str) -> None:
 		self.message_manager.add_new_task(new_task)


### PR DESCRIPTION
this little change can enhance the use of local models with Ollama, possibiliting the use of models that not suport tool calling method with the option `"json_schema"`.

From the docs of [langchain](https://python.langchain.com/api_reference/ollama/chat_models/langchain_ollama.chat_models.ChatOllama.html#langchain_ollama.chat_models.ChatOllama.with_structured_output):  
![image](https://github.com/user-attachments/assets/fe2b34ea-1ad8-4224-8b72-a11a426694e7)  
https://ollama.com/blog/structured-outputs

When testing, the results can be more reliable with little local models, not having errors when parsing (but the overall result is cannot be very good, because little models without vision cannot do to much here)

can help on [145](https://github.com/browser-use/web-ui/issues/145)

