### PR TITLE
Fix incorrect import of BrowserContext in documentation example

### DIFF
--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -65,7 +65,7 @@ You can configure how the agent interacts with the browser. To see more `Browser
 
 ```python
 from browser_use import Agent, Browser
-from playwright.async_api import BrowserContext
+from browser_use.browser.context import BrowserContext
 
 # Reuse existing browser
 browser = Browser()


### PR DESCRIPTION
### Description  
This PR fixes an incorrect import statement in the documentation example for reusing an existing browser instance. The current example imports `BrowserContext` from `playwright.async_api`, but it should be imported from `browser_use.browser.context` to align with the design of the `browser_use` library.

### Changes Made  
- Updated the sample code in the documentation to replace:
  ```python
  from playwright.async_api import BrowserContext
  ```
  with:
  ```python
  from browser_use.browser.context import BrowserContext
  ```
### Why this change is necessary  
The incorrect import may cause confusion or lead to unintended behavior when users follow the documentation. Using the correct `BrowserContext` ensures consistency with the library's intended usage and leverages its full capabilities.  

Let me know if you'd like any refinements to this text!