### PR TITLE
fix: Execute initial actions when rerun history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ AgentHistoryList.json
 gcp-login.json
 .vscode
 .ruff_cache
+.idea

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -592,6 +592,10 @@ class Agent:
 		Returns:
 		        List of action results
 		"""
+		# Execute initial actions if provided
+		if self.initial_actions:
+			await self.controller.multi_act(self.initial_actions, self.browser_context, check_for_new_elements=False)
+		
 		results = []
 
 		for i, history_item in enumerate(history.history):

--- a/browser_use/dom/history_tree_processor/service.py
+++ b/browser_use/dom/history_tree_processor/service.py
@@ -64,17 +64,19 @@ class HistoryTreeProcessor:
 			dom_history_element.entire_parent_branch_path
 		)
 		attributes_hash = HistoryTreeProcessor._attributes_hash(dom_history_element.attributes)
+		xpath_hash = HistoryTreeProcessor._xpath_hash(dom_history_element.xpath)
 
-		return HashedDomElement(branch_path_hash, attributes_hash)
+		return HashedDomElement(branch_path_hash, attributes_hash, xpath_hash)
 
 	@staticmethod
 	def _hash_dom_element(dom_element: DOMElementNode) -> HashedDomElement:
 		parent_branch_path = HistoryTreeProcessor._get_parent_branch_path(dom_element)
 		branch_path_hash = HistoryTreeProcessor._parent_branch_path_hash(parent_branch_path)
 		attributes_hash = HistoryTreeProcessor._attributes_hash(dom_element.attributes)
+		xpath_hash = HistoryTreeProcessor._xpath_hash(dom_element.xpath)
 		# text_hash = DomTreeProcessor._text_hash(dom_element)
 
-		return HashedDomElement(branch_path_hash, attributes_hash)
+		return HashedDomElement(branch_path_hash, attributes_hash, xpath_hash)
 
 	@staticmethod
 	def _get_parent_branch_path(dom_element: DOMElementNode) -> list[str]:
@@ -97,6 +99,10 @@ class HistoryTreeProcessor:
 	def _attributes_hash(attributes: dict[str, str]) -> str:
 		attributes_string = ''.join(f'{key}={value}' for key, value in attributes.items())
 		return hashlib.sha256(attributes_string.encode()).hexdigest()
+
+	@staticmethod
+	def _xpath_hash(xpath: str) -> str:
+		return hashlib.sha256(xpath.encode()).hexdigest()
 
 	@staticmethod
 	def _text_hash(dom_element: DOMElementNode) -> str:

--- a/browser_use/dom/history_tree_processor/view.py
+++ b/browser_use/dom/history_tree_processor/view.py
@@ -10,6 +10,7 @@ class HashedDomElement:
 
 	branch_path_hash: str
 	attributes_hash: str
+	xpath_hash: str
 	# text_hash: str
 
 


### PR DESCRIPTION
I've defined go_to_url in initial_action. If I directly run rerun_history, it will fail because the web page hasn't been opened.