### PR TITLE
Fix README: Correct demo file path after directory restructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ uv pip install gradio
 ```
 
 ```bash
-python examples/gradio_demo.py
+python examples/ui/gradio_demo.py
 ```
 
 # Demos


### PR DESCRIPTION
This PR updates the README file to reflect the correct path for the demo file. 

### Context
In commit c7008a70c203a71f45ef0766bc23149cd00a8f95, the `gradio_demo.py` file was moved from `examples/` to `examples/ui/`, but the README wasn't updated to reflect this change. This led to confusion when trying to run the demo as per the README instructions.

### Changes
- Updated the path for running the demo in the README from `python examples/gradio_demo.py` to `python examples/ui/gradio_demo.py`.

### Impact
This change ensures that the instructions in the README are accurate and aligned with the current project structure.

Please review and merge to keep the documentation consistent with the codebase.
