### PR TITLE
Dont select body as clickable

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -137,6 +137,11 @@
 
     // Helper function to check if element is interactive
     function isInteractiveElement(element) {
+        // Immediately return false for body tag
+        if (element.tagName.toLowerCase() === 'body') {
+            return false;
+        }
+
         // Base interactive elements and roles
         const interactiveElements = new Set([
             'a', 'button', 'details', 'embed', 'input', 'label',
@@ -164,7 +169,7 @@
             interactiveElements.has(tagName) ||
             interactiveRoles.has(role) ||
             interactiveRoles.has(ariaRole) ||
-            (tabIndex !== null && tabIndex !== '-1') ||
+            (tabIndex !== null && tabIndex !== '-1' && element.parentElement?.tagName.toLowerCase() !== 'body') ||
             element.getAttribute('data-action') === 'a-dropdown-select' ||
             element.getAttribute('data-action') === 'a-dropdown-button';
 
@@ -240,13 +245,17 @@
         const isDraggable = element.draggable ||
             element.getAttribute('draggable') === 'true';
 
+        // Additional check to prevent body from being marked as interactive
+        if (element.tagName.toLowerCase() === 'body' || element.parentElement?.tagName.toLowerCase() === 'body') {
+            return false;
+        }
+
         return hasAriaProps ||
             // hasClickStyling ||
             hasClickHandler ||
             hasClickListeners ||
             // isFormRelated ||
             isDraggable;
-
     }
 
     // Helper function to check if element is visible


### PR DESCRIPTION
This pull request includes changes to the `browser_use/dom/buildDomTree.js` file to improve the handling of the `<body>` tag in the DOM tree. The changes ensure that the `<body>` tag is not incorrectly marked as interactive.

Improvements to handling of `<body>` tag:

* Added a check in the `isInteractiveElement` function to immediately return false if the element is the `<body>` tag.
* Modified the condition that checks the `tabIndex` attribute to ensure that elements with a parent `<body>` tag are not considered interactive.
* Added an additional check in the draggable element detection to prevent the `<body>` tag or its children from being marked as interactive.