### PR TITLE
added groq example to supported-models.mdx in docs

### DIFF
--- a/docs/customize/supported-models.mdx
+++ b/docs/customize/supported-models.mdx
@@ -210,10 +210,36 @@ agent = Agent(
 )
 ```
 
+### Groq
+
+Groq offers a generous free tier for calling APIs.
+
+```python
+from langchain_groq import ChatGroq
+from browser_use import Agent
+
+# Initialize the model
+llm = ChatGroq(
+    model="mixtral-8x7b-32768",
+    temperature=0.0,
+)
+
+# Create agent with the model
+agent = Agent(
+    task="Your task here",
+    llm=llm
+)
+```
+
+Required environment variables:
+
+```bash .env
+GROQ_API_KEY=
+```
+
 Required environment variables: None!
 
 ## Coming soon
 (We are working on it)
-- Groq
 - Github
 - Fine-tuned models


### PR DESCRIPTION
I have added a groq example to supported models in docs. I used the same model given [here](https://python.langchain.com/docs/integrations/chat/groq/) and the fact that Groq and OpenAI have similar APIs in langchain