### PR TITLE
Solving the installation issue #441

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 version = "0.1.30"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.11,<4.0"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Fix Python version compatibility issue

Updated the Python version constraint in pyproject.toml from ">=3.11" to ">=3.11,<4.0" to resolve dependency conflicts with langchain-google-genai which requires Python <4.0.

This change:
- Maintains the minimum Python requirement of 3.11
- Adds an upper bound of Python <4.0
- Resolves poetry install failures due to version incompatibility
- Ensures compatibility with all project dependencies

The error was occurring because langchain-google-genai requires Python <4.0, but our project didn't specify an upper bound for the Python version.

Issue: #441 