### PR TITLE
Check for pause more often

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -235,6 +235,12 @@ class Agent:
 	def add_new_task(self, new_task: str) -> None:
 		self.message_manager.add_new_task(new_task)
 
+	def _check_if_stopped_or_paused(self) -> bool:
+		if self._stopped or self._paused:
+			logger.debug('Agent paused after getting state')
+			raise InterruptedError
+		return False
+
 	@time_execution_async('--step')
 	async def step(self, step_info: Optional[AgentStepInfo] = None) -> None:
 		"""Execute one step of the task"""
@@ -246,12 +252,12 @@ class Agent:
 		try:
 			state = await self.browser_context.get_state()
 
-			if self._stopped or self._paused:
-				logger.debug('Agent paused after getting state')
-				raise InterruptedError
+			self._check_if_stopped_or_paused()
 
 			self.message_manager.add_state_message(state, self._last_result, step_info, self.use_vision)
 			input_messages = self.message_manager.get_messages()
+
+			self._check_if_stopped_or_paused()
 
 			try:
 				model_output = await self.get_next_action(input_messages)
@@ -262,9 +268,7 @@ class Agent:
 				self._save_conversation(input_messages, model_output)
 				self.message_manager._remove_last_state_message()  # we dont want the whole state in the chat history
 
-				if self._stopped or self._paused:
-					logger.debug('Agent paused after getting next action')
-					raise InterruptedError
+				self._check_if_stopped_or_paused()
 
 				self.message_manager.add_model_output(model_output)
 			except Exception as e:
@@ -277,6 +281,7 @@ class Agent:
 				self.browser_context,
 				page_extraction_llm=self.page_extraction_llm,
 				sensitive_data=self.sensitive_data,
+				check_break_if_paused=lambda: self._check_if_stopped_or_paused(),
 			)
 			self._last_result = result
 
@@ -287,6 +292,11 @@ class Agent:
 
 		except InterruptedError:
 			logger.debug('Agent paused')
+			self._last_result = [
+				ActionResult(
+					error='The agent was paused - now continuing actions might need to be repeated', include_in_memory=True
+				)
+			]
 			return
 		except Exception as e:
 			result = await self._handle_step_error(e)
@@ -488,6 +498,7 @@ class Agent:
 					self.browser_context,
 					check_for_new_elements=False,
 					page_extraction_llm=self.page_extraction_llm,
+					check_break_if_paused=lambda: self._check_if_stopped_or_paused(),
 				)
 				self._last_result = result
 

--- a/examples/features/pause_agent.py
+++ b/examples/features/pause_agent.py
@@ -16,7 +16,8 @@ class AgentController:
 	def __init__(self):
 		llm = ChatOpenAI(model='gpt-4o')
 		self.agent = Agent(
-			task="Go to wikipedia.org and search for 'Python programming language', then read the first paragraph", llm=llm
+			task='open in one action https://www.google.com, https://www.wikipedia.org, https://www.youtube.com, https://www.github.com, https://amazon.com',
+			llm=llm,
 		)
 		self.running = False
 


### PR DESCRIPTION
This pull request includes several changes to improve the handling of paused or stopped states in the `browser_use` module. The main focus is on refactoring the code to centralize the check for paused or stopped states and ensuring this check is consistently applied throughout the relevant methods.

Refactoring and state check improvements:

* Added a new method `_check_if_stopped_or_paused` to the `Agent` class in `browser_use/agent/service.py` to centralize the logic for checking if the agent is paused or stopped.
* Replaced individual checks for `_stopped` or `_paused` with calls to the new `_check_if_stopped_or_paused` method in the `step` method of `browser_use/agent/service.py`. [[1]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92L249-R261) [[2]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92L265-R271) [[3]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R284)
* Updated the `run` method in `browser_use/agent/service.py` to include the new `_check_if_stopped_or_paused` method.
* Modified the `multi_act` method in `browser_use/controller/service.py` to accept a `check_break_if_paused` parameter and call this function at various points to ensure the paused state is checked. [[1]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225R447) [[2]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225R458-R465) [[3]](diffhunk://#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225R474-R475)

Other changes:

* Updated the import statements in `browser_use/controller/service.py` to include the `Callable` type.
* Changed the task description in the `AgentController` class in `examples/features/pause_agent.py` to open multiple websites in one action.