### PR TITLE
Fix broken navigation icon for sensitive data docs page

### DIFF
--- a/docs/customize/sensitive-data.mdx
+++ b/docs/customize/sensitive-data.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sensitive Data"
 description: "Handle sensitive information securely by preventing the model from seeing actual passwords."
-icon: "shield-lock"
+icon: "shield"
 ---
 
 ## Handling Sensitive Data


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1552" alt="image" src="https://github.com/user-attachments/assets/0c00317e-5ec9-4930-bd59-1add4b553283" /> | <img width="1552" alt="image" src="https://github.com/user-attachments/assets/d29e770a-cd9a-44e2-937a-b7d99d88dc09" /> | 

On the left-hand side of the navigation bar, you can see that there was no icon for the Sensitive Data documents page. This PR fixes this.

Bug caused in #503 