### PR TITLE
fix: ensure save_conversation_path ends with a slash and add tests for conversation logging

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -111,6 +111,8 @@ class Agent:
 		self.use_vision = use_vision
 		self.llm = llm
 		self.save_conversation_path = save_conversation_path
+		if self.save_conversation_path and '/' not in self.save_conversation_path:
+			self.save_conversation_path = f'{self.save_conversation_path}/'
 		self.save_conversation_path_encoding = save_conversation_path_encoding
 		self._last_result = None
 		self.include_attributes = include_attributes

--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -35,7 +35,7 @@ agent = Agent(
     llm=llm,
     controller=custom_controller,  # For custom tool calling
     use_vision=True,              # Enable vision capabilities
-    save_conversation_path="logs/conversation.json"  # Save chat logs
+    save_conversation_path="logs/conversation"  # Save chat logs
 )
 ```
 

--- a/tests/test_save_conversation.py
+++ b/tests/test_save_conversation.py
@@ -1,0 +1,83 @@
+"""
+Simple try of the agent.
+
+@dev You need to add OPENAI_API_KEY to your environment variables.
+"""
+
+import os
+import shutil
+import sys
+
+from browser_use.browser.browser import Browser, BrowserConfig
+from browser_use.browser.context import BrowserContext
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from langchain_openai import ChatOpenAI
+
+from browser_use import Agent, AgentHistoryList
+
+llm = ChatOpenAI(model='gpt-4o')
+
+
+async def test_save_conversation_contains_slash():
+	if os.path.exists('./logs'):
+		shutil.rmtree('./logs')
+
+	agent = Agent(
+		task=('go to google.com and search for text "hi there"'),
+		llm=llm,
+		browser_context=BrowserContext(
+			browser=Browser(config=BrowserConfig(headless=False, disable_security=True)),
+		),
+		save_conversation_path='logs/conversation',
+	)
+	history: AgentHistoryList = await agent.run(20)
+
+	result = history.final_result()
+	assert result is not None
+
+	assert os.path.exists('./logs'), 'logs directory was not created'
+	assert os.path.exists('./logs/conversation_2.txt'), 'logs file was not created'
+
+
+async def test_save_conversation_not_contains_slash():
+	if os.path.exists('./logs'):
+		shutil.rmtree('./logs')
+
+	agent = Agent(
+		task=('go to google.com and search for text "hi there"'),
+		llm=llm,
+		browser_context=BrowserContext(
+			browser=Browser(config=BrowserConfig(headless=False, disable_security=True)),
+		),
+		save_conversation_path='logs',
+	)
+	history: AgentHistoryList = await agent.run(20)
+
+	result = history.final_result()
+	assert result is not None
+
+	assert os.path.exists('./logs'), 'logs directory was not created'
+	assert os.path.exists('./logs/_2.txt'), 'logs file was not created'
+
+
+async def test_save_conversation_deep_directory():
+	if os.path.exists('./logs'):
+		shutil.rmtree('./logs')
+
+	agent = Agent(
+		task=('go to google.com and search for text "hi there"'),
+		llm=llm,
+		browser_context=BrowserContext(
+			browser=Browser(config=BrowserConfig(headless=False, disable_security=True)),
+		),
+		save_conversation_path='logs/deep/directory/conversation',
+	)
+	history: AgentHistoryList = await agent.run(20)
+
+	result = history.final_result()
+	assert result is not None
+
+	assert os.path.exists('./logs/deep/directory'), 'logs directory was not created'
+	assert os.path.exists('./logs/deep/directory/conversation_2.txt'), 'logs file was not created'


### PR DESCRIPTION
fix: #305 

This pull request introduces changes to handle the `save_conversation_path` more robustly in the `Agent` class and adds tests to ensure the functionality works as expected. The most important changes include modifying the initialization of the `save_conversation_path` attribute, updating the documentation to reflect the new behavior, and adding comprehensive tests.

### Changes to `save_conversation_path` handling:

* [`browser_use/agent/service.py`](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R114-R115): Added logic to ensure the `save_conversation_path` ends with a slash if it is not a file path.

### Documentation updates:

* [`docs/customize/agent-settings.mdx`](diffhunk://#diff-b58565bb1723aaf24e80921a03fa5a7dbee47d416c10e22143b98f1641f77886L38-R38): Updated the example to use a directory path for `save_conversation_path` instead of a file path.

### Added tests:

* [`tests/test_save_conversation.py`](diffhunk://#diff-988af4ea2e8d46b176c9f8ed6786318a5d9329edcf329300ce3a69ef6eb2f456R1-R83): Added tests to verify the `save_conversation_path` functionality, including cases with and without slashes and deep directory structures.