### PR TITLE
Update Prompt Action Names to Align with Current Implementation

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -45,9 +45,9 @@ class SystemPrompt:
        {"click_element": {"index": 3}}
      ]
    - Navigation and extraction: [
-       {"open_new_tab": {}},
+       {"open_tab": {}},
        {"go_to_url": {"url": "https://example.com"}},
-       {"extract_page_content": {}}
+       {"extract_content": ""}
      ]
 
 
@@ -96,7 +96,7 @@ class SystemPrompt:
 - If you get stuck, 
 
 10. Extraction:
-- If your task is to find information or do research - call extract_page_content on the specific pages to get and store the information.
+- If your task is to find information or do research - call extract_content on the specific pages to get and store the information.
 
 """
 		text += f'   - use maximum {self.max_actions_per_step} actions per sequence'


### PR DESCRIPTION
## Summary

This PR addresses inconsistencies between the action names described in the prompt and those defined in the current implementation. The outdated prompt examples are causing unnecessary confusion for the LLM when generating actions.

## Changes

- Updated the "Navigation and extraction" example in the prompt:
  - Changed `open_new_tab` to `open_tab`
  - Changed `extract_page_content` to `extract_content`

https://github.com/browser-use/browser-use/blob/5d1197e5d3b8b7d191aac638b052007882504040/browser_use/controller/service.py#L153-L166

Please review these changes and let me know if any further adjustments are needed.
