### PR TITLE
Update Sample Code to Properly Utilize DeepSeek API Key for Dual LLM Usage

### DIFF
--- a/examples/features/planner.py
+++ b/examples/features/planner.py
@@ -12,8 +12,11 @@ api_key = os.getenv('DEEPSEEK_API_KEY', '')
 if not api_key:
 	raise ValueError('DEEPSEEK_API_KEY is not set')
 
-
-llm = ChatOpenAI(model='gpt-4o', temperature=0.0)
+llm = ChatOpenAI(
+	base_url='https://api.deepseek.com/v1',
+	model='deepseek-chat',
+	api_key=SecretStr(api_key),
+)
 planner_llm = ChatOpenAI(
 	model='o3-mini',
 )


### PR DESCRIPTION
I noticed that the sample code in [this commit](https://github.com/browser-use/browser-use/commit/98f159e8b4295a07aacd6bbed9a212b1fbf0ca2f#diff-30808312c8d80d554b811329fee070cd52bf72b0a3ef5c0165bd8cf547bae32a) references `DEEPSEEK_API_KEY` and uses `SecretStr`, yet these elements are not utilized in the subsequent code. The commit message suggests that the original intent was to demonstrate a sample using two different LLMs.

**Proposed Changes:**  
- Replace the current instantiation:  
  ```python
  llm = ChatOpenAI(model='gpt-4o', temperature=0.0)
  ```  
- With the following:  
  ```python
  llm = ChatOpenAI(
      base_url='https://api.deepseek.com/v1',
      model='deepseek-chat',
      api_key=SecretStr(api_key),
  )
  ```

**Rationale:**  
This update properly utilizes the DeepSeek API key and aligns the sample code with the intended demonstration of using two LLMs. It helps ensure that the example code accurately reflects the documented functionality.

