### PR TITLE
bug fix syntax warning invalid escape

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class BrowserConfig:
-	"""
+	r"""
 	Configuration for the Browser.
 
 	Default values:


### PR DESCRIPTION
Fix Pylint warning for backslashes in docstring
