### PR TITLE
fix(context): reload page for CDP remote browser connections

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -216,6 +216,8 @@ class BrowserContext:
 
 	def _add_new_page_listener(self, context: PlaywrightBrowserContext):
 		async def on_page(page: Page):
+			if self.browser.config.cdp_url:
+                		await page.reload() # Reload the page to avoid timeout errors
 			await page.wait_for_load_state()
 			logger.debug(f'New page opened: {page.url}')
 			if self.session is not None:


### PR DESCRIPTION
Problem
When using CDP (Chrome DevTools Protocol) connections, page operations were resulting in timeout errors after 30000ms. This specifically occurred during page load state verification: await page.wait_for_load_state()
The error manifests in the following call stack:

context.py line 219 - Initial wait_for_load_state call Propagates through Playwright's async API
Times out in frame implementation while waiting for load state

Solution
Implemented page reloading specifically for CDP connections to prevent these timeout errors. This addresses the underlying issue where the page load state was not being properly detected in CDP scenarios. 

Implementation Details

Added conditional page reload for CDP connection types Maintains existing behavior for non-CDP connections Ensures proper page load state verification

Testing

Verified fix resolves timeout errors with CDP connections Confirmed existing functionality remains intact for other connection types

Reference
Solution approach based on discord support ticket - https://discord.com/channels/1303749220842340412/1334218695509016657/1334517519611990056