### PR TITLE
Fix Pass sensitive_data to multi_act executed via rerun_history

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -689,6 +689,7 @@ class Agent:
 				page_extraction_llm=self.page_extraction_llm,
 				check_break_if_paused=lambda: self._check_if_stopped_or_paused(),
 				available_file_paths=self.available_file_paths,
+				sensitive_data=self.sensitive_data,
 			)
 
 		results = []
@@ -749,6 +750,7 @@ class Agent:
 			self.browser_context,
 			page_extraction_llm=self.page_extraction_llm,
 			check_break_if_paused=lambda: self._check_if_stopped_or_paused(),
+			sensitive_data=self.sensitive_data,
 		)
 
 		await asyncio.sleep(delay)


### PR DESCRIPTION
**Issue:**
- https://github.com/browser-use/browser-use/issues/695

**Description:**  
This PR addresses issue [#695](https://github.com/browser-use/browser-use/issues/695) by ensuring that the `sensitive_data` argument is properly passed to `multi_act` when it is executed via `rerun_history()`. This change guarantees that sensitive data is correctly handled throughout the process.

**Changes:**  
- Updated `multi_act`—executed via `rerun_history()`—to properly receive the `sensitive_data` argument.  