### PR TITLE
fix: optimize macOS font loading for better CJK support

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -834,9 +834,9 @@ class Agent:
 				]
 			elif platform.system() == 'Darwin':  # macOS
 				font_options = [
-					'/System/Library/Fonts/PingFang.ttc',
-					'/System/Library/Fonts/Apple Color Emoji.ttc',
-					'/System/Library/Fonts/Helvetica.ttc',
+					'Hiragino Sans GB',  # Primary font with full Unicode support (CJK + Latin)
+					'.AppleSystemUIFont',  # System UI font as fallback
+					'Apple Color Emoji',  # Emoji and special characters
 				]
 			else:  # Linux and others
 				font_options = [


### PR DESCRIPTION
Following up on #711, some macOS devices still experienced font rendering issues.
This commit:
- Simplifies macOS font options to use only essential fonts
- Uses Hiragino Sans GB as primary font for its complete Unicode support
- Keeps .AppleSystemUIFont as system fallback
- Retains Apple Color Emoji for emoji support

This change ensures more reliable CJK text rendering across different macOS versions
without requiring additional font installations.

Fixes remaining font issues from #711