### PR TITLE
Avoid logging sensitive information on input_text logs in controller

### DIFF
--- a/browser_use/controller/registry/service.py
+++ b/browser_use/controller/registry/service.py
@@ -122,6 +122,8 @@ class Registry:
 				extra_args['page_extraction_llm'] = page_extraction_llm
 			if 'available_file_paths' in parameter_names:
 				extra_args['available_file_paths'] = available_file_paths
+			if action_name == 'input_text' and sensitive_data:
+				extra_args['has_sensitive_data'] = True
 			if is_pydantic:
 				return await action.function(validated_params, **extra_args)
 			return await action.function(**validated_params.model_dump(), **extra_args)

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -125,7 +125,7 @@ class Controller:
 			'Input text into a input interactive element',
 			param_model=InputTextAction,
 		)
-		async def input_text(params: InputTextAction, browser: BrowserContext):
+		async def input_text(params: InputTextAction, browser: BrowserContext, has_sensitive_data: bool = False):
 			session = await browser.get_session()
 			state = session.cached_state
 
@@ -134,7 +134,10 @@ class Controller:
 
 			element_node = state.selector_map[params.index]
 			await browser._input_text_element_node(element_node, params.text)
-			msg = f'⌨️  Input {params.text} into index {params.index}'
+			if not has_sensitive_data:
+				msg = f'⌨️  Input {params.text} into index {params.index}'
+			else:
+				msg = f'⌨️  Input sensitive data into index {params.index}'
 			logger.info(msg)
 			logger.debug(f'Element xpath: {element_node.xpath}')
 			return ActionResult(extracted_content=msg, include_in_memory=True)


### PR DESCRIPTION
Fixes #713

This PR will add the extra arg to input_text action to avoid logging sensitive information.