### PR TITLE
Update Documentation:  Clarify the Distinction Between browser-use’s Browser and Playwright’s Browser

### DIFF
--- a/docs/customize/custom-functions.mdx
+++ b/docs/customize/custom-functions.mdx
@@ -43,6 +43,13 @@ agent = Agent(
 
 For actions that need browser access, simply add the `browser` parameter inside the function parameters:
 
+<Note>
+  Please note that browser-use’s `Browser` class is entirely different from
+  Playwright’s `Browser`. It employs its own abstraction layer for browser
+  control, resulting in numerous differences in available methods and behavior
+  compared to Playwright’s implementation.
+</Note>
+
 ```python
 from browser_use import Browser, Controller, ActionResult
 

--- a/docs/customize/custom-functions.mdx
+++ b/docs/customize/custom-functions.mdx
@@ -44,10 +44,9 @@ agent = Agent(
 For actions that need browser access, simply add the `browser` parameter inside the function parameters:
 
 <Note>
-  Please note that browser-use’s `Browser` class is entirely different from
-  Playwright’s `Browser`. It employs its own abstraction layer for browser
-  control, resulting in numerous differences in available methods and behavior
-  compared to Playwright’s implementation.
+  Please note that browser-use’s `Browser` class is a wrapper class around
+  Playwright’s `Browser`. The `Browser.playwright_browser` attr can be used
+  to directly access the Playwright browser object if needed.
 </Note>
 
 ```python


### PR DESCRIPTION
While addressing a recent issue, we noticed that some users are confusing browser-use’s Browser class with Playwright’s Browser. I understand that this mix-up is somewhat understandable given the similar naming and usage patterns.

- https://github.com/browser-use/browser-use/issues/708
- https://github.com/browser-use/browser-use/issues/722
- https://github.com/browser-use/browser-use/issues/687

This PR adds a note in the documentation (in the custom functions section) to clearly state that browser-use employs its own for browser control.

