### PR TITLE
Fixed the screenshot flickering issue

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -15,6 +15,7 @@ from playwright.async_api import (
 )
 
 from browser_use.browser.context import BrowserContext, BrowserContextConfig
+from browser_use.browser.utils.screen_resolution import get_screen_resolution, get_window_adjustments
 
 logger = logging.getLogger(__name__)
 
@@ -179,6 +180,8 @@ class Browser:
 
 	async def _setup_standard_browser(self, playwright: Playwright) -> PlaywrightBrowser:
 		"""Sets up and returns a Playwright Browser instance with anti-detection measures."""
+		screen_size = get_screen_resolution()
+		offset_x, offset_y = get_window_adjustments()
 		browser = await playwright.chromium.launch(
 			headless=self.config.headless,
 			args=[
@@ -194,8 +197,9 @@ class Browser:
 				'--no-first-run',
 				'--no-default-browser-check',
 				'--no-startup-window',
-				'--window-position=0,0',
-				# '--window-size=1280,1000',
+				f'--window-position={offset_x},{offset_y}',
+				f'--window-size={screen_size["width"]},{screen_size["height"]}',
+        		'--force-device-scale-factor=1',
 			]
 			+ self.disable_security_args
 			+ self.config.extra_chromium_args,

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -266,8 +266,7 @@ class BrowserContext:
 		else:
 			# Original code for creating new context
 			context = await browser.new_context(
-				viewport=self.config.browser_window_size,
-				no_viewport=False,
+				no_viewport=True,
 				user_agent=self.config.user_agent,
 				java_script_enabled=True,
 				bypass_csp=self.config.disable_security,

--- a/browser_use/browser/tests/screenshot_test.py
+++ b/browser_use/browser/tests/screenshot_test.py
@@ -1,37 +1,34 @@
+import asyncio
 import base64
 
 import pytest
 
 from browser_use.browser.browser import Browser, BrowserConfig
 
-
-@pytest.fixture
-async def browser():
-	browser_service = Browser(config=BrowserConfig(headless=True))
-	yield browser_service
-
-	await browser_service.close()
-
-
-# @pytest.mark.skip(reason='takes too long')
-def test_take_full_page_screenshot(browser):
-	# Go to a test page
-	browser.go_to_url('https://example.com')
-
-	# Take full page screenshot
-	screenshot_b64 = browser.take_screenshot(full_page=True)
-
-	# Verify screenshot is not empty and is valid base64
-	assert screenshot_b64 is not None
-	assert isinstance(screenshot_b64, str)
-	assert len(screenshot_b64) > 0
-
-	# Test we can decode the base64 string
+async def test_take_full_page_screenshot():
+	browser = Browser(config=BrowserConfig(headless=False, disable_security=True))
 	try:
-		base64.b64decode(screenshot_b64)
-	except Exception as e:
-		pytest.fail(f'Failed to decode base64 screenshot: {str(e)}')
+		async with await browser.new_context() as context:
+			page = await context.get_current_page()
+			# Go to a test page
+			await page.goto('https://example.com')
 
+			await asyncio.sleep(3)
+			# Take full page screenshot
+			screenshot_b64 = await context.take_screenshot(full_page=True)
+			await asyncio.sleep(3)
+			# Verify screenshot is not empty and is valid base64
+			assert screenshot_b64 is not None
+			assert isinstance(screenshot_b64, str)
+			assert len(screenshot_b64) > 0
+
+			# Test we can decode the base64 string
+			try:
+				base64.b64decode(screenshot_b64)
+			except Exception as e:
+				pytest.fail(f'Failed to decode base64 screenshot: {str(e)}')
+	finally:
+		await browser.close()
 
 if __name__ == '__main__':
-	test_take_full_page_screenshot(Browser(config=BrowserConfig(headless=False)))
+	asyncio.run(test_take_full_page_screenshot())

--- a/browser_use/browser/utils/screen_resolution.py
+++ b/browser_use/browser/utils/screen_resolution.py
@@ -1,24 +1,31 @@
 import sys
 
 def get_screen_resolution():
-    if sys.platform == "darwin":  # Correct check for macOS
+    if sys.platform == "darwin":  # macOS
         try:
-            from AppKit import NSScreen  # macOS-only import
+            from AppKit import NSScreen
             screen = NSScreen.mainScreen().frame()
             return {"width": int(screen.size.width), "height": int(screen.size.height)}
         except ImportError:
             print("AppKit is not available. Make sure you are running this on macOS.")
-            return {"width": 1920, "height": 1080}
+        except Exception as e:
+            print(f"Error retrieving macOS screen resolution: {e}")
+        return {"width": 2560, "height": 1664}
 
     else:  # Windows & Linux
         try:
-            from screeninfo import get_monitors  # Cross-platform library
-            monitor = get_monitors()[0]  # Get primary monitor
+            from screeninfo import get_monitors
+            monitors = get_monitors()
+            if not monitors:
+                raise Exception("No monitors detected.")
+            monitor = monitors[0]
             return {"width": monitor.width, "height": monitor.height}
         except ImportError:
-            print("screeninfo package not found. Install it using 'pip install screeninfo'")
-            return {"width": 1920, "height": 1080}
-        
+            print("screeninfo package not found. Install it using 'pip install screeninfo'.")
+        except Exception as e:
+            print(f"Error retrieving screen resolution: {e}")
+
+        return {"width": 1920, "height": 1080}
 
 def get_window_adjustments():
     """Returns recommended x, y offsets for window positioning"""
@@ -26,5 +33,5 @@ def get_window_adjustments():
         return -4, 24  # macOS has a small title bar, no border
     elif sys.platform == "win32":  # Windows
         return -8, 0  # Windows has a border on the left
-    else:  # Linux (varies by window manager)
-        return 0, 0  # Adjust as needed for your WM
+    else:  # Linux
+        return 0, 0

--- a/browser_use/browser/utils/screen_resolution.py
+++ b/browser_use/browser/utils/screen_resolution.py
@@ -1,0 +1,30 @@
+import sys
+
+def get_screen_resolution():
+    if sys.platform == "darwin":  # Correct check for macOS
+        try:
+            from AppKit import NSScreen  # macOS-only import
+            screen = NSScreen.mainScreen().frame()
+            return {"width": int(screen.size.width), "height": int(screen.size.height)}
+        except ImportError:
+            print("AppKit is not available. Make sure you are running this on macOS.")
+            return {"width": 1920, "height": 1080}
+
+    else:  # Windows & Linux
+        try:
+            from screeninfo import get_monitors  # Cross-platform library
+            monitor = get_monitors()[0]  # Get primary monitor
+            return {"width": monitor.width, "height": monitor.height}
+        except ImportError:
+            print("screeninfo package not found. Install it using 'pip install screeninfo'")
+            return {"width": 1920, "height": 1080}
+        
+
+def get_window_adjustments():
+    """Returns recommended x, y offsets for window positioning"""
+    if sys.platform == "darwin":  # macOS
+        return -4, 24  # macOS has a small title bar, no border
+    elif sys.platform == "win32":  # Windows
+        return -8, 0  # Windows has a border on the left
+    else:  # Linux (varies by window manager)
+        return 0, 0  # Adjust as needed for your WM


### PR DESCRIPTION
Issue link:
https://github.com/browser-use/browser-use/issues/673
https://github.com/browser-use/browser-use/issues/663

If the user's monitor size is different from the default viewport size of playwright(which is 1280x720, then the playwright would resize the browser viewport to take screenshot.
I added the screen_resolution.py to dynamically set the playwright window size and window position using screen_info library.
Also, the screenshot_test.py file wasn't working, so i fixed it.