### PR TITLE
【bug fix】xpath caused error: strict mode conflict: locator

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -158,7 +158,7 @@
       }
 
       const tagName = currentElement.nodeName.toLowerCase();
-      const xpathIndex = index > 0 ? `[${index + 1}]` : "";
+      const xpathIndex = index >= 0 ? `[${index + 1}]` : "";
       segments.unshift(`${tagName}${xpathIndex}`);
 
       currentElement = currentElement.parentNode;


### PR DESCRIPTION
【bug fix】
ERROR    [browser] Failed to locate element: Locator.element_handle: Error: strict mode violation: locator("html > body > div > div > div > section > aside > div > ul > li.el-menu-item[role=\"menuitem\"]") resolved to 7 elements

【description】
I tried to find elements on the page through a locator, but the locator matched multiple elements (7). The xpath's judgment logic causes the first css_selector of the element group to be'li' instead of'li: nth-of-type(1)', resulting in Failed to locate element