### PR TITLE
Doc fix: Fixed broken link to extra_chromium_args

### DIFF
--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -28,21 +28,21 @@ config = BrowserConfig(
 
 ## Core Settings
 
-- **headless** (default: `False`)  
+- **headless** (default: `False`)
   Runs the browser without a visible UI. Note that some websites may detect headless mode.
 
-- **disable_security** (default: `True`)  
+- **disable_security** (default: `True`)
   Disables browser security features. While this can fix certain functionality issues (like cross-site iFrames), it should be used cautiously, especially when visiting untrusted websites.
 
 ### Additional Settings
 
-- **extra_chromium_args** (default: `[]`)  
-  Additional arguments passed to the browser at launch. See the [full list of available arguments](https://github.com/browser-use/browser-use/blob/main/browser_use/browser/browser.py#L154).
+- **extra_chromium_args** (default: `[]`)
+  Additional arguments passed to the browser at launch. See the [full list of available arguments](https://github.com/browser-use/browser-use/blob/main/browser_use/browser/browser.py#L180).
 
-- **proxy** (default: `None`)  
+- **proxy** (default: `None`)
   Standard Playwright proxy settings for using external proxy services.
 
-- **new_context_config** (default: `BrowserContextConfig()`)  
+- **new_context_config** (default: `BrowserContextConfig()`)
   Default settings for new browser contexts. See Context Configuration below.
 
 <Note>
@@ -64,7 +64,7 @@ config = BrowserConfig(
 )
 ```
 
-- **wss_url** (default: `None`)  
+- **wss_url** (default: `None`)
   WebSocket URL for connecting to external browser providers (e.g., anchorbrowser.com, steel.dev, browserbase.com, browserless.io).
 
 <Note>
@@ -82,7 +82,7 @@ config = BrowserConfig(
 )
 ```
 
-- **cdp_url** (default: `None`)  
+- **cdp_url** (default: `None`)
   URL for connecting to a Chrome instance via CDP. Commonly used for debugging or connecting to locally running Chrome instances.
 
 ### Local Chrome Instance (binary)
@@ -95,7 +95,7 @@ config = BrowserConfig(
 )
 ```
 
-- **chrome_instance_path** (default: `None`)  
+- **chrome_instance_path** (default: `None`)
   Path to connect to an existing Chrome installation. Particularly useful for workflows requiring existing login states or browser preferences.
 
 <Note>This will overwrite other browser settings.</Note>
@@ -133,40 +133,40 @@ async def run_search():
 
 ### Page Load Settings
 
-- **minimum_wait_page_load_time** (default: `0.5`)  
+- **minimum_wait_page_load_time** (default: `0.5`)
   Minimum time to wait before capturing page state for LLM input.
 
-- **wait_for_network_idle_page_load_time** (default: `1.0`)  
+- **wait_for_network_idle_page_load_time** (default: `1.0`)
   Time to wait for network activity to cease. Increase to 3-5s for slower websites. This tracks essential content loading, not dynamic elements like videos.
 
-- **maximum_wait_page_load_time** (default: `5.0`)  
+- **maximum_wait_page_load_time** (default: `5.0`)
   Maximum time to wait for page load before proceeding.
 
 ### Display Settings
 
-- **browser_window_size** (default: `{'width': 1280, 'height': 1100}`)  
+- **browser_window_size** (default: `{'width': 1280, 'height': 1100}`)
   Browser window dimensions. The default size is optimized for general use cases and interaction with common UI elements like cookie banners.
 
-- **locale** (default: `None`)  
+- **locale** (default: `None`)
   Specify user locale, for example en-GB, de-DE, etc. Locale will affect navigator.language value, Accept-Language request header value as well as number and date formatting rules. If not provided, defaults to the system default locale.
 
-- **highlight_elements** (default: `True`)  
+- **highlight_elements** (default: `True`)
   Highlight interactive elements on the screen with colorfull bounding boxes.
 
-- **viewport_expansion** (default: `500`)  
+- **viewport_expansion** (default: `500`)
   Viewport expansion in pixels. With this you can controll how much of the page is included in the context of the LLM. If set to -1, all elements from the entire page will be included (this leads to high token usage). If set to 0, only the elements which are visible in the viewport will be included.
   Default is 500 pixels, that means that we inlcude a little bit more than the visible viewport inside the context.
 
-### Restrict URLs 
+### Restrict URLs
 
-- **allowed_domains** (default: `None`)  
-  List of allowed domains that the agent can access. If None, all domains are allowed. 
+- **allowed_domains** (default: `None`)
+  List of allowed domains that the agent can access. If None, all domains are allowed.
   Example: ['google.com', 'wikipedia.org'] - Here the agent will only be able to access google and wikipedia.
 
 ### Debug and Recording
 
-- **save_recording_path** (default: `None`)  
+- **save_recording_path** (default: `None`)
   Directory path for saving video recordings.
 
-- **trace_path** (default: `None`)  
+- **trace_path** (default: `None`)
   Directory path for saving trace files. Files are automatically named as `{trace_path}/{context_id}.zip`.


### PR DESCRIPTION
The link to the `extra_chromium_args` in the documentation https://docs.browser-use.com/customize/browser-settings#additional-settings, points to a line of code which doesn't give the arguments https://github.com/browser-use/browser-use/blob/main/browser_use/browser/browser.py#L154. 

Instead, it should point to https://github.com/browser-use/browser-use/blob/main/browser_use/browser/browser.py#L180.