### PR TITLE
Fix Schema Validation for AgentOutput

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -111,7 +111,11 @@ class AgentOutput(BaseModel):
 	model_config = ConfigDict(arbitrary_types_allowed=True)
 
 	current_state: AgentBrain
-	action: list[ActionModel]
+	action: list[ActionModel] = Field(
+		...,  # This means the field is required
+		description="List of actions to execute",
+		min_items=1,  # Ensure at least one action is provided
+	)
 
 	@staticmethod
 	def type_with_custom_actions(custom_actions: Type[ActionModel]) -> Type['AgentOutput']:
@@ -119,10 +123,17 @@ class AgentOutput(BaseModel):
 		model_ = create_model(
 			'AgentOutput',
 			__base__=AgentOutput,
-			action=(list[custom_actions], Field(...)),  # Properly annotated field with no default
+			action=(
+				list[custom_actions],
+				Field(
+					...,
+					description="List of actions to execute",
+					min_items=1
+				)
+			),
 			__module__=AgentOutput.__module__,
 		)
-		model_.__doc__ = 'AgentOutput model'
+		model_.__doc__ = 'AgentOutput model with custom actions'
 		return model_
 
 


### PR DESCRIPTION
# Description

This PR addresses the schema validation issue for the `AgentOutput` class in the `agent/views.py` file. The previous implementation allowed an empty array for the `action` field, which caused errors in function calls. This update ensures that the `action` field is properly defined, requiring at least one action to be specified.

---

## Changes Made

### Updated `AgentOutput` Class
- Defined the `action` field with proper metadata using Pydantic's `Field`.
- Set `min_items=1` to enforce that at least one action is provided.
- Added a description to clarify the purpose of the field.

```python
class AgentOutput(BaseModel):
    ...
    action: list[ActionModel] = Field(
        ...,  # This means the field is required
        description="List of actions to execute",
        min_items=1,  # Ensure at least one action is provided
    )
```

### Modified `type_with_custom_actions` Method
- Ensured that the new `action` field schema is preserved when creating dynamic models.

```python
@staticmethod
def type_with_custom_actions(custom_actions: Type[ActionModel]) -> Type['AgentOutput']:
    ...
    action=(
        list[custom_actions],
        Field(
            ...,
            description="List of actions to execute",
            min_items=1
        )
    ),
```

---

## Testing
- The changes have been tested against the existing functionality to ensure compatibility.
- Additional tests can be added to verify the behavior of the `AgentOutput` class with various action inputs.

---

## Related Issues
- Resolves #759 (Invalid schema for function 'AgentOutput')