### PR TITLE
build: add repository url to pypi definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "markdownify==0.14.1",
     "langchain-core>=0.3.35",
 ]
+urls = { "Repository" = "https://github.com/browser-use/browser-use" }
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
makes it easier to jump to the repo from pypi