### PR TITLE
use camoufox for bot evasion

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -18,6 +18,8 @@ from browser_use.browser.context import BrowserContext, BrowserContextConfig
 
 logger = logging.getLogger(__name__)
 
+CAMOUFOX = True
+
 
 @dataclass
 class BrowserConfig:
@@ -179,6 +181,12 @@ class Browser:
 
 	async def _setup_standard_browser(self, playwright: Playwright) -> PlaywrightBrowser:
 		"""Sets up and returns a Playwright Browser instance with anti-detection measures."""
+		if CAMOUFOX:
+			from camoufox.async_api import AsyncCamoufox
+
+			browser = await AsyncCamoufox(proxy=self.config.proxy, geoip=True).start()
+			return browser
+
 		browser = await playwright.chromium.launch(
 			headless=self.config.headless,
 			args=[

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -264,6 +264,10 @@ class BrowserContext:
 			# Connect to existing Chrome instance instead of creating new one
 			context = browser.contexts[0]
 		else:
+			# camofoux
+			if True:
+				return await browser.new_context()
+
 			# Original code for creating new context
 			context = await browser.new_context(
 				viewport=self.config.browser_window_size,


### PR DESCRIPTION
The existing bot evasion doesn't work at all. This is slightly better:

https://github.com/tinyfish-io/tf-playwright-stealth

But still fails on many sites. Camoufox is a impressive piece of engineering and
it looks to be compatible with the playwright API.

I *just* got this working, so before putting more effort I want to kick the tires and see what breaks.
Wanted to post this here in case others were running into issues as well.
