### PR TITLE
Metadata in history

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -238,7 +238,7 @@ class MessageManager:
 
 	def cut_messages(self):
 		"""Get current message list, potentially trimmed to max tokens"""
-		diff = self.state.history.total_tokens - self.settings.max_input_tokens
+		diff = self.state.history.current_tokens - self.settings.max_input_tokens
 		if diff <= 0:
 			return None
 
@@ -252,9 +252,9 @@ class MessageManager:
 					msg.message.content.remove(item)
 					diff -= self.settings.image_tokens
 					msg.metadata.tokens -= self.settings.image_tokens
-					self.state.history.total_tokens -= self.settings.image_tokens
+					self.state.history.current_tokens -= self.settings.image_tokens
 					logger.debug(
-						f'Removed image with {self.settings.image_tokens} tokens - total tokens now: {self.state.history.total_tokens}/{self.settings.max_input_tokens}'
+						f'Removed image with {self.settings.image_tokens} tokens - total tokens now: {self.state.history.current_tokens}/{self.settings.max_input_tokens}'
 					)
 				elif 'text' in item and isinstance(item, dict):
 					text += item['text']
@@ -290,7 +290,7 @@ class MessageManager:
 		last_msg = self.state.history.messages[-1]
 
 		logger.debug(
-			f'Added message with {last_msg.metadata.tokens} tokens - total tokens now: {self.state.history.total_tokens}/{self.settings.max_input_tokens} - total messages: {len(self.state.history.messages)}'
+			f'Added message with {last_msg.metadata.tokens} tokens - total tokens now: {self.state.history.current_tokens}/{self.settings.max_input_tokens} - total messages: {len(self.state.history.messages)}'
 		)
 
 	def _remove_last_state_message(self) -> None:

--- a/browser_use/agent/message_manager/tests.py
+++ b/browser_use/agent/message_manager/tests.py
@@ -174,7 +174,7 @@ def test_token_overflow_handling_with_real_flow(message_manager: MessageManager,
 			else:
 				raise e
 
-		assert message_manager.state.history.total_tokens <= message_manager.settings.max_input_tokens + 100
+		assert message_manager.state.history.current_tokens <= message_manager.settings.max_input_tokens + 100
 
 		last_msg = messages[-1]
 		assert isinstance(last_msg, HumanMessage)
@@ -217,7 +217,7 @@ def test_token_overflow_handling_with_real_flow(message_manager: MessageManager,
 		assert f'step {i}' in messages[-1].content  # Should contain current step info
 
 		# Log token usage for debugging
-		token_usage = message_manager.state.history.total_tokens
+		token_usage = message_manager.state.history.current_tokens
 		token_limit = message_manager.settings.max_input_tokens
 		# print(f'Step {i}: Using {token_usage}/{token_limit} tokens')
 
@@ -231,7 +231,7 @@ def test_token_overflow_handling_with_real_flow(message_manager: MessageManager,
 			real_tokens.append(message_manager._count_tokens(msg.message))
 		assert total_tokens == sum(real_tokens)
 		assert stored_tokens == real_tokens
-		assert message_manager.state.history.total_tokens == total_tokens
+		assert message_manager.state.history.current_tokens == total_tokens
 
 
 # pytest -s browser_use/agent/message_manager/tests.py

--- a/browser_use/agent/message_manager/views.py
+++ b/browser_use/agent/message_manager/views.py
@@ -64,7 +64,7 @@ class MessageHistory(BaseModel):
 	"""History of messages with metadata"""
 
 	messages: list[ManagedMessage] = Field(default_factory=list)
-	total_tokens: int = 0
+	current_tokens: int = 0
 
 	model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -74,7 +74,7 @@ class MessageHistory(BaseModel):
 			self.messages.append(ManagedMessage(message=message, metadata=metadata))
 		else:
 			self.messages.insert(position, ManagedMessage(message=message, metadata=metadata))
-		self.total_tokens += metadata.tokens
+		self.current_tokens += metadata.tokens
 
 	def add_model_output(self, output: 'AgentOutput') -> None:
 		"""Add model output as AI message"""
@@ -103,20 +103,20 @@ class MessageHistory(BaseModel):
 
 	def get_total_tokens(self) -> int:
 		"""Get total tokens in history"""
-		return self.total_tokens
+		return self.current_tokens
 
 	def remove_oldest_message(self) -> None:
 		"""Remove oldest non-system message"""
 		for i, msg in enumerate(self.messages):
 			if not isinstance(msg.message, SystemMessage):
-				self.total_tokens -= msg.metadata.tokens
+				self.current_tokens -= msg.metadata.tokens
 				self.messages.pop(i)
 				break
 
 	def remove_last_state_message(self) -> None:
 		"""Remove last state message from history"""
 		if len(self.messages) > 2 and isinstance(self.messages[-1].message, HumanMessage):
-			self.total_tokens -= self.messages[-1].metadata.tokens
+			self.current_tokens -= self.messages[-1].metadata.tokens
 			self.messages.pop()
 
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -383,7 +383,7 @@ class Agent(Generic[Context]):
 					step_number=self.state.n_steps,
 					step_start_time=step_start_time,
 					step_end_time=step_end_time,
-					tokens=self._message_manager.state.history.current_tokens,
+					input_tokens=self._message_manager.state.history.current_tokens,
 				)
 				self._make_history_item(model_output, state, result, metadata)
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -382,7 +382,7 @@ class Agent(Generic[Context]):
 				metadata = StepMetadata(
 					step_start_time=step_start_time,
 					step_end_time=step_end_time,
-					total_tokens=self._message_manager.state.history.total_tokens,
+					tokens=self._message_manager.state.history.current_tokens,
 				)
 				self._make_history_item(model_output, state, result, metadata)
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -380,6 +380,7 @@ class Agent(Generic[Context]):
 
 			if state:
 				metadata = StepMetadata(
+					step_number=self.state.n_steps,
 					step_start_time=step_start_time,
 					step_end_time=step_end_time,
 					tokens=self._message_manager.state.history.current_tokens,

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -99,6 +99,7 @@ class StepMetadata(BaseModel):
 	step_start_time: float
 	step_end_time: float
 	tokens: int  # Approximate tokens from message manager for this step
+	step_number: int
 
 	@property
 	def duration_seconds(self) -> float:
@@ -189,7 +190,6 @@ class AgentHistoryList(BaseModel):
 
 	history: list[AgentHistory]
 
-	@property
 	def total_duration_seconds(self) -> float:
 		"""Get total duration of all steps in seconds"""
 		total = 0.0
@@ -198,7 +198,6 @@ class AgentHistoryList(BaseModel):
 				total += h.metadata.duration_seconds
 		return total
 
-	@property
 	def total_tokens(self) -> int:
 		"""
 		Get total tokens used across all steps.
@@ -210,6 +209,10 @@ class AgentHistoryList(BaseModel):
 			if h.metadata:
 				total += h.metadata.tokens
 		return total
+
+	def token_usage(self) -> list[int]:
+		"""Get token usage for each step"""
+		return [h.metadata.tokens for h in self.history if h.metadata]
 
 	def __str__(self) -> str:
 		"""Representation of the AgentHistoryList object"""

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -98,7 +98,7 @@ class StepMetadata(BaseModel):
 
 	step_start_time: float
 	step_end_time: float
-	total_tokens: int  # Approximate tokens from message manager for this step
+	tokens: int  # Approximate tokens from message manager for this step
 
 	@property
 	def duration_seconds(self) -> float:
@@ -208,7 +208,7 @@ class AgentHistoryList(BaseModel):
 		total = 0
 		for h in self.history:
 			if h.metadata:
-				total += h.metadata.total_tokens
+				total += h.metadata.tokens
 		return total
 
 	def __str__(self) -> str:

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -93,6 +93,19 @@ class ActionResult(BaseModel):
 	include_in_memory: bool = False  # whether to include in past messages as context or not
 
 
+class StepMetadata(BaseModel):
+	"""Metadata for a single step including timing and token information"""
+
+	step_start_time: float
+	step_end_time: float
+	total_tokens: int  # Approximate tokens from message manager for this step
+
+	@property
+	def duration_seconds(self) -> float:
+		"""Calculate step duration in seconds"""
+		return self.step_end_time - self.step_start_time
+
+
 class AgentBrain(BaseModel):
 	"""Current state of the agent"""
 
@@ -135,6 +148,7 @@ class AgentHistory(BaseModel):
 	model_output: AgentOutput | None
 	result: list[ActionResult]
 	state: BrowserStateHistory
+	metadata: Optional[StepMetadata] = None
 
 	model_config = ConfigDict(arbitrary_types_allowed=True, protected_namespaces=())
 
@@ -166,6 +180,7 @@ class AgentHistory(BaseModel):
 			'model_output': model_output_dump,
 			'result': [r.model_dump(exclude_none=True) for r in self.result],
 			'state': self.state.to_dict(),
+			'metadata': self.metadata.model_dump() if self.metadata else None,
 		}
 
 
@@ -173,6 +188,28 @@ class AgentHistoryList(BaseModel):
 	"""List of agent history items"""
 
 	history: list[AgentHistory]
+
+	@property
+	def total_duration_seconds(self) -> float:
+		"""Get total duration of all steps in seconds"""
+		total = 0.0
+		for h in self.history:
+			if h.metadata:
+				total += h.metadata.duration_seconds
+		return total
+
+	@property
+	def total_tokens(self) -> int:
+		"""
+		Get total tokens used across all steps.
+		Note: These are from the approximate token counting of the message manager.
+		For accurate token counting, use tools like LangChain Smith or OpenAI's token counters.
+		"""
+		total = 0
+		for h in self.history:
+			if h.metadata:
+				total += h.metadata.total_tokens
+		return total
 
 	def __str__(self) -> str:
 		"""Representation of the AgentHistoryList object"""

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -98,7 +98,7 @@ class StepMetadata(BaseModel):
 
 	step_start_time: float
 	step_end_time: float
-	tokens: int  # Approximate tokens from message manager for this step
+	input_tokens: int  # Approximate tokens from message manager for this step
 	step_number: int
 
 	@property
@@ -198,7 +198,7 @@ class AgentHistoryList(BaseModel):
 				total += h.metadata.duration_seconds
 		return total
 
-	def total_tokens(self) -> int:
+	def total_input_tokens(self) -> int:
 		"""
 		Get total tokens used across all steps.
 		Note: These are from the approximate token counting of the message manager.
@@ -207,12 +207,12 @@ class AgentHistoryList(BaseModel):
 		total = 0
 		for h in self.history:
 			if h.metadata:
-				total += h.metadata.tokens
+				total += h.metadata.input_tokens
 		return total
 
-	def token_usage(self) -> list[int]:
+	def input_token_usage(self) -> list[int]:
 		"""Get token usage for each step"""
-		return [h.metadata.tokens for h in self.history if h.metadata]
+		return [h.metadata.input_tokens for h in self.history if h.metadata]
 
 	def __str__(self) -> str:
 		"""Representation of the AgentHistoryList object"""

--- a/browser_use/telemetry/views.py
+++ b/browser_use/telemetry/views.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, Optional
-
-from browser_use.controller.registry.views import ActionModel
+from typing import Any, Dict, Sequence
 
 
 @dataclass
@@ -57,5 +55,5 @@ class AgentEndTelemetryEvent(BaseTelemetryEvent):
 	steps: int
 	max_steps_reached: bool
 	success: bool
-	errors: list[str]
+	errors: Sequence[str | None]
 	name: str = 'agent_end'


### PR DESCRIPTION
This pull request includes several changes to the `browser_use/agent` module, focusing on improving token management, adding step metadata, and enhancing telemetry. Below is a summary of the most important changes:

### Token Management Improvements:
* Changed references from `total_tokens` to `current_tokens` in `browser_use/agent/message_manager/service.py` to better reflect the current token count. [[1]](diffhunk://#diff-a645f889b350b316a359aaa814e265de21353384e684368f3fd339d614527b2eL241-R241) [[2]](diffhunk://#diff-a645f889b350b316a359aaa814e265de21353384e684368f3fd339d614527b2eL255-R257) [[3]](diffhunk://#diff-a645f889b350b316a359aaa814e265de21353384e684368f3fd339d614527b2eL293-R293)
* Updated `MessageHistory` class to use `current_tokens` instead of `total_tokens` in `browser_use/agent/message_manager/views.py`. [[1]](diffhunk://#diff-041f71998b80e7e704fe30509b3326893365322a9654c912170c858a195352c9L67-R67) [[2]](diffhunk://#diff-041f71998b80e7e704fe30509b3326893365322a9654c912170c858a195352c9L77-R77) [[3]](diffhunk://#diff-041f71998b80e7e704fe30509b3326893365322a9654c912170c858a195352c9L106-R119)

### Step Metadata Enhancements:
* Added `StepMetadata` class to store metadata for each step, including timing and token information, in `browser_use/agent/views.py`.
* Modified `AgentHistory` and `AgentHistoryList` classes to include and utilize `StepMetadata` for better tracking and reporting of step durations and token usage. [[1]](diffhunk://#diff-e2324115a49f49c3aed0bc724a18f350a3491be1bc9bd7e9dd12b32d581c27e4R152) [[2]](diffhunk://#diff-e2324115a49f49c3aed0bc724a18f350a3491be1bc9bd7e9dd12b32d581c27e4R184) [[3]](diffhunk://#diff-e2324115a49f49c3aed0bc724a18f350a3491be1bc9bd7e9dd12b32d581c27e4R193-R216)


### Miscellaneous Changes:
* Added import statements for `time` and `StepMetadata` in `browser_use/agent/service.py`. [[1]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R7) [[2]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R35)
* Included step start and end times in the `step` method and passed metadata to `_make_history_item` in `browser_use/agent/service.py`. [[1]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R306) [[2]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R367) [[3]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92L378-R388) [[4]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R430) [[5]](diffhunk://#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92L436-R447)