### PR TITLE
Works for immo24

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -858,15 +858,23 @@
       return null;
     }
 
-    // Check viewport if needed
+    // Early viewport check - only filter out elements clearly outside viewport
     if (viewportExpansion !== -1) {
       const rect = getCachedBoundingRect(node);
-      if (!rect || (
+      const style = getCachedComputedStyle(node);
+
+      // Skip viewport check for fixed/sticky elements as they may appear anywhere
+      const isFixedOrSticky = style && (style.position === 'fixed' || style.position === 'sticky');
+
+      // Check if element has actual dimensions
+      const hasSize = node.offsetWidth > 0 || node.offsetHeight > 0;
+
+      if (!rect || (!isFixedOrSticky && !hasSize && (
         rect.bottom < -viewportExpansion ||
         rect.top > window.innerHeight + viewportExpansion ||
         rect.right < -viewportExpansion ||
         rect.left > window.innerWidth + viewportExpansion
-      )) {
+      ))) {
         if (debugMode) PERF_METRICS.nodeMetrics.skippedNodes++;
         return null;
       }


### PR DESCRIPTION
This pull request includes an update to the `browser_use/dom/buildDomTree.js` file to improve the viewport check logic for DOM elements. The most important changes include an early viewport check, handling of fixed/sticky elements, and ensuring elements have actual dimensions before applying the viewport check.

Improvements to viewport check logic:

* [`browser_use/dom/buildDomTree.js`](diffhunk://#diff-8f70f7a52b8e76e1c2669b77e09c25410507572b842d6503a101290ef135793fL861-R877): Added an early viewport check to filter out elements clearly outside the viewport.
* [`browser_use/dom/buildDomTree.js`](diffhunk://#diff-8f70f7a52b8e76e1c2669b77e09c25410507572b842d6503a101290ef135793fL861-R877): Introduced logic to skip the viewport check for fixed or sticky elements since they may appear anywhere on the page.
* [`browser_use/dom/buildDomTree.js`](diffhunk://#diff-8f70f7a52b8e76e1c2669b77e09c25410507572b842d6503a101290ef135793fL861-R877): Added a check to ensure elements have actual dimensions (i.e., non-zero width or height) before applying the viewport check.