### PR TITLE
Fix: Corrected typo in telemetry logging

### DIFF
--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -42,7 +42,7 @@ class ProductTelemetry:
 		if telemetry_disabled:
 			self._posthog_client = None
 		else:
-			logging.info(
+			logger.info(
 				'Anonymized telemetry enabled. See https://docs.browser-use.com/development/telemetry for more information.'
 			)
 			self._posthog_client = Posthog(


### PR DESCRIPTION
Changed logging from "logging.info()" to "logger.info()"  in telemetry to ensure proper logging through the configured logger.

This fix addresses the issue where telemetry logs were being sent to the root logger instead of the specified logger as shown below : 
![Using_root_logger](https://github.com/user-attachments/assets/9b820a9b-a913-4c6b-b2bc-2968a4d029fc)

After the fix, it will be : 
![Using_configured_logger](https://github.com/user-attachments/assets/0b7a4e9e-6734-4352-a8fd-9f0c800b4441)



