### PR TITLE
Fix interactive element handling in isTopElement function

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -653,6 +653,17 @@
   function isTopElement(element) {
     const rect = getCachedBoundingRect(element);
 
+    if interactiveElements(element) {
+      const rect = getCachedBoundingRect(element);
+      if (!rect) return false;
+      
+      return rect.width > 0 && 
+             rect.height > 0 && 
+             rect.left < window.innerWidth &&
+             rect.right > 0 &&
+             rect.top < window.innerHeight &&
+             rect.bottom > 0;
+    }
     // If element is not in viewport, consider it top
     const isInViewport = (
       rect.left < window.innerWidth &&


### PR DESCRIPTION
Currently, some interacive elements don't appear as topElement even though they are. Example is the login form in https://coned.com

This is fixed in this PR.
<img width="758" alt="Screenshot 2025-03-03 at 15 22 06" src="https://github.com/user-attachments/assets/eb2ca3d7-813c-44d4-b965-810965e8dbdc" />
