### PR TITLE
process elements next to shadowroot along with shadowroot

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -927,6 +927,15 @@
     if (node.tagName) {
       const tagName = node.tagName.toLowerCase();
 
+      // Handle shadow DOM
+      if (node.shadowRoot) {
+        nodeData.shadowRoot = true;
+        for (const child of node.shadowRoot.childNodes) {
+          const domElement = buildDomTree(child, parentIframe);
+          if (domElement) nodeData.children.push(domElement);
+        }
+      }
+
       // Handle iframes
       if (tagName === "iframe") {
         try {
@@ -951,14 +960,6 @@
       ) {
         // Process all child nodes to capture formatted text
         for (const child of node.childNodes) {
-          const domElement = buildDomTree(child, parentIframe);
-          if (domElement) nodeData.children.push(domElement);
-        }
-      }
-      // Handle shadow DOM
-      else if (node.shadowRoot) {
-        nodeData.shadowRoot = true;
-        for (const child of node.shadowRoot.childNodes) {
           const domElement = buildDomTree(child, parentIframe);
           if (domElement) nodeData.children.push(domElement);
         }

--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -928,6 +928,8 @@
       const tagName = node.tagName.toLowerCase();
 
       // Handle shadow DOM
+      // Process shadowRoot separately because other elements can exist alongside the shadowRoot element,
+      // and they would be ignored if it were processed as part of else if branch below
       if (node.shadowRoot) {
         nodeData.shadowRoot = true;
         for (const child of node.shadowRoot.childNodes) {


### PR DESCRIPTION
This adresses issue https://github.com/browser-use/browser-use/issues/903 
With the current implementation, if a node contains both a shadowRoot and other elements, only the shadowRoot is processed, while the other elements inside the node are ignored. I was using an older version (0.1.20) of browser-use on some pages that heavily rely on shadowRoots, and it was working back then.