### PR TITLE
Fix: Unable to Retrieve Interactive Elements Bound with addEventListener

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -136,11 +136,54 @@ class BrowserContextConfig:
 	_force_keep_context_alive: bool = False
 
 
-@dataclass
 class BrowserSession:
-	context: PlaywrightBrowserContext
-	cached_state: BrowserState | None
+	
+	def __init__(
+			self,
+			context: PlaywrightBrowserContext,
+			cached_state: BrowserState | None=None
+		):
+		init_script = """
+			(() => {
+				if (!window.getEventListeners) {
+					window.getEventListeners = function (node) {
+						return node.__listeners || {};
+					};
 
+					// Save the original addEventListener
+					const originalAddEventListener = Element.prototype.addEventListener;
+
+					const eventProxy = {
+						addEventListener: function (type, listener, options = { once: false, passive: false, capture: false }) {
+							// Initialize __listeners if not exists
+							if (!this.__listeners) {
+								this.__listeners = {};
+							}
+
+							// Initialize array for this event type if not exists
+							if (!this.__listeners[type]) {
+								this.__listeners[type] = [];
+							}
+
+							// Add the listener to __listeners
+							this.__listeners[type].push({
+								listener: listener,
+								type: type,
+								...options
+							});
+
+							// Call original addEventListener using the saved reference
+							return originalAddEventListener.call(this, type, listener, options);
+						}
+					};
+
+					Element.prototype.addEventListener = eventProxy.addEventListener;
+				}
+			})()
+			"""
+		self.context = context
+		self.cached_state = cached_state
+		self.context.on('page', lambda page: page.add_init_script(init_script))
 
 @dataclass
 class BrowserContextState:

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -154,8 +154,13 @@ class BrowserSession:
 					const originalAddEventListener = Element.prototype.addEventListener;
 
 					const eventProxy = {
-						addEventListener: function (type, listener, options = { once: false, passive: false, capture: false }) {
+						addEventListener: function (type, listener, options = {}) {
 							// Initialize __listeners if not exists
+							const defaultOptions = { once: false, passive: false, capture: false };
+							if(typeof options === 'boolean') {
+								options = { capture: options };
+							}
+							options = { ...defaultOptions, ...options };
 							if (!this.__listeners) {
 								this.__listeners = {};
 							}
@@ -164,6 +169,7 @@ class BrowserSession:
 							if (!this.__listeners[type]) {
 								this.__listeners[type] = [];
 							}
+							
 
 							// Add the listener to __listeners
 							this.__listeners[type].push({


### PR DESCRIPTION
Since window.getEventListeners is not available in Playwright, it is unable to retrieve some interactive elements that have event listeners bound via addEventListener. This fix injects JavaScript code to intercept the addEventListener function and manually simulate window.getEventListeners each time a BrowserSession is initialized, resolving the issue. An example can be seen on the homepage of https://en.fofa.info/.

Before fix
<img width="1282" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/582e9a04-c0cd-4018-9cba-f8b8797d57f5" />

After fix
<img width="1282" alt="FQFA" src="https://github.com/user-attachments/assets/1f324526-60a7-427a-b56e-617575c56f85" />
