### PR TITLE
Update isContentEditable handling to check readonly and disabled attr…

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -1084,10 +1084,16 @@ class BrowserContext:
 				pass
 
 			# Get element properties to determine input method
+			tag_handle = await element_handle.get_property("tagName")
+			tag_name = (await tag_handle.json_value()).lower()
 			is_contenteditable = await element_handle.get_property('isContentEditable')
+			readonly_handle = await element_handle.get_property("readOnly")
+			disabled_handle = await element_handle.get_property("disabled")
 
-			# Different handling for contenteditable vs input fields
-			if await is_contenteditable.json_value():
+			readonly = await readonly_handle.json_value() if readonly_handle else False
+			disabled = await disabled_handle.json_value() if disabled_handle else False
+
+			if (await is_contenteditable.json_value() or tag_name == 'input') and not (readonly or disabled):
 				await element_handle.evaluate('el => el.textContent = ""')
 				await element_handle.type(text, delay=5)
 			else:


### PR DESCRIPTION
Update isContentEditable handling to include `input`

- Retrieve tag name and isContentEditable property from element_handle.
- Check for readonly and disabled attributes before inputting text.
