### PR TITLE
[bug][multi_act] Detect index change caused by page change in multi_act

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -659,7 +659,20 @@ class Agent(Generic[Context]):
 		for i, action in enumerate(actions):
 			if action.get_index() is not None and i != 0:
 				new_state = await self.browser_context.get_state()
-				new_path_hashes = set(e.hash.branch_path_hash for e in new_state.selector_map.values())
+				new_selector_map = new_state.selector_map
+
+				# Detect index change after previous action
+				orig_target = cached_selector_map.get(action.get_index())  # type: ignore
+				orig_target_hash = orig_target.hash.branch_path_hash if orig_target else None
+				new_target = new_selector_map.get(action.get_index())  # type: ignore
+				new_target_hash = new_target.hash.branch_path_hash if new_target else None
+				if orig_target_hash != new_target_hash:
+					msg = f'Element index changed after action {i} / {len(actions)}, because page changed.'
+					logger.info(msg)
+					results.append(ActionResult(extracted_content=msg, include_in_memory=True))
+					break
+
+				new_path_hashes = set(e.hash.branch_path_hash for e in new_selector_map.values())
 				if check_for_new_elements and not new_path_hashes.issubset(cached_path_hashes):
 					# next action requires index but there are new elements on the page
 					msg = f'Something new appeared after action {i} / {len(actions)}'


### PR DESCRIPTION
This PR fixed an issue in multi_act, in some cases the element index can change after previous action, because the page just changed.

One example is when changing language on amazon.com:
![iShot_2025-03-05_00 58 22](https://github.com/user-attachments/assets/55399ee0-c76d-489a-a472-df9cb89f04f4)

After selecting another language, before clicking submit button, the index changed:
![iShot_2025-03-05_00 58 33](https://github.com/user-attachments/assets/2071b5c0-e7cf-4958-a4de-cc6af95d1635)

Sample log after this fix:
```
INFO     [agent] 🎯 Next goal: Select English language option
INFO     [agent] 🛠️  Action 1/2: {"click_element":{"index":25}}
INFO     [agent] 🛠️  Action 2/2: {"click_element":{"index":36}}
INFO     [controller] 🖱️  Clicked button with index 25: 
INFO     [agent] Element index changed after action 1 / 2, because page changed.

INFO     [agent] 🛠️  Action 1/2: {"click_element":{"index":25}}
INFO     [agent] 🛠️  Action 2/2: {"click_element":{"index":34}}
INFO     [controller] 🖱️  Clicked button with index 25: 
INFO     [controller] 🖱️  Clicked button with index 34: 
```