### PR TITLE
Fix special case for viewport expansion in visibility check

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -391,7 +391,7 @@
         rect.top > window.innerHeight + viewportExpansion ||
         rect.right < -viewportExpansion ||
         rect.left > window.innerWidth + viewportExpansion
-      );
+      ) || viewportExpansion === -1;
 
       // Check parent visibility
       const parentElement = textNode.parentElement;


### PR DESCRIPTION
I've identified an issue in the isTextNodeVisible function where we need to handle the special case when viewportExpansion is set to -1, which should bypass the viewport check entirely.
```js
function isTextNodeVisible(textNode) {
    // ... existing code ...

    // Simple viewport check without scroll calculations
    const isInViewport = !(
      rect.bottom < -viewportExpansion ||
      rect.top > window.innerHeight + viewportExpansion ||
      rect.right < -viewportExpansion ||
      rect.left > window.innerWidth + viewportExpansion
    ) || viewportExpansion === -1; // here

    // ... existing code ...
}

```
This change ensures that when viewportExpansion is set to -1, the text node will be considered in the viewport regardless of its actual position. This matches the behavior in other parts of the code where a value of -1 for viewportExpansion means "consider all elements regardless of viewport position."