### PR TITLE
HAR file recording

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -122,6 +122,7 @@ class BrowserContextConfig:
 
 	save_recording_path: str | None = None
 	save_downloads_path: str | None = None
+	save_har_path: str | None = None
 	trace_path: str | None = None
 	locale: str | None = None
 	user_agent: str = (
@@ -325,6 +326,7 @@ class BrowserContext:
 				ignore_https_errors=self.config.disable_security,
 				record_video_dir=self.config.save_recording_path,
 				record_video_size=self.config.browser_window_size,
+				record_har_path = self.config.save_har_path,
 				locale=self.config.locale,
 			)
 


### PR DESCRIPTION
These changes will allow for the recording of the HAR file (a JSON-formatted archive file format for logging of a web browser's interaction with a site) while the agent is running, along with specifying where this HAR file should be saved.

Added a `save_har_path` to class BrowserContextConfig to store the path where the HAR file should be saved.
Added `record_har_path = self.config.save_har_path` to context initialization to enable HAR file recording itself.

Solution for #966.