### PR TITLE
Add logging of total tokens used to facilitate cost calculation

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -743,7 +743,7 @@ class Agent(Generic[Context]):
 			logger.info('❌ Unfinished')
 
 		total_tokens = self.state.history.total_input_tokens()
-		logger.info(f'📝 Total tokens used (approximate): {total_tokens}')
+		logger.info(f'📝 Total input tokens used (approximate): {total_tokens}')
 
 		if self.register_done_callback:
 			await self.register_done_callback(self.state.history)

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -742,6 +742,9 @@ class Agent(Generic[Context]):
 		else:
 			logger.info('❌ Unfinished')
 
+		total_tokens = self.state.history.total_input_tokens()
+		logger.info(f'📝 Total tokens used (approximate): {total_tokens}')
+
 		if self.register_done_callback:
 			await self.register_done_callback(self.state.history)
 


### PR DESCRIPTION
This pull request addresses issue #804 by adding logging of the total input tokens used during processing. This enhancement allows users to calculate costs associated with token usage more accurately.

By implementing this feature, users can monitor and manage their token usage more effectively, aiding in cost estimation and optimization.

Screenshot:
<img width="431" alt="screenshot 2025-03-08 20 10 59" src="https://github.com/user-attachments/assets/46be20f8-f41c-432e-8124-d05d30005031" />
