### PR TITLE
Make the context in `extract_content` action smaller

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -179,11 +179,15 @@ class Controller(Generic[Context]):
 		@self.registry.action(
 			'Extract page content to retrieve specific information from the page, e.g. all company names, a specifc description, all information about, links with companies in structured format or simply links',
 		)
-		async def extract_content(goal: str, browser: BrowserContext, page_extraction_llm: BaseChatModel):
+		async def extract_content(goal: str, should_strip_link_urls: bool, browser: BrowserContext, page_extraction_llm: BaseChatModel):
 			page = await browser.get_current_page()
 			import markdownify
 
-			content = markdownify.markdownify(await page.content(), strip=['a', 'img'])
+			strip = []
+			if should_strip_link_urls:
+				strip = ['a', 'img']
+
+			content = markdownify.markdownify(await page.content(), strip=strip)
 
 			prompt = 'Your task is to extract the content of the page. You will be given a page and a goal and you should extract all relevant information around this goal from the page. If the goal is vague, summarize the page. Respond in json format. Extraction goal: {goal}, Page: {page}'
 			template = PromptTemplate(input_variables=['goal', 'page'], template=prompt)

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -183,7 +183,7 @@ class Controller(Generic[Context]):
 			page = await browser.get_current_page()
 			import markdownify
 
-			content = markdownify.markdownify(await page.content())
+			content = markdownify.markdownify(await page.content(), strip=['a', 'img'])
 
 			prompt = 'Your task is to extract the content of the page. You will be given a page and a goal and you should extract all relevant information around this goal from the page. If the goal is vague, summarize the page. Respond in json format. Extraction goal: {goal}, Page: {page}'
 			template = PromptTemplate(input_variables=['goal', 'page'], template=prompt)


### PR DESCRIPTION
Adding the `strip` option to Markdownify will keep the text but not add the url to the output.

from their [docs](https://github.com/matthewwithanm/python-markdownify?tab=readme-ov-file#options):
```
from markdownify import markdownify as md
md('<b>Yay</b> <a href="http://github.com">GitHub</a>', strip=['a'])  # > '**Yay** GitHub'
```


This has lowered the character count of a page like [Amazon](https://www.amazon.com/s?k=clocks&crid=1SLPSQOSK7JDP&sprefix=clocks%2Caps%2C226&ref=nb_sb_noss_1) from 367277 characters to 48969.

Quick fix to a more deep problem.