### PR TITLE
Bugfix: in case if node element has a shadow dom, all other children are not processed

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -955,16 +955,16 @@
           if (domElement) nodeData.children.push(domElement);
         }
       }
-      // Handle shadow DOM
-      else if (node.shadowRoot) {
-        nodeData.shadowRoot = true;
-        for (const child of node.shadowRoot.childNodes) {
-          const domElement = buildDomTree(child, parentIframe);
-          if (domElement) nodeData.children.push(domElement);
-        }
-      }
-      // Handle regular elements
       else {
+        // Handle shadow DOM
+        if (node.shadowRoot) {
+          nodeData.shadowRoot = true;
+          for (const child of node.shadowRoot.childNodes) {
+            const domElement = buildDomTree(child, parentIframe);
+            if (domElement) nodeData.children.push(domElement);
+          }
+        }
+        // Handle regular elements
         for (const child of node.childNodes) {
           const domElement = buildDomTree(child, parentIframe);
           if (domElement) nodeData.children.push(domElement);


### PR DESCRIPTION
`examples/ui/command_line.py` doesn't work for reddit.com, since the parent node containing the search bar interactive element also includes a shadow DOM. Instead of processing either shadow DOM or regular children, we should process all of them.

![Screenshot 2025-03-11 at 09 55 54](https://github.com/user-attachments/assets/55f5eea2-04c2-4cbe-868c-9e7dd449042c)
