### PR TITLE
fix: swaped the langchain bedrock function

### DIFF
--- a/examples/models/bedrock_claude.py
+++ b/examples/models/bedrock_claude.py
@@ -7,7 +7,7 @@ Automated news analysis and sentiment scoring using Bedrock.
 import os
 import sys
 
-from langchain_aws import ChatBedrock
+from langchain_aws import ChatBedrockConverse
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import argparse
@@ -19,7 +19,7 @@ from browser_use.controller.service import Controller
 
 
 def get_llm():
-    return ChatBedrock(
+    return ChatBedrockConverse(
         model_id="us.anthropic.claude-3-5-sonnet-20241022-v2:0",
         temperature=0.0,
         max_tokens=None,


### PR DESCRIPTION
Fix for #988 .

Replaced the langchain [ChatBedrock](https://python.langchain.com/docs/integrations/chat/bedrock/) with langchains new [ChatBedrockConverse](https://python.langchain.com/api_reference/aws/chat_models/langchain_aws.chat_models.bedrock_converse.ChatBedrockConverse.html) which fixes the issue.