### PR TITLE
 fix: empty interacted element in history when interacted index is 0

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -166,7 +166,7 @@ class AgentHistory(BaseModel):
 		elements = []
 		for action in model_output.action:
 			index = action.get_index()
-			if index and index in selector_map:
+			if index != None and index in selector_map:
 				el: DOMElementNode = selector_map[index]
 				elements.append(HistoryTreeProcessor.convert_dom_element_to_history_element(el))
 			else:

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -166,7 +166,7 @@ class AgentHistory(BaseModel):
 		elements = []
 		for action in model_output.action:
 			index = action.get_index()
-			if index != None and index in selector_map:
+			if index is not None and index in selector_map:
 				el: DOMElementNode = selector_map[index]
 				elements.append(HistoryTreeProcessor.convert_dom_element_to_history_element(el))
 			else:


### PR DESCRIPTION
potiential value of `index` could be None and numeric. If the value is `0`, it always skips css selector appending.