### PR TITLE
Update context.py to use no_viewport setting from BrowserConfigSettings

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -318,7 +318,7 @@ class BrowserContext:
 			# Original code for creating new context
 			context = await browser.new_context(
 				viewport=self.config.browser_window_size,
-				no_viewport=False,
+				no_viewport=self.config.no_viewport,
 				user_agent=self.config.user_agent,
 				java_script_enabled=True,
 				bypass_csp=self.config.disable_security,


### PR DESCRIPTION
Using no_viewport from browser config settings rather than hardcoded false that seem to be something overlooked.