### PR TITLE
Update quickstart.mdx to use uv

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -35,7 +35,7 @@ uv pip install browser-use
 Then install playwright:
 
 ```bash
-playwright install
+uv run playwright install
 ```
 
 ## Create an agent


### PR DESCRIPTION
If you have another version of playwright installed and don't prefix with `uv run`, then you won't install the proper versions of the browsers.