### PR TITLE
Fix hardcoded model name check and replace with configurable param

### DIFF
--- a/browser_use/agent/message_manager/utils.py
+++ b/browser_use/agent/message_manager/utils.py
@@ -33,11 +33,11 @@ def extract_json_from_model_output(content: str) -> dict:
 		raise ValueError('Could not parse response.')
 
 
-def convert_input_messages(input_messages: list[BaseMessage], model_name: Optional[str]) -> list[BaseMessage]:
+def convert_input_messages(input_messages: list[BaseMessage], model_name: Optional[str], non_function_calling_models: Optional[bool]) -> list[BaseMessage]:
 	"""Convert input messages to a format that is compatible with the planner model"""
 	if model_name is None:
 		return input_messages
-	if model_name == 'deepseek-reasoner' or 'deepseek-r1' in model_name:
+	if non_function_calling_models:
 		converted_input_messages = _convert_messages_for_non_function_calling_models(input_messages)
 		merged_input_messages = _merge_successive_messages(converted_input_messages, HumanMessage)
 		merged_input_messages = _merge_successive_messages(merged_input_messages, AIMessage)

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -121,6 +121,7 @@ class Agent(Generic[Context]):
 		],
 		max_actions_per_step: int = 10,
 		tool_calling_method: Optional[ToolCallingMethod] = 'auto',
+		non_function_calling_models: Optional[bool] = False,
 		page_extraction_llm: Optional[BaseChatModel] = None,
 		planner_llm: Optional[BaseChatModel] = None,
 		planner_interval: int = 1,  # Run planner every N steps
@@ -158,6 +159,7 @@ class Agent(Generic[Context]):
 			page_extraction_llm=page_extraction_llm,
 			planner_llm=planner_llm,
 			planner_interval=planner_interval,
+			non_function_calling_models=non_function_calling_models,
 		)
 
 		# Initialize state
@@ -498,8 +500,8 @@ class Agent(Generic[Context]):
 
 	def _convert_input_messages(self, input_messages: list[BaseMessage]) -> list[BaseMessage]:
 		"""Convert input messages to the correct format"""
-		if self.model_name == 'deepseek-reasoner' or 'deepseek-r1' in self.model_name:
-			return convert_input_messages(input_messages, self.model_name)
+		if self.settings.non_function_calling_models:
+			return convert_input_messages(input_messages, self.model_name, self.settings.non_function_calling_models)
 		else:
 			return input_messages
 

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -55,6 +55,7 @@ class AgentSettings(BaseModel):
 	max_actions_per_step: int = 10
 
 	tool_calling_method: Optional[ToolCallingMethod] = 'auto'
+	non_function_calling_models: Optional[bool] = False
 	page_extraction_llm: Optional[BaseChatModel] = None
 	planner_llm: Optional[BaseChatModel] = None
 	planner_interval: int = 1  # Run planner every N steps


### PR DESCRIPTION
Currently browser-use has a hardcoded model name check for Deepseek like : 

```py
if model_name == 'deepseek-reasoner' or 'deepseek-r1' in model_name
```

This causes an issue if we are using Operouter where model name param can be like `deepseek/deepseek-r1` OR if we are using any other models like LLama etc . 

<img width="588" alt="Screenshot 2025-03-18 at 7 12 38 AM" src="https://github.com/user-attachments/assets/ba4ba93e-0f74-46c7-b16a-154869de365c" />

With the current fix user can easily use any models , Example code : 

```py
from langchain_openai import ChatOpenAI
from browser_use import Agent, Controller, ActionResult, BrowserConfig, Browser
from dotenv import load_dotenv
load_dotenv()

llm = ChatOpenAI(
    model="deepseek/deepseek-r1",
    base_url="https://openrouter.ai/api/v1"
)

    agent = Agent(
        task="Open google.com , Search Deepseek pricing",
        llm=llm,
        use_vision=False,
        max_failures=2,
		max_actions_per_step=1,
        tool_calling_method="raw",
        non_function_calling_models=True
    )
```