### PR TITLE
log meaningful error message if llm doesnt give response

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -512,8 +512,7 @@ class Agent(Generic[Context]):
 			try:
 				output = self.llm.invoke(input_messages)
 			except Exception as e:
-				logger.info("error during llm invocation")
-				logger.error(e)
+				logger.error(f"Error during LLM invocation: {e}")
 			# TODO: currently invoke does not return reasoning_content, we should override invoke
 			output.content = self._remove_think_tags(str(output.content))
 			try:
@@ -528,16 +527,14 @@ class Agent(Generic[Context]):
 			try:
 				response: dict[str, Any] = await structured_llm.ainvoke(input_messages)  # type: ignore
 			except Exception as e:
-				logger.info("error during llm invocation")
-				logger.error(e)
+				logger.error(f"Error during LLM invocation: {e}")
 			parsed: AgentOutput | None = response['parsed']
 		else:
 			structured_llm = self.llm.with_structured_output(self.AgentOutput, include_raw=True, method=self.tool_calling_method)
 			try:
 				response: dict[str, Any] = await structured_llm.ainvoke(input_messages) 
 			except Exception as e:
-				logger.info("error during llm invocation")
-				logger.error(e)
+				logger.error(f"Error during LLM invocation: {e}")
 			parsed: AgentOutput | None = response['parsed']
 			
 		if parsed is None:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -588,7 +588,7 @@ class Agent(Generic[Context]):
 
 	# @observe(name='agent.run', ignore_output=True)
 	@time_execution_async('--run (agent)')
-	async def run(self, max_steps: int = 3) -> AgentHistoryList:
+	async def run(self, max_steps: int = 100) -> AgentHistoryList:
 		"""Execute the task with maximum number of steps"""
 		try:
 			self._log_agent_run()

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -525,9 +525,13 @@ class Agent(Generic[Context]):
 			parsed: AgentOutput | None = response['parsed']
 		else:
 			structured_llm = self.llm.with_structured_output(self.AgentOutput, include_raw=True, method=self.tool_calling_method)
-			response: dict[str, Any] = await structured_llm.ainvoke(input_messages)  # type: ignore
+			try:
+				response: dict[str, Any] = await structured_llm.ainvoke(input_messages) 
+			except Exception as e:
+				logger.info("error during llm invocation")
+				logger.error(e)
 			parsed: AgentOutput | None = response['parsed']
-
+			
 		if parsed is None:
 			raise ValueError('Could not parse response.')
 


### PR DESCRIPTION
PR for this issue: https://github.com/browser-use/browser-use/issues/1056
Please let me know if. you need any more changes to be done.
Thinking of adding similar error messages for the other llm invoking functions in the if-else branch too
I just added it onto the function with llm call, if there is a more elegant way ,with less repetitive code please guide me on that