### PR TITLE
Improve detection of foreground active tab using document.hasFocus()

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -1239,6 +1239,12 @@ class BrowserContext:
 	async def _get_current_page(self, session: BrowserSession) -> Page:
 		pages = session.context.pages
 
+		# Try by checking pages for focused+visible first
+		for page in pages:
+			visibility = await self.get_page_visibility(page)
+			if visibility['page_is_focused']:
+				return page
+
 		# Try to find page by target ID if using CDP
 		if self.browser.config.cdp_url and self.state.target_id:
 			targets = await self._get_cdp_targets()
@@ -1274,7 +1280,7 @@ class BrowserContext:
 		await cdp_session.detach()
 	
 		return {
-		"target_id": target_id,
+			"target_id": target_id,
 			"window_id": window_id,
 			"window_state": window_state,
 			"window_bounds": window_bounds,

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -1251,38 +1251,38 @@ class BrowserContext:
 		# Fallback to last page
 		return pages[-1] if pages else await session.context.new_page()
 
-        async def get_page_visibility(page):
-	    	cdp_session = await page.context.new_cdp_session(page)
-	    	target_info = await cdp_session.send("Target.getTargetInfo")
-	    	target_id = target_info["targetInfo"]["targetId"]
-	    
-	    	window_info = await cdp_session.send("Browser.getWindowForTarget", {"targetId": target_id})
-	    	window_id = window_info["windowId"]
-	    	window_bounds = await cdp_session.send("Browser.getWindowBounds", {"windowId": window_id})
-	    	window_state = window_bounds.get("bounds", {}).get("windowState")	 # The state can be "normal", "minimized", "maximized", "fullscreen"
-	    	is_foreground = window_state != "minimized"
-	    
-	    	is_visible = await cdp_session.send("Runtime.evaluate", {
+	async def get_page_visibility(page):
+		cdp_session = await page.context.new_cdp_session(page)
+		target_info = await cdp_session.send("Target.getTargetInfo")
+		target_id = target_info["targetInfo"]["targetId"]
+	
+		window_info = await cdp_session.send("Browser.getWindowForTarget", {"targetId": target_id})
+		window_id = window_info["windowId"]
+		window_bounds = await cdp_session.send("Browser.getWindowBounds", {"windowId": window_id})
+		window_state = window_bounds.get("bounds", {}).get("windowState")	 # The state can be "normal", "minimized", "maximized", "fullscreen"
+		is_foreground = window_state != "minimized"
+	
+		is_visible = await cdp_session.send("Runtime.evaluate", {
 			"expression": "document.visibilityState === 'visible'",
 			"returnByValue": True
-	    	})
+		})
 		is_focused = await cdp_session.send("Runtime.evaluate", {
 			"expression": "document.hasFocus()",
 			"returnByValue": True
-	    	})
-                page_bounds = await cdp_session.send("Page.getLayoutMetrics")  # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-getLayoutMetrics
-	    	await cdp_session.detach()
-	    
-	    	return {
-			"target_id": target_id,
-	        	"window_id": window_id,
-	        	"window_state": window_state,
+		})
+		page_bounds = await cdp_session.send("Page.getLayoutMetrics")  # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-getLayoutMetrics
+		await cdp_session.detach()
+	
+		return {
+		"target_id": target_id,
+			"window_id": window_id,
+			"window_state": window_state,
 			"window_bounds": window_bounds,
 			"window_is_visible": is_foreground,
 			"page_is_visible": is_visible,
 			"page_is_focused": is_focused,
-                        "page_bounds": page_bounds,
-	    	}
+			"page_bounds": page_bounds,
+		}
 
 	async def get_selector_map(self) -> SelectorMap:
 		session = await self.get_session()


### PR DESCRIPTION
`(WIP) pending confirmation that this is useful/needed`

My code in this PR fixes the immediate issue of not being able to detect the most recently opened foreground tab properly, but the long-term fix is to refactor the code to better track which tab is "current" for the agent vs "current" for the human watching. Keeping those separate would allow a user to continue using their browser normally without breaking `browser-use`'s interactions with a particular tab.

If it's not a design goal of `browser-use` to allow parallel browser driving by agent & human on separate tabs, let me know and I will change my approach.

Subtasks:

- [x] adds a new helper `context.get_page_visibility(page)` to get tab visibility info
- [x] change `_get_current_page` to use new helper method and filter for focused tab
- [ ] make sure detection of newly opened tabs can distinguish human-opened vs agent-opened
	- create new `get_current_human_page` to detect which tab the human user is focused on (can use my new `document.Focus()` code)
	- create new `get_current_agent_page` to detect which tab the agent is focused on (can use `browser_context.on('page', handler)` and `context.expect_page()` to update an attr on self that keeps a reference to the current tab the agent is driving)



```python
async with context.expect_page() as new_page_info:
	# agent opens new tab 
	await page.get_by_text("Open new tab").click()
	
	# context handler immediately gives us the new tab reference,
	# no need to get_current_page() or iterate through all pages checking visiblity
    page = await new_page_info.value
```

Possibly related issues:

- https://github.com/browser-use/browser-use/issues/974 (should definitely fix this one)
- https://github.com/browser-use/browser-use/issues/993
- https://github.com/browser-use/browser-use/issues/475#issuecomment-2642422124
- https://github.com/browser-use/browser-use/issues/660