### PR TITLE
fix: cast element id to string in buildDomTree.js

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -536,18 +536,18 @@
 
     // Additional checks for cookie banners and consent UI
     const isCookieBanner =
-      element.id?.toLowerCase().includes('cookie') ||
-      element.id?.toLowerCase().includes('consent') ||
-      element.id?.toLowerCase().includes('notice') ||
+      element.id?.toString().toLowerCase().includes('cookie') ||
+      element.id?.toString().toLowerCase().includes('consent') ||
+      element.id?.toString().toLowerCase().includes('notice') ||
       (element.classList && (
         element.classList.contains('otCenterRounded') ||
         element.classList.contains('ot-sdk-container')
       )) ||
       element.getAttribute('data-nosnippet') === 'true' ||
-      element.getAttribute('aria-label')?.toLowerCase().includes('cookie') ||
-      element.getAttribute('aria-label')?.toLowerCase().includes('consent') ||
+      element.getAttribute('aria-label')?.toString().toLowerCase().includes('cookie') ||
+      element.getAttribute('aria-label')?.toString().toLowerCase().includes('consent') ||
       (element.tagName.toLowerCase() === 'div' && (
-        element.id?.includes('onetrust') ||
+        element.id?.toString().toLowerCase().includes('onetrust') ||
         (element.classList && (
           element.classList.contains('onetrust') ||
           element.classList.contains('cookie') ||


### PR DESCRIPTION
I encountered an error on a specific webpage due to the element ID not always being a string.
Explicitly casting the `element.id` to a string resolves the issue.

### Error details:

```
ERROR    [dom] Error evaluating JavaScript: Page.evaluate: TypeError: element.id?.toLowerCase is not a function
    at isInteractiveElement (eval at evaluate (:234:30), <anonymous>:541:19)
    at buildDomTree (eval at evaluate (:234:30), <anonymous>:909:36)
    at buildDomTree (eval at evaluate (:234:30), <anonymous>:971:30)
    at buildDomTree (eval at evaluate (:234:30), <anonymous>:971:30)
    at buildDomTree (eval at evaluate (:234:30), <anonymous>:971:30)
    at buildDomTree (eval at evaluate (:234:30), <anonymous>:971:30)
    at buildDomTree (eval at evaluate (:234:30), <anonymous>:971:30)
    at buildDomTree (eval at evaluate (:234:30), <anonymous>:971:30)
    at buildDomTree (eval at evaluate (:234:30), <anonymous>:816:28)
    at eval (eval at evaluate (:234:30), <anonymous>:999:18)
```