### PR TITLE
feat: Added the ability to select the default search engine

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -86,6 +86,7 @@ class Agent(Generic[Context]):
 		browser: Browser | None = None,
 		browser_context: BrowserContext | None = None,
 		controller: Controller[Context] = Controller(),
+		default_search_engine: str = "google",
 		# Initial agent run parameters
 		sensitive_data: Optional[Dict[str, str]] = None,
 		initial_actions: Optional[List[Dict[str, Dict[str, Any]]]] = None,
@@ -137,6 +138,7 @@ class Agent(Generic[Context]):
 		self.llm = llm
 		self.controller = controller
 		self.sensitive_data = sensitive_data
+		self.default_search_engine = default_search_engine
 
 		self.settings = AgentSettings(
 			use_vision=use_vision,
@@ -681,6 +683,7 @@ class Agent(Generic[Context]):
 				self.sensitive_data,
 				self.settings.available_file_paths,
 				context=self.context,
+				default_search_engine=self.default_search_engine,
 			)
 
 			results.append(result)

--- a/browser_use/controller/views.py
+++ b/browser_use/controller/views.py
@@ -8,6 +8,11 @@ class SearchGoogleAction(BaseModel):
 	query: str
 
 
+class SearchAction(BaseModel):
+	query: str
+	engine: str = "google"  # Default to Google, but allow other options
+
+
 class GoToUrlAction(BaseModel):
 	url: str
 


### PR DESCRIPTION
## 📌 Description  
Added a default_engine option for users that want to use a different search engine.

e.g. yahoo 

## 🔗 Related Issue  
https://github.com/browser-use/browser-use/issues/1044

## ✨ Type of Change  
- [X] 🚀 New Feature  
- [ ] 🐛 Bug Fix  
- [ ] 🛠 Refactor  
- [x] 📖 Documentation Update  
- [ ] 🔄 Other (please describe)  

## ✅ How Has This Been Tested?  
<!-- Describe how you tested your changes. Provide test cases, commands, or scenarios used to verify it. -->  
Unit Test