### PR TITLE
Ensure viewPortExpansion properly filters elements outside the viewport

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -858,26 +858,9 @@
       return null;
     }
 
-    // Early viewport check - only filter out elements clearly outside viewport
-    if (viewportExpansion !== -1) {
-      const rect = getCachedBoundingRect(node);
-      const style = getCachedComputedStyle(node);
-
-      // Skip viewport check for fixed/sticky elements as they may appear anywhere
-      const isFixedOrSticky = style && (style.position === 'fixed' || style.position === 'sticky');
-
-      // Check if element has actual dimensions
-      const hasSize = node.offsetWidth > 0 || node.offsetHeight > 0;
-
-      if (!rect || (!isFixedOrSticky && !hasSize && (
-        rect.bottom < -viewportExpansion ||
-        rect.top > window.innerHeight + viewportExpansion ||
-        rect.right < -viewportExpansion ||
-        rect.left > window.innerWidth + viewportExpansion
-      ))) {
-        if (debugMode) PERF_METRICS.nodeMetrics.skippedNodes++;
-        return null;
-      }
+    if (!isInExpandedViewport(node, viewportExpansion)) {
+      if (debugMode) PERF_METRICS.nodeMetrics.skippedNodes++;
+      return null;
     }
 
     // Process element node


### PR DESCRIPTION
### **Fix: Ensure `viewPortExpansion` properly filters elements outside the viewport**  

#### **Description**  
While working with browser interactions, I noticed that the `viewPortExpansion` parameter had no effect on filtering elements in the `SelectorMap`. As a result, elements outside the viewport were still selectable by the LLM, even when `viewport_expansion = 0`.  

This issue was caused by the fact that `isInExpandedViewport` was **defined but never actually used**. The previous implementation contained an inline viewport check, but it did not consistently exclude elements that were outside the visible area on scrollable pages.  

#### **Fix**  
- The existing function `isInExpandedViewport` is now used to filter out elements properly.  
- This ensures that only elements within the expanded viewport are included in the `SelectorMap`.  
- The behavior now correctly respects `viewport_expansion` values, preventing unintended selections.  

#### **Impact**  
- Fixes incorrect element selection on scrollable pages.  
- Ensures that `viewport_expansion` behaves as expected.  
- Reduces unnecessary processing of off-screen elements.  

Let me know if any further refinements are needed! 🚀  
