### PR TITLE
Ignore LangChainBetaWarning

### DIFF
--- a/browser_use/agent/message_manager/views.py
+++ b/browser_use/agent/message_manager/views.py
@@ -6,6 +6,10 @@ from langchain_core.load import dumpd, load
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from pydantic import BaseModel, ConfigDict, Field, model_serializer, model_validator
 
+from warnings import filterwarnings
+from langchain_core._api import LangChainBetaWarning
+filterwarnings("ignore", category=LangChainBetaWarning)
+
 if TYPE_CHECKING:
 	from browser_use.agent.views import AgentOutput
 


### PR DESCRIPTION
Ignores
```
browser_use\agent\message_manager\views.py:59: LangChainBetaWarning: The function `load` is in beta. It is actively being worked on, so the API may change.
  value['message'] = load(value['message'])
  ```