### PR TITLE
Open cross-origin iframes in a new tab to avoid needing `--disable-web-security`

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -1204,12 +1204,12 @@ class BrowserContext:
 		for page_id, page in enumerate(session.context.pages):
 			try:
 				tab_info = TabInfo(page_id=page_id, url=page.url, title=await asyncio.wait_for(page.title(), timeout=1))
-				tabs_info.append(tab_info)
 			except asyncio.TimeoutError:
 				# page.title() can hang forever on tabs that are crashed/dissapeared/about:blank
 				# we dont want to try automating those tabs because they will hang the whole script
-				logger.debug('Failed to get tab info for tab: %s (ignoring)', page_id)
-				continue
+				logger.debug('Failed to get tab info for tab #%s: %s (ignoring)', page_id, page.url)
+				tab_info = TabInfo(page_id=page_id, url='about:blank', title='ignore this tab and do not use it')
+			tabs_info.append(tab_info)
 
 		return tabs_info
 

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -760,8 +760,10 @@ class BrowserContext:
 		# Check if current page is still valid, if not switch to another available page
 		try:
 			page = await self.get_current_page()
-			# Test if page is still accessible
+			# Test if page and its iframes are still accessible
 			await page.evaluate('1')
+			# for frame in page.frames:
+			# 	await frame.evaluate('1')
 		except Exception as e:
 			logger.debug(f'Current page is no longer accessible: {str(e)}')
 			# Get all available pages

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -792,12 +792,14 @@ class BrowserContext:
 			for url in iframe_urls:
 				if url in [tab.url for tab in tabs_info]:
 					continue  # skip if the iframe if we already have it open in a tab
+				new_page_id = tabs_info[-1].page_id + 1
+				logger.debug(f'Opening cross-origin iframe in new tab #{new_page_id}: {url}')
 				await self.create_new_tab(url)
 				tabs_info.append(
 					TabInfo(
-						page_id=tabs_info[-1].page_id + 1,
+						page_id=new_page_id,
 						url=url,
-						title=f'Popup opened by page: {page.url}',
+						title=f'iFrame opened as new tab, treat as part of the page: {page.url}',
 					)
 				)
 

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -799,7 +799,8 @@ class BrowserContext:
 					TabInfo(
 						page_id=new_page_id,
 						url=url,
-						title=f'iFrame opened as new tab, treat as part of the page: {page.url}',
+						title=f'iFrame opened as new tab, treat as if embedded inside page #{self.state.target_id}: {page.url}',
+						parent_page_id=self.state.target_id,
 					)
 				)
 

--- a/browser_use/browser/views.py
+++ b/browser_use/browser/views.py
@@ -14,6 +14,7 @@ class TabInfo(BaseModel):
 	page_id: int
 	url: str
 	title: str
+	parent_page_id: Optional[int] = None  # parent page that contains this popup or cross-origin iframe
 
 
 @dataclass

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -1,6 +1,6 @@
 import asyncio
-import json
 import enum
+import json
 import logging
 from typing import Dict, Generic, Optional, Type, TypeVar
 

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -1,9 +1,8 @@
 import asyncio
-import re
-import json
 import enum
 import json
 import logging
+import re
 from typing import Dict, Generic, Optional, Type, TypeVar
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -166,7 +165,7 @@ class Controller(Generic[Context]):
 			logger.info(msg)
 			logger.debug(f'Element xpath: {element_node.xpath}')
 			return ActionResult(extracted_content=msg, include_in_memory=True)
-		
+
 		# Save PDF
 		@self.registry.action(
 			'Save the current page as a PDF file',
@@ -179,7 +178,7 @@ class Controller(Generic[Context]):
 
 			await page.emulate_media('screen')
 			await page.pdf(path=sanitized_filename, format='A4', print_background=False)
-			msg = f"Saving page with URL {page.url} as PDF to ./{sanitized_filename}"
+			msg = f'Saving page with URL {page.url} as PDF to ./{sanitized_filename}'
 			logger.info(msg)
 			return ActionResult(extracted_content=msg, include_in_memory=True)
 
@@ -211,7 +210,7 @@ class Controller(Generic[Context]):
 
 			content = markdownify.markdownify(await page.content())
 
-			# append iframe content into the page so it's accessible to the LLM too
+			# manually append iframe text into the content so it's readable by the LLM (includes cross-origin iframes)
 			for iframe in page.frames:
 				if iframe.url != page.url and not iframe.url.startswith('data:'):
 					content += f'\n\nIFRAME {iframe.url}:\n'

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -193,6 +193,12 @@ class Controller(Generic[Context]):
 
 			content = markdownify.markdownify(await page.content())
 
+			# append iframe content into the page so it's accessible to the LLM too
+			for iframe in page.frames:
+				if iframe.url != page.url and not iframe.url.startswith('data:'):
+					content += f'\n\nIFRAME {iframe.url}:\n'
+					content += markdownify.markdownify(await iframe.content())
+
 			prompt = 'Your task is to extract the content of the page. You will be given a page and a goal and you should extract all relevant information around this goal from the page. If the goal is vague, summarize the page. Respond in json format. Extraction goal: {goal}, Page: {page}'
 			template = PromptTemplate(input_variables=['goal', 'page'], template=prompt)
 			try:

--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -955,16 +955,16 @@
           if (domElement) nodeData.children.push(domElement);
         }
       }
-      // Handle shadow DOM
-      else if (node.shadowRoot) {
-        nodeData.shadowRoot = true;
-        for (const child of node.shadowRoot.childNodes) {
-          const domElement = buildDomTree(child, parentIframe);
-          if (domElement) nodeData.children.push(domElement);
-        }
-      }
       // Handle regular elements
       else {
+        // Handle shadow DOM
+        if (node.shadowRoot) {
+          nodeData.shadowRoot = true;
+          for (const child of node.shadowRoot.childNodes) {
+            const domElement = buildDomTree(child, parentIframe);
+            if (domElement) nodeData.children.push(domElement);
+          }
+        }
         for (const child of node.childNodes) {
           const domElement = buildDomTree(child, parentIframe);
           if (domElement) nodeData.children.push(domElement);

--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -775,7 +775,8 @@
       element.hasAttribute("role") ||
       element.hasAttribute("tabindex") ||
       element.hasAttribute("aria-") ||
-      element.hasAttribute("data-action");
+      element.hasAttribute("data-action") ||
+      element.getAttribute("contenteditable") == "true";
 
     return hasQuickInteractiveAttr;
   }

--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -1,12 +1,5 @@
-(
-  args = {
-    doHighlightElements: true,
-    focusHighlightIndex: -1,
-    viewportExpansion: 0,
-    debugMode: false,
-  }
-) => {
-  const { doHighlightElements, focusHighlightIndex, viewportExpansion, debugMode } = args;
+({ doHighlightElements=true, focusHighlightIndex=-1, viewportExpansion=0, debugMode=false, indexOffset=0 }={}) => {
+  // console.log('indexOffset', indexOffset)
   let highlightIndex = 0; // Reset highlight index
 
   // Add timing stack to handle recursion
@@ -183,7 +176,7 @@
    */
   const DOM_HASH_MAP = {};
 
-  const ID = { current: 0 };
+  const ID = { current: indexOffset };
 
   const HIGHLIGHT_CONTAINER_ID = "playwright-highlight-container";
 
@@ -1057,6 +1050,6 @@
   }
 
   return debugMode ?
-    { rootId, map: DOM_HASH_MAP, perfMetrics: PERF_METRICS } :
-    { rootId, map: DOM_HASH_MAP };
+    { rootId, map: DOM_HASH_MAP, perfMetrics: PERF_METRICS, indexOffset } :
+    { rootId, map: DOM_HASH_MAP, indexOffset };
 };

--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -800,6 +800,10 @@
       return null;
     }
 
+    // FOR DEBUGGING: mark the node as having been processed by buildDomTree.js
+    // so that playwright can tell if it's been processed or not
+    // node.setAttribute('data-browser-use-built-dom-tree', 'true');
+
     // Special handling for root node (body)
     if (node === document.body) {
       const nodeData = {
@@ -936,6 +940,9 @@
               const domElement = buildDomTree(child, node);
               if (domElement) nodeData.children.push(domElement);
             }
+            // mark the iframe as having been processed by buildDomTree.js
+            // so that playwright can tell if got processed already or if it needs special handling
+            node.contentWindow._loadedBrowserUseBuildDomTree = true;
           }
         } catch (e) {
           console.warn("Unable to access iframe:", e);

--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -1,5 +1,12 @@
-({ doHighlightElements=true, focusHighlightIndex=-1, viewportExpansion=0, debugMode=false, indexOffset=0 }={}) => {
-  // console.log('indexOffset', indexOffset)
+(
+  args = {
+    doHighlightElements: true,
+    focusHighlightIndex: -1,
+    viewportExpansion: 0,
+    debugMode: false,
+  }
+) => {
+  const { doHighlightElements, focusHighlightIndex, viewportExpansion, debugMode } = args;
   let highlightIndex = 0; // Reset highlight index
 
   // Add timing stack to handle recursion
@@ -176,7 +183,7 @@
    */
   const DOM_HASH_MAP = {};
 
-  const ID = { current: indexOffset };
+  const ID = { current: 0 };
 
   const HIGHLIGHT_CONTAINER_ID = "playwright-highlight-container";
 
@@ -768,8 +775,8 @@
       element.hasAttribute("role") ||
       element.hasAttribute("tabindex") ||
       element.hasAttribute("aria-") ||
-      element.hasAttribute("data-action") ||
-      element.getAttribute("contenteditable") == "true";
+      element.hasAttribute("data-action");
+
     return hasQuickInteractiveAttr;
   }
 
@@ -792,10 +799,6 @@
       if (debugMode) PERF_METRICS.nodeMetrics.skippedNodes++;
       return null;
     }
-
-    // FOR DEBUGGING: mark the node as having been processed by buildDomTree.js
-    // so that playwright can tell if it's been processed or not
-    // node.setAttribute('data-browser-use-built-dom-tree', 'true');
 
     // Special handling for root node (body)
     if (node === document.body) {
@@ -933,9 +936,6 @@
               const domElement = buildDomTree(child, node);
               if (domElement) nodeData.children.push(domElement);
             }
-            // mark the iframe as having been processed by buildDomTree.js
-            // so that playwright can tell if got processed already or if it needs special handling
-            node.contentWindow._loadedBrowserUseBuildDomTree = true;
           }
         } catch (e) {
           console.warn("Unable to access iframe:", e);
@@ -1050,6 +1050,6 @@
   }
 
   return debugMode ?
-    { rootId, map: DOM_HASH_MAP, perfMetrics: PERF_METRICS, indexOffset } :
-    { rootId, map: DOM_HASH_MAP, indexOffset };
+    { rootId, map: DOM_HASH_MAP, perfMetrics: PERF_METRICS } :
+    { rootId, map: DOM_HASH_MAP };
 };

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -3,7 +3,8 @@ import json
 import logging
 from dataclasses import dataclass
 from importlib import resources
-from typing import TYPE_CHECKING, Optional, TypeVar
+from typing import TYPE_CHECKING, Optional
+from urllib.parse import urlparse
 
 if TYPE_CHECKING:
 	from playwright.async_api import Page
@@ -26,95 +27,6 @@ class ViewportInfo:
 	height: int
 
 
-T = TypeVar('T', dict, list, int)
-
-
-def merge_dom_trees(value_a: T, value_b: T) -> T:
-	"""merge two buildDomTree.js result dicts. used to put together results from parent frame and child cross-origin iframes"""
-
-	if isinstance(value_a, dict) and isinstance(value_b, dict):
-		merged_tree = value_a.copy()
-		for key, value in value_b.items():
-			if key == 'rootId':
-				# original top parent rootId should never change
-				continue
-
-			if key in merged_tree:
-				merged_tree[key] = merge_dom_trees(merged_tree[key], value)
-			else:
-				merged_tree[key] = value
-
-		return merged_tree
-
-	elif isinstance(value_a, list) and isinstance(value_b, list):
-		merged_tree = value_a.copy()
-		for value in value_b:
-			if value not in merged_tree:
-				merged_tree.append(value)
-
-		return merged_tree
-
-	elif isinstance(value_a, (int, float)) and isinstance(value_b, (int, float)):
-		# assumes all numeric values in perf metrics are summable totals counts or seconds/milliseconds
-		# may not always be true in the future, e.g. if we add any avg values then naiive sum will be wrong
-		return value_a + value_b
-
-	elif isinstance(value_a, str) and isinstance(value_b, str):
-		if value_a == value_b:
-			return value_a
-
-	raise TypeError(f'Cannot merge {type(value_a)}: {value_a} and {type(value_b)}: {value_b}')
-
-
-def link_cross_origin_iframes(eval_page: dict) -> dict:
-	"""link cross-origin iframes to their parent frame"""
-	for node in eval_page['map'].values():
-		if node['tagName'] == 'iframe' and not node['children']:
-			# locate the child frame's body and put it in the children
-			# so that it's handled the same as a same-origin iframe
-			for elem in eval_page['map'].values():
-				if elem.get('parentFrameId') == node['id']:
-					node['children'].append(elem)
-					break
-
-	return eval_page
-
-
-def dump_frame_tree(frame, indent=''):
-	"""From: https://playwright.dev/python/docs/api/class-frame"""
-	yield (indent + frame.name + '@' + frame.url)
-	for child in frame.child_frames:
-		yield from dump_frame_tree(child, indent + '    ')
-
-
-# def find_nested_iframes(root_frame) -> dict[str, 'Frame']:
-# 	"""
-# 	iteratively find all iframes in the page
-# 	assumptions:
-# 	- iframes can be nested
-# 	- iframes can be cross-origin-iframes
-# 	- non-cross-origin iframes can nested inside cross-origin iframes
-# 	- iframes arent guaranteed to have any id, name, or unique src url
-# 	- iframes and their content can be added/removed/updated multiple times per second by JS
-# 	"""
-
-# 	frame_idx = 0
-
-# 	all_frames = {f'{frame_idx}': root_frame}
-# 	frames_to_search = [list(all_frames.keys())[0]]
-# 	while frames_to_search:
-# 		frame_idx += 1
-# 		frame_id = frames_to_search.pop()
-# 		frame = all_frames[frame_id]
-
-# 		for child_frame in frame.child_frames if hasattr(frame, 'child_frames') else frame.frames:
-# 			child_frame_id = f'{frame_id}/{frame_idx}'
-# 			all_frames[child_frame_id] = child_frame
-# 			frames_to_search.append(child_frame_id)
-
-# 	return all_frames
-
-
 class DomService:
 	def __init__(self, page: 'Page'):
 		self.page = page
@@ -132,6 +44,14 @@ class DomService:
 	) -> DOMState:
 		element_tree, selector_map = await self._build_dom_tree(highlight_elements, focus_element, viewport_expansion)
 		return DOMState(element_tree=element_tree, selector_map=selector_map)
+
+	@time_execution_async('--get_cross_origin_iframes')
+	async def get_cross_origin_iframes(self) -> list[str]:
+		return [
+			frame.url
+			for frame in self.page.frames
+			if urlparse(frame.url).netloc != urlparse(self.page.url).netloc and not frame.url.startswith('data:')
+		]
 
 	@time_execution_async('--build_dom_tree')
 	async def _build_dom_tree(
@@ -168,52 +88,11 @@ class DomService:
 			'debugMode': debug_mode,
 		}
 
-		logger.debug('Running buildDomTree.js on: %s', self.page.url)
-
-		# 1. recursively find all nested iframes
-		# 2. filter to only include cross-origin iframes
-		# 3. run buildDomTree.js on all cross-origin iframes + top-level-page in parallel
-		# 4. merge the results into a single flat selector_map
-
-		print(list(dump_frame_tree(self.page.main_frame)))
-
 		try:
 			eval_page: dict = await self.page.evaluate(self.js_code, args)
 		except Exception as e:
 			logger.error('Error evaluating JavaScript: %s', e)
 			raise
-
-		# # also run buildDomTree.js on all cross-origin iframes
-		# inner_iframes = [
-		# 	await frame.frame_element()
-		# 	for frame in self.page.frames
-		# 	if frame.url != self.page.url and not frame.url.startswith('data:')
-		# ]
-		# for frame in inner_iframes:
-		# 	try:
-		# 		# check if the frame already has a buildDomTree.js
-		# 		inner_target = await frame.content_frame()
-		# 		has_built_dom_tree = await inner_target.evaluate('window._loadedBrowserUseBuildDomTree')
-		# 		if has_built_dom_tree:
-		# 			# was already processed by buildDomTree.js's iframe-traveral handling
-		# 			continue
-		# 		else:
-		# 			logger.debug('Found cross-origin iframe that needs special handling: %s', inner_target.url)
-		# 			# start the index offset from the last index of the parent frame so that child element idx dont conflict
-		# 			iframe_args = {
-		# 				**args,
-		# 				'indexOffset': len(eval_page['map']),
-		# 				'parentFrameId': frame.parent_frame_id,
-		# 			}
-		# 			iframe_results: dict = await inner_target.evaluate(self.js_code, iframe_args)
-		# 			eval_page: dict = merge_dom_trees(eval_page, iframe_results)
-
-		# 	except Exception as e:
-		# 		logger.error('Error checking page for cross origin iframes: %s', e)
-		# 		# frames often dissapear upon navigation, page changes, etc. no need to hard fail here
-		# 		continue
-
-		# eval_page = link_cross_origin_iframes(eval_page)
 
 		# Only log performance metrics in debug mode
 		if debug_mode and 'perfMetrics' in eval_page:

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -47,11 +47,20 @@ class DomService:
 
 	@time_execution_async('--get_cross_origin_iframes')
 	async def get_cross_origin_iframes(self) -> list[str]:
+		# invisible cross-origin iframes are used for ads and tracking, dont open those
+		hidden_frame_urls = await self.page.locator('iframe').filter(visible=False).evaluate_all('e => e.map(e => e.src)')
+
+		is_ad_url = lambda url: any(
+			domain in urlparse(url).netloc for domain in ('doubleclick.net', 'adroll.com', 'googletagmanager.com')
+		)
+
 		return [
 			frame.url
 			for frame in self.page.frames
 			if urlparse(frame.url).netloc  # exclude data:urls and about:blank
-			and urlparse(frame.url).netloc != urlparse(self.page.url).netloc
+			and urlparse(frame.url).netloc != urlparse(self.page.url).netloc  # exclude same-origin iframes
+			and frame.url not in hidden_frame_urls  # exclude hidden frames
+			and not is_ad_url(frame.url)  # exclude most common ad network tracker frame URLs
 		]
 
 	@time_execution_async('--build_dom_tree')

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -54,6 +54,26 @@ class DomService:
 		if await self.page.evaluate('1+1') != 2:
 			raise ValueError('The page cannot evaluate javascript code properly')
 
+		if self.page.url == 'about:blank':
+			# short-circuit if the page is a new empty tab for speed, no need to inject buildDomTree.js
+			return (
+				DOMElementNode(
+					tag_name='body',
+					xpath='',
+					attributes={},
+					children=[],
+					is_visible=False,
+					is_interactive=False,
+					is_top_element=True,
+					is_in_viewport=False,
+					highlight_index=None,
+					shadow_root=False,
+					parent=None,
+					viewport_info=None,
+				),
+				{},
+			)
+
 		# NOTE: We execute JS code in the browser to extract important DOM information.
 		#       The returned hash map contains information about the DOM tree and the
 		#       relationship between the DOM elements.

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -50,7 +50,8 @@ class DomService:
 		return [
 			frame.url
 			for frame in self.page.frames
-			if urlparse(frame.url).netloc != urlparse(self.page.url).netloc and not frame.url.startswith('data:')
+			if urlparse(frame.url).netloc  # exclude data:urls and about:blank
+			and urlparse(frame.url).netloc != urlparse(self.page.url).netloc
 		]
 
 	@time_execution_async('--build_dom_tree')
@@ -96,7 +97,11 @@ class DomService:
 
 		# Only log performance metrics in debug mode
 		if debug_mode and 'perfMetrics' in eval_page:
-			logger.debug('DOM Tree Building Performance Metrics:\n%s', json.dumps(eval_page['perfMetrics'], indent=2))
+			logger.debug(
+				'DOM Tree Building Performance Metrics for: %s\n%s',
+				self.page.url,
+				json.dumps(eval_page['perfMetrics'], indent=2),
+			)
 
 		return await self._construct_dom_tree(eval_page)
 

--- a/examples/features/cross_origin_iframes.py
+++ b/examples/features/cross_origin_iframes.py
@@ -1,0 +1,50 @@
+"""
+Example of how it supports cross-origin iframes.
+
+@dev You need to add OPENAI_API_KEY to your environment variables.
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import asyncio
+
+from dotenv import load_dotenv
+from langchain_openai import ChatOpenAI
+
+from browser_use import Agent, Controller
+from browser_use.browser.browser import Browser, BrowserConfig
+
+load_dotenv()
+
+
+browser = Browser(
+	config=BrowserConfig(
+		headless=False,
+		cdp_url='http://localhost:9222',
+	)
+)
+controller = Controller()
+
+
+async def main():
+	agent = Agent(
+		# task='Click "Go cross-site (simple page)" button on https://csreis.github.io/tests/cross-site-iframe.html then tell me the text within',
+		task='Go to https://pirate.github.io/financial-dashboard/iframe.html and click Tools > Edit',
+		llm=ChatOpenAI(model='gpt-4o', temperature=0.0),
+		controller=controller,
+		browser=browser,
+	)
+
+	await agent.run()
+	await browser.close()
+
+	input('Press Enter to close...')
+
+
+if __name__ == '__main__':
+	try:
+		asyncio.run(main())
+	except Exception as e:
+		print(e)

--- a/examples/features/cross_origin_iframes.py
+++ b/examples/features/cross_origin_iframes.py
@@ -32,16 +32,7 @@ controller = Controller()
 
 async def main():
 	agent = Agent(
-		# task='Click "Go cross-site (simple page)" button on https://csreis.github.io/tests/cross-site-iframe.html then tell me the text within',
-		# task='Go to https://pirate.github.io/financial-dashboard/iframe.html and click Tools > Edit',
-		task="""
-			1. Go to https://trailhead.salesforce.com/today (if any login is needed, username: salesforce@sweeting.me password: SfTestPassword992)
-			2. Scroll down to Your Personalized Recommendations > Admin Beginner and click the Start button
-			3. Click the big blue "Start" button on the left
-			4. Scroll all the way to the bottom of the page and under "Choose hands-on org" make sure "My Trailhead Playground 1" is selected, then click "Launch"
-			5. Once the org loads in a new tab, click "Dashboards" in the menubar at the top
-			6. Click the "teset234234" dashboard and wait till it loads
-		""",
+		task='Click "Go cross-site (simple page)" button on https://csreis.github.io/tests/cross-site-iframe.html then tell me the text within',
 		llm=ChatOpenAI(model='gpt-4o', temperature=0.0),
 		controller=controller,
 		browser=browser,

--- a/examples/features/cross_origin_iframes.py
+++ b/examples/features/cross_origin_iframes.py
@@ -33,7 +33,15 @@ controller = Controller()
 async def main():
 	agent = Agent(
 		# task='Click "Go cross-site (simple page)" button on https://csreis.github.io/tests/cross-site-iframe.html then tell me the text within',
-		task='Go to https://pirate.github.io/financial-dashboard/iframe.html and click Tools > Edit',
+		# task='Go to https://pirate.github.io/financial-dashboard/iframe.html and click Tools > Edit',
+		task="""
+			1. Go to https://trailhead.salesforce.com/today (if any login is needed, username: salesforce@sweeting.me password: SfTestPassword992)
+			2. Scroll down to Your Personalized Recommendations > Admin Beginner and click the Start button
+			3. Click the big blue "Start" button on the left
+			4. Scroll all the way to the bottom of the page and under "Choose hands-on org" make sure "My Trailhead Playground 1" is selected, then click "Launch"
+			5. Once the org loads in a new tab, click "Dashboards" in the menubar at the top
+			6. Click the "teset234234" dashboard and wait till it loads
+		""",
 		llm=ChatOpenAI(model='gpt-4o', temperature=0.0),
 		controller=controller,
 		browser=browser,

--- a/examples/features/cross_origin_iframes.py
+++ b/examples/features/cross_origin_iframes.py
@@ -16,13 +16,15 @@ from langchain_openai import ChatOpenAI
 from browser_use import Agent, Controller
 from browser_use.browser.browser import Browser, BrowserConfig
 
+# Load environment variables
 load_dotenv()
+if not os.getenv('OPENAI_API_KEY'):
+	raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')
 
 
 browser = Browser(
 	config=BrowserConfig(
-		headless=False,
-		cdp_url='http://localhost:9222',
+		browser_instance_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
 	)
 )
 controller = Controller()

--- a/examples/use-cases/google_sheets.py
+++ b/examples/use-cases/google_sheets.py
@@ -15,7 +15,7 @@ from browser_use.browser.browser import Browser, BrowserConfig
 
 browser = Browser(
 	config=BrowserConfig(
-		chrome_instance_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+		browser_instance_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
 	),
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "requests>=2.32.3",
     "posthog>=3.7.0",
-    "playwright>=1.49.0",
+    "playwright>=1.51.0",
     "setuptools>=75.8.0",
     "langchain-core==0.3.35",
     "markdownify==1.1.0",


### PR DESCRIPTION
Related issues (this first-pass PR does not fully fix all of these, but it should help):

- https://github.com/browser-use/browser-use/issues/700 (azure nested iframes)
- https://github.com/browser-use/browser-use/issues/853 (salesforce nested iframes)
- https://github.com/browser-use/browser-use/issues/566 (amazon iframes)
- https://github.com/browser-use/browser-use/issues/923 (captcha.com demo iframes)
- https://github.com/browser-use/browser-use/issues/443 (some other payment gateway iframe)

---

This PR attempts to break CORS from the agent's perspectve and allow `buildDOMTree.js` to traverse cross-origin iframes just like it currently does non-cross-origin iframes. Unfortunately the same approach used for same-origin frames is not possible, browser security forces us to go around the wall via playwright instead, but this introduces several new hurdles.

We have to create a new id translation mapping that mutates all the subframe generated DOM trees to reconnect the references to cross-origin parents & children. We also have to deterministically merge/offset all the IDs and update child id references to prevent conflicts, without introducing any dependency between frames during tree generation to keep it parallel.

---

#### The main challenges

- playwright doesn't deterministically provide all the frames in the first place‼️ with identical settings some pageloads `page.frames` contain cross-origin frames, exit, retry and the next time it doesn't, retry a few times then it does, etc. there is a race or timing issue
- iframes arent guaranteed to have any id, name, or unique src url, the standard API to pierce and find a nested iframe [only accepts `name=` or `url=`](https://github.com/microsoft/playwright/issues/7982) as lookup params and nothing else.
- iframes and their content can be added/removed/updated multiple times per second by JS, and their context handles and all child handles (and potentially nested frames) break any time they navigate
- non-cross-origin iframes can nested inside cross-origin iframes and vice versa up to 3x deep
 	
#### In an ideal world we'd want

- every `<iframe />` to have a stable and globally unique `name="..."` or `url="..."` attr
- which means `page.frame('name')` works to pierce and get that specific iframe even if nested
- it also lets us merge separate DOMTree maps without conflicts because every frame ends up with a unique xpath `/html/body/iframe[somename]/html/body/iframe[othername]`
- all frames should inject `buildDOMTree.js` in parallel for speed, and output should be merged at the end. building it frame by frame and passing the growing `indexOffset` counter between them serially is too slow

---

#### Approaches tried

- [x] ~~pre-tagging every iframe encountered with a `data-browser-use-iframe-id={idx}` attr~~ doesn't work because JS frameworks like react/vue/etc redraw the element immediately, also doesn't solve the issue of how to pierce parent frames to find the element later
- [x] ~~using playwright to trick the browser into thinking it's a same-origin domain by rewriting the iframe request and response URLs~~ too complex/browser security prevents it without crazy root CA hacks
- [x] ~~passing an `indexOffset` counter into `buildDOMTree.js` so the IDs it generates don't conflict with the parent frame~~ forces them to run serially, or forces us to switch to a longer ID format w/ random ids (which might break vision, the system prompt, or lower LLM success)
- [x] ~~give up on nested and non-unique iframes and only support top-level cross-origin and same-origin iframes~~ I got this 1/2 working but it's slow and makes some pages more buggy
- [x] ⭐️ **SIMPLEST SOLUTION: if any visible (non-ads) cross-origin iframe is present on the page, simply open the url for it in a new tab and treat it like a separate page, with a special title telling the LLM it's a popup that should be treated as part of the previous page**