### PR TITLE
Fixed allowed_domains restriction feature

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -614,6 +614,10 @@ class BrowserContext:
 			parsed_url = urlparse(url)
 			domain = parsed_url.netloc.lower()
 
+   			# Special case: Allow 'about:blank' explicitly
+			if url == "about:blank":
+				return True
+
 			# Remove port number if present
 			if ':' in domain:
 				domain = domain.split(':')[0]


### PR DESCRIPTION
Hi, 

I tested the `allowed_domains/restrict_urls` feature and noticed that when enabling domain restrictions, all domains (including the allowed ones) gets blocked. 

After debugging, I found that `about:blank` was incorrectly flagged as a non-allowed URL, which prevented navigation. 

This PR modifies `_is_url_allowed` to explicitly allow `"about:blank"`, as it's a common default in browser automation.

Let me know if any further adjustments are needed—this fix worked in my case.

Detailed Issue opened: https://github.com/browser-use/browser-use/issues/1120
