### PR TITLE
fix: Move HTTPX client cleanup from agent to browser close 

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -981,25 +981,6 @@ class Agent(Generic[Context]):
 	def message_manager(self) -> MessageManager:
 		return self._message_manager
 
-	async def cleanup_httpx_clients(self):
-		"""Cleanup all httpx clients"""
-		import httpx
-		import gc
-
-		# Force garbage collection to make sure all clients are in memory
-		gc.collect()
-		
-		# Get all httpx clients
-		clients = [obj for obj in gc.get_objects() if isinstance(obj, httpx.AsyncClient)]
-		
-		# Close all clients
-		for client in clients:
-			if not client.is_closed:
-				try:
-					await client.aclose()
-				except Exception as e:
-					logger.debug(f"Error closing httpx client: {e}")
-
 	async def close(self):
 		"""Close all resources"""
 		try:
@@ -1008,9 +989,6 @@ class Agent(Generic[Context]):
 				await self.browser_context.close()
 			if self.browser and not self.injected_browser:
 				await self.browser.close()
-			
-			# Then cleanup httpx clients
-			await self.cleanup_httpx_clients()
 			
 			# Force garbage collection
 			gc.collect()


### PR DESCRIPTION
The original original PR ([#895](https://github.com/browser-use/browser-use/pull/895)) addressed the resource warnings and potential memory leaks by adding HTTPX client cleanup to the agent's closing procedure, it introduced a new issue in multi-agent scenarios.  
When one agent closes, it cleans up ALL HTTPX clients in memory, including those being used by other agents in the same context.  

### Reference Demo
test.py
```  python
import os
import sys
import asyncio

sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

from langchain_openai import ChatOpenAI
from dotenv import load_dotenv

from browser_use import Agent, Browser

# Load environment variables
load_dotenv()
if not os.getenv('OPENAI_API_KEY'):
    raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')

async def main():
    browser = Browser()
    async with await browser.new_context() as context:
        model = ChatOpenAI(model='gpt-4o')

        # Initialize browser agent
        agent1 = Agent(
            task='search iphone 17 news on google and pick 3 sources.',
            llm=model,
            browser_context=context,
        )
        agent2 = Agent(
            task='compare all the content found and summarize the key information about iPhone 17.',
            llm=model,
            browser_context=context,
        )
        await agent1.run()
        await agent2.run()

if __name__ == "__main__":
    asyncio.run(main())
```  

### Fix
This PR moves HTTPX cleanup from agent to browser level to:
- Avoid breaking the multi-agent tasks, only cleans connections when browser fully closes.  
- Respects the _force_keep_browser_alive flag.  

