### PR TITLE
Update supported-models.mdx

### DIFF
--- a/docs/customize/supported-models.mdx
+++ b/docs/customize/supported-models.mdx
@@ -113,15 +113,13 @@ AZURE_OPENAI_KEY=
 ```python
 from langchain_google_genai import ChatGoogleGenerativeAI
 from browser_use import Agent
-from pydantic import SecretStr
-import os
 from dotenv import load_dotenv
+
+# Read GOOGLE_API_KEY into env
 load_dotenv()
 
-api_key = os.getenv("GEMINI_API_KEY")
-
 # Initialize the model
-llm = ChatGoogleGenerativeAI(model='gemini-2.0-flash-exp', api_key=SecretStr(os.getenv('GEMINI_API_KEY')))
+llm = ChatGoogleGenerativeAI(model='gemini-2.0-flash-exp')
 
 # Create agent with the model
 agent = Agent(
@@ -133,7 +131,7 @@ agent = Agent(
 Required environment variables:
 
 ```bash .env
-GEMINI_API_KEY=
+GOOGLE_API_KEY=
 ```
 
 
@@ -145,7 +143,10 @@ The example is available [here](https://github.com/browser-use/browser-use/blob/
 from langchain_openai import ChatOpenAI
 from browser_use import Agent
 from pydantic import SecretStr
+from dotenv import load_dotenv
 
+load_dotenv()
+api_key = os.getenv("DEEPSEEK_API_KEY")
 
 # Initialize the model
 llm=ChatOpenAI(base_url='https://api.deepseek.com/v1', model='deepseek-chat', api_key=SecretStr(api_key))
@@ -172,7 +173,10 @@ It does not support vision. The model is open-source so you could also use it wi
 from langchain_openai import ChatOpenAI
 from browser_use import Agent
 from pydantic import SecretStr
+from dotenv import load_dotenv
 
+load_dotenv()
+api_key = os.getenv("DEEPSEEK_API_KEY")
 
 # Initialize the model
 llm=ChatOpenAI(base_url='https://api.deepseek.com/v1', model='deepseek-reasoner', api_key=SecretStr(api_key))


### PR DESCRIPTION
Update examples with GoogleGenerativeAI and DeepSeek

- For the GoogleGenerativeAI example: there is some redundant code and since there is no need to explicitly pass in api_key for GoogleGenerativeAI, simply loading `GOOGLE_API_KEY` into the env vars would be sufficient (reference: https://python.langchain.com/api_reference/google_genai/chat_models/langchain_google_genai.chat_models.ChatGoogleGenerativeAI.html)
- For the DeepSeek examples: add the missing logic of loading api_key 