### PR TITLE
fix error: name 'browser_class' is not defined

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -226,6 +226,7 @@ class Browser:
 				'--no-startup-window',
 			],
 		}
+		browser_class = getattr(playwright, self.config.browser_class)
 		browser = await browser_class.launch(
 			headless=self.config.headless,
 			args=args[self.config.browser_class] + self.disable_security_args + self.config.extra_browser_args,


### PR DESCRIPTION
When I first tried to run examples/simple.py，there is an error：Failed to initialize Playwright browser: name 'browser_class' is not defined

This PR fixes the error.