### PR TITLE
fix: update hatch build includes for correct package structure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build]
 include = [
+  "browser_use/**/*.py",
+  "!browser_use/**/tests/*.py",
+  "!browser_use/**/tests.py",
+  "browser_use/agent/system_prompt.md",
   "browser_use/dom/buildDomTree.js",
 ]
 


### PR DESCRIPTION
PR #1035 change added an incomplete `[tool.hatch.build]` [section](https://github.com/browser-use/browser-use/pull/1035/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R57-R62) that only included:   
```yaml
[tool.hatch.build]
include = [
  "browser_use/dom/buildDomTree.js",
]
```  
This build configuration only included the JavaScript file, causing build issues.
  
### Fix
Expanded the build configuration to properly include Python modules and assets while excluding tests.

### before  
![image](https://github.com/user-attachments/assets/e8f75f04-e80d-480d-81ca-81417b727776)  

### after  
![image](https://github.com/user-attachments/assets/8dbd88a6-8c67-4c9c-a03c-761107f5c6fe)  


