### PR TITLE
Disable opening cross-origin iframes in new tabs for now

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -352,7 +352,7 @@ class BrowserContext:
 				ignore_https_errors=self.config.disable_security,
 				record_video_dir=self.config.save_recording_path,
 				record_video_size=self.config.browser_window_size,
-				record_har_path = self.config.save_har_path,
+				record_har_path=self.config.save_har_path,
 				locale=self.config.locale,
 				is_mobile=self.config.is_mobile,
 				has_touch=self.config.has_touch,
@@ -823,21 +823,23 @@ class BrowserContext:
 
 			# Get all cross-origin iframes within the page and open them in new tabs
 			# mark the titles of the new tabs so the LLM knows to check them for additional content
-			iframe_urls = await dom_service.get_cross_origin_iframes()
-			for url in iframe_urls:
-				if url in [tab.url for tab in tabs_info]:
-					continue  # skip if the iframe if we already have it open in a tab
-				new_page_id = tabs_info[-1].page_id + 1
-				logger.debug(f'Opening cross-origin iframe in new tab #{new_page_id}: {url}')
-				await self.create_new_tab(url)
-				tabs_info.append(
-					TabInfo(
-						page_id=new_page_id,
-						url=url,
-						title=f'iFrame opened as new tab, treat as if embedded inside page #{self.state.target_id}: {page.url}',
-						parent_page_id=self.state.target_id,
-					)
-				)
+			# unfortunately too buggy for now, too many sites use invisible cross-origin iframes for ads, tracking, youtube videos, social media, etc.
+			# and it distracts the bot by openeing a lot of new tabs
+			# iframe_urls = await dom_service.get_cross_origin_iframes()
+			# for url in iframe_urls:
+			# 	if url in [tab.url for tab in tabs_info]:
+			# 		continue  # skip if the iframe if we already have it open in a tab
+			# 	new_page_id = tabs_info[-1].page_id + 1
+			# 	logger.debug(f'Opening cross-origin iframe in new tab #{new_page_id}: {url}')
+			# 	await self.create_new_tab(url)
+			# 	tabs_info.append(
+			# 		TabInfo(
+			# 			page_id=new_page_id,
+			# 			url=url,
+			# 			title=f'iFrame opened as new tab, treat as if embedded inside page #{self.state.target_id}: {page.url}',
+			# 			parent_page_id=self.state.target_id,
+			# 		)
+			# 	)
 
 			screenshot_b64 = await self.take_screenshot()
 			pixels_above, pixels_below = await self.get_scroll_info(page)


### PR DESCRIPTION
We tried to support cross-origin frames without needing to `--disable-web-security` by opening them in new tabs, but unfortunately too many sites use hidden embedded cross-origin iframes for ads and tracking, and it confuses the bot to open those in new tabs.

- https://github.com/browser-use/browser-use/pull/1114
- https://github.com/browser-use/browser-use/issues/1153#issuecomment-2755601621