### PR TITLE
Kill spawned chrome subprocess group on `browser.close()` when `keep_alive=False`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pyobjc>=11.0; platform_system == 'darwin'",
     "screeninfo>=0.8.1; platform_system != 'darwin'",
     "typing-extensions>=4.12.2",
+    "psutil>=7.0.0",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
Fixes https://github.com/browser-use/browser-use/issues/839#issuecomment-2753754385