### PR TITLE
Add support for registering actions that should only apply to some pages e.g. `*.example.com`

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -199,7 +199,7 @@ class Agent(Generic[Context]):
 
 		# Initialize available actions for system prompt (only non-filtered actions)
 		# These will be used for the system prompt to maintain caching
-		self.available_actions = self.controller.registry.get_prompt_description()
+		self.unfiltered_actions = self.controller.registry.get_prompt_description()
 
 		self.tool_calling_method = self._set_tool_calling_method()
 		self.settings.message_context = self._set_message_context()
@@ -209,7 +209,7 @@ class Agent(Generic[Context]):
 		self._message_manager = MessageManager(
 			task=task,
 			system_message=SystemPrompt(
-				action_description=self.available_actions,
+				action_description=self.unfiltered_actions,
 				max_actions_per_step=self.settings.max_actions_per_step,
 				override_system_message=override_system_message,
 				extend_system_message=extend_system_message,
@@ -251,11 +251,10 @@ class Agent(Generic[Context]):
 	def _set_message_context(self) -> str | None:
 		if self.tool_calling_method == 'raw':
 			# For raw tool calling, only include actions with no filters initially
-			unfiltered_actions = self.controller.registry.get_prompt_description()
 			if self.settings.message_context:
-				self.settings.message_context += f'\n\nAvailable actions: {unfiltered_actions}'
+				self.settings.message_context += f'\n\nAvailable actions: {self.unfiltered_actions}'
 			else:
-				self.settings.message_context = f'Available actions: {unfiltered_actions}'
+				self.settings.message_context = f'Available actions: {self.unfiltered_actions}'
 		return self.settings.message_context
 
 	def _set_browser_use_version_and_source(self) -> None:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -250,10 +250,12 @@ class Agent(Generic[Context]):
 
 	def _set_message_context(self) -> str | None:
 		if self.tool_calling_method == 'raw':
+			# For raw tool calling, only include actions with no filters initially
+			unfiltered_actions = self.controller.registry.get_prompt_description()
 			if self.settings.message_context:
-				self.settings.message_context += f'\n\nAvailable actions: {self.available_actions}'
+				self.settings.message_context += f'\n\nAvailable actions: {unfiltered_actions}'
 			else:
-				self.settings.message_context = f'Available actions: {self.available_actions}'
+				self.settings.message_context = f'Available actions: {unfiltered_actions}'
 		return self.settings.message_context
 
 	def _set_browser_use_version_and_source(self) -> None:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -308,6 +308,7 @@ class Agent(Generic[Context]):
 
 	def _setup_action_models(self) -> None:
 		"""Setup dynamic action models from controller's registry"""
+		# Initially only include actions with no filters
 		self.ActionModel = self.controller.registry.create_action_model()
 		# Create output model with the dynamic actions
 		self.AgentOutput = AgentOutput.type_with_custom_actions(self.ActionModel)
@@ -359,25 +360,29 @@ class Agent(Generic[Context]):
 
 		try:
 			state = await self.browser_context.get_state()
+			active_page = await self.browser_context.get_current_page()
 
 			await self._raise_if_stopped_or_paused()
-			
+
+			# Update action models with page-specific actions
+			await self._update_action_models_for_page(active_page)
+
 			# Get page-specific filtered actions
-			page_filtered_actions = self.controller.registry.get_prompt_description(state.page)
-			
+			page_filtered_actions = self.controller.registry.get_prompt_description(active_page)
+
 			# If there are page-specific actions, add them as a special message for this step only
 			if page_filtered_actions:
-				page_action_message = f"For this page, these additional actions are available:\n{page_filtered_actions}"
+				page_action_message = f'For this page, these additional actions are available:\n{page_filtered_actions}'
 				self._message_manager._add_message_with_tokens(HumanMessage(content=page_action_message))
-			
+
 			# If using raw tool calling method, we need to update the message context with new actions
 			if self.tool_calling_method == 'raw':
 				# For raw tool calling, get all non-filtered actions plus the page-filtered ones
 				all_unfiltered_actions = self.controller.registry.get_prompt_description()
 				all_actions = all_unfiltered_actions
 				if page_filtered_actions:
-					all_actions += "\n" + page_filtered_actions
-				
+					all_actions += '\n' + page_filtered_actions
+
 				context_lines = self._message_manager.settings.message_context.split('\n')
 				non_action_lines = [line for line in context_lines if not line.startswith('Available actions:')]
 				updated_context = '\n'.join(non_action_lines)
@@ -1143,16 +1148,16 @@ class Agent(Generic[Context]):
 
 		# Get current state to filter actions by page
 		state = await self.browser_context.get_state()
-		
+
 		# Get all standard actions (no filter) and page-specific actions
 		standard_actions = self.controller.registry.get_prompt_description()  # No page = system prompt actions
 		page_actions = self.controller.registry.get_prompt_description(state.page)  # Page-specific actions
-		
+
 		# Combine both for the planner
 		all_actions = standard_actions
 		if page_actions:
-			all_actions += "\n" + page_actions
-			
+			all_actions += '\n' + page_actions
+
 		# Create planner message history using full message history with all available actions
 		planner_messages = [
 			PlannerPrompt(all_actions).get_system_message(),
@@ -1218,3 +1223,14 @@ class Agent(Generic[Context]):
 
 		except Exception as e:
 			logger.error(f'Error during cleanup: {e}')
+
+	async def _update_action_models_for_page(self, page) -> None:
+		"""Update action models with page-specific actions"""
+		# Create new action model with current page's filtered actions
+		self.ActionModel = self.controller.registry.create_action_model(page=page)
+		# Update output model with the new actions
+		self.AgentOutput = AgentOutput.type_with_custom_actions(self.ActionModel)
+
+		# Update done action model too
+		self.DoneActionModel = self.controller.registry.create_action_model(include_actions=['done'], page=page)
+		self.DoneAgentOutput = AgentOutput.type_with_custom_actions(self.DoneActionModel)

--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -6,6 +6,7 @@ import asyncio
 import gc
 import logging
 import os
+import socket
 import subprocess
 from typing import Literal
 
@@ -250,12 +251,10 @@ class Browser:
 		}
 
 		# check if port 9222 is already taken, if so remove the remote-debugging-port arg to prevent conflicts
-		try:
-			response = requests.get('http://localhost:9222/json/version', timeout=2)
-			if response.status_code == 200:
+		with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+			if s.connect_ex(('localhost', 9222)) == 0:
 				chrome_args.remove('--remote-debugging-port=9222')
-		except Exception:
-			pass
+				chrome_args.remove('--remote-debugging-address=0.0.0.0')
 
 		browser_class = getattr(playwright, self.config.browser_class)
 		args = {

--- a/browser_use/browser/chrome.py
+++ b/browser_use/browser/chrome.py
@@ -106,7 +106,7 @@ CHROME_ARGS = [
 	# Extensions
 	# chrome://inspect/#extensions
 	# f'--load-extension={CHROME_EXTENSIONS.map(({unpacked_path}) => unpacked_path).join(',')}',  # not needed when using existing profile that already has extensions installed
-	f'--allowlisted-extension-id={",".join(CHROME_EXTENSIONS.keys())}',
+	# f'--allowlisted-extension-id={",".join(CHROME_EXTENSIONS.keys())}',
 	'--allow-legacy-extension-manifests',
 	'--allow-pre-commit-input',  # allow JS mutations before page rendering is complete
 	'--disable-blink-features=AutomationControlled',  # hide the signatures that announce browser is being remote-controlled

--- a/browser_use/controller/registry/service.py
+++ b/browser_use/controller/registry/service.py
@@ -49,6 +49,7 @@ class Registry(Generic[Context]):
 		self,
 		description: str,
 		param_model: Optional[Type[BaseModel]] = None,
+		domains: Optional[list[str]] = None,
 	):
 		"""Decorator for registering actions"""
 
@@ -79,6 +80,7 @@ class Registry(Generic[Context]):
 				description=description,
 				function=wrapped_func,
 				param_model=actual_param_model,
+				domains=domains,
 			)
 			self.registry.actions[func.__name__] = action
 			return func

--- a/browser_use/controller/registry/service.py
+++ b/browser_use/controller/registry/service.py
@@ -195,16 +195,17 @@ class Registry(Generic[Context]):
 				page_filter_match = action.page_filter(page)
 
 			# Check domains if present
-			domains_match = False
+			domains_match = True  # Default to True if no filter
 			if action.domains is not None and page.url:
+				domains_match = False
 				# Try to match any of the domain patterns
 				for domain_pattern in action.domains:
 					if self.registry._match_domain(domain_pattern, page.url):
 						domains_match = True
 						break
 
-			# Only include action if either filter matches
-			if page_filter_match or domains_match:
+			# Include action if both filters match (or if either is not present)
+			if page_filter_match and domains_match:
 				available_actions[name] = action
 
 		fields = {

--- a/browser_use/controller/registry/service.py
+++ b/browser_use/controller/registry/service.py
@@ -50,6 +50,7 @@ class Registry(Generic[Context]):
 		description: str,
 		param_model: Optional[Type[BaseModel]] = None,
 		domains: Optional[list[str]] = None,
+		page_filter: Optional[Callable[[Any], bool]] = None,
 	):
 		"""Decorator for registering actions"""
 
@@ -81,6 +82,7 @@ class Registry(Generic[Context]):
 				function=wrapped_func,
 				param_model=actual_param_model,
 				domains=domains,
+				page_filter=page_filter,
 			)
 			self.registry.actions[func.__name__] = action
 			return func
@@ -196,6 +198,10 @@ class Registry(Generic[Context]):
 
 		return create_model('ActionModel', __base__=ActionModel, **fields)  # type:ignore
 
-	def get_prompt_description(self) -> str:
-		"""Get a description of all actions for the prompt"""
-		return self.registry.get_prompt_description()
+	def get_prompt_description(self, page=None) -> str:
+		"""Get a description of all actions for the prompt
+		
+		If page is provided, only include actions that are available for that page
+		based on their filter_func
+		"""
+		return self.registry.get_prompt_description(page)

--- a/browser_use/controller/registry/views.py
+++ b/browser_use/controller/registry/views.py
@@ -128,16 +128,17 @@ class ActionRegistry(BaseModel):
 				page_filter_match = action.page_filter(page)
 
 			# Check domains if present
-			domains_match = False
+			domains_match = True  # Default to True if no filter
 			if action.domains is not None and page.url:
+				domains_match = False
 				# Try to match any of the domain patterns
 				for domain_pattern in action.domains:
 					if self._match_domain(domain_pattern, page.url):
 						domains_match = True
 						break
 
-			# Include action if either filter matches
-			if page_filter_match or domains_match:
+			# Include action if both filters match (or if either is not present)
+			if page_filter_match and domains_match:
 				filtered_actions.append(action)
 
 		return '\n'.join(action.prompt_description() for action in filtered_actions)

--- a/browser_use/controller/registry/views.py
+++ b/browser_use/controller/registry/views.py
@@ -10,6 +10,7 @@ class RegisteredAction(BaseModel):
 	description: str
 	function: Callable
 	param_model: Type[BaseModel]
+	domains: list[str] | None = None  # e.g. ['*.google.com', 'www.bing.com', 'yahoo.*]
 
 	model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/examples/custom-functions/action_filters.py
+++ b/examples/custom-functions/action_filters.py
@@ -1,0 +1,105 @@
+"""
+This example demonstrates how to use action filters to expose different actions
+based on the current page URL or page content.
+
+There are two ways to filter actions:
+1. Using `domains` parameter with glob patterns to match specific domains
+2. Using `page_filter` function for more complex filtering based on page content
+
+Actions with no filters will be included in the system prompt. Actions with filters
+will only be dynamically added when the agent is on a matching page.
+"""
+
+import asyncio
+import os
+from typing import Optional
+
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+
+from browser_use.agent.service import Agent
+from browser_use.browser.browser import Browser
+from browser_use.controller.service import Controller, Registry
+
+# Initialize controller and registry
+controller = Controller()
+registry = controller.registry
+
+
+# Define a standard action with no filters (always available)
+@registry.action(
+    description="Navigate to a URL"
+)
+async def navigate(url: str):
+    """Navigate to a specific URL"""
+    return f"Would navigate to {url}"
+
+
+# Action only available on Google
+@registry.action(
+    description="Search on Google",
+    domains=["google.com", "*.google.com"]  # Matches google.com and any subdomain
+)
+async def google_search(query: str):
+    """Perform a Google search"""
+    return f"Would search for '{query}' on Google"
+
+
+# Action only available on GitHub
+@registry.action(
+    description="Search GitHub repositories",
+    domains=["github.com"]
+)
+async def github_search(repo_query: str):
+    """Search for repositories on GitHub"""
+    return f"Would search for GitHub repos matching '{repo_query}'"
+
+
+# Action that uses a complex page filter function
+# Note: For real use, you would need an async page filter or access HTML content via DOM
+@registry.action(
+    description="Login to account (only available on login pages)",
+    page_filter=lambda page: "login" in page.url.lower() or 
+                             page.url.endswith("signin") or
+                             page.url.endswith("sign-in")
+)
+async def login(username: str, password: str):
+    """Login to the current site"""
+    return f"Would login with username '{username}'"
+
+
+# Action for admin pages using both domain and page filter
+@registry.action(
+    description="Admin-only action",
+    domains=["example.com"],
+    page_filter=lambda page: "admin" in page.url.lower()
+)
+class AdminAction(BaseModel):
+    action_type: str = Field(description="Type of admin action to perform")
+    
+    async def execute(self):
+        return f"Would perform admin action: {self.action_type}"
+
+
+async def main():
+    """Main function to run the example"""
+    browser = Browser()
+    llm = ChatOpenAI(model_name="gpt-4o")
+    
+    # Create the agent
+    agent = Agent(
+        task="Demonstrate how action filters work by visiting different websites",
+        llm=llm,
+        browser=browser,
+        controller=controller,
+    )
+    
+    # Run the agent
+    await agent.run(max_steps=10)
+    
+    # Cleanup
+    await browser.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/use-cases/google_sheets.py
+++ b/examples/use-cases/google_sheets.py
@@ -29,7 +29,7 @@ controller = Controller()
 
 
 def is_google_sheet(page) -> bool:
-	return page.url.startswith('https://docs.google.com/spreadsheets/')
+	return page.url.startswith('https://docas.google.com/spreadsheets/')
 
 
 # TODO: refactor if not is_google_sheet(page): checks below to something like this:
@@ -49,11 +49,9 @@ async def open_google_sheet(browser: BrowserContext, google_sheet_url: str):
 	return ActionResult(extracted_content=f'Opened Google Sheet {google_sheet_url}', include_in_memory=False)
 
 
-@controller.registry.action('Google Sheets: Get the contents of the entire sheet')
+@controller.registry.action('Google Sheets: Get the contents of the entire sheet', page_filter=is_google_sheet)
 async def get_sheet_contents(browser: BrowserContext):
 	page = await browser.get_current_page()
-	if not is_google_sheet(page):
-		return ActionResult(error='Current page is not a Google Sheet')
 
 	# select all cells
 	await page.keyboard.press('Enter')
@@ -65,11 +63,9 @@ async def get_sheet_contents(browser: BrowserContext):
 	return ActionResult(extracted_content=extracted_tsv, include_in_memory=True)
 
 
-@controller.registry.action('Google Sheets: Select a specific cell or range of cells')
+@controller.registry.action('Google Sheets: Select a specific cell or range of cells', page_filter=is_google_sheet)
 async def select_cell_or_range(browser: BrowserContext, cell_or_range: str):
 	page = await browser.get_current_page()
-	if not is_google_sheet(page):
-		return ActionResult(error='Current page is not a Google Sheet')
 
 	await page.keyboard.press('Enter')  # make sure we dont delete current cell contents if we were last editing
 	await page.keyboard.press('Escape')  # to clear current focus (otherwise select range popup is additive)
@@ -87,11 +83,9 @@ async def select_cell_or_range(browser: BrowserContext, cell_or_range: str):
 	return ActionResult(extracted_content=f'Selected cell {cell_or_range}', include_in_memory=False)
 
 
-@controller.registry.action('Google Sheets: Get the contents of a specific cell or range of cells')
+@controller.registry.action('Google Sheets: Get the contents of a specific cell or range of cells', page_filter=is_google_sheet)
 async def get_range_contents(browser: BrowserContext, cell_or_range: str):
 	page = await browser.get_current_page()
-	if not is_google_sheet(page):
-		return ActionResult(error='Current page is not a Google Sheet')
 
 	await select_cell_or_range(browser, cell_or_range)
 
@@ -101,21 +95,17 @@ async def get_range_contents(browser: BrowserContext, cell_or_range: str):
 	return ActionResult(extracted_content=extracted_tsv, include_in_memory=True)
 
 
-@controller.registry.action('Google Sheets: Clear the currently selected cells')
+@controller.registry.action('Google Sheets: Clear the currently selected cells', page_filter=is_google_sheet)
 async def clear_selected_range(browser: BrowserContext):
 	page = await browser.get_current_page()
-	if not is_google_sheet(page):
-		return ActionResult(error='Current page is not a Google Sheet')
 
 	await page.keyboard.press('Backspace')
 	return ActionResult(extracted_content='Cleared selected range', include_in_memory=False)
 
 
-@controller.registry.action('Google Sheets: Input text into the currently selected cell')
+@controller.registry.action('Google Sheets: Input text into the currently selected cell', page_filter=is_google_sheet)
 async def input_selected_cell_text(browser: BrowserContext, text: str):
 	page = await browser.get_current_page()
-	if not is_google_sheet(page):
-		return ActionResult(error='Current page is not a Google Sheet')
 
 	await page.keyboard.type(text, delay=0.1)
 	await page.keyboard.press('Enter')  # make sure to commit the input so it doesnt get overwritten by the next action
@@ -123,11 +113,9 @@ async def input_selected_cell_text(browser: BrowserContext, text: str):
 	return ActionResult(extracted_content=f'Inputted text {text}', include_in_memory=False)
 
 
-@controller.registry.action('Google Sheets: Batch update a range of cells')
+@controller.registry.action('Google Sheets: Batch update a range of cells', page_filter=is_google_sheet)
 async def update_range_contents(browser: BrowserContext, range: str, new_contents_tsv: str):
 	page = await browser.get_current_page()
-	if not is_google_sheet(page):
-		return ActionResult(error='Current page is not a Google Sheet')
 
 	await select_cell_or_range(browser, range)
 

--- a/examples/use-cases/google_sheets.py
+++ b/examples/use-cases/google_sheets.py
@@ -29,13 +29,7 @@ controller = Controller()
 
 
 def is_google_sheet(page) -> bool:
-	return page.url.startswith('https://docas.google.com/spreadsheets/')
-
-
-# TODO: refactor if not is_google_sheet(page): checks below to something like this:
-# @controller.registry.action('Do something with a Google Sheet', page_filter=is_google_sheet)
-# async def some_google_sheet_action(browser: BrowserContext):
-# 	...
+	return page.url.startswith('https://docs.google.com/spreadsheets/')
 
 
 @controller.registry.action('Google Sheets: Open a specific Google Sheet')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ include = [
 
 [tool.uv]
 dev-dependencies = [
+    "ipdb>=0.13.13",
     "ruff>=0.11.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "langchain-aws>=0.2.11",
     "langchain-fireworks>=0.2.6",
     "langchain-google-genai==2.0.8",
+    "pytest>=8.3.5",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 # pyobjc: only used to get screen resolution on macOS
 # screeninfo: only used to get screen resolution on Linux/Windows
 # markdownify: used for page text content extraction for passing to LLM
+# openai: datalib,voice-helpers are actually NOT NEEDED but openai produces noisy errors on exit without them TODO: fix
 urls = { "Repository" = "https://github.com/browser-use/browser-use" }
 
 [project.optional-dependencies]

--- a/tests/test_action_filters.py
+++ b/tests/test_action_filters.py
@@ -1,0 +1,243 @@
+import pytest
+from unittest.mock import MagicMock
+from playwright.async_api import Page
+
+from browser_use.controller.registry.views import ActionRegistry, RegisteredAction
+from browser_use.controller.registry.service import Registry
+
+
+class TestActionFilters:
+    def test_get_prompt_description_no_filters(self):
+        """Test that system prompt only includes actions with no filters"""
+        registry = ActionRegistry()
+        
+        # Add actions with and without filters
+        no_filter_action = RegisteredAction(
+            name="no_filter_action",
+            description="Action with no filters",
+            function=lambda: None,
+            param_model=MagicMock(),
+            domains=None,
+            page_filter=None
+        )
+        
+        page_filter_action = RegisteredAction(
+            name="page_filter_action",
+            description="Action with page filter",
+            function=lambda: None,
+            param_model=MagicMock(),
+            domains=None,
+            page_filter=lambda page: True
+        )
+        
+        domain_filter_action = RegisteredAction(
+            name="domain_filter_action",
+            description="Action with domain filter",
+            function=lambda: None,
+            param_model=MagicMock(),
+            domains=["example.com"],
+            page_filter=None
+        )
+        
+        registry.actions = {
+            "no_filter_action": no_filter_action,
+            "page_filter_action": page_filter_action,
+            "domain_filter_action": domain_filter_action
+        }
+        
+        # System prompt (no page) should only include actions with no filters
+        system_description = registry.get_prompt_description()
+        assert "no_filter_action" in system_description
+        assert "page_filter_action" not in system_description
+        assert "domain_filter_action" not in system_description
+    
+    def test_page_filter_matching(self):
+        """Test that page filters work correctly"""
+        registry = ActionRegistry()
+        
+        # Create a mock page
+        mock_page = MagicMock(spec=Page)
+        mock_page.url = "https://example.com/page"
+        
+        # Create actions with different page filters
+        matching_action = RegisteredAction(
+            name="matching_action",
+            description="Action with matching page filter",
+            function=lambda: None,
+            param_model=MagicMock(),
+            domains=None,
+            page_filter=lambda page: "example.com" in page.url
+        )
+        
+        non_matching_action = RegisteredAction(
+            name="non_matching_action",
+            description="Action with non-matching page filter",
+            function=lambda: None,
+            param_model=MagicMock(),
+            domains=None,
+            page_filter=lambda page: "other.com" in page.url
+        )
+        
+        registry.actions = {
+            "matching_action": matching_action,
+            "non_matching_action": non_matching_action
+        }
+        
+        # Page-specific description should only include matching actions
+        page_description = registry.get_prompt_description(mock_page)
+        assert "matching_action" in page_description
+        assert "non_matching_action" not in page_description
+    
+    def test_domain_filter_matching(self):
+        """Test that domain filters work correctly with glob patterns"""
+        registry = ActionRegistry()
+        
+        # Create actions with different domain patterns
+        actions = {
+            "exact_match": RegisteredAction(
+                name="exact_match",
+                description="Exact domain match",
+                function=lambda: None,
+                param_model=MagicMock(),
+                domains=["example.com"],
+                page_filter=None
+            ),
+            "subdomain_match": RegisteredAction(
+                name="subdomain_match",
+                description="Subdomain wildcard match",
+                function=lambda: None,
+                param_model=MagicMock(),
+                domains=["*.example.com"],
+                page_filter=None
+            ),
+            "prefix_match": RegisteredAction(
+                name="prefix_match",
+                description="Prefix wildcard match",
+                function=lambda: None,
+                param_model=MagicMock(),
+                domains=["example*"],
+                page_filter=None
+            ),
+            "non_matching": RegisteredAction(
+                name="non_matching",
+                description="Non-matching domain",
+                function=lambda: None,
+                param_model=MagicMock(),
+                domains=["other.com"],
+                page_filter=None
+            )
+        }
+        
+        registry.actions = actions
+        
+        # Test exact domain match
+        mock_page = MagicMock(spec=Page)
+        mock_page.url = "https://example.com/page"
+        
+        exact_match_description = registry.get_prompt_description(mock_page)
+        assert "exact_match" in exact_match_description
+        assert "non_matching" not in exact_match_description
+        
+        # Test subdomain match
+        mock_page.url = "https://sub.example.com/page"
+        subdomain_match_description = registry.get_prompt_description(mock_page)
+        assert "subdomain_match" in subdomain_match_description
+        assert "exact_match" not in subdomain_match_description
+        
+        # Test prefix match
+        mock_page.url = "https://example123.org/page"
+        prefix_match_description = registry.get_prompt_description(mock_page)
+        assert "prefix_match" in prefix_match_description
+    
+    def test_domain_and_page_filter_together(self):
+        """Test that actions can be filtered by both domain and page filter"""
+        registry = ActionRegistry()
+        
+        # Create a mock page
+        mock_page = MagicMock(spec=Page)
+        mock_page.url = "https://example.com/admin"
+        
+        # Actions with different combinations of filters
+        actions = {
+            "domain_only": RegisteredAction(
+                name="domain_only",
+                description="Domain filter only",
+                function=lambda: None,
+                param_model=MagicMock(),
+                domains=["example.com"],
+                page_filter=None
+            ),
+            "page_only": RegisteredAction(
+                name="page_only", 
+                description="Page filter only",
+                function=lambda: None,
+                param_model=MagicMock(),
+                domains=None,
+                page_filter=lambda page: "admin" in page.url
+            ),
+            "both_matching": RegisteredAction(
+                name="both_matching",
+                description="Both filters matching",
+                function=lambda: None,
+                param_model=MagicMock(),
+                domains=["example.com"],
+                page_filter=lambda page: "admin" in page.url
+            ),
+            "both_one_fail": RegisteredAction(
+                name="both_one_fail",
+                description="One filter fails",
+                function=lambda: None,
+                param_model=MagicMock(),
+                domains=["other.com"],
+                page_filter=lambda page: "admin" in page.url
+            ),
+        }
+        
+        registry.actions = actions
+        
+        # Check that all matching filters are included
+        description = registry.get_prompt_description(mock_page)
+        assert "domain_only" in description
+        assert "page_only" in description
+        assert "both_matching" in description
+        assert "both_one_fail" in description  # Should match because page_filter matches
+
+    @pytest.mark.asyncio
+    async def test_registry_action_decorator(self):
+        """Test the action decorator with filters"""
+        registry = Registry()
+        
+        # Define actions with different filters
+        @registry.action(
+            description="No filter action",
+        )
+        def no_filter_action():
+            pass
+        
+        @registry.action(
+            description="Domain filter action",
+            domains=["example.com"]
+        )
+        def domain_filter_action():
+            pass
+        
+        @registry.action(
+            description="Page filter action",
+            page_filter=lambda page: "admin" in page.url
+        )
+        def page_filter_action():
+            pass
+        
+        # Check that system prompt only includes the no_filter_action
+        system_description = registry.get_prompt_description()
+        assert "No filter action" in system_description
+        assert "Domain filter action" not in system_description
+        assert "Page filter action" not in system_description
+        
+        # Check that page-specific prompt includes the right actions
+        mock_page = MagicMock(spec=Page)
+        mock_page.url = "https://example.com/admin"
+        
+        page_description = registry.get_prompt_description(mock_page)
+        assert "Domain filter action" in page_description
+        assert "Page filter action" in page_description

--- a/tests/test_action_filters.py
+++ b/tests/test_action_filters.py
@@ -1,243 +1,240 @@
-import pytest
 from unittest.mock import MagicMock
-from playwright.async_api import Page
 
-from browser_use.controller.registry.views import ActionRegistry, RegisteredAction
+import pytest
+from playwright.async_api import Page
+from pydantic import BaseModel
+
 from browser_use.controller.registry.service import Registry
+from browser_use.controller.registry.views import ActionRegistry, RegisteredAction
+
+
+class EmptyParamModel(BaseModel):
+	pass
 
 
 class TestActionFilters:
-    def test_get_prompt_description_no_filters(self):
-        """Test that system prompt only includes actions with no filters"""
-        registry = ActionRegistry()
-        
-        # Add actions with and without filters
-        no_filter_action = RegisteredAction(
-            name="no_filter_action",
-            description="Action with no filters",
-            function=lambda: None,
-            param_model=MagicMock(),
-            domains=None,
-            page_filter=None
-        )
-        
-        page_filter_action = RegisteredAction(
-            name="page_filter_action",
-            description="Action with page filter",
-            function=lambda: None,
-            param_model=MagicMock(),
-            domains=None,
-            page_filter=lambda page: True
-        )
-        
-        domain_filter_action = RegisteredAction(
-            name="domain_filter_action",
-            description="Action with domain filter",
-            function=lambda: None,
-            param_model=MagicMock(),
-            domains=["example.com"],
-            page_filter=None
-        )
-        
-        registry.actions = {
-            "no_filter_action": no_filter_action,
-            "page_filter_action": page_filter_action,
-            "domain_filter_action": domain_filter_action
-        }
-        
-        # System prompt (no page) should only include actions with no filters
-        system_description = registry.get_prompt_description()
-        assert "no_filter_action" in system_description
-        assert "page_filter_action" not in system_description
-        assert "domain_filter_action" not in system_description
-    
-    def test_page_filter_matching(self):
-        """Test that page filters work correctly"""
-        registry = ActionRegistry()
-        
-        # Create a mock page
-        mock_page = MagicMock(spec=Page)
-        mock_page.url = "https://example.com/page"
-        
-        # Create actions with different page filters
-        matching_action = RegisteredAction(
-            name="matching_action",
-            description="Action with matching page filter",
-            function=lambda: None,
-            param_model=MagicMock(),
-            domains=None,
-            page_filter=lambda page: "example.com" in page.url
-        )
-        
-        non_matching_action = RegisteredAction(
-            name="non_matching_action",
-            description="Action with non-matching page filter",
-            function=lambda: None,
-            param_model=MagicMock(),
-            domains=None,
-            page_filter=lambda page: "other.com" in page.url
-        )
-        
-        registry.actions = {
-            "matching_action": matching_action,
-            "non_matching_action": non_matching_action
-        }
-        
-        # Page-specific description should only include matching actions
-        page_description = registry.get_prompt_description(mock_page)
-        assert "matching_action" in page_description
-        assert "non_matching_action" not in page_description
-    
-    def test_domain_filter_matching(self):
-        """Test that domain filters work correctly with glob patterns"""
-        registry = ActionRegistry()
-        
-        # Create actions with different domain patterns
-        actions = {
-            "exact_match": RegisteredAction(
-                name="exact_match",
-                description="Exact domain match",
-                function=lambda: None,
-                param_model=MagicMock(),
-                domains=["example.com"],
-                page_filter=None
-            ),
-            "subdomain_match": RegisteredAction(
-                name="subdomain_match",
-                description="Subdomain wildcard match",
-                function=lambda: None,
-                param_model=MagicMock(),
-                domains=["*.example.com"],
-                page_filter=None
-            ),
-            "prefix_match": RegisteredAction(
-                name="prefix_match",
-                description="Prefix wildcard match",
-                function=lambda: None,
-                param_model=MagicMock(),
-                domains=["example*"],
-                page_filter=None
-            ),
-            "non_matching": RegisteredAction(
-                name="non_matching",
-                description="Non-matching domain",
-                function=lambda: None,
-                param_model=MagicMock(),
-                domains=["other.com"],
-                page_filter=None
-            )
-        }
-        
-        registry.actions = actions
-        
-        # Test exact domain match
-        mock_page = MagicMock(spec=Page)
-        mock_page.url = "https://example.com/page"
-        
-        exact_match_description = registry.get_prompt_description(mock_page)
-        assert "exact_match" in exact_match_description
-        assert "non_matching" not in exact_match_description
-        
-        # Test subdomain match
-        mock_page.url = "https://sub.example.com/page"
-        subdomain_match_description = registry.get_prompt_description(mock_page)
-        assert "subdomain_match" in subdomain_match_description
-        assert "exact_match" not in subdomain_match_description
-        
-        # Test prefix match
-        mock_page.url = "https://example123.org/page"
-        prefix_match_description = registry.get_prompt_description(mock_page)
-        assert "prefix_match" in prefix_match_description
-    
-    def test_domain_and_page_filter_together(self):
-        """Test that actions can be filtered by both domain and page filter"""
-        registry = ActionRegistry()
-        
-        # Create a mock page
-        mock_page = MagicMock(spec=Page)
-        mock_page.url = "https://example.com/admin"
-        
-        # Actions with different combinations of filters
-        actions = {
-            "domain_only": RegisteredAction(
-                name="domain_only",
-                description="Domain filter only",
-                function=lambda: None,
-                param_model=MagicMock(),
-                domains=["example.com"],
-                page_filter=None
-            ),
-            "page_only": RegisteredAction(
-                name="page_only", 
-                description="Page filter only",
-                function=lambda: None,
-                param_model=MagicMock(),
-                domains=None,
-                page_filter=lambda page: "admin" in page.url
-            ),
-            "both_matching": RegisteredAction(
-                name="both_matching",
-                description="Both filters matching",
-                function=lambda: None,
-                param_model=MagicMock(),
-                domains=["example.com"],
-                page_filter=lambda page: "admin" in page.url
-            ),
-            "both_one_fail": RegisteredAction(
-                name="both_one_fail",
-                description="One filter fails",
-                function=lambda: None,
-                param_model=MagicMock(),
-                domains=["other.com"],
-                page_filter=lambda page: "admin" in page.url
-            ),
-        }
-        
-        registry.actions = actions
-        
-        # Check that all matching filters are included
-        description = registry.get_prompt_description(mock_page)
-        assert "domain_only" in description
-        assert "page_only" in description
-        assert "both_matching" in description
-        assert "both_one_fail" in description  # Should match because page_filter matches
+	def test_get_prompt_description_no_filters(self):
+		"""Test that system prompt only includes actions with no filters"""
+		registry = ActionRegistry()
 
-    @pytest.mark.asyncio
-    async def test_registry_action_decorator(self):
-        """Test the action decorator with filters"""
-        registry = Registry()
-        
-        # Define actions with different filters
-        @registry.action(
-            description="No filter action",
-        )
-        def no_filter_action():
-            pass
-        
-        @registry.action(
-            description="Domain filter action",
-            domains=["example.com"]
-        )
-        def domain_filter_action():
-            pass
-        
-        @registry.action(
-            description="Page filter action",
-            page_filter=lambda page: "admin" in page.url
-        )
-        def page_filter_action():
-            pass
-        
-        # Check that system prompt only includes the no_filter_action
-        system_description = registry.get_prompt_description()
-        assert "No filter action" in system_description
-        assert "Domain filter action" not in system_description
-        assert "Page filter action" not in system_description
-        
-        # Check that page-specific prompt includes the right actions
-        mock_page = MagicMock(spec=Page)
-        mock_page.url = "https://example.com/admin"
-        
-        page_description = registry.get_prompt_description(mock_page)
-        assert "Domain filter action" in page_description
-        assert "Page filter action" in page_description
+		# Add actions with and without filters
+		no_filter_action = RegisteredAction(
+			name='no_filter_action',
+			description='Action with no filters',
+			function=lambda: None,
+			param_model=EmptyParamModel,
+			domains=None,
+			page_filter=None,
+		)
+
+		page_filter_action = RegisteredAction(
+			name='page_filter_action',
+			description='Action with page filter',
+			function=lambda: None,
+			param_model=EmptyParamModel,
+			domains=None,
+			page_filter=lambda page: True,
+		)
+
+		domain_filter_action = RegisteredAction(
+			name='domain_filter_action',
+			description='Action with domain filter',
+			function=lambda: None,
+			param_model=EmptyParamModel,
+			domains=['example.com'],
+			page_filter=None,
+		)
+
+		registry.actions = {
+			'no_filter_action': no_filter_action,
+			'page_filter_action': page_filter_action,
+			'domain_filter_action': domain_filter_action,
+		}
+
+		# System prompt (no page) should only include actions with no filters
+		system_description = registry.get_prompt_description()
+		assert 'no_filter_action' in system_description
+		assert 'page_filter_action' not in system_description
+		assert 'domain_filter_action' not in system_description
+
+	def test_page_filter_matching(self):
+		"""Test that page filters work correctly"""
+		registry = ActionRegistry()
+
+		# Create a mock page
+		mock_page = MagicMock(spec=Page)
+		mock_page.url = 'https://example.com/page'
+
+		# Create actions with different page filters
+		matching_action = RegisteredAction(
+			name='matching_action',
+			description='Action with matching page filter',
+			function=lambda: None,
+			param_model=EmptyParamModel,
+			domains=None,
+			page_filter=lambda page: 'example.com' in page.url,
+		)
+
+		non_matching_action = RegisteredAction(
+			name='non_matching_action',
+			description='Action with non-matching page filter',
+			function=lambda: None,
+			param_model=EmptyParamModel,
+			domains=None,
+			page_filter=lambda page: 'other.com' in page.url,
+		)
+
+		registry.actions = {'matching_action': matching_action, 'non_matching_action': non_matching_action}
+
+		# Page-specific description should only include matching actions
+		page_description = registry.get_prompt_description(mock_page)
+		assert 'matching_action' in page_description
+		assert 'non_matching_action' not in page_description
+
+	def test_domain_filter_matching(self):
+		"""Test that domain filters work correctly with glob patterns"""
+		registry = ActionRegistry()
+
+		# Create actions with different domain patterns
+		actions = {
+			'exact_match': RegisteredAction(
+				name='exact_match',
+				description='Exact domain match',
+				function=lambda: None,
+				param_model=EmptyParamModel,
+				domains=['example.com'],
+				page_filter=None,
+			),
+			'subdomain_match': RegisteredAction(
+				name='subdomain_match',
+				description='Subdomain wildcard match',
+				function=lambda: None,
+				param_model=EmptyParamModel,
+				domains=['*.example.com'],
+				page_filter=None,
+			),
+			'prefix_match': RegisteredAction(
+				name='prefix_match',
+				description='Prefix wildcard match',
+				function=lambda: None,
+				param_model=EmptyParamModel,
+				domains=['example*'],
+				page_filter=None,
+			),
+			'non_matching': RegisteredAction(
+				name='non_matching',
+				description='Non-matching domain',
+				function=lambda: None,
+				param_model=EmptyParamModel,
+				domains=['other.com'],
+				page_filter=None,
+			),
+		}
+
+		registry.actions = actions
+
+		# Test exact domain match
+		mock_page = MagicMock(spec=Page)
+		mock_page.url = 'https://example.com/page'
+
+		exact_match_description = registry.get_prompt_description(mock_page)
+		assert 'exact_match' in exact_match_description
+		assert 'non_matching' not in exact_match_description
+
+		# Test subdomain match
+		mock_page.url = 'https://sub.example.com/page'
+		subdomain_match_description = registry.get_prompt_description(mock_page)
+		assert 'subdomain_match' in subdomain_match_description
+		assert 'exact_match' not in subdomain_match_description
+
+		# Test prefix match
+		mock_page.url = 'https://example123.org/page'
+		prefix_match_description = registry.get_prompt_description(mock_page)
+		assert 'prefix_match' in prefix_match_description
+
+	def test_domain_and_page_filter_together(self):
+		"""Test that actions can be filtered by both domain and page filter"""
+		registry = ActionRegistry()
+
+		# Create a mock page
+		mock_page = MagicMock(spec=Page)
+		mock_page.url = 'https://example.com/admin'
+
+		# Actions with different combinations of filters
+		actions = {
+			'domain_only': RegisteredAction(
+				name='domain_only',
+				description='Domain filter only',
+				function=lambda: None,
+				param_model=EmptyParamModel,
+				domains=['example.com'],
+				page_filter=None,
+			),
+			'page_only': RegisteredAction(
+				name='page_only',
+				description='Page filter only',
+				function=lambda: None,
+				param_model=EmptyParamModel,
+				domains=None,
+				page_filter=lambda page: 'admin' in page.url,
+			),
+			'both_matching': RegisteredAction(
+				name='both_matching',
+				description='Both filters matching',
+				function=lambda: None,
+				param_model=EmptyParamModel,
+				domains=['example.com'],
+				page_filter=lambda page: 'admin' in page.url,
+			),
+			'both_one_fail': RegisteredAction(
+				name='both_one_fail',
+				description='One filter fails',
+				function=lambda: None,
+				param_model=EmptyParamModel,
+				domains=['other.com'],
+				page_filter=lambda page: 'admin' in page.url,
+			),
+		}
+
+		registry.actions = actions
+
+		# Check that all matching filters are included
+		description = registry.get_prompt_description(mock_page)
+		assert 'domain_only' in description
+		assert 'page_only' in description
+		assert 'both_matching' in description
+		assert 'both_one_fail' in description  # Should match because page_filter matches
+
+	@pytest.mark.asyncio
+	async def test_registry_action_decorator(self):
+		"""Test the action decorator with filters"""
+		registry = Registry()
+
+		# Define actions with different filters
+		@registry.action(
+			description='No filter action',
+		)
+		def no_filter_action():
+			pass
+
+		@registry.action(description='Domain filter action', domains=['example.com'])
+		def domain_filter_action():
+			pass
+
+		@registry.action(description='Page filter action', page_filter=lambda page: 'admin' in page.url)
+		def page_filter_action():
+			pass
+
+		# Check that system prompt only includes the no_filter_action
+		system_description = registry.get_prompt_description()
+		assert 'No filter action' in system_description
+		assert 'Domain filter action' not in system_description
+		assert 'Page filter action' not in system_description
+
+		# Check that page-specific prompt includes the right actions
+		mock_page = MagicMock(spec=Page)
+		mock_page.url = 'https://example.com/admin'
+
+		page_description = registry.get_prompt_description(mock_page)
+		assert 'Domain filter action' in page_description
+		assert 'Page filter action' in page_description


### PR DESCRIPTION
Fixes https://linear.app/browser-use/issue/TRI-5/add-domains=[onlysomedomain]-filter-to-restrict-actions-to-specific

Action filters (domains and page_filter) let you limit actions available to the Agent on a step-by-step/page-by-page basis.

```python
@registry.action(..., domains=['*'], page_filter=lambda page: return True)
async def some_action(browser: BrowserContext):
    ...
```

This helps prevent the LLM from deciding to use an action that is not compatible with the current page.
It helps limit decision fatique by scoping actions only to pages where they make sense.
It also helps prevent mis-triggering stateful actions or actions that could break other programs or leak secrets.

#### Use Cases

  - only run an action on certain domains
    `@registry.action(..., domains=['example.com', '*.example.com', 'example.co.*'])` (supports globs, but no regex)
  - only fill in a password on a specific login page url
    `@registry.action(..., page_filter=lambda p: p.url == 'https://example.com/some/login/page/')`
  - only run if this action has not run before on this page
    `@registry.action(..., page_filter=lambda p: p.url not in Path('log.txt').read_text())`

During each step, the agent recalculates the actions available specifically for that page, and updates the per-step available tools context (both raw and pydantic depending on what the model supports).

```python
# Action will only be available to Agent on Google domains because of the domain filter
@registry.action(description='Trigger disco mode', domains=['google.com', '*.google.com'])
async def disco_mode(browser: BrowserContext):
	page = await browser.get_current_page()
	await page.evaluate("""() => { 
        // define the wiggle animation
        document.styleSheets[0].insertRule('@keyframes wiggle { 0% { transform: rotate(0deg); } 50% { transform: rotate(10deg); } 100% { transform: rotate(0deg); } }');
        
        document.querySelectorAll("*").forEach(element => {
            element.style.animation = "wiggle 0.5s infinite";
        });
    }""")


# you can create a custom page filter function that determines if the action should be available for a given page
def is_login_page(page) -> bool:
	return 'login' in page.url.lower() or page.url.endswith('signin') or page.url.endswith('sign-in')


# then use it in the action decorator to limit the action to only be available on pages where the filter returns True
@registry.action(description='Use the force, luke', page_filter=is_login_page)
async def use_the_force(browser: BrowserContext):
	page = await browser.get_current_page()
	await page.evaluate("""() => { 
        document.querySelector('body').innerHTML = 'These are not the droids you are looking for';
    }""")
```


- [x] make sure it works for models with structured tool calling (figure out how to extend tools list on a message-by-message basis without having to blow away system prompt cache each time), it's possible entire list of pydantic registeredactions OpenAPI JSON schema is passed up-front
- [x] make sure it works for models without tool calling support (raw)
- [ ] ~~support async page_filters so that you can access content/evalute JS~~ will do in future PR
- [x] add example usage demo: `examples/custom-functions/actions_filters.py`
- [x] add tests for domain and function-based action filtering
<img width="2025" alt="image" src="https://github.com/user-attachments/assets/cca9fff0-b92c-4fe8-8ecf-d48d8b62aa74" />

