### PR TITLE
removed forced shadow root open

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -399,12 +399,6 @@ class BrowserContext:
                     Promise.resolve({ state: Notification.permission }) :
                     originalQuery(parameters)
             );
-            (function () {
-                const originalAttachShadow = Element.prototype.attachShadow;
-                Element.prototype.attachShadow = function attachShadow(options) {
-                    return originalAttachShadow.call(this, { ...options, mode: "open" });
-                };
-            })();
             """
 		)
 


### PR DESCRIPTION
Issue : https://github.com/browser-use/browser-use/issues/917

Background: Shadow Dom elements are used to encapsulate frontend logic. There are two types: open and closed. The ones which are open are easily accessible using element.shadowRoot. But, the ones which are a closed will give null. [ref](https://stackoverflow.com/questions/39931284/what-is-the-difference-between-open-and-closed-shadow-dom-encapsulation-mode)

When you want to create shadow dom elements you use the global attachShadow function. for eg,
```
class MyComponent extends HTMLElement {
    constructor() {
        super();
        this.attachShadow({ mode: "open" }); // Calls attachShadow with open mode
        this.shadowRoot.innerHTML = `<button>Click Me</button>`;
    }
}
customElements.define("my-component", MyComponent);
```
The issue is occurring because there is an init_script (which I am removing in this PR) which is being triggered before any webpage loads.  This script contains a code to intercept the call to global attachShadow function and passes a patch to use only open mode.

This is causing issues. This script code is basically taken from this [issue](https://github.com/microsoft/playwright/issues/23047) from playwright. This a flaky. If you check the comments of one of the maintainers of playwright ([comment](https://github.com/microsoft/playwright/issues/23047#issuecomment-1551652078)), he has mentioned that `Simply turning closed shadow roots into open ones will probably affect the behavior of some pages, because DOM APIs will behave differently now`. 
And I verified this, I ran the code without these lines of script and the shadowRoot was intialized successfully (i could see the `# shadow-root (open)` element and upon clicking it revealed the interactive button element it contained. But when this buggy script is applied, it doesnt let the shadow root to initialize (it showed `<!---->` instead of `# shadow-root(open)` and this `<!---->` was not clickable, hence the shadow root was not intialized properly). If this shadow element doesnt get initialized, the dom tree will not have the interactive button and the buildDomTree.js will not be able to highlight the interactive button.

Possible fixes:
Level 1: Remove the buggy script. This PR does this. I think this is one of the easiest solutions. Note that I tried other usual ways like using if statement like this but it didn't work:
```
 if (options.mode === "closed") {
            console.log("Forcing shadow root to open for:", this);
            return originalAttachShadow.call(this, { ...options, mode: "open" });
        } else {
            console.log("Shadow root mode is already open for:", this);
            return originalAttachShadow.call(this, options);
        }
```


Level 2: If you see this [comment](https://github.com/microsoft/playwright/issues/23047#issuecomment-2393077737) in the playwright issue, one person has recommended to use chrome's api called [chrome.dom.openOrClosedShadowRoot](https://developer.chrome.com/docs/extensions/reference/api/dom). But this would require loading a dummy extension because chrome api is only avaible in extension context. And to load an extension, one would require persistent context and user data dir. Also, it would require different handling for firefox and webkit. I am not even sure if this approach will work, haven't tested it.

Level 3: Move to some other library than playwright which is more apt for anti detection. Here is one more [comment](https://github.com/microsoft/playwright/issues/33725#issuecomment-2497195075) by the maintainer of playwright where he states: `Helping to circumvent anitbot mechanisms is out of scope for Playwright, which is focused on testing.`
So we can use [Patchright](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright/issues/28#issuecomment-2737129193). This is an improved patched version of playwright which is more undetectable and recently they have handled closed shadow roots as well. But it is somewhat buggy too (check their github there are a lot of thing to be done). There could be other libraries which we can explore.