### PR TITLE
Log active LLM models on agent startup

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -189,6 +189,11 @@ class Agent(Generic[Context]):
 
 		# Model setup
 		self._set_model_names()
+		logger.info(
+			f"Starting an agent with main_model={self.model_name}, planner_model={self.planner_model_name}, "
+			f"extraction_model={self.settings.page_extraction_llm.model_name if hasattr(self.settings.page_extraction_llm, 'model_name') else None}"
+		)
+
 
 		# LLM API connection setup
 		llm_api_env_vars = REQUIRED_LLM_API_ENV_VARS[self.llm.__class__.__name__]


### PR DESCRIPTION
## Changes

Enhance logging by explicitly reporting which LLM models are being used when the agent starts.
These loggings were included in the `service.py` file, into the constructor of the `Agent` class (since logging should be done when models are in use at startup).

## Example log

```
INFO [agent] Starting an agent with main_model=gpt-4o, planner_model=gpt-3.5-turbo, extraction_model=None
```

Fixes: #1217 