### PR TITLE
fixed logged in state

### DIFF
--- a/browser_use/browser/chrome.py
+++ b/browser_use/browser/chrome.py
@@ -99,8 +99,8 @@ CHROME_ARGS = [
 	# chrome://profile-internals
 	# f'--user-data-dir={CHROME_PROFILE_PATH}',     # managed by playwright arg instead
 	# f'--profile-directory={CHROME_PROFILE_USER}',
-	'--password-store=basic',  # use mock keychain instead of OS-provided keychain (we manage auth.json instead)
-	'--use-mock-keychain',
+	# '--password-store=basic',  # use mock keychain instead of OS-provided keychain (we manage auth.json instead)
+	# '--use-mock-keychain',
 	'--disable-cookie-encryption',  # we need to be able to write unencrypted cookies to save/load auth.json
 	'--disable-sync',  # don't try to use Google account sync features while automation is active
 	# Extensions


### PR DESCRIPTION
Issue link: https://github.com/browser-use/browser-use/issues/1225

@pirate I saw that you refactored the code to use chrome_args from the chrome.py constants file, but the two flags I have commented out in this PR, are causing issues. I know you are progressing towards auth.json. But, meanwhile that is achieved, lets comment these flags. Because if these are enabled, one will not be able to even run the 'Google Docs' demo in the readme.