### PR TITLE
Add Retry Handling to Bedrock

### DIFF
--- a/examples/models/bedrock_claude.py
+++ b/examples/models/bedrock_claude.py
@@ -19,17 +19,10 @@ from browser_use.browser.browser import Browser, BrowserConfig
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-
 def get_llm():
+	config = Config(retries={'max_attempts': 10, 'mode': 'adaptive'})
+	bedrock_client = boto3.client('bedrock-runtime', region_name='us-east-1', config=config)
 
-	config = Config(
-            retries = {
-                'max_attempts': 10,
-                'mode': 'adaptive'
-            }
-        )
-	bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1", config=config)
-	
 	return ChatBedrockConverse(
 		model_id='us.anthropic.claude-3-5-sonnet-20241022-v2:0',
 		temperature=0.0,

--- a/examples/models/bedrock_claude.py
+++ b/examples/models/bedrock_claude.py
@@ -6,23 +6,34 @@ Automated news analysis and sentiment scoring using Bedrock.
 
 import os
 import sys
-
+import asyncio
+import argparse
+from browser_use import Agent
+from botocore.config import Config
 from langchain_aws import ChatBedrockConverse
+from browser_use.controller.service import Controller
+from browser_use.browser.browser import Browser, BrowserConfig
+
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-import argparse
-import asyncio
 
-from browser_use import Agent
-from browser_use.browser.browser import Browser, BrowserConfig
-from browser_use.controller.service import Controller
 
 
 def get_llm():
+
+	config = Config(
+            retries = {
+                'max_attempts': 10,
+                'mode': 'adaptive'
+            }
+        )
+	bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1", config=config)
+	
 	return ChatBedrockConverse(
 		model_id='us.anthropic.claude-3-5-sonnet-20241022-v2:0',
 		temperature=0.0,
 		max_tokens=None,
+		client=bedrock_client,
 	)
 
 

--- a/examples/models/bedrock_claude.py
+++ b/examples/models/bedrock_claude.py
@@ -13,11 +13,11 @@ import boto3
 from botocore.config import Config
 from langchain_aws import ChatBedrockConverse
 
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from browser_use import Agent
 from browser_use.browser.browser import Browser, BrowserConfig
 from browser_use.controller.service import Controller
-
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 def get_llm():

--- a/examples/models/bedrock_claude.py
+++ b/examples/models/bedrock_claude.py
@@ -6,6 +6,7 @@ Automated news analysis and sentiment scoring using Bedrock.
 
 import os
 import sys
+import boto3
 import asyncio
 import argparse
 from browser_use import Agent

--- a/examples/models/bedrock_claude.py
+++ b/examples/models/bedrock_claude.py
@@ -4,17 +4,18 @@ Automated news analysis and sentiment scoring using Bedrock.
 @dev Ensure AWS environment variables are set correctly for Bedrock access.
 """
 
+import argparse
+import asyncio
 import os
 import sys
+
 import boto3
-import asyncio
-import argparse
-from browser_use import Agent
 from botocore.config import Config
 from langchain_aws import ChatBedrockConverse
-from browser_use.controller.service import Controller
-from browser_use.browser.browser import Browser, BrowserConfig
 
+from browser_use import Agent
+from browser_use.browser.browser import Browser, BrowserConfig
+from browser_use.controller.service import Controller
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "langchain-google-genai==2.1.2",
     "langchain>=0.3.21",
     "langchain-aws>=0.2.11",
+    "botocore>=1.37.23",
     "google-api-core>=2.24.0",
     "pyperclip>=1.9.0",
     "pyobjc>=11.0; platform_system == 'darwin'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
     "faiss-cpu>=1.10.0",
     "mem0ai==0.1.81",
 ]
+
+# botocore: only needed for Bedrock Claude boto3 examples/models/bedrock_claude.py 
 # pydantic: >2.11 introduces many pydantic deprecation warnings until langchain-core upgrades their pydantic support lets keep it on 2.10
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
Currently, [bedrock_claude.py](https://github.com/browser-use/browser-use/blob/main/examples/models/bedrock_claude.py) lacks retry handling due to bedrock rate limits, causing agents to shut down prematurely without completing their tasks. This PR resolves this issue by implementing adaptive retry handling for Bedrock requests.

Tested this out with claude 3.5 sonnet v2 in bedrock.


Also, will update the docs later on to add documentation to bedrock.