### PR TITLE
fix: use correct config when creating browser context

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -125,7 +125,7 @@ class Browser:
 
 	async def new_context(self, config: BrowserContextConfig | None = None) -> BrowserContext:
 		"""Create a browser context"""
-		return BrowserContext(config=config or self.config, browser=self)
+		return BrowserContext(config=config or self.config.new_context_config, browser=self)
 
 	async def get_playwright_browser(self) -> PlaywrightBrowser:
 		"""Get a browser context"""

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -234,7 +234,7 @@ class BrowserContext:
 	):
 		self.context_id = str(uuid.uuid4())
 
-		self.config = config or BrowserContextConfig(**browser.config)
+		self.config = config or browser.config.new_context_config
 		self.browser = browser
 
 		self.state = state or BrowserContextState()


### PR DESCRIPTION
### Issue
The browser context creation was failing with an error: `'BrowserConfig' object has no attribute 'user_agent'`.  
This occurred because we were trying to initialize a BrowserContextConfig with attributes from a BrowserConfig object, which doesn't have all the required attributes.  

### Fix
Use the existing new_context_config attribute from BrowserConfig instead of attempting to convert the entire BrowserConfig object to a BrowserContextConfig.
