### PR TITLE
Docs: Update system prompt customization documentation

### DIFF
--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -47,7 +47,8 @@ agent = Agent(
   - Disable to reduce costs or use models without vision support
   - For GPT-4o, image processing costs approximately 800-1000 tokens (~$0.002 USD) per image (but this depends on the defined screen size)
 - `save_conversation_path`: Path to save the complete conversation history. Useful for debugging.
-- `system_prompt_class`: Custom system prompt class. See <a href="/customize/system-prompt">System Prompt</a> for customization options.
+- `override_system_message`: Completely replace the default system prompt with a custom one.
+- `extend_system_message`: Add additional instructions to the default system prompt.
 
 <Note>
   Vision capabilities are recommended for better web interaction understanding,
@@ -183,7 +184,7 @@ agent = Agent(
 
 You can configure the agent and provide a separate message to help the LLM understand the task better.
 
-```python 
+```python
 from langchain_openai import ChatOpenAI
 
 agent = Agent(


### PR DESCRIPTION
The `system_prompt_class` parameter has been removed and replaced with two new parameters: `override_system_message` and `extend_system_message`. This change was introduced in commit [2a6416f](https://github.com/browser-use/browser-use/commit/2a6416f2722be97e6633196362b4ee524c38e750) to provide more flexible system prompt customization options.

The new parameters offer two ways to customize the system prompt:
- `override_system_message`: Completely replace the default system prompt with a custom one
- `extend_system_message`: Add additional instructions to the default system prompt

This change simplifies the system prompt customization process and makes it more intuitive for users. The documentation has been updated to reflect these changes.

Fixes #1172