### PR TITLE
Fix: Remove unnecessary await from _verified_api_keys

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -767,7 +767,7 @@ class Agent(Generic[Context]):
 		signal_handler.register()
 
 		# Start non-blocking LLM connection verification
-		assert await self.llm._verified_api_keys, 'Failed to verify LLM API keys'
+		assert self.llm._verified_api_keys, 'Failed to verify LLM API keys'
 
 		try:
 			self._log_agent_run()


### PR DESCRIPTION
This PR fixes an issue where the code was unnecessarily awaiting the `_verified_api_keys` property in the Agent's `run` method. 

The property is a boolean attribute and doesn't need to be awaited since it's not a coroutine or awaitable object.

Fix:
- Remove the `await` keyword from `assert await self.llm._verified_api_keys` 