### PR TITLE
Add support for Gemma-IT models and fix Unicode encoding

### DIFF
--- a/browser_use/agent/message_manager/utils.py
+++ b/browser_use/agent/message_manager/utils.py
@@ -37,7 +37,9 @@ def convert_input_messages(input_messages: list[BaseMessage], model_name: Option
 	"""Convert input messages to a format that is compatible with the planner model"""
 	if model_name is None:
 		return input_messages
-	if model_name == 'deepseek-reasoner' or 'deepseek-r1' in model_name:
+	if (model_name == 'deepseek-reasoner' or 
+		'deepseek-r1' in model_name or 
+		('gemma' in model_name and '-it' in model_name)):
 		converted_input_messages = _convert_messages_for_non_function_calling_models(input_messages)
 		merged_input_messages = _merge_successive_messages(converted_input_messages, HumanMessage)
 		merged_input_messages = _merge_successive_messages(merged_input_messages, AIMessage)
@@ -87,7 +89,7 @@ def _merge_successive_messages(messages: list[BaseMessage], class_to_merge: Type
 	return merged_messages
 
 
-def save_conversation(input_messages: list[BaseMessage], response: Any, target: str, encoding: Optional[str] = None) -> None:
+def save_conversation(input_messages: list[BaseMessage], response: Any, target: str, encoding: Optional[str] = 'utf-8') -> None:
 	"""Save conversation history to file."""
 
 	# create folders if not exists


### PR DESCRIPTION
This PR addresses two issues:

1. Issue #1237: Added support for Gemma instruction-tuned (IT) models by modifying the message conversion logic to handle these models similarly to DeepSeek models.

2. Issue #1241: Fixed Unicode encoding issue by setting UTF-8 as the default encoding in save_conversation function.

For issue #1245 (No module named 'mem0'), we verified that mem0ai is already correctly listed as a dependency in pyproject.toml. The issue is likely due to user-specific installation problems rather than a package dependency issue.

Link to Devin run: https://app.devin.ai/sessions/e445b9ff18394bedbee4d13350e40464