### PR TITLE
Fix Azure OpenAI example by disabling memory feature

### DIFF
--- a/examples/models/azure_openai.py
+++ b/examples/models/azure_openai.py
@@ -38,6 +38,7 @@ llm = AzureChatOpenAI(
 agent = Agent(
 	task='Go to amazon.com, search for laptop, sort by best rating, and give me the price of the first result',
 	llm=llm,
+	enable_memory=False,
 )
 
 


### PR DESCRIPTION
This PR addresses an issue where the Azure OpenAI example fails to run after recent memory handling changes introduced in PR #1205. 

The simple fix adds `enable_memory=False` to the Agent initialization, which should be sufficient for demo purposes, allowing the example to run without requiring OpenAI API credentials for memory features.

![image](https://github.com/user-attachments/assets/1c320d88-f806-4819-991a-b25d54c23089)
