### PR TITLE
Add timeout param to go_to_url

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -98,7 +98,7 @@ class Controller(Generic[Context]):
 		@self.registry.action('Navigate to URL in the current tab', param_model=GoToUrlAction)
 		async def go_to_url(params: GoToUrlAction, browser: BrowserContext):
 			page = await browser.get_current_page()
-			await page.goto(params.url)
+			await page.goto(params.url, timeout=params.timeout)
 			await page.wait_for_load_state()
 			msg = f'🔗  Navigated to {params.url}'
 			logger.info(msg)

--- a/browser_use/controller/views.py
+++ b/browser_use/controller/views.py
@@ -10,6 +10,7 @@ class SearchGoogleAction(BaseModel):
 
 class GoToUrlAction(BaseModel):
 	url: str
+	timeout: Optional[int]  # Timeout in milliseconds
 
 
 class WaitForElementAction(BaseModel):


### PR DESCRIPTION
We are trying to work with a website that has a very slow initial load time (>30 seconds). We are currently providing a `go_to_url` action in the `initial_actions` param of the `Agent` class, which has a default timeout of 30 seconds and so fails each time. Unfortunately this action does not support a timeout param, despite the `page.goto` method supporting it.

I've made an attempt to fix this (it works for our local instance) and figured I would contribute those changes upstream. Feel free to reject the PR and/or implement it another way.

:)