### PR TITLE
Fix incorrect documentation for SystemPrompt customization

### DIFF
--- a/docs/customize/system-prompt.mdx
+++ b/docs/customize/system-prompt.mdx
@@ -19,21 +19,27 @@ You can customize the system prompt by extending the `SystemPrompt` class. Inter
 Create a custom system prompt by inheriting from the base class.
 
 ```python
-from browser_use import Agent, SystemPrompt
-
+from browser_use import SystemPrompt
+from langchain_core.messages import SystemMessage
+from overrides import overrides
 class MySystemPrompt(SystemPrompt):
-    def important_rules(self) -> str:
+    @overrides
+    def get_system_message(self) -> SystemMessage:
+        
         # Get existing rules from parent class
-        existing_rules = super().important_rules()
+        existing_prompt = self.prompt_template.format(max_actions=self.max_actions_per_step)
 
         # Add your custom rules
-        new_rules = """
-9. MOST IMPORTANT RULE:
-- ALWAYS open first a new tab and go to wikipedia.com no matter the task!!!
-"""
+        new_prompt = """
+            10. MOST IMPORTANT RULE:
+            - You must response, think, reason Only Korean
+            - You must find "ReactModal__Overlay" attribute when you search sections
+            - You must search another apporach, another section, another actions even you faced retry the situations over twice times
+        """
 
         # Make sure to use this pattern otherwise the exiting rules will be lost
-        return f'{existing_rules}\n{new_rules}'
+        return SystemMessage(content=f'{existing_prompt}\n{new_prompt}')
+
 ```
 
 ## Using Custom System Prompt


### PR DESCRIPTION
### Summary
This PR fixes incorrect information in the official documentation ([link](https://docs.browser-use.com/customize/system-prompt)) related to customizing SystemPrompt in the stable version (v0.1.40) of browser-use.

### Problem
The documentation currently suggests overriding important_rules() method, which does not exist or get called in the stable version. In v0.1.40, the only relevant method that affects the system prompt is get_system_message().

As a result, users following the documentation for the stable release will see no effect from their changes, leading to confusion and potential misimplementation.

### What’s Changed
Updated the example code to override the correct method get_system_message() instead of the non-functional important_rules() method. Also included how to properly append custom rules to the existing system prompt using prompt_template.

### Suggested Fix in Docs (Before → After)
#### Before:
```python
from browser_use import Agent, SystemPrompt

class MySystemPrompt(SystemPrompt):
    def important_rules(self) -> str:
        # Get existing rules from parent class
        existing_rules = super().important_rules()

        # Add your custom rules
        new_rules = """
9. MOST IMPORTANT RULE:
- ALWAYS open first a new tab and go to wikipedia.com no matter the task!!!
"""

        # Make sure to use this pattern otherwise the exiting rules will be lost
        return f'{existing_rules}\n{new_rules}'
```

#### After:
```python
from browser_use import SystemPrompt
from langchain_core.messages import SystemMessage
from overrides import overrides
class MySystemPrompt(SystemPrompt):
    @overrides
    def get_system_message(self) -> SystemMessage:
        
        # Get existing rules from parent class
        existing_prompt = self.prompt_template.format(max_actions=self.max_actions_per_step)

        # Add your custom rules
        new_prompt = """
            10. MOST IMPORTANT RULE:
            - You must response, think, reason Only Korean
            - You must find "ReactModal__Overlay" attribute when you search sections
            - You must search another apporach, another section, another actions even you faced retry the situations over twice times
        """

        # Make sure to use this pattern otherwise the exiting rules will be lost
        return SystemMessage(content=f'{existing_prompt}\n{new_prompt}')
```
### Why It Matters
This correction helps new users get started without confusion and ensures the documentation aligns with the currently shipped stable version.

### Notes
I understand this was fixed in the beta version, but most users are on the stable version, and documentation should not mislead them.

Suggest clearly indicating version compatibility or updating the stable docs accordingly.

### According issues
close #1298 