### PR TITLE
fix: fix BrowserContext initialization in new_context method

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -133,7 +133,7 @@ class Browser:
 
 	async def new_context(self, config: BrowserContextConfig | None = None) -> BrowserContext:
 		"""Create a browser context"""
-		return BrowserContext(config=config or self.config, browser=self)
+		return BrowserContext(config=config, browser=self)
 
 	async def get_playwright_browser(self) -> PlaywrightBrowser:
 		"""Get a browser context"""


### PR DESCRIPTION
### Problem  
When `config=None` is passed to `Browser.new_context()`, it passes the BrowserConfig object directly to BrowserContext rather than allowing `BrowserContext.__init__` to handle the config creation logic properly.
```  
def __init__(
  self,
  browser: 'Browser',
  config: BrowserContextConfig | None = None,
  state: Optional[BrowserContextState] = None,
):
  self.context_id = str(uuid.uuid4())
  
  self.config = config or BrowserContextConfig(**(browser.config.model_dump() if browser.config else {}))
```  

resulting in errors like:
```  
'BrowserConfig' object has no attribute 'user_agent'
```  

![image](https://github.com/user-attachments/assets/1699f052-fad2-4104-9fff-7b063b61f0fa)  

### Testing
```python  
import os
import sys
import asyncio

from dotenv import load_dotenv
from langchain_openai import ChatOpenAI
from browser_use.browser.browser import Browser, BrowserConfig, BrowserContext
from browser_use import Agent

load_dotenv()

llm = ChatOpenAI(
	model='gpt-4o-mini',
)
task = 'Find the founders of browser-use and draft them a short personalized message'

async def main():
  browser = Browser(
    config=BrowserConfig(
      headless=False,
    )
  )
  async with await browser.new_context() as context:
    agent = Agent(
      task=task, 
      llm=llm, 
      browser_context=context,
      generate_gif=False,
      enable_memory=False,
    )
    await agent.run()

  await browser.close()

if __name__ == '__main__':
	asyncio.run(main())

```  
