### PR TITLE
Follow XDG Base Directory Specification to store telemetry_user_id

### DIFF
--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -20,6 +20,14 @@ POSTHOG_EVENT_SETTINGS = {
 }
 
 
+def xdg_cache_home() -> Path:
+	default = Path.home() / '.cache'
+	env_var = os.getenv('XDG_CACHE_HOME')
+	if env_var and (path := Path(env_var)).is_absolute():
+		return path
+	return default
+
+
 @singleton
 class ProductTelemetry:
 	"""
@@ -28,7 +36,7 @@ class ProductTelemetry:
 	If the environment variable `ANONYMIZED_TELEMETRY=False`, anonymized telemetry will be disabled.
 	"""
 
-	USER_ID_PATH = str(Path.home() / '.cache' / 'browser_use' / 'telemetry_user_id')
+	USER_ID_PATH = str(xdg_cache_home() / 'browser_use' / 'telemetry_user_id')
 	PROJECT_API_KEY = 'phc_F8JMNjW1i2KbGUTaW1unnDdLSPCoyc52SGRU0JecaUh'
 	HOST = 'https://eu.i.posthog.com'
 	UNKNOWN_USER_ID = 'UNKNOWN'


### PR DESCRIPTION
The `telemetry_user_id` is always stored in `~/.cache`. This is annoying for users that have set a different `XDG_CACHE_HOME` in their env.

Implementation follows the latest version of the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/).