### PR TITLE
Use ainvoke for async LLM call in extract_content

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -325,7 +325,7 @@ class Controller(Generic[Context]):
 			prompt = 'Your task is to extract the content of the page. You will be given a page and a goal and you should extract all relevant information around this goal from the page. If the goal is vague, summarize the page. Respond in json format. Extraction goal: {goal}, Page: {page}'
 			template = PromptTemplate(input_variables=['goal', 'page'], template=prompt)
 			try:
-				output = page_extraction_llm.invoke(template.format(goal=goal, page=content))
+				output = await page_extraction_llm.ainvoke(template.format(goal=goal, page=content))
 				msg = f'📄  Extracted from page\n: {output.content}\n'
 				logger.info(msg)
 				return ActionResult(extracted_content=msg, include_in_memory=True)


### PR DESCRIPTION
https://github.com/browser-use/browser-use/blob/eb6ad20bd981ec83ad7aa7383f47eafb65b5342b/browser_use/controller/service.py#L328

Replaced synchronous invoke with await ainvoke in the extract_content method to support proper async behavior under concurrent load.

This improves performance in high-concurrency situations and avoids blocking the event loop.