### PR TITLE
Ensure element handle is visible before trying to scroll into view

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -1221,7 +1221,9 @@ class BrowserContext:
 				# Try to scroll into view if hidden
 				element_handle = await current_frame.query_selector(css_selector)
 				if element_handle:
-					await element_handle.scroll_into_view_if_needed()
+					is_hidden = await element_handle.is_hidden()
+					if not is_hidden:
+						await element_handle.scroll_into_view_if_needed()
 					return element_handle
 				return None
 		except Exception as e:
@@ -1239,7 +1241,9 @@ class BrowserContext:
 			# Use XPath to locate the element
 			element_handle = await current_frame.query_selector(f'xpath={xpath}')
 			if element_handle:
-				await element_handle.scroll_into_view_if_needed()
+				is_hidden = await element_handle.is_hidden()
+				if not is_hidden:
+					await element_handle.scroll_into_view_if_needed()
 				return element_handle
 			return None
 		except Exception as e:
@@ -1257,7 +1261,9 @@ class BrowserContext:
 			# Use CSS selector to locate the element
 			element_handle = await current_frame.query_selector(css_selector)
 			if element_handle:
-				await element_handle.scroll_into_view_if_needed()
+				is_hidden = await element_handle.is_hidden()
+				if not is_hidden:
+					await element_handle.scroll_into_view_if_needed()
 				return element_handle
 			return None
 		except Exception as e:
@@ -1294,7 +1300,9 @@ class BrowserContext:
 			else:
 				element_handle = elements[0]
 
-			await element_handle.scroll_into_view_if_needed()
+			is_hidden = await element_handle.is_hidden()
+			if not is_hidden:
+				await element_handle.scroll_into_view_if_needed()
 			return element_handle
 		except Exception as e:
 			logger.error(f"❌  Failed to locate element by text '{text}': {str(e)}")
@@ -1319,7 +1327,9 @@ class BrowserContext:
 			# Ensure element is ready for input
 			try:
 				await element_handle.wait_for_element_state('stable', timeout=1000)
-				await element_handle.scroll_into_view_if_needed(timeout=1000)
+				is_hidden = await element_handle.is_hidden()
+				if not is_hidden:
+					await element_handle.scroll_into_view_if_needed(timeout=1000)
 			except Exception:
 				pass
 

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -176,7 +176,9 @@ class Controller(Generic[Context]):
 				element_node = await browser.get_locate_element_by_css_selector(params.css_selector)
 				if element_node:
 					try:
-						await element_node.scroll_into_view_if_needed()
+						is_hidden = await element_node.is_hidden()
+						if not is_hidden:
+							await element_node.scroll_into_view_if_needed()
 						await element_node.click(timeout=1500, force=True)
 					except Exception:
 						try:
@@ -197,7 +199,9 @@ class Controller(Generic[Context]):
 				element_node = await browser.get_locate_element_by_xpath(params.xpath)
 				if element_node:
 					try:
-						await element_node.scroll_into_view_if_needed()
+						is_hidden = await element_node.is_hidden()
+						if not is_hidden:
+							await element_node.scroll_into_view_if_needed()
 						await element_node.click(timeout=1500, force=True)
 					except Exception:
 						try:
@@ -221,7 +225,9 @@ class Controller(Generic[Context]):
 
 				if element_node:
 					try:
-						await element_node.scroll_into_view_if_needed()
+						is_hidden = await element_node.is_hidden()
+						if not is_hidden:
+							await element_node.scroll_into_view_if_needed()
 						await element_node.click(timeout=1500, force=True)
 					except Exception:
 						try:


### PR DESCRIPTION
## What
Added a `not is_hidden` check before every `scroll_into_view_if_needed()` call.

## Why
Noticed when trying to upload a file on this [website](https://v0-download-and-upload-text.vercel.app/) the agent timed out: `Failed to locate element: ElementHandle.scroll_into_view_if_needed: Timeout 30000ms exceeded.`

When looking closer at the HTML code of the website I noticed the button for uploading itself did not have any input for `type=file`, instead it had a sibling `<input type="file" accept=".txt" class="hidden">` which was hidden. This is the element we would have needed to perform the upload.

So whenever we tried to find the element using `await browser.get_locate_element(file_upload_dom_el)`, it tried to scroll into view, but couldn't since the element was hidden.

## Testing
Tested locally with the same file upload website. 