### PR TITLE
Fix prompt variable syntax: replace {{max_actions}} with {max_actions}

### DIFF
--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -23,7 +23,7 @@ Example:
 "next_goal": "What needs to be done with the next immediate action"}},
 "action":[{{"one_action_name": {{// action-specific parameter}}}}, // ... more actions in sequence]}}
 
-2. ACTIONS: You can specify multiple actions in the list to be executed in sequence. But always specify only one action name per item. Use maximum {{max_actions}} actions per sequence.
+2. ACTIONS: You can specify multiple actions in the list to be executed in sequence. But always specify only one action name per item. Use maximum {max_actions} actions per sequence.
 Common action sequences:
 - Form filling: [{{"input_text": {{"index": 1, "text": "username"}}}}, {{"input_text": {{"index": 2, "text": "password"}}}}, {{"click_element": {{"index": 3}}}}]
 - Navigation and extraction: [{{"go_to_url": {{"url": "https://example.com"}}}}, {{"extract_content": {{"goal": "extract the names"}}}}]


### PR DESCRIPTION
The double braces prevented the value from being interpolated properly. Updated to single braces so `format` correctly replaces it with the real value.