### PR TITLE
add langchain-deepseek as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "langchain-anthropic==0.3.3",
     "langchain-ollama==0.3.0",
     "langchain-google-genai==2.1.2",
+    "langchain-deepseek>=0.1.3",
     "langchain>=0.3.21",
     "langchain-aws>=0.2.11",
     "botocore>=1.37.23",


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added langchain-deepseek as a dependency to support proper environment variable validation. This change ensures DeepSeek API users can leverage native DeepSeek integration rather than using workarounds with the OpenAI client.

**Dependencies**
- Added langchain-deepseek (version >=0.1.3) to the project dependencies.

**Bug Fixes**
- Fixed environment variable validation for DeepSeek API users who previously had to use OpenAI client workarounds.

<!-- End of auto-generated description by mrge. -->

since now the validation of the required LLM env vars is made using this logic: 
`llm_api_env_vars = REQUIRED_LLM_API_ENV_VARS.get(self.llm.__class__.__name__, []) `
you have to use the langchain's deepseek class if using deepseek api, when before you could bypass it with something like this:

```python
model = ChatOpenAI(
			base_url='https://api.deepseek.com/v1',
			model='deepseek-chat',
			api_key=SecretStr(api_key),
		)
```