### PR TITLE
Assign playwright if successful start prior to browser initialization

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -146,9 +146,9 @@ class Browser:
 	async def _init(self):
 		"""Initialize the browser session"""
 		playwright = await async_playwright().start()
-		browser = await self._setup_browser(playwright)
-
 		self.playwright = playwright
+
+		browser = await self._setup_browser(playwright)
 		self.playwright_browser = browser
 
 		return self.playwright_browser


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed a bug in browser initialization by storing the playwright reference before browser setup. This change ensures the playwright instance is properly assigned even if browser initialization fails.

**Bug Fixes**
- Moved the playwright assignment before browser setup to prevent reference loss during errors.
- Reordered initialization sequence to ensure proper cleanup if browser setup fails.

<!-- End of auto-generated description by mrge. -->

Fixes #1351 