### PR TITLE
feat: add agent setting to generate playwright locators

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -32,6 +32,8 @@ REQUIRED_LLM_API_ENV_VARS = {
 	'ChatOllama': [],
 }
 
+PlaywrightLocatorLanguage = Literal['javascript', 'python']
+
 
 class AgentSettings(BaseModel):
 	"""Options for the agent"""
@@ -62,6 +64,12 @@ class AgentSettings(BaseModel):
 		'aria-expanded',
 	]
 	max_actions_per_step: int = 10
+
+	playwright_locator_language: Optional[PlaywrightLocatorLanguage] = None
+	"""
+	When set, generates a playwright locator for each interacted element, if it has an xpath, in the
+	specified language. When not set, no playwright locators are generated.
+	"""
 
 	tool_calling_method: Optional[ToolCallingMethod] = 'auto'
 	page_extraction_llm: Optional[BaseChatModel] = None

--- a/browser_use/dom/history_tree_processor/view.py
+++ b/browser_use/dom/history_tree_processor/view.py
@@ -51,6 +51,13 @@ class DOMHistoryElement:
 	viewport_coordinates: Optional[CoordinateSet] = None
 	viewport_info: Optional[ViewportInfo] = None
 
+	locator_str: Optional[str] = None
+	"""
+	Playwright locator string for the element.
+
+	It only gets set if playwright locator codegen is enabled, and the element has an xpath.
+	"""
+
 	def to_dict(self) -> dict:
 		page_coordinates = self.page_coordinates.model_dump() if self.page_coordinates else None
 		viewport_coordinates = self.viewport_coordinates.model_dump() if self.viewport_coordinates else None
@@ -67,4 +74,5 @@ class DOMHistoryElement:
 			'page_coordinates': page_coordinates,
 			'viewport_coordinates': viewport_coordinates,
 			'viewport_info': viewport_info,
+			'locator_str': self.locator_str,
 		}

--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -49,6 +49,16 @@ agent = Agent(
 - `save_conversation_path`: Path to save the complete conversation history. Useful for debugging.
 - `override_system_message`: Completely replace the default system prompt with a custom one.
 - `extend_system_message`: Add additional instructions to the default system prompt.
+- `playwright_locator_language`: Set to `"javascript"` or `"python"` to generate playwright locators
+  for each interacted element in that respective language.
+
+<Note>
+  When generating Playwright locators, you must handle injecting the `playwright` instance into the
+  browser context. This is outside the scope of browser-use. One way of achieving this is to start
+  playwright and "pause" the page. See Playwright's [Test Generator
+  documentation](https://playwright.dev/python/docs/codegen#record-using-custom-setup) for more
+  information.
+</Note>
 
 <Note>
   Vision capabilities are recommended for better web interaction understanding,


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added Playwright locator generation for interacted elements with language selection options. This feature helps users create reliable Playwright test scripts by automatically generating locators in JavaScript or Python.

**New Features**
- Added `playwright_locator_language` agent setting that accepts `"javascript"` or `"python"` values
- Implemented automatic generation of Playwright locators for elements with XPaths
- Added locator strings to state history for each interacted element
- Updated documentation with usage instructions and requirements

**Refactors**
- Restructured element interaction tracking to support locator generation
- Improved error handling for locator generation failures

<!-- End of auto-generated description by mrge. -->

# Preface

Hello! We had a project requirement to generate Playwright locators which required changes to browser-use, so I figured I'd create a PR here to see if it made sense to include. I will say, that the, as far as I can tell, full implementation of this feature is outside the scope of browser-use, because `playwright` must be made accessible in the browser, which, by default, it is not, and seems outside the scope of browser-use.

One method of injecting `playwright` is to launch a browser with CDP enabled, run some Playwright code, "pause" the page (which opens a codegen window), and connect to that browser with browser-use over CDP. You can read more here: https://playwright.dev/python/docs/codegen#record-using-custom-setup

# Summary

This change adds a new agent setting, `playwright_locator_language` which can be set to enable Playwright locator codegen for all interacted elements. It defaults to `None`, but accepts values of `"javascript"` and `"python"`, which control the language the codegen outputs.

The generated locator string will exist in the state history as part of the agent history item.

### Example

Element with XPath `html/body/dialog/form/button` could generate a Playwright locator string of `get_by_role("button", name="Login")`.