### PR TITLE
Fix: Default to BrowserContextConfig in Browser.new_context

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -133,7 +133,9 @@ class Browser:
 
 	async def new_context(self, config: BrowserContextConfig | None = None) -> BrowserContext:
 		"""Create a browser context"""
-		return BrowserContext(config=config or self.config, browser=self)
+		# Use a default BrowserContextConfig if none is provided, instead of self.config
+		context_config = config or BrowserContextConfig()
+		return BrowserContext(config=context_config, browser=self)
 
 	async def get_playwright_browser(self) -> PlaywrightBrowser:
 		"""Get a browser context"""


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed a type mismatch bug in Browser.new_context by using BrowserContextConfig instead of BrowserConfig. This prevents AttributeError when accessing user_agent attribute that exists in BrowserContextConfig but not in BrowserConfig.

**Bug Fixes**
- Changed Browser.new_context to default to a new BrowserContextConfig instance instead of self.config
- Added explanatory comment to clarify the configuration object usage
- Prevents AttributeError when the BrowserContext constructor tries to access missing attributes

<!-- End of auto-generated description by mrge. -->

The Browser.new_context method previously defaulted to using the Browser instance's own config (self.config), which is a BrowserConfig object. This caused an AttributeError when the BrowserContext constructor tried to access the user_agent attribute, as BrowserConfig lacks this attribute.

This change modifies Browser.new_context to default to a new BrowserContextConfig instance when no specific config is provided, ensuring the BrowserContext receives a configuration object with the expected attributes.