### PR TITLE
Fix non-alphabet character rendering issues in gif picture

### DIFF
--- a/browser_use/agent/gif.py
+++ b/browser_use/agent/gif.py
@@ -49,7 +49,8 @@ def create_history_gif(
 	# Try to load nicer fonts
 	try:
 		# Try different font options in order of preference
-		font_options = ['Helvetica', 'Arial', 'DejaVuSans', 'Verdana']
+		# ArialUni is a font that comes with Office and can render most non-alphabet characters
+		font_options = ['Helvetica', 'ArialUni', 'Arial', 'DejaVuSans', 'Verdana']
 		font_loaded = False
 
 		for font_name in font_options:


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Added ArialUni font to the rendering options for GIF images to properly display non-alphabetic Unicode characters. This fix addresses issue #648 by supporting Chinese, Japanese, Korean, and other international character sets.

**Bug Fixes**
- Added ArialUni font to the font preference list for GIF rendering
- Prioritized ArialUni before Arial to better handle non-alphabetic characters

**Dependencies**
- Requires ArialUni font, which comes with Microsoft Office
- Font can be downloaded from GitHub if Office is not installed

<!-- End of auto-generated description by mrge. -->

Added ArialUni font rendering option, which is an Arial Unicode font that comes with MS Office and can be used to render most non-alphabetic Unicode characters, including Chinese, Japanese, Korean, etc. This addresses issue #648.

Dependencies:

If Microsoft Office is installed on the system, this font is automatically usable. If not, this font can be easily downloaded from: https://github.com/kaienfr/Font/blob/master/font/ARIALUNI.TTF