### PR TITLE
Fix AgentHookFunc type

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -83,7 +83,7 @@ def log_response(response: AgentOutput) -> None:
 
 Context = TypeVar('Context')
 
-AgentHookFunc = Callable[['Agent'], None]
+AgentHookFunc = Callable[['Agent'], Awaitable[None]]
 
 
 class Agent(Generic[Context]):


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed the AgentHookFunc type definition to correctly reflect its awaitable nature in the agent service. This change resolves linter errors and clarifies how the hooks should be implemented.

**Bug Fixes**
- Updated AgentHookFunc type from `Callable[['Agent'], None]` to `Callable[['Agent'], Awaitable[None]]` to match actual usage.
- Resolved linter errors in custom hooks implementation where async functions were expected.

<!-- End of auto-generated description by mrge. -->

Fix AgentHookFunc type to be awaitable to correctly reflect usage of await on_step_start(self) and await on_step_end(self) in the agent service

Originally we had defined
AgentHookFunc = Callable[['Agent'], None]

However we had args of this type:
on_step_start: AgentHookFunc | None = None, on_step_end: AgentHookFunc 
Which we called like this:
if on_step_start is not None:
    await on_step_start(self)
if on_step_end is not None:
    await on_step_end(self)

So really the type should be awaitable
AgentHookFunc = Callable[['Agent'], Awaitable[None]]

This change clears up the linter error that was present in custom-functions\custom_hooks_before_after_step.py
And makes the usage of these hooks more clear