### PR TITLE
Fix: incorrect config type in BrowserContext instantiation

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -133,7 +133,7 @@ class Browser:
 
 	async def new_context(self, config: BrowserContextConfig | None = None) -> BrowserContext:
 		"""Create a browser context"""
-		return BrowserContext(config=config or self.config, browser=self)
+		return BrowserContext(config=config or BrowserContextConfig(**(self.config.model_dump() if self.config else {})), browser=self)
 
 	async def get_playwright_browser(self) -> PlaywrightBrowser:
 		"""Get a browser context"""


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed a type mismatch in the BrowserContext instantiation process. This change ensures the correct configuration type is passed when creating a new browser context.

**Bug Fixes**
- Updated the `new_context` method to properly convert the browser's config to a BrowserContextConfig object.
- Resolved issue #1377 where incorrect config type was causing instantiation problems.

<!-- End of auto-generated description by mrge. -->

The problem description refers to this PR https://github.com/browser-use/browser-use/issues/1377