### PR TITLE
fix config merging between BrowserConfig and BrowserContextConfig in Browser.new_context

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -133,8 +133,8 @@ class Browser:
 
 	async def new_context(self, config: BrowserContextConfig | None = None) -> BrowserContext:
 		"""Create a browser context"""
-		browser_config = dict(self.config or {})
-		context_config = dict(config or {})
+		browser_config = self.config.model_dump() if self.config else {}
+		context_config = config.model_dump() if config else {}
 		merged_config = {**browser_config, **context_config}
 		return BrowserContext(config=BrowserContextConfig(**merged_config), browser=self)
 

--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -133,9 +133,10 @@ class Browser:
 
 	async def new_context(self, config: BrowserContextConfig | None = None) -> BrowserContext:
 		"""Create a browser context"""
-		return BrowserContext(
-			config=config or BrowserContextConfig(**(self.config.model_dump() if self.config else {})), browser=self
-		)
+		browser_config = dict(self.config or {})
+		context_config = dict(config or {})
+		merged_config = {**browser_config, **context_config}
+		return BrowserContext(config=BrowserContextConfig(**merged_config), browser=self)
 
 	async def get_playwright_browser(self) -> PlaywrightBrowser:
 		"""Get a browser context"""


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed a bug in the configuration merging logic between Browser and BrowserContext objects. This ensures that context-specific configurations properly override browser-level defaults when creating a new browser context.

**Bug Fixes**
- Replaced the direct model_dump approach with proper dictionary merging
- Ensured context-specific configurations take precedence over browser defaults
- Improved code readability by breaking the operation into clear, separate steps

<!-- End of auto-generated description by mrge. -->

