### PR TITLE
Fix: newlines in attribute values

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -1212,6 +1212,9 @@ class BrowserContext:
 					css_selector += f'[{safe_attribute}]'
 				elif any(char in value for char in '"\'<>`\n\r\t'):
 					# Use contains for values with special characters
+					# For newline-containing text, only use the part before the newline
+					if '\n' in value:
+						value = value.split('\n')[0]
 					# Regex-substitute *any* whitespace with a single space, then strip.
 					collapsed_value = re.sub(r'\s+', ' ', value).strip()
 					# Escape embedded double-quotes.


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed CSS selector generation for elements with newline characters in attribute values by truncating values at the first newline.

<!-- End of auto-generated description by mrge. -->

