### PR TITLE
fix: set highlight div backgroundColor to transparent

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -212,6 +212,7 @@
         container.style.width = "100%";
         container.style.height = "100%";
         container.style.zIndex = "2147483647";
+        container.style.backgroundColor = 'transparent';
         document.body.appendChild(container);
       }
 


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Fixed highlight container transparency by setting the backgroundColor to transparent, preventing potential overlay issues in the DOM tree visualization.

<!-- End of auto-generated description by mrge. -->

https://github.com/bytedance/UI-TARS-desktop/pull/500