### PR TITLE
fix: Make memory module optional for Python 3.13 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ With pip (Python>=3.11):
 pip install browser-use
 ```
 
+For memory functionality (requires Python<3.13 due to PyTorch compatibility):  
+
+```bash
+pip install "browser-use[memory]"
+```
+
 Install Playwright:
 ```bash
 playwright install chromium

--- a/browser_use/agent/memory/service.py
+++ b/browser_use/agent/memory/service.py
@@ -9,7 +9,6 @@ from langchain_core.messages import (
 	HumanMessage,
 )
 from langchain_core.messages.utils import convert_to_openai_messages
-from mem0 import Memory as Mem0Memory
 from pydantic import BaseModel
 
 from browser_use.agent.message_manager.service import MessageManager
@@ -51,6 +50,9 @@ class Memory:
 		self.llm = llm
 		self.settings = settings
 		self._memory_config = self.settings.config or self._get_default_config(llm)
+		
+		# Import mem0 here - if it's not installed, the ImportError will propagate up
+		from mem0 import Memory as Mem0Memory
 		self.mem0 = Mem0Memory.from_config(config_dict=self._memory_config)
 
 	@staticmethod

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -254,18 +254,26 @@ class Agent(Generic[Context]):
 		)
 
 		if self.settings.enable_memory:
-			memory_settings = MemorySettings(
-				agent_id=self.state.agent_id,
-				interval=self.settings.memory_interval,
-				config=self.settings.memory_config,
-			)
+			try:
+				memory_settings = MemorySettings(
+					agent_id=self.state.agent_id,
+					interval=self.settings.memory_interval,
+					config=self.settings.memory_config,
+				)
 
-			# Initialize memory
-			self.memory = Memory(
-				message_manager=self._message_manager,
-				llm=self.llm,
-				settings=memory_settings,
-			)
+				# Initialize memory
+				self.memory = Memory(
+					message_manager=self._message_manager,
+					llm=self.llm,
+					settings=memory_settings,
+				)
+			except ImportError:
+				logger.warning(
+					"Memory functionality was enabled but required packages are not installed. "
+					"Install with 'pip install browser-use[memory]' to use memory features."
+				)
+				self.memory = None
+				self.settings.enable_memory = False
 		else:
 			self.memory = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = [
     "typing-extensions>=4.12.2",
     "psutil>=7.0.0",
     "faiss-cpu>=1.10.0",
+]
+
+# Optional dependencies for memory functionality
+[project.optional-dependencies]
+memory = [
     "mem0ai==0.1.88",
     "sentence-transformers>=4.0.2"
 ]
@@ -46,8 +51,9 @@ dependencies = [
 # screeninfo: only used to get screen resolution on Linux/Windows
 # markdownify: used for page text content extraction for passing to LLM
 # openai: datalib,voice-helpers are actually NOT NEEDED but openai produces noisy errors on exit without them TODO: fix
-urls = { "Repository" = "https://github.com/browser-use/browser-use" }
-
+# mem0ai and sentence-transformers: only used for memory functionality, moved to optional dependencies
+[project.urls]
+Repository = "https://github.com/browser-use/browser-use"
 
 [tool.codespell]
 ignore-words-list = "bu"


### PR DESCRIPTION
<!-- This is an auto-generated description by mrge. -->
## Summary by mrge
Made the memory module optional to support Python 3.13, allowing the package to work without memory features if dependencies are missing.

- **Dependencies**
  - Moved memory-related packages to optional dependencies.
  - Updated code to handle missing memory dependencies with a warning instead of failing.

<!-- End of auto-generated description by mrge. -->

## Description

This addresses issue #1361 by making the memory functionality optional to support Python 3.13.

The `mem0` package depends on `sentence_transformers`, which requires PyTorch, but PyTorch has [issues](https://github.com/pytorch/pytorch/issues/130249) supporting Python 3.13. This causes failures when trying to use browser-use with Python 3.13.

## Changes

1. Moved `mem0ai` and `sentence-transformers` to optional dependencies in `pyproject.toml`
2. Modified the memory module to lazy imports

## Testing

Tested with:
- Python 3.13 without memory dependencies: ✅ Works with warning message
![image](https://github.com/user-attachments/assets/001e96cc-86c0-4df3-8226-556eef1fb789)  


- Python 3.11 with memory dependencies: ✅ Works with full memory functionality
![image](https://github.com/user-attachments/assets/4df69510-de37-450c-af70-85f729fd4727)  

## Demo
```python  
import os
import asyncio
from dotenv import load_dotenv
from langchain_openai import ChatOpenAI
from browser_use import Agent

load_dotenv()
if not os.getenv('OPENAI_API_KEY'):
	raise ValueError('OPENAI_API_KEY is not set. Please add it to your environment variables.')

async def main():
	llm = ChatOpenAI(
		model='gpt-4o-mini',
	)

	agent = Agent(
		task='search the author of browser-use on google',
		llm=llm,
		enable_memory=True
	)
	await agent.run()
	input('Press Enter to exit')

if __name__ == '__main__':
	asyncio.run(main())
```  

