### PR TITLE
fix: update version retrieval method to use importlib.metadata

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -326,9 +326,9 @@ class Agent(Generic[Context]):
 				source = 'git'
 			else:
 				# If no repo files found, try getting version from pip
-				import pkg_resources
+				from importlib.metadata import version
 
-				version = pkg_resources.get_distribution('browser-use').version
+				version = version('browser-use')
 				source = 'pip'
 		except Exception:
 			version = 'unknown'


### PR DESCRIPTION
Fixes #1415 <!-- This is an auto-generated description by mrge. -->
---


## Summary by mrge
Updated version retrieval to use importlib.metadata instead of pkg_resources for better compatibility.

<!-- End of auto-generated description by mrge. -->

