### PR TITLE
fix: update example_tool_call to use click_element_by_index action

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -83,19 +83,19 @@ class MessageManager:
 						""".strip(),
 						'memory': """
 							I searched for 'iPhone retailers' on Google. From the Google Search results page, 
-							I used the 'click_element' tool to click on a element labelled 'Best Buy' but calling 
-							the tool did not direct me to a new page. I then used the 'click_element' tool to click 
-							on a element labelled 'Apple' which redirected me to the 'Apple' company homepage. 
+							I used the 'click_element_by_index' tool to click on element at index [45] labeled 'Best Buy' but calling 
+							the tool did not direct me to a new page. I then used the 'click_element_by_index' tool to click 
+							on element at index [82] labeled 'Apple' which redirected me to the 'Apple' company homepage. 
 							Currently at step 3/15.
 						""".strip(),
 						'next_goal': """
 							Looking at reported structure of the current page, I can see the item '[127]<h3 iPhone/>' 
 							in the content. I think this button will lead to more information and potentially prices 
-							for iPhones. I'll click on the link to 'iPhone' at index [127] using the 'click_element' 
+							for iPhones. I'll click on the link at index [127] using the 'click_element_by_index' 
 							tool and hope to see prices on the next page.
 						""".strip(),
 					},
-					'action': [{'click_element': {'index': 127}}],
+					'action': [{'click_element_by_index': {'index': 127}}],
 				},
 				'id': str(self.state.tool_id),
 				'type': 'tool_call',


### PR DESCRIPTION
## Description
This fixes #1430 where clicking actions stopped working after recent changes to the click action implementations. The root cause was that the `example_tool_call` in the message manager was using the old action format, while the actual implementation has been changed through several commits:

1. `click_element` was renamed to `click_element_by_index` in [63f54cc](https://github.com/browser-use/browser-use/commit/63f54cc10061e677c3aa65c5a7e5da6ba5e06aab#diff-af6f6bc87d2d09d2a9f08f03fc959eb25b5637f37e959ec655daeba030ede225L114-R117)
2. Then `ClickElementByTextAction` and `ClickElementByXpathAction` were removed in [dd29dfb](https://github.com/browser-use/browser-use/commit/dd29dfb7c7f8424ce3be50fe409aa8e441f2ee93)
3. `ClickElementBySelectorAction` was also removed in [922ad08](https://github.com/browser-use/browser-use/commit/922ad08fd71c73627151b02fb213fd1b51200e69)

This left only `click_element_by_index` as the valid click action, but the `example_tool_call` was still using the old format.  
We kept `click_element_by_index` instead of reverting to `click_element` as it better reflects the index-based selection approach and prevents confusion if other click methods are added in the future.

## Before
![image](https://github.com/user-attachments/assets/c0c75899-3d01-41b4-bfd6-6e955dd4d834)  

## After
![image](https://github.com/user-attachments/assets/bdeb3e35-5a71-414a-8178-877514258d95)  

