### PR TITLE
change GOOGLE_API_KEY to GEMINI_API_KEY.

### DIFF
--- a/docs/customize/supported-models.mdx
+++ b/docs/customize/supported-models.mdx
@@ -115,7 +115,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from browser_use import Agent
 from dotenv import load_dotenv
 
-# Read GOOGLE_API_KEY into env
+# Read GEMINI_API_KEY into env
 load_dotenv()
 
 # Initialize the model
@@ -131,7 +131,7 @@ agent = Agent(
 Required environment variables:
 
 ```bash .env
-GOOGLE_API_KEY=
+GEMINI_API_KEY=
 ```
 
 


### PR DESCRIPTION
Changed GOOGLE_API_KEY to GEMINI_API_KEY. If one sets their Gemini API key as GOOGLE_API_KEY in their .env file these errors return:
```
WARNING  [agent] ❌ LLM API Key environment variables not set up for ChatGoogleGenerativeAI, missing: ['GEMINI_API_KEY']
ValueError: LLM API Key environment variables not set up for ChatGoogleGenerativeAI, missing: ['GEMINI_API_KEY']
```
This fix makes the docs clearer and avoid the user being led into setting up their key as GOOGLE_API_KEY<!-- This is an auto-generated description by mrge. -->
---


## Summary by mrge
Updated the documentation to use GEMINI_API_KEY instead of GOOGLE_API_KEY for Gemini model setup, preventing user errors and setup issues.

<!-- End of auto-generated description by mrge. -->

