### PR TITLE
Fix: add an extra check in the DOM processing code for file tree nodes

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -726,6 +726,12 @@
       // If checking listeners fails, rely on other checks
     }
 
+    // Added: Treat file tree nodes as interactive.
+    // This ensures that elements within a file tree (with class "file-tree-node") are considered clickable.
+    if (element.classList && element.classList.contains('file-tree-node')) {
+      return true;
+    }
+
     return false
   }
 


### PR DESCRIPTION
In version 0.1.41 the file tree nodes are seen as common elements rather than interactive ones so the agent incorrectly reports that files were downloaded even though none were.

Proposed fix:
In the DOM helper function `isInteractiveElement` , add a check for file tree nodes so that these elements are now treated as interactive and downloadable.

Fixes #1433 <!-- This is an auto-generated description by mrge. -->
---


## Summary by mrge
File tree nodes are now correctly recognized as interactive elements, so the agent no longer reports false file downloads.

<!-- End of auto-generated description by mrge. -->

