### PR TITLE
Fixs #1442 : 'AgentSettings' object has no attribute 'enable_memory'

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -215,7 +215,7 @@ class Agent(Generic[Context]):
 			f'{" +tools" if self.tool_calling_method == "function_calling" else ""}'
 			f'{" +rawtools" if self.tool_calling_method == "raw" else ""}'
 			f'{" +vision" if self.settings.use_vision else ""}'
-			f'{" +memory" if self.settings.enable_memory else ""}, '
+			f'{" +memory" if self.enable_memory else ""}, '
 			f'planner_model={self.planner_model_name}'
 			f'{" +reasoning" if self.settings.is_planner_reasoning else ""}'
 			f'{" +vision" if self.settings.use_vision_for_planner else ""}, '


### PR DESCRIPTION
Fixes https://github.com/browser-use/browser-use/issues/1442
Fix: Corrected reference to enable_memory attribute in agent initialization.

Replaced self.settings.enable_memory with self.enable_memory to fix the error: 'AgentSettings' object has no attribute 'enable_memory'.
<!-- This is an auto-generated description by mrge. -->
---


## Summary by mrge
Fixed an error in agent initialization by using self.enable_memory instead of self.settings.enable_memory. This prevents attribute errors when starting the agent.

<!-- End of auto-generated description by mrge. -->

