### PR TITLE
Update mem0ai as a dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "typing-extensions>=4.12.2",
     "psutil>=7.0.0",
     "faiss-cpu>=1.10.0",
+    "mem0ai==0.1.93",
 ]
 # botocore: only needed for Bedrock Claude boto3 examples/models/bedrock_claude.py 
 # pydantic: >2.11 introduces many pydantic deprecation warnings until langchain-core upgrades their pydantic support lets keep it on 2.10
@@ -49,7 +50,6 @@ dependencies = [
 # Optional dependencies for memory functionality
 [project.optional-dependencies]
 memory = [
-    "mem0ai==0.1.91",
     "sentence-transformers>=4.0.2",
 ]
 


### PR DESCRIPTION
Given that we have enabled memory as default, we should move `mem0ai` into the main dependency list. By default, `mem0ai` library is pretty light weight and doesn't incur any overhead in terms of developer experience. 