### PR TITLE
ruff rule FAST002: FastAPI dependency without `Annotated`

### DIFF
--- a/examples/features/pause_agent.py
+++ b/examples/features/pause_agent.py
@@ -9,7 +9,6 @@ dotenv.load_dotenv()
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import threading
-import time
 
 from langchain_openai import ChatOpenAI
 
@@ -98,7 +97,7 @@ async def main():
 					agent_thread.join()
 			break
 
-		time.sleep(0.1)  # Small delay to prevent CPU spinning
+		asyncio.sleep(0.1)  # Small delay to prevent CPU spinning
 
 
 if __name__ == '__main__':

--- a/examples/features/pause_agent.py
+++ b/examples/features/pause_agent.py
@@ -97,7 +97,7 @@ async def main():
 					agent_thread.join()
 			break
 
-		asyncio.sleep(0.1)  # Small delay to prevent CPU spinning
+		await asyncio.sleep(0.1)  # Small delay to prevent CPU spinning
 
 
 if __name__ == '__main__':

--- a/examples/integrations/slack/slack_api.py
+++ b/examples/integrations/slack/slack_api.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Annotated
 
 from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -101,7 +102,7 @@ class SlackBot:
 
 
 @app.post('/slack/events')
-async def slack_events(request: Request, slack_bot: SlackBot = Depends()):
+async def slack_events(request: Request, slack_bot: Annotated[SlackBot, Depends()]):
 	try:
 		if not slack_bot.signature_verifier.is_valid_request(await request.body(), dict(request.headers)):
 			logger.warning('Request verification failed')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ line-length = 130
 fix = true
 
 [tool.ruff.lint]
-select = ["ASYNC", "E", "F", "I", "PLE"]
+select = ["ASYNC", "E", "F", "FAST", "I", "PLE"]
 ignore = ["ASYNC109", "E101", "E402", "E501", "F841", "E731"]  # TODO: determine if adding timeouts to all the unbounded async functions is needed / worth-it so we can un-ignore ASYNC109
 unfixable = ["E101", "E402", "E501", "F841", "E731"]
 


### PR DESCRIPTION
https://fastapi.tiangolo.com/tutorial/query-params-str-validations/?h=annotated#advantages-of-annotated

% `ruff rule FAST002`
# fast-api-non-annotated-dependency (FAST002)

Derived from the **FastAPI** linter.

Fix is sometimes available.

## What it does
Identifies FastAPI routes with deprecated uses of `Depends` or similar.

## Why is this bad?
The [FastAPI documentation] recommends the use of [`typing.Annotated`][typing-annotated]
for defining route dependencies and parameters, rather than using `Depends`,
`Query` or similar as a default value for a parameter. Using this approach
everywhere helps ensure consistency and clarity in defining dependencies
and parameters.

`Annotated` was added to the `typing` module in Python 3.9; however,
the third-party [`typing_extensions`][typing-extensions] package
provides a backport that can be used on older versions of Python.

## Example

```python
from fastapi import Depends, FastAPI

app = FastAPI()


async def common_parameters(q: str | None = None, skip: int = 0, limit: int = 100):
    return {"q": q, "skip": skip, "limit": limit}


@app.get("/items/")
async def read_items(commons: dict = Depends(common_parameters)):
    return commons
```

Use instead:

```python
from typing import Annotated

from fastapi import Depends, FastAPI

app = FastAPI()


async def common_parameters(q: str | None = None, skip: int = 0, limit: int = 100):
    return {"q": q, "skip": skip, "limit": limit}


@app.get("/items/")
async def read_items(commons: Annotated[dict, Depends(common_parameters)]):
    return commons
```

[FastAPI documentation]: https://fastapi.tiangolo.com/tutorial/query-params-str-validations/?h=annotated#advantages-of-annotated
[typing-annotated]: https://docs.python.org/3/library/typing.html#typing.Annotated
[typing-extensions]: https://typing-extensions.readthedocs.io/en/stable/

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added the ruff FAST002 rule to enforce using typing.Annotated for FastAPI dependencies, and updated code to use Annotated in a Slack integration example.

- **Dependencies**
  - Enabled the FAST linter rules in ruff configuration.
- **Refactors**
  - Updated a FastAPI route to use Annotated[SlackBot, Depends()] instead of Depends().
  - Replaced time.sleep with asyncio.sleep in an example for better async support.

<!-- End of auto-generated description by mrge. -->

