### PR TITLE
chore: replace playwright with patchright

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ For memory functionality (requires Python<3.13 due to PyTorch compatibility):
 pip install "browser-use[memory]"
 ```
 
-Install Playwright:
+Install Patchright:
 ```bash
-playwright install chromium
+patchright install chromium
 ```
 
 Spin up your agent:

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -32,10 +32,10 @@ Install the dependencies:
 uv pip install browser-use
 ```
 
-Then install playwright:
+Then install patchright:
 
 ```bash
-uv run playwright install
+uv run patchright install
 ```
 
 ## Create an agent

--- a/examples/custom-functions/action_filters.py
+++ b/examples/custom-functions/action_filters.py
@@ -20,7 +20,7 @@ During each step, the agent recalculates the actions available specifically for 
 import asyncio
 
 from langchain_openai import ChatOpenAI
-from playwright.async_api import Page
+from patchright.async_api import Page
 
 from browser_use.agent.service import Agent, Browser, BrowserContext, Controller
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "requests>=2.32.3",
     "posthog>=3.7.0",
     "patchright>=1.51.0",
-    "playwright>=1.51.0",
     "markdownify==1.1.0",
     "langchain-core==0.3.49",
     "langchain-openai==0.3.11",

--- a/tests/test_action_filters.py
+++ b/tests/test_action_filters.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from playwright.async_api import Page
+from patchright.async_api import Page
 from pydantic import BaseModel
 
 from browser_use.controller.registry.service import Registry


### PR DESCRIPTION
Replace playwright with patchright across the repo. 
Since we're using patchright, we don't need both packages.

Changes:
- Remove playwright dependency
- Update docs
- Update some imports from playwright to patchright


