### PR TITLE
fix: Revert enable_memory default to False

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -150,7 +150,7 @@ class Agent(Generic[Context]):
 		#
 		context: Context | None = None,
 		# Memory settings
-		enable_memory: bool = True,
+		enable_memory: bool = False,
 		memory_config: Optional[MemoryConfig] = None,
 	):
 		if page_extraction_llm is None:


### PR DESCRIPTION
This PR reverts `enable_memory` back to `False` by default, 
restoring the behavior from commit [28aa38c](https://github.com/browser-use/browser-use/commit/28aa38c7d5fc25a6265b91b54d55050894bd1fe8). 

I think this change was inadvertently introduced in [9960465](https://github.com/browser-use/browser-use/commit/99604656e4c37f3c8dd75af8a42f334ccb108c54#diff-3736f406057606f65f3ea79952b7f0ec8f8a22f25a49d7a0771f4cfbf43cbb92R151).  
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Reverted the default value of `enable_memory` to `False` to match previous behavior.

<!-- End of auto-generated description by mrge. -->

