### PR TITLE
docs: be specific with respect to headless mode warning

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -59,7 +59,11 @@ class BrowserConfig(BaseModel):
 
 	Default values:
 		headless: False
-			Whether to run browser in headless mode (not recommended)
+			Whether to run browser in headless mode (not recommended).
+			While Google search often works,  many sites that implement anti-bot and anti-scraping measures.
+			Example:
+			- abc
+			- xyz
 
 		disable_security: False
 			Disable browser security features (required for cross-origin iframe support)


### PR DESCRIPTION
A lot of things have worked in headless mode for me, and I'm curious why the warning was put there. Which websites and scenarios make headless mode fail? Or is it primarily because of vision? Might be nice to clarify.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Clarified the headless mode warning in the browser config docstring with examples of sites that may block headless browsers.

<!-- End of auto-generated description by mrge. -->

