### PR TITLE
feat(browser): option to control window focusing

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -82,6 +82,9 @@ class BrowserConfig(BaseModel):
 
 		deterministic_rendering: False
 			Enable deterministic rendering (makes GPU/font rendering consistent across different OS's and docker)
+
+		bring_to_front: True
+			Whether to automatically bring browser windows/tabs to front when interacting
 	"""
 
 	model_config = ConfigDict(
@@ -106,6 +109,7 @@ class BrowserConfig(BaseModel):
 	disable_security: bool = False  # disable_security=True is dangerous as any malicious URL visited could embed an iframe for the user's bank, and use their cookies to steal money
 	deterministic_rendering: bool = False
 	keep_alive: bool = Field(default=False, alias='_force_keep_browser_alive')  # used to be called _force_keep_browser_alive
+	bring_to_front: bool = True  # Whether to automatically bring browser windows/tabs to front when interacting
 
 	proxy: ProxySettings | None = None
 	new_context_config: BrowserContextConfig = Field(default_factory=BrowserContextConfig)

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -399,8 +399,9 @@ class BrowserContext:
 						break
 
 		# Bring page to front
-		logger.debug('🫨  Bringing tab to front: %s', active_page)
-		await active_page.bring_to_front()
+		if self.browser.config.bring_to_front:
+			logger.debug('🫨  Bringing tab to front: %s', active_page)
+			await active_page.bring_to_front()
 		await active_page.wait_for_load_state('load')
 
 		self.active_tab = active_page
@@ -998,7 +999,8 @@ class BrowserContext:
 		"""
 		page = await self.get_current_page()
 
-		await page.bring_to_front()
+		if self.browser.config.bring_to_front:
+			await page.bring_to_front()
 		await page.wait_for_load_state()
 
 		screenshot = await page.screenshot(
@@ -1486,7 +1488,6 @@ class BrowserContext:
 					break
 
 		self.active_tab = page
-		await page.bring_to_front()
 		await page.wait_for_load_state()
 
 	@time_execution_async('--create_new_tab')

--- a/browser_use/browser/dolphin_service.py
+++ b/browser_use/browser/dolphin_service.py
@@ -98,7 +98,6 @@ class DolphinBrowser(Browser):
 
 		# Set the current page to the selected tab
 		self.page = self._pages[page_id]
-		await self.page.bring_to_front()  # Bring tab to the front
 		await self.wait_for_page_load()
 
 	async def get_tabs_info(self) -> list[TabInfo]:


### PR DESCRIPTION
Add new configuration option that determines whether browser windows/tabs are automatically brought to front when interacting with them. Default is set to true for backward compatibility with existing behavior.

This gives users more control over browser behavior, particularly useful in when running browser automation tasks in the background where focus stealing might be undesirable.

Should be tested more before merging.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a new setting to control whether browser windows or tabs are brought to the front when used. The default is true, but users can now turn this off to prevent focus stealing during automation.

<!-- End of auto-generated description by mrge. -->

