### PR TITLE
fix status code when checking if chrome browser is already running

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -190,7 +190,7 @@ class Browser:
 			# Check if browser is already running
 			async with httpx.AsyncClient() as client:
 				response = await client.get('http://localhost:9222/json/version', timeout=2)
-				if response.status == 200:
+				if response.status_code == 200:
 					logger.info('🔌  Reusing existing browser found running on http://localhost:9222')
 					browser_class = getattr(playwright, self.config.browser_class)
 					browser = await browser_class.connect_over_cdp(
@@ -227,7 +227,7 @@ class Browser:
 			try:
 				async with httpx.AsyncClient() as client:
 					response = await client.get('http://localhost:9222/json/version', timeout=2)
-					if response.status == 200:
+					if response.status_code == 200:
 						break
 			except httpx.RequestError:
 				pass


### PR DESCRIPTION
This PR fixes connecting to already running chrome instance or when using user provided chrome binary path.

We check if browser is already running using below code

```
async with httpx.AsyncClient() as client:
				response = await client.get('http://localhost:9222/json/version', timeout=2)
				if response.status == 200:
					logger.info('🔌  Reusing existing browser found running on http://localhost:9222')
					browser_class = getattr(playwright, self.config.browser_class)

```
`response` object is an instance of `Response` class in `httpx` library. `response` object has `status_code` property and not `status`. This PR fixes this issue.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed a bug where checking if Chrome is already running used the wrong status code property, which could cause connection issues.

- **Bug Fixes**
  - Replaced response.status with response.status_code when verifying the running Chrome instance.

<!-- End of auto-generated description by mrge. -->

