### PR TITLE
Add handling of interactive elements inside html slot tags

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -1186,6 +1186,13 @@
           if (domElement) nodeData.children.push(domElement);
         }
       }
+      // Handle slots
+      if (tagName === "slot") {
+        for (const child of node.childNodes) {
+          const domElement = buildDomTree(child, parentIframe, nodeWasHighlighted);
+          if (domElement) nodeData.children.push(domElement);
+        }
+      }
       else {
         // Handle shadow DOM
         if (node.shadowRoot) {


### PR DESCRIPTION
This PR adds the functionality that interactive elements inside a html slot tag are taken into account to be marked as interactive and not ignored. Similar to the handling of iframes and shadow DOMs.