### PR TITLE
Fix: Correct subprocess creation using asyncio.create_subprocess_exec

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -213,14 +213,13 @@ class Browser:
 				*self.config.extra_browser_args,
 			},
 		]
-		self._chrome_subprocess = psutil.Process(
-			await asyncio.create_subprocess_shell(
-				chrome_launch_cmd,
-				stdout=subprocess.DEVNULL,
-				stderr=subprocess.DEVNULL,
-				shell=False,
-			).pid
+		process = await asyncio.create_subprocess_exec(
+			chrome_launch_cmd[0],
+			*chrome_launch_cmd[1:],
+			stdout=subprocess.DEVNULL,
+			stderr=subprocess.DEVNULL,
 		)
+		self._chrome_subprocess = psutil.Process(process.pid)
 
 		# Attempt to connect again after starting a new instance
 		for _ in range(10):


### PR DESCRIPTION
When using `browser_binary_path` to connect to a user-provided browser instance, the code incorrectly attempted to access the `.pid` attribute of the coroutine object returned by `asyncio.create_subprocess_shell` before it was awaited. This caused a `RuntimeWarning` and an `AttributeError: 'coroutine' object has no attribute 'pid'`.

A subsequent attempt to fix this by changing to `shell=True` and joining the command arguments into a string resulted in an `ECONNREFUSED` error, likely because the browser process failed to start correctly with the debugging port enabled.

## Solution

This PR fixes the subprocess creation by:

1.  Using `asyncio.create_subprocess_exec` instead of `asyncio.create_subprocess_shell`. `create_subprocess_exec` is the appropriate function for launching an executable directly with a list of arguments (equivalent to `shell=False`).
2.  Ensuring that `await` is correctly used before accessing the `.pid` attribute of the returned process object.

This resolves the `RuntimeWarning`, `AttributeError`, and `ECONNREFUSED` errors, allowing the agent to correctly launch and connect to a user-provided browser instance.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed subprocess creation for user-provided browser instances by using asyncio.create_subprocess_exec and awaiting the process before accessing its pid. This prevents errors and allows the agent to launch and connect to the browser correctly.

<!-- End of auto-generated description by mrge. -->

