### PR TITLE
prevent github actions from running twice for each commit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,20 +16,14 @@ on:
 
 jobs:
   build:
-    name: Build Package
+    name: pip-build
     runs-on: ubuntu-latest
     if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork))
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup uv and cache packages
-        uses: astral-sh/setup-uv@v5
-
-      - name: Build the package
-        run: uv build --python 3.12
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv build --python 3.12
+      - uses: actions/upload-artifact@v4
         with:
           name: dist-artifact
           path: |
@@ -37,7 +31,7 @@ jobs:
             dist/*.tar.gz
 
   build_test:
-    name: ${{ matrix.os }} • ${{ matrix.python-version }}
+    name: pip-install-${{ matrix.os }}-py-${{ matrix.python-version }}
     needs: build
     runs-on: ${{ matrix.os }}
     if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork))
@@ -48,12 +42,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup uv and cache packages
-        uses: astral-sh/setup-uv@v5
-
-      - name: Download build artifact
-        uses: actions/download-artifact@v4
+      - uses: astral-sh/setup-uv@v5
+      - uses: actions/download-artifact@v4
         with:
           name: dist-artifact
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,17 +8,12 @@ on:
     tags:
       - '*'
   pull_request:
-    branches:
-      - main
-      - stable
-      - 'releases/**'
   workflow_dispatch:
 
 jobs:
   build:
     name: pip-build
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork))
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
@@ -34,7 +29,6 @@ jobs:
     name: pip-install-${{ matrix.os }}-py-${{ matrix.python-version }}
     needs: build
     runs-on: ${{ matrix.os }}
-    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork))
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup uv and cache packages
-        uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v5
       - run: uv run pre-commit run --all-files
 
   lint-typecheck:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,17 +8,12 @@ on:
     tags:
       - '*'
   pull_request:
-    branches:
-      - main
-      - stable
-      - 'releases/**'
   workflow_dispatch:
 
 jobs:
   lint-syntax:
     name: syntax-errors
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork))
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
@@ -27,7 +22,6 @@ jobs:
   lint-style:
     name: code-style
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork))
     steps:
       - uses: actions/checkout@v4
       - name: Setup uv and cache packages
@@ -37,7 +31,6 @@ jobs:
   lint-typecheck:
     name: type-checker
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork))
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,16 +32,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup uv and cache packages
         uses: astral-sh/setup-uv@v5
-      - run: uv run ruff check --no-fix --select PLE
-
-  lint-style:
-    name: Style
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup uv and cache packages
-        uses: astral-sh/setup-uv@v5
-      - run: uv run ruff format
       - run: uv run pre-commit run --all-files
 
   lint-typecheck:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,4 +1,4 @@
-name: build
+name: package
 on:
   push:
     branches:
@@ -26,7 +26,7 @@ jobs:
             dist/*.tar.gz
 
   build_test:
-    name: pip-install-${{ matrix.os }}-py-${{ matrix.python-version }}
+    name: pip-install-on-${{ matrix.os }}-py-${{ matrix.python-version }}
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,28 +18,28 @@ jobs:
     strategy:
       matrix:
         test:
-        - tests/browser/patchright
-        - tests/browser/user_binary
-        - tests/browser/remote_cdp
-        - tests/models/openai
-        - tests/models/google
-        - tests/models/anthropic
-        - tests/models/azure
-        - tests/models/deepseek
-        - tests/models/grok
-        - tests/functionality/click
-        - tests/functionality/tabs
-        - tests/functionality/input
-        - tests/functionality/scroll
-        - tests/functionality/upload
-        - tests/functionality/download
-        - tests/functionality/save
-        - tests/functionality/vision
-        - tests/functionality/memory
-        - tests/functionality/planner
-        - tests/functionality/hooks
+        - browser/patchright
+        - browser/user_binary
+        - browser/remote_cdp
+        - models/openai
+        - models/google
+        - models/anthropic
+        - models/azure
+        - models/deepseek
+        - models/grok
+        - functionality/click
+        - functionality/tabs
+        - functionality/input
+        - functionality/scroll
+        - functionality/upload
+        - functionality/download
+        - functionality/save
+        - functionality/vision
+        - functionality/memory
+        - functionality/planner
+        - functionality/hooks
         
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
-      - run: uv run --with=dotenv pytest ${{ matrix.test }}.py || true
+      - run: uv run --with=dotenv pytest tests/${{ matrix.test }}.py || true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,17 +9,12 @@ on:
     tags:
       - '*'
   pull_request:
-    branches:
-      - main
-      - stable
-      - 'releases/**'
   workflow_dispatch:
     
 jobs:
   tests:
     name: ${{matrix.test}} 
     runs-on: ubuntu-latest
-    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork))
     strategy:
       matrix:
         test:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Updated GitHub Actions workflows to prevent duplicate runs on each commit by refining trigger conditions and splitting jobs for build, lint, and test.

- **CI Improvements**
  - Added separate build and test workflows with checks to avoid double execution.
  - Updated lint workflow to split syntax, style, and type checks.
  - Simplified publish workflow to only run on releases and scheduled events.

<!-- End of auto-generated description by mrge. -->

