### PR TITLE
fix: add cursor:pointer handling in buildDomTree and update test URLs to handle expander icons

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -933,6 +933,11 @@
       return false;
     }
 
+    // treat any element with cursor:pointer as distinct (e.g. expansion icons)
+    const style = getCachedComputedStyle(element);
+    if (style && style.cursor === 'pointer') {
+      return true;
+    }
 
     const tagName = element.tagName.toLowerCase();
     const role = element.getAttribute('role');

--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -933,12 +933,6 @@
       return false;
     }
 
-    // treat any element with cursor:pointer as distinct (e.g. expansion icons)
-    const style = getCachedComputedStyle(element);
-    if (style && style.cursor === 'pointer') {
-      return true;
-    }
-
     const tagName = element.tagName.toLowerCase();
     const role = element.getAttribute('role');
 

--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -963,6 +963,7 @@
     }
     // Check for other common interaction event listeners
     try {
+      const getEventListeners = window.getEventListenersForNode;
       if (typeof getEventListeners === 'function') {
         const listeners = getEventListeners(element);
         const interactionEvents = ['mousedown', 'mouseup', 'keydown', 'keyup', 'submit', 'change', 'input', 'focus', 'blur'];

--- a/browser_use/dom/tests/extraction_test.py
+++ b/browser_use/dom/tests/extraction_test.py
@@ -62,6 +62,8 @@ async def test_focus_vs_all_elements():
 	context = BrowserContext(browser=browser, config=config)
 
 	websites = [
+		'https://demos.telerik.com/kendo-react-ui/treeview/overview/basic/func?theme=default-ocean-blue-a11y',
+		'https://www.ycombinator.com/companies',
 		'https://kayak.com/flights',
 		# 'https://en.wikipedia.org/wiki/Humanist_Party_of_Ontario',
 		# 'https://www.google.com/travel/flights?tfs=CBwQARoJagcIARIDTEpVGglyBwgBEgNMSlVAAUgBcAGCAQsI____________AZgBAQ&tfu=KgIIAw&hl=en-US&gl=US',


### PR DESCRIPTION
    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Elements with cursor:pointer are now treated as distinct in buildDomTree, improving detection of clickable icons. Test URLs were updated to include pages with expander icons.

<!-- End of auto-generated description by mrge. -->

Fixes https://github.com/browser-use/browser-use/issues/1433

