### PR TITLE
Fix: Avoid redundant calls to results.get('results', []) in Memory._create

### DIFF
--- a/browser_use/agent/memory/service.py
+++ b/browser_use/agent/memory/service.py
@@ -144,8 +144,9 @@ class Memory:
 				memory_type='procedural_memory',
 				metadata={'step': current_step},
 			)
-			if len(results.get('results', [])):
-				return results.get('results', [])[0].get('memory')
+			results_list = results.get('results', [])
+			if results_list:
+				return results_list[0].get('memory')
 			return None
 		except Exception as e:
 			logger.error(f'Error creating procedural memory: {e}')


### PR DESCRIPTION
## PR Title
**Fix: Avoid redundant calls to `results.get('results', [])` in Memory._create**

---

## Description

This PR refactors the `_create` method inside the `Memory` class to avoid calling `results.get('results', [])` twice.

Currently, the code checks the length of `results.get('results', [])` and then accesses the first element via another call to `results.get('results', [])`. This can be inefficient and potentially problematic if `results` is dynamic.

Instead, we store the result list once in a variable and reuse it, improving efficiency, consistency, and readability.

---

## Changes

- Store `results.get('results', [])` in a local variable `results_list`.
- Reuse `results_list` for checking and accessing the first result safely.

---

## Before

```python
if len(results.get('results', [])):
    return results.get('results', [])[0].get('memory')
return None
```

---

## After

```python
results_list = results.get('results', [])
if results_list:
    return results_list[0].get('memory')
return None
```

---

## Why

- Avoid redundant dictionary access.
- Prevent possible inconsistency if `results` is a dynamic object.
- Slight performance improvement.
- Cleaner, more maintainable code.

---

## Checklist

- [x] Code compiles and runs correctly.
- [x] No breaking changes introduced.
- [x] PR improves performance, clarity, and reliability slightly.
- [x] Added clear explanation in PR description.

---

## Notes

This is a minor fix but a good general best practice for handling structured results safely, especially when dealing with external libraries (like `mem0`).


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Refactored the Memory._create method to store results.get('results', []) in a variable, avoiding redundant dictionary access.

- **Refactors**
  - Saves the results list once and reuses it for checks and access.

<!-- End of auto-generated description by mrge. -->

