### PR TITLE
fix: error in done action when using sensitive_data with custom output_model

### DIFF
--- a/browser_use/controller/registry/service.py
+++ b/browser_use/controller/registry/service.py
@@ -170,9 +170,9 @@ class Registry(Generic[Context]):
 				return [replace_secrets(v) for v in value]
 			return value
 
-		for key, value in params.model_dump().items():
-			params.__dict__[key] = replace_secrets(value)
-		return params
+		params_dump = params.model_dump()
+		processed_params = replace_secrets(params_dump)
+		return type(params).model_validate(processed_params)
 
 	# @time_execution_sync('--create_action_model')
 	def create_action_model(self, include_actions: Optional[list[str]] = None, page=None) -> Type[ActionModel]:


### PR DESCRIPTION
### Summary

This PR fixes a critical bug that makes it impossible to use `sensitive_data` with custom `output_model`. Using these two together causes error in the "done" action:

```
Error executing action done: 'dict' object has no attribute 'model_dump'
```

### To reproduce

This bug is reproducible by combining two official examples: Sensitive Data and Output Format. Use this Gist to reproduce: https://gist.github.com/BohdanPetryshyn/1ab5e94b3e32668f3de332daf5218d26

### Cause

When processing secrets, the existing code replaces Pydantic instances in `__dict__` with plain dictionaries obtained with `params.model_dump()` on the previous line.

https://github.com/browser-use/browser-use/blob/88fb9a1ff5f90d4c1354ec62c7e03f46ed402989/browser_use/controller/registry/service.py#L174

### Fix

Instead of incorrectly modifying the internal `__dict__` property, I propose to fully dump and reconstruct the Pydantic instance. This fixes the bug.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed a bug where using sensitive_data with a custom Pydantic output_model caused errors by breaking the model instance.

- **Bug Fixes**
  - Now reconstructs the Pydantic model after replacing secrets, preventing attribute errors.

<!-- End of auto-generated description by mrge. -->

