### PR TITLE
[FEAT] add dialog listner to context

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -19,11 +19,10 @@ from patchright._impl._errors import TimeoutError
 from patchright.async_api import Browser as PlaywrightBrowser
 from patchright.async_api import (
 	BrowserContext as PlaywrightBrowserContext,
-)
-from patchright.async_api import (
 	ElementHandle,
 	FrameLocator,
 	Page,
+	Dialog,
 )
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -351,7 +350,13 @@ class BrowserContext:
 
 		playwright_browser = await self.browser.get_playwright_browser()
 		context = await self._create_context(playwright_browser)
-		self._page_event_handler = None
+		self._add_new_page_listener(context)
+
+		# Add dialog listener to the context
+		async def on_dialog(dialog: Dialog):
+			logger.debug(f'✅ Accepting dialog: {dialog.type}')
+			await dialog.accept()
+		context.on("dialog", on_dialog)
 
 		# Get or create a page to use
 		pages = context.pages


### PR DESCRIPTION
**Problem:**
System alerts (like `alert`, `confirm`, `prompt`) were not being handled, potentially causing page freezes or timeouts because Playwright waits for dialogs to be dismissed or accepted.

**Related Issues**
#1343, #165

**Solution:**
Added an event listener for the `dialog` event at the `BrowserContext` level within the `_initialize_session` method.

This listener:
- Is attached when the browser context is initialized or reused.
- Automatically handles dialogs that appear on any page within the context.
- Automatically accepts all dialogs using `dialog.accept()`.
- Logs the acceptance of the dialog, including its type.

This ensures that unexpected dialogs don't block automation workflows by automatically accepting them.

![Screenshot 2025-04-29 225314](https://github.com/user-attachments/assets/088d82cf-d2ea-4868-99fd-464823a71260)
