### PR TITLE
Fix: Allow user-provided no_viewport setting in browser sizing

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -471,16 +471,13 @@ class BrowserContext:
 		else:
 			kwargs = {}
 			# Set viewport for both headless and non-headless modes
-			kwargs['viewport'] = self.config.browser_window_size.model_dump()
-			# Important: set no_viewport to False to ensure the viewport size is applied
-			kwargs['no_viewport'] = False
-			# Only set viewport in headless mode, let window size define viewport in headful mode
 			if self.browser.config.headless:
 				kwargs['viewport'] = self.config.browser_window_size.model_dump()
 				kwargs['no_viewport'] = False
 			else:
-				# In headful mode, let the window size set the viewport
-				kwargs['no_viewport'] = True
+				# In headful mode, respect user setting for no_viewport if provided, otherwise default to True
+				kwargs['viewport'] = self.config.browser_window_size.model_dump()
+				kwargs['no_viewport'] = self.config.no_viewport if self.config.no_viewport is not None else True
 
 			if self.config.user_agent is not None:
 				kwargs['user_agent'] = self.config.user_agent
@@ -505,7 +502,7 @@ class BrowserContext:
 			await context.tracing.start(screenshots=True, snapshots=True, sources=True)
 
 		# Resize the window for non-headless mode
-		if not self.browser.config.headless and not self.config.no_viewport:
+		if not self.browser.config.headless:
 			await self._resize_window(context)
 
 		# Load cookies if they exist

--- a/tests/test_browser_window_size_height_no_viewport.py
+++ b/tests/test_browser_window_size_height_no_viewport.py
@@ -1,0 +1,33 @@
+import asyncio
+
+from browser_use.browser.browser import Browser, BrowserConfig
+from browser_use.browser.context import BrowserContextConfig, BrowserContextWindowSize
+
+
+async def test():
+	print('Testing browser window sizing with no_viewport=False...')
+	browser = Browser(BrowserConfig(headless=False))
+	context_config = BrowserContextConfig(browser_window_size=BrowserContextWindowSize(width=1440, height=900), no_viewport=False)
+	browser_context = await browser.new_context(config=context_config)
+	page = await browser_context.get_current_page()
+	await page.goto('https://example.com')
+	await asyncio.sleep(2)
+	viewport = await page.evaluate('() => ({width: window.innerWidth, height: window.innerHeight})')
+	print('Configured size: width=1440, height=900')
+	print(f'Actual viewport size: {viewport}')
+
+	# Get the actual window size
+	window_size = await page.evaluate("""
+        () => ({
+            width: window.outerWidth,
+            height: window.outerHeight
+        })
+    """)
+	print(f'Actual window size: {window_size}')
+
+	await browser_context.close()
+	await browser.close()
+
+
+if __name__ == '__main__':
+	asyncio.run(test())


### PR DESCRIPTION
## Fix: Respect user-provided no_viewport setting in browser window sizing #1397 

### Description
This PR enhances the browser window sizing functionality to respect the user-provided `no_viewport` setting. Previously, the non-headless mode would always force `no_viewport=True`, which prevented custom viewport sizes from being applied correctly.

### Changes
- Modified `_create_context` method to respect user-provided `no_viewport` setting in non-headless mode
- Added `_resize_window` method to properly adjust the browser window size
- Added helper methods to consistently apply viewport sizing across different scenarios
- Added test to verify proper window and viewport sizing with `no_viewport=False`


### Testing

- Added test script tests/test_browser_window_size_height_no_viewport.py
- Verified that viewport dimensions match the configured size:  Configured size- width=1440, height=900

### Screenshots


<img width="913" alt="Screenshot 2025-04-30 at 9 23 50 PM" src="https://github.com/user-attachments/assets/6056bbe3-b409-48f6-a2b2-c942c08ee6e0" />

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed browser window sizing to respect the user-provided no_viewport setting, allowing custom viewport sizes in non-headless mode.

- **Bug Fixes**
  - Updated context creation to use the user’s no_viewport value.
  - Added a test to confirm correct window and viewport sizing when no_viewport is set to False.

<!-- End of auto-generated description by mrge. -->

