### PR TITLE
Fix Gemini 500 Error Handling: Prevent Indefinite Agent.run() Hanging

### DIFF
--- a/browser_use/exceptions.py
+++ b/browser_use/exceptions.py
@@ -1,5 +1,6 @@
 class LLMException(Exception):
-	def __init__(self, status_code, message):
+	def __init__(self, status_code, message, retriable=True):
 		self.status_code = status_code
 		self.message = message
+		self.retriable = retriable  # Flag to indicate if this error can be retried
 		super().__init__(f'Error {status_code}: {message}')


### PR DESCRIPTION
this pr fixes an issue where agent.run() would hang forever after getting a 500 error from google’s gemini api.

fixes #1497 

the problem
when gemini returns a 500 internal server error, the agent doesn’t know it’s unrecoverable. it just logs the error, keeps incrementing the failure counter, and gets stuck in an endless loop trying to recover the browser window. basically, it never gives up, even when it should.

what changed
added a retriable flag to llmexception so we can tell which errors are worth retrying and which aren’t

gemini’s “500 an internal error has occurred” is now flagged as non-retriable

if the agent hits a non-retriable error, we immediately max out the failure counter so it shuts down gracefully

added clear messaging so it’s obvious why the agent stopped

stops wasting resources trying to recover from something that’s not fixable

this improves the user experience without changing how retriable errors are handled.

this is a focused fix that only affects error handling, normal agent behavior stays the same.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where the agent would hang forever after a Gemini API 500 error by marking these errors as non-retriable and shutting down the agent gracefully.

- **Bug Fixes**
  - Added a retriable flag to LLMException to distinguish between retriable and non-retriable errors.
  - Gemini 500 errors are now treated as non-retriable, causing the agent to stop instead of looping.
  - Improved error messages to make shutdown reasons clear.

<!-- End of auto-generated description by mrge. -->

