### PR TITLE
Fix: Terminal reset sequence when exiting with Ctrl+C 

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -136,9 +136,30 @@ class SignalHandler:
 
 		# Force immediate exit - more reliable than sys.exit()
 		print('\n\n🛑  Got second Ctrl+C. Exiting immediately...\n', file=stderr)
-		# write carriage return + newline + ASNI reset to both stdout and stderr to clear any color codes
-		print('\r\033[0m', end='', flush=True, file=stderr)
-		print('\r\033[0m', end='', flush=True)
+		
+		# Reset terminal to a clean state by sending multiple escape sequences
+		# Order matters for terminal resets - we try different approaches
+		
+		# Reset terminal modes for both stdout and stderr
+		print('\033[?25h', end='', flush=True, file=stderr)  # Show cursor
+		print('\033[?25h', end='', flush=True)  # Show cursor
+		
+		# Reset text attributes and terminal modes
+		print('\033[0m', end='', flush=True, file=stderr)    # Reset text attributes
+		print('\033[0m', end='', flush=True)                 # Reset text attributes
+		
+		# Disable special input modes that may cause arrow keys to output control chars
+		print('\033[?1l', end='', flush=True, file=stderr)   # Reset cursor keys to normal mode
+		print('\033[?1l', end='', flush=True)                # Reset cursor keys to normal mode
+		
+		# Disable bracketed paste mode
+		print('\033[?2004l', end='', flush=True, file=stderr)
+		print('\033[?2004l', end='', flush=True)
+		
+		# Carriage return helps ensure a clean line
+		print('\r', end='', flush=True, file=stderr)
+		print('\r', end='', flush=True)
+		
 		os._exit(0)
 
 	def sigint_handler(self) -> None:


### PR DESCRIPTION
this pr fixes an issue where control characters show up after using ctrl+c to exit a browser-use session.

the problem was that the terminal wasn’t fully resetting, which messed with things like arrow keys.

i updated the _handle_second_ctrl_c() method to include a more complete set of ansi escape sequences. this properly resets the terminal state, brings back the cursor, and clears up the arrow key behavior.

fixes #1431
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed terminal reset when exiting with Ctrl+C to prevent control characters and restore normal arrow key behavior.

- **Bug Fixes**
  - Added full set of ANSI escape sequences to reset terminal state, show the cursor, and clear special input modes.

<!-- End of auto-generated description by mrge. -->

