### PR TITLE
removing the browser channel from the _setup_browser in browser.py

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -317,7 +317,6 @@ class Browser:
 
 		browser = await browser_class.launch(
 			headless=self.config.headless,
-			channel='chrome',
 			args=args[self.config.browser_class],
 			proxy=self.config.proxy.model_dump() if self.config.proxy else None,
 			handle_sigterm=False,


### PR DESCRIPTION
It seems that having the channel specified to 'chrome' is causing Chrome not to open, it's possible the class should be 'chromium'. I tried a variety of combinations and noticed that once the channel was gone the browser opened up and worked well again.

The bug can be reproduced simply by trying to start browser use with settings as follows:

* NOTE: The llm_client is Azure Open AI (which brings another point, if you are using the Azure Open AI client the memory feature does not work properly).

            browser = Browser(
                config=BrowserConfig(
                    headless=self.headless,
                )
            )

            self.agent = Agent(
                task=task,
                llm=self.llm_client,
                browser=browser,
                use_vision=True
                planner_llm=self.llm_client,
                planner_interval=1,
                use_vision_for_planner=False,
                sensitive_data=self.sensitive_data,
                
                # there is currently an issue with the memory in the browser_use agent
                # if you want to use it you will also need to set the AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_KEY variable
                enable_memory=False,
            )


Once I remove the 'channel' argument from the browser.py, everything works again.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Removed the 'channel' argument from browser setup to fix an issue where Chrome would not open. This change allows the browser to launch correctly in all configurations.

<!-- End of auto-generated description by mrge. -->

