### PR TITLE
Lowering the z-index

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -211,7 +211,7 @@
         container.style.left = "0";
         container.style.width = "100%";
         container.style.height = "100%";
-        container.style.zIndex = "2147483647";
+        container.style.zIndex = "2147483640";
         container.style.backgroundColor = 'transparent';
         document.body.appendChild(container);
       }


### PR DESCRIPTION
Lowering the z-index a little bit to allow the recorder in web-ui to be on top of the highlighted boxes. Also allows in the future the possibility of some elements being on top of the highlight boxes.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Lowered the z-index of the highlight box container so the recorder and other elements can appear above it in the web UI.

<!-- End of auto-generated description by mrge. -->

