### PR TITLE
Fix faiss-cpu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "screeninfo>=0.8.1; platform_system != 'darwin'",
     "typing-extensions>=4.12.2",
     "psutil>=7.0.0",
-    "faiss-cpu>=1.10.0",
+    "faiss-cpu>=1.9.0",
     "mem0ai==0.1.93",
 ]
 # botocore: only needed for Bedrock Claude boto3 examples/models/bedrock_claude.py 


### PR DESCRIPTION
Fixes: #1505 

Here we tried installing `faiss-cpu==1.9.0` and it seems to have been working with Mac, Windows and also with older windows OS version. Attaching screenshots:
![Screenshot 2025-04-30 at 9 55 38 AM](https://github.com/user-attachments/assets/74439e3f-efe0-42d2-bde1-dd3d57ea3242)
![Screenshot 2025-04-30 at 9 56 36 AM](https://github.com/user-attachments/assets/0f966c13-efb7-42c3-bd37-de213fd4bc14)
![WhatsApp Image 2025-05-01 at 21 39 39 (1)](https://github.com/user-attachments/assets/63c8e1e3-9334-4d53-bfac-1913e7ad519c)

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Changed faiss-cpu dependency to version 1.9.0 to improve compatibility with Mac and Windows systems.

<!-- End of auto-generated description by mrge. -->

