### PR TITLE
Fix: Make viewport_expansion=-1 parameter work properly to include all page elements

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -756,12 +756,12 @@
     let isAnyRectInViewport = false;
     for (const rect of rects) {
       // Use the same logic as isInExpandedViewport check
-      if (rect.width > 0 && rect.height > 0 && !( // Only check non-empty rects
+      if (viewportExpansion === -1 || (rect.width > 0 && rect.height > 0 && !( // Only check non-empty rects
         rect.bottom < -viewportExpansion ||
         rect.top > window.innerHeight + viewportExpansion ||
         rect.right < -viewportExpansion ||
         rect.left > window.innerWidth + viewportExpansion
-      ) || viewportExpansion === -1) {
+      ))) {
         isAnyRectInViewport = true;
         break;
       }
@@ -827,8 +827,6 @@
    * Checks if an element is within the expanded viewport.
    */
   function isInExpandedViewport(element, viewportExpansion) {
-    return true
-
     if (viewportExpansion === -1) {
       return true;
     }
@@ -849,7 +847,6 @@
         boundingRect.left > window.innerWidth + viewportExpansion
       );
     }
-
 
     // Check if *any* client rect is within the viewport
     for (const rect of rects) {

--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -161,8 +161,10 @@ async def run_search():
   Highlight interactive elements on the screen with colorful bounding boxes.
 
 - **viewport_expansion** (default: `500`)
-  Viewport expansion in pixels. With this you can control how much of the page is included in the context of the LLM. If set to -1, all elements from the entire page will be included (this leads to high token usage). If set to 0, only the elements which are visible in the viewport will be included.
-  Default is 500 pixels, that means that we include a little bit more than the visible viewport inside the context.
+  Viewport expansion in pixels. With this you can control how much of the page is included in the context of the LLM. Setting this parameter controls the highlighting of elements:
+  - `-1`: All elements from the entire page will be included, regardless of visibility (highest token usage but most complete).
+  - `0`: Only elements which are currently visible in the viewport will be included.
+  - `500` (default): Elements in the viewport plus an additional 500 pixels in each direction will be included, providing a balance between context and token usage.
 
 ### Restrict URLs
 


### PR DESCRIPTION
fixes a bug where viewport_expansion=-1 didn’t include all elements as expected, as reported in #1516. the issue was caused by isInExpandedViewport always returning true, which bypassed the actual param logic. the early viewport filter in buildDomTree also ran even when -1 was set, and isTopElement wasn’t handling -1 correctly either. cleaned up those checks and updated the docs to explain how -1 works. tested that it now pulls in the full page as intended.

fixes #1516
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed a bug where setting viewport_expansion to -1 did not include all page elements as expected.

- **Bug Fixes**
  - Corrected logic so that viewport_expansion=-1 now includes every element on the page.
  - Updated documentation to clearly explain how -1, 0, and other values work.

<!-- End of auto-generated description by mrge. -->

