### PR TITLE
fix(eval): update GOOGLE_API_KEY comment to GEMINI_API_KEY

### DIFF
--- a/eval/service.py
+++ b/eval/service.py
@@ -393,7 +393,7 @@ def get_llm(model_name: str):
 			kwargs['api_key'] = api_key_secret
 		return ChatAnthropic(**kwargs)
 	elif provider == 'google':
-		# Note: Google client often uses env var GOOGLE_API_KEY directly if api_key=None
+		# Note: Google client often uses env var GEMINI_API_KEY directly if api_key=None
 		kwargs = {
 			'model': config['model_name'],
 			'temperature': 0.0,


### PR DESCRIPTION
Changed GOOGLE_API_KEY to GEMINI_API_KEY. Updated comment to reference the correct environment variable.

ref: https://github.com/browser-use/browser-use/pull/1435
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated a comment in eval/service.py to reference GEMINI_API_KEY instead of GOOGLE_API_KEY for the Google client.

<!-- End of auto-generated description by mrge. -->

