### PR TITLE
BREAKING CHANGE: remove `window_size=BrowserWindowContextSize(width, height)` in favor of flat `window_width` and `window_height`

### DIFF
--- a/examples/use-cases/web_voyager_agent.py
+++ b/examples/use-cases/web_voyager_agent.py
@@ -13,7 +13,6 @@ from pydantic import SecretStr
 
 from browser_use.agent.service import Agent
 from browser_use.browser.browser import Browser, BrowserConfig, BrowserContextConfig
-from browser_use.browser.context import BrowserContextWindowSize
 
 # Load environment variables
 load_dotenv()
@@ -42,8 +41,11 @@ browser = Browser(
 			disable_security=True,
 			minimum_wait_page_load_time=1,  # 3 on prod
 			maximum_wait_page_load_time=10,  # 20 on prod
-			# no_viewport=True,
-			browser_window_size=BrowserContextWindowSize(width=1280, height=1100),
+			# Set no_viewport=False to constrain the viewport to the specified dimensions
+			# This is useful for specific cases where you need a fixed viewport size
+			no_viewport=False,
+			window_width=1280,
+			window_height=1100,
 			# trace_path='./tmp/web_voyager_agent',
 		),
 	)

--- a/tests/test_browser_config_models.py
+++ b/tests/test_browser_config_models.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from browser_use.browser.browser import Browser, BrowserConfig, ProxySettings
-from browser_use.browser.context import BrowserContext, BrowserContextConfig, BrowserContextWindowSize
+from browser_use.browser.context import BrowserContext, BrowserContextConfig
 
 
 @pytest.mark.asyncio
@@ -33,33 +33,27 @@ async def test_proxy_settings_pydantic_model():
 
 
 @pytest.mark.asyncio
-async def test_window_size_pydantic_model():
+async def test_window_size_config():
 	"""
-	Test that BrowserContextWindowSize as a Pydantic model is correctly converted to a dictionary when used.
+	Test that BrowserContextConfig correctly handles window_width and window_height properties.
 	"""
-	# Create BrowserContextWindowSize with Pydantic model
-	window_size = BrowserContextWindowSize(width=1280, height=1100)
+	# Create config with specific window dimensions
+	config = BrowserContextConfig(window_width=1280, window_height=1100)
 
-	# Verify the model has correct dict-like access
-	assert window_size['width'] == 1280
-	assert window_size.get('height') == 1100
-	assert window_size.get('nonexistent', 'default') == 'default'
+	# Verify the properties are set correctly
+	assert config.window_width == 1280
+	assert config.window_height == 1100
 
 	# Verify model_dump works correctly
-	window_dict = window_size.model_dump()
-	assert isinstance(window_dict, dict)
-	assert window_dict['width'] == 1280
-	assert window_dict['height'] == 1100
+	config_dict = config.model_dump()
+	assert isinstance(config_dict, dict)
+	assert config_dict['window_width'] == 1280
+	assert config_dict['window_height'] == 1100
 
-	# Create a context config with the window size and test initialization
-	config = BrowserContextConfig(browser_window_size=window_size)
-	assert config.browser_window_size == window_size
-
-	# You can also create from a dictionary
-	config2 = BrowserContextConfig(browser_window_size={'width': 1920, 'height': 1080})
-	assert isinstance(config2.browser_window_size, BrowserContextWindowSize)
-	assert config2.browser_window_size.width == 1920
-	assert config2.browser_window_size.height == 1080
+	# Create with different values
+	config2 = BrowserContextConfig(window_width=1920, window_height=1080)
+	assert config2.window_width == 1920
+	assert config2.window_height == 1080
 
 
 @pytest.mark.asyncio
@@ -70,17 +64,15 @@ async def test_window_size_with_real_browser():
 	passed to Playwright and the actual browser window is configured with these settings.
 	This test is skipped in CI environments.
 	"""
-	# Create window size with specific dimensions we can check
-	window_size = BrowserContextWindowSize(width=1024, height=768)
-
 	# Create browser config with headless mode
 	browser_config = BrowserConfig(
 		headless=True,  # Use headless for faster test
 	)
 
-	# Create context config with our window size
+	# Create context config with specific dimensions we can check
 	context_config = BrowserContextConfig(
-		browser_window_size=window_size,
+		window_width=1024,
+		window_height=768,
 		maximum_wait_page_load_time=2.0,  # Faster timeouts for test
 		minimum_wait_page_load_time=0.2,
 		no_viewport=True,  # Use actual window size instead of viewport
@@ -134,7 +126,7 @@ async def test_window_size_with_real_browser():
                 }
             """)
 
-			print(f'Window size config: {window_size.model_dump()}')
+			print(f'Window size config: width={context_config.window_width}, height={context_config.window_height}')
 			print(f'Browser viewport size: {viewport_size}')
 
 			# This is a lightweight test to verify that the page has a size (details may vary by browser)

--- a/tests/test_browser_window_size_height.py
+++ b/tests/test_browser_window_size_height.py
@@ -8,14 +8,13 @@ import sys
 from typing import Any
 
 from browser_use.browser.browser import Browser, BrowserConfig
-from browser_use.browser.context import BrowserContextConfig, BrowserContextWindowSize
+from browser_use.browser.context import BrowserContextConfig
 
 
 async def main():
 	"""Demonstrate setting a custom browser window size"""
 	# Create a browser with a specific window size
-	window_size = BrowserContextWindowSize(width=800, height=400)  # Small size to clearly demonstrate the fix
-	config = BrowserContextConfig(browser_window_size=window_size)
+	config = BrowserContextConfig(window_width=800, window_height=400)  # Small size to clearly demonstrate the fix
 
 	browser = None
 	browser_context = None
@@ -63,11 +62,11 @@ async def main():
 			}
 		""")
 
-		print(f'Configured window size: {window_size.model_dump()}')
+		print(f'Configured window size: width={config.window_width}, height={config.window_height}')
 		print(f'Actual viewport size: {viewport_size}')
 
 		# Validate the window size
-		validate_window_size(window_size.model_dump(), viewport_size)
+		validate_window_size({'width': config.window_width, 'height': config.window_height}, viewport_size)
 
 		# Wait a bit more to see the window
 		await asyncio.sleep(3)

--- a/tests/test_browser_window_size_height_no_viewport.py
+++ b/tests/test_browser_window_size_height_no_viewport.py
@@ -1,13 +1,13 @@
 import asyncio
 
 from browser_use.browser.browser import Browser, BrowserConfig
-from browser_use.browser.context import BrowserContextConfig, BrowserContextWindowSize
+from browser_use.browser.context import BrowserContextConfig
 
 
 async def test():
 	print('Testing browser window sizing with no_viewport=False...')
 	browser = Browser(BrowserConfig(headless=False))
-	context_config = BrowserContextConfig(browser_window_size=BrowserContextWindowSize(width=1440, height=900), no_viewport=False)
+	context_config = BrowserContextConfig(window_width=1440, window_height=900, no_viewport=False)
 	browser_context = await browser.new_context(config=context_config)
 	page = await browser_context.get_current_page()
 	await page.goto('https://example.com')


### PR DESCRIPTION
Also changes the default to be `no_viewport=True`.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Replaced the BrowserContextWindowSize model with simple window_width and window_height fields in BrowserContextConfig. The default is now no_viewport=True, so the browser window size determines the viewport unless no_viewport is set to False.

- **Refactors**
  - Removed BrowserContextWindowSize and updated all usage to window_width and window_height.
  - Updated tests and examples to use the new fields and defaults.

<!-- End of auto-generated description by mrge. -->

