### PR TITLE
fix security issue with url parsing

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -743,16 +743,15 @@ class BrowserContext:
 		try:
 			from urllib.parse import urlparse
 
-			parsed_url = urlparse(url)
-			domain = parsed_url.netloc.lower()
-
 			# Special case: Allow 'about:blank' explicitly
 			if url == 'about:blank':
 				return True
 
-			# Remove port number if present
-			if ':' in domain:
-				domain = domain.split(':')[0]
+			parsed_url = urlparse(url)
+
+			# Extract only the hostname component (without auth credentials or port)
+			# Hostname returns only the domain portion, ignoring username:password and port
+			domain = parsed_url.hostname.lower() if parsed_url.hostname else ''
 
 			# Check if domain matches any allowed domain pattern
 			return any(

--- a/tests/test_url_allowlist_security.py
+++ b/tests/test_url_allowlist_security.py
@@ -1,0 +1,21 @@
+from browser_use.browser.context import BrowserContext, BrowserContextConfig
+
+
+class TestUrlAllowlistSecurity:
+	"""Tests for URL allowlist security bypass prevention."""
+
+	def test_authentication_bypass_prevention(self):
+		"""Test that the URL allowlist cannot be bypassed using authentication credentials."""
+		# Create a context config with a sample allowed domain
+		config = BrowserContextConfig(allowed_domains=['example.com'])
+		context = BrowserContext(browser=None, config=config)
+
+		# Security vulnerability test cases
+		# These should all be detected as malicious despite containing "example.com"
+		assert context._is_url_allowed('https://example.com:password@malicious.com') is False
+		assert context._is_url_allowed('https://example.com@malicious.com') is False
+		assert context._is_url_allowed('https://example.com%20@malicious.com') is False
+		assert context._is_url_allowed('https://example.com%3A@malicious.com') is False
+
+		# Make sure legitimate auth credentials still work
+		assert context._is_url_allowed('https://user:password@example.com') is True


### PR DESCRIPTION
Fixes https://github.com/browser-use/browser-use/security/advisories/GHSA-x39x-9qw5-ghrf

Read + run the test to verify it: `uv run pytest tests/test_url_allowlist_security.py`

Specifically verifies that URLs with authentication credential-based bypass attempts are properly detected and disallowed, including:

  1. https://example.com:password@malicious.com - Using the colon in the example.com domain to trick the URL parser
  2. https://example.com@malicious.com - Using example.com as a username
  3. https://example.com%20@malicious.com - Using URL-encoded space character to bypass checks
  4. https://example.com%3A@malicious.com - Using URL-encoded colon character to bypass checks

  All these malicious URLs are now properly detected as non-allowed URLs, while legitimate credentials like https://user:password@example.com still work correctly.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed a security issue where URLs with embedded credentials or encoded characters could bypass domain checks. Now, only the actual hostname is used for validation, blocking malicious URL formats.

- **Bug Fixes**
  - Blocks URLs like https://example.com:password@malicious.com and similar tricks.
  - Legitimate credentials (e.g., https://user:password@example.com) still work.

<!-- End of auto-generated description by mrge. -->

