### PR TITLE
Fix get_current_page foreground tab detection, improve viewport resizing, and add security warnings

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         - functionality/planner
         - functionality/hooks
         - test_controller
-        
+        - test_tab_management
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ AgentHistory.json
 AgentHistoryList.json
 private_example.py
 private_example
+
+uv.lock

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -288,11 +288,11 @@ class Agent(Generic[Context]):
 				'⚠️⚠️⚠️ Agent(sensitive_data=••••••••) was provided but BrowserContextConfig(allowed_domains=[...]) is not locked down! ⚠️⚠️⚠️\n'
 				'          ☠️ If the agent visits a malicious website and encounters a prompt-injection attack, your sensitive_data may be exposed!\n\n'
 				'             https://docs.browser-use.com/customize/browser-settings#restrict-urls\n'
-				'Waiting 30 seconds before continuing... Press [Ctrl+C] to abort.'
+				'Waiting 10 seconds before continuing... Press [Ctrl+C] to abort.'
 			)
 			if sys.stdin.isatty():
 				try:
-					time.sleep(30)
+					time.sleep(10)
 				except KeyboardInterrupt:
 					print(
 						'\n\n 🛑 Exiting now... set BrowserContextConfig(allowed_domains=["example.com", "example.org"]) to only domains you trust to see your sensitive_data.'

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -290,7 +290,7 @@ class Agent(Generic[Context]):
 				'             https://docs.browser-use.com/customize/browser-settings#restrict-urls\n'
 				'Waiting 30 seconds before continuing... Press [Ctrl+C] to abort.'
 			)
-			if not sys.stdin.isatty():
+			if sys.stdin.isatty():
 				try:
 					time.sleep(30)
 				except KeyboardInterrupt:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -445,7 +445,7 @@ class Agent(Generic[Context]):
 
 		try:
 			state = await self.browser_context.get_state(cache_clickable_elements_hashes=True)
-			active_page = await self.browser_context.get_current_page()
+			current_page = await self.browser_context.get_current_page()
 
 			# generate procedural memory if needed
 			if self.enable_memory and self.memory and self.state.n_steps % self.memory.config.memory_interval == 0:
@@ -454,10 +454,10 @@ class Agent(Generic[Context]):
 			await self._raise_if_stopped_or_paused()
 
 			# Update action models with page-specific actions
-			await self._update_action_models_for_page(active_page)
+			await self._update_action_models_for_page(current_page)
 
 			# Get page-specific filtered actions
-			page_filtered_actions = self.controller.registry.get_prompt_description(active_page)
+			page_filtered_actions = self.controller.registry.get_prompt_description(current_page)
 
 			# If there are page-specific actions, add them as a special message for this step only
 			if page_filtered_actions:

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -1219,7 +1219,6 @@ class BrowserContext:
 				url=page.url,
 				title=await page.title(),
 				tabs=tabs_info,
-				current_tab_id=agent_current_page_id,
 				screenshot=screenshot_b64,
 				pixels_above=pixels_above,
 				pixels_below=pixels_below,

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -196,7 +196,6 @@ class CachedStateClickableElementsHashes:
 
 class BrowserSession:
 	def __init__(self, context: PlaywrightBrowserContext, cached_state: BrowserState | None = None):
-		self.active_tab = None
 		self.context = context
 		self.cached_state = cached_state
 
@@ -228,7 +227,10 @@ class BrowserContext:
 
 		# Initialize these as None - they'll be set up when needed
 		self.session: BrowserSession | None = None
-		self.active_tab: Page | None = None
+
+		# Tab references - separate concepts for agent intent and browser state
+		self.agent_current_page: Page | None = None  # The tab the agent intends to interact with
+		self.human_current_page: Page | None = None  # The tab currently shown in the browser UI
 
 	async def __aenter__(self):
 		"""Async context manager entry"""
@@ -274,7 +276,8 @@ class BrowserContext:
 
 		finally:
 			# Dereference everything
-			self.active_tab = None
+			self.agent_current_page = None
+			self.human_current_page = None
 			self.session = None
 			self._page_event_handler = None
 
@@ -288,6 +291,8 @@ class BrowserContext:
 					asyncio.run(self.session.context._impl_obj.close())
 
 				self.session = None
+				self.agent_current_page = None
+				self.human_current_page = None
 				gc.collect()
 			except Exception as e:
 				logger.warning(f'Failed to force close browser context: {e}')
@@ -301,6 +306,9 @@ class BrowserContext:
 		context = await self._create_context(playwright_browser)
 		self._page_event_handler = None
 
+		# auto-attach the foregrounding-detection listener to all new pages opened
+		context.on('page', self._add_tab_foregrounding_listener)
+
 		# Get or create a page to use
 		pages = context.pages
 
@@ -309,7 +317,7 @@ class BrowserContext:
 			cached_state=None,
 		)
 
-		active_page = None
+		current_page = None
 		if self.browser.config.cdp_url:
 			# If we have a saved target ID, try to find and activate it
 			if self.state.target_id:
@@ -319,68 +327,137 @@ class BrowserContext:
 						# Find matching page by URL
 						for page in pages:
 							if page.url == target['url']:
-								active_page = page
+								current_page = page
 								break
 						break
 
 		# If no target ID or couldn't find it, use existing page or create new
-		if not active_page:
+		if not current_page:
 			if (
 				pages
 				and pages[0].url
 				and not pages[0].url.startswith('chrome://')  # skip chrome internal pages e.g. settings, history, etc
 				and not pages[0].url.startswith('chrome-extension://')  # skip hidden extension background pages
 			):
-				active_page = pages[0]
-				logger.debug('🔍  Using existing page: %s', active_page.url)
+				current_page = pages[0]
+				logger.debug('🔍  Using existing page: %s', current_page.url)
 			else:
-				active_page = await context.new_page()
-				await active_page.goto('about:blank')
-				logger.debug('🆕  Created new page: %s', active_page.url)
+				current_page = await context.new_page()
+				await current_page.goto('about:blank')
+				logger.debug('🆕  Created new page: %s', current_page.url)
 
 			# Get target ID for the active page
 			if self.browser.config.cdp_url:
 				targets = await self._get_cdp_targets()
 				for target in targets:
-					if target['url'] == active_page.url:
+					if target['url'] == current_page.url:
 						self.state.target_id = target['targetId']
 						break
 
 		# Bring page to front
-		logger.debug('🫨  Bringing tab to front: %s', active_page)
-		await active_page.bring_to_front()
-		await active_page.wait_for_load_state('load')
+		logger.debug('🫨  Bringing tab to front: %s', current_page)
+		await current_page.bring_to_front()
+		await current_page.wait_for_load_state('load')
 
 		# Set the viewport size for the active page
-		try:
-			if self.config.no_viewport is False:
-				viewport_size = {'width': self.config.window_width, 'height': self.config.window_height}
-				await active_page.set_viewport_size(viewport_size)
-				logger.debug(f'Set viewport size to {self.config.window_width}x{self.config.window_height}')
-			else:
-				logger.debug('Skipping viewport size setting in _initialize_session because no_viewport is not False')
-		except Exception as e:
-			logger.debug(f'Failed to set viewport size: {e}')
+		await self.set_viewport_size(current_page)
 
-		self.active_tab = active_page
+		# Initialize both tab references to the same page initially
+		self.agent_current_page = current_page
+		self.human_current_page = current_page
+
+		# Set up visibility listeners for all existing tabs
+		for page in pages:
+			if not page.url.startswith('chrome-extension://') and not page.url.startswith('chrome://') and not page.is_closed():
+				await self._add_tab_foregrounding_listener(page)
+				# logger.debug(f'👁️  Added visibility listener to existing tab: {page.url}')
 
 		return self.session
 
-	def _add_new_page_listener(self, context: PlaywrightBrowserContext):
-		async def on_page(page: Page):
-			if self.browser.config.cdp_url:
-				await page.reload()  # Reload the page to avoid timeout errors
-			await page.wait_for_load_state()
-			logger.debug(f'📑  New page opened: {page.url}')
+	async def _add_tab_foregrounding_listener(self, page: Page):
+		"""
+		Attaches listeners that detect when the human steals active tab focus away from the agent.
 
-			if not page.url.startswith('chrome-extension://') and not page.url.startswith('chrome://'):
-				self.active_tab = page
+		Uses a combination of:
+		- visibilitychange events
+		- window focus/blur events
+		- pointermove events
 
-			if self.session is not None:
-				self.state.target_id = None
+		This multi-method approach provides more reliable detection across browsers.
 
-		self._page_event_handler = on_page
-		context.on('page', on_page)
+		TODO: pester the playwright team to add a new event that fires when a headful tab is focused.
+		OR implement a browser-use chrome extension that acts as a bridge to the chrome.tabs API.
+
+		        - https://github.com/microsoft/playwright/issues/1290
+		        - https://github.com/microsoft/playwright/issues/2286
+		        - https://github.com/microsoft/playwright/issues/3570
+		        - https://github.com/microsoft/playwright/issues/13989
+		"""
+
+		def trunc(s, max_len=None):
+			s = s.replace('https://', '').replace('http://', '').replace('www.', '')
+			if max_len is not None and len(s) > max_len:
+				return s[:max_len] + '…'
+			return s
+
+		try:
+			# Generate a unique function name for this page
+			visibility_func_name = f'onVisibilityChange_{id(page)}{id(page.url)}'
+
+			# Define the callback that will be called from browser when tab becomes visible
+			async def on_visibility_change(data):
+				source = data.get('source', 'unknown')
+
+				# Log before and after for debugging
+				old_foreground = self.human_current_page
+				if old_foreground.url != page.url:
+					logger.warning(
+						f'👁️ Foregound tab changed by human from {trunc(old_foreground.url, 22) if old_foreground else "about:blank"} to {trunc(page.url, 22)} ({source}) but agent will stay on {trunc(self.agent_current_page.url, 22)}'
+					)
+
+				# Update foreground tab
+				self.human_current_page = page
+
+			# Expose the function to the browser
+			await page.expose_function(visibility_func_name, on_visibility_change)
+
+			# Set up multiple visibility detection methods in the browser
+			js_code = """() => {
+				// --- Method 1: visibilitychange event (unfortunately *all* tabs are always marked visible by playwright, usually does not fire) ---
+				document.addEventListener('visibilitychange', () => {
+					if (document.visibilityState === 'visible') {
+						window.onVisibilityChange_TABID({ source: 'visibilitychange' });
+					}
+				});
+				
+				// --- Method 2: focus/blur events, most reliable method for headful browsers ---
+				window.addEventListener('focus', () => {
+					window.onVisibilityChange_TABID({ source: 'focus' });
+				});
+				
+				// --- Method 3: pointermove events (may be fired by agent if we implement AI hover movements) ---
+				// Use a throttled handler to avoid excessive calls
+				// let lastMove = 0;
+				// window.addEventListener('pointermove', () => {
+				// 	const now = Date.now();
+				// 	if (now - lastMove > 1000) {  // Throttle to once per second
+				// 		lastMove = now;
+				// 		window.onVisibilityChange_TABID({ source: 'pointermove' });
+				// 	}
+				// });
+			}""".replace('onVisibilityChange_TABID', visibility_func_name)
+			# multiple reasons for doing it this way ^: stealth, uniqueness, sometimes pageload is cancelled and it runs twice, etc.
+			await page.evaluate(js_code)
+
+			# re-add listener to the page for when it navigates to a new url, because previous listeners will be cleared
+			page.on('domcontentloaded', self._add_tab_foregrounding_listener)
+			logger.debug(f'👀 Added tab focus listeners to tab: {page.url}')
+
+			if page.url != self.agent_current_page.url:
+				await on_visibility_change({'source': 'navigation'})
+
+		except Exception as e:
+			logger.debug(f'Failed to add tab focus listener to {page.url}: {e}')
 
 	async def get_session(self) -> BrowserSession:
 		"""Lazy initialization of the browser and related components"""
@@ -393,9 +470,114 @@ class BrowserContext:
 		return self.session
 
 	async def get_current_page(self) -> Page:
-		"""Get the current page"""
+		"""Legacy method for backwards compatibility, prefer get_agent_current_page()"""
+		return await self.get_agent_current_page()
+
+	async def _reconcile_tab_state(self) -> None:
+		"""Reconcile tab state when tabs might be out of sync.
+
+		This method ensures that:
+		1. Both tab references (agent_current_page and human_current_page) are valid
+		2. Recovers invalid tab references using valid ones
+		3. Handles the case where both references are invalid
+		"""
 		session = await self.get_session()
-		return await self._get_current_page(session)
+
+		agent_tab_valid = (
+			self.agent_current_page
+			and self.agent_current_page in session.context.pages
+			and not self.agent_current_page.is_closed()
+		)
+
+		human_current_page_valid = (
+			self.human_current_page
+			and self.human_current_page in session.context.pages
+			and not self.human_current_page.is_closed()
+		)
+
+		# Case 1: Both references are valid - nothing to do
+		if agent_tab_valid and human_current_page_valid:
+			return
+
+		# Case 2: Only agent_current_page is valid - update human_current_page
+		if agent_tab_valid and not human_current_page_valid:
+			self.human_current_page = self.agent_current_page
+			return
+
+		# Case 3: Only human_current_page is valid - update agent_current_page
+		if human_current_page_valid and not agent_tab_valid:
+			self.agent_current_page = self.human_current_page
+			return
+
+		# Case 4: Neither reference is valid - recover from available tabs
+		non_extension_pages = [
+			page
+			for page in session.context.pages
+			if not page.url.startswith('chrome-extension://') and not page.url.startswith('chrome://')
+		]
+
+		if non_extension_pages:
+			# Update both tab references to the most recently opened non-extension page
+			recovered_page = non_extension_pages[-1]
+			self.agent_current_page = recovered_page
+			self.human_current_page = recovered_page
+			return
+
+		# Case 5: No valid pages at all - create a new page
+		try:
+			new_page = await session.context.new_page()
+			self.agent_current_page = new_page
+			self.human_current_page = new_page
+		except Exception:
+			# Last resort - recreate the session
+			logger.warning('⚠️  No browser window available, recreating session')
+			await self._initialize_session()
+			if session.context.pages:
+				page = session.context.pages[0]
+				self.agent_current_page = page
+				self.human_current_page = page
+
+	async def get_agent_current_page(self) -> Page:
+		"""Get the page that the agent is currently working with.
+
+		This method prioritizes agent_current_page over human_current_page, ensuring
+		that agent operations happen on the intended tab regardless of user
+		interaction with the browser.
+
+		If agent_current_page is invalid or closed, it will attempt to recover
+		with a valid tab reference by reconciling the tab state.
+		"""
+		session = await self.get_session()
+
+		# First check if agent_current_page is valid
+		if (
+			self.agent_current_page
+			and self.agent_current_page in session.context.pages
+			and not self.agent_current_page.is_closed()
+		):
+			return self.agent_current_page
+
+		# If we're here, reconcile tab state and try again
+		await self._reconcile_tab_state()
+
+		# After reconciliation, agent_current_page should be valid
+		if (
+			self.agent_current_page
+			and self.agent_current_page in session.context.pages
+			and not self.agent_current_page.is_closed()
+		):
+			return self.agent_current_page
+
+		# If still invalid, fall back to first page method as last resort
+		logger.warning('⚠️  Failed to get agent current page, falling back to first page')
+		if session.context.pages:
+			page = session.context.pages[0]
+			self.agent_current_page = page
+			self.human_current_page = page
+			return page
+
+		# If no pages, create one
+		return await session.context.new_page()
 
 	async def _create_context(self, browser: PlaywrightBrowser):
 		"""Creates a new browser context with anti-detection measures and loads cookies if available."""
@@ -404,14 +586,14 @@ class BrowserContext:
 			# For existing contexts, we need to set the viewport size manually
 			if context.pages and not self.browser.config.headless:
 				for page in context.pages:
-					await self._set_viewport_size_for_page(page)
+					await self.set_viewport_size(page)
 		elif self.browser.config.browser_binary_path and len(browser.contexts) > 0 and not self.config.force_new_context:
 			# Connect to existing Chrome instance instead of creating new one
 			context = browser.contexts[0]
 			# For existing contexts, we need to set the viewport size manually
 			if context.pages and not self.browser.config.headless:
 				for page in context.pages:
-					await self._set_viewport_size_for_page(page)
+					await self.set_viewport_size(page)
 		else:
 			kwargs = {}
 			# Set viewport for both headless and non-headless modes
@@ -535,21 +717,24 @@ class BrowserContext:
 
 		return context
 
-	async def _set_viewport_size_for_page(self, page: Page) -> None:
-		"""Helper method to set viewport size for a page"""
+	async def set_viewport_size(self, page: Page) -> None:
+		"""
+		Central method to set viewport size for a page.
+		Simple for now, but we may need to add more logic here in the future to rezise surrounding window, change recording options, etc.
+		"""
 		try:
-			# Only set viewport size if no_viewport is False
+			# Only set viewport size if no_viewport is False (aka viewport=True)
 			if self.config.no_viewport is False:
 				viewport_size = {'width': self.config.window_width, 'height': self.config.window_height}
 				await page.set_viewport_size(viewport_size)
 				logger.debug(f'Set viewport size to {self.config.window_width}x{self.config.window_height}')
-			else:
-				logger.debug('Skipping viewport size setting because no_viewport is not False')
+			# else:
+			# logger.debug('Skipping viewport size setting because no_viewport is not False')
 		except Exception as e:
 			logger.debug(f'Failed to set viewport size for page: {e}')
 
 	async def _wait_for_stable_network(self):
-		page = await self.get_current_page()
+		page = await self.get_agent_current_page()
 
 		pending_requests = set()
 		last_activity = asyncio.get_event_loop().time()
@@ -731,7 +916,7 @@ class BrowserContext:
 			await self._wait_for_stable_network()
 
 			# Check if the loaded URL is allowed
-			page = await self.get_current_page()
+			page = await self.get_agent_current_page()
 			await self._check_and_handle_navigation(page)
 		except URLNotAllowedError as e:
 			raise e
@@ -787,23 +972,23 @@ class BrowserContext:
 			raise URLNotAllowedError(f'Navigation to non-allowed URL: {page.url}')
 
 	async def navigate_to(self, url: str):
-		"""Navigate to a URL"""
+		"""Navigate the agent's current tab to a URL"""
 		if not self._is_url_allowed(url):
 			raise BrowserError(f'Navigation to non-allowed URL: {url}')
 
-		page = await self.get_current_page()
+		page = await self.get_agent_current_page()
 		await page.goto(url)
 		await page.wait_for_load_state()
 
 	async def refresh_page(self):
-		"""Refresh the current page"""
-		page = await self.get_current_page()
+		"""Refresh the agent's current page"""
+		page = await self.get_agent_current_page()
 		await page.reload()
 		await page.wait_for_load_state()
 
 	async def go_back(self):
-		"""Navigate back in history"""
-		page = await self.get_current_page()
+		"""Navigate the agent's tab back in browser history"""
+		page = await self.get_agent_current_page()
 		try:
 			# 10 ms timeout
 			await page.go_back(timeout=10, wait_until='domcontentloaded')
@@ -813,8 +998,8 @@ class BrowserContext:
 			logger.debug(f'⏮️  Error during go_back: {e}')
 
 	async def go_forward(self):
-		"""Navigate forward in history"""
-		page = await self.get_current_page()
+		"""Navigate the agent's tab forward in browser history"""
+		page = await self.get_agent_current_page()
 		try:
 			await page.go_forward(timeout=10, wait_until='domcontentloaded')
 		except Exception as e:
@@ -822,26 +1007,43 @@ class BrowserContext:
 			logger.debug(f'⏭️  Error during go_forward: {e}')
 
 	async def close_current_tab(self):
-		"""Close the current tab"""
+		"""Close the current tab that the agent is working with.
+
+		This closes the tab that the agent is currently using (agent_current_page),
+		not necessarily the tab that is visible to the user (human_current_page).
+		If they are the same tab, both references will be updated.
+		"""
 		session = await self.get_session()
-		page = await self._get_current_page(session)
+		page = await self.get_agent_current_page()
+
+		# Check if this is the foreground tab as well
+		is_foreground = page == self.human_current_page
+
+		# Close the tab
 		await page.close()
-		self.active_tab = None
+
+		# Clear agent's reference to the closed tab
+		self.agent_current_page = None
+
+		# Clear foreground reference if needed
+		if is_foreground:
+			self.human_current_page = None
+
 		# Switch to the first available tab if any exist
 		if session.context.pages:
 			await self.switch_to_tab(0)
-			self.active_tab = session.context.pages[0]
+			# switch_to_tab already updates both tab references
 
-		# otherwise the browser will be closed
+		# Otherwise, the browser will be closed
 
 	async def get_page_html(self) -> str:
-		"""Get the current page HTML content"""
-		page = await self.get_current_page()
+		"""Get the HTML content of the agent's current page"""
+		page = await self.get_agent_current_page()
 		return await page.content()
 
 	async def execute_javascript(self, script: str):
-		"""Execute JavaScript code on the page"""
-		page = await self.get_current_page()
+		"""Execute JavaScript code on the agent's current page"""
+		page = await self.get_agent_current_page()
 		return await page.evaluate(script)
 
 	async def get_page_structure(self) -> str:
@@ -911,7 +1113,7 @@ class BrowserContext:
 			return getPageStructure();
 		})()"""
 
-		page = await self.get_current_page()
+		page = await self.get_agent_current_page()
 		structure = await page.evaluate(debug_script)
 		return structure
 
@@ -962,19 +1164,12 @@ class BrowserContext:
 
 		# Check if current page is still valid, if not switch to another available page
 		try:
-			page = await self.get_current_page()
+			page = await self.get_agent_current_page()
 			# Test if page is still accessible
 			await page.evaluate('1')
 		except Exception as e:
 			logger.debug(f'👋  Current page is no longer accessible: {str(e)}')
-			# Get all available pages
-			pages = session.context.pages
-			if pages:
-				self.state.target_id = None
-				page = await self._get_current_page(session)
-				logger.debug(f'🔄  Switched to page: {await page.title()}')
-			else:
-				raise BrowserError('Browser closed: no valid pages available')
+			raise BrowserError('Browser closed: no valid pages available')
 
 		try:
 			await self.remove_highlights()
@@ -1010,12 +1205,21 @@ class BrowserContext:
 			screenshot_b64 = await self.take_screenshot()
 			pixels_above, pixels_below = await self.get_scroll_info(page)
 
+			# Find the agent's active tab ID
+			agent_current_page_id = 0
+			if self.agent_current_page:
+				for tab_info in tabs_info:
+					if tab_info.url == self.agent_current_page.url:
+						agent_current_page_id = tab_info.page_id
+						break
+
 			self.current_state = BrowserState(
 				element_tree=content.element_tree,
 				selector_map=content.selector_map,
 				url=page.url,
 				title=await page.title(),
 				tabs=tabs_info,
+				current_tab_id=agent_current_page_id,
 				screenshot=screenshot_b64,
 				pixels_above=pixels_above,
 				pixels_below=pixels_below,
@@ -1035,9 +1239,10 @@ class BrowserContext:
 		"""
 		Returns a base64 encoded screenshot of the current page.
 		"""
-		page = await self.get_current_page()
+		page = await self.get_agent_current_page()
 
-		await page.bring_to_front()
+		# We no longer force tabs to the foreground as it disrupts user focus
+		# await page.bring_to_front()
 		await page.wait_for_load_state()
 
 		screenshot = await page.screenshot(
@@ -1058,7 +1263,7 @@ class BrowserContext:
 		Handles cases where the page might be closed or inaccessible.
 		"""
 		try:
-			page = await self.get_current_page()
+			page = await self.get_agent_current_page()
 			await page.evaluate(
 				"""
                 try {
@@ -1256,7 +1461,7 @@ class BrowserContext:
 
 	@time_execution_async('--get_locate_element')
 	async def get_locate_element(self, element: DOMElementNode) -> ElementHandle | None:
-		current_frame = await self.get_current_page()
+		current_frame = await self.get_agent_current_page()
 
 		# Start with the target element and collect all parents
 		parents: list[DOMElementNode] = []
@@ -1304,7 +1509,7 @@ class BrowserContext:
 		"""
 		Locates an element on the page using the provided XPath.
 		"""
-		current_frame = await self.get_current_page()
+		current_frame = await self.get_agent_current_page()
 
 		try:
 			# Use XPath to locate the element
@@ -1324,7 +1529,7 @@ class BrowserContext:
 		"""
 		Locates an element on the page using the provided CSS selector.
 		"""
-		current_frame = await self.get_current_page()
+		current_frame = await self.get_agent_current_page()
 
 		try:
 			# Use CSS selector to locate the element
@@ -1348,7 +1553,7 @@ class BrowserContext:
 		If `nth` is provided, it returns the nth matching element (0-based).
 		If `element_type` is provided, filters by tag name (e.g., 'button', 'span').
 		"""
-		current_frame = await self.get_current_page()
+		current_frame = await self.get_agent_current_page()
 		try:
 			# handle also specific element type or use any type.
 			selector = f'{element_type or "*"}:text("{text}")'
@@ -1427,7 +1632,7 @@ class BrowserContext:
 		"""
 		Optimized method to click an element using xpath.
 		"""
-		page = await self.get_current_page()
+		page = await self.get_agent_current_page()
 
 		try:
 			# Highlight before clicking
@@ -1524,20 +1729,16 @@ class BrowserContext:
 					self.state.target_id = target['targetId']
 					break
 
-		self.active_tab = page
+		# Update both tab references - agent wants this tab, and it's now in the foreground
+		self.agent_current_page = page
+		self.human_current_page = page
+
+		# Bring tab to front and wait for it to load
 		await page.bring_to_front()
 		await page.wait_for_load_state()
 
-		# Set the viewport size for the tab if no_viewport is False
-		try:
-			if self.config.no_viewport is False:
-				viewport_size = {'width': self.config.window_width, 'height': self.config.window_height}
-				await page.set_viewport_size(viewport_size)
-				logger.debug(f'Set viewport size to {self.config.window_width}x{self.config.window_height}')
-			else:
-				logger.debug('Skipping viewport size setting in switch_to_tab because no_viewport is not False')
-		except Exception as e:
-			logger.debug(f'Failed to set viewport size: {e}')
+		# Set the viewport size for the tab
+		await self.set_viewport_size(page)
 
 	@time_execution_async('--create_new_tab')
 	async def create_new_tab(self, url: str | None = None) -> None:
@@ -1548,20 +1749,14 @@ class BrowserContext:
 		session = await self.get_session()
 		new_page = await session.context.new_page()
 
-		self.active_tab = new_page
+		# Update both tab references - agent wants this tab, and it's now in the foreground
+		self.agent_current_page = new_page
+		self.human_current_page = new_page
 
 		await new_page.wait_for_load_state()
 
-		# Set the viewport size for the new tab if no_viewport is False
-		try:
-			if self.config.no_viewport is False:
-				viewport_size = {'width': self.config.window_width, 'height': self.config.window_height}
-				await new_page.set_viewport_size(viewport_size)
-				logger.debug(f'Set viewport size to {self.config.window_width}x{self.config.window_height}')
-			else:
-				logger.debug('Skipping viewport size setting in create_new_tab because no_viewport is not False')
-		except Exception as e:
-			logger.debug(f'Failed to set viewport size: {e}')
+		# Set the viewport size for the new tab
+		await self.set_viewport_size(new_page)
 
 		if url:
 			await new_page.goto(url)
@@ -1575,42 +1770,7 @@ class BrowserContext:
 					self.state.target_id = target['targetId']
 					break
 
-	# endregion
-
 	# region - Helper methods for easier access to the DOM
-	async def _get_current_page(self, session: BrowserSession) -> Page:
-		pages = session.context.pages
-
-		# Try to find page by target ID if using CDP
-		if self.browser.config.cdp_url and self.state.target_id:
-			targets = await self._get_cdp_targets()
-			for target in targets:
-				if target['targetId'] == self.state.target_id:
-					for page in pages:
-						if page.url == target['url']:
-							return page
-
-		if self.active_tab and self.active_tab in session.context.pages and not self.active_tab.is_closed():
-			return self.active_tab
-
-		# fall back to most recently opened non-extension page (extensions are almost always invisible background targets)
-		non_extension_pages = [
-			page for page in pages if not page.url.startswith('chrome-extension://') and not page.url.startswith('chrome://')
-		]
-		if non_extension_pages:
-			return non_extension_pages[-1]
-
-		# Fallback to opening a new tab in the active window
-		try:
-			return await session.context.new_page()
-		except Exception:
-			# there is no browser window available (perhaps the user closed it?)
-			# reopen a new window in the browser and try again
-			logger.warning('⚠️  No browser window available, opening a new window')
-			await self._initialize_session()
-			page = await session.context.new_page()
-			self.active_tab = page
-			return page
 
 	async def get_selector_map(self) -> SelectorMap:
 		session = await self.get_session()
@@ -1691,7 +1851,6 @@ class BrowserContext:
 		for page in pages:
 			await page.close()
 
-		self.active_tab = None
 		session.cached_state = None
 		self.state.target_id = None
 
@@ -1732,15 +1891,8 @@ class BrowserContext:
 			page = context.pages[0]
 			window_size = {'width': self.config.window_width, 'height': self.config.window_height}
 
-			# First, set the viewport size if no_viewport is False
-			try:
-				if self.config.no_viewport is False:
-					await page.set_viewport_size(window_size)
-					logger.debug(f'Set viewport size to {window_size["width"]}x{window_size["height"]}')
-				else:
-					logger.debug('Skipping viewport size setting in _resize_window because no_viewport is not False')
-			except Exception as e:
-				logger.debug(f'Viewport resize failed: {e}')
+			# First, set the viewport size
+			await self.set_viewport_size(page)
 
 			# Then, try to set the actual window size using CDP
 			try:
@@ -1800,5 +1952,5 @@ class BrowserContext:
 		Raises:
 		    TimeoutError: If the element does not become visible within the specified timeout.
 		"""
-		page = await self.get_current_page()
+		page = await self.get_agent_current_page()
 		await page.wait_for_selector(selector, state='visible', timeout=timeout)

--- a/browser_use/browser/views.py
+++ b/browser_use/browser/views.py
@@ -32,6 +32,7 @@ class BrowserState(DOMState):
 	url: str
 	title: str
 	tabs: list[TabInfo]
+	current_tab_id: int = 0
 	screenshot: str | None = None
 	pixels_above: int = 0
 	pixels_below: int = 0

--- a/browser_use/browser/views.py
+++ b/browser_use/browser/views.py
@@ -32,7 +32,6 @@ class BrowserState(DOMState):
 	url: str
 	title: str
 	tabs: list[TabInfo]
-	current_tab_id: int = 0
 	screenshot: str | None = None
 	pixels_above: int = 0
 	pixels_below: int = 0

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -190,8 +190,8 @@ class Controller(Generic[Context]):
 		@self.registry.action('Switch tab', param_model=SwitchTabAction)
 		async def switch_tab(params: SwitchTabAction, browser: BrowserContext):
 			await browser.switch_to_tab(params.page_id)
-			# Wait for tab to be ready
-			page = await browser.get_current_page()
+			# Wait for tab to be ready and ensure references are synchronized
+			page = await browser.get_agent_current_page()
 			await page.wait_for_load_state()
 			msg = f'🔄  Switched to tab {params.page_id}'
 			logger.info(msg)
@@ -200,6 +200,8 @@ class Controller(Generic[Context]):
 		@self.registry.action('Open url in new tab', param_model=OpenTabAction)
 		async def open_tab(params: OpenTabAction, browser: BrowserContext):
 			await browser.create_new_tab(params.url)
+			# Ensure tab references are properly synchronized
+			page = await browser.get_agent_current_page()
 			msg = f'🔗  Opened new tab with {params.url}'
 			logger.info(msg)
 			return ActionResult(extracted_content=msg, include_in_memory=True)

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -201,7 +201,7 @@ class Controller(Generic[Context]):
 		async def open_tab(params: OpenTabAction, browser: BrowserContext):
 			await browser.create_new_tab(params.url)
 			# Ensure tab references are properly synchronized
-			page = await browser.get_agent_current_page()
+			await browser.get_agent_current_page()  # this has side-effects (even though it looks like a getter)
 			msg = f'🔗  Opened new tab with {params.url}'
 			logger.info(msg)
 			return ActionResult(extracted_content=msg, include_in_memory=True)

--- a/tests/test_tab_management.py
+++ b/tests/test_tab_management.py
@@ -1,0 +1,406 @@
+import asyncio
+import logging
+
+import pytest
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use.agent.views import ActionModel
+from browser_use.browser.browser import Browser, BrowserConfig
+from browser_use.browser.context import BrowserContext
+from browser_use.controller.service import Controller
+
+# Set up test logging
+logger = logging.getLogger('tab_tests')
+logger.setLevel(logging.DEBUG)
+
+
+class TestTabManagement:
+	"""Tests for the tab management system with separate agent_current_page and human_current_page references."""
+
+	@pytest.fixture(scope='module')
+	def event_loop(self):
+		"""Create and provide an event loop for async tests."""
+		loop = asyncio.get_event_loop_policy().new_event_loop()
+		yield loop
+		loop.close()
+
+	@pytest.fixture(scope='module')
+	async def browser(self, event_loop):
+		"""Create and provide a Browser instance with security disabled."""
+		browser_instance = Browser(
+			config=BrowserConfig(
+				headless=True,
+				disable_security=True,
+			)
+		)
+		yield browser_instance
+		await browser_instance.close()
+
+	@pytest.fixture
+	async def browser_context(self, browser):
+		"""Create and provide a BrowserContext instance with a properly initialized tab."""
+		context = BrowserContext(browser=browser)
+
+		# Initialize a session
+		session = await context.get_session()
+
+		# Ensure we start with no pages (close any that might exist)
+		for page in session.context.pages:
+			await page.close()
+
+		# Create an initial tab and wait for it to load completely
+		await context.create_new_tab('https://example.com/page1')
+		await asyncio.sleep(1)  # Wait for the tab to fully initialize
+
+		# Verify that agent_current_page and human_current_page are properly set
+		assert context.agent_current_page is not None
+		assert context.human_current_page is not None
+		assert 'example.com' in context.agent_current_page.url
+
+		yield context
+		await context.close()
+
+	@pytest.fixture
+	def controller(self):
+		"""Create and provide a Controller instance."""
+		return Controller()
+
+	# Helper methods
+
+	async def _execute_action(self, controller, browser_context, action_data):
+		"""Generic helper to execute any action via the controller."""
+		# Dynamically create an appropriate ActionModel class
+		action_type = list(action_data.keys())[0]
+		action_value = action_data[action_type]
+
+		# Create the ActionModel with the single action field
+		class DynamicActionModel(ActionModel):
+			pass
+
+		# Dynamically add the field with the right type annotation
+		setattr(DynamicActionModel, action_type, type(action_value) | None)
+
+		# Execute the action
+		result = await controller.act(DynamicActionModel(**action_data), browser_context)
+
+		# Give the browser a moment to process the action
+		await asyncio.sleep(0.5)
+
+		return result
+
+	async def _ensure_synchronized_state(self, browser_context):
+		"""Helper to ensure tab references are properly synchronized before tests."""
+		# Make sure agent_current_page and human_current_page are set and valid
+		session = await browser_context.get_session()
+
+		if not browser_context.agent_current_page or browser_context.agent_current_page not in session.context.pages:
+			if session.context.pages:
+				browser_context.agent_current_page = session.context.pages[0]
+			else:
+				# Create a tab with a real website
+				await browser_context.create_new_tab('https://example.com/page1')
+				await asyncio.sleep(1)  # Wait longer for tab to initialize
+
+		if not browser_context.human_current_page or browser_context.human_current_page not in session.context.pages:
+			browser_context.human_current_page = browser_context.agent_current_page
+
+	async def _simulate_user_tab_change(self, page, browser_context):
+		"""Simulate a user changing tabs by properly triggering events with Playwright."""
+		logger.debug(
+			f'BEFORE: agent_tab={browser_context.agent_current_page.url if browser_context.agent_current_page else "None"}, '
+			f'human_current_page={browser_context.human_current_page.url if browser_context.human_current_page else "None"}'
+		)
+		logger.debug(f'Simulating user changing to -> {page.url}')
+
+		# First bring the page to front - this is the physical action a user would take
+		await page.bring_to_front()
+
+		# To simulate a user switching tabs, we need to trigger the right events
+		# Use Playwright's dispatch_event method to properly trigger events from outside
+
+		await page.evaluate("""() => window.dispatchEvent(new Event('focus'))""")
+		logger.debug('Dispatched window.focus event')
+
+		# Give the event handlers time to process
+		await asyncio.sleep(0.5)
+
+		logger.debug(
+			f'AFTER: agent_tab URL={browser_context.agent_current_page.url if browser_context.agent_current_page else "None"}, '
+			f'human_current_page URL={browser_context.human_current_page.url if browser_context.human_current_page else "None"}'
+		)
+
+	# Tab management tests
+
+	@pytest.mark.asyncio
+	async def test_open_tab_updates_both_references(self, browser_context):
+		"""Test that open_tab correctly updates both tab references."""
+		# Ensure tab references are synchronized
+		await self._ensure_synchronized_state(browser_context)
+
+		# Store initial tab count and references
+		session = await browser_context.get_session()
+		initial_tab_count = len(session.context.pages)
+		initial_agent_tab = browser_context.agent_current_page
+
+		# Open a new tab directly via BrowserContext
+		await browser_context.create_new_tab('https://example.com/page2')
+
+		# Give time for events to process
+		await asyncio.sleep(1)
+
+		# Verify a new tab was created
+		session = await browser_context.get_session()
+		assert len(session.context.pages) == initial_tab_count + 1
+
+		# Both references should be set to the new tab and different from initial tab
+		assert browser_context.human_current_page is not None
+		assert browser_context.agent_current_page is not None
+		assert browser_context.human_current_page == browser_context.agent_current_page
+		assert initial_agent_tab != browser_context.agent_current_page
+		assert 'example.com/page2' in browser_context.agent_current_page.url
+
+	@pytest.mark.asyncio
+	async def test_switch_tab_updates_both_references(self, browser_context):
+		"""Test that switch_tab updates both tab references."""
+		# Ensure we start with at least one tab
+		await self._ensure_synchronized_state(browser_context)
+
+		# Create a new tab in addition to existing one
+		await browser_context.create_new_tab('https://example.com/page2')
+		await asyncio.sleep(1)
+
+		# Verify we now have the second tab active
+		assert 'example.com/page2' in browser_context.agent_current_page.url
+
+		# Switch to the first tab
+		session = await browser_context.get_session()
+		first_tab = session.context.pages[0]
+		await browser_context.switch_to_tab(0)
+		await asyncio.sleep(0.5)
+
+		# Both references should point to the first tab
+		assert browser_context.human_current_page is not None
+		assert browser_context.agent_current_page is not None
+		assert browser_context.human_current_page == browser_context.agent_current_page
+		assert browser_context.agent_current_page == first_tab
+		assert 'example.com/page1' in browser_context.agent_current_page.url
+
+		# Verify the underlying page is correct by checking we can interact with it
+		page = await browser_context.get_agent_current_page()
+		title = await page.title()
+		assert 'Example' in title
+
+	@pytest.mark.asyncio
+	async def test_close_tab_handles_references_correctly(self, browser_context):
+		"""Test that closing a tab updates references correctly."""
+		# Ensure we start with at least one tab
+		await self._ensure_synchronized_state(browser_context)
+
+		# Create two tabs with different URLs
+		initial_tab = browser_context.agent_current_page
+		await browser_context.create_new_tab('https://example.com/page2')
+		await asyncio.sleep(1)
+
+		# Verify the second tab is now active
+		assert 'example.com/page2' in browser_context.agent_current_page.url
+
+		# Close the current tab
+		await browser_context.close_current_tab()
+		await asyncio.sleep(0.5)
+
+		# Both references should be updated to the remaining available tab
+		assert browser_context.human_current_page is not None
+		assert browser_context.agent_current_page is not None
+		assert browser_context.human_current_page == browser_context.agent_current_page
+		assert browser_context.agent_current_page == initial_tab
+		assert not browser_context.human_current_page.is_closed()
+		assert 'example.com/page1' in browser_context.human_current_page.url
+
+	@pytest.mark.asyncio
+	async def test_user_changes_tab(self, browser_context):
+		"""Test that agent_current_page is preserved when user changes the foreground tab."""
+		# Ensure we start with at least one tab
+		await self._ensure_synchronized_state(browser_context)
+
+		# Create a second tab with a different URL
+		await browser_context.create_new_tab('https://example.com/page2')
+		await asyncio.sleep(1)
+		assert 'example.com/page2' in browser_context.agent_current_page.url
+
+		# Switch back to the first tab for the agent
+		session = await browser_context.get_session()
+		first_tab = session.context.pages[0]
+		await browser_context.switch_to_tab(0)
+		await self._simulate_user_tab_change(first_tab, browser_context)
+		await asyncio.sleep(0.5)
+
+		# Store agent's active tab
+		agent_tab = browser_context.agent_current_page
+		assert 'example.com/page1' in agent_tab.url
+
+		# Simulate user switching to the second tab
+		session = await browser_context.get_session()
+		user_tab = session.context.pages[1]  # Second tab
+
+		# First, log the visibility listeners
+		listeners = await user_tab.evaluate("() => Object.keys(window).filter(k => k.startsWith('onVisibilityChange'))")
+		logger.debug(f'Tab visibility listeners: {listeners}')
+
+		# Make sure handlers exist before attempting to trigger them
+		assert len(listeners) > 0, 'No visibility listeners found on the page'
+
+		# Now try the simulation
+		await self._simulate_user_tab_change(user_tab, browser_context)
+
+		# Verify agent_current_page remains unchanged while human_current_page changed
+		assert browser_context.agent_current_page == agent_tab
+		assert browser_context.human_current_page != browser_context.agent_current_page
+		assert 'example.com/page1' in browser_context.agent_current_page.url
+		assert 'example.com/page2' in browser_context.human_current_page.url
+
+	@pytest.mark.asyncio
+	async def test_get_agent_current_page(self, browser_context):
+		"""Test that get_agent_current_page returns agent_current_page regardless of human_current_page."""
+		# Ensure we start with at least one tab
+		await self._ensure_synchronized_state(browser_context)
+
+		# Create a second tab with a different URL
+		await browser_context.create_new_tab('https://example.com/page2')
+		await asyncio.sleep(1)
+
+		# Switch back to the first tab for the agent
+		await browser_context.switch_to_tab(0)
+		await asyncio.sleep(0.5)
+
+		# Simulate user switching to the second tab
+		session = await browser_context.get_session()
+		user_tab = session.context.pages[1]  # Second tab
+		await self._simulate_user_tab_change(user_tab, browser_context)
+
+		# Verify get_agent_current_page returns agent's tab, not foreground tab
+		agent_page = await browser_context.get_agent_current_page()
+		assert agent_page == browser_context.agent_current_page
+		assert agent_page != browser_context.human_current_page
+		assert 'example.com/page1' in agent_page.url
+
+		# Call a method on the page to verify it's fully functional
+		title = await agent_page.title()
+		assert 'Example' in title
+
+	@pytest.mark.asyncio
+	async def test_browser_operations_use_agent_current_page(self, browser_context):
+		"""Test that browser operations use agent_current_page, not human_current_page."""
+		# Ensure we start with at least one tab
+		await self._ensure_synchronized_state(browser_context)
+
+		# Create a second tab with a different URL
+		await browser_context.create_new_tab('https://example.com/page2')
+		await asyncio.sleep(1)
+
+		# Switch back to the first tab for the agent
+		await browser_context.switch_to_tab(0)
+		await asyncio.sleep(0.5)
+
+		# Simulate user switching to the second tab
+		session = await browser_context.get_session()
+		user_tab = session.context.pages[1]  # Second tab
+		await self._simulate_user_tab_change(user_tab, browser_context)
+
+		# Verify we have the setup we want
+		assert browser_context.human_current_page != browser_context.agent_current_page
+		assert 'example.com/page2' in browser_context.human_current_page.url
+		assert 'example.com/page1' in browser_context.agent_current_page.url
+
+		# Execute a navigation directly on agent's tab
+		agent_page = await browser_context.get_agent_current_page()
+		await agent_page.goto('https://bing.com')
+		await asyncio.sleep(0.5)
+
+		# Verify navigation happened on agent_current_page
+		assert 'bing.com' in browser_context.agent_current_page.url
+		# But human_current_page remains unchanged
+		assert 'example.com/page2' in browser_context.human_current_page.url
+
+	@pytest.mark.asyncio
+	async def test_tab_reference_recovery(self, browser_context):
+		"""Test recovery when a tab reference becomes invalid."""
+		# Ensure we start with at least one valid tab
+		await self._ensure_synchronized_state(browser_context)
+
+		# Create a second tab so we have multiple
+		await browser_context.create_new_tab('https://example.com/page2')
+		await asyncio.sleep(1)
+
+		# Deliberately corrupt the agent_current_page reference
+		browser_context.agent_current_page = None
+
+		# Call get_agent_current_page, which should recover the reference
+		agent_page = await browser_context.get_agent_current_page()
+
+		# Verify recovery worked
+		assert agent_page is not None
+		assert not agent_page.is_closed()
+
+		# Verify the tab is fully functional
+		title = await agent_page.title()
+		assert title, 'Page should have a title'
+
+		# Verify both references are now valid again
+		assert browser_context.agent_current_page is not None
+		assert browser_context.human_current_page is not None
+
+	@pytest.mark.asyncio
+	async def test_reconcile_tab_state_handles_both_invalid(self, browser_context):
+		"""Test that reconcile_tab_state can recover when both tab references are invalid."""
+		# Ensure we start with at least one valid tab
+		await self._ensure_synchronized_state(browser_context)
+
+		# Corrupt both references
+		browser_context.agent_current_page = None
+		browser_context.human_current_page = None
+
+		# Call reconcile_tab_state directly
+		await browser_context._reconcile_tab_state()
+
+		# Verify both references are restored
+		assert browser_context.agent_current_page is not None
+		assert browser_context.human_current_page is not None
+		# and they are the same tab
+		assert browser_context.agent_current_page == browser_context.human_current_page
+		# and the tab is valid
+		assert not browser_context.agent_current_page.is_closed()
+
+	@pytest.mark.asyncio
+	async def test_race_condition_resilience(self, browser_context):
+		"""Test resilience against race conditions in tab operations."""
+		# Ensure we start with at least one valid tab
+		await self._ensure_synchronized_state(browser_context)
+
+		# Create two more tabs to have three in total
+		await browser_context.create_new_tab('https://example.com/page2')
+		await asyncio.sleep(0.5)
+		await browser_context.create_new_tab('https://example.com/page3')
+		await asyncio.sleep(0.5)
+
+		# Verify we have at least 3 tabs
+		session = await browser_context.get_session()
+		assert len(session.context.pages) >= 3
+
+		# Perform a series of rapid tab switches to simulate race conditions
+		for i in range(5):
+			tab_index = i % 3
+			await browser_context.switch_to_tab(tab_index)
+			await asyncio.sleep(0.1)  # Very short delay between switches
+
+		# Verify the state is consistent after rapid operations
+		assert browser_context.human_current_page is not None
+		assert browser_context.agent_current_page is not None
+		assert browser_context.human_current_page == browser_context.agent_current_page
+		assert not browser_context.human_current_page.is_closed()
+
+		# Verify we can still navigate on the final tab
+		page = await browser_context.get_agent_current_page()
+		await page.goto('https://example.com/page4')
+		assert 'example.com/page4' in page.url


### PR DESCRIPTION
- implements separate tracking of `agent_current_page` and `human_current_page` so that agent is no longer confused by human stealing active tab focus (+ shows a warning when that happens)
- implement consistent naming everywhere: "page" insetead of "tab" in variable names to reflect that they contain a Playwright `Page` object
- DRY the viewport resizing code that was duplicated all over
- add security warning to encourage people to implement URL restrictions when using sensitive data https://docs.browser-use.com/customize/browser-settings#restrict-urls
- add warning when some required permissions are needed
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Improved tab tracking by separating agent and human foreground tab detection, added security warnings for unsafe sensitive data usage, and made viewport resizing consistent. Also added tests for tab management and warnings for missing required permissions.

- **Bug Fixes**
  - Fixed agent confusion when the user changes the active browser tab by tracking agent and human current pages separately.
  - Prevented flickering and inconsistent viewport sizing by centralizing viewport resizing logic.

- **Security**
  - Added a warning if sensitive data is used without restricting allowed domains.
  - Warned when required permissions (clipboard-read, clipboard-write) are missing.

<!-- End of auto-generated description by mrge. -->

