### PR TITLE
Add warning when sensitive data is missing any keys

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
         - functionality/hooks
         - test_controller
         - test_tab_management
+        - test_sensitive_data
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -62,7 +62,7 @@ class MessageManager:
 
 		if self.settings.sensitive_data:
 			info = f'Here are placeholders for sensitive data: {list(self.settings.sensitive_data.keys())}'
-			info += 'To use them, write <secret>the placeholder name</secret>'
+			info += '\nTo use them, write <secret>the placeholder name</secret>'
 			info_message = HumanMessage(content=info)
 			self._add_message_with_tokens(info_message, message_type='init')
 
@@ -216,10 +216,19 @@ class MessageManager:
 		def replace_sensitive(value: str) -> str:
 			if not self.settings.sensitive_data:
 				return value
-			for key, val in self.settings.sensitive_data.items():
-				if not val:
-					continue
+
+			# Create a dictionary with all key-value pairs from sensitive_data where value is not None or empty
+			valid_sensitive_data = {k: v for k, v in self.settings.sensitive_data.items() if v}
+
+			# If there are no valid sensitive data entries, just return the original value
+			if not valid_sensitive_data:
+				logger.warning('No valid entries found in sensitive_data dictionary')
+				return value
+
+			# Replace all valid sensitive data values with their placeholder tags
+			for key, val in valid_sensitive_data.items():
 				value = value.replace(val, f'<secret>{key}</secret>')
+
 			return value
 
 		if isinstance(message.content, str):

--- a/docs/customize/sensitive-data.mdx
+++ b/docs/customize/sensitive-data.mdx
@@ -45,6 +45,14 @@ In this example:
 2. When the model wants to use your password it outputs x_password - and we replace it with the actual value.
 3. When your password is visible on the current page, we replace it in the LLM input - so that the model never has it in its state.
 
+### Missing or Empty Values
+
+When working with sensitive data, keep these details in mind:
+
+- If a key referenced by the model (`<secret>key_name</secret>`) is missing from your `sensitive_data` dictionary, a warning will be logged but the substitution tag will be preserved.
+- If you provide an empty value for a key in the `sensitive_data` dictionary, it will be treated the same as a missing key.
+- The system will always attempt to process all valid substitutions, even if some keys are missing or empty.
+
 Warning: Vision models still see the image of the page - where the sensitive data might be visible.
 
 This approach ensures that sensitive information remains secure while still allowing the agent to perform tasks that require authentication.

--- a/tests/test_sensitive_data.py
+++ b/tests/test_sensitive_data.py
@@ -1,0 +1,91 @@
+import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from browser_use.agent.message_manager.service import MessageManager, MessageManagerSettings
+from browser_use.agent.views import MessageManagerState
+from browser_use.controller.registry.service import Registry
+
+
+class SensitiveParams(BaseModel):
+	"""Test parameter model for sensitive data testing."""
+
+	text: str = Field(description='Text with sensitive data placeholders')
+
+
+@pytest.fixture
+def registry():
+	return Registry()
+
+
+@pytest.fixture
+def message_manager():
+	return MessageManager(
+		task='Test task',
+		system_message=SystemMessage(content='System message'),
+		settings=MessageManagerSettings(),
+		state=MessageManagerState(),
+	)
+
+
+def test_replace_sensitive_data_with_missing_keys(registry):
+	"""Test that _replace_sensitive_data handles missing keys gracefully"""
+	# Create a simple Pydantic model with sensitive data placeholders
+	params = SensitiveParams(text='Please enter <secret>username</secret> and <secret>password</secret>')
+
+	# Case 1: All keys present
+	sensitive_data = {'username': 'user123', 'password': 'pass456'}
+	result = registry._replace_sensitive_data(params, sensitive_data)
+	assert 'user123' in result.text
+	assert 'pass456' in result.text
+	# Both keys should be replaced
+
+	# Case 2: One key missing
+	sensitive_data = {'username': 'user123'}  # password is missing
+	result = registry._replace_sensitive_data(params, sensitive_data)
+	assert 'user123' in result.text
+	assert '<secret>password</secret>' in result.text
+	# Verify the behavior - username replaced, password kept as tag
+
+	# Case 3: Multiple keys missing
+	sensitive_data = {}  # both keys missing
+	result = registry._replace_sensitive_data(params, sensitive_data)
+	assert '<secret>username</secret>' in result.text
+	assert '<secret>password</secret>' in result.text
+	# Verify both tags are preserved when keys are missing
+
+	# Case 4: One key empty
+	sensitive_data = {'username': 'user123', 'password': ''}
+	result = registry._replace_sensitive_data(params, sensitive_data)
+	assert 'user123' in result.text
+	assert '<secret>password</secret>' in result.text
+	# Empty value should be treated the same as missing key
+
+
+def test_filter_sensitive_data(message_manager):
+	"""Test that _filter_sensitive_data handles all sensitive data scenarios correctly"""
+	# Set up a message with sensitive information
+	message = HumanMessage(content='My username is admin and password is secret123')
+
+	# Case 1: No sensitive data provided
+	message_manager.settings.sensitive_data = None
+	result = message_manager._filter_sensitive_data(message)
+	assert result.content == 'My username is admin and password is secret123'
+
+	# Case 2: All sensitive data is properly replaced
+	message_manager.settings.sensitive_data = {'username': 'admin', 'password': 'secret123'}
+	result = message_manager._filter_sensitive_data(message)
+	assert '<secret>username</secret>' in result.content
+	assert '<secret>password</secret>' in result.content
+
+	# Case 3: Make sure it works with nested content
+	nested_message = HumanMessage(content=[{'type': 'text', 'text': 'My username is admin and password is secret123'}])
+	result = message_manager._filter_sensitive_data(nested_message)
+	assert '<secret>username</secret>' in result.content[0]['text']
+	assert '<secret>password</secret>' in result.content[0]['text']
+
+	# Case 4: Test with empty values
+	message_manager.settings.sensitive_data = {'username': 'admin', 'password': ''}
+	result = message_manager._filter_sensitive_data(message)
+	assert '<secret>username</secret>' in result.content
+	# Only username should be replaced since password is empty


### PR DESCRIPTION
Fixes #728
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added warnings when sensitive data keys are missing or empty, and updated logic to preserve unreplaced placeholders. Also added tests and documentation for these cases.

- **Bug Fixes**
  - Logs a warning if a sensitive data key is missing or empty during substitution.
  - Leaves the placeholder tag unchanged if no value is found.

- **Tests and Docs**
  - Added tests for missing and empty sensitive data keys.
  - Updated documentation to explain the new behavior.

<!-- End of auto-generated description by mrge. -->

