### PR TITLE
Fix: Exclude disabled LWC components from interactive elements list

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -753,6 +753,11 @@
       if (element.inert) {
         return false;
       }
+      
+      // Check specifically for disabled="true" attribute which is common in LWC framework
+      if (element.getAttribute('disabled') === 'true') {
+        return false;
+      }
 
       return true;
     }
@@ -773,6 +778,10 @@
       element.getAttribute('data-toggle') === 'dropdown' ||
       element.getAttribute('aria-haspopup') === 'true'
     )) {
+      // Check specifically for disabled="true" attribute for LWC elements
+      if (element.getAttribute('disabled') === 'true') {
+        return false;
+      }
       return true;
     }
 
@@ -802,7 +811,13 @@
       interactiveRoles.has(role) ||
       interactiveRoles.has(ariaRole);
 
-    if (hasInteractiveRole) return true;
+    if (hasInteractiveRole) {
+      // Check specifically for disabled="true" attribute for elements with ARIA roles
+      if (element.getAttribute('disabled') === 'true') {
+        return false;
+      }
+      return true;
+    }
 
     // check whether element has event listeners
     try {


### PR DESCRIPTION
fixes a bug where disabled elements on lwc sites were being treated as interactive. for example, buttons with disabled="true" were still being clicked, which caused loops or failed interactions.

what changed:
added a check for the disabled attribute inside isInteractiveElement. this applies to regular form elements, elements styled to look interactive, and those using aria roles.

how to test:
run the agent on a site built with lwc. it should now ignore anything marked as disabled.

fixes #1469