### PR TITLE
Integrated patchright chrome as suggested.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,12 @@ FROM python:3.11.3-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-# Install system dependencies
+# Install minimal system dependencies required for Chrome
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
     curl \
+    git \
     unzip \
-    xvfb \
     libnss3 \
-    libatk-bridge2.0-0 \
-    libgtk-3-0 \
     libxss1 \
     libasound2 \
     libx11-xcb1 \
@@ -38,7 +35,7 @@ WORKDIR /app
 # Copy project files
 COPY . /app/
 
-# Change ownership to the non-root user
+# Change ownership
 RUN chown -R appuser:appgroup /app
 
 # Switch to non-root user
@@ -46,11 +43,13 @@ USER appuser
 
 # Install Python dependencies
 RUN pip install --upgrade pip \
-    && pip install .
+    && pip install . \
+    && pip install patchright \
+    && patchright install chrome
 
-# Define health check (example: adjust as needed)
+# Healthcheck (optional)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8000/health || exit 1
 
-# Define default command
+# Default command
 CMD ["python", "-m", "browser_use"]


### PR DESCRIPTION
### What [maintainers](https://github.com/pirate) suggested
Just patchright chrome and avoid installing WebKit/Firefox unnecessarily.

### What this PR does
- Perfectly patchright chrome.
- Avoids installing WebKit/Firefox.
- Keeps everything cleaner, faster, and more maintainable.

### Here's the summary:

| Feature                        | Before                             | After                                  |
|-------------------------------|-------------------------------------|----------------------------------------|
| Base Image                    | `python:3.11.3-slim`                | `python:3.11.3-slim` (unchanged)       |
| Browser Support               | Chromium + Firefox + WebKit        | **Chromium-only** via `patchright`     |
| Extra Dependencies            | Many (GTK, WebKit, etc.)           | Minimal Chrome-only dependencies       |
| Patching                      |  None                             |  Chrome patched with `patchright`    |

Check out [Reference PR](https://github.com/browser-use/browser-use/pull/1542) to get complete picture.















    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Switched the Dockerfile to use only Chromium with patchright, removing unnecessary WebKit and Firefox dependencies for a faster, cleaner build.

- **Dependencies**
  - Installed patchright and applied it to Chrome.
  - Removed WebKit and Firefox-related packages.

<!-- End of auto-generated description by mrge. -->

