### PR TITLE
Fix Azure OpenAI API tool calling method to use function_calling instead of tools

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -406,13 +406,8 @@ class Agent(Generic[Context]):
 			elif self.chat_model_library == 'ChatOpenAI':
 				return 'function_calling'
 			elif self.chat_model_library == 'AzureChatOpenAI':
-				# Azure OpenAI API requires 'tools' parameter for GPT-4
-				# The error 'content must be either a string or an array' occurs when
-				# the API expects a tools array but gets something else
-				if 'gpt-4' in self.model_name.lower():
-					return 'tools'
-				else:
-					return 'function_calling'
+				# Azure OpenAI API now requires 'function_calling' instead of 'tools'
+				return 'function_calling'
 			else:
 				return None
 		else:


### PR DESCRIPTION
fixes issue where azure openai gpt-4o fails with “tools” param. azure only supports “function_calling” now, so we always use that. removed old logic checking for gpt-4. tested and it works. fixes #1578.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated Azure OpenAI API tool calling to always use "function_calling" instead of "tools" to fix compatibility with GPT-4o.

- **Bug Fixes**
  - Removed old logic for "tools" to prevent API errors with Azure GPT-4o.

<!-- End of auto-generated description by mrge. -->

