### PR TITLE
chore: Bedrock optional dependencies

### DIFF
--- a/examples/models/bedrock_claude.py
+++ b/examples/models/bedrock_claude.py
@@ -1,6 +1,8 @@
 """
 Automated news analysis and sentiment scoring using Bedrock.
 
+Ensure you have browser-use installed with `examples` extra, i.e. `uv install 'browser-use[examples]'`
+
 @dev Ensure AWS environment variables are set correctly for Bedrock access.
 """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "langchain-deepseek>=0.1.3",
     "langchain>=0.3.21",
     "langchain-aws>=0.2.11",
-    "botocore>=1.37.23",
     "google-api-core>=2.24.0",
     "pyperclip>=1.9.0",
     "pyobjc>=11.0; platform_system == 'darwin'",
@@ -40,7 +39,6 @@ dependencies = [
     "click>=8.1.8",
     "textual>=3.2.0",
 ]
-# botocore: only needed for Bedrock Claude boto3 examples/models/bedrock_claude.py 
 # pydantic: >2.11 introduces many pydantic deprecation warnings until langchain-core upgrades their pydantic support lets keep it on 2.10
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste
@@ -52,10 +50,14 @@ dependencies = [
 # click: used for command-line argument parsing
 # textual: used for terminal UI
 
-# Optional dependencies for memory functionality
 [project.optional-dependencies]
+# Optional dependencies for memory functionality
 memory = [
     "sentence-transformers>=4.0.2",
+]
+examples = [
+    # botocore: only needed for Bedrock Claude boto3 examples/models/bedrock_claude.py 
+    "botocore>=1.37.23",
 ]
 
 [project.urls]


### PR DESCRIPTION

Moved the Bedrock Claude example's botocore dependency to an optional "examples" extra, making it easier to install only when needed.

- **Dependencies**
  - Removed botocore from main dependencies.
  - Added a "examples" optional extra for botocore.
  - Updated example instructions to mention the new install method.

Fixes https://github.com/browser-use/browser-use/issues/1312

