### PR TITLE
handle case where model responds with an object in a list instead of flat object

### DIFF
--- a/browser_use/agent/message_manager/utils.py
+++ b/browser_use/agent/message_manager/utils.py
@@ -38,7 +38,14 @@ def extract_json_from_model_output(content: str) -> dict:
 			if '\n' in content:
 				content = content.split('\n', 1)[1]
 		# Parse the cleaned content
-		return json.loads(content)
+		result_dict = json.loads(content)
+
+		# some models occasionally respond with a list containing one dict: https://github.com/browser-use/browser-use/issues/1458
+		if isinstance(result_dict, list) and len(result_dict) == 1 and isinstance(result_dict[0], dict):
+			result_dict = result_dict[0]
+
+		assert isinstance(result_dict, dict), f'Expected JSON dictionary in response, got JSON {type(result_dict)} instead'
+		return result_dict
 	except json.JSONDecodeError as e:
 		logger.warning(f'Failed to parse model output: {content} {str(e)}')
 		raise ValueError('Could not parse response.')


### PR DESCRIPTION
Fixes #1458 
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed JSON parsing to handle cases where the model returns a list with a single object instead of a flat object.

- **Bug Fixes**
  - Unwraps single-item lists containing a dict before returning the result.
  - Adds a check to ensure the final output is always a dictionary.

<!-- End of auto-generated description by mrge. -->

