### PR TITLE
Fix: Add missing 'grant_permissions' method to DummyContext to resolve AttributeError in test

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -516,7 +516,7 @@ async def test_browser_window_size(monkeypatch):
 
 		async def close(self):
 			pass
-		
+
 		async def grant_permissions(self, permissions, origin=None):
 			pass
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -516,6 +516,9 @@ async def test_browser_window_size(monkeypatch):
 
 		async def close(self):
 			pass
+		
+		async def grant_permissions(self, permissions, origin=None):
+			pass
 
 	class DummyBrowser:
 		def __init__(self):


### PR DESCRIPTION

### Description

This PR resolves a failure in the `test_browser_window_size` test, which was caused by the mocked `DummyContext` class missing the `grant_permissions` method. The absence of this method resulted in an `AttributeError` during test execution when the method was called as part of the browser context initialization.

### Failing Test Screenshot

Before fix:
![Screenshot 2025-05-06 165139](https://github.com/user-attachments/assets/045c6794-c215-427f-a2d2-6755582d45f6)

### Fix Summary

To address the issue, the following method was added to the `DummyContext` mock:

```python
async def grant_permissions(self, permissions, origin=None):
    pass
```

This mock implementation aligns with the expected `BrowserContext` API, preventing the error and allowing the test to run successfully.

### Changes

* **DummyContext**: Added an `async grant_permissions()` method that takes `permissions` and an optional `origin` parameter, mirroring the real browser context interface.

### Result

After applying the fix, the test now passes successfully:

After fix:
![Screenshot 2025-05-06 165218](https://github.com/user-attachments/assets/dc00dab0-983f-4351-a9a2-1666c414ad05)


    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added the missing grant_permissions method to DummyContext to fix an AttributeError in the test_browser_window_size test. This allows the test to run without errors.

<!-- End of auto-generated description by mrge. -->

