### PR TITLE
feat: add dockerhub workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,53 @@
+name: DockerHub
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  build_api:
+      name: Push API to Dockerhub
+      runs-on: ubuntu-latest
+      permissions:
+        packages: write
+        contents: read
+        attestations: write
+        id-token: write
+      steps:
+        - name: Check out the repo
+          uses: actions/checkout@v4
+
+        - name: Set up QEMU
+          uses: docker/setup-qemu-action@v3
+
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v3
+
+        - name: Log in to Docker Hub
+          uses: docker/login-action@v3
+          with:
+            username: ${{ secrets.DOCKER_USERNAME }}
+            password: ${{ secrets.DOCKER_PASSWORD }}
+
+        - name: Extract metadata (tags, labels) for Docker
+          id: meta
+          uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+          with:
+            images: browseruse/browser-use
+
+        - name: Build and push Docker image
+          id: push
+          uses: docker/build-push-action@v6
+          with:
+            platforms: linux/amd64,linux/arm64
+            context: .
+            file: ./Dockerfile
+            push: true
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
+            cache-from: type=registry,ref=browseruse/browser-use:buildcache
+            cache-to: type=registry,ref=browseruse/browser-use:buildcache,mode=max


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a GitHub Actions workflow to build and push Docker images to Docker Hub on pull requests, pushes to main, and releases.

- **New Features**
  - Builds multi-architecture Docker images for the API.
  - Pushes images to Docker Hub with automatic tagging and caching.

<!-- End of auto-generated description by mrge. -->

