### PR TITLE
fix: when set sensitive_data, get allowed_domains,error

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -283,7 +283,7 @@ class Agent(Generic[Context]):
 			self.memory = None
 
 		# Huge security warning if sensitive_data is provided but allowed_domains is not set
-		if self.sensitive_data and not self.browser.config.new_context_config.allowed_domains:
+		if self.sensitive_data and not browser_context.config.allowed_domains:
 			logger.error(
 				'⚠️⚠️⚠️ Agent(sensitive_data=••••••••) was provided but BrowserContextConfig(allowed_domains=[...]) is not locked down! ⚠️⚠️⚠️\n'
 				'          ☠️ If the agent visits a malicious website and encounters a prompt-injection attack, your sensitive_data may be exposed!\n\n'


### PR DESCRIPTION
fix: when set sensitive_data
- but not set allowed_domains,will have error: 'Agent' object has no attribute 'browser'
- if i set allowed_domains,it will have this error, because **allowed_domains is seted in browser_context** and **self.browser is seted in line 308,310 below code `self.browser.config.new_context_config.allowed_domains`**(line 286)
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an error that occurred when sensitive_data was set without allowed_domains, which caused a missing attribute error in the agent.

<!-- End of auto-generated description by mrge. -->

