### PR TITLE
fix: suppress FAISS-related deprecation warnings

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -1,3 +1,11 @@
+import warnings
+
+# Suppress specific deprecation warnings from FAISS
+warnings.filterwarnings('ignore', category=DeprecationWarning, module='faiss.loader')
+warnings.filterwarnings('ignore', message='builtin type SwigPyPacked has no __module__ attribute')
+warnings.filterwarnings('ignore', message='builtin type SwigPyObject has no __module__ attribute')
+warnings.filterwarnings('ignore', message='builtin type swigvarlink has no __module__ attribute')
+
 from browser_use.logging_config import setup_logging
 
 setup_logging()


### PR DESCRIPTION
suppressing faiss-related deprecation warnings during import. added warning filters in `browser_use/__init.py__` to hide numpy and swig warnings that don’t affect functionality. confirmed faiss still works, warnings are gone, no breaking changes. 

fixes #1603. this is a temp fix until faiss updates their numpy usage. only filters specific noise, other warnings stay visible.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Suppressed FAISS-related deprecation warnings during import to reduce noise in logs. Only specific numpy and SWIG warnings are hidden; all other warnings remain visible.

<!-- End of auto-generated description by mrge. -->

