### PR TITLE
fix: when set sensitive_data, get allowed_domains,error

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -282,8 +282,17 @@ class Agent(Generic[Context]):
 		else:
 			self.memory = None
 
+		# Browser setup
+		self.injected_browser = browser is not None
+		self.injected_browser_context = browser_context is not None
+		self.browser = browser or Browser()
+		self.browser.config.new_context_config.disable_security = self.browser.config.disable_security
+		self.browser_context = browser_context or BrowserContext(
+			browser=self.browser, config=self.browser.config.new_context_config
+		)
+
 		# Huge security warning if sensitive_data is provided but allowed_domains is not set
-		if self.sensitive_data and not self.browser.config.new_context_config.allowed_domains:
+		if self.sensitive_data and not self.browser_context.config.allowed_domains:
 			logger.error(
 				'⚠️⚠️⚠️ Agent(sensitive_data=••••••••) was provided but BrowserContextConfig(allowed_domains=[...]) is not locked down! ⚠️⚠️⚠️\n'
 				'          ☠️ If the agent visits a malicious website and encounters a prompt-injection attack, your sensitive_data may be exposed!\n\n'
@@ -302,14 +311,7 @@ class Agent(Generic[Context]):
 				pass  # no point waiting if we're not in an interactive shell
 			logger.warning('‼️ Continuing with insecure settings for now... but this will become a hard error in the future!')
 
-		# Browser setup
-		self.injected_browser = browser is not None
-		self.injected_browser_context = browser_context is not None
-		self.browser = browser or Browser()
-		self.browser.config.new_context_config.disable_security = self.browser.config.disable_security
-		self.browser_context = browser_context or BrowserContext(
-			browser=self.browser, config=self.browser.config.new_context_config
-		)
+
 
 		# Callbacks
 		self.register_new_step_callback = register_new_step_callback

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -311,8 +311,6 @@ class Agent(Generic[Context]):
 				pass  # no point waiting if we're not in an interactive shell
 			logger.warning('‼️ Continuing with insecure settings for now... but this will become a hard error in the future!')
 
-
-
 		# Callbacks
 		self.register_new_step_callback = register_new_step_callback
 		self.register_done_callback = register_done_callback


### PR DESCRIPTION
fix: when set sensitive_data
- but not set allowed_domains,will have error: 'Agent' object has no attribute 'browser'
- if i set allowed_domains,it will have this error, because **allowed_domains is seted in browser_context** and **self.browser is seted in line 308,310 below code `self.browser.config.new_context_config.allowed_domains`**(line 286)
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an error where setting sensitive_data without allowed_domains caused an attribute error in the Agent class.

- **Bug Fixes**
  - Moved browser setup earlier in initialization to ensure browser and browser_context are always set before checking allowed_domains.

<!-- End of auto-generated description by mrge. -->

