### PR TITLE
Preserve DOM Integrity During Screenshots to Restore Cache Behavior

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -1247,6 +1247,7 @@ class BrowserContext:
 		screenshot = await page.screenshot(
 			full_page=full_page,
 			animations='disabled',
+			caret='initial',
 		)
 
 		screenshot_b64 = base64.b64encode(screenshot).decode('utf-8')


### PR DESCRIPTION
## 🖼️ Fix: Preserve DOM Integrity During Screenshots to Restore Cache Behavior

### Context

A screenshot is automatically taken at each action in `_get_updated_state`. By default, `page.screenshot` has the `caret` parameter set to `None`, which implicitly falls back to `'hide'`. When `caret='hide'`, Playwright modifies the DOM to hide carets in input fields.

These minor DOM modifications persist after the screenshot and alter the hash of affected elements, breaking the caching mechanism in `rerun_history`.

### What’s Fixed

We now explicitly set `caret='initial'` in `page.screenshot`, preventing any DOM changes. This preserves element hashes and re-enables effective caching when rerunning tests involving input fields.

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Screenshots now preserve the DOM by preventing Playwright from hiding input carets, which restores correct cache behavior for rerun history.

<!-- End of auto-generated description by mrge. -->

