### PR TITLE
Fix: when no_viewport is True then browser window size determines the viewport

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -271,6 +271,7 @@ class Browser:
 			and hasattr(self.config, 'new_context_config')
 			and hasattr(self.config.new_context_config, 'window_width')
 			and hasattr(self.config.new_context_config, 'window_height')
+			and not self.config.new_context_config.no_viewport
 		):
 			screen_size = {
 				'width': self.config.new_context_config.window_width,


### PR DESCRIPTION
When no_viewport=True, the browser window size should determine the viewport.
However, the current condition incorrectly applies a fixed viewport using window_width and window_height even when no_viewport=True.

code to reproduce it :

```python
browser = Browser(
	config=BrowserConfig(
		headless=False,
		new_context_config=BrowserContextConfig(
			viewport_expansion=0,
			no_viewport=True,
			window_width=700,
			window_height=600,
			wait_for_network_idle_page_load_time=5.0,
			locale='en-US',
			highlight_elements=True,
		)
	)
)

agent = Agent(
	task='Go to amazon.com, search for laptop, sort by best rating, and give me the price of the first result',
	llm=llm,
	max_actions_per_step=4,
	browser=browser
)
```
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where the browser used a fixed viewport size even when no_viewport=True. Now, the browser window size sets the viewport as expected when no_viewport is enabled.

<!-- End of auto-generated description by mrge. -->

