### PR TITLE
MOD: update doc about how to use allowed_domains with sensitive_data

### DIFF
--- a/docs/customize/sensitive-data.mdx
+++ b/docs/customize/sensitive-data.mdx
@@ -15,7 +15,8 @@ Here's an example of how to use sensitive data:
 ```python
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
-from browser_use import Agent
+from browser_use import Agent, Browser, BrowserConfig
+from browser_use.browser.context import BrowserContextConfig
 
 load_dotenv()
 
@@ -32,6 +33,11 @@ sensitive_data = {'x_name': 'magnus', 'x_password': '12345678'}
 # Use the placeholder names in your task description
 task = 'go to x.com and login with x_name and x_password then write a post about the meaning of life'
 
+# Configure allowed_domains that the agent should be restricted to in BrowserContextConfig
+context_config = BrowserContextConfig(
+    allowed_domains=['example.com'],
+)
+
 # Pass the sensitive data to the agent
 agent = Agent(
     task=task,
@@ -39,8 +45,8 @@ agent = Agent(
     sensitive_data=sensitive_data,
     browser=Browser(
         config=BrowserConfig(
-            allowed_domains=['example.com'],  # domains that the agent should be restricted to
-        ),
+            new_context_config=context_config
+        )
     )
 )
 


### PR DESCRIPTION
[Document update] https://github.com/browser-use/browser-use/blob/main/docs/customize/sensitive-data.mdx

How to use `allowed_domains` with `sensitive_data`: 
This parameter has been moved from BrowserConfig to BrowserContextConfig

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Updated the documentation to show how to use allowed_domains with sensitive_data by moving allowed_domains to BrowserContextConfig in the example.

<!-- End of auto-generated description by mrge. -->

