### PR TITLE
add searchBing action (to skip CAPTCHA  in google)

### DIFF
--- a/browser_use/agent/playwright_script_generator.py
+++ b/browser_use/agent/playwright_script_generator.py
@@ -51,6 +51,7 @@ class PlaywrightScriptGenerator:
 			'close_tab': self._map_close_tab,
 			'switch_tab': self._map_switch_tab,
 			'search_google': self._map_search_google,
+			'search_bing':self._map_search_bing,
 			'drag_drop': self._map_drag_drop,
 			'extract_content': self._map_extract_content,
 			'click_download_button': self._map_click_download_button,
@@ -397,7 +398,28 @@ class PlaywrightScriptGenerator:
 		else:
 			script_lines.append(f'            # Skipping search_google ({step_info_str}): missing or invalid query')
 		return script_lines
-
+		
+	def _map_search_bing(self, params: dict, step_info_str: str, **kwargs) -> list[str]:
+		query = params.get('query')
+		goto_timeout = self._get_goto_timeout()
+		script_lines = []
+		if query and isinstance(query, str):
+			clean_query = f'replace_sensitive_data({json.dumps(query)}, SENSITIVE_DATA)'
+			search_url_expression = f'f"https://www.bing.com/search?q={{ urllib.parse.quote_plus({clean_query}) }}"'
+			script_lines.extend(
+				[
+					f'            search_url = {search_url_expression}',
+					f'            print(f"Searching Bing for query related to: {{ {clean_query} }} ({step_info_str})")',
+					f'            await page.goto(search_url, timeout={goto_timeout})',
+					f"            await page.wait_for_load_state('load', timeout={goto_timeout})",
+					'            await page.wait_for_timeout(1000)',
+				]
+			)
+		else:
+	 
+			script_lines.append(f'            # Skipping search_bing ({step_info_str}): missing or invalid query')
+		return script_lines
+	
 	def _map_drag_drop(self, params: dict, step_info_str: str, **kwargs) -> list[str]:
 		source_sel = params.get('element_source')
 		target_sel = params.get('element_target')

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -27,6 +27,7 @@ from browser_use.controller.views import (
 	Position,
 	ScrollAction,
 	SearchGoogleAction,
+	SearchBingAction,
 	SendKeysAction,
 	SwitchTabAction,
 )
@@ -76,7 +77,18 @@ class Controller(Generic[Context]):
 			)
 			async def done(params: DoneAction):
 				return ActionResult(is_done=True, success=params.success, extracted_content=params.text)
-
+    # Basic Navigation Actions in Bing
+		@self.registry.action(
+			'Search the query in Bing in the current tab.especially when confronting with CAPTCHA.Use this for general web searches. the query should be a search query like humans search in Bing, concrete and not vague or super long. More the single most important items. ',
+			param_model=SearchBingAction,
+		)
+		async def search_bing(params: SearchBingAction, browser: BrowserContext):
+			page = await browser.get_current_page()
+			await page.goto(f'https://www.bing.com/search?q={params.query}')
+			await page.wait_for_load_state()
+			msg = f'🔍  Searched for "{params.query}" in Bing'
+			logger.info(msg)
+			
 		# Basic Navigation Actions
 		@self.registry.action(
 			'Search the query in Google in the current tab, the query should be a search query like humans search in Google, concrete and not vague or super long. More the single most important items. ',

--- a/browser_use/controller/views.py
+++ b/browser_use/controller/views.py
@@ -7,7 +7,7 @@ class SearchGoogleAction(BaseModel):
 
 
 class SearchBingAction(BaseModel):
-	query:str
+	query: str
 
 
 class GoToUrlAction(BaseModel):

--- a/browser_use/controller/views.py
+++ b/browser_use/controller/views.py
@@ -4,9 +4,11 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 # Action Input Models
 class SearchGoogleAction(BaseModel):
 	query: str
-	
+
+
 class SearchBingAction(BaseModel):
 	query:str
+
 
 class GoToUrlAction(BaseModel):
 	url: str

--- a/browser_use/controller/views.py
+++ b/browser_use/controller/views.py
@@ -4,7 +4,9 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 # Action Input Models
 class SearchGoogleAction(BaseModel):
 	query: str
-
+	
+class SearchBingAction(BaseModel):
+	query:str
 
 class GoToUrlAction(BaseModel):
 	url: str

--- a/browser_use/controller/views.py
+++ b/browser_use/controller/views.py
@@ -7,7 +7,7 @@ class SearchGoogleAction(BaseModel):
 
 
 class SearchBingAction(BaseModel):
-	query: str
+	query: str 
 
 
 class GoToUrlAction(BaseModel):


### PR DESCRIPTION
### Problem Description
Suggest add an action to use searchBing instead of searchGoogle for stuck in CAPTCHA .Espcially for Chinese user，In most time, they was stuck in google CAPTCHA anti-robot test ，due to use vpn in same ip. I suggest add more action to use bing to skip it，and improve its applicability range.

### Proposed Solution
I add a action in
browse_use/agent/PlaywrightScriptGenerator.py
browse_use/controller/service.py
browse_use/controller/view.py
and  I have tried to modify the
browser-use/browser_use/agent/system_prompt.md
to indicate "new search (e.g., using search_bing action with a query )"and "if encounter with CAPTCHA, skip it."

of course，the system_prompt.md could keep former one
I suggest add "search in bing" in task description prompt. It will work also, llm will do aciton "saerchBing" first . 
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Added a new searchBing action to let users search with Bing when Google CAPTCHA blocks access.

- **New Features**
  - Added searchBing action to the agent, service, and view layers.
  - Updated prompts to suggest using Bing if Google search is blocked.

<!-- End of auto-generated description by mrge. -->

