### PR TITLE
fix user_data_dir not expanded in chrome_launch_args

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -225,7 +225,8 @@ class Browser:
 			try:
 				# ~/.config/browseruse/profiles/default
 				user_data_dir = Path('~/.config') / 'browseruse' / 'profiles' / 'default'
-				user_data_dir.expanduser().mkdir(parents=True, exist_ok=True)
+				user_data_dir = user_data_dir.expanduser()
+				user_data_dir.mkdir(parents=True, exist_ok=True)
 			except Exception as e:
 				logger.error(f'❌  Failed to create ~/.config/browseruse directory: {type(e).__name__}: {e}')
 				user_data_dir = fallback_user_data_dir


### PR DESCRIPTION
Fixed tilde expansion in browser profile path handling. 
Previously, when creating a user data directory with a tilde (\~) in the path, the code correctly expanded the tilde when creating the directory but didn't save the expanded path. Thus later on in `chrome_launch_args` Chrome receiving a path with a literal "~" character in the --user-data-dir argument, causing profiles to be created in unexpected locations such as `/Users/<username>/browser_use_workspace/~/.config/browseruse/profiles/default`. 
The fix properly stores the expanded path by assigning the result of expanduser() back to the user_data_dir variable, ensuring Chrome receives the fully resolved home directory path.
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed an issue where the user data directory path with a tilde (~) was not fully expanded, causing Chrome to use the wrong profile location.

- **Bug Fixes**
  - Ensured the expanded home directory path is used when launching Chrome.

<!-- End of auto-generated description by mrge. -->

