### PR TITLE
add `allowed_domains=['*.example.com']` glob pattern matching support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,7 @@ jobs:
         - test_controller
         - test_tab_management
         - test_sensitive_data
+        - test_url_allowlist_security
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -957,7 +957,7 @@ class BrowserContext:
 			parsed_url = urlparse(url)
 
 			# Special case: Allow 'about:blank' explicitly
-			if url == 'about:blank' or parsed_url.scheme in ('chrome', 'brave', 'edge', 'chrome-extension'):
+			if url == 'about:blank' or parsed_url.scheme.lower() in ('chrome', 'brave', 'edge', 'chrome-extension'):
 				return True
 
 			# Extract only the hostname component (without auth credentials or port)
@@ -984,12 +984,12 @@ class BrowserContext:
 							return True
 				else:
 					# Standard matching (exact or subdomain)
-					if domain == allowed_domain or domain.endswith('.' + allowed_domain):
+					if domain == allowed_domain:
 						return True
 
 			return False
 		except Exception as e:
-			logger.error(f'⛔️  Error checking URL allowlist: {str(e)}')
+			logger.error(f'⛔️  Error checking URL allowlist: {type(e).__name__}: {e}')
 			return False
 
 	async def _check_and_handle_navigation(self, page: Page) -> None:

--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -174,7 +174,7 @@ async def run_search():
 
 - **allowed_domains** (default: `None`)
   List of allowed domains that the agent can access. If None, all domains are allowed.
-  Example: ['google.com', '*.wikipedia.org'] - Here the agent will only be able to access google and wikipedia.
+  Example: ['google.com', '*.wikipedia.org'] - Here the agent will only be able to access `google.com` exactly and `wikipedia.org` + `*.wikipedia.org`.
   
   Glob patterns are supported:
   - `['example.com']` ✅ will match only `example.com` exactly, subdomains will not be allowed.
@@ -182,8 +182,8 @@ async def run_search():
     `['google.com', 'www.google.com', 'myaccount.google.com', 'mail.google.com', 'docs.google.com']`
   - `['*.example.com']` ⚠️ **CAUTION** this will match `example.com` and *all* subdomains.
     Make sure *all* the subdomains are safe for the agent! `abc.example.com`, `def.example.com`, ..., `useruploads.example.com`, `admin.example.com`
-  - `['*google.com']` ❌ **DON'T DO THIS**, it will match `google.com`, `mail.google.com`, `docs.google.com`, etc. *but also `evilgoogle.com`*
-  - `['*.google.*]` ❌ **DON'T DO THIS**, it will match `google.com`, `google.co.uk`, `google.fr`, etc. *but also `www.google.evil.com`*
+  - `['*google.com']` ❌ **DON'T DO THIS**, it will match any domains that end in `google.com`, *including `evilgoogle.com`*
+  - `['*.google.*']` ❌ **DON'T DO THIS**, it will match `google.com`, `google.co.uk`, `google.fr`, etc. *but also `www.google.evil.com`*
 
 ### Session Management
 

--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -174,11 +174,16 @@ async def run_search():
 
 - **allowed_domains** (default: `None`)
   List of allowed domains that the agent can access. If None, all domains are allowed.
-  Example: ['google.com', 'wikipedia.org'] - Here the agent will only be able to access google and wikipedia.
+  Example: ['google.com', '*.wikipedia.org'] - Here the agent will only be able to access google and wikipedia.
   
   Glob patterns are supported:
-  - `['*.example.com']` will match both `sub.example.com` and `example.com`
-  - `['*google.com']` will match `google.com`, `www.google.com`, and `anygoogle.com`
+  - `['example.com']` ✅ will match only `example.com` exactly, subdomains will not be allowed.
+    It's always the most secure to list all the domains you want to give the access to explicitly e.g.
+    `['google.com', 'www.google.com', 'myaccount.google.com', 'mail.google.com', 'docs.google.com']`
+  - `['*.example.com']` ⚠️ **CAUTION** this will match `example.com` and *all* subdomains.
+    Make sure *all* the subdomains are safe for the agent! `abc.example.com`, `def.example.com`, ..., `useruploads.example.com`, `admin.example.com`
+  - `['*google.com']` ❌ **DON'T DO THIS**, it will match `google.com`, `mail.google.com`, `docs.google.com`, etc. *but also `evilgoogle.com`*
+  - `['*.google.*]` ❌ **DON'T DO THIS**, it will match `google.com`, `google.co.uk`, `google.fr`, etc. *but also `www.google.evil.com`*
 
 ### Session Management
 

--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -175,6 +175,10 @@ async def run_search():
 - **allowed_domains** (default: `None`)
   List of allowed domains that the agent can access. If None, all domains are allowed.
   Example: ['google.com', 'wikipedia.org'] - Here the agent will only be able to access google and wikipedia.
+  
+  Glob patterns are supported:
+  - `['*.example.com']` will match both `sub.example.com` and `example.com`
+  - `['*google.com']` will match `google.com`, `www.google.com`, and `anygoogle.com`
 
 ### Session Management
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -15,7 +15,7 @@ def test_is_url_allowed():
 	Scenario 1: When allowed_domains is None, all URLs should be allowed.
 	Scenario 2: When allowed_domains is a list, only URLs matching the allowed domain(s) are allowed.
 	Scenario 3: When the URL is malformed, it should return False.
-	Scenario 4: When allowed_domains contain glob patterns, matching should work according to glob rules.
+	Scenario 4: When allowed_domains contain glob patterns, see: test_url_allowlist_security.py
 	"""
 	# Create a dummy Browser mock. Only the 'config' attribute is needed for _is_url_allowed.
 	dummy_browser = Mock()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -15,6 +15,7 @@ def test_is_url_allowed():
 	Scenario 1: When allowed_domains is None, all URLs should be allowed.
 	Scenario 2: When allowed_domains is a list, only URLs matching the allowed domain(s) are allowed.
 	Scenario 3: When the URL is malformed, it should return False.
+	Scenario 4: When allowed_domains contain glob patterns, matching should work according to glob rules.
 	"""
 	# Create a dummy Browser mock. Only the 'config' attribute is needed for _is_url_allowed.
 	dummy_browser = Mock()

--- a/tests/test_url_allowlist_security.py
+++ b/tests/test_url_allowlist_security.py
@@ -19,3 +19,47 @@ class TestUrlAllowlistSecurity:
 
 		# Make sure legitimate auth credentials still work
 		assert context._is_url_allowed('https://user:password@example.com') is True
+
+	def test_glob_pattern_matching(self):
+		"""Test that glob patterns in allowed_domains work correctly."""
+		# Test *.example.com pattern (should match subdomains and main domain)
+		glob_config = BrowserContextConfig(allowed_domains=['*.example.com'])
+		glob_context = BrowserContext(browser=None, config=glob_config)
+
+		# Should match subdomains
+		assert glob_context._is_url_allowed('https://sub.example.com') is True
+		assert glob_context._is_url_allowed('https://deep.sub.example.com') is True
+
+		# Should also match main domain
+		assert glob_context._is_url_allowed('https://example.com') is True
+
+		# Should not match other domains
+		assert glob_context._is_url_allowed('https://notexample.com') is False
+		assert glob_context._is_url_allowed('https://example.org') is False
+
+		# Test more complex glob patterns
+		stars_config = BrowserContextConfig(allowed_domains=['*google.com', 'wiki*'])
+		stars_context = BrowserContext(browser=None, config=stars_config)
+
+		# Should match domains ending with google.com
+		assert stars_context._is_url_allowed('https://google.com') is True
+		assert stars_context._is_url_allowed('https://www.google.com') is True
+		assert stars_context._is_url_allowed('https://anygoogle.com') is True
+
+		# Should match domains starting with wiki
+		assert stars_context._is_url_allowed('https://wiki.org') is True
+		assert stars_context._is_url_allowed('https://wikipedia.org') is True
+
+		# Should not match other domains
+		assert stars_context._is_url_allowed('https://example.com') is False
+
+		# Test browser internal URLs
+		assert stars_context._is_url_allowed('chrome://settings') is True
+		assert stars_context._is_url_allowed('about:blank') is True
+
+		# Test security for glob patterns (authentication credentials bypass attempts)
+		# These should all be detected as malicious despite containing allowed domain patterns
+		assert glob_context._is_url_allowed('https://allowed.example.com:password@notallowed.com') is False
+		assert glob_context._is_url_allowed('https://subdomain.example.com@evil.com') is False
+		assert glob_context._is_url_allowed('https://sub.example.com%20@malicious.org') is False
+		assert stars_context._is_url_allowed('https://anygoogle.com@evil.org') is False


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added support for glob patterns like *.example.com in allowed_domains, letting users match subdomains and customize domain access rules.

- **Docs**
  - Updated documentation with examples and warnings for safe glob pattern usage.
- **Tests**
  - Added tests to cover glob pattern matching and edge cases.

<!-- End of auto-generated description by mrge. -->

