### PR TITLE
Change Gemini model name in docs

### DIFF
--- a/docs/customize/supported-models.mdx
+++ b/docs/customize/supported-models.mdx
@@ -10,7 +10,7 @@ Browser Use supports various LangChain chat models. Here's how to configure and 
 
 ## Model Recommendations
 
-We have yet to test performance across all models. Currently, we achieve the best results using GPT-4o with an 89% accuracy on the [WebVoyager Dataset](https://browser-use.com/posts/sota-technical-report). DeepSeek-V3 is 30 times cheaper than GPT-4o. Gemini-2.0-exp is also gaining popularity in the community because it is currently free.
+We have yet to test performance across all models. Currently, we achieve the best results using GPT-4o with an 89% accuracy on the [WebVoyager Dataset](https://browser-use.com/posts/sota-technical-report). DeepSeek-V3 is 30 times cheaper than GPT-4o. Gemini-2.0-flash is also gaining popularity in the community because it is currently free.
 We also support local models, like Qwen 2.5, but be aware that small models often return the wrong output structure-which lead to parsing errors. We believe that local models will improve significantly this year.
 
 


### PR DESCRIPTION
I understand typo and nit fixes aren't preferred in PRs, but felt specifying the actual model name (gemini-2.0-flash, not gemini-2.0-exp) that is free to use, would be helpful for the users. 

I apologize if this is inconsequential!