### PR TITLE
Store eval page

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -22,13 +22,13 @@ from playwright.async_api import ElementHandle, FrameLocator, Page
 from pydantic import BaseModel, ConfigDict, Field
 
 from browser_use.browser.views import (
-    BrowserError,
-    BrowserState,
-    TabInfo,
-    URLNotAllowedError,
+	BrowserError,
+	BrowserState,
+	TabInfo,
+	URLNotAllowedError,
 )
 from browser_use.dom.clickable_element_processor.service import (
-    ClickableElementProcessor,
+	ClickableElementProcessor,
 )
 from browser_use.dom.service import DomService
 from browser_use.dom.views import DOMElementNode, SelectorMap
@@ -229,7 +229,7 @@ class BrowserContext:
 		# Tab references - separate concepts for agent intent and browser state
 		self.agent_current_page: Page | None = None  # The tab the agent intends to interact with
 		self.human_current_page: Page | None = None  # The tab currently shown in the browser UI
-		self.eval_page: dict|None = None  # Dictionary produced by evaluating js script in the browser
+		self.eval_page: dict | None = None  # Dictionary produced by evaluating js script in the browser
 
 	async def __aenter__(self):
 		"""Async context manager entry"""

--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -17,23 +17,19 @@ from typing import TYPE_CHECKING
 import anyio
 from playwright._impl._errors import TimeoutError
 from playwright.async_api import Browser as PlaywrightBrowser
-from playwright.async_api import (
-	BrowserContext as PlaywrightBrowserContext,
-)
-from playwright.async_api import (
-	ElementHandle,
-	FrameLocator,
-	Page,
-)
+from playwright.async_api import BrowserContext as PlaywrightBrowserContext
+from playwright.async_api import ElementHandle, FrameLocator, Page
 from pydantic import BaseModel, ConfigDict, Field
 
 from browser_use.browser.views import (
-	BrowserError,
-	BrowserState,
-	TabInfo,
-	URLNotAllowedError,
+    BrowserError,
+    BrowserState,
+    TabInfo,
+    URLNotAllowedError,
 )
-from browser_use.dom.clickable_element_processor.service import ClickableElementProcessor
+from browser_use.dom.clickable_element_processor.service import (
+    ClickableElementProcessor,
+)
 from browser_use.dom.service import DomService
 from browser_use.dom.views import DOMElementNode, SelectorMap
 from browser_use.utils import time_execution_async, time_execution_sync
@@ -233,6 +229,7 @@ class BrowserContext:
 		# Tab references - separate concepts for agent intent and browser state
 		self.agent_current_page: Page | None = None  # The tab the agent intends to interact with
 		self.human_current_page: Page | None = None  # The tab currently shown in the browser UI
+		self.eval_page: dict|None = None  # Dictionary produced by evaluating js script in the browser
 
 	async def __aenter__(self):
 		"""Async context manager entry"""
@@ -1221,7 +1218,7 @@ class BrowserContext:
 		try:
 			await self.remove_highlights()
 			dom_service = DomService(page)
-			content = await dom_service.get_clickable_elements(
+			content, self.eval_page = await dom_service.get_clickable_elements(
 				focus_element=focus_element,
 				viewport_expansion=self.config.viewport_expansion,
 				highlight_elements=self.config.highlight_elements,

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -9,11 +9,11 @@ if TYPE_CHECKING:
 	from playwright.async_api import Page
 
 from browser_use.dom.views import (
-	DOMBaseNode,
-	DOMElementNode,
-	DOMState,
-	DOMTextNode,
-	SelectorMap,
+    DOMBaseNode,
+    DOMElementNode,
+    DOMState,
+    DOMTextNode,
+    SelectorMap,
 )
 from browser_use.utils import time_execution_async
 
@@ -40,9 +40,9 @@ class DomService:
 		highlight_elements: bool = True,
 		focus_element: int = -1,
 		viewport_expansion: int = 0,
-	) -> DOMState:
-		element_tree, selector_map = await self._build_dom_tree(highlight_elements, focus_element, viewport_expansion)
-		return DOMState(element_tree=element_tree, selector_map=selector_map)
+	) -> tuple[DOMState, dict]:
+		(element_tree, selector_map), eval_page = await self._build_dom_tree(highlight_elements, focus_element, viewport_expansion)
+		return DOMState(element_tree=element_tree, selector_map=selector_map), eval_page
 
 	@time_execution_async('--get_cross_origin_iframes')
 	async def get_cross_origin_iframes(self) -> list[str]:
@@ -68,7 +68,7 @@ class DomService:
 		highlight_elements: bool,
 		focus_element: int,
 		viewport_expansion: int,
-	) -> tuple[DOMElementNode, SelectorMap]:
+	) -> tuple[tuple[DOMElementNode, SelectorMap], dict]:
 		if await self.page.evaluate('1+1') != 2:
 			raise ValueError('The page cannot evaluate javascript code properly')
 
@@ -84,6 +84,7 @@ class DomService:
 					parent=None,
 				),
 				{},
+				None,
 			)
 
 		# NOTE: We execute JS code in the browser to extract important DOM information.
@@ -111,7 +112,7 @@ class DomService:
 				json.dumps(eval_page['perfMetrics'], indent=2),
 			)
 
-		return await self._construct_dom_tree(eval_page)
+		return await self._construct_dom_tree(eval_page), eval_page
 
 	@time_execution_async('--construct_dom_tree')
 	async def _construct_dom_tree(

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -9,11 +9,11 @@ if TYPE_CHECKING:
 	from playwright.async_api import Page
 
 from browser_use.dom.views import (
-    DOMBaseNode,
-    DOMElementNode,
-    DOMState,
-    DOMTextNode,
-    SelectorMap,
+	DOMBaseNode,
+	DOMElementNode,
+	DOMState,
+	DOMTextNode,
+	SelectorMap,
 )
 from browser_use.utils import time_execution_async
 
@@ -41,7 +41,9 @@ class DomService:
 		focus_element: int = -1,
 		viewport_expansion: int = 0,
 	) -> tuple[DOMState, dict]:
-		(element_tree, selector_map), eval_page = await self._build_dom_tree(highlight_elements, focus_element, viewport_expansion)
+		(element_tree, selector_map), eval_page = await self._build_dom_tree(
+			highlight_elements, focus_element, viewport_expansion
+		)
 		return DOMState(element_tree=element_tree, selector_map=selector_map), eval_page
 
 	@time_execution_async('--get_cross_origin_iframes')


### PR DESCRIPTION
Storing eval page in context so that we can use it for custom operations if needed
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Stored the eval page dictionary in context after evaluating the browser page, making it available for custom operations later. 

- **Refactors**
  - Updated methods to return and store the eval page alongside DOM state.

<!-- End of auto-generated description by mrge. -->

