### PR TITLE
Fix Httpx issue closing all clients

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -422,6 +422,6 @@ class Browser:
 		except Exception as e:
 			logger.debug(f'Failed to cleanup browser in destructor: {e}')
 
-	# no-op because httpx clients are by their creators, not by the Browser class
 	async def cleanup_httpx_clients(self):
+		"""No-op method - browser instances shouldn't close httpx clients they didn't create."""
 		pass

--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -422,22 +422,6 @@ class Browser:
 		except Exception as e:
 			logger.debug(f'Failed to cleanup browser in destructor: {e}')
 
+	# no-op because httpx clients are by their creators, not by the Browser class
 	async def cleanup_httpx_clients(self):
-		"""Cleanup all httpx clients"""
-		import gc
-
-		import httpx
-
-		# Force garbage collection to make sure all clients are in memory
-		gc.collect()
-
-		# Get all httpx clients
-		clients = [obj for obj in gc.get_objects() if isinstance(obj, httpx.AsyncClient)]
-
-		# Close all clients
-		for client in clients:
-			if not client.is_closed:
-				try:
-					await client.aclose()
-				except Exception as e:
-					logger.debug(f'Error closing httpx client: {e}')
+		pass

--- a/browser_use/browser/tests/httpx_client_test.py
+++ b/browser_use/browser/tests/httpx_client_test.py
@@ -1,40 +1,39 @@
-import asyncio
-import pytest
 import httpx
+import pytest
 
 from browser_use.browser.browser import Browser, BrowserConfig
 
 
 @pytest.mark.asyncio
 async def test_browser_close_doesnt_affect_external_httpx_clients():
-    """
-    Test that Browser.close() doesn't close HTTPX clients created outside the Browser instance.
-    This test demonstrates the issue where Browser.close() is closing all HTTPX clients.
-    """
-    # Create an external HTTPX client that should remain open
-    external_client = httpx.AsyncClient()
-    
-    # Create a Browser instance
-    browser = Browser(config=BrowserConfig(headless=True))
-    
-    # Close the browser (which should trigger cleanup_httpx_clients)
-    await browser.close()
-    
-    # Check if the external client is still usable
-    try:
-        # If the client is closed, this will raise RuntimeError
-        # Using a simple HEAD request to a reliable URL
-        await external_client.head("https://www.example.com", timeout=2.0)
-        client_is_closed = False
-    except RuntimeError as e:
-        # If we get "Cannot send a request, as the client has been closed"
-        client_is_closed = "client has been closed" in str(e)
-    except Exception:
-        # Any other exception means the client is not closed but request failed
-        client_is_closed = False
-    finally:
-        # Always clean up our test client properly
-        await external_client.aclose()
-    
-    # Our external client should not be closed by browser.close()
-    assert not client_is_closed, "External HTTPX client was incorrectly closed by Browser.close()" 
+	"""
+	Test that Browser.close() doesn't close HTTPX clients created outside the Browser instance.
+	This test demonstrates the issue where Browser.close() is closing all HTTPX clients.
+	"""
+	# Create an external HTTPX client that should remain open
+	external_client = httpx.AsyncClient()
+
+	# Create a Browser instance
+	browser = Browser(config=BrowserConfig(headless=True))
+
+	# Close the browser (which should trigger cleanup_httpx_clients)
+	await browser.close()
+
+	# Check if the external client is still usable
+	try:
+		# If the client is closed, this will raise RuntimeError
+		# Using a simple HEAD request to a reliable URL
+		await external_client.head('https://www.example.com', timeout=2.0)
+		client_is_closed = False
+	except RuntimeError as e:
+		# If we get "Cannot send a request, as the client has been closed"
+		client_is_closed = 'client has been closed' in str(e)
+	except Exception:
+		# Any other exception means the client is not closed but request failed
+		client_is_closed = False
+	finally:
+		# Always clean up our test client properly
+		await external_client.aclose()
+
+	# Our external client should not be closed by browser.close()
+	assert not client_is_closed, 'External HTTPX client was incorrectly closed by Browser.close()'

--- a/browser_use/browser/tests/httpx_client_test.py
+++ b/browser_use/browser/tests/httpx_client_test.py
@@ -1,0 +1,40 @@
+import asyncio
+import pytest
+import httpx
+
+from browser_use.browser.browser import Browser, BrowserConfig
+
+
+@pytest.mark.asyncio
+async def test_browser_close_doesnt_affect_external_httpx_clients():
+    """
+    Test that Browser.close() doesn't close HTTPX clients created outside the Browser instance.
+    This test demonstrates the issue where Browser.close() is closing all HTTPX clients.
+    """
+    # Create an external HTTPX client that should remain open
+    external_client = httpx.AsyncClient()
+    
+    # Create a Browser instance
+    browser = Browser(config=BrowserConfig(headless=True))
+    
+    # Close the browser (which should trigger cleanup_httpx_clients)
+    await browser.close()
+    
+    # Check if the external client is still usable
+    try:
+        # If the client is closed, this will raise RuntimeError
+        # Using a simple HEAD request to a reliable URL
+        await external_client.head("https://www.example.com", timeout=2.0)
+        client_is_closed = False
+    except RuntimeError as e:
+        # If we get "Cannot send a request, as the client has been closed"
+        client_is_closed = "client has been closed" in str(e)
+    except Exception:
+        # Any other exception means the client is not closed but request failed
+        client_is_closed = False
+    finally:
+        # Always clean up our test client properly
+        await external_client.aclose()
+    
+    # Our external client should not be closed by browser.close()
+    assert not client_is_closed, "External HTTPX client was incorrectly closed by Browser.close()" 


### PR DESCRIPTION
Resolves Issue #1628. The httpx clients are typically closed automatically when they go out of scope or when their owners close them. External libraries like OpenAI's SDK or Langchain manage their own HTTPX clients. Global cleanup can be dangerous - it's better for each component to manage its own resources. Removing this method shouldn't cause memory leaks since responsible libraries handle their own cleanup.

Test showing before and after change.  Screenshot:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/fcdc80ef-20f2-4af0-96da-f2c79214fd3b" />

    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Removed global cleanup of httpx clients from the Browser class to prevent closing clients owned by external libraries.

- **Bug Fixes**
  - Browser.close() no longer closes httpx clients it did not create.
  - Added a test to confirm external httpx clients remain open after closing the browser.

<!-- End of auto-generated description by mrge. -->

