### PR TITLE
Fix revalidation of user-provided `MemoryConfig()`

### DIFF
--- a/browser_use/agent/memory/service.py
+++ b/browser_use/agent/memory/service.py
@@ -57,7 +57,7 @@ class Memory:
 				self.config.embedder_dims = 512
 		else:
 			# Ensure LLM instance is set in the config
-			self.config = MemoryConfig(config)  # re-validate user-provided config
+			self.config = MemoryConfig(**dict(config))  # re-validate untrusted user-provided config
 			self.config.llm_instance = llm
 
 		# Check for required packages


### PR DESCRIPTION
Fixes #1663 
    
<!-- This is an auto-generated description by mrge. -->
---

## Summary by mrge
Fixed revalidation of user-provided MemoryConfig to safely handle untrusted config input.

<!-- End of auto-generated description by mrge. -->

