### PR TITLE
fix: detect interactive elements with click event listener 

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -830,8 +830,10 @@
         const listeners = getEventListeners(element);
         const mouseEvents = ['click', 'mousedown', 'mouseup', 'dblclick'];
         for (const eventType of mouseEvents) {
-          if (listeners[eventType] && listeners[eventType].length > 0) {
-            return true; // Found a mouse interaction listener
+          for (const listener of listeners) {
+            if (listener.type === eventType) {
+               return true; // Found a mouse interaction listener
+            }
           }
         }
       } else {
@@ -1117,10 +1119,12 @@
       const getEventListeners = window.getEventListenersForNode;
       if (typeof getEventListeners === 'function') {
         const listeners = getEventListeners(element);
-        const interactionEvents = ['mousedown', 'mouseup', 'keydown', 'keyup', 'submit', 'change', 'input', 'focus', 'blur'];
+        const interactionEvents = ['click', 'mousedown', 'mouseup', 'keydown', 'keyup', 'submit', 'change', 'input', 'focus', 'blur'];
         for (const eventType of interactionEvents) {
-          if (listeners[eventType] && listeners[eventType].length > 0) {
-            return true; // Found a common interaction listener
+          for (const listener of listeners) {
+            if (listener.type === eventType) {
+               return true; // Found a common interaction listener
+            }
           }
         }
       } else {


### PR DESCRIPTION
fix: detect interactive elements with click event listener : **adding 'click' mouse event check and fixing element mouse event check**

## chrome debug
The element of "不购买行李额" is not hightlighted  in the picture，and **it is a div element with class "baggage-chooser".**
![image](https://github.com/user-attachments/assets/bcefa3d1-833b-48b7-bef2-e8a879b4436c)

When we use `window.getEventListenersForNode`,it **return array of listener object** and div element with class "baggage-chooser" has the **click event.**
![img_v3_02me_187b388f-1388-4234-b835-cc7b9a7c62ag](https://github.com/user-attachments/assets/15543013-a858-4d48-9d3f-bbb1b1e18e03)

## before fix
before fix: the element of "不购买行李额" is not hightlighted  in the picture
![image](https://github.com/user-attachments/assets/72b834c0-1272-465e-a4af-1633c5b21633)


## after fix
after fix: the element of "不购买行李额" is **hightlighted with number 8**  in the picture
![image](https://github.com/user-attachments/assets/7253aa7c-c0fb-4ff2-9946-428596d620d4)




    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed detection of interactive elements by checking for click event listeners, so elements with click handlers are now correctly highlighted.

<!-- End of auto-generated description by cubic. -->

