### PR TITLE
fix:using f-string to refer outer variable, fix glob WARNING log in allowed_domains

### DIFF
--- a/browser_use/browser/context.py
+++ b/browser_use/browser/context.py
@@ -960,7 +960,7 @@ class BrowserContext:
 					# glob patterns are very easy to mess up and match too many domains by accident
 					# e.g. if you only need to access gmail, don't use *.google.com because an attacker could convince the agent to visit a malicious doc
 					# on docs.google.com/s/some/evil/doc to set up a prompt injection attack
-					"⚠️ Allowing agent to visit {domain} based on allowed_domains=['{glob}', ...]. Set allowed_domains=['{domain}', ...] explicitly to avoid the security risks of glob patterns!"
+					f"⚠️ Allowing agent to visit {domain} based on allowed_domains=['{glob}', ...]. Set allowed_domains=['{domain}', ...] explicitly to avoid the security risks of glob patterns!"
 				)
 				_GLOB_WARNING_SHOWN = True
 


### PR DESCRIPTION
fix: **using f-string** to refer outer variable to fix glob WARNING   log  in allowed_domains

when I use glob "*.xx.com" in allowed_domains,the log show as below:
```
⚠️ Allowing agent to visit {domain} based on allowed_domains=['{glob}', ...]. Set allowed_domains=['{domain}', ...] explicitly to avoid the security risks of glob patterns!
```
so,I add f-string  to refer outer variable `domain` and `glob`
```
WARNING  [browser] ⚠️ Allowing agent to visit www.xx.com based on allowed_domains=['*.xx.com', ...]. Set allowed_domains=['www.xx.com', ...] explicitly to avoid the security risks of glob patterns!
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed log message to correctly show the actual domain and glob values by using an f-string.

<!-- End of auto-generated description by cubic. -->

