### PR TITLE
Fixed the issue where getEventListeners was unavailable when used in page.evaluate. Changed to a custom event listener detection approach.

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -824,26 +824,20 @@
 
     if (hasInteractiveRole) return true;
 
-    // check whether element has event listeners
-    try {
-      if (typeof getEventListeners === 'function') {
-        const listeners = getEventListeners(element);
-        const mouseEvents = ['click', 'mousedown', 'mouseup', 'dblclick'];
-        for (const eventType of mouseEvents) {
-          if (listeners[eventType] && listeners[eventType].length > 0) {
-            return true; // Found a mouse interaction listener
-          }
-        }
-      } else {
-        // Fallback: Check common event attributes if getEventListeners is not available
-        const commonMouseAttrs = ['onclick', 'onmousedown', 'onmouseup', 'ondblclick'];
-        if (commonMouseAttrs.some(attr => element.hasAttribute(attr))) {
-          return true;
-        }
+    // Enhanced event listener check
+    if (window._eventListeners && window._eventListeners.has(element)) {
+      const map = window._eventListeners.get(element);
+      return Object.keys(map).length > 0;
+    }
+    const eventAttrs = [
+      'onclick', 'onmousedown', 'onmouseup', 'ondblclick',
+      'onmouseover', 'onmouseout', 'onfocus', 'onblur',
+      'onkeydown', 'onkeyup', 'onchange', 'onsubmit'
+    ];
+    for (const attr of eventAttrs) {
+      if (element.hasAttribute(attr) || typeof element[attr] === 'function') {
+        return true;
       }
-    } catch (e) {
-      // console.warn(`Could not check event listeners for ${element.tagName}:`, e);
-      // If checking listeners fails, rely on other checks
     }
 
     return false

--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -824,20 +824,28 @@
 
     if (hasInteractiveRole) return true;
 
-    // Enhanced event listener check
-    if (window._eventListeners && window._eventListeners.has(element)) {
-      const map = window._eventListeners.get(element);
-      return Object.keys(map).length > 0;
-    }
-    const eventAttrs = [
-      'onclick', 'onmousedown', 'onmouseup', 'ondblclick',
-      'onmouseover', 'onmouseout', 'onfocus', 'onblur',
-      'onkeydown', 'onkeyup', 'onchange', 'onsubmit'
-    ];
-    for (const attr of eventAttrs) {
-      if (element.hasAttribute(attr) || typeof element[attr] === 'function') {
-        return true;
+    // check whether element has event listeners
+    try {
+      if (typeof getEventListeners === 'function') {
+        const listeners = getEventListeners(element);
+        const mouseEvents = ['click', 'mousedown', 'mouseup', 'dblclick'];
+        for (const eventType of mouseEvents) {
+          if (listeners[eventType] && listeners[eventType].length > 0) {
+            return true; // Found a mouse interaction listener
+          }
+        }
+      } else {
+        // Fallback: Check common event attributes if getEventListeners is not available
+        const commonMouseAttrs = ['onclick', 'onmousedown', 'onmouseup', 'ondblclick'];
+        for (const attr of commonMouseAttrs) {
+          if (element.hasAttribute(attr) || typeof element[attr] === 'function') {
+            return true;
+          }
+        }
       }
+    } catch (e) {
+      // console.warn(`Could not check event listeners for ${element.tagName}:`, e);
+      // If checking listeners fails, rely on other checks
     }
 
     return false


### PR DESCRIPTION
I have also noticed this issue recently:https://github.com/browser-use/browser-use/pull/932
I saw that this issue was said to have been resolved, but in fact it wasn't. Could you please tell me if it hasn't been merged into the master branch yet? Then I also tried to solve it. The following solution is also feasible.Adjustments related to getEventListeners:

// Enhanced event listener check
if (window._eventListeners && window._eventListeners.has(element)) {
  const map = window._eventListeners.get(element);
  return Object.keys(map).length > 0;
}
const eventAttrs = [
  'onclick', 'onmousedown', 'onmouseup', 'ondblclick',
  'onmouseover', 'onmouseout', 'onfocus', 'onblur',
  'onkeydown', 'onkeyup', 'onchange', 'onsubmit'
];
for (const attr of eventAttrs) {
  if (element.hasAttribute(attr) || typeof element[attr] === 'function') {
    return true;
  }
}
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced getEventListeners with a custom event listener detection method to fix compatibility issues in page.evaluate.

- **Bug Fixes**
  - Detects event listeners using window._eventListeners and common event attributes instead of getEventListeners.

<!-- End of auto-generated description by cubic. -->

