### PR TITLE
Remove redundant URL assertions in BrowserSession class for cleaner c…

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1810,10 +1810,6 @@ class BrowserSession(BaseModel):
 
 		assert self.human_current_page is not None
 		assert self.agent_current_page is not None
-		if url:
-			assert self.agent_current_page.url == url
-		else:
-			assert self.agent_current_page.url == 'about:blank'
 
 		return new_page
 


### PR DESCRIPTION

Key change:

* Removed the conditional assertion block that validated the `agent_current_page.url` against the provided `url` or defaulted to `'about:blank'` if no `url` was given. This simplifies the method by eliminating this validation step. (`[browser_use/browser/session.pyL1813-L1816](diffhunk://#diff-e142e11363a7bd72394889d79ed603bfae645f171d276986c93769356698be9aL1813-L1816)`)…ode.


The key problem was that this gives an error for redirects - e.g. url https://www.kayak.com but gets changed to https://www.kayak.com/
Or e.g. if amazon.com redirects to amazon.de

I think we don't need this check.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed redundant URL assertions in the BrowserSession class to prevent errors from redirects and simplify the code.

<!-- End of auto-generated description by cubic. -->

