### PR TITLE
Fix #1747: use model_validate for MemoryConfig re-validation under Pydantic v2

### DIFF
--- a/browser_use/agent/memory/service.py
+++ b/browser_use/agent/memory/service.py
@@ -57,7 +57,7 @@ class Memory:
 				self.config.embedder_dims = 512
 		else:
 			# Ensure LLM instance is set in the config
-			self.config = MemoryConfig(**dict(config))  # re-validate untrusted user-provided config
+			self.config = MemoryConfig.model_validate(config) # Validate using the Pydantic v2
 			self.config.llm_instance = llm
 
 		# Check for required packages


### PR DESCRIPTION
# Fix TypeError when re-validating MemoryConfig in agent initialization

This PR fixes a Pydantic v2 compatibility issue that occurs when passing a custom `memory_config` parameter to the Agent constructor with `enable_memory=True`.

The current implementation attempts to re-validate the config by calling `MemoryConfig(config)`, which is not valid in Pydantic v2 as it doesn't accept a model instance as a positional argument. This PR updates the code to use the proper `MemoryConfig.model_validate(config)` validation method.

**Changes:**

* Updated `browser_use/agent/memory/service.py` to use `model_validate()` for config re-validation.
* Ensures backward compatibility with existing code.
* Fixes issue #1747 

**Testing:**

* Manually tested with custom memory configurations.
* Confirmed no regressions with existing memory functionality.