### PR TITLE
Add Attribute Compression for Reduced Token Usage

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -28,6 +28,7 @@ class MessageManagerSettings(BaseModel):
 	message_context: str | None = None
 	sensitive_data: dict[str, str] | None = None
 	available_file_paths: list[str] | None = None
+	compress_attributes: bool = False
 
 
 class MessageManager:
@@ -152,6 +153,7 @@ class MessageManager:
 			result=result,
 			include_attributes=self.settings.include_attributes,
 			step_info=step_info,
+			compress_attributes=self.settings.compress_attributes,
 		).get_user_message(use_vision)
 		self._add_message_with_tokens(state_message)
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -160,6 +160,7 @@ class Agent(Generic[Context]):
 		enable_memory: bool = True,
 		memory_config: MemoryConfig | None = None,
 		source: str | None = None,
+		compress_attributes: bool = False,
 	):
 		if page_extraction_llm is None:
 			page_extraction_llm = llm
@@ -193,6 +194,7 @@ class Agent(Generic[Context]):
 			is_planner_reasoning=is_planner_reasoning,
 			save_playwright_script_path=save_playwright_script_path,
 			extend_planner_system_message=extend_planner_system_message,
+			compress_attributes=compress_attributes,
 		)
 
 		# Memory settings
@@ -266,6 +268,7 @@ class Agent(Generic[Context]):
 				message_context=self.settings.message_context,
 				sensitive_data=sensitive_data,
 				available_file_paths=self.settings.available_file_paths,
+				compress_attributes=self.settings.compress_attributes,
 			),
 			state=self.state.message_manager_state,
 		)
@@ -1114,6 +1117,7 @@ class Agent(Generic[Context]):
 				browser_state_summary=browser_state_summary,
 				result=self.state.last_result,
 				include_attributes=self.settings.include_attributes,
+				compress_attributes=self.settings.compress_attributes,
 			)
 			msg = [SystemMessage(content=system_msg), content.get_user_message(self.settings.use_vision)]
 		else:

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -73,6 +73,7 @@ class AgentSettings(BaseModel):
 
 	# Playwright script generation setting
 	save_playwright_script_path: str | None = None  # Path to save the generated Playwright script
+	compress_attributes: bool = False
 
 
 class AgentState(BaseModel):

--- a/browser_use/dom/compression.py
+++ b/browser_use/dom/compression.py
@@ -1,0 +1,87 @@
+"""
+Attribute compression utilities for reducing token usage in LLM prompts.
+
+This module provides functions for compressing HTML attributes in a way that's both
+compact and understandable by LLMs.
+"""
+
+# Attribute mapping: full_name -> short_code
+ATTRIBUTE_MAP = {
+	'type': 't',
+	'placeholder': 'p',
+	'aria-label': 'a',
+	'role': 'r',
+	'name': 'n',
+	'id': 'i',
+	'class': 'c',
+	'value': 'v',
+	'href': 'h',
+	'target': 'tg',
+	'title': 'ti',
+	'alt': 'al',
+}
+
+
+def get_compression_documentation(include_attributes: list[str] | None = None) -> str:
+	"""Generate documentation for the attribute compression format.
+
+	Args:
+	    include_attributes: List of attribute names to include in documentation.
+	                     If None or empty, all available attributes will be included.
+
+	Returns:
+	    str: Formatted documentation string explaining the compression format.
+	"""
+	# Filter ATTRIBUTE_MAP to only include requested attributes
+	attribute_items = ATTRIBUTE_MAP.items()
+	if include_attributes:
+		attribute_items = [(attr, code) for attr, code in attribute_items if attr in include_attributes]
+	else:
+		# no include_attributes so no need to provide description of attributes
+		return ''
+
+	# Get the longest code for alignment
+	max_code_len = max(len(code) for _, code in attribute_items)
+
+	# Build attribute mapping section with only included attributes
+	mapping_lines = [f'- @{code.ljust(max_code_len)} - {attr_name}' for attr_name, code in sorted(attribute_items)]
+
+	# Build the full documentation
+	lines = [
+		'[ATTRIBUTE COMPRESSION ENABLED]',
+		"Interactive element attributes are compressed to save tokens. Here's the format:",
+		'- @code - attribute_name',
+		'',
+		'Available attribute mappings:',
+		*mapping_lines,
+		'',
+		'Examples:',
+		"  <button type='submit' class='btn'> becomes [1] <button @t='submit' @c='btn'>",
+		"  <a href='/login' title='Sign in'> becomes [2] <a @h='/login' @ti='Sign in'>",
+	]
+
+	return '\n'.join(lines)
+
+
+def compress_attributes(attributes: dict[str, str]) -> str:
+	"""Compress a dictionary of attributes into a space-separated string.
+
+	Args:
+	    attributes: Dictionary of attribute names and values
+
+	Returns:
+	    str: Compressed attribute string with values in single quotes (e.g., "@t='submit' @c='btn btn-primary'")
+	"""
+	if not attributes:
+		return ''
+
+	compressed = []
+	for key, value in attributes.items():
+		# Use mapped key or original key
+		short_key = ATTRIBUTE_MAP.get(key, key)
+		# Escape single quotes in the value
+		escaped_value = str(value).replace("'", "\\'")
+		# Add single quotes around the value
+		compressed.append(f"@{short_key}='{escaped_value}'")
+
+	return ' '.join(compressed)

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -150,8 +150,13 @@ class DOMElementNode(DOMBaseNode):
 		return '\n'.join(text_parts).strip()
 
 	@time_execution_sync('--clickable_elements_to_string')
-	def clickable_elements_to_string(self, include_attributes: list[str] | None = None) -> str:
-		"""Convert the processed DOM content to HTML."""
+	def clickable_elements_to_string(self, include_attributes: list[str] | None = None, compress_attributes: bool = False) -> str:
+		"""Convert the processed DOM content to HTML.
+
+		Args:
+		    include_attributes: List of attribute names to include
+		    compress_attributes: Whether to compress attribute names for token efficiency
+		"""
 		formatted_text = []
 
 		def process_node(node: DOMBaseNode, depth: int) -> None:
@@ -190,9 +195,13 @@ class DOMElementNode(DOMBaseNode):
 							del attributes_to_include['placeholder']
 
 						if attributes_to_include:
-							# Format as key1='value1' key2='value2'
-							attributes_html_str = ' '.join(f"{key}='{value}'" for key, value in attributes_to_include.items())
+							if compress_attributes:
+								from browser_use.dom.compression import compress_attributes as compress
 
+								attributes_html_str = compress(attributes_to_include)
+							else:
+								# Format as key1='value1' key2='value2'
+								attributes_html_str = ' '.join(f"{key}='{value}'" for key, value in attributes_to_include.items())
 					# Build the line
 					if node.is_new:
 						highlight_indicator = f'*[{node.highlight_index}]*'

--- a/examples/features/compress_attributes.py
+++ b/examples/features/compress_attributes.py
@@ -1,0 +1,44 @@
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from langchain_google_genai import ChatGoogleGenerativeAI
+from pydantic import SecretStr
+
+from browser_use import Agent
+from browser_use.browser import BrowserProfile, BrowserSession
+
+api_key = os.getenv('GOOGLE_API_KEY')
+if not api_key:
+	raise ValueError('GOOGLE_API_KEY is not set')
+
+llm = ChatGoogleGenerativeAI(model='gemini-2.0-flash-exp', api_key=SecretStr(api_key))
+
+browser_session = BrowserSession(
+	browser_profile=BrowserProfile(
+		viewport_expansion=0,
+		user_data_dir='~/.config/browseruse/profiles/default',
+	)
+)
+
+
+async def run_search():
+	agent = Agent(
+		task='Go to amazon.com, search for laptop, sort by best rating, and give me the price of the first result',
+		llm=llm,
+		max_actions_per_step=4,
+		browser_session=browser_session,
+		compress_attributes=True,
+	)
+
+	await agent.run(max_steps=25)
+
+
+if __name__ == '__main__':
+	asyncio.run(run_search())


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>DOM Element Attribute Compression</h1>

<p>Reduces token usage in LLM prompts<p>
<h2>Changes</h2>
<ul>
<li>Added <code>compression.py</code> with:
<ul>
<li><code>ATTRIBUTE_MAP</code> for common attribute mappings (e.g., <code>type</code> → <code>@t</code>)</li>
<li><code>compress_attributes()</code> to convert attribute dicts to compressed strings</li>
<li><code>get_compression_documentation()</code> to explain the compression format</li>
</ul>
</li>
<li>Updated <code>DOMElementNode.clickable_elements_to_string()</code> to support optional compression</li>
<li>Added example script <code>compress_attributes.py</code></li>
</ul>
<h2>Original vs Compressed Sizes</h2>

Attribute | Original | Compressed | Size Reduction
-- | -- | -- | --
type | 4 chars | @t (2 chars) | 50%
placeholder | 11 chars | @p (2 chars) | 82%
aria-label | 10 chars | @A (2 chars) | 80%
role | 4 chars | @r (2 chars) | 50%
name | 4 chars | @n (2 chars) | 50%
class | 5 chars | @c (2 chars) | 60%
value | 5 chars | @v (2 chars) | 60%
href | 4 chars | @h (2 chars) | 50%
target | 6 chars | @tg (3 chars) | 50%
title | 5 chars | @ti (3 chars) | 40%
id | 2 chars | @i (2 chars) | 0%
alt | 3 chars | @al (3 chars) | 0%


<h2>Compression Format</h2>
<p>Interactive element attributes are compressed to save tokens. Here's the format:</p>
<ul>
<li>@code - attribute_name</li>
</ul>
<p>Examples:
<code>&lt;button type='submit' class='btn'&gt;</code> becomes <code>[1] &lt;button @t='submit' @c='btn'&gt;</code>
<code>&lt;a href='/login' title='Sign in'&gt;</code> becomes <code>[2] &lt;a @h='/login' @ti='Sign in'&gt;</code></p></body></html><!--EndFragment-->
</body>
</html>
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added attribute compression to reduce token usage in LLM prompts by shortening common HTML attribute names.

- **New Features**
  - Added a compression utility that maps common attribute names (like type, class, href) to short codes (e.g., @t, @c, @h).
  - Updated DOM element string output to support compressed attributes.
  - Added an option to enable or disable attribute compression.
  - Included an example script showing how to use attribute compression.

<!-- End of auto-generated description by cubic. -->

