### PR TITLE
fix: fixing interactive element event checking

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -824,12 +824,28 @@
 
     if (hasInteractiveRole) return true;
 
-    // Check common event attributes (getEventListeners doesn't work in page.evaluate context)
-    const commonMouseAttrs = ['onclick', 'onmousedown', 'onmouseup', 'ondblclick'];
-    for (const attr of commonMouseAttrs) {
-      if (element.hasAttribute(attr) || typeof element[attr] === 'function') {
-        return true;
+    // check whether element has event listeners by window.getEventListeners
+    try {
+      if (typeof getEventListeners === 'function') {
+        const listeners = getEventListeners(element);
+        const mouseEvents = ['click', 'mousedown', 'mouseup', 'dblclick'];
+        for (const eventType of mouseEvents) {
+          if (listeners[eventType] && listeners[eventType].length > 0) {
+            return true; // Found a mouse interaction listener
+          }
+        }
+      } else {
+        // Fallback: Check common event attributes if getEventListeners is not availabl (getEventListeners doesn't work in page.evaluate context)
+        const commonMouseAttrs = ['onclick', 'onmousedown', 'onmouseup', 'ondblclick'];
+        for (const attr of commonMouseAttrs) {
+          if (element.hasAttribute(attr) || typeof element[attr] === 'function') {
+            return true;
+          }
+        }
       }
+    } catch (e) {
+      // console.warn(`Could not check event listeners for ${element.tagName}:`, e);
+      // If checking listeners fails, rely on other checks
     }
 
     return false


### PR DESCRIPTION
fix: fixing interactive element event checking: **restore code for using window.getEventListeners**

### solving issues:
[DOM Service Fails to Distinguish Adjacent Elements](https://github.com/browser-use/browser-use/issues/1728#issuecomment-2906566032)

### before fixing:
![image](https://github.com/user-attachments/assets/ba08f914-7376-469a-ba56-881e953c4b1c)

### after fixing:
the element "Past day" is highlighted with number 18,and the element "Web Search" is highlighted with number 20
![image](https://github.com/user-attachments/assets/74b998cd-0d54-4396-bb4f-a32363fcaacc)
