### PR TITLE
fix: handle www.* domain matching + improved .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ __pycache__/
 .ipynb_checkpoints
 
 # Virtual Environments
-.venv
+.venv*
 venv/
 
 # IDEs

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -410,12 +410,14 @@ def match_url_with_domain_pattern(url: str, domain_pattern: str, log_warnings: b
 		# Extract only the hostname and scheme components
 		scheme = parsed_url.scheme.lower() if parsed_url.scheme else ''
 		domain = parsed_url.hostname.lower() if parsed_url.hostname else ''
+		domain = _normalize_domain_for_www(domain)
 
 		if not scheme or not domain:
 			return False
 
 		# Normalize the domain pattern
 		domain_pattern = domain_pattern.lower()
+		domain_pattern = _normalize_domain_for_www(domain_pattern)
 
 		# Handle pattern with scheme
 		if '://' in domain_pattern:
@@ -477,3 +479,8 @@ def match_url_with_domain_pattern(url: str, domain_pattern: str, log_warnings: b
 		logger = logging.getLogger(__name__)
 		logger.error(f'⛔️ Error matching URL {url} with pattern {domain_pattern}: {type(e).__name__}: {e}')
 		return False
+
+
+def _normalize_domain_for_www(d: str) -> str:
+	"""Helper function to normalize domains by removing www prefix"""
+	return d[4:] if d.startswith('www.') else d

--- a/tests/ci/test_sensitive_data.py
+++ b/tests/ci/test_sensitive_data.py
@@ -107,6 +107,8 @@ def test_match_url_with_domain_pattern():
 	assert match_url_with_domain_pattern('https://example.com', 'example.com') is True
 	assert match_url_with_domain_pattern('http://example.com', 'example.com') is False  # Default scheme is now https
 	assert match_url_with_domain_pattern('https://google.com', 'example.com') is False
+	assert match_url_with_domain_pattern('https://www.example.com', 'example.com') is True
+	assert match_url_with_domain_pattern('https://example.com', 'www.example.com') is True
 
 	# Test subdomain pattern matches
 	assert match_url_with_domain_pattern('https://sub.example.com', '*.example.com') is True


### PR DESCRIPTION
When using custom actions and providing config like `domains=['amazon.com']`, the current approach will not match the URL because amazon.com redirects to www.amazon.com

This PR aims to fix the issue by normalizing the domain in the `match_url_with_domain_pattern` function, tests added.

The `.gitignore` file change aims to include folders like `.venv-py312` and ignore them.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed domain matching to treat www.example.com and example.com as equal, so URLs with or without "www" now match as expected. Updated .gitignore to ignore all .venv* folders.

- **Bug Fixes**
  - Normalized domains in match_url_with_domain_pattern to handle "www" prefixes.
  - Added tests for matching both www and non-www domains.

<!-- End of auto-generated description by cubic. -->

