### PR TITLE
Auto-inherit DISPLAY env var in headful mode

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -736,7 +736,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			self.window_size = self.window_size or display_size or ViewportSize(width=1280, height=1100)
 			self.no_viewport = True if self.no_viewport is None else self.no_viewport
 			self.viewport = None if self.no_viewport else self.viewport
-			
+
 			# Auto-inherit DISPLAY environment variable for headful mode
 			if 'DISPLAY' in os.environ and 'DISPLAY' not in self.env:
 				self.env['DISPLAY'] = os.environ['DISPLAY']

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -736,6 +736,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			self.window_size = self.window_size or display_size or ViewportSize(width=1280, height=1100)
 			self.no_viewport = True if self.no_viewport is None else self.no_viewport
 			self.viewport = None if self.no_viewport else self.viewport
+			
+			# Auto-inherit DISPLAY environment variable for headful mode
+			if 'DISPLAY' in os.environ and 'DISPLAY' not in self.env:
+				self.env['DISPLAY'] = os.environ['DISPLAY']
 
 		# automatically setup viewport if any config requires it
 		use_viewport = self.headless or self.viewport or self.device_scale_factor


### PR DESCRIPTION
## Summary
- Automatically inherit the DISPLAY environment variable when running in non-headless mode
- Fixes #1773 - "Missing X server or $DISPLAY" error when launching headed browsers on Linux

## Problem
When running browser-use with `headless=False` on Linux systems with X11, users get an error:
```
Missing X server or $DISPLAY
The platform failed to initialize. Exiting.
```

This happens because the browser subprocess doesn't inherit the DISPLAY environment variable from the parent process.

## Solution
Added logic in `BrowserProfile` to automatically inherit the DISPLAY environment variable when:
1. Running in headful mode (`headless=False`)
2. DISPLAY exists in the parent process environment
3. DISPLAY hasn't been explicitly set in the config

This allows users to run headed browsers without manually specifying `env={'DISPLAY': os.environ['DISPLAY']}`.

## Test plan
- [x] Tested on Ubuntu with X11 display
- [x] Verified that headed mode now works without manual DISPLAY configuration
- [x] Confirmed that explicit env settings still override the auto-inheritance

Fixes #1773

🤖 Generated with [Claude Code](https://claude.ai/code)