### PR TITLE
Fix: Prevent crash by using threading workaround for async in sync environments

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -601,12 +601,18 @@ class Agent(Generic[Context]):
 				def run_in_thread():
 					new_loop = asyncio.new_event_loop()
 					asyncio.set_event_loop(new_loop)
-					result["value"] = new_loop.run_until_complete(test_all_methods())
-					new_loop.close()
-
+					try:
+						result["value"] = new_loop.run_until_complete(test_all_methods())
+					except Exception as e:
+						result["error"] = e
+					finally:
+						new_loop.close()
+						
 				t = Thread(target=run_in_thread)
 				t.start()
 				t.join()
+				if "error" in result:
+					raise result["error"]
 				results = result["value"]
 
 			except RuntimeError:


### PR DESCRIPTION
Changes:
1. Replaced asyncio.run() with a thread-based event loop fallback for environments with a running event loop.
2. Ensures compatibility in other async runtimes.
3. Maintains parallel testing and sequential fallback logic for tool calling method detection.

Why:
* Fixes runtime warnings caused by asyncio.run() in already-running event loops.

RuntimeWarning in console logs (before fix):
C:\Users\test\AppData\Local\Programs\Python\Python312\Lib\site-packages\browser_use\agent\service.py:616: RuntimeWarning: coroutine 'Agent._detect_best_tool_calling_method.<locals>.test_all_methods' was never awaited
  return method
RuntimeWarning: Enable tracemalloc to get the object allocation traceback

Test code:
import asyncio
import os
import sys
from dotenv import load_dotenv
from browser_use import Agent, BrowserSession
from langchain_openai import ChatOpenAI

sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
load_dotenv()

llm = ChatOpenAI(model='gpt-4o')

browser_session = BrowserSession()

async def main():
    await browser_session.start()
    agent = Agent(
        task='What theories are displayed on the page?',
        initial_actions=[
            {'open_tab': {'url': 'https://www.google.com'}},
            {'open_tab': {'url': 'https://en.wikipedia.org/wiki/Randomness'}},
            {'scroll_down': {'amount': 1000}},
        ],
        llm=llm,
        browser_session=browser_session
    )
    await agent.run()

if __name__ == '__main__':
    asyncio.run(main())


After a thorough review, I believe that the Issue has been resolved after the fix. Kindly request you to review and merge the same.
Thanking you,
Ajith George Sam
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a crash caused by using asyncio.run() in environments with an active event loop by switching to a thread-based workaround. This prevents runtime warnings and ensures compatibility with different async runtimes.

- **Bug Fixes**
  - Replaced asyncio.run() with a thread-based event loop when a loop is already running.
  - Maintained fallback logic for tool calling method detection.

<!-- End of auto-generated description by cubic. -->

