### PR TITLE
Fix: Prevent crash by using threading workaround for async in sync environments

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -11,6 +11,7 @@ import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, Generic, TypeVar
+from threading import Thread
 
 from dotenv import load_dotenv
 
@@ -592,7 +593,31 @@ class Agent(Generic[Context]):
 				return results
 
 			# Execute async tests
-			results = asyncio.run(test_all_methods())
+			try:
+				loop = asyncio.get_running_loop()
+				# Running loop: create a new loop in a separate thread
+				result = {}
+
+				def run_in_thread():
+					new_loop = asyncio.new_event_loop()
+					asyncio.set_event_loop(new_loop)
+					try:
+						result["value"] = new_loop.run_until_complete(test_all_methods())
+					except Exception as e:
+						result["error"] = e
+					finally:
+						new_loop.close()
+						
+				t = Thread(target=run_in_thread)
+				t.start()
+				t.join()
+				if "error" in result:
+					raise result["error"]
+				results = result["value"]
+
+			except RuntimeError:
+				# No running loop: use asyncio.run
+				results = asyncio.run(test_all_methods())
 
 			# Process results in order of preference
 			for i, method in enumerate(methods_to_try):


### PR DESCRIPTION
Changes:
1. Replaced asyncio.run() with a thread-based event loop fallback for environments with a running event loop.
2. Ensures compatibility in other async runtimes.
3. Maintains parallel testing and sequential fallback logic for tool calling method detection.

Why:
* Fixes runtime warnings caused by asyncio.run() in already-running event loops.

RuntimeWarning in console logs (before fix):
C:\Users\test\AppData\Local\Programs\Python\Python312\Lib\site-packages\browser_use\agent\service.py:616: RuntimeWarning: coroutine 'Agent._detect_best_tool_calling_method..test_all_methods' was never awaited
return method
RuntimeWarning: Enable tracemalloc to get the object allocation traceback

Test code:
import asyncio
import os
import sys
from dotenv import load_dotenv
from browser_use import Agent, BrowserSession
from langchain_openai import ChatOpenAI

sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))

load_dotenv()

llm = ChatOpenAI(model='gpt-4o')
browser_session = BrowserSession()

async def main():
    await browser_session.start()
    agent = Agent(
        task='What theories are displayed on the page?',
        initial_actions=[
            {'open_tab': {'url': 'https://www.google.com'}},
            {'open_tab': {'url': 'https://en.wikipedia.org/wiki/Randomness'}},
            {'scroll_down': {'amount': 1000}},
        ],
        llm=llm,
        browser_session=browser_session
    )
    await agent.run()

if __name__ == '__main__':
    asyncio.run(main())

After a thorough review, I believe that the Issue has been resolved after the fix. Kindly request you to review and merge the same.
Thanking you,
Ajith George Sam

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a crash caused by using asyncio.run() in environments with an active event loop by adding a thread-based workaround.

- **Bug Fixes**
  - Replaced asyncio.run() with a thread-based event loop when a loop is already running.
  - Prevents runtime warnings and ensures compatibility with other async runtimes.

<!-- End of auto-generated description by cubic. -->

