### PR TITLE
Fix: Ensure BrowserSession.start() is called before agent run

### DIFF
--- a/examples/features/initial_actions.py
+++ b/examples/features/initial_actions.py
@@ -10,25 +10,25 @@ load_dotenv()
 
 from langchain_openai import ChatOpenAI
 
-from browser_use import Agent
+from browser_use import Agent, BrowserSession
 
 llm = ChatOpenAI(model='gpt-4o')
 
-initial_actions = [
-	{'open_tab': {'url': 'https://www.google.com'}},
-	{'open_tab': {'url': 'https://en.wikipedia.org/wiki/Randomness'}},
-	{'scroll_down': {'amount': 1000}},
-]
-agent = Agent(
-	task='What theories are displayed on the page?',
-	initial_actions=initial_actions,
-	llm=llm,
-)
-
+browser_session = BrowserSession()
 
 async def main():
-	await agent.run(max_steps=10)
-
+    await browser_session.start()
+    agent = Agent(
+        task='What theories are displayed on the page?',
+        initial_actions=[
+            {'open_tab': {'url': 'https://www.google.com'}},
+            {'open_tab': {'url': 'https://en.wikipedia.org/wiki/Randomness'}},
+            {'scroll_down': {'amount': 1000}},
+        ],
+        llm=llm,
+        browser_session=browser_session
+    )
+    await agent.run(max_steps=10)
 
 if __name__ == '__main__':
-	asyncio.run(main())
+    asyncio.run(main())


### PR DESCRIPTION
This PR fixes a Runtime Error in the browser_use agent initialization caused by BrowserSession.start() not being called before invoking agent.run(). This caused the following exception: RuntimeError: BrowserSession(...).start() must be called first to launch or connect to the browser

Changes Made:
1. Added browser_session = BrowserSession() and await browser_session.start() before initializing the Agent.
2. Passed the browser_session explicitly into the Agent constructor.

**Before:**
--> Agent was initialized and run without starting the BrowserSession, causing a runtime error.
Error Traceback logs (before fix) :
ERROR    [agent] Agent run failed with exception: BrowserSession(...).start() must be called first to launch or connect to the browser

**After:**
--> BrowserSession is properly started before use, allowing the agent to perform actions successfully.
Success logs (after fix):
INFO     [agent] ✅ Task completed successfully