### PR TITLE
Add screenshot timeout and fallback method when full-page screenshot times out

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -1,6 +1,13 @@
+import asyncio
+import sys
+
 from browser_use.logging_config import setup_logging
 
 setup_logging()
+
+# Set Windows event loop policy for Playwright compatibility
+if sys.platform.startswith('win'):
+	asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 from browser_use.agent.prompts import SystemPrompt
 from browser_use.agent.service import Agent

--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -3,11 +3,14 @@ import sys
 
 from browser_use.logging_config import setup_logging
 
-setup_logging()
+logger = setup_logging()
 
 # Set Windows event loop policy for Playwright compatibility
 if sys.platform.startswith('win'):
-	asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+	try:
+		asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+	except Exception as e:
+		logger.error(f'❌  Failed to set Windows event loop policy: {type(e).__name__}: {e}')
 
 from browser_use.agent.prompts import SystemPrompt
 from browser_use.agent.service import Agent

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1641,26 +1641,72 @@ class BrowserSession(BaseModel):
 		"""
 		assert self.agent_current_page is not None, 'Agent current page is not set'
 
-		# We no longer force tabs to the foreground as it disrupts user focus
-		# await self.agent_current_page.bring_to_front()
 		page = await self.get_current_page()
 		await page.wait_for_load_state(
 			timeout=5000,
 		)  # page has already loaded by this point, this is extra for previous action animations/frame loads to settle
 
-		screenshot = await self.agent_current_page.screenshot(
-			full_page=full_page,
-			animations='disabled',
-			caret='initial',
-		)
+		# 0. Attempt full-page screenshot (sometimes times out for huge pages)
+		try:
+			screenshot = await page.screenshot(
+				full_page=True,
+				scale='css',
+				timeout=15000,
+				animations='disabled',
+				caret='initial',
+			)
 
-		screenshot_b64 = base64.b64encode(screenshot).decode('utf-8')
+			screenshot_b64 = base64.b64encode(screenshot).decode('utf-8')
+			return screenshot_b64
+		except Exception as e:
+			logger.error(f'❌  Failed to take full-page screenshot: {e} falling back to viewport-only screenshot')
 
-		# await self.remove_highlights()
+		# Fallback method: manually expand the viewport and take a screenshot of the entire viewport
 
-		return screenshot_b64
+		# 1. Get current page dimensions
+		dimensions = await page.evaluate("""() => {
+			return {
+				width: window.innerWidth,
+				height: window.innerHeight,
+				devicePixelRatio: window.devicePixelRatio || 1
+			};
+		}""")
 
-	# endregion
+		# 2. Save current viewport state and calculate expanded dimensions
+		original_viewport = page.viewport_size
+		viewport_expansion = self.browser_profile.viewport_expansion if self.browser_profile.viewport_expansion else 0
+
+		expanded_width = dimensions['width']  # Keep width unchanged
+		expanded_height = dimensions['height'] + viewport_expansion
+
+		# 3. Expand the viewport if we are using one
+		if original_viewport:
+			await page.set_viewport_size({'width': expanded_width, 'height': expanded_height})
+
+		try:
+			# 4. Take full-viewport screenshot
+			screenshot = await page.screenshot(
+				full_page=False,
+				scale='css',
+				timeout=30000,
+				clip={'x': 0, 'y': 0, 'width': expanded_width, 'height': expanded_height},
+				animations='disabled',
+				caret='initial',
+			)
+			# TODO: manually take multiple clipped screenshots to capture the full height and stitch them together?
+
+			screenshot_b64 = base64.b64encode(screenshot).decode('utf-8')
+			return screenshot_b64
+
+		finally:
+			# 5. Restore original viewport state if we expanded it
+			if original_viewport:
+				# Viewport was originally enabled, restore to original dimensions
+				await page.set_viewport_size(original_viewport)
+			else:
+				# Viewport was originally disabled, no need to restore it
+				# await page.set_viewport_size(None)  # unfortunately this is not supported by playwright
+				pass
 
 	# region - User Actions
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1651,7 +1651,7 @@ class BrowserSession(BaseModel):
 		# 0. Attempt full-page screenshot (sometimes times out for huge pages)
 		try:
 			screenshot = await page.screenshot(
-				full_page=True,
+				full_page=full_page,
 				scale='css',
 				timeout=15000,
 				animations='disabled',

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any, Self
 from urllib.parse import urlparse
 
+os.environ['PW_TEST_SCREENSHOT_NO_FONTS_READY'] = '1'  # https://github.com/microsoft/playwright/issues/35972
+
 import psutil
 from patchright.async_api import Playwright as PatchrightPlaywright
 from playwright.async_api import Browser as PlaywrightBrowser
@@ -1690,8 +1692,8 @@ class BrowserSession(BaseModel):
 				scale='css',
 				timeout=30000,
 				clip={'x': 0, 'y': 0, 'width': expanded_width, 'height': expanded_height},
-				animations='disabled',
-				caret='initial',
+				# animations='disabled',   # these can cause CSP errors on some pages, leading to a red herring "waiting for fonts to load" error
+				# caret='initial',
 			)
 			# TODO: manually take multiple clipped screenshots to capture the full height and stitch them together?
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1633,6 +1633,7 @@ class BrowserSession(BaseModel):
 			raise
 
 	# region - Browser Actions
+	@require_initialization
 	@time_execution_async('--take_screenshot')
 	async def take_screenshot(self, full_page: bool = False) -> str:
 		"""
@@ -1643,7 +1644,9 @@ class BrowserSession(BaseModel):
 		# We no longer force tabs to the foreground as it disrupts user focus
 		# await self.agent_current_page.bring_to_front()
 		page = await self.get_current_page()
-		await page.wait_for_load_state()
+		await page.wait_for_load_state(
+			timeout=5000,
+		)  # page has already loaded by this point, this is extra for previous action animations/frame loads to settle
 
 		screenshot = await self.agent_current_page.screenshot(
 			full_page=full_page,

--- a/browser_use/logging_config.py
+++ b/browser_use/logging_config.py
@@ -137,3 +137,5 @@ def setup_logging():
 		third_party = logging.getLogger(logger_name)
 		third_party.setLevel(logging.ERROR)
 		third_party.propagate = False
+
+	return logger


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a timeout for full-page screenshots and a fallback method that captures the visible viewport if the full-page screenshot fails.

- **Bug Fixes**
  - Logs an error and falls back to viewport-only screenshots when full-page capture times out.
  - Sets the correct Windows event loop policy for Playwright compatibility.

<!-- End of auto-generated description by cubic. -->

