### PR TITLE
Teach browser use to solve datepicker faster

### DIFF
--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -32,6 +32,18 @@ Interactive Elements
 Common action sequences:
 
 - Form filling: [{{"input_text": {{"index": 1, "text": "username"}}}}, {{"input_text": {{"index": 2, "text": "password"}}}}, {{"click_element": {{"index": 3}}}}]
+- Repetitive date navigation (e.g., inside date pickers): 
+  [{{"click_element_multiple_times": {{
+    "index": 5, // index of the action that will either increment or decrement the element
+    "mode": "date|month|year|month-year", 
+    "current": {{"date": 1}} or {{"month": "June"}} or {{"month": "June", "year": 2025}} or {{"year": 2024}},
+    "target": {{"date": 10}} or {{"month": "August"}} or {{"month": "February", "year": 2026}} or {{"year": 2028}}
+  }}}}] 
+  – This action allows intelligent repetitive clicking on navigation elements (e.g., inside date pickers). Use this action only when the element moves the navigation one step forward or backward.Based on the `mode`, the system calculates how many times to click the element (`times` field internally). Modes:
+  - `"date"`: Use when each click advances the **day** only. `current` and `target` must include only the `"date"` field (integers).
+  - `"month"`: Use when each click changes **month only** (ignoring year). Provide `"month"` fields (e.g., `"June"`).
+  - `"year"`: Use when each click changes **year**. Provide `"year"` fields (e.g., `2025`).
+  - `"month-year"`: Each click moves forward/back by one month, and year rolls over automatically. Provide both `"month"` and `"year"` fields.
 - Navigation and extraction: [{{"go_to_url": {{"url": "https://example.com"}}}}, {{"extract_content": {{"goal": "extract the names"}}}}]
 - Actions are executed in the given order
 - If the page changes after an action, the sequence is interrupted and you get the new state.

--- a/browser_use/controller/datapickerSolver.py
+++ b/browser_use/controller/datapickerSolver.py
@@ -1,0 +1,47 @@
+MONTHS = {
+	'January': 1,
+	'February': 2,
+	'March': 3,
+	'April': 4,
+	'May': 5,
+	'June': 6,
+	'July': 7,
+	'August': 8,
+	'September': 9,
+	'October': 10,
+	'November': 11,
+	'December': 12,
+}
+
+
+def calculate_times_to_click(mode: str, current: dict, target: dict) -> int:
+	"""
+	Calculate how many times to click a navigation element to go from current to target value,
+	based on the mode of navigation (e.g., daily, monthly, yearly).
+
+	:param mode: One of "date", "month", "year", "month-year"
+	:param current: Dict with only the relevant fields
+	:param target: Dict with only the relevant fields
+	:return: Integer number of clicks
+	"""
+
+	if mode == 'date':
+		# Expect fields: date (int)
+		return abs(target['date'] - current['date'])
+
+	elif mode == 'month':
+		# Expect fields: month (str)
+		return abs(MONTHS[target['month']] - MONTHS[current['month']])
+
+	elif mode == 'year':
+		# Expect fields: year (int)
+		return abs(target['year'] - current['year'])
+
+	elif mode == 'month-year':
+		# Expect fields: month (str), year (int)
+		curr_total = current['year'] * 12 + MONTHS[current['month']]
+		targ_total = target['year'] * 12 + MONTHS[target['month']]
+		return abs(targ_total - curr_total)
+
+	else:
+		raise ValueError(f'Unsupported mode: {mode}')


### PR DESCRIPTION
## Summary
Enhanced the controller to support date picker navigation with date/month/year selection.


## Problem
Date selection required O(n) LLM calls (n = date difference), causing inefficiency.

## Solution
- Reduced LLM calls to constant time (2-4 calls max)
- Added direct date calculation in backend
- Maintains all existing functionality

## Before
Selecting a date 6 months away required 6 separate LLM calls:
1. Click next month
2. Click next month
3. Click next month
4. Click next month
5. Click next month
6. Click next month
7. Select date

## After
Now takes just 2-4  steps:
1. Calculate exact clicks needed (6 months)
2. Execute all clicks in one action

![datepicker](https://github.com/user-attachments/assets/45defbfc-75a9-44b9-8a62-00d3beb14bfa)
