### PR TITLE
Plug and Play Browser Drivers

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -21,7 +21,7 @@ from browser_use.dom.history_tree_processor.service import (
 )
 from browser_use.dom.views import SelectorMap
 
-ToolCallingMethod = Literal['function_calling', 'json_mode', 'raw', 'auto', 'tools']
+ToolCallingMethod = Literal['function_calling', 'json_mode', 'raw', 'auto', 'tools', None]
 REQUIRED_LLM_API_ENV_VARS = {
 	'ChatOpenAI': ['OPENAI_API_KEY'],
 	'AzureChatOpenAI': ['AZURE_OPENAI_ENDPOINT', 'AZURE_OPENAI_KEY'],
@@ -64,7 +64,7 @@ class AgentSettings(BaseModel):
 	]
 	max_actions_per_step: int = 10
 
-	tool_calling_method: ToolCallingMethod | None = 'auto'
+	tool_calling_method: ToolCallingMethod = 'auto'
 	page_extraction_llm: BaseChatModel | None = None
 	planner_llm: BaseChatModel | None = None
 	planner_interval: int = 1  # Run planner every N steps

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1105,7 +1105,7 @@ class BrowserSession(BaseModel):
 	async def get_cookies(self) -> list[dict[str, Any]]:
 		if self.browser_context:
 			return await self.browser_context.cookies()
-		return []		
+		return []
 
 	async def save_cookies(self, path: Path | None = None) -> None:
 		"""

--- a/browser_use/controller/registry/views.py
+++ b/browser_use/controller/registry/views.py
@@ -1,14 +1,11 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING
+from typing import Any
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from playwright.async_api import Page
 from pydantic import BaseModel, ConfigDict
 
 from browser_use.browser import BrowserSession
-
-if TYPE_CHECKING:
-	from browser_use.agent.service import Context
+from browser_use.typing import Page
 
 
 class RegisteredAction(BaseModel):
@@ -152,7 +149,7 @@ class SpecialActionParameters(BaseModel):
 	# e.g. can contain anything, external db connections, file handles, queues, runtime config objects, etc.
 	# that you might want to be able to access quickly from within many of your actions
 	# browser-use code doesn't use this at all, we just pass it down to your actions for convenience
-	context: 'Context | None' = None
+	context: Any = None
 
 	# browser-use session object, can be used to create new tabs, navigate, access playwright objects, etc.
 	browser_session: BrowserSession | None = None

--- a/browser_use/dom/history_tree_processor/view.py
+++ b/browser_use/dom/history_tree_processor/view.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -31,8 +32,8 @@ class CoordinateSet(BaseModel):
 
 
 class ViewportInfo(BaseModel):
-	scroll_x: int
-	scroll_y: int
+	scroll_x: int | None = None  # made optional
+	scroll_y: int | None = None  # made optional
 	width: int
 	height: int
 
@@ -50,7 +51,7 @@ class DOMHistoryElement:
 	viewport_coordinates: CoordinateSet | None = None
 	viewport_info: ViewportInfo | None = None
 
-	def to_dict(self) -> dict:
+	def to_dict(self) -> dict[str, Any]:
 		page_coordinates = self.page_coordinates.model_dump() if self.page_coordinates else None
 		viewport_coordinates = self.viewport_coordinates.model_dump() if self.viewport_coordinates else None
 		viewport_info = self.viewport_info.model_dump() if self.viewport_info else None

--- a/browser_use/drivers/playwright.py
+++ b/browser_use/drivers/playwright.py
@@ -73,9 +73,9 @@ class PlaywrightBrowser(Browser):
 	async def open(self, **kwargs: Any) -> Browser:
 		"""Open a connection to browser"""
 		assert self._browser_type is not None, 'Browser type is not initialized'
-		if "endpoint_url" in kwargs:
+		if 'endpoint_url' in kwargs:
 			self._browser = await self._browser_type.connect_over_cdp(**kwargs)
-		elif "ws_endpoint" in kwargs:
+		elif 'ws_endpoint' in kwargs:
 			self._browser = await self._browser_type.connect(**kwargs)
 		else:
 			self._browser = await self._browser_type.launch(**kwargs)

--- a/browser_use/drivers/playwright.py
+++ b/browser_use/drivers/playwright.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any, Literal
+
+from patchright.async_api import Playwright as _Patchright
+from playwright.async_api import Browser as _Browser
+from playwright.async_api import BrowserContext as _BrowserContext
+from playwright.async_api import BrowserType as _BrowserType
+from playwright.async_api import ElementHandle as _ElementHandle
+from playwright.async_api import Frame as _Frame
+from playwright.async_api import Locator as _Locator
+from playwright.async_api import Page as _Page
+from playwright.async_api import Playwright as _Playwright
+from playwright.async_api import async_playwright
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+from browser_use.typing import (
+	Browser,
+	Download,
+	Driver,
+	ElementHandle,
+	Frame,
+	Keyboard,
+	Locator,
+	Mouse,
+	Page,
+	Tracing,
+	ViewportSize,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PlaywrightDriver(Driver):
+	def __init__(self, profile: BrowserProfile, backend=async_playwright) -> None:
+		super().__init__(profile)
+		self.backend = backend
+
+	async def init_impl(self) -> None:
+		self.impl = PlaywrightBrowser(self.profile, backend=self.backend)
+		await self.impl.setup()
+
+
+class PlaywrightBrowser(Browser):
+	def __init__(self, profile: BrowserProfile, backend) -> None:
+		super().__init__()
+		logger.info(f'🛠️  Created BrowserEngine: {self.__class__.__name__}')
+		self._profile = profile
+		self._backend = backend
+		self._playwright: _Playwright | _Patchright | None = None
+		self._browser_type: _BrowserType | None = None
+		self._browser: _Browser | None = None
+
+	async def setup(self) -> Browser:
+		"""Setup connector"""
+		logger.info(f'🛠️  Initializing BrowserEngine: {self.__class__.__name__} channel={self._profile.channel}')
+		self._playwright = await self._backend().start()  # type: ignore
+		assert isinstance(self._playwright, (_Playwright, _Patchright)), 'Playwright object is not initialized'
+		if self._profile.channel == 'chromium':
+			self._browser_type = self._playwright.chromium  # type: ignore
+		elif self._profile.channel == 'firefox':
+			self._browser_type = self._playwright.firefox  # type: ignore
+		elif self._profile.channel == 'webkit':
+			self._browser_type = self._playwright.webkit  # type: ignore
+		else:
+			raise ValueError(f'Invalid browser name: {self._profile.channel}')
+		assert self._browser_type is not None, 'Browser type is not initialized'
+		return self
+
+	async def open(self, **kwargs: Any) -> Browser:
+		"""Open a connection to browser"""
+		assert self._browser_type is not None, 'Browser type is not initialized'
+		if "endpoint_url" in kwargs:
+			self._browser = await self._browser_type.connect_over_cdp(**kwargs)
+		elif "ws_endpoint" in kwargs:
+			self._browser = await self._browser_type.connect(**kwargs)
+		else:
+			self._browser = await self._browser_type.launch(**kwargs)
+		assert self._browser is not None, 'Browser is not initialized'
+		logger.info(f'🛠️  BrowserEngine.open(): {self.__class__.__name__} channel={self._profile.channel}')
+		return self
+
+	async def close(self) -> None:
+		"""Close a connection to browser"""
+		logger.info(f'🛠️  BrowserEngine.close(): {self.__class__.__name__} channel={self._profile.channel}')
+		if self._browser:
+			await self._browser.close()
+		if self._playwright:
+			await self._playwright.stop()
+
+	async def new_session(self, **kwargs: Any) -> BrowserSession:
+		"""Create a new browser session"""
+		logger.info(f'🛠️  BrowserEngine.new_context(): {self.__class__.__name__} channel={self._profile.channel}')
+		assert self._browser is not None, 'Browser is not initialized'
+		ctx: _BrowserContext = await self._browser.new_context(**kwargs)
+		return PlaywrightSession(self._profile, ctx)
+
+	def is_connected(self) -> bool:
+		assert self._browser is not None, 'Browser is not initialized'
+		return self._browser.is_connected()
+
+	@property
+	def sessions(self) -> list[BrowserSession]:
+		"""Get all browser contexts"""
+		logger.info(f'🛠️  BrowserEngine.contexts(): {self.__class__.__name__} channel={self._profile.channel}')
+		assert self._browser is not None, 'Browser is not initialized'
+		return [PlaywrightSession(self._profile, ctx) for ctx in self._browser.contexts]
+
+	@property
+	def version(self) -> str:
+		"""Get the browser version"""
+		logger.info(f'🛠️  BrowserEngine.version(): {self.__class__.__name__} channel={self._profile.channel}')
+		assert self._browser is not None, 'Browser is not initialized'
+		return self._browser.version
+
+
+class PlaywrightSession(BrowserSession):
+	def __init__(self, profile: BrowserProfile, ctx: _BrowserContext | None = None) -> None:
+		super().__init__(browser_profile=profile)
+		self.browser_context: _BrowserContext | None = ctx  # To store playwright context object
+
+	@property
+	def browser(self) -> Browser:
+		assert isinstance(self.driver, PlaywrightDriver), 'Driver is not a PlaywrightDriver'
+		return PlaywrightBrowser(self.browser_profile, self.driver.backend)
+
+	async def new_page(self) -> Page:
+		assert self.browser_context is not None, 'Context is not initialized'
+		page = await self.browser_context.new_page()
+		return PlaywrightPage(page)
+
+	async def close(self) -> None:
+		assert self.browser_context is not None, 'Context is not initialized'
+		return await self.browser_context.close()
+
+	@property
+	def tracing(self) -> Tracing:
+		assert self.browser_context is not None, 'Context is not initialized'
+		return PlaywrightTracing(self.browser_context.tracing)
+
+	@property
+	def pages(self) -> list[Page]:
+		assert self.browser_context is not None, 'Context is not initialized'
+		return [PlaywrightPage(page) for page in self.browser_context.pages]
+
+	async def grant_permissions(self, permissions: list[str], origin: str | None = None) -> None:
+		assert self.browser_context is not None, 'Context is not initialized'
+		await self.browser_context.grant_permissions(permissions, origin=origin)
+
+	async def add_cookies(self, cookies: list[dict[str, Any]]) -> None:
+		assert self.browser_context is not None, 'Context is not initialized'
+		await self.browser_context.add_cookies(cookies)  # type: ignore
+
+	async def add_init_script(self, script: str) -> None:
+		assert self.browser_context is not None, 'Context is not initialized'
+		await self.browser_context.add_init_script(script)
+
+	def remove_listener(self, event: str, handler: Any) -> None:
+		assert self.browser_context is not None, 'Context is not initialized'
+		self.browser_context.remove_listener(event, handler)
+
+	def on(self, event: str, handler: Any) -> None:
+		self.browser_context.on(event, handler)  # type: ignore
+
+	async def cookies(self) -> list[dict[str, Any]]:
+		assert self.browser_context is not None, 'Context is not initialized'
+		cookies = await self.browser_context.cookies()
+		return [vars(cookie) for cookie in cookies]
+
+
+class PlaywrightTracing(Tracing):
+	def __init__(self, tracing: Any):
+		self._tracing = tracing
+
+	async def start(self, **kwargs: Any) -> None:
+		await self._tracing.start(**kwargs)
+
+	async def stop(self, **kwargs: Any) -> None:
+		await self._tracing.stop(**kwargs)
+
+
+class PlaywrightFrame(Frame):
+	def __init__(self, frame: _Frame):
+		self._frame = frame
+
+	@property
+	def url(self) -> str:
+		return self._frame.url
+
+	async def content(self) -> str:
+		return await self._frame.content()
+
+	async def evaluate(self, script: str, *args: Any, **kwargs: Any) -> Any:
+		return await self._frame.evaluate(script, *args, **kwargs)
+
+	async def query_selector(self, selector: str) -> ElementHandle | None:
+		handle = await self._frame.query_selector(selector)
+		if handle is None:
+			return None
+		return PlaywrightElementHandle(handle)
+
+	async def query_selector_all(self, selector: str) -> list[ElementHandle]:
+		handles = await self._frame.query_selector_all(selector)
+		return [PlaywrightElementHandle(h) for h in handles]
+
+	def locator(self, selector: str) -> Locator:
+		return PlaywrightLocator(self._frame.locator(selector))
+
+	async def click(self, *args: Any, **kwargs: Any) -> Any:
+		await self._frame.click(*args, **kwargs)
+
+
+class PlaywrightKeyboard(Keyboard):
+	def __init__(self, keyboard: Any):
+		self._keyboard = keyboard
+
+	async def press(self, keys: str) -> None:
+		await self._keyboard.press(keys)
+
+	async def type(self, text: str, delay: float = 0) -> None:
+		await self._keyboard.type(text, delay=delay)
+
+
+class PlaywrightMouse(Mouse):
+	def __init__(self, mouse: Any):
+		self._mouse = mouse
+
+	async def move(self, x: int, y: int) -> None:
+		await self._mouse.move(x, y)
+
+	async def down(self) -> None:
+		await self._mouse.down()
+
+	async def up(self) -> None:
+		await self._mouse.up()
+
+
+class PlaywrightDownload(Download):
+	def __init__(self, download: Any):
+		self._download = download
+
+	@property
+	def suggested_filename(self) -> str:
+		return self._download.suggested_filename
+
+	async def save_as(self, path: str) -> None:
+		await self._download.save_as(path)
+
+	@property
+	async def value(self) -> None:
+		return None
+
+
+class PlaywrightPage(Page):
+	def __init__(self, page: _Page):
+		self._page: _Page = page
+
+	async def goto(self, url: str, **kwargs: Any) -> None:
+		await self._page.goto(url, **kwargs)
+
+	async def click(self, selector: str) -> None:
+		await self._page.click(selector)
+
+	async def fill(self, selector: str, text: str) -> None:
+		await self._page.fill(selector, text)
+
+	async def get_content(self) -> str:
+		return await self._page.content()
+
+	async def screenshot(self, **kwargs: Any) -> bytes:
+		return await self._page.screenshot(**kwargs)
+
+	async def close(self) -> None:
+		await self._page.close()
+
+	async def wait_for_load_state(
+		self, state: Literal['domcontentloaded', 'load', 'networkidle'] | None = 'load', **kwargs: Any
+	) -> None:
+		await self._page.wait_for_load_state(state, **kwargs)
+
+	@property
+	def context(self) -> _BrowserContext:
+		return self._page.context
+
+	@property
+	def url(self) -> str:
+		return self._page.url
+
+	async def set_viewport_size(self, viewport: ViewportSize) -> None:
+		await self._page.set_viewport_size(**viewport.model_dump())
+
+	def is_closed(self) -> bool:
+		return self._page.is_closed()
+
+	async def bring_to_front(self) -> None:
+		await self._page.bring_to_front()
+
+	async def expose_function(self, name: str, func: Callable[..., Any]) -> None:
+		await self._page.expose_function(name, func)  # type: ignore
+
+	async def go_back(self, **kwargs: Any) -> None:
+		await self._page.go_back(**kwargs)
+
+	async def go_forward(self, **kwargs: Any) -> None:
+		await self._page.go_forward(**kwargs)
+
+	async def wait_for_selector(self, selector: str, **kwargs: Any) -> None:
+		await self._page.wait_for_selector(selector, **kwargs)
+
+	async def content(self) -> str:
+		return await self._page.content()
+
+	async def title(self) -> str:
+		return await self._page.title()
+
+	@property
+	def frames(self) -> list[Frame]:
+		return [PlaywrightFrame(frame) for frame in self._page.frames]
+
+	async def emulate_media(self, **kwargs: Any) -> None:
+		await self._page.emulate_media(**kwargs)
+
+	async def pdf(self, **kwargs: Any) -> Any:
+		return await self._page.pdf(**kwargs)
+
+	@property
+	def keyboard(self) -> Keyboard:
+		return PlaywrightKeyboard(self._page.keyboard)
+
+	def get_by_text(self, text: str, exact: bool = False) -> Locator:
+		return PlaywrightLocator(self._page.get_by_text(text, exact=exact))
+
+	@property
+	def mouse(self) -> Mouse:
+		return PlaywrightMouse(self._page.mouse)
+
+	async def viewport_size(self) -> ViewportSize:
+		vs = self._page.viewport_size
+		return ViewportSize(width=vs['width'], height=vs['height']) if vs else ViewportSize(width=0, height=0)
+
+	async def reload(self) -> None:
+		await self._page.reload()
+
+	async def expect_download(self, *args: Any, **kwargs: Any) -> Download:
+		cm = self._page.expect_download(*args, **kwargs)
+		download = await cm.__aenter__()
+		return PlaywrightDownload(download)
+
+	async def wait_for_timeout(self, timeout: float) -> None:
+		await self._page.wait_for_timeout(timeout)
+
+	async def type(self, selector: str, text: str, delay: float = 0) -> None:
+		await self._page.type(selector, text, delay=delay)
+
+	def locator(self, selector: str) -> Locator:
+		return PlaywrightLocator(self._page.locator(selector))
+
+	async def query_selector(self, selector: str) -> ElementHandle | None:
+		handle = await self._page.query_selector(selector)
+		if handle is None:
+			return None
+		return PlaywrightElementHandle(handle)
+
+	async def query_selector_all(self, selector: str) -> list[ElementHandle]:
+		handles = await self._page.query_selector_all(selector)
+		return [PlaywrightElementHandle(h) for h in handles]
+
+	async def evaluate(self, script: str, *args: Any, **kwargs: Any) -> Any:
+		return await self._page.evaluate(script, *args, **kwargs)
+
+	def on(self, event: str, handler: Any) -> None:
+		self._page.on(event, handler)  # type: ignore
+
+	def remove_listener(self, event: str, handler: Any) -> None:
+		self._page.remove_listener(event, handler)  # type: ignore
+
+
+class PlaywrightElementHandle(ElementHandle):
+	def __init__(self, element_handle: _ElementHandle):
+		self._element_handle = element_handle
+
+	async def is_visible(self) -> bool:
+		return await self._element_handle.is_visible()
+
+	async def is_hidden(self) -> bool:
+		return await self._element_handle.is_hidden()
+
+	async def bounding_box(self) -> dict[str, Any] | None:
+		bbox = await self._element_handle.bounding_box()
+		return dict(bbox) if bbox else None
+
+	async def scroll_into_view_if_needed(self, timeout: int | float | None = None) -> None:
+		kwargs: dict[str, Any] = {}
+		if timeout is not None:
+			kwargs['timeout'] = timeout
+		await self._element_handle.scroll_into_view_if_needed(**kwargs)
+
+	async def element_handle(self) -> ElementHandle:
+		return self
+
+	async def wait_for_element_state(
+		self,
+		state: Literal['disabled', 'editable', 'enabled', 'hidden', 'stable', 'visible'],
+		timeout: int | float | None = None,
+	) -> None:
+		await self._element_handle.wait_for_element_state(state, timeout=timeout)
+
+	async def query_selector(self, selector: str) -> ElementHandle | None:
+		handle = await self._element_handle.query_selector(selector)
+		if handle is None:
+			return None
+		return PlaywrightElementHandle(handle)
+
+	async def query_selector_all(self, selector: str) -> list[ElementHandle]:
+		handles = await self._element_handle.query_selector_all(selector)
+		return [PlaywrightElementHandle(h) for h in handles]
+
+	def on(self, event: str, handler: Any) -> None:
+		self._element_handle.on(event, handler)
+
+	def remove_listener(self, event: str, handler: Any) -> None:
+		self._element_handle.remove_listener(event, handler)
+
+	async def click(self, *args: Any, **kwargs: Any) -> Any:
+		await self._element_handle.click(*args, **kwargs)
+
+	async def get_property(self, property_name: str) -> Any:
+		return await self._element_handle.get_property(property_name)
+
+	async def evaluate(self, script: str, *args: Any, **kwargs: Any) -> Any:
+		return await self._element_handle.evaluate(script, *args, **kwargs)
+
+	async def type(self, text: str, delay: float = 0) -> None:
+		await self._element_handle.type(text, delay=delay)
+
+	async def fill(self, text: str, timeout: float | None = None) -> None:
+		kwargs: dict[str, Any] = {}
+		if timeout is not None:
+			kwargs['timeout'] = timeout
+		await self._element_handle.fill(text, **kwargs)
+
+	async def clear(self, timeout: float | None = None) -> None:
+		kwargs: dict[str, Any] = {}
+		if timeout is not None:
+			kwargs['timeout'] = timeout
+		await self._element_handle.fill('', **kwargs)
+
+
+class PlaywrightLocator(Locator):
+	def __init__(self, locator: _Locator):
+		self._locator = locator
+
+	def filter(self, **kwargs: Any) -> Locator:
+		return PlaywrightLocator(self._locator.filter(**kwargs))
+
+	async def evaluate_all(self, expression: str) -> Any:
+		return await self._locator.evaluate_all(expression)
+
+	async def count(self) -> int:
+		return await self._locator.count()
+
+	@property
+	def first(self) -> Locator:
+		return PlaywrightLocator(self._locator.first)
+
+	def nth(self, index: int) -> Locator:
+		return PlaywrightLocator(self._locator.nth(index))
+
+	async def select_option(self, **kwargs: Any) -> Any:
+		return await self._locator.select_option(**kwargs)
+
+	async def element_handle(self) -> ElementHandle | None:
+		handle = await self._locator.element_handle()
+		return PlaywrightElementHandle(handle) if handle else None
+
+	def locator(self, selector: str) -> Locator:
+		return PlaywrightLocator(self._locator.locator(selector))
+
+	async def click(self, *args: Any, **kwargs: Any) -> Any:
+		try:
+			handle = await self._locator.element_handle()
+			await handle.click(*args, **kwargs)
+		except Exception:
+			logger.error(f'Error clicking on element: {self._locator}')
+			raise
+
+	async def evaluate(self, script: str, *args: Any, **kwargs: Any) -> Any:
+		try:
+			handle = await self._locator.element_handle()
+			return await handle.evaluate(script, *args, **kwargs)
+		except Exception:
+			logger.error(f'Error evaluating element: {self._locator}')
+			raise
+
+	async def fill(self, text: str, timeout: float | None = None) -> None:
+		kwargs: dict[str, Any] = {}
+		if timeout is not None:
+			kwargs['timeout'] = timeout
+		await self._locator.fill(text, **kwargs)

--- a/browser_use/typing.py
+++ b/browser_use/typing.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+	# these will create circular imports
+	from browser_use.browser import BrowserProfile, BrowserSession
+
+logger = logging.getLogger(__name__)
+
+
+class ViewportSize(BaseModel):
+	"""Represents a viewport size"""
+	width: int
+	height: int
+
+class ClientCertificate(BaseModel):
+    """Represents a client certificate for authentication"""
+    cert: str
+    key: str
+
+class Geolocation(BaseModel):
+    """Represents geographical location coordinates"""
+    latitude: float
+    longitude: float
+    accuracy: float | None = None
+
+class HttpCredentials(BaseModel):
+    """Represents HTTP authentication credentials"""
+    username: str
+    password: str
+
+class ProxySettings(BaseModel):
+    """Represents proxy server settings"""
+    server: str
+    bypass: str | None = None
+    username: str | None = None
+    password: str | None = None
+
+class StorageState(BaseModel):
+    """Represents browser storage state"""
+    cookies: list[dict[str, Any]] = []
+    origins: list[dict[str, Any]] = []
+
+
+class EventEmitterMixin(ABC):
+	@abstractmethod
+	def on(self, event: str, handler: Any) -> None: ...
+
+	@abstractmethod
+	def remove_listener(self, event: str, handler: Any) -> None: ...
+
+
+class PropertyMixin(ABC):
+	@abstractmethod
+	async def get_property(self, property_name: str) -> Any: ...
+
+
+class LocatorMixin(ABC):
+	@abstractmethod
+	def locator(self, selector: str) -> 'Locator': ...
+
+
+class QueryableMixin(ABC):
+	@abstractmethod
+	async def query_selector(self, selector: str) -> 'ElementHandle | None': ...
+
+	@abstractmethod
+	async def query_selector_all(self, selector: str) -> list['ElementHandle']: ...
+
+	@abstractmethod
+	async def evaluate(self, script: str, *args: Any, **kwargs: Any) -> Any: ...
+
+	@abstractmethod
+	async def click(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+class Browser(ABC):
+	@abstractmethod
+	async def new_session(self, **kwargs: Any) -> 'BrowserSession':
+		pass
+
+	@abstractmethod
+	def is_connected(self) -> bool:
+		pass
+
+	@abstractmethod
+	async def open(self, **kwargs: Any) -> 'Browser':
+		pass
+
+	@abstractmethod
+	async def close(self) -> None:
+		pass
+
+	@property
+	@abstractmethod
+	def sessions(self) -> list['BrowserSession']:
+		pass
+
+	@property
+	@abstractmethod
+	def version(self) -> str:
+		pass
+
+
+class BrowserContext(ABC):
+	@abstractmethod
+	async def new_page(self) -> 'Page':
+		pass
+
+	@abstractmethod
+	async def close(self) -> None:
+		pass
+
+	@property
+	@abstractmethod
+	def pages(self) -> list['Page']:
+		pass
+
+	@property
+	@abstractmethod
+	def browser(self) -> 'Browser':
+		pass
+
+	@abstractmethod
+	async def expose_binding(self, name: str, func: Any) -> None:
+		pass
+
+	@abstractmethod
+	async def add_init_script(self, script: str) -> None:
+		pass
+
+	@abstractmethod
+	async def cookies(self) -> list[dict[str, Any]]:
+		pass
+	
+	@abstractmethod
+	async def storage_state(self) -> StorageState:
+		pass
+	
+	@abstractmethod
+	async def add_cookies(self, cookies: list[dict[str, Any]]) -> None:
+		pass
+
+	@abstractmethod
+	async def grant_permissions(self, permissions: list[str]) -> None:
+		pass
+
+	@abstractmethod
+	async def set_default_timeout(self, timeout: float) -> None:
+		pass
+
+	@abstractmethod
+	async def set_default_navigation_timeout(self, timeout: float) -> None:
+		pass
+
+	@abstractmethod
+	async def set_extra_http_headers(self, headers: dict[str, str]) -> None:
+		pass
+
+	@abstractmethod
+	async def set_geolocation(self, geolocation: Geolocation) -> None:
+		pass
+
+
+class Frame(QueryableMixin, LocatorMixin, ABC):
+	@property
+	@abstractmethod
+	def url(self) -> str:
+		pass
+
+	@abstractmethod
+	async def content(self) -> str:
+		pass
+
+
+class Page(EventEmitterMixin, QueryableMixin, LocatorMixin, ABC):
+	@property
+	@abstractmethod
+	def context(self) -> 'BrowserContext':
+		pass
+
+	@abstractmethod
+	async def goto(self, url: str, **kwargs: Any) -> None:
+		pass
+
+	@abstractmethod
+	async def click(self, selector: str) -> None:
+		pass
+
+	@abstractmethod
+	async def fill(self, selector: str, text: str) -> None:
+		pass
+
+	@abstractmethod
+	async def get_content(self) -> str:
+		pass
+
+	@abstractmethod
+	async def screenshot(self, **kwargs: Any) -> bytes:
+		pass
+
+	@abstractmethod
+	async def close(self) -> None:
+		pass
+
+	@abstractmethod
+	async def wait_for_load_state(
+		self, state: Literal['domcontentloaded', 'load', 'networkidle'] | None = 'load', **kwargs: Any
+	) -> None:
+		pass
+
+	@property
+	@abstractmethod
+	def url(self) -> str:
+		pass
+
+	@abstractmethod
+	async def set_viewport_size(self, viewport: ViewportSize) -> None:
+		pass
+
+	@abstractmethod
+	def is_closed(self) -> bool:
+		pass
+
+	@abstractmethod
+	async def bring_to_front(self) -> None:
+		pass
+
+	@abstractmethod
+	async def expose_function(self, name: str, func: Any) -> None:
+		pass
+
+	@abstractmethod
+	async def go_back(self, **kwargs: Any) -> None:
+		pass
+
+	@abstractmethod
+	async def go_forward(self, **kwargs: Any) -> None:
+		pass
+
+	@abstractmethod
+	async def wait_for_selector(self, selector: str, **kwargs: Any) -> None:
+		pass
+
+	@abstractmethod
+	async def content(self) -> str:
+		pass
+
+	@abstractmethod
+	async def title(self) -> str:
+		pass
+
+	@property
+	@abstractmethod
+	def frames(self) -> list[Frame]:
+		pass
+
+	@abstractmethod
+	async def emulate_media(self, **kwargs: Any) -> None:
+		pass
+
+	@abstractmethod
+	async def pdf(self, **kwargs: Any) -> Any:
+		pass
+
+	@property
+	@abstractmethod
+	def keyboard(self) -> 'Keyboard':
+		pass
+
+	@abstractmethod
+	async def type(self, selector: str, text: str, delay: float = 0) -> None: ...
+
+	@abstractmethod
+	def get_by_text(self, text: str, exact: bool = False) -> 'Locator':
+		pass
+
+	@property
+	@abstractmethod
+	def mouse(self) -> 'Mouse':
+		pass
+
+	@abstractmethod
+	async def viewport_size(self) -> ViewportSize:
+		pass
+
+	@abstractmethod
+	async def reload(self) -> None:
+		pass
+
+	@abstractmethod
+	async def expect_download(self, *args: Any, **kwargs: Any) -> 'Download':
+		pass
+
+	@abstractmethod
+	async def wait_for_timeout(self, timeout: float) -> None:
+		pass
+
+
+class ElementHandle(QueryableMixin, EventEmitterMixin, PropertyMixin, ABC):
+	@abstractmethod
+	async def is_visible(self) -> bool:
+		pass
+
+	@abstractmethod
+	async def is_hidden(self) -> bool:
+		pass
+
+	@abstractmethod
+	async def bounding_box(self) -> dict[str, Any] | None:
+		pass
+
+	@abstractmethod
+	async def scroll_into_view_if_needed(self, timeout: int | float | None = None) -> None:
+		pass
+
+	@abstractmethod
+	async def element_handle(self) -> 'ElementHandle':
+		pass
+
+	@abstractmethod
+	async def type(self, text: str, delay: float = 0) -> None: ...
+
+	@abstractmethod
+	async def wait_for_element_state(
+		self,
+		state: Literal['disabled', 'editable', 'enabled', 'hidden', 'stable', 'visible'],
+		timeout: int | float | None = None,
+	) -> None:
+		pass
+
+	@abstractmethod
+	async def clear(self, timeout: float | None = None) -> None:
+		pass
+
+	@abstractmethod
+	async def fill(self, text: str, timeout: float | None = None) -> None: ...
+
+
+class Tracing(ABC):
+	@abstractmethod
+	async def start(self, **kwargs: Any) -> None:
+		pass
+
+	@abstractmethod
+	async def stop(self, **kwargs: Any) -> None:
+		pass
+
+
+class Locator(LocatorMixin, ABC):
+	@abstractmethod
+	def filter(self, **kwargs: Any) -> 'Locator':
+		pass
+
+	@abstractmethod
+	async def evaluate_all(self, expression: str) -> Any:
+		pass
+
+	@abstractmethod
+	async def count(self) -> int:
+		pass
+
+	@property
+	@abstractmethod
+	def first(self) -> 'Locator':
+		pass
+
+	@abstractmethod
+	def nth(self, index: int) -> 'Locator':
+		pass
+
+	@abstractmethod
+	async def select_option(self, **kwargs: Any) -> Any:
+		pass
+
+	@abstractmethod
+	async def element_handle(self) -> 'ElementHandle | None':
+		pass
+
+
+class Keyboard(ABC):
+	@abstractmethod
+	async def press(self, keys: str) -> None:
+		pass
+
+	@abstractmethod
+	async def type(self, text: str, delay: float = 0) -> None:
+		pass
+
+
+class Mouse(ABC):
+	@abstractmethod
+	async def move(self, x: int, y: int) -> None:
+		pass
+
+	@abstractmethod
+	async def down(self) -> None:
+		pass
+
+	@abstractmethod
+	async def up(self) -> None:
+		pass
+
+
+class Download(ABC):
+	@property
+	@abstractmethod
+	def suggested_filename(self) -> str:
+		pass
+
+	@abstractmethod
+	async def save_as(self, path: str) -> None:
+		pass
+
+	@property
+	@abstractmethod
+	async def value(self):
+		pass
+
+
+class Driver(ABC):
+	def __init__(self, profile: 'BrowserProfile') -> None:
+		self.profile = profile
+		self.impl: Browser | None = None
+		logger.info(f'🌎🚗 Created BrowserDriver instance: name={self.__class__.__name__}, profile={self.profile}')
+
+	@property
+	def chromium(self) -> Browser:
+		assert self.profile.channel == 'chromium', f'Invalid browser class: {self.profile.channel}'
+		assert self.impl is not None, f'Driver {self.__class__.__name__} is not initialized'
+		return self.impl
+
+	@property
+	def firefox(self) -> Browser:
+		assert self.profile.channel == 'firefox', f'Invalid browser class: {self.profile.channel}'
+		assert self.impl is not None, f'Driver {self.__class__.__name__} is not initialized'
+		return self.impl
+
+	@property
+	def webkit(self) -> Browser:
+		assert self.profile.channel == 'webkit', f'Invalid browser class: {self.profile.channel}'
+		assert self.impl is not None, f'Driver {self.__class__.__name__} is not initialized'
+		return self.impl
+
+	@abstractmethod
+	async def init_impl(self) -> None: ...
+
+	"""
+	Initialize the driver implementation.
+	
+	"""
+
+	async def setup(self) -> 'Driver':
+		logger.info(f'🌎🚗 BrowserDriver.setup(): name={self.__class__.__name__}')
+
+		await self.init_impl()
+		assert self.impl is not None, f'Driver {self.__class__.__name__} is not initialized'
+		await self.impl.open()
+		return self
+
+	async def stop(self) -> None:
+		logger.info(f'\U0001f30e\U0001f697 BrowserDriver.stop(): name={self.__class__.__name__}')
+		assert self.impl is not None, f'Driver {self.__class__.__name__} is not initialized'
+		await self.impl.close()
+
+	async def __aenter__(self):
+		logger.info(f'🌎🚗 BrowserDriver.__aenter__(): name={self.__class__.__name__}')
+		await self.setup()
+		return self
+
+	async def __aexit__(self, exc_type: Any, exc: Any, tb: Any):
+		logger.info(f'🌎🚗 BrowserDriver.__aexit__(): name={self.__class__.__name__}')
+		await self.stop()

--- a/browser_use/typing.py
+++ b/browser_use/typing.py
@@ -15,36 +15,47 @@ logger = logging.getLogger(__name__)
 
 class ViewportSize(BaseModel):
 	"""Represents a viewport size"""
+
 	width: int
 	height: int
 
+
 class ClientCertificate(BaseModel):
-    """Represents a client certificate for authentication"""
-    cert: str
-    key: str
+	"""Represents a client certificate for authentication"""
+
+	cert: str
+	key: str
+
 
 class Geolocation(BaseModel):
-    """Represents geographical location coordinates"""
-    latitude: float
-    longitude: float
-    accuracy: float | None = None
+	"""Represents geographical location coordinates"""
+
+	latitude: float
+	longitude: float
+	accuracy: float | None = None
+
 
 class HttpCredentials(BaseModel):
-    """Represents HTTP authentication credentials"""
-    username: str
-    password: str
+	"""Represents HTTP authentication credentials"""
+
+	username: str
+	password: str
+
 
 class ProxySettings(BaseModel):
-    """Represents proxy server settings"""
-    server: str
-    bypass: str | None = None
-    username: str | None = None
-    password: str | None = None
+	"""Represents proxy server settings"""
+
+	server: str
+	bypass: str | None = None
+	username: str | None = None
+	password: str | None = None
+
 
 class StorageState(BaseModel):
-    """Represents browser storage state"""
-    cookies: list[dict[str, Any]] = []
-    origins: list[dict[str, Any]] = []
+	"""Represents browser storage state"""
+
+	cookies: list[dict[str, Any]] = []
+	origins: list[dict[str, Any]] = []
 
 
 class EventEmitterMixin(ABC):
@@ -62,15 +73,15 @@ class PropertyMixin(ABC):
 
 class LocatorMixin(ABC):
 	@abstractmethod
-	def locator(self, selector: str) -> 'Locator': ...
+	def locator(self, selector: str) -> Locator: ...
 
 
 class QueryableMixin(ABC):
 	@abstractmethod
-	async def query_selector(self, selector: str) -> 'ElementHandle | None': ...
+	async def query_selector(self, selector: str) -> ElementHandle | None: ...
 
 	@abstractmethod
-	async def query_selector_all(self, selector: str) -> list['ElementHandle']: ...
+	async def query_selector_all(self, selector: str) -> list[ElementHandle]: ...
 
 	@abstractmethod
 	async def evaluate(self, script: str, *args: Any, **kwargs: Any) -> Any: ...
@@ -81,7 +92,7 @@ class QueryableMixin(ABC):
 
 class Browser(ABC):
 	@abstractmethod
-	async def new_session(self, **kwargs: Any) -> 'BrowserSession':
+	async def new_session(self, **kwargs: Any) -> BrowserSession:
 		pass
 
 	@abstractmethod
@@ -89,7 +100,7 @@ class Browser(ABC):
 		pass
 
 	@abstractmethod
-	async def open(self, **kwargs: Any) -> 'Browser':
+	async def open(self, **kwargs: Any) -> Browser:
 		pass
 
 	@abstractmethod
@@ -98,7 +109,7 @@ class Browser(ABC):
 
 	@property
 	@abstractmethod
-	def sessions(self) -> list['BrowserSession']:
+	def sessions(self) -> list[BrowserSession]:
 		pass
 
 	@property
@@ -109,7 +120,7 @@ class Browser(ABC):
 
 class BrowserContext(ABC):
 	@abstractmethod
-	async def new_page(self) -> 'Page':
+	async def new_page(self) -> Page:
 		pass
 
 	@abstractmethod
@@ -118,12 +129,12 @@ class BrowserContext(ABC):
 
 	@property
 	@abstractmethod
-	def pages(self) -> list['Page']:
+	def pages(self) -> list[Page]:
 		pass
 
 	@property
 	@abstractmethod
-	def browser(self) -> 'Browser':
+	def browser(self) -> Browser:
 		pass
 
 	@abstractmethod
@@ -137,11 +148,11 @@ class BrowserContext(ABC):
 	@abstractmethod
 	async def cookies(self) -> list[dict[str, Any]]:
 		pass
-	
+
 	@abstractmethod
 	async def storage_state(self) -> StorageState:
 		pass
-	
+
 	@abstractmethod
 	async def add_cookies(self, cookies: list[dict[str, Any]]) -> None:
 		pass
@@ -181,7 +192,7 @@ class Frame(QueryableMixin, LocatorMixin, ABC):
 class Page(EventEmitterMixin, QueryableMixin, LocatorMixin, ABC):
 	@property
 	@abstractmethod
-	def context(self) -> 'BrowserContext':
+	def context(self) -> BrowserContext:
 		pass
 
 	@abstractmethod
@@ -270,19 +281,19 @@ class Page(EventEmitterMixin, QueryableMixin, LocatorMixin, ABC):
 
 	@property
 	@abstractmethod
-	def keyboard(self) -> 'Keyboard':
+	def keyboard(self) -> Keyboard:
 		pass
 
 	@abstractmethod
 	async def type(self, selector: str, text: str, delay: float = 0) -> None: ...
 
 	@abstractmethod
-	def get_by_text(self, text: str, exact: bool = False) -> 'Locator':
+	def get_by_text(self, text: str, exact: bool = False) -> Locator:
 		pass
 
 	@property
 	@abstractmethod
-	def mouse(self) -> 'Mouse':
+	def mouse(self) -> Mouse:
 		pass
 
 	@abstractmethod
@@ -294,7 +305,7 @@ class Page(EventEmitterMixin, QueryableMixin, LocatorMixin, ABC):
 		pass
 
 	@abstractmethod
-	async def expect_download(self, *args: Any, **kwargs: Any) -> 'Download':
+	async def expect_download(self, *args: Any, **kwargs: Any) -> Download:
 		pass
 
 	@abstractmethod
@@ -320,7 +331,7 @@ class ElementHandle(QueryableMixin, EventEmitterMixin, PropertyMixin, ABC):
 		pass
 
 	@abstractmethod
-	async def element_handle(self) -> 'ElementHandle':
+	async def element_handle(self) -> ElementHandle:
 		pass
 
 	@abstractmethod
@@ -354,7 +365,7 @@ class Tracing(ABC):
 
 class Locator(LocatorMixin, ABC):
 	@abstractmethod
-	def filter(self, **kwargs: Any) -> 'Locator':
+	def filter(self, **kwargs: Any) -> Locator:
 		pass
 
 	@abstractmethod
@@ -367,11 +378,11 @@ class Locator(LocatorMixin, ABC):
 
 	@property
 	@abstractmethod
-	def first(self) -> 'Locator':
+	def first(self) -> Locator:
 		pass
 
 	@abstractmethod
-	def nth(self, index: int) -> 'Locator':
+	def nth(self, index: int) -> Locator:
 		pass
 
 	@abstractmethod
@@ -379,7 +390,7 @@ class Locator(LocatorMixin, ABC):
 		pass
 
 	@abstractmethod
-	async def element_handle(self) -> 'ElementHandle | None':
+	async def element_handle(self) -> ElementHandle | None:
 		pass
 
 
@@ -424,7 +435,7 @@ class Download(ABC):
 
 
 class Driver(ABC):
-	def __init__(self, profile: 'BrowserProfile') -> None:
+	def __init__(self, profile: BrowserProfile) -> None:
 		self.profile = profile
 		self.impl: Browser | None = None
 		logger.info(f'🌎🚗 Created BrowserDriver instance: name={self.__class__.__name__}, profile={self.profile}')
@@ -455,7 +466,7 @@ class Driver(ABC):
 	
 	"""
 
-	async def setup(self) -> 'Driver':
+	async def setup(self) -> Driver:
 		logger.info(f'🌎🚗 BrowserDriver.setup(): name={self.__class__.__name__}')
 
 		await self.init_impl()

--- a/docs/customize/custom-functions.mdx
+++ b/docs/customize/custom-functions.mdx
@@ -116,7 +116,7 @@ For example, actions that need to run playwright code to interact with the brows
 #### Example: Action uses the current `page`
 
 ```python
-from playwright.async_api import Page
+from browser_use.typing import Page
 from browser_use import Controller, ActionResult
 
 controller = Controller()

--- a/examples/browser/stealth.py
+++ b/examples/browser/stealth.py
@@ -14,7 +14,8 @@ from imgcat import imgcat
 from langchain_openai import ChatOpenAI
 from patchright.async_api import async_playwright as async_patchright
 
-from browser_use.browser import BrowserSession
+from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.drivers.playwright import PlaywrightDriver
 
 llm = ChatOpenAI(model='gpt-4o')
 
@@ -28,10 +29,12 @@ async def main():
 	# Default Playwright Chromium Browser
 	normal_browser_session = BrowserSession(
 		# executable_path=<defaults to playwright builtin browser stored in ms-cache directory>,
-		user_data_dir=None,
-		headless=False,
-		# deterministic_rendering=False,
-		# disable_security=False,
+		browser_profile=BrowserProfile(
+			user_data_dir=None,
+			headless=False,
+			disable_security=False,
+			deterministic_rendering=False,
+		),
 	)
 	await normal_browser_session.start()
 	await normal_browser_session.create_new_tab('https://abrahamjuliot.github.io/creepjs/')
@@ -42,13 +45,13 @@ async def main():
 
 	print('\n\nPATCHRIGHT STEALTH BROWSER:')
 	patchright_browser_session = BrowserSession(
-		# cdp_url='wss://browser.zenrows.com?apikey=your-api-key-here&proxy_region=na',
-		#                or try anchor browser, browserless, steel.dev, browserbase, oxylabs, brightdata, etc.
-		playwright=patchright,
-		user_data_dir='~/.config/browseruse/profiles/stealth',
-		headless=False,
-		disable_security=False,
-		deterministic_rendering=False,
+		driver=PlaywrightDriver(profile=BrowserProfile(), backend=async_patchright),
+		browser_profile=BrowserProfile(
+			user_data_dir='~/.config/browseruse/profiles/stealth',
+			headless=False,
+			disable_security=False,
+			deterministic_rendering=False,
+		),
 	)
 	await patchright_browser_session.start()
 	await patchright_browser_session.create_new_tab('https://abrahamjuliot.github.io/creepjs/')
@@ -61,11 +64,13 @@ async def main():
 	if Path('/Applications/Brave Browser.app/Contents/MacOS/Brave Browser').is_file():
 		print('\n\nBRAVE BROWSER:')
 		brave_browser_session = BrowserSession(
-			executable_path='/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
-			headless=False,
-			disable_security=False,
-			user_data_dir='~/.config/browseruse/profiles/brave',
-			deterministic_rendering=False,
+			browser_profile=BrowserProfile(
+				executable_path='/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+				user_data_dir='~/.config/browseruse/profiles/brave',
+				headless=False,
+				disable_security=False,
+				deterministic_rendering=False,
+			),
 		)
 		await brave_browser_session.start()
 		await brave_browser_session.create_new_tab('https://abrahamjuliot.github.io/creepjs/')
@@ -77,12 +82,14 @@ async def main():
 	if Path('/Applications/Brave Browser.app/Contents/MacOS/Brave Browser').is_file():
 		print('\n\nBRAVE + PATCHRIGHT STEALTH BROWSER:')
 		brave_patchright_browser_session = BrowserSession(
-			executable_path='/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
-			playwright=patchright,
-			headless=False,
-			disable_security=False,
-			user_data_dir=None,
-			deterministic_rendering=False,
+			driver=PlaywrightDriver(profile=BrowserProfile(), backend=async_patchright),
+			browser_profile=BrowserProfile(
+				executable_path='/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+				user_data_dir=None,
+				headless=False,
+				disable_security=False,
+				deterministic_rendering=False,
+			),
 			**patchright.devices['iPhone 13'],  # emulate other devices: https://playwright.dev/python/docs/emulation
 		)
 		await brave_patchright_browser_session.start()

--- a/examples/custom-functions/action_filters.py
+++ b/examples/custom-functions/action_filters.py
@@ -28,10 +28,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from langchain_openai import ChatOpenAI
-from playwright.async_api import Page
 
 from browser_use.agent.service import Agent, Controller
 from browser_use.browser import BrowserSession
+from browser_use.typing import Page
 
 # Initialize controller and registry
 controller = Controller()

--- a/examples/custom-functions/clipboard.py
+++ b/examples/custom-functions/clipboard.py
@@ -10,11 +10,11 @@ load_dotenv()
 
 import pyperclip
 from langchain_openai import ChatOpenAI
-from playwright.async_api import Page
 
 from browser_use import Agent, Controller
 from browser_use.agent.views import ActionResult
 from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.typing import Page
 
 browser_profile = BrowserProfile(
 	headless=False,

--- a/tests/ci/test_registry.py
+++ b/tests/ci/test_registry.py
@@ -14,7 +14,6 @@ import asyncio
 import logging
 
 import pytest
-from playwright.async_api import Page
 from pydantic import Field
 from pytest_httpserver import HTTPServer
 
@@ -28,6 +27,7 @@ from browser_use.controller.views import (
 	NoParamsAction,
 	SearchGoogleAction,
 )
+from browser_use.typing import Page
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)

--- a/tests/test_action_filters.py
+++ b/tests/test_action_filters.py
@@ -1,11 +1,11 @@
 from unittest.mock import MagicMock
 
 import pytest
-from playwright.async_api import Page
 from pydantic import BaseModel
 
 from browser_use.controller.registry.service import Registry
 from browser_use.controller.registry.views import ActionRegistry, RegisteredAction
+from browser_use.typing import Page
 
 
 class EmptyParamModel(BaseModel):


### PR DESCRIPTION
Abstracted playwright driver out from browser use code, adding support to implement and switch to non-playwright/patchwright browser drivers.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Abstracted browser driver logic from browser session code, enabling support for plug-and-play browser drivers beyond Playwright.

- **Refactors**
  - Moved all browser driver interfaces to a new `browser_use/typing.py` file.
  - Added a new `browser_use/drivers/playwright.py` driver and updated code to use driver abstraction.
  - Updated imports and type hints across the codebase to use the new driver interfaces.
  - Updated examples and tests to use the new driver abstraction.

<!-- End of auto-generated description by cubic. -->

