### PR TITLE
Fix available vector providers, local logic, and example

### DIFF
--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -299,7 +299,7 @@ The `MemoryConfig` model provides these configuration options:
 
 #### Vector Store Settings
 - `vector_store_provider`: Choose the vector store backend. Supported options include:
-  `'faiss'` (default), `'qdrant'`, `'pinecone'`, `'supabase'`, `'elasticsearch'`, `'chroma'`, `'weaviate'`, `'milvus'`, `'pgvector'`, `'upstash_vector'`, `'vertex_ai_vector_search'`, `'azure_ai_search'`, `'lancedb'`, `'mongodb'`, `'redis'`, `'memory'` (in-memory, non-persistent).
+  `'faiss'` (default), `'qdrant'`, `'pinecone'`, `'supabase'`, `'elasticsearch'`, `'chroma'`, `'weaviate'`, `'milvus'`, `'pgvector'`, `'upstash_vector'`, `'vertex_ai_vector_search'`, `'azure_ai_search'`, `'redis'`.
 - `vector_store_collection_name`: (Optional) Specify a custom name for the collection or index in your vector store. If not provided, a default name is generated (especially for local stores like FAISS/Chroma) or used by Mem0.
 - `vector_store_base_path`: Path for local vector stores like FAISS or Chroma (e.g., `/tmp/mem0`). Default is `/tmp/mem0`.
 - `vector_store_config_override`: (Optional) A dictionary to provide or override specific configuration parameters required by Mem0 for the chosen `vector_store_provider`. This is where you'd put connection details like `host`, `port`, `api_key`, `url`, `environment`, etc., for cloud-based or server-based vector stores.

--- a/examples/features/custom_vector_store.py
+++ b/examples/features/custom_vector_store.py
@@ -1,7 +1,8 @@
 """
 Script that demonstrates how to use the new customizable MemoryConfig with Browser Use, showcasing two different vector store providers:
 the default FAISS (local) and a more scalable option like Qdrant
-You'll need a Qdrant server running locally and the qdrant python client installed (pip install qdrant-client) to run the Qdrant example.
+You'll need a Qdrant server running locally to run the Qdrant example.
+You can visualize your Qdrant memories at http://localhost:6333/dashboard#/collections
 """
 
 import asyncio
@@ -10,7 +11,8 @@ import os
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
 
-from browser_use import Agent, MemoryConfig
+from browser_use import Agent
+from browser_use.agent.memory import MemoryConfig
 
 # Load environment variables (e.g., OPENAI_API_KEY)
 load_dotenv()
@@ -57,10 +59,8 @@ async def run_agent_with_memory_config(
 	# Let's refine how to access summaries. The summary is added as a 'memory' type message.
 
 	summaries_created = []
-	for (
-		step_messages
-	) in agent.message_manager.state.history.raw_messages:  # Assuming raw_messages contains the list of BaseMessage
-		if isinstance(step_messages, list):  # if raw_messages is a list of lists
+	for step_messages in agent.message_manager.state.history.get_messages():
+		if isinstance(step_messages, list):
 			for msg in step_messages:
 				if (
 					hasattr(msg, 'additional_kwargs')
@@ -121,7 +121,7 @@ async def main():
 
 	print('\n === PAUSE: Check FAISS data in /tmp/mem0... (if created) ===\n')
 	# You might need to adjust the path based on your embedder_dims, e.g., /tmp/mem0_1536_faiss
-	# input("Press Enter to continue to Qdrant example...")
+	input('Press Enter to continue to Qdrant example...')
 
 	# --- Scenario 2: Qdrant Memory ---
 	# Ensure Qdrant server is running (e.g., `docker run -p 6333:6333 qdrant/qdrant`)
@@ -166,4 +166,8 @@ async def main():
 
 
 if __name__ == '__main__':
+	import sys
+
+	if sys.platform.startswith('win'):
+		asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 	asyncio.run(main())


### PR DESCRIPTION
Removed LanceDB, MongoDB, and `memory` from the vector providers as Mem0 no longer supports those. Also, greatly improved the local vector stores logic:

- **Default `collection_name`**:
    *   If `vector_store_collection_name` is explicitly provided by the user, it will always be used.
    *   For providers that typically use local file-based storage (`faiss`, `chroma` in local mode, `qdrant` in local file mode), if no collection name is provided, a default of `mem0_<provider_name>_<embedder_dims>` will be generated. This helps differentiate collections when using the same base path for different embedding models/dimensions.
    *   For `upstash_vector`, the default collection name will be `""` (empty string) as per its documentation.
    *   For many other server-based providers (like `elasticsearch`, `milvus`, `pgvector`, `redis`, `weaviate`, `supabase`, `azure_ai_search`, and `qdrant` in server mode), if no collection name is provided, their common documented default of `mem0` will be used.
    *   A fallback of `mem0_default_collection` will be used for any other cases (e.g., providers like Pinecone where a name is usually required from the user, but this ensures a value is present if somehow missed).

- **Default `path`**:
    *   For `faiss`, `chroma` (in local mode), and `qdrant` (in local file-based mode), if a `path` is not specified in `vector_store_config_override`, a default path will be generated using the pattern: `f'{self.vector_store_base_path}_{self.embedder_dims}_{self.vector_store_provider}'`.
    *   This default path logic will only apply if the provider is not configured with server/remote parameters (e.g., `host`, `port`, `url`, `api_key` for Chroma and Qdrant).
    *   Other server-based providers (Elasticsearch, Milvus, etc.) do not typically take a `path` argument directly in their Mem0 configuration for their data directory; their persistence is managed by the server's own settings.
    
Finally, the import error in the example was fixed and a few lines were added in the end to make it compatible with windows.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed unsupported vector providers (LanceDB, MongoDB, memory) and improved default logic for local vector store collection names and paths. Fixed import errors and added Windows compatibility in the example.

- **Bug Fixes**
  - Fixed default collection name and path generation for local and server-based vector stores.
  - Fixed import and event loop issues in the custom vector store example.

<!-- End of auto-generated description by cubic. -->

