### PR TITLE
Auto-apply `storage_state.json` even when connecting to existing browsers

### DIFF
--- a/browser_use/agent/playwright_script_generator.py
+++ b/browser_use/agent/playwright_script_generator.py
@@ -116,7 +116,7 @@
 # 				'height': self.context_config.window_height,
 # 			}
 
-# 		# Note: cookies_file and save_downloads_path are handled separately
+# 		# Note: cookies_file and downloads_dir are handled separately
 
 # 		# Filter out None values
 # 		options_dict = {k: v for k, v in options_dict.items() if v is not None}
@@ -438,8 +438,8 @@
 # 		index = params.get('index')
 # 		selector = self._get_selector_for_action(history_item, action_index_in_step)
 # 		download_dir_in_script = "'./files'"  # Default
-# 		if self.context_config and self.context_config.save_downloads_path:
-# 			download_dir_in_script = repr(self.context_config.save_downloads_path)
+# 		if self.context_config and self.context_config.downloads_dir:
+# 			download_dir_in_script = repr(self.context_config.downloads_dir)
 
 # 		script_lines = []
 # 		if selector and index is not None:

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -586,7 +586,6 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	profile_directory: str = 'Default'  # e.g. 'Profile 1', 'Profile 2', 'Custom Profile', etc.
 
 	save_recording_path: str | None = Field(default=None, description='Directory for video recordings.')
-	save_downloads_path: str | None = Field(default=None, description='Directory for saving downloads.')
 	save_har_path: str | None = Field(default=None, description='Directory for saving HAR files.')
 	trace_path: str | None = Field(default=None, description='Directory for saving trace files.')
 
@@ -606,6 +605,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	downloads_dir: Path | str = Field(
 		default=Path('~/.config/browseruse/downloads').expanduser(),
 		description='Directory for downloads.',
+		validation_alias=AliasChoices('save_downloads_path'),
 	)
 	# uploads_dir: Path | None = Field(default=None, description='Directory for uploads (defaults to downloads_dir if not set).')
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -32,7 +32,7 @@ from browser_use.browser.views import (
 from browser_use.dom.clickable_element_processor.service import ClickableElementProcessor
 from browser_use.dom.service import DomService
 from browser_use.dom.views import DOMElementNode, SelectorMap
-from browser_use.utils import match_url_with_domain_pattern, time_execution_async, time_execution_sync
+from browser_use.utils import match_url_with_domain_pattern, merge_dicts, time_execution_async, time_execution_sync
 
 # Check if running in Docker
 IN_DOCKER = os.environ.get('IN_DOCKER', 'false').lower()[0] in 'ty1'
@@ -770,9 +770,8 @@ class BrowserSession(BaseModel):
 		except Exception as e:
 			logger.warning(f'⚠️ Failed to update browser geolocation {self.browser_profile.geolocation}: {type(e).__name__}: {e}')
 
-		# if self.storage_state:
-		#   TODO: implement applying self.stroage_state to an existing browser_context, currently only works on browser.new_context() I think
-		# 	await self.browser_context.set_storage_state(self.storage_state)
+		if self.storage_state:
+			await self.load_storage_state()
 
 		page = None
 
@@ -988,7 +987,7 @@ class BrowserSession(BaseModel):
 			async def perform_click(click_func):
 				"""Performs the actual click, handling both download
 				and navigation scenarios."""
-				if self.browser_profile.save_downloads_path:
+				if self.browser_profile.downloads_dir:
 					try:
 						# Try short-timeout expect_download to detect a file download has been been triggered
 						async with page.expect_download(timeout=5000) as download_info:
@@ -996,10 +995,8 @@ class BrowserSession(BaseModel):
 						download = await download_info.value
 						# Determine file path
 						suggested_filename = download.suggested_filename
-						unique_filename = await self._get_unique_filename(
-							self.browser_profile.save_downloads_path, suggested_filename
-						)
-						download_path = os.path.join(self.browser_profile.save_downloads_path, unique_filename)
+						unique_filename = await self._get_unique_filename(self.browser_profile.downloads_dir, suggested_filename)
+						download_path = os.path.join(self.browser_profile.downloads_dir, unique_filename)
 						await download.save_as(download_path)
 						logger.debug(f'⬇️  Download triggered. Saved file to: {download_path}')
 						return download_path
@@ -1092,53 +1089,142 @@ class BrowserSession(BaseModel):
 			return await self.browser_context.cookies()
 		return []
 
-	async def save_cookies(self, path: Path | None = None) -> None:
+	async def save_cookies(self, *args, **kwargs) -> None:
 		"""
-		Save cookies to the specified path or the default cookies_file in the downloads_dir.
+		Old name for the new save_storage_state() function.
 		"""
-		if self.browser_context:
-			# old deprecated cookies_file method:
-			cookies = await self.browser_context.cookies()
-			out_path = path or self.browser_profile.cookies_file
-			if out_path:
-				# If out_path is not absolute, resolve relative to downloads_dir
-				out_path = Path(out_path)
-				if not out_path.is_absolute():
-					out_path = Path(self.browser_profile.downloads_dir or '.') / out_path
-				out_path.parent.mkdir(parents=True, exist_ok=True)
-				out_path.write_text(json.dumps(cookies, indent=4))  # TODO: replace with anyio asyncio or anyio write
+		await self.save_storage_state(*args, **kwargs)
 
-			# new recommended storage_state method:
-			storage_state = await self.browser_context.storage_state()
-			storage_state_path = Path(self.browser_profile.downloads_dir or '.') / 'storage_state.json'
-			storage_state_path.write_text(json.dumps(storage_state, indent=4))
+	@require_initialization
+	async def save_storage_state(self, path: Path | None = None) -> None:
+		"""
+		Save cookies to the specified path or the configured cookies_file and/or storage_state.
+		"""
+		storage_state = await self.browser_context.storage_state()
+		cookies = storage_state['cookies']
+		if cookies and self.browser_profile.cookies_file:
+			# only show warning if they configured cookies_file (not if they passed in a path to this function as an arg)
+			logger.warning(
+				'⚠️ cookies_file is deprecated and will be removed in a future version. '
+				'Please use storage_state instead for loading cookies and other browser state. '
+				'See: https://playwright.dev/python/docs/api/class-browsercontext#browser-context-storage-state'
+			)
 
-	async def load_cookies_from_file(self) -> None:
-		"""
-		Load cookies from the cookies_file if it exists and apply them to the browser context.
-		"""
-		if not self.browser_profile.cookies_file or not self.browser_context:
+		# save cookies_file if passed a cookies file path or if profile cookies_file is configured
+		path_is_storage_state = path and str(path).endswith('storage_state.json')
+		if (path and not path_is_storage_state) or self.browser_profile.cookies_file:
+			try:
+				cookies_file_path = Path(path or self.browser_profile.cookies_file).expanduser().resolve()
+				cookies_file_path.parent.mkdir(parents=True, exist_ok=True)
+				cookies_file_path.write_text(json.dumps(cookies, indent=4))  # TODO: convert to async
+				logger.info(f'🍪 Saved {len(cookies)} cookies to cookies_file={_log_pretty_path(cookies_file_path)}')
+			except Exception as e:
+				logger.warning(
+					f'❌ Failed to save cookies to cookies_file={_log_pretty_path(cookies_file_path)}: {type(e).__name__}: {e}'
+				)
+
+		if path:
+			# if they passed in a path to the old save_cookies function,
+			# also save a new storage_state.json next to it to encourage adoption of the new format
+			storage_state_path = Path(path).expanduser().resolve().parent / 'storage_state.json'
+		else:
+			# otherwise use configured storage_state path
+			storage_state_path = self.browser_profile.storage_state
+
+		if storage_state_path is None:
+			return
+		elif not isinstance(storage_state_path, (str, Path)):
+			logger.warning('⚠️ storage_state must be a json file path to be able to update it, skipping...')
 			return
 
-		# Show deprecation warning
-		logger.warning(
-			'⚠️ cookies_file is deprecated and will be removed in a future version. '
-			'Please use storage_state instead for loading cookies and other browser state. '
-			'See: https://playwright.dev/python/docs/api/class-browsercontext#browser-context-storage-state'
-		)
+		try:
+			storage_state_path = Path(storage_state_path).expanduser().resolve()
+			storage_state_path.parent.mkdir(parents=True, exist_ok=True)
+			storage_state = await self.browser_context.storage_state()
 
-		cookies_path = Path(self.browser_profile.cookies_file)
-		if not cookies_path.is_absolute():
-			cookies_path = Path(self.browser_profile.downloads_dir or '.') / cookies_path
+			# always merge storage states, never overwrite (so two browsers can share the same storage_state.json)
+			if storage_state_path.exists():
+				try:
+					existing_storage_state = json.loads(storage_state_path.read_text())  # TODO: convert to async
+					merged_storage_state = merge_dicts(existing_storage_state, storage_state)
+					# in case another process races us and updates the file here, we will overwrite their changes
+					# if we really want to support real concurrency we need a sqlite database or something
+					storage_state_path.write_text(json.dumps(merged_storage_state, indent=4))  # TODO: convert to async
+				except Exception as e:
+					logger.warning(
+						f'❌ Failed to merge storage state with existing storage_state={_log_pretty_path(storage_state_path)}: {type(e).__name__}: {e}'
+					)
+					return
 
-		if cookies_path.exists():
+			storage_state_path.write_text(json.dumps(storage_state, indent=4))  # TODO: convert to async
+			logger.info(
+				f'🍪 Saved {len(storage_state["cookies"])} cookies to storage_state={_log_pretty_path(storage_state_path)}'
+			)
+		except Exception as e:
+			logger.warning(
+				f'❌ Failed to save storage state to storage_state={_log_pretty_path(storage_state_path)}: {type(e).__name__}: {e}'
+			)
+
+	@require_initialization
+	async def load_storage_state(self) -> None:
+		"""
+		Load cookies from the storage_state or cookies_file and apply them to the browser context.
+		"""
+
+		if self.browser_profile.cookies_file:
+			# Show deprecation warning
+			logger.warning(
+				'⚠️ cookies_file is deprecated and will be removed in a future version. '
+				'Please use storage_state instead for loading cookies and other browser state. '
+				'See: https://playwright.dev/python/docs/api/class-browsercontext#browser-context-storage-state'
+			)
+
+			cookies_path = Path(self.browser_profile.cookies_file)
+			if not cookies_path.is_absolute():
+				cookies_path = Path(self.browser_profile.downloads_dir or '.') / cookies_path
+
 			try:
 				cookies_data = json.loads(cookies_path.read_text())
 				if cookies_data:
 					await self.browser_context.add_cookies(cookies_data)
-					logger.info(f'🍪 Loaded {len(cookies_data)} cookies from {_log_pretty_path(cookies_path)}')
+					logger.info(f'🍪 Loaded {len(cookies_data)} cookies from cookies_file={_log_pretty_path(cookies_path)}')
 			except Exception as e:
-				logger.warning(f'❌ Failed to load cookies from {_log_pretty_path(cookies_path)}: {type(e).__name__}: {e}')
+				logger.warning(
+					f'❌ Failed to load cookies from cookies_file={_log_pretty_path(cookies_path)}: {type(e).__name__}: {e}'
+				)
+
+		if self.browser_profile.storage_state:
+			storage_state = self.browser_profile.storage_state
+			if isinstance(storage_state, (str, Path)):
+				try:
+					storage_state = json.loads(Path(storage_state).read_text())
+				except Exception as e:
+					logger.warning(
+						f'❌ Failed to load cookies from storage_state={_log_pretty_path(self.browser_profile.storage_state)}: {type(e).__name__}: {e}'
+					)
+					return
+
+			try:
+				assert isinstance(storage_state, dict), f'Got unexpected type for storage_state: {type(storage_state)}'
+				await self.browser_context.add_cookies(storage_state['cookies'])
+				# TODO: also handle localStroage, IndexedDB, SessionStorage
+				# playwright doesn't provide an API for setting these before launch
+				# https://playwright.dev/python/docs/auth#session-storage
+				# await self.browser_context.add_local_storage(storage_state['localStorage'])
+				logger.info(
+					f'🍪 Loaded {len(storage_state["cookies"])} cookies from storage_state={_log_pretty_path(self.browser_profile.storage_state)}'
+				)
+			except Exception as e:
+				logger.warning(
+					f'❌ Failed to load cookies from storage_state={_log_pretty_path(self.browser_profile.storage_state)}: {type(e).__name__}: {e}'
+				)
+				return
+
+	async def load_cookies_from_file(self, *args, **kwargs) -> None:
+		"""
+		Old name for the new load_storage_state() function.
+		"""
+		await self.load_storage_state(*args, **kwargs)
 
 	# @property
 	# def browser_extension_pages(self) -> list[Page]:

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -477,3 +477,17 @@ def match_url_with_domain_pattern(url: str, domain_pattern: str, log_warnings: b
 		logger = logging.getLogger(__name__)
 		logger.error(f'⛔️ Error matching URL {url} with pattern {domain_pattern}: {type(e).__name__}: {e}')
 		return False
+
+
+def merge_dicts(a: dict, b: dict, path: tuple[str, ...] = ()):
+	for key in b:
+		if key in a:
+			if isinstance(a[key], dict) and isinstance(b[key], dict):
+				merge_dicts(a[key], b[key], path + [str(key)])
+			elif isinstance(a[key], list) and isinstance(b[key], list):
+				a[key] = a[key] + b[key]
+			elif a[key] != b[key]:
+				raise Exception('Conflict at ' + '.'.join(path + (str(key),)))
+		else:
+			a[key] = b[key]
+	return a

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -483,7 +483,7 @@ def merge_dicts(a: dict, b: dict, path: tuple[str, ...] = ()):
 	for key in b:
 		if key in a:
 			if isinstance(a[key], dict) and isinstance(b[key], dict):
-				merge_dicts(a[key], b[key], path + [str(key)])
+				merge_dicts(a[key], b[key], path + (str(key),))
 			elif isinstance(a[key], list) and isinstance(b[key], list):
 				a[key] = a[key] + b[key]
 			elif a[key] != b[key]:

--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -298,13 +298,20 @@ Time to wait between agent actions.
 cookies_file: str | None = None
 ```
 
+JSON file path to save cookies to.
+
 <Warning>
 This option is DEPRECATED. Use [`storage_state`](#storage-state) instead, it's the standard playwright format and also supports `localStorage`!
 
-You must transfer any cookies from your existing `cookies_file` to the new format manually, or run `playwright open https://example.com/ --save-storage=auth.json` to create a new file in the new format.
+Transfer any cookies from your existing `cookies_file` to the new JSON format:
+
+`cookies_file.json`: `[{cookie}, {cookie}, {cookie}]`  
+⬇️
+`storage_state.json`: `{"cookies": [{cookie}, {cookie}, {cookie}], "origins": {... optional localstorage state ...}}`
+
+Or run `playwright open https://example.com/ --save-storage=storage_state.json` and log into any sites you need.
 </Warning>
 
-File to save cookies to.
 
 #### `downloads_dir`
 

--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -312,15 +312,9 @@ File to save cookies to.
 downloads_dir: Path | str = '~/.config/browseruse/downloads'
 ```
 
-Directory for downloads.
+Directory to save browser downloads in.
 
-#### `save_downloads_path`
-
-```python
-save_downloads_path: str | None = None
-```
-
-Directory for saving downloads (alternative to downloads_dir).
+(previously called `save_downloads_path` in some places)
 
 #### `profile_directory`
 
@@ -328,7 +322,7 @@ Directory for saving downloads (alternative to downloads_dir).
 profile_directory: str = 'Default'
 ```
 
-Chrome profile directory name (e.g., 'Profile 1', 'Profile 2').
+Chrome profile subdirectory name inside of your `user_data_dir` (e.g. `Default`, `Profile 1`, `Work`, etc.).
 
 #### `window_position`
 

--- a/examples/features/download_file.py
+++ b/examples/features/download_file.py
@@ -20,7 +20,7 @@ if not api_key:
 llm = ChatGoogleGenerativeAI(model='gemini-2.0-flash-exp', api_key=SecretStr(api_key))
 browser_session = BrowserSession(
 	browser_profile=BrowserProfile(
-		save_downloads_path=os.path.join(os.path.expanduser('~'), 'downloads'),
+		downloads_dir='~/Downloads',
 		user_data_dir='~/.config/browseruse/profiles/default',
 	)
 )


### PR DESCRIPTION
- merge duplicate `save_downloads_path` and `downloads_dir` options
- improve auto-detection and migration of old `cookies_file` to new `storage_state`
- auto-apply `storage_state` and `cookies_file` on launch *and* on connection to existing browsers.
- create new `BrowserSession.load_storage_state()` and `BrowserSession.save_storage_state()` methods