### PR TITLE
Fix missing await keyword for asyncio.sleep() in extraction test

### DIFF
--- a/tests/extraction_test.py
+++ b/tests/extraction_test.py
@@ -83,7 +83,7 @@ async def test_focus_vs_all_elements():
 	for website in websites:
 		# sleep 2
 		await page.goto(website)
-		asyncio.sleep(1)
+		await asyncio.sleep(1)
 
 		last_clicked_index = None  # Track the index for text input
 		while True:


### PR DESCRIPTION
## Problem
 `tests/extraction_test.py` calls `asyncio.sleep(1)` without `await`, causing the coroutine to never execute.

## Solution
Added missing `await` keyword to ensure proper 1-second delay after page navigation.
