### PR TITLE
feat: Convert file operations to async in BrowserSession

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1161,7 +1161,7 @@ class BrowserSession(BaseModel):
 			else:
 				# No existing file, write the new storage state
 				await anyio.Path(storage_state_path).write_text(json.dumps(storage_state, indent=4))
-			
+
 			logger.info(
 				f'🍪 Saved {len(storage_state["cookies"])} cookies to storage_state={_log_pretty_path(storage_state_path)}'
 			)


### PR DESCRIPTION
## MOTIVATION:
File operations in BrowserSession are blocking the event loop. There were TODO comments to convert these to async but they weren't implemented yet.

## CHANGES:
- Replace sync file ops with anyio.Path() async versions (6 locations)  
- Add proper if/else logic to storage state handling
- Remove TODO comments that are now addressed
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Converted all file operations in BrowserSession to async to prevent blocking the event loop and improve I/O performance.

- **Refactors**
  - Replaced sync file reads and writes with async anyio.Path methods.
  - Updated storage state logic for better error handling and merging.
  - Removed outdated TODO comments.

<!-- End of auto-generated description by cubic. -->

