### PR TITLE
Fix: Windows ProactorEventLoop for Playwright asyncio compatibility

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -8,7 +8,7 @@ logger = setup_logging()
 # Set Windows event loop policy for Playwright compatibility
 if sys.platform.startswith('win'):
 	try:
-		asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+		asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 	except Exception as e:
 		logger.error(f'❌  Failed to set Windows event loop policy: {type(e).__name__}: {e}')
 

--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -1,16 +1,6 @@
-import asyncio
-import sys
-
 from browser_use.logging_config import setup_logging
 
 logger = setup_logging()
-
-# Set Windows event loop policy for Playwright compatibility
-if sys.platform.startswith('win'):
-	try:
-		asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
-	except Exception as e:
-		logger.error(f'❌  Failed to set Windows event loop policy: {type(e).__name__}: {e}')
 
 from browser_use.agent.prompts import SystemPrompt
 from browser_use.agent.service import Agent


### PR DESCRIPTION
Fixes:
https://github.com/browser-use/browser-use/issues/1876

Problem:
Using `WindowsSelectorEventLoopPolicy()` on Windows causes NotImplementedError with asyncio.create_subprocess_exec, which Playwright relies on.

Fix:
Replaced `WindowsSelectorEventLoopPolicy()` with `WindowsProactorEventLoopPolicy()` for full asyncio subprocess support.
   
   It also works by just removing the below line:
   `asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())`
   
   maybe because Python on Windows uses WindowsProactorEventLoopPolicy by default (starting Python 3.8).
  
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switched to WindowsProactorEventLoopPolicy on Windows to fix Playwright compatibility issues with asyncio subprocesses.

<!-- End of auto-generated description by cubic. -->

