### PR TITLE
docs: fixing grammar error in browser-settings.mdx

### DIFF
--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -167,7 +167,7 @@ A `BrowserProfile` is a static config template for a `BrowserSession()`.
 
 It can validate and hold all the standard [playwright arguments](#playwright) and the extra config arguments Browser Use provides.
 
-It allows you do do things like start multiple browser processes with *some* shared config:
+It allows you to do things like start multiple browser processes with *some* shared config:
 
 ```python
 from browser_use.browser import BrowserProfile


### PR DESCRIPTION
fixing grammar error in browser-settings.mdx: changing `do do` to `to do`.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a grammar error in browser-settings.mdx

<!-- End of auto-generated description by cubic. -->

