### PR TITLE
fix: expose ANCHOR_BROWSER_API_KEY variable in the evals workflow .yaml

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -17,6 +17,7 @@ jobs:
       XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
       EVALUATION_TOOL_URL: ${{ secrets.EVALUATION_TOOL_URL }}
       EVALUATION_TOOL_SECRET_KEY: ${{ secrets.EVALUATION_TOOL_SECRET_KEY }}
+      ANCHOR_BROWSER_API_KEY: ${{ secrets.ANCHOR_BROWSER_API_KEY }}
 
     steps:
       - name: Determine branch to checkout


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added the ANCHOR_BROWSER_API_KEY secret to the evals workflow so it is available during job runs.

<!-- End of auto-generated description by cubic. -->

