### PR TITLE
feat: support changing eval task set

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -80,6 +80,7 @@ jobs:
           DEFAULT_MEMORY_INTERVAL="10"
           DEFAULT_MAX_ACTIONS_PER_STEP="10"
           DEFAULT_PLANNER_INTERVAL="1"
+          DEFAULT_TEST_CASE="OnlineMind2Web"
 
           # Extract and apply defaults using parameter expansion
           MODEL="${{ github.event.client_payload.script_args.model }}"
@@ -118,6 +119,9 @@ jobs:
           PLANNER_INTERVAL="${{ github.event.client_payload.script_args.planner_interval }}"
           PLANNER_INTERVAL="${PLANNER_INTERVAL:-$DEFAULT_PLANNER_INTERVAL}"
 
+          TEST_CASE="${{ github.event.client_payload.script_args.test_case }}"
+          TEST_CASE="${TEST_CASE:-$DEFAULT_TEST_CASE}"
+
           # Optional parameters (no defaults)
           USER_MESSAGE="${{ github.event.client_payload.script_args.user_message }}"
           DEVELOPER_ID="${{ github.event.client_payload.script_args.developer_id }}"
@@ -137,6 +141,7 @@ jobs:
             "--memory-interval" "$MEMORY_INTERVAL"
             "--max-actions-per-step" "$MAX_ACTIONS_PER_STEP"
             "--planner-interval" "$PLANNER_INTERVAL"
+            "--test-case" "$TEST_CASE"
           )
 
           # Add boolean flags conditionally

--- a/eval/service.py
+++ b/eval/service.py
@@ -633,15 +633,16 @@ async def reformat_agent_history(
 
 
 class Task:
-	def __init__(self, task_id, confirmed_task, website, reference_length, level):
+	def __init__(self, task_id, confirmed_task, website=None, reference_length=None, level=None, cluster_id=None):
 		self.task_id = task_id
 		self.confirmed_task = confirmed_task
 		self.website = website
 		self.reference_length = reference_length
 		self.level = level
+		self.cluster_id = cluster_id
 
 	def __str__(self):
-		return f'Task(task_id={self.task_id}, confirmed_task={self.confirmed_task}, website={self.website}, reference_length={self.reference_length}, level={self.level})'
+		return f'Task(task_id={self.task_id}, confirmed_task={self.confirmed_task}, website={self.website}, reference_length={self.reference_length}, level={self.level}, cluster_id={self.cluster_id})'
 
 	def __repr__(self):
 		return self.__str__()
@@ -822,6 +823,7 @@ class TaskResult:
 			'taskWebsite': task.website,
 			'taskReferenceLength': task.reference_length,
 			'taskLevel': task.level,
+			'taskClusterId': task.cluster_id,
 			'actionHistory': [],
 			'finalResultResponse': 'None',
 			'selfReportCompleted': False,
@@ -1655,6 +1657,9 @@ if __name__ == '__main__':
 		help='Model to use for planning (separate from main agent model)',
 	)
 	parser.add_argument('--planner-interval', type=int, default=1, help='Run planner every N steps (default: 1)')
+	parser.add_argument(
+		'--test-case', type=str, default='OnlineMind2Web', help='Name of the test case to fetch (default: OnlineMind2Web)'
+	)
 	args = parser.parse_args()
 
 	# Set up logging - Make sure logger is configured before use in fetch function
@@ -1710,14 +1715,13 @@ if __name__ == '__main__':
 		# --- Fetch Tasks from Server ---
 		CONVEX_URL = os.getenv('EVALUATION_TOOL_URL')
 		SECRET_KEY = os.getenv('EVALUATION_TOOL_SECRET_KEY')
-		TEST_CASE_NAME = 'OnlineMind2Web'  # Name of the test case to fetch
 
 		if not CONVEX_URL or not SECRET_KEY:
 			logger.error('Error: EVALUATION_TOOL_URL or EVALUATION_TOOL_SECRET_KEY environment variables not set.')
 			exit(1)  # Exit if config is missing
 
-		logger.info(f"Attempting to fetch task list '{TEST_CASE_NAME}' from server...")
-		fetched_task_data = fetch_tasks_from_server(CONVEX_URL, SECRET_KEY, TEST_CASE_NAME)
+		logger.info(f"Attempting to fetch task list '{args.test_case}' from server...")
+		fetched_task_data = fetch_tasks_from_server(CONVEX_URL, SECRET_KEY, args.test_case)
 
 		if fetched_task_data is None:
 			logger.error('Failed to fetch tasks from the server. Exiting.')
@@ -1728,7 +1732,7 @@ if __name__ == '__main__':
 			logger.info(f'Successfully loaded {len(tasks)} tasks from the server.')
 		except TypeError as e:
 			logger.error(
-				f'Error creating Task objects from fetched data. Ensure the data structure matches Task requirements (task_id, confirmed_task, etc.). Error: {type(e).__name__}: {e}'
+				f'Error creating Task objects from fetched data. Ensure the data structure includes required fields (task_id, confirmed_task). Optional fields: website, reference_length, level, cluster_id. Error: {type(e).__name__}: {e}'
 			)
 			logger.error(f'First item in fetched data: {fetched_task_data[0] if fetched_task_data else "None"}')
 			exit(1)
@@ -1746,7 +1750,7 @@ if __name__ == '__main__':
 			'end_index': args.end,
 			'headless': args.headless,
 			'use_vision': not args.no_vision,
-			'task_source': TEST_CASE_NAME,
+			'task_source': args.test_case,
 			'llm_judge': args.eval_model,
 		}
 
@@ -1759,6 +1763,7 @@ if __name__ == '__main__':
 			'evalGroup': args.eval_group,
 			'developerId': args.developer_id,
 			'totalTasks': len(tasks) - args.start if args.end is None else args.end - args.start,
+			'testCaseName': args.test_case,
 			'additionalData': additional_run_data,
 		}
 


### PR DESCRIPTION
The service for evals was always fetching the online-mind2web taskset, now it accepts an argument for a task set by name so multiple task sets can be used.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for selecting different evaluation task sets by name instead of always using the default.

- **New Features**
  - Accepts a task set name as an argument in both the workflow and service.
  - Fetches and runs the specified task set during evaluation.

<!-- End of auto-generated description by cubic. -->

