### PR TITLE
fix(MessageManager): convert SystemMessage to HumanMessage for '.*gemma.*-it' models

### DIFF
--- a/browser_use/agent/message_manager/tests.py
+++ b/browser_use/agent/message_manager/tests.py
@@ -236,23 +236,24 @@ def test_token_overflow_handling_with_real_flow(message_manager: MessageManager,
 
 
 def test_system_message_conversion():
-    """Test that system messages are converted to human messages for models that don't support them"""
-    system_msg = SystemMessage(content="System instruction")
-    human_msg = HumanMessage(content="Human message")
-    messages = [system_msg, human_msg]
+	"""Test that system messages are converted to human messages for models that don't support them"""
+	system_msg = SystemMessage(content='System instruction')
+	human_msg = HumanMessage(content='Human message')
+	messages = [system_msg, human_msg]
 
-    # Test with a model that supports system messages
-    converted = convert_input_messages(messages, "gpt-4")
-    assert isinstance(converted[0], SystemMessage)
-    assert isinstance(converted[1], HumanMessage)
-    assert len(converted) == 2
+	# Test with a model that supports system messages
+	converted = convert_input_messages(messages, 'gpt-4')
+	assert isinstance(converted[0], SystemMessage)
+	assert isinstance(converted[1], HumanMessage)
+	assert len(converted) == 2
 
-    # Test with a model that doesn't support system messages
-    converted = convert_input_messages(messages, "gemma-3-4b-it")
-    assert isinstance(converted[0], HumanMessage)
-    assert isinstance(converted[1], HumanMessage)
-    assert len(converted) == 2
-    assert converted[0].content == system_msg.content
-    assert converted[1].content == human_msg.content
+	# Test with a model that doesn't support system messages
+	converted = convert_input_messages(messages, 'gemma-3-4b-it')
+	assert isinstance(converted[0], HumanMessage)
+	assert isinstance(converted[1], HumanMessage)
+	assert len(converted) == 2
+	assert converted[0].content == system_msg.content
+	assert converted[1].content == human_msg.content
+
 
 # pytest -s browser_use/agent/message_manager/tests.py

--- a/browser_use/agent/message_manager/tests.py
+++ b/browser_use/agent/message_manager/tests.py
@@ -4,6 +4,7 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
 from browser_use.agent.message_manager.service import MessageManager, MessageManagerSettings
+from browser_use.agent.message_manager.utils import convert_input_messages
 from browser_use.agent.views import ActionResult
 from browser_use.browser.views import BrowserStateSummary, TabInfo
 from browser_use.dom.views import DOMElementNode, DOMTextNode
@@ -233,5 +234,25 @@ def test_token_overflow_handling_with_real_flow(message_manager: MessageManager,
 		assert stored_tokens == real_tokens
 		assert message_manager.state.history.current_tokens == total_tokens
 
+
+def test_system_message_conversion():
+    """Test that system messages are converted to human messages for models that don't support them"""
+    system_msg = SystemMessage(content="System instruction")
+    human_msg = HumanMessage(content="Human message")
+    messages = [system_msg, human_msg]
+
+    # Test with a model that supports system messages
+    converted = convert_input_messages(messages, "gpt-4")
+    assert isinstance(converted[0], SystemMessage)
+    assert isinstance(converted[1], HumanMessage)
+    assert len(converted) == 2
+
+    # Test with a model that doesn't support system messages
+    converted = convert_input_messages(messages, "gemma-3-4b-it")
+    assert isinstance(converted[0], HumanMessage)
+    assert isinstance(converted[1], HumanMessage)
+    assert len(converted) == 2
+    assert converted[0].content == system_msg.content
+    assert converted[1].content == human_msg.content
 
 # pytest -s browser_use/agent/message_manager/tests.py

--- a/browser_use/agent/message_manager/utils.py
+++ b/browser_use/agent/message_manager/utils.py
@@ -35,7 +35,6 @@ def is_model_without_system_message_support(model_name: str) -> bool:
 	return any(re.match(pattern, model_name) for pattern in MODELS_WITHOUT_SYSTEM_MESSAGE_PATTERNS)
 
 
-
 def extract_json_from_model_output(content: str) -> dict:
 	"""Extract JSON from model output, handling both plain JSON and code-block-wrapped JSON."""
 	try:
@@ -75,7 +74,9 @@ def convert_input_messages(input_messages: list[BaseMessage], model_name: str | 
 	return input_messages
 
 
-def _convert_messages_for_non_function_calling_models(input_messages: list[BaseMessage], model_name: str | None = None) -> list[BaseMessage]:
+def _convert_messages_for_non_function_calling_models(
+	input_messages: list[BaseMessage], model_name: str | None = None
+) -> list[BaseMessage]:
 	"""Convert messages for non-function-calling models and handle system message conversion if needed"""
 	output_messages = []
 	for message in input_messages:


### PR DESCRIPTION
Some models (e.g. Gemma instruction-tuned models) [don't support SystemMessage](https://ai.google.dev/gemma/docs/core/prompt-structure#system-instructions), returning an error

```console
INFO     [agent] 🧠 LLM call => ChatGoogleGenerativeAI [✉️ 4 msg, ~4685 tk, 11665 char] => raw text
ERROR    [agent] Failed to invoke model: Invalid argument provided to Gemini: 400 Developer instruction is not enabled for models/gemma-3-27b-it
```

By converting `SystemMessage`s to `HumanMessage`s inside of `MessageManager`, we can successfully use these Gemma models without issue.

This PR follows the convention introduced in #1257 by introducing a `MODELS_WITHOUT_SYSTEM_MESSAGE_PATTERNS` list to detect affected models.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed errors with Gemma instruction-tuned models by converting SystemMessage to HumanMessage, allowing these models to work without issues.

- **Bug Fixes**
  - Added logic to detect Gemma models and convert unsupported SystemMessages.
  - Updated tests to check correct message conversion.

<!-- End of auto-generated description by cubic. -->

