### PR TITLE
rolling back requests library to 2.32.2 due to security vulnerabilty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "httpx>=0.27.2",
     "pydantic>=2.11.5",
     "python-dotenv>=1.0.1",
-    "requests>=2.32.3",
+    "requests>=2.32.2",
     "posthog>=3.7.0",
     "playwright>=1.52.0",
     "markdownify==1.1.0",


### PR DESCRIPTION
There is a critical vulnerability reported in the requests 2.32.3 library (as seen here: https://vulert.com/vuln-db/pypi-requests-2-32-3-177728). 

The vulnerability is not present in 2.32.2. This pull request is to downgrade the requests library to a more stable version. I have tested this change by re-creating the venv and re-creating it as well as running the browser-use component with memory and vision turned on as well as memory and llm vision turned off. 