### PR TITLE
fix: Handle str type for executable_path and user_data_dir in BrowserProfile validation

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -656,12 +656,12 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		is_using_non_default_chrome = self.executable_path or self.channel not in (BROWSERUSE_DEFAULT_CHANNEL, None)
 		if self.user_data_dir == BROWSERUSE_DEFAULT_PROFILE_DIR and is_using_non_default_chrome:
 			alternate_name = (
-				self.executable_path.name.lower().replace(' ', '-') if self.executable_path else self.channel.name.lower()
+				Path(self.executable_path).name.lower().replace(' ', '-') if self.executable_path else self.channel.name.lower()
 			)
 			logger.warning(
 				f'⚠️ {self} Changing user_data_dir= {_log_pretty_path(self.user_data_dir)} ➡️ .../default-{alternate_name} to avoid {alternate_name.upper()} corruping default profile created by {BROWSERUSE_DEFAULT_CHANNEL.name}'
 			)
-			self.user_data_dir = self.user_data_dir.parent / f'default-{alternate_name}'
+			self.user_data_dir = Path(self.user_data_dir).parent / f'default-{alternate_name}'
 		return self
 
 	def get_args(self) -> list[str]:

--- a/tests/test_browser_profile.py
+++ b/tests/test_browser_profile.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+
+
+@pytest.mark.parametrize(
+	'executable_path',
+	[
+		'/test/chrome',  # str
+		Path('/test/chrome'),  # Path
+		None,  # None
+	],
+	ids=['str', 'Path', 'None'],
+)
+def test_executable_path_field_types(executable_path):
+	"""Test executable_path accepts str, Path, and None types without throwing exceptions."""
+	BrowserProfile(executable_path=executable_path)
+
+
+@pytest.mark.parametrize(
+	'user_data_dir',
+	[
+		'/test/profile',  # str
+		Path('/test/profile'),  # Path
+		None,  # None - incognito mode
+	],
+	ids=['str', 'Path', 'None'],
+)
+def test_user_data_dir_field_types(user_data_dir):
+	"""Test user_data_dir accepts str, Path, and None types without throwing exceptions."""
+	BrowserProfile(user_data_dir=user_data_dir)


### PR DESCRIPTION
## Problem

The `warn_user_data_dir_non_default_version` validator in `BrowserProfile` assumed `executable_path` and `user_data_dir` were always `Path` objects, but these fields are typed as `str | Path | None`. When these fields contain string values, calling Path-specific attributes like `.name` or `.parent` would cause `AttributeError`.

**Error Example:**
```python
profile = BrowserProfile(executable_path="/usr/bin/chrome")  # str type
# AttributeError: 'str' object has no attribute 'name'
```

## Solution

Wrapped both field accesses with `Path()` to handle both string and Path inputs consistently:
- Line 659: `Path(self.executable_path).name` 
- Line 664: `Path(self.user_data_dir).parent`

This follows the existing project pattern used throughout the codebase (e.g., `browser_use/browser/session.py:335`, `browser_use/agent/views.py:259`).

## Changes

- **Fixed**: `executable_path.name` → `Path(executable_path).name`
- **Fixed**: `user_data_dir.parent` → `Path(user_data_dir).parent` 
- **Added**: Comprehensive parametrized tests covering str, Path, and None inputs

## Testing

```bash
uv run pytest tests/test_browser_profile.py -v  # ✅ All tests pass
uv run ruff check browser_use/browser/profile.py  # ✅ Code style passes
```

Tests verify that `BrowserProfile` accepts string, Path, and None values for both `executable_path` and `user_data_dir` without throwing exceptions.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where BrowserProfile would raise errors if executable_path or user_data_dir were given as strings instead of Path objects.

- **Bug Fixes**
  - Wrapped these fields with Path() to handle both str and Path types safely.
  - Added tests to confirm support for str, Path, and None values.

<!-- End of auto-generated description by cubic. -->

