### PR TITLE
PreFix/browser context validation v2 (#1934)

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -52,8 +52,9 @@ from browser_use.agent.views import (
 	StepMetadata,
 	ToolCallingMethod,
 )
+import patchright.async_api
 from browser_use.browser import BrowserProfile, BrowserSession
-
+from patchright.async_api import BrowserContext as PatchrightBrowserContext
 # from lmnr.sdk.decorators import observe
 from browser_use.browser.views import BrowserStateSummary
 from browser_use.controller.registry.views import ActionModel

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -52,9 +52,8 @@ from browser_use.agent.views import (
 	StepMetadata,
 	ToolCallingMethod,
 )
-import patchright.async_api
 from browser_use.browser import BrowserProfile, BrowserSession
-from patchright.async_api import BrowserContext as PatchrightBrowserContext
+
 # from lmnr.sdk.decorators import observe
 from browser_use.browser.views import BrowserStateSummary
 from browser_use.controller.registry.views import ActionModel

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -188,7 +188,7 @@ class BrowserSession(BaseModel):
 		validation_alias=AliasChoices('playwright_browser'),
 		exclude=True,
 	)
-	browser_context: InstanceOf[BrowserContext] | None = Field(
+	browser_context: BrowserContext | None = Field(
 		default=None,
 		description='playwright BrowserContext object to use (optional)',
 		validation_alias=AliasChoices('playwright_browser_context', 'context'),

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -25,7 +25,6 @@ except ImportError:
 import langchain_anthropic
 import langchain_google_genai
 import langchain_openai
-from patchright.async_api import async_playwright
 
 try:
 	import readline
@@ -1239,7 +1238,7 @@ async def textual_interface(config: dict[str, Any]):
 		# Create BrowserSession directly with config parameters
 		browser_session = BrowserSession(
 			**browser_config,
-			playwright=(await async_playwright().start()),
+			playwright=(await ().start()),
 			channel=BrowserChannel.CHROME,
 			user_data_dir='~/.browseruse/profiles/default/cli',
 		)


### PR DESCRIPTION
**Fix:** Allow `patchright.BrowserContext` in `BrowserSession` validation (#1934)

This change resolves the `ValidationError` (Issue #1934) encountered when initializing an Agent with a `browser_context` created using `patchright`. The `BrowserSession` class's `browser_context` field now correctly accepts `patchright.async_api.BrowserContext` instances by updating its Pydantic type hint from `InstanceOf[BrowserContext]` to `BrowserContext` directly.

The code change is located in the file `browser_use/browser/service.py`.


**Old Line:**
```python
browser_context: InstanceOf[BrowserContext] | None = Field(
```

**New Line:**
```python
browser_context: BrowserContext | None = Field(
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a validation error so that BrowserSession now accepts patchright.BrowserContext objects for the browser_context field.

<!-- End of auto-generated description by cubic. -->

