### PR TITLE
Fix: Improve recognition of custom button elements in DOM tree

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -1068,7 +1068,7 @@
       typeof element.onclick === 'function';
 
     // Check for semantic class names suggesting interactivity
-    const hasInteractiveClass = /\b(btn|clickable|menu|item|entry|link)\b/i.test(element.className || '');
+    const hasInteractiveClass = /\b(btn|clickable|menu|item|entry|link)\b|(\w*[-_]?btn\b)/i.test(element.className || '');
 
     // Determine whether the element is inside a known interactive container
     const isInKnownContainer = Boolean(


### PR DESCRIPTION
Fixes #842

This PR addresses the issue where buttons with custom styling (like those with class 'nav-btn pull-left') weren't being recognized as interactive elements. Modified the buildDomTree.js file to properly identify these elements as clickable buttons in the DOM tree.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved detection of custom-styled button elements in the DOM tree so that buttons with class names like 'nav-btn' are now recognized as interactive.

- **Bug Fixes**
  - Updated class name matching to include patterns like 'nav-btn' and similar custom button classes.

<!-- End of auto-generated description by cubic. -->

