### PR TITLE
Fix event loop issues with multiple `BrowserSession` objects per thread

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "faiss-cpu>=1.11.0",
     "mem0ai>=0.1.104",
     "uuid7>=0.1.0",
-    "patchright>=1.52.4",
+    "patchright>=1.52.5",
     "aiofiles>=24.1.0",
 ]
 # google-api-core: only used for Google LLM APIs

--- a/tests/ci/evaluate_tasks.py
+++ b/tests/ci/evaluate_tasks.py
@@ -70,6 +70,7 @@ async def run_single_task(task_file):
 			headless=True,
 			user_data_dir=None,
 			chromium_sandbox=False,  # Disable sandbox for CI environment (GitHub Actions)
+			stealth=True,
 		)
 		session = BrowserSession(browser_profile=profile)
 		print('[DEBUG] Browser session created', file=sys.stderr)

--- a/tests/ci/test_browser_session_via_cdp.py
+++ b/tests/ci/test_browser_session_via_cdp.py
@@ -24,3 +24,4 @@ async def test_connection_via_cdp(monkeypatch):
 
 	await browser_session.close()
 	await browser.close()
+	await playwright.stop()


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed event loop issues by ensuring only one Playwright or Patchright API object is created per thread, preventing multiple connections and related errors. 

- **Bug Fixes**
  - Added global variables to reuse Playwright and Patchright instances.
  - Updated session setup to avoid duplicate API object creation.

<!-- End of auto-generated description by cubic. -->

