### PR TITLE
Require `BrowserSession` with `keep_alive=True` be started manually before passing to `Agent()`

### DIFF
--- a/browser_use/agent/memory/service.py
+++ b/browser_use/agent/memory/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import warnings
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import (
@@ -79,7 +80,9 @@ class Memory:
 				)
 
 		# Initialize Mem0 with the configuration
-		self.mem0 = Mem0Memory.from_config(config_dict=self.config.full_config_dict)
+		with warnings.catch_warnings():
+			warnings.filterwarnings('ignore', category=DeprecationWarning)
+			self.mem0 = Mem0Memory.from_config(config_dict=self.config.full_config_dict)
 
 	@time_execution_sync('--create_procedural_memory')
 	def create_procedural_memory(self, current_step: int) -> None:

--- a/browser_use/agent/memory/service.py
+++ b/browser_use/agent/memory/service.py
@@ -90,7 +90,9 @@ class Memory:
 					import tempfile
 					import uuid
 
-					logger.warning('⚠️ Mem0 SQLite migration error detected. Using a temporary database to avoid conflicts.')
+					logger.warning(
+						f'⚠️ Mem0 SQLite migration error detected in {self.config.full_config_dict}. Using a temporary database to avoid conflicts.\n{type(e).__name__}: {e}'
+					)
 					# Create a unique temporary database path
 					temp_dir = tempfile.gettempdir()
 					unique_id = str(uuid.uuid4())[:8]

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -313,6 +313,18 @@ class Agent(Generic[Context]):
 		browser_profile = browser_profile or DEFAULT_BROWSER_PROFILE
 
 		if browser_session:
+			# Check if user is trying to reuse an uninitialized session
+			if browser_session.browser_profile.keep_alive and not browser_session.initialized:
+				self.logger.error(
+					'❌ Passed a BrowserSession with keep_alive=True that is not initialized. '
+					'Call await browser_session.start() before passing it to Agent() to reuse the same browser. '
+					'Otherwise, each agent will launch its own browser instance.'
+				)
+				raise ValueError(
+					'BrowserSession with keep_alive=True must be initialized before passing to Agent. '
+					'Call: await browser_session.start()'
+				)
+
 			# always copy sessions that are passed in to avoid conflicting with other agents sharing the same session
 			self.browser_session = browser_session.model_copy(
 				update={

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -325,12 +325,12 @@ class Agent(Generic[Context]):
 					'Call: await browser_session.start()'
 				)
 
-			# always copy sessions that are passed in to avoid conflicting with other agents sharing the same session
+			# always copy sessions that are passed in to avoid agents overwriting each other's agent_current_page and human_current_page by accident
 			self.browser_session = browser_session.model_copy(
-				update={
-					'agent_current_page': None,
-					'human_current_page': None,
-				},
+				# update={
+				# 	'agent_current_page': None,   # dont reset these, let the next agent start on the same page as the last agent
+				# 	'human_current_page': None,
+				# },
 			)
 		else:
 			self.browser_session = BrowserSession(

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -555,7 +555,6 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		from_attributes=True,
 		validate_by_name=True,
 		validate_by_alias=True,
-		populate_by_name=True,
 	)
 
 	# ... extends options defined in:

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -534,7 +534,7 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
-	user_data_dir: str | Path | None = BROWSERUSE_PROFILES_DIR / 'default'
+	user_data_dir: str | Path | None = None
 
 
 class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, BrowserLaunchArgs, BrowserNewContextArgs):

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -309,7 +309,7 @@ class BrowserChannel(str, Enum):
 
 BROWSERUSE_CONFIG_DIR = Path('~/.config/browseruse').expanduser().resolve()
 BROWSERUSE_PROFILES_DIR = BROWSERUSE_CONFIG_DIR / 'profiles'
-BROWSERUSE_DEFAULT_PROFILE_DIR = BROWSERUSE_PROFILES_DIR / 'default'
+BROWSERUSE_CHROMIUM_USER_DATA_DIR = BROWSERUSE_PROFILES_DIR / 'default'
 BROWSERUSE_DEFAULT_CHANNEL = BrowserChannel.CHROMIUM
 
 
@@ -534,7 +534,7 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
-	user_data_dir: str | Path | None = None
+	user_data_dir: str | Path | None = BROWSERUSE_CHROMIUM_USER_DATA_DIR
 
 
 class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, BrowserLaunchArgs, BrowserNewContextArgs):
@@ -603,7 +603,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	save_har_path: str | None = Field(default=None, description='Directory for saving HAR files.')
 	trace_path: str | None = Field(default=None, description='Directory for saving trace files.')
 
-	cookies_file: str | None = Field(
+	cookies_file: Path | None = Field(
 		default=None, description='File to save cookies to. DEPRECATED, use `storage_state` instead.'
 	)
 
@@ -652,8 +652,8 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	def warn_user_data_dir_non_default_version(self) -> Self:
 		"""If user is using default profile dir with a non-default channel, force-change it to avoid corrupting the default data dir."""
 
-		is_using_non_default_chrome = self.executable_path or self.channel not in (BROWSERUSE_DEFAULT_CHANNEL, None)
-		if self.user_data_dir == BROWSERUSE_DEFAULT_PROFILE_DIR and is_using_non_default_chrome:
+		is_not_using_default_chromium = self.executable_path or self.channel not in (BROWSERUSE_DEFAULT_CHANNEL, None)
+		if self.user_data_dir == BROWSERUSE_CHROMIUM_USER_DATA_DIR and is_not_using_default_chromium:
 			alternate_name = (
 				self.executable_path.name.lower().replace(' ', '-') if self.executable_path else self.channel.name.lower()
 			)

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1514,9 +1514,9 @@ class BrowserSession(BaseModel):
 				'See: https://playwright.dev/python/docs/api/class-browsercontext#browser-context-storage-state'
 			)
 
-			cookies_path = Path(self.browser_profile.cookies_file)
+			cookies_path = Path(self.browser_profile.cookies_file).expanduser().resolve()
 			if not cookies_path.is_absolute():
-				cookies_path = Path(self.browser_profile.downloads_path or '.') / cookies_path
+				cookies_path = Path(self.browser_profile.downloads_path or '.').expanduser().resolve() / cookies_path.name
 
 			try:
 				cookies_data = json.loads(cookies_path.read_text())

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1490,6 +1490,7 @@ class BrowserSession(BaseModel):
 
 		if isinstance(self.browser_profile.storage_state, (str, Path)):
 			await self._save_storage_state_to_file(self.browser_profile.storage_state, storage_state)
+			return
 
 		raise Exception(f'Got unexpected type for storage_state: {type(self.browser_profile.storage_state)}')
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1292,11 +1292,11 @@ class BrowserSession(BaseModel):
 						unique_filename = await self._get_unique_filename(self.browser_profile.downloads_path, suggested_filename)
 						download_path = os.path.join(self.browser_profile.downloads_path, unique_filename)
 						await download.save_as(download_path)
-						self.logger.info(f'⬇️ Download triggered. Saved file to: {download_path}')
+						self.logger.info(f'⬇️ Downloaded file to: {download_path}')
 						return download_path
 					except Exception:
 						# If no download is triggered, treat as normal click
-						self.logger.debug('No download triggered within timeout. Checking navigation...')
+						# self.logger.debug('No download triggered within timeout. Checking navigation...')
 						await page.wait_for_load_state()
 						await self._check_and_handle_navigation(page)
 				else:
@@ -1798,14 +1798,16 @@ class BrowserSession(BaseModel):
 			bytes_used = None
 
 		tab_idx = self.tabs.index(page)
+		extra_delay = ''
+		if remaining > 0:
+			extra_delay = f', waiting +{remaining:.2f}s for all frames to finish'
+
 		if bytes_used is not None:
 			self.logger.info(
-				f'➡️ Page navigation [{tab_idx}]{_log_pretty_url(page.url, 40)} used {bytes_used / 1024:.1f} KB in {elapsed:.2f}s, waiting +{remaining:.2f}s for all frames to finish'
+				f'➡️ Page navigation [{tab_idx}]{_log_pretty_url(page.url, 40)} used {bytes_used / 1024:.1f} KB in {elapsed:.2f}s{extra_delay}'
 			)
 		else:
-			self.logger.info(
-				f'➡️ Page navigation [{tab_idx}]{_log_pretty_url(page.url, 40)} took {elapsed:.2f}s, waiting +{remaining:.2f}s for all frames to finish'
-			)
+			self.logger.info(f'➡️ Page navigation [{tab_idx}]{_log_pretty_url(page.url, 40)} took {elapsed:.2f}s{extra_delay}')
 
 		# Sleep remaining time if needed
 		if remaining > 0:

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -2834,7 +2834,7 @@ class BrowserSession(BaseModel):
 
 			// Create the image element
 			const img = document.createElement('img');
-			img.src = 'https://github.com/browser-use.png';
+			img.src = 'https://cf.browser-use.com/logo.svg';
 			img.alt = 'Browser-Use';
 			img.style.width = '200px';
 			img.style.height = 'auto';

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -281,7 +281,7 @@ class BrowserSession(BaseModel):
 
 		# Use timeout to prevent indefinite waiting on lock acquisition
 
-		async with asyncio.timeout(60):  # 30 second timeout for launching
+		async with asyncio.timeout(60):  # 60 overall second timeout for entire launching process
 			async with self._start_lock:
 				if self.initialized:
 					if self.is_connected():
@@ -360,7 +360,7 @@ class BrowserSession(BaseModel):
 		# trying to launch/kill browsers at the same time is an easy way to trash an entire user_data_dir
 		# it's worth the 1s or 2s of delay in the worst case to avoid race conditions, user_data_dir can be a few GBs
 		# Use timeout to prevent indefinite waiting on lock acquisition
-		async with asyncio.timeout(30):  # 15 second timeout for stop operations
+		async with asyncio.timeout(30):  # 30 second timeout for stop operations
 			async with self._start_lock:
 				# save cookies to disk if cookies_file or storage_state is configured
 				# but only if the browser context is still connected
@@ -1508,7 +1508,7 @@ class BrowserSession(BaseModel):
 				'See: https://playwright.dev/python/docs/api/class-browsercontext#browser-context-storage-state'
 			)
 
-			cookies_path = Path(self.browser_profile.cookies_file).expanduser().resolve()
+			cookies_path = Path(self.browser_profile.cookies_file).expanduser()
 			if not cookies_path.is_absolute():
 				cookies_path = Path(self.browser_profile.downloads_path or '.').expanduser().resolve() / cookies_path.name
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1154,7 +1154,7 @@ class BrowserSession(BaseModel):
 				self.browser_pid = None
 
 		if not already_disconnected:
-			self.logger.debug(f'🪢 Browser {self._connection_str} disconnected')
+			self.logger.debug(f'⚰️ Browser {self._connection_str} disconnected')
 
 	# --- Tab management ---
 	async def get_current_page(self) -> Page:
@@ -1292,7 +1292,7 @@ class BrowserSession(BaseModel):
 						unique_filename = await self._get_unique_filename(self.browser_profile.downloads_path, suggested_filename)
 						download_path = os.path.join(self.browser_profile.downloads_path, unique_filename)
 						await download.save_as(download_path)
-						self.logger.debug(f'⬇️ Download triggered. Saved file to: {download_path}')
+						self.logger.info(f'⬇️ Download triggered. Saved file to: {download_path}')
 						return download_path
 					except Exception:
 						# If no download is triggered, treat as normal click
@@ -1799,11 +1799,11 @@ class BrowserSession(BaseModel):
 
 		tab_idx = self.tabs.index(page)
 		if bytes_used is not None:
-			self.logger.debug(
+			self.logger.info(
 				f'➡️ Page navigation [{tab_idx}]{_log_pretty_url(page.url, 40)} used {bytes_used / 1024:.1f} KB in {elapsed:.2f}s, waiting +{remaining:.2f}s for all frames to finish'
 			)
 		else:
-			self.logger.debug(
+			self.logger.info(
 				f'➡️ Page navigation [{tab_idx}]{_log_pretty_url(page.url, 40)} took {elapsed:.2f}s, waiting +{remaining:.2f}s for all frames to finish'
 			)
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -225,7 +225,7 @@ class BrowserSession(BaseModel):
 
 	@model_validator(mode='after')
 	def apply_session_overrides_to_profile(self) -> Self:
-		"""Apply any extra **kwargs passed to BrowserSession(...) as config overrides on top of browser_profile"""
+		"""Apply any extra **kwargs passed to BrowserSession(...) as session-specific config overrides on top of browser_profile"""
 		session_own_fields = type(self).model_fields.keys()
 
 		# get all the extra kwarg overrides passed to BrowserSession(...) that are actually
@@ -235,10 +235,7 @@ class BrowserSession(BaseModel):
 		# FOR REPL DEBUGGING ONLY, NEVER ALLOW CIRCULAR REFERENCES IN REAL CODE:
 		# self.browser_profile._in_use_by_session = self
 
-		# Only create a copy if there are actual overrides to apply
-		if profile_overrides:
-			# replace browser_profile with patched version
-			self.browser_profile = self.browser_profile.model_copy(update=profile_overrides)
+		self.browser_profile = self.browser_profile.model_copy(update=profile_overrides)
 
 		# FOR REPL DEBUGGING ONLY, NEVER ALLOW CIRCULAR REFERENCES IN REAL CODE:
 		# self.browser_profile._in_use_by_session = self

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -442,6 +442,22 @@ class BrowserSession(BaseModel):
 		await self.start()
 		return self
 
+	def __eq__(self, other: object) -> bool:
+		"""Check if two BrowserSession instances are using the same browser and have the same Agent state."""
+
+		if not isinstance(other, BrowserSession):
+			return False
+
+		# Two sessions are considered equal if they're connected to the same remote browser and are looking at the same page
+		# the .browser, .browser_context, .playwright object identities don't have to match
+		return (
+			self.browser_pid == other.browser_pid
+			and self.cdp_url == other.cdp_url
+			and self.wss_url == other.wss_url
+			and self.agent_current_page == other.agent_current_page
+			and self.human_current_page == other.human_current_page
+		)
+
 	async def __aexit__(self, exc_type, exc_val, exc_tb):
 		# self.logger.debug(
 		# 	f'⏹️ Stopping gracefully browser_pid={self.browser_pid} user_data_dir= {_log_pretty_path(self.browser_profile.user_data_dir) or "<incognito>"} keep_alive={self.browser_profile.keep_alive} (context manager exit)'

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -2587,10 +2587,15 @@ class BrowserSession(BaseModel):
 
 		# Update both tab references - agent wants this tab, and it's now in the foreground
 		self.agent_current_page = page
+
+		# in order for a human watching to be able to follow along with what the agent is doing
+		# bring the agent's active tab to the foreground
+		if self.human_current_page != page:
+			# TODO: figure out how to do this without bringing the entire window to the foreground and stealing foreground app focus
+			await page.bring_to_front()
+
 		self.human_current_page = page
 
-		# Bring tab to front and wait for it to load
-		await page.bring_to_front()
 		await page.wait_for_load_state()
 
 		# Set the viewport size for the tab

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -25,7 +25,6 @@ except ImportError:
 import langchain_anthropic
 import langchain_google_genai
 import langchain_openai
-from patchright.async_api import async_playwright
 
 try:
 	import readline
@@ -41,14 +40,13 @@ os.environ['BROWSER_USE_LOGGING_LEVEL'] = 'result'
 from browser_use import Agent, Controller
 from browser_use.agent.views import AgentSettings
 from browser_use.browser import BrowserSession
-from browser_use.browser.profile import BrowserChannel
 from browser_use.logging_config import addLoggingLevel
 
 # Paths
 USER_CONFIG_DIR = Path.home() / '.config' / 'browseruse'
 USER_CONFIG_FILE = USER_CONFIG_DIR / 'config.json'
 CHROME_PROFILES_DIR = USER_CONFIG_DIR / 'profiles'
-USER_DATA_DIR = CHROME_PROFILES_DIR / 'default'
+USER_DATA_DIR = CHROME_PROFILES_DIR / 'cli'
 
 # Default User settings
 MAX_HISTORY_LENGTH = 100
@@ -1178,7 +1176,11 @@ async def run_prompt_mode(prompt: str, ctx: click.Context, debug: bool = False):
 
 		# Create browser session with config parameters
 		browser_config = config.get('browser', {})
-		browser_session = BrowserSession(stealth=True, **browser_config)
+		browser_session = BrowserSession(
+			stealth=True,
+			user_data_dir=USER_DATA_DIR,
+			**browser_config,
+		)
 
 		# Create and run agent
 		agent = Agent(
@@ -1238,10 +1240,9 @@ async def textual_interface(config: dict[str, Any]):
 
 		# Create BrowserSession directly with config parameters
 		browser_session = BrowserSession(
+			stealth=True,
+			user_data_dir=USER_DATA_DIR,
 			**browser_config,
-			playwright=(await async_playwright().start()),
-			channel=BrowserChannel.CHROME,
-			user_data_dir='~/.browseruse/profiles/default/cli',
 		)
 		logger.debug('BrowserSession initialized successfully')
 

--- a/docs/customize/real-browser.mdx
+++ b/docs/customize/real-browser.mdx
@@ -249,7 +249,7 @@ reused_session = BrowserSession(
     user_data_dir='~/.config/browseruse/profiles/default',
     keep_alive=True,  # dont close browser after 1st agent.run() ends
 )
-await shared_browser.start()   # when keep_alive=True, session must be started manually
+await reused_session.start()   # when keep_alive=True, session must be started manually
 
 agent1 = Agent(
     task="The first task...",

--- a/docs/customize/real-browser.mdx
+++ b/docs/customize/real-browser.mdx
@@ -178,12 +178,18 @@ agent = Agent(
    )
    ```
 
-3. **Enable keep_alive for multiple tasks**: Keep the browser open between agent runs:
+3. **Enable `keep_alive=True`** If you want to use a single `BrowserSession` with more than one agent:
    ```python
    browser_session = BrowserSession(
        keep_alive=True,
        ...
    )
+   await browser_session.start()  # start the session yourself before passing to Agent
+   ...
+   agent = Agent(..., browser_session=browser_session)
+   await agent.run()
+   ...
+   await browser_session.kill()   # end the session yourself, shortcut for keep_alive=False + .stop()
    ```
 
 ## Re-Using a Browser
@@ -233,8 +239,7 @@ await agent2.run()
 ### Sequential Agents, Same Profile, Same Browser
 
 If you are only running one agent at a time, they can re-use the same active `BrowserSession` and avoid having to relaunch chrome.
-Each agent will start off looking at the same tab the last agent ended off on. 
-You can also pass in a specific playwright page using `Agent(..., page=page)` if you prefer.
+Each agent will start off looking at the same tab the last agent ended off on.
 
 ```python
 from browser_use import Agent, BrowserSession
@@ -244,11 +249,12 @@ reused_session = BrowserSession(
     user_data_dir='~/.config/browseruse/profiles/default',
     keep_alive=True,  # dont close browser after 1st agent.run() ends
 )
+await shared_browser.start()   # when keep_alive=True, session must be started manually
 
 agent1 = Agent(
     task="The first task...",
     llm=ChatOpenAI(model="gpt-4o-mini"),
-    browser_session=reused_session,      # pass a session or page=page
+    browser_session=reused_session,
 )
 await agent1.run()
 
@@ -274,6 +280,7 @@ shared_browser = BrowserSession(
     keep_alive=True,
     headless=True,
 )
+await shared_browser.start()   # when keep_alive=True, you must start the session yourself
 
 agent1 = Agent(
     task="The first task...",
@@ -308,20 +315,22 @@ context = await browser.new_context()
 shared_page = await context.new_page()
 await shared_page.goto('https://example.com', wait_until='domcontentloaded')
 
+shared_session = BrowserSession(page=shared_page, keep_alive=True)
+await shared_session.start()
+
 agent1 = Agent(
     task="Fill out the form in section A...",
     llm=ChatOpenAI(model="gpt-4o-mini"),
-    page=shared_page,                              # pass the Page in
-    # ^ shortcut for: browser_session=BrowserSession(page=page)
+    browser_session=shared_session
 )
 agent2 = Agent(
     task="Fill out the form in section B...",
     llm=ChatOpenAI(model="gpt-4o-mini"),
-    page=shared_page,                           # re-use the same Page
+    browser_session=shared_session,
 )
 await asyncio.gather(agent1.run(), agent2.run()) # run in parallel
 
-await browser.close()
+await shared_session.kill()
 ```
 
 ### Parallel Agents, Same Profile, Different Browsers
@@ -351,9 +360,11 @@ shared_profile = BrowserProfile(
 )
 
 window1 = BrowserSession(browser_profile=profile_a)
+await window1.start()
 agent1 = Agent(browser_session=window1)
 
 window2 = BrowserSession(browser_profile=profile_a)
+await window2.start()
 agent2 = Agent(browser_session=window2)
 
 await asyncio.gather(agent1.run(), agent2.run())  # run in parallel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,8 +117,8 @@ include = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "module"
-asyncio_default_test_loop_scope = "module"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 markers = [
     "slow: marks tests as slow (deselect with `-m 'not slow'`)",
     "integration: marks tests as integration tests",

--- a/tests/agent_tasks/captcha_cloudflare.yaml
+++ b/tests/agent_tasks/captcha_cloudflare.yaml
@@ -1,5 +1,5 @@
 name: Cloudflare captcha
-task: Go to https://2captcha.com/demo/cloudflare-turnstile and solve the captcha, then click on check, then extract the "hostname" value from the displayed dictionary under "Captcha is passed successfully!"
+task: Go to https://2captcha.com/demo/cloudflare-turnstile and solve the captcha, wait a few seconds, then click on check, wait a few more seconds for it to complete, then extract the "hostname" value from the displayed dictionary under "Captcha is passed successfully!"
 judge_context:
   - The agent must solve the captcha
   - The hostname returned should be "example.com"

--- a/tests/agent_tasks/captcha_cloudflare.yaml
+++ b/tests/agent_tasks/captcha_cloudflare.yaml
@@ -1,6 +1,6 @@
 name: Cloudflare captcha
-task: Go to https://2captcha.com/demo/cloudflare-turnstile and solve the captcha then click on check and return the hostname of the dictionary
+task: Go to https://2captcha.com/demo/cloudflare-turnstile and solve the captcha, then click on check, then extract the "hostname" value from the displayed dictionary under "Captcha is passed successfully!"
 judge_context:
   - The agent must solve the captcha
-  - The hostname should be example.com
+  - The hostname returned should be "example.com"
 max_steps: 6

--- a/tests/ci/test_browser_session_downloads.py
+++ b/tests/ci/test_browser_session_downloads.py
@@ -8,7 +8,7 @@ import pytest
 from browser_use.browser import BrowserSession
 
 
-@pytest.fixture
+@pytest.fixture(scope='function')
 async def test_server(httpserver):
 	"""Setup test HTTP server with a simple page."""
 	html_content = """
@@ -32,7 +32,6 @@ async def test_server(httpserver):
 	return httpserver
 
 
-@pytest.mark.asyncio
 async def test_download_detection_timing(test_server, tmp_path):
 	"""Test that download detection adds 5 second delay to clicks when downloads_dir is set."""
 
@@ -118,7 +117,6 @@ async def test_download_detection_timing(test_server, tmp_path):
 	assert duration_no_downloads < 3, f'Expected <3s without downloads_dir, got {duration_no_downloads:.2f}s'
 
 
-@pytest.mark.asyncio
 async def test_actual_download_detection(test_server, tmp_path):
 	"""Test that actual downloads are detected correctly."""
 

--- a/tests/ci/test_browser_session_start.py
+++ b/tests/ci/test_browser_session_start.py
@@ -784,7 +784,9 @@ class TestBrowserSessionReusePatterns:
 				},
 				"action": [
 					{
-						"create_new_tab": {}
+						"open_tab": {
+							"url": "https://example.com"
+						}
 					}
 				]
 			}
@@ -840,8 +842,20 @@ class TestBrowserSessionReusePatterns:
 			results = await asyncio.gather(agent1.run(), agent2.run(), agent3.run())
 
 			# Verify all agents used the same browser session (using __eq__ to check browser_pid, cdp_url, wss_url)
-			assert agent1.browser_session == agent2.browser_session == agent3.browser_session
-			assert agent1.browser_session == shared_browser
+			# Debug: print the browser sessions to see what's different
+			print(f'Agent1 session: {agent1.browser_session}')
+			print(f'Agent2 session: {agent2.browser_session}')
+			print(f'Agent3 session: {agent3.browser_session}')
+			print(f'Shared session: {shared_browser}')
+
+			# Check each pair individually
+			assert agent1.browser_session == agent2.browser_session, (
+				f'agent1 != agent2: {agent1.browser_session} != {agent2.browser_session}'
+			)
+			assert agent2.browser_session == agent3.browser_session, (
+				f'agent2 != agent3: {agent2.browser_session} != {agent3.browser_session}'
+			)
+			assert agent1.browser_session == shared_browser, f'agent1 != shared: {agent1.browser_session} != {shared_browser}'
 			assert shared_browser.initialized
 
 			# Verify multiple tabs were created

--- a/tests/ci/test_browser_session_start.py
+++ b/tests/ci/test_browser_session_start.py
@@ -16,8 +16,8 @@ from pathlib import Path
 import pytest
 
 from browser_use.browser.profile import (
+	BROWSERUSE_CHROMIUM_USER_DATA_DIR,
 	BROWSERUSE_DEFAULT_CHANNEL,
-	BROWSERUSE_DEFAULT_PROFILE_DIR,
 	BrowserChannel,
 	BrowserProfile,
 )
@@ -495,7 +495,7 @@ class TestBrowserSessionStart:
 		# Test 1: Chromium with default user_data_dir and default channel should work fine
 		session = BrowserSession(
 			headless=True,
-			user_data_dir=BROWSERUSE_DEFAULT_PROFILE_DIR,
+			user_data_dir=BROWSERUSE_CHROMIUM_USER_DATA_DIR,
 			channel=BROWSERUSE_DEFAULT_CHANNEL,  # chromium
 			keep_alive=False,
 		)
@@ -505,21 +505,21 @@ class TestBrowserSessionStart:
 			assert session.initialized is True
 			assert session.browser_context is not None
 			# Verify the user_data_dir wasn't changed
-			assert session.browser_profile.user_data_dir == BROWSERUSE_DEFAULT_PROFILE_DIR
+			assert session.browser_profile.user_data_dir == BROWSERUSE_CHROMIUM_USER_DATA_DIR
 		finally:
 			await session.kill()
 
 		# Test 2: Chrome with default user_data_dir should show warning and change dir
 		profile2 = BrowserProfile(
 			headless=True,
-			user_data_dir=BROWSERUSE_DEFAULT_PROFILE_DIR,
+			user_data_dir=BROWSERUSE_CHROMIUM_USER_DATA_DIR,
 			channel=BrowserChannel.CHROME,
 			keep_alive=False,
 		)
 
 		# The validator should have changed the user_data_dir
-		assert profile2.user_data_dir != BROWSERUSE_DEFAULT_PROFILE_DIR
-		assert profile2.user_data_dir == BROWSERUSE_DEFAULT_PROFILE_DIR.parent / 'default-chrome'
+		assert profile2.user_data_dir != BROWSERUSE_CHROMIUM_USER_DATA_DIR
+		assert profile2.user_data_dir == BROWSERUSE_CHROMIUM_USER_DATA_DIR.parent / 'default-chrome'
 
 		# Check warning was logged
 		warning_found = any(

--- a/tests/ci/test_browser_session_start.py
+++ b/tests/ci/test_browser_session_start.py
@@ -734,8 +734,7 @@ class TestBrowserSessionReusePatterns:
 			assert reused_session.initialized
 
 		finally:
-			# Clean up
-			await reused_session.close()
+			await reused_session.kill()
 
 	async def test_parallel_agents_same_browser_multiple_tabs(self):
 		"""Test Parallel Agents, Same Browser, Multiple Tabs pattern"""
@@ -856,8 +855,7 @@ class TestBrowserSessionReusePatterns:
 			assert len(tabs_info) >= 3
 
 		finally:
-			# Clean up
-			await shared_browser.close()
+			await shared_browser.kill()
 			storage_state_path.unlink(missing_ok=True)
 
 	async def test_parallel_agents_same_browser_same_tab(self, mock_llm):
@@ -904,7 +902,7 @@ class TestBrowserSessionReusePatterns:
 
 		finally:
 			# Clean up
-			await shared_browser.close()
+			await shared_browser.kill()
 
 	async def test_parallel_agents_same_profile_different_browsers(self, mock_llm):
 		"""Test Parallel Agents, Same Profile, Different Browsers pattern (recommended)"""
@@ -964,7 +962,6 @@ class TestBrowserSessionReusePatterns:
 			assert Path(auth_json_path).exists()
 
 		finally:
-			# Clean up
-			await window1.close()
-			await window2.close()
+			await window1.kill()
+			await window2.kill()
 			auth_json_path.unlink(missing_ok=True)

--- a/tests/ci/test_browser_session_start.py
+++ b/tests/ci/test_browser_session_start.py
@@ -42,15 +42,7 @@ class TestBrowserSessionStart:
 		"""Create a BrowserSession instance without starting it."""
 		session = BrowserSession(browser_profile=browser_profile)
 		yield session
-		# Cleanup: ensure session is stopped
-		try:
-			# logger.info(f'Fixture cleanup: keep_alive={session.browser_profile.keep_alive}, setting to False')
-			session.browser_profile.keep_alive = False
-			await session.stop()
-			# logger.info('Fixture cleanup completed')
-		except Exception as e:
-			# logger.error(f'Fixture cleanup failed: {e}')
-			pass
+		await session.kill()
 
 	async def test_start_already_started_session(self, browser_session):
 		"""Test calling .start() on a session that's already started."""

--- a/tests/ci/test_browser_session_start.py
+++ b/tests/ci/test_browser_session_start.py
@@ -487,14 +487,7 @@ class TestBrowserSessionStart:
 			assert session.browser.is_connected()
 
 		finally:
-			# Force complete cleanup
-			session.browser_profile.keep_alive = False
-			await session.stop()
-
-			# Ensure playwright is stopped
-			if hasattr(session, 'playwright') and session.playwright:
-				await session.playwright.stop()
-				session.playwright = None
+			await session.kill()
 
 	async def test_user_data_dir_not_allowed_to_corrupt_default_profile(self, caplog):
 		"""Test user_data_dir handling for different browser channels and version mismatches."""
@@ -514,8 +507,7 @@ class TestBrowserSessionStart:
 			# Verify the user_data_dir wasn't changed
 			assert session.browser_profile.user_data_dir == BROWSERUSE_DEFAULT_PROFILE_DIR
 		finally:
-			session.browser_profile.keep_alive = False
-			await session.stop()
+			await session.kill()
 
 		# Test 2: Chrome with default user_data_dir should show warning and change dir
 		profile2 = BrowserProfile(
@@ -876,6 +868,7 @@ class TestBrowserSessionReusePatterns:
 		shared_browser = BrowserSession(
 			user_data_dir=None,
 			headless=True,
+			keep_alive=True,  # Keep the browser alive for reuse
 		)
 
 		try:

--- a/tests/ci/test_browser_session_via_cdp.py
+++ b/tests/ci/test_browser_session_via_cdp.py
@@ -4,7 +4,7 @@ from playwright.async_api import async_playwright
 from browser_use.browser import BrowserSession
 
 
-async def test_connection_via_cdp(monkeypatch):
+async def test_connection_via_cdp():
 	browser_session = BrowserSession(
 		cdp_url='http://localhost:9898',
 	)
@@ -17,11 +17,10 @@ async def test_connection_via_cdp(monkeypatch):
 	playwright = await async_playwright().start()
 	browser = await playwright.chromium.launch(args=['--remote-debugging-port=9898'])
 
-	await browser_session.start()
-	await browser_session.create_new_tab()
+	async with await browser_session.start():
+		await browser_session.create_new_tab()
 
-	assert (await browser_session.get_current_page()).url == 'about:blank'
+		assert (await browser_session.get_current_page()).url == 'about:blank'
 
-	await browser_session.close()
-	await browser.close()
-	await playwright.stop()
+		await browser_session.close()
+		await browser.close()

--- a/tests/ci/test_browser_session_viewport_and_proxy.py
+++ b/tests/ci/test_browser_session_viewport_and_proxy.py
@@ -1,4 +1,4 @@
-from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.browser import BrowserSession
 from browser_use.browser.profile import ProxySettings
 
 
@@ -32,73 +32,66 @@ async def test_window_size_with_real_browser():
 	This test is skipped in CI environments.
 	"""
 	# Create browser profile with headless mode and specific dimensions
-	browser_profile = BrowserProfile(
+	browser_session = BrowserSession(
 		user_data_dir=None,
 		headless=True,  # window size gets converted to viewport size in headless mode
 		window_size={'width': 999, 'height': 888},
 		maximum_wait_page_load_time=2.0,
 		minimum_wait_page_load_time=0.2,
 	)
+	await browser_session.start()
+	page = await browser_session.get_current_page()
+	assert page is not None, 'Failed to get current page'
 
-	# Create browser session
-	browser_session = BrowserSession(browser_profile=browser_profile)
-	try:
-		await browser_session.start()
-		# Get the current page
-		page = await browser_session.get_current_page()
-		assert page is not None, 'Failed to get current page'
+	# Get the context configuration used for browser window size
+	video_size = await page.evaluate("""
+			() => {
+				// This returns information about the context recording settings
+				// which should match our configured video size (browser_window_size)
+				try {
+					const settings = window.getPlaywrightContextSettings ? 
+						window.getPlaywrightContextSettings() : null;
+					if (settings && settings.recordVideo) {
+						return settings.recordVideo.size;
+					}
+				} catch (e) {}
+				
+				// Fallback to window dimensions
+				return {
+					width: window.innerWidth,
+					height: window.innerHeight
+				};
+			}
+		""")
 
-		# Get the context configuration used for browser window size
-		video_size = await page.evaluate("""
-                () => {
-                    // This returns information about the context recording settings
-                    // which should match our configured video size (browser_window_size)
-                    try {
-                        const settings = window.getPlaywrightContextSettings ? 
-                            window.getPlaywrightContextSettings() : null;
-                        if (settings && settings.recordVideo) {
-                            return settings.recordVideo.size;
-                        }
-                    } catch (e) {}
-                    
-                    // Fallback to window dimensions
-                    return {
-                        width: window.innerWidth,
-                        height: window.innerHeight
-                    };
-                }
-            """)
+	# Let's also check the viewport size
+	actual_size = await page.evaluate("""
+			() => {
+				return {
+					width: window.innerWidth,
+					height: window.innerHeight
+				}
+			}
+		""")
 
-		# Let's also check the viewport size
-		actual_size = await page.evaluate("""
-                () => {
-                    return {
-                        width: window.innerWidth,
-                        height: window.innerHeight
-                    }
-                }
-            """)
+	print(f'Browser configured window_size={browser_session.browser_profile.window_size}')
+	print(f'Browser configured viewport_size: {browser_session.browser_profile.viewport}')
+	print(f'Browser content actual size: {actual_size}')
 
-		print(f'Browser configured window_size={browser_session.browser_profile.window_size}')
-		print(f'Browser configured viewport_size: {browser_session.browser_profile.viewport}')
-		print(f'Browser content actual size: {actual_size}')
+	# This is a lightweight test to verify that the page has a size (details may vary by browser)
+	assert actual_size['width'] > 0, 'Expected viewport width to be positive'
+	assert actual_size['height'] > 0, 'Expected viewport height to be positive'
 
-		# This is a lightweight test to verify that the page has a size (details may vary by browser)
-		assert actual_size['width'] > 0, 'Expected viewport width to be positive'
-		assert actual_size['height'] > 0, 'Expected viewport height to be positive'
-
-		# assert that window_size got converted to viewport_size in headless mode
-		assert browser_session.browser_profile.headless is True
-		assert browser_session.browser_profile.viewport == {'width': 999, 'height': 888}
-		assert browser_session.browser_profile.window_size is None
-		assert browser_session.browser_profile.window_position is None
-		assert browser_session.browser_profile.no_viewport is False
-		# screen should be the detected display size (or default if no display detected)
-		assert browser_session.browser_profile.screen is not None
-		assert browser_session.browser_profile.screen['width'] > 0
-		assert browser_session.browser_profile.screen['height'] > 0
-	finally:
-		await browser_session.stop()
+	# assert that window_size got converted to viewport_size in headless mode
+	assert browser_session.browser_profile.headless is True
+	assert browser_session.browser_profile.viewport == {'width': 999, 'height': 888}
+	assert browser_session.browser_profile.window_size is None
+	assert browser_session.browser_profile.window_position is None
+	assert browser_session.browser_profile.no_viewport is False
+	# screen should be the detected display size (or default if no display detected)
+	assert browser_session.browser_profile.screen is not None
+	assert browser_session.browser_profile.screen['width'] > 0
+	assert browser_session.browser_profile.screen['height'] > 0
 
 
 async def test_proxy_with_real_browser():
@@ -122,22 +115,17 @@ async def test_proxy_with_real_browser():
 	assert isinstance(proxy_dict, dict)
 	assert proxy_dict['server'] == 'http://non.existent.proxy:9999'
 
-	# Create browser profile with proxy
-	browser_profile = BrowserProfile(
+	# Create browser session
+	browser_session = BrowserSession(
 		headless=True,
 		proxy=proxy_settings,
 		user_data_dir=None,
 	)
+	await browser_session.start()
+	# Success - the browser was initialized with our proxy settings
+	# We won't try to make requests (which would fail with non-existent proxy)
+	print('✅ Browser initialized with proxy settings successfully')
+	assert browser_session.browser_profile.proxy == proxy_settings
 
-	# Create browser session
-	browser_session = BrowserSession(browser_profile=browser_profile)
-	try:
-		await browser_session.start()
-		# Success - the browser was initialized with our proxy settings
-		# We won't try to make requests (which would fail with non-existent proxy)
-		print('✅ Browser initialized with proxy settings successfully')
-		assert browser_session.browser_profile.proxy == proxy_settings
-		# TODO: create a network request in the browser and verify it goes through the proxy?
-		# would require setting up a whole fake proxy in a fixture
-	finally:
-		await browser_session.stop()
+	# TODO: create a network request in the browser and verify it goes through the proxy?
+	# would require setting up a whole fake proxy in a fixture


### PR DESCRIPTION
## Lessons Learned

- playwright really doesn't ever allow more than one playwright API object in scope per thread `await async_playwright().start()`
- playwright wont let you start a new playwright API object after you call `.stop()` on the first one
- playwright will handle cleaning it up when your process exits, trying to close it prematurely usually just causes problems
- `BrowserSession` agent state (current page, cached dom tree, etc) should likely be tracked separately from session connection state like `browser_pid`, `browser_context`, etc.

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Improved BrowserSession re-use by requiring sessions with keep_alive=True to be started before passing to Agent, added equality checks for sessions, clarified documentation, and expanded tests for all documented re-use patterns.

- **Bug Fixes**
  - Raise an error if an uninitialized keep_alive session is passed to Agent.
  - Fix storage_state save logic and downloads timing tests.
  - Only bring agent tab to front when needed.

- **Docs and Tests**
  - Updated docs to clarify manual start/stop for keep_alive sessions.
  - Added tests covering all browser re-use examples.

<!-- End of auto-generated description by cubic. -->

