### PR TITLE
fix: remove non-functional save_recording_path parameter

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -599,7 +599,6 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	profile_directory: str = 'Default'  # e.g. 'Profile 1', 'Profile 2', 'Custom Profile', etc.
 
-	save_recording_path: str | None = Field(default=None, description='Directory for video recordings.')
 	save_har_path: str | None = Field(default=None, description='Directory for saving HAR files.')
 	trace_path: str | None = Field(default=None, description='Directory for saving trace files.')
 

--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -376,14 +376,6 @@ window_position: dict | None = {"width": 0, "height": 0}
 
 Window position from top-left corner.
 
-#### `save_recording_path`
-
-```python
-save_recording_path: str | None = None
-```
-
-Directory path for saving video recordings.
-
 #### `trace_path`
 
 ```python
@@ -797,6 +789,10 @@ record_video_dir: str | Path | None = None
 ```
 
 Directory to save video recordings. [Playwright Docs: `record_video_dir`](https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-persistent-context-option-record-video-dir)
+
+<Note>
+This is the standard Playwright parameter for video recording. If you previously used `save_recording_path`, please update your code to use `record_video_dir` instead.
+</Note>
 
 #### `record_video_size`
 

--- a/examples/features/parallel_agents.py
+++ b/examples/features/parallel_agents.py
@@ -17,7 +17,7 @@ browser_session = BrowserSession(
 	browser_profile=BrowserProfile(
 		disable_security=True,
 		headless=False,
-		save_recording_path='./tmp/recordings',
+		record_video_dir='./tmp/recordings',
 		user_data_dir='~/.config/browseruse/profiles/default',
 	)
 )


### PR DESCRIPTION
- Remove save_recording_path field from BrowserProfile class
- Remove documentation for save_recording_path parameter
- Add migration note directing users to use record_video_dir instead

The save_recording_path parameter was defined in BrowserProfile but never actually processed by the browser launch methods. Users should use the standard Playwright record_video_dir parameter instead, which is properly implemented and functional.

Fixes user reports of video recording not working when using save_recording_path as mentioned in #1935 