### PR TITLE
centralize playwright/patchwright imports, and update typing/checks to reduce lint errors

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -25,7 +25,6 @@ from langchain_core.messages import (
 	HumanMessage,
 	SystemMessage,
 )
-from playwright.async_api import Browser, BrowserContext, Page
 from pydantic import BaseModel, ValidationError
 from uuid_extensions import uuid7str
 
@@ -68,6 +67,7 @@ from browser_use.telemetry.service import ProductTelemetry
 from browser_use.telemetry.views import (
 	AgentTelemetryEvent,
 )
+from browser_use.typing import Browser, BrowserContext, Page
 from browser_use.utils import get_browser_use_version, time_execution_async, time_execution_sync
 
 logger = logging.getLogger(__name__)
@@ -435,11 +435,13 @@ class Agent(Generic[Context]):
 	@property
 	def browser(self) -> Browser:
 		assert self.browser_session is not None, 'BrowserSession is not set up'
+		assert self.browser_session.browser is not None, 'Browser is not set up'
 		return self.browser_session.browser
 
 	@property
 	def browser_context(self) -> BrowserContext:
 		assert self.browser_session is not None, 'BrowserSession is not set up'
+		assert self.browser_session.browser_context is not None, 'BrowserContext is not set up'
 		return self.browser_session.browser_context
 
 	@property

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -8,32 +8,11 @@ from re import Pattern
 from typing import Annotated, Any, Literal, Self
 from urllib.parse import urlparse
 
-from playwright._impl._api_structures import (
-	ClientCertificate,
-	Geolocation,
-	HttpCredentials,
-	ProxySettings,
-	StorageState,
-	ViewportSize,
-)
 from pydantic import AfterValidator, AliasChoices, BaseModel, ConfigDict, Field, model_validator
 from uuid_extensions import uuid7str
 
+from browser_use.typing import ClientCertificate, Geolocation, HttpCredentials, ProxySettings, ViewportSize
 from browser_use.utils import _log_pretty_path, logger
-
-# fix pydantic error on python 3.11
-# PydanticUserError: Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12.
-# For further information visit https://errors.pydantic.dev/2.10/u/typed-dict-version
-if sys.version_info < (3, 12):
-	from typing_extensions import TypedDict
-
-	# convert new-style typing.TypedDict used by playwright to old-style typing_extensions.TypedDict used by pydantic
-	ClientCertificate = TypedDict('ClientCertificate', ClientCertificate.__annotations__, total=ClientCertificate.__total__)
-	Geolocation = TypedDict('Geolocation', Geolocation.__annotations__, total=Geolocation.__total__)
-	ProxySettings = TypedDict('ProxySettings', ProxySettings.__annotations__, total=ProxySettings.__total__)
-	ViewportSize = TypedDict('ViewportSize', ViewportSize.__annotations__, total=ViewportSize.__total__)
-	HttpCredentials = TypedDict('HttpCredentials', HttpCredentials.__annotations__, total=HttpCredentials.__total__)
-	StorageState = TypedDict('StorageState', StorageState.__annotations__, total=StorageState.__total__)
 
 IN_DOCKER = os.environ.get('IN_DOCKER', 'false').lower()[0] in 'ty1'
 CHROME_DEBUG_PORT = 9242  # use a non-default port to avoid conflicts with other tools / devs using 9222

--- a/browser_use/controller/registry/service.py
+++ b/browser_use/controller/registry/service.py
@@ -8,7 +8,6 @@ from inspect import Parameter, iscoroutinefunction, signature
 from typing import Any, Generic, Optional, TypeVar, Union, get_args, get_origin
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from playwright.async_api import Page
 from pydantic import BaseModel, Field, create_model
 
 from browser_use.browser import BrowserSession
@@ -23,6 +22,7 @@ from browser_use.telemetry.views import (
 	ControllerRegisteredFunctionsTelemetryEvent,
 	RegisteredFunction,
 )
+from browser_use.typing import Page
 from browser_use.utils import match_url_with_domain_pattern, time_execution_async
 
 Context = TypeVar('Context')
@@ -366,7 +366,9 @@ class Registry(Generic[Context]):
 			url_info = f' on {current_url}' if current_url and current_url != 'about:blank' else ''
 			logger.info(f'🔒 Using sensitive data placeholders: {", ".join(sorted(placeholders_used))}{url_info}')
 
-	def _replace_sensitive_data(self, params: BaseModel, sensitive_data: dict[str, Any], current_url: str = None) -> BaseModel:
+	def _replace_sensitive_data(
+		self, params: BaseModel, sensitive_data: dict[str, Any], current_url: str | None = None
+	) -> BaseModel:
 		"""
 		Replaces sensitive data placeholders in params with actual values.
 

--- a/browser_use/controller/registry/views.py
+++ b/browser_use/controller/registry/views.py
@@ -2,10 +2,10 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from playwright.async_api import Page
 from pydantic import BaseModel, ConfigDict
 
 from browser_use.browser import BrowserSession
+from browser_use.typing import Page
 
 if TYPE_CHECKING:
 	from browser_use.agent.service import Context

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -159,6 +159,7 @@ class Controller(Generic[Context]):
 			msg = None
 
 			try:
+				assert element_node is not None, f'Element with index {params.index} does not exist'
 				download_path = await browser_session._click_element_node(element_node)
 				if download_path:
 					msg = f'💾  Downloaded file to {download_path}'
@@ -195,6 +196,7 @@ class Controller(Generic[Context]):
 				raise Exception(f'Element index {params.index} does not exist - retry or use alternative actions')
 
 			element_node = await browser_session.get_dom_element_by_index(params.index)
+			assert element_node is not None, f'Element with index {params.index} does not exist'
 			await browser_session._input_text_element_node(element_node, params.text)
 			if not has_sensitive_data:
 				msg = f'⌨️  Input {params.text} into index {params.index}'
@@ -901,7 +903,7 @@ class Controller(Generic[Context]):
 		browser_session: BrowserSession,
 		#
 		page_extraction_llm: BaseChatModel | None = None,
-		sensitive_data: dict[str, str] | None = None,
+		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		available_file_paths: list[str] | None = None,
 		#
 		context: Context | None = None,

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -7,7 +7,6 @@ from typing import Generic, TypeVar, cast
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.prompts import PromptTemplate
-from playwright.async_api import ElementHandle, Page
 
 # from lmnr.sdk.laminar import Laminar
 from pydantic import BaseModel
@@ -30,6 +29,7 @@ from browser_use.controller.views import (
 	SendKeysAction,
 	SwitchTabAction,
 )
+from browser_use.typing import ElementHandle, Page
 from browser_use.utils import time_execution_sync
 
 logger = logging.getLogger(__name__)

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
-	from playwright.async_api import Page
+	from browser_use.typing import Page
 
 from browser_use.dom.views import (
 	DOMBaseNode,

--- a/browser_use/dom/tests/test_accessibility_playground.py
+++ b/browser_use/dom/tests/test_accessibility_playground.py
@@ -14,7 +14,7 @@ Run with: python browser_use/dom/tests/test_accessibility_playground.py
 
 import asyncio
 
-from playwright.async_api import async_playwright
+from browser_use.typing import async_playwright
 
 # Change this to any site you want to test
 

--- a/browser_use/typing/__init__.py
+++ b/browser_use/typing/__init__.py
@@ -1,0 +1,53 @@
+# centralize imports for browser typing
+
+import sys
+
+from patchright.async_api import Browser as PatchrightBrowser
+from patchright.async_api import BrowserContext as PatchrightBrowserContext
+from patchright.async_api import ElementHandle as PatchrightElementHandle
+from patchright.async_api import FrameLocator as PatchrightFrameLocator
+from patchright.async_api import Page as PatchrightPage
+from patchright.async_api import Playwright as _Patchright
+from patchright.async_api import async_playwright as _async_patchright
+from playwright.async_api import Browser as PlaywrightBrowser
+from playwright.async_api import BrowserContext as PlaywrightBrowserContext
+from playwright.async_api import ElementHandle as PlaywrightElementHandle
+from playwright.async_api import FrameLocator as PlaywrightFrameLocator
+from playwright.async_api import Page as PlaywrightPage
+from playwright.async_api import Playwright as _Playwright
+from playwright.async_api import async_playwright as _async_playwright
+from pydantic import InstanceOf
+
+# Define types to be Union[Patchright, Playwright]
+Browser = InstanceOf[PatchrightBrowser] | InstanceOf[PlaywrightBrowser]
+BrowserContext = InstanceOf[PatchrightBrowserContext] | InstanceOf[PlaywrightBrowserContext]
+Page = InstanceOf[PatchrightPage] | InstanceOf[PlaywrightPage]
+ElementHandle = InstanceOf[PatchrightElementHandle] | InstanceOf[PlaywrightElementHandle]
+FrameLocator = InstanceOf[PatchrightFrameLocator] | InstanceOf[PlaywrightFrameLocator]
+PlaywrightOrPatchright = InstanceOf[_Patchright] | InstanceOf[_Playwright]
+
+async_patchright = _async_patchright
+async_playwright = _async_playwright
+
+from playwright._impl._api_structures import (
+	ClientCertificate,
+	Geolocation,
+	HttpCredentials,
+	ProxySettings,
+	StorageState,
+	ViewportSize,
+)
+
+# fix pydantic error on python 3.11
+# PydanticUserError: Please use `typing_extensions.TypedDict` instead of `typing.TypedDict` on Python < 3.12.
+# For further information visit https://errors.pydantic.dev/2.10/u/typed-dict-version
+if sys.version_info < (3, 12):
+	from typing_extensions import TypedDict
+
+	# convert new-style typing.TypedDict used by playwright to old-style typing_extensions.TypedDict used by pydantic
+	ClientCertificate = TypedDict('ClientCertificate', ClientCertificate.__annotations__, total=ClientCertificate.__total__)
+	Geolocation = TypedDict('Geolocation', Geolocation.__annotations__, total=Geolocation.__total__)
+	ProxySettings = TypedDict('ProxySettings', ProxySettings.__annotations__, total=ProxySettings.__total__)
+	ViewportSize = TypedDict('ViewportSize', ViewportSize.__annotations__, total=ViewportSize.__total__)
+	HttpCredentials = TypedDict('HttpCredentials', HttpCredentials.__annotations__, total=HttpCredentials.__total__)
+	StorageState = TypedDict('StorageState', StorageState.__annotations__, total=StorageState.__total__)

--- a/browser_use/typing/__init__.py
+++ b/browser_use/typing/__init__.py
@@ -16,15 +16,14 @@ from playwright.async_api import FrameLocator as PlaywrightFrameLocator
 from playwright.async_api import Page as PlaywrightPage
 from playwright.async_api import Playwright as _Playwright
 from playwright.async_api import async_playwright as _async_playwright
-from pydantic import InstanceOf
 
 # Define types to be Union[Patchright, Playwright]
-Browser = InstanceOf[PatchrightBrowser] | InstanceOf[PlaywrightBrowser]
-BrowserContext = InstanceOf[PatchrightBrowserContext] | InstanceOf[PlaywrightBrowserContext]
-Page = InstanceOf[PatchrightPage] | InstanceOf[PlaywrightPage]
-ElementHandle = InstanceOf[PatchrightElementHandle] | InstanceOf[PlaywrightElementHandle]
-FrameLocator = InstanceOf[PatchrightFrameLocator] | InstanceOf[PlaywrightFrameLocator]
-PlaywrightOrPatchright = InstanceOf[_Patchright] | InstanceOf[_Playwright]
+Browser = PatchrightBrowser | PlaywrightBrowser
+BrowserContext = PatchrightBrowserContext | PlaywrightBrowserContext
+Page = PatchrightPage | PlaywrightPage
+ElementHandle = PatchrightElementHandle | PlaywrightElementHandle
+FrameLocator = PatchrightFrameLocator | PlaywrightFrameLocator
+PlaywrightOrPatchright = _Patchright | _Playwright
 
 async_patchright = _async_patchright
 async_playwright = _async_playwright

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -539,7 +539,7 @@ def get_browser_use_version() -> str:
 		return 'unknown'
 
 
-def _log_pretty_path(path: Path | None) -> str:
+def _log_pretty_path(path: str | Path | None) -> str:
 	"""Pretty-print a path, shorten home dir to ~ and cwd to ."""
 
 	if not path or not str(path).strip():

--- a/examples/browser/stealth.py
+++ b/examples/browser/stealth.py
@@ -12,9 +12,9 @@ load_dotenv()
 
 from imgcat import imgcat
 from langchain_openai import ChatOpenAI
-from patchright.async_api import async_playwright as async_patchright
 
 from browser_use.browser import BrowserSession
+from browser_use.typing import async_patchright
 
 llm = ChatOpenAI(model='gpt-4o')
 

--- a/examples/custom-functions/action_filters.py
+++ b/examples/custom-functions/action_filters.py
@@ -28,10 +28,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from langchain_openai import ChatOpenAI
-from playwright.async_api import Page
 
 from browser_use.agent.service import Agent, Controller
 from browser_use.browser import BrowserSession
+from browser_use.typing import Page
 
 # Initialize controller and registry
 controller = Controller()

--- a/examples/custom-functions/clipboard.py
+++ b/examples/custom-functions/clipboard.py
@@ -10,11 +10,11 @@ load_dotenv()
 
 import pyperclip
 from langchain_openai import ChatOpenAI
-from playwright.async_api import Page
 
 from browser_use import Agent, Controller
 from browser_use.agent.views import ActionResult
 from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.typing import Page
 
 browser_profile = BrowserProfile(
 	headless=False,

--- a/examples/features/multiple_tasks.py
+++ b/examples/features/multiple_tasks.py
@@ -9,11 +9,11 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from langchain_google_genai import ChatGoogleGenerativeAI
-from playwright.async_api import async_playwright
 from pydantic import SecretStr
 
 from browser_use import Agent
 from browser_use.browser import BrowserSession
+from browser_use.typing import async_playwright
 
 api_key = os.getenv('GOOGLE_API_KEY')
 

--- a/tests/ci/test_agent_multiprocessing.py
+++ b/tests/ci/test_agent_multiprocessing.py
@@ -19,10 +19,10 @@ from unittest.mock import AsyncMock
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage
-from playwright.async_api import async_playwright
 
 from browser_use import Agent, setup_logging
 from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.typing import async_playwright
 
 # Set up test logging
 setup_logging()

--- a/tests/ci/test_browser_session_via_cdp.py
+++ b/tests/ci/test_browser_session_via_cdp.py
@@ -1,7 +1,7 @@
 import pytest
-from playwright.async_api import async_playwright
 
 from browser_use.browser import BrowserSession
+from browser_use.typing import async_playwright
 
 
 async def test_connection_via_cdp():

--- a/tests/ci/test_registry.py
+++ b/tests/ci/test_registry.py
@@ -752,7 +752,7 @@ class TestValidationRules:
 		registry = Registry()
 
 		# Using 'page' with str type should error
-		with pytest.raises(ValueError, match='conflicts with special argument.*page: Page'):
+		with pytest.raises(ValueError, match=rf'conflicts with special argument.*page: {repr(Page)}'):
 
 			@registry.action('Navigate')
 			async def navigate_to_page(page: str, browser_session: BrowserSession):
@@ -926,7 +926,7 @@ class TestErrorMessages:
 			error_msg = str(e)
 			assert 'page: str' in error_msg
 			assert 'conflicts' in error_msg
-			assert 'page: Page' in error_msg  # Show expected type
+			assert f'page: {repr(Page)}' in error_msg  # Show expected type
 			assert 'bad' in error_msg.lower()  # Show function name
 
 

--- a/tests/ci/test_registry.py
+++ b/tests/ci/test_registry.py
@@ -14,7 +14,6 @@ import asyncio
 import logging
 
 import pytest
-from playwright.async_api import Page
 from pydantic import Field
 from pytest_httpserver import HTTPServer
 from pytest_httpserver.httpserver import HandlerType
@@ -29,6 +28,7 @@ from browser_use.controller.views import (
 	NoParamsAction,
 	SearchGoogleAction,
 )
+from browser_use.typing import Page
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)

--- a/tests/test_action_filters.py
+++ b/tests/test_action_filters.py
@@ -1,11 +1,11 @@
 from unittest.mock import MagicMock
 
 import pytest
-from playwright.async_api import Page
 from pydantic import BaseModel
 
 from browser_use.controller.registry.service import Registry
 from browser_use.controller.registry.views import ActionRegistry, RegisteredAction
+from browser_use.typing import Page
 
 
 class EmptyParamModel(BaseModel):

--- a/tests/test_full_screen.py
+++ b/tests/test_full_screen.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from playwright.async_api import async_playwright
+from browser_use.typing import async_playwright
 
 
 async def test_full_screen(start_fullscreen: bool, maximize: bool):


### PR DESCRIPTION
* Centralized imports from both Playwright and Patchwright into a single, unified module. Prevents scattered imports across the codebase.
* Refactored type definitions and runtime type checks for better readability and consistency.
* Updated lint rules to enforce stricter, more accurate typing.
* Cleaned up deprecated references and updated import paths—fixing lint errors.