### PR TITLE
perf: getCachedClientRects for isInExpandedViewport

### DIFF
--- a/browser_use/dom/buildDomTree.js
+++ b/browser_use/dom/buildDomTree.js
@@ -957,7 +957,7 @@
       return true;
     }
 
-    const rects = element.getClientRects(); // Use getClientRects
+    const rects = getCachedClientRects(element); // Use cached client rects
 
     if (!rects || rects.length === 0) {
       // Fallback to getBoundingClientRect if getClientRects is empty,


### PR DESCRIPTION
Use `getCachedClientRects` instead of `element.getClientRects` directly.

Optimize performance for `isInExpandedViewport` `isTopElement` same logic.