### PR TITLE
#1970 get_all_text_till_next_clickable_element returns incorrect text

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -177,15 +177,15 @@ class DOMElementNode(DOMBaseNode):
 
 						# if aria-label == text of the node, don't include it
 						if (
-								attributes_to_include.get('aria-label')
-								and attributes_to_include.get('aria-label', '').strip() == text.strip()
+							attributes_to_include.get('aria-label')
+							and attributes_to_include.get('aria-label', '').strip() == text.strip()
 						):
 							del attributes_to_include['aria-label']
 
 						# if placeholder == text of the node, don't include it
 						if (
-								attributes_to_include.get('placeholder')
-								and attributes_to_include.get('placeholder', '').strip() == text.strip()
+							attributes_to_include.get('placeholder')
+							and attributes_to_include.get('placeholder', '').strip() == text.strip()
 						):
 							del attributes_to_include['placeholder']
 
@@ -223,17 +223,14 @@ class DOMElementNode(DOMBaseNode):
 			elif isinstance(node, DOMTextNode):
 				# Add text only if it doesn't have a highlighted parent
 				if (
-						node.parent.highlight_index is None
-						and node.parent
-						and node.parent.is_visible
-						and node.parent.is_top_element
+					node.parent.highlight_index is None
+					and node.parent
+					and node.parent.is_visible
+					and node.parent.is_top_element
 				):  # and node.is_parent_top_element()
 					formatted_text.append(f'{depth_str}{node.text}')
 
-		try:
-			process_node(self, 0)
-		except Exception as e:
-			print(e)
+		process_node(self, 0)
 		return '\n'.join(formatted_text)
 
 

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -162,8 +162,6 @@ class DOMElementNode(DOMBaseNode):
 				# Add element with highlight_index
 				if node.highlight_index is not None:
 					next_depth += 1
-
-					text = node.get_all_text_till_next_clickable_element()
 					attributes_html_str = ''
 					if include_attributes:
 						attributes_to_include = {
@@ -174,20 +172,6 @@ class DOMElementNode(DOMBaseNode):
 						# if tag == role attribute, don't include it
 						if node.tag_name == attributes_to_include.get('role'):
 							del attributes_to_include['role']
-
-						# if aria-label == text of the node, don't include it
-						if (
-							attributes_to_include.get('aria-label')
-							and attributes_to_include.get('aria-label', '').strip() == text.strip()
-						):
-							del attributes_to_include['aria-label']
-
-						# if placeholder == text of the node, don't include it
-						if (
-							attributes_to_include.get('placeholder')
-							and attributes_to_include.get('placeholder', '').strip() == text.strip()
-						):
-							del attributes_to_include['placeholder']
 
 						if attributes_to_include:
 							# Format as key1='value1' key2='value2'
@@ -204,13 +188,7 @@ class DOMElementNode(DOMBaseNode):
 					if attributes_html_str:
 						line += f' {attributes_html_str}'
 
-					if text:
-						# Add space before >text only if there were NO attributes added before
-						if not attributes_html_str:
-							line += ' '
-						line += f'>{text}'
-					# Add space before /> only if neither attributes NOR text were added
-					elif not attributes_html_str:
+					if not attributes_html_str:
 						line += ' '
 
 					line += ' />'  # 1 token
@@ -222,13 +200,13 @@ class DOMElementNode(DOMBaseNode):
 
 			elif isinstance(node, DOMTextNode):
 				# Add text only if it doesn't have a highlighted parent
-				if (
-					not node.has_parent_with_highlight_index()
-					and node.parent
-					and node.parent.is_visible
-					and node.parent.is_top_element
-				):  # and node.is_parent_top_element()
-					formatted_text.append(f'{depth_str}{node.text}')
+				# if (
+				# 	not node.has_parent_with_highlight_index()
+				# 	and node.parent
+				# 	and node.parent.is_visible
+				# 	and node.parent.is_top_element
+				# ):  # and node.is_parent_top_element()
+				formatted_text.append(f'{depth_str}{node.text}')
 
 		process_node(self, 0)
 		return '\n'.join(formatted_text)


### PR DESCRIPTION
Fixed the issue of #1970 html structural disorder.
---

Call the `get_all_text_till_next_clickable_element` method with `max_depth=1` to only get the text nodes among the children of an interactive (clickable) node, without recursively processing descendant nodes. The processing of descendant nodes should be handled by the `clickable_elements_to_string` function with the following code:

```python
for child in node.children:
    process_node(child, next_depth)
```

Also, change

```python
not node.has_parent_with_highlight_index()
```

to

```python
node.parent.highlight_index is None
```

so that it does not recursively check ancestor nodes. This allows elements like "Gender" in the following HTML to be output:

```html
<div style="cursor: pointer;">
    <p>
        Gender:
    </p>
</div>
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed incorrect text extraction in get_all_text_till_next_clickable_element by improving how adjacent text nodes and tags are handled. This resolves HTML structure issues and changes how text is displayed for elements like <a> tags.

<!-- End of auto-generated description by cubic. -->

