### PR TITLE
remove unused success parameter from ActionResult in service.py

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -192,7 +192,7 @@ class Controller(Generic[Context]):
 					msg += f' - {new_tab_msg}'
 					logger.info(new_tab_msg)
 					await browser_session.switch_to_tab(-1)
-				return ActionResult(extracted_content=msg, include_in_memory=True, success=True)
+				return ActionResult(extracted_content=msg, include_in_memory=True)
 			except Exception as e:
 				error_msg = str(e)
 				if 'Execution context was destroyed' in error_msg or 'Cannot find context with specified id' in error_msg:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the unused success parameter from the ActionResult return in service.py to clean up the code.

<!-- End of auto-generated description by cubic. -->

