### PR TITLE
Update dependencies in pyproject.toml and rename evaluation workflow

### DIFF
--- a/.github/workflows/laminar_eval.yaml
+++ b/.github/workflows/laminar_eval.yaml
@@ -1,4 +1,4 @@
-name: Run Evaluation Script
+name: Run Laminar Eval Script
 
 on:
   repository_dispatch:
@@ -47,7 +47,7 @@ jobs:
           activate-environment: true
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra eval
 
       - name: Detect installed Playwright version
         id: playwright_version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,7 @@ dependencies = [
     "mem0ai>=0.1.106",
     "uuid7>=0.1.0",
     "patchright>=1.52.5",
-    "aiofiles>=24.1.0",
-    "lmnr[all]>=0.6.10",
-]
+    "aiofiles>=24.1.0"]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste
 # pyobjc: only used to get screen resolution on macOS
@@ -68,7 +66,7 @@ examples = [
     "browserbase>=0.4.0",
 ]
 eval = [
-    "lmnr[all]>=0.6.10",
+    "lmnr[all]>=0.6.11",
 ]
 all = [
     "browser-use[memory,cli,examples]",
@@ -164,6 +162,5 @@ dev-dependencies = [
     "pyright>=1.1.399",
     "ty>=0.0.1a1",
     # "pytest-playwright-asyncio>=0.7.0",  # not actually needed I think
-    "pytest-xdist>=3.7.0",
-    "lmnr[all]>=0.6.11",
+    "pytest-xdist>=3.7.0"
 ]


### PR DESCRIPTION
- Removed duplicate lmnr dependency from the `dependencies` section in `pyproject.toml`.
- Updated `lmnr` version to `0.6.11` in the `eval` extras group.
- Renamed the evaluation workflow from "Run Evaluation Script" to "Run Laminar Eval Script" for clarity.
- Adjusted the dependency installation command in the workflow to include the `--extra eval` flag.