### PR TITLE
Update evaluation workflow to use laminar_eval.py

### DIFF
--- a/.github/workflows/laminar_eval.yaml
+++ b/.github/workflows/laminar_eval.yaml
@@ -136,7 +136,7 @@ jobs:
 
           # Build command using array for cleaner construction
           CMD_ARGS=(
-            "python" "eval/service.py"
+            "python" "eval/laminar_eval.py"
             "--model" "$MODEL"
             "--eval-model" "$EVAL_MODEL"
             "--parallel-runs" "$PARALLEL_RUNS"


### PR DESCRIPTION
- Changed the script executed in the evaluation workflow from `eval/service.py` to `eval/laminar_eval.py` for consistency with recent updates.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the evaluation workflow to run eval/laminar_eval.py instead of eval/service.py for consistency with recent changes.

<!-- End of auto-generated description by cubic. -->

