### PR TITLE
add retry for actions that fail due to page navigation mid-action

### DIFF
--- a/tests/ci/test_controller.py
+++ b/tests/ci/test_controller.py
@@ -1195,7 +1195,7 @@ class TestControllerIntegration:
 
 		# This should fail if page_extraction_llm is not passed correctly
 		with pytest.raises(RuntimeError) as exc_info:
-			await controller.act(ExtractContentActionModel(**extract_action), browser_session)
+			await controller.act(ExtractContentActionModel(**extract_action), browser_session, page_extraction_llm=None)
 
 		# Should fail because page_extraction_llm is required but not provided
 		assert 'page_extraction_llm' in str(exc_info.value)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a retry for actions that fail due to page navigation errors, improving reliability when the page is closed or navigated away mid-action.

- **Bug Fixes**
  - Retries the action once with a fresh page if a page error occurs.
  - Added a test to confirm the retry logic works as expected.

<!-- End of auto-generated description by cubic. -->

