### PR TITLE
Pass laminar_eval_id from frontend

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -167,6 +167,7 @@ jobs:
           DEVELOPER_ID="${{ github.event.client_payload.script_args.developer_id }}"
           PLANNER_MODEL="${{ github.event.client_payload.script_args.planner_model }}"
           RUN_ID="${{ github.event.client_payload.script_args.run_id }}"
+          LAMINAR_EVAL_ID="${{ github.event.client_payload.script_args.laminar_eval_id }}"
 
           # Build command using array for cleaner construction
           CMD_ARGS=(
@@ -198,6 +199,7 @@ jobs:
           [[ -n "$DEVELOPER_ID" ]] && CMD_ARGS+=("--developer-id" "$DEVELOPER_ID")
           [[ -n "$PLANNER_MODEL" ]] && CMD_ARGS+=("--planner-model" "$PLANNER_MODEL")
           [[ -n "$RUN_ID" ]] && CMD_ARGS+=("--run-id" "$RUN_ID")
+          [[ -n "$LAMINAR_EVAL_ID" ]] && CMD_ARGS+=("--laminar-eval-id" "$LAMINAR_EVAL_ID")
 
           # Convert array to command string with proper escaping
           printf -v CMD_STRING '%q ' "${CMD_ARGS[@]}"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for passing an existing laminar_eval_id from the frontend to reuse Laminar evaluation runs instead of always creating new ones.

- **New Features**
  - Accepts laminar_eval_id as an argument in the evaluation pipeline and workflow.
  - Skips creating a new Laminar evaluation if an ID is provided.

<!-- End of auto-generated description by cubic. -->

