### PR TITLE
fix: fixing open file encoding error in windows

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -36,7 +36,7 @@ class SystemPrompt:
 		"""Load the prompt template from the markdown file."""
 		try:
 			# This works both in development and when installed as a package
-			with importlib.resources.files('browser_use.agent').joinpath('system_prompt.md').open('r') as f:
+			with importlib.resources.files('browser_use.agent').joinpath('system_prompt.md').open('r', encoding='utf-8') as f:
 				self.prompt_template = f.read()
 		except Exception as e:
 			raise RuntimeError(f'Failed to load system prompt template: {e}')


### PR DESCRIPTION
fix: [Bug: Failed to load system prompt template: 'gbk' codec can't decode byte 0x94 in position 2390: illegal multibyte sequence #2038](https://github.com/browser-use/browser-use/issues/2038)

In Python, when using the open() function without specifying an encoding, the default encoding is determined by:
Python 3.10+: defaults to using the encoding returned by locale.getpreferredencoding(False)

In my windows computer, locale.getpreferredencoding(False) return `cp936` (equivalent to GBK), so I add encoding param in open function to use `utf-8` encoding.
```
import locale

print(locale.getpreferredencoding(False))
```
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a file encoding error when loading the system prompt template on Windows by setting the file to open with UTF-8 encoding.

<!-- End of auto-generated description by cubic. -->

