### PR TITLE
Always generate a new temp `user_data_dir` to uniquely identify launched `browser_pid` when `user_data_dir=None`

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -643,6 +643,7 @@ class BrowserSession(BaseModel):
 					task._log_destroy_pending = False  # type: ignore
 			except Exception:
 				pass
+			self.playwright = None
 
 		atexit.register(shudown_playwright)
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -470,31 +470,8 @@ class BrowserSession(BaseModel):
 		self.browser_profile.keep_alive = False
 		await self.stop()
 
-		# Clean up playwright instance to prevent background tasks from running
-		if self.playwright:
-			try:
-				await self.playwright.stop()
-				# Give playwright tasks a moment to clean up properly
-				# This prevents "Task was destroyed but it is pending!" warnings
-				await asyncio.sleep(0.1)
-				# self.logger.debug('🎭 Stopped playwright node.js API worker')
-			except Exception as e:
-				self.logger.warning(f'❌ Error stopping playwright node.js API subprocess: {type(e).__name__}: {e}')
-			finally:
-				# Clear global references if they match this instance
-				global GLOBAL_PLAYWRIGHT_API_OBJECT, GLOBAL_PATCHRIGHT_API_OBJECT
-				global GLOBAL_PLAYWRIGHT_EVENT_LOOP, GLOBAL_PATCHRIGHT_EVENT_LOOP
-
-				if self.playwright == GLOBAL_PLAYWRIGHT_API_OBJECT:
-					GLOBAL_PLAYWRIGHT_API_OBJECT = None
-					GLOBAL_PLAYWRIGHT_EVENT_LOOP = None
-					# self.logger.debug('🧹 Cleared global playwright references')
-				elif self.playwright == GLOBAL_PATCHRIGHT_API_OBJECT:
-					GLOBAL_PATCHRIGHT_API_OBJECT = None
-					GLOBAL_PATCHRIGHT_EVENT_LOOP = None
-					# self.logger.debug('🧹 Cleared global patchright references')
-
-				self.playwright = None
+		# do not stop self.playwright here as its likely used by other parallel browser_sessions
+		# let it be cleaned up by the garbage collector when no refs use it anymore
 
 	async def new_context(self, **kwargs):
 		"""Deprecated: Provides backwards-compatibility with old class method Browser().new_context()."""

--- a/tests/ci/test_browser_session_start.py
+++ b/tests/ci/test_browser_session_start.py
@@ -485,8 +485,7 @@ class TestBrowserSessionStart:
 			await session.stop()
 			# Browser should still be connected
 			assert session.initialized is True
-			assert session.browser is not None
-			assert session.browser.is_connected()
+			assert session.browser_context and session.browser_context.pages[0]
 
 		finally:
 			await session.kill()

--- a/tests/ci/test_browser_session_start.py
+++ b/tests/ci/test_browser_session_start.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import logging
 from pathlib import Path
+import tempfile
 
 import pytest
 
@@ -572,53 +573,6 @@ class TestBrowserSessionStart:
 
 class TestBrowserSessionReusePatterns:
 	"""Tests for all browser re-use patterns documented in docs/customize/real-browser.mdx"""
-
-	@pytest.fixture(scope='module')
-	def mock_llm(self):
-		"""Mock LLM for agent tests"""
-		from unittest.mock import MagicMock
-
-		from langchain_core.language_models.chat_models import BaseChatModel
-
-		# Create a MagicMock that supports dictionary-style access
-		mock = MagicMock(spec=BaseChatModel)
-
-		# Skip verification by setting these attributes
-		mock._verified_api_keys = True
-		mock._verified_tool_calling_method = 'raw'
-		mock.model_name = 'mock-llm'
-
-		# Mock the invoke method to return a proper response
-		def mock_invoke(*args, **kwargs):
-			response = MagicMock()
-			# Return a valid JSON response that completes the task
-			response.content = """
-			{
-				"thinking": "null",
-				"evaluation_previous_goal": "Starting the task",
-				"memory": "Task started",
-				"next_goal": "Complete the task",
-				"action": [
-					{
-						"done": {
-							"text": "Task completed successfully",
-							"success": true
-						}
-					}
-				]
-			}
-			"""
-			return response
-
-		mock.invoke = mock_invoke
-
-		# Create an async version of the mock_invoke
-		async def mock_ainvoke(*args, **kwargs):
-			return mock_invoke(*args, **kwargs)
-
-		mock.ainvoke = mock_ainvoke
-
-		return mock
 
 	async def test_sequential_agents_same_profile_different_browser(self, mock_llm):
 		"""Test Sequential Agents, Same Profile, Different Browser pattern"""

--- a/tests/ci/test_browser_session_tab_management.py
+++ b/tests/ci/test_browser_session_tab_management.py
@@ -364,10 +364,10 @@ class TestTabManagement:
 			return f'connected: {connected}'
 
 		# Run all operations concurrently
-		results = await asyncio.gather(close_context(), access_pages(), check_connection(), return_exceptions=True)
+		results = list(await asyncio.gather(close_context(), access_pages(), check_connection(), return_exceptions=True))
 
 		# All operations should complete without crashes
-		assert all(not isinstance(r, Exception) for r in results)
+		assert results and all(not isinstance(r, Exception) for r in results)
 		assert 'closed' in results
 
 		await browser_session.kill()

--- a/tests/ci/test_browser_session_tab_management.py
+++ b/tests/ci/test_browser_session_tab_management.py
@@ -345,7 +345,7 @@ class TestTabManagement:
 
 		async def close_context():
 			await barrier.wait()
-			await browser_session.browser_context.browser.close()
+			await browser_session.browser_context.close()
 			assert browser_session.is_connected() is False
 			return 'closed'
 


### PR DESCRIPTION
…d temp browsers
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Now always creates a unique temporary user_data_dir when launching a browser with user_data_dir=None, making it easier to identify the correct browser_pid for each session.

- **Refactors**
  - Generates a temp user_data_dir for each new browser session if none is provided.
  - Cleans up temp user_data_dir after the browser stops.

<!-- End of auto-generated description by cubic. -->

