### PR TITLE
Make `BrowserSession.is_connected()` async and ensure at least one tab always exists in context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ We want our library APIs to be ergonomic, intuitive, and hard to get wrong.
 - We keep the main code for each sub-component in a `service.py` file usually, and we keep most pydantic models in `views.py` files unless they are long enough deserve their own file
 - Use runtime assertions at the start and end of functions to enforce constraints and assumptions
 - Prefer `from uuid_extensions import uuid7str` +  `id: str = Field(default_factory=uuid7str)` for all new id fields
-- Run tests using `uv run pytest -vx tests/ci`
+- Run tests using `uv run pytest -vxs tests/ci`
 - Run the type checker using `uv run pyright`
 
 ## Keep Examples & Tests Up-To-Date

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1423,7 +1423,7 @@ class BrowserSession(BaseModel):
 				self.agent_current_page = first_available_tab
 				self.human_current_page = first_available_tab
 			else:
-				# if all tabs are closed, open a new one
+				# if all tabs are closed, open a new one, never allow a context with 0 tabs
 				new_tab = await self.create_new_tab()
 				self.agent_current_page = new_tab
 				self.human_current_page = new_tab
@@ -3016,9 +3016,9 @@ class BrowserSession(BaseModel):
 		except Exception:
 			self.initialized = False
 
-		if not self.initialized or not self.is_connected():
+		if not self.initialized or not self.browser_context:
 			# If we were initialized but lost connection, reset state first to avoid infinite loops
-			if self.initialized and not self.is_connected():
+			if self.initialized and not self.browser_context:
 				self.logger.warning(
 					f'💔 Browser {self._connection_str} disconnected while trying to create a new tab, reconnecting...'
 				)

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -276,7 +276,7 @@ class BrowserSession(BaseModel):
 		async with asyncio.timeout(60):  # 60 second overall timeout for entire launching process to avoid deadlocks
 			async with self._start_lock:  # prevent parallel calls to start() / stop() / save_storage_state() from clashing
 				if self.initialized:
-					if self.is_connected():
+					if await self.is_connected():
 						return self
 					else:
 						next_step = (
@@ -353,7 +353,7 @@ class BrowserSession(BaseModel):
 			async with self._start_lock:
 				# save cookies to disk if cookies_file or storage_state is configured
 				# but only if the browser context is still connected
-				if self.is_connected():
+				if await self.is_connected():
 					try:
 						await asyncio.wait_for(self.save_storage_state(), timeout=5)
 					except Exception as e:
@@ -1278,7 +1278,7 @@ class BrowserSession(BaseModel):
 		if self.browser_profile.keep_alive is None:
 			self.browser_profile.keep_alive = keep_alive
 
-	def is_connected(self) -> bool:
+	async def is_connected(self) -> bool:
 		"""
 		Check if the browser session has valid, connected browser and context objects.
 		Returns False if any of the following conditions are met:
@@ -1298,7 +1298,11 @@ class BrowserSession(BaseModel):
 			# TODO: figure out a better synchronous test for whether browser_context is usable
 			# this is a hacky workaround for the fact that playwright's browser_context has no is_connected() method
 			# and browser_context.browser is None when we launch with a persistent context (basically always)
-			return bool(self.browser_context.pages)
+			if self.browser_context.pages:
+				return True
+			else:
+				await self.create_new_tab()
+				return True
 		except Exception:
 			return False
 

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -54,9 +54,9 @@ class Config:
 		return os.getenv('BROWSER_USE_CLOUD_SYNC', str(self.ANONYMIZED_TELEMETRY)).lower()[:1] in 'ty1'
 
 	@property
-	def BROWSER_USE_CLOUD_URL(self) -> str:
-		url = os.getenv('BROWSER_USE_CLOUD_URL', 'https://cloud.browser-use.com')
-		assert '://' in url, 'BROWSER_USE_CLOUD_URL must be a valid URL'
+	def BROWSER_USE_CLOUD_API_URL(self) -> str:
+		url = os.getenv('BROWSER_USE_CLOUD_API_URL', 'https://api.browser-use.com')
+		assert '://' in url, 'BROWSER_USE_CLOUD_API_URL must be a valid URL'
 		return url
 
 	@property

--- a/browser_use/controller/registry/service.py
+++ b/browser_use/controller/registry/service.py
@@ -203,6 +203,10 @@ class Registry(Generic[Context]):
 								raise ValueError(f'Action {func.__name__} requires file_system but none provided.')
 							elif param.name == 'page':
 								raise ValueError(f'Action {func.__name__} requires page but none provided.')
+							elif param.name == 'available_file_paths':
+								raise ValueError(f'Action {func.__name__} requires available_file_paths but none provided.')
+							elif param.name == 'file_system':
+								raise ValueError(f'Action {func.__name__} requires file_system but none provided.')
 							else:
 								raise ValueError(f"{func.__name__}() missing required special parameter '{param.name}'")
 						call_args.append(value)
@@ -218,6 +222,10 @@ class Registry(Generic[Context]):
 							raise ValueError(f'Action {func.__name__} requires file_system but none provided.')
 						elif param.name == 'page':
 							raise ValueError(f'Action {func.__name__} requires page but none provided.')
+						elif param.name == 'available_file_paths':
+							raise ValueError(f'Action {func.__name__} requires available_file_paths but none provided.')
+						elif param.name == 'file_system':
+							raise ValueError(f'Action {func.__name__} requires file_system but none provided.')
 						else:
 							raise ValueError(f"{func.__name__}() missing required special parameter '{param.name}'")
 				else:

--- a/browser_use/sync/auth.py
+++ b/browser_use/sync/auth.py
@@ -293,7 +293,7 @@ class DeviceAuthClient:
 				response = getattr(e, 'response')
 				if hasattr(response, 'status_code') and hasattr(response, 'text'):
 					logger.debug(
-						f'Failed to get pre-auth token for cloud sync: HTTP {response.status_code} - {response.text[:200]}'
+						f'Failed to get pre-auth token for cloud sync: HTTP {response.request.url} {response.status_code} - {response.text}'
 					)
 				else:
 					logger.debug(f'Failed to get pre-auth token for cloud sync: {type(e).__name__}: {e}')

--- a/browser_use/sync/auth.py
+++ b/browser_use/sync/auth.py
@@ -61,7 +61,7 @@ class DeviceAuthClient:
 
 	def __init__(self, base_url: str | None = None, http_client: httpx.AsyncClient | None = None):
 		# Backend API URL for OAuth requests - can be passed directly or defaults to env var
-		self.base_url = base_url or CONFIG.BROWSER_USE_CLOUD_URL
+		self.base_url = base_url or CONFIG.BROWSER_USE_CLOUD_API_URL
 		self.client_id = 'library'
 		self.scope = 'read write'
 
@@ -257,7 +257,7 @@ class DeviceAuthClient:
 			device_auth = await self.start_device_authorization(agent_session_id)
 
 			# Use frontend URL for user-facing links
-			frontend_url = CONFIG.BROWSER_USE_CLOUD_UI_URL or self.base_url
+			frontend_url = CONFIG.BROWSER_USE_CLOUD_UI_URL or self.base_url.replace('//api.', '//cloud.')
 
 			# Replace backend URL with frontend URL in verification URIs
 			verification_uri = device_auth['verification_uri'].replace(self.base_url, frontend_url)

--- a/browser_use/sync/service.py
+++ b/browser_use/sync/service.py
@@ -76,7 +76,7 @@ class CloudSync:
 				elif response.status_code >= 400:
 					# Log error but don't raise - we want to fail silently
 					logger.warning(
-						f'Failed to send event to cloud: POST {response.request.url} {response.status_code} - {response.text[:200]}'
+						f'Failed to send event to cloud: POST {response.request.url} {response.status_code} - {response.text}'
 					)
 		except httpx.TimeoutException:
 			logger.warning(f'⚠️ Event send timed out after 10 seconds: {event}')

--- a/browser_use/sync/service.py
+++ b/browser_use/sync/service.py
@@ -21,7 +21,7 @@ class CloudSync:
 
 	def __init__(self, base_url: str | None = None, enable_auth: bool = True):
 		# Backend API URL for all API requests - can be passed directly or defaults to env var
-		self.base_url = base_url or CONFIG.BROWSER_USE_CLOUD_URL
+		self.base_url = base_url or CONFIG.BROWSER_USE_CLOUD_API_URL
 		self.enable_auth = enable_auth
 		self.auth_client = DeviceAuthClient(base_url=self.base_url) if enable_auth else None
 		self.pending_events: list[BaseEvent] = []
@@ -75,7 +75,9 @@ class CloudSync:
 					self.pending_events.append(event)
 				elif response.status_code >= 400:
 					# Log error but don't raise - we want to fail silently
-					logger.warning(f'Failed to send event to cloud: HTTP {response.status_code} - {response.text[:200]}')
+					logger.warning(
+						f'Failed to send event to cloud: POST {response.request.url} {response.status_code} - {response.text[:200]}'
+					)
 		except httpx.TimeoutException:
 			logger.warning(f'⚠️ Event send timed out after 10 seconds: {event}')
 		except httpx.ConnectError as e:

--- a/tests/ci/conftest.py
+++ b/tests/ci/conftest.py
@@ -42,7 +42,7 @@ def setup_test_environment():
 		'SKIP_LLM_API_KEY_VERIFICATION': 'true',
 		'ANONYMIZED_TELEMETRY': 'false',
 		'BROWSER_USE_CLOUD_SYNC': 'true',
-		'BROWSER_USE_CLOUD_URL': 'http://placeholder-will-be-replaced-by-specific-test-fixtures',
+		'BROWSER_USE_CLOUD_API_URL': 'http://placeholder-will-be-replaced-by-specific-test-fixtures',
 		'BROWSER_USE_CLOUD_UI_URL': 'http://placeholder-will-be-replaced-by-specific-test-fixtures',
 		'BROWSER_USE_CONFIG_DIR': config_dir,
 	}
@@ -169,7 +169,7 @@ def cloud_sync(httpserver: HTTPServer):
 
 	# Set up test environment
 	test_http_server_url = httpserver.url_for('')
-	os.environ['BROWSER_USE_CLOUD_URL'] = test_http_server_url
+	os.environ['BROWSER_USE_CLOUD_API_URL'] = test_http_server_url
 	os.environ['BROWSER_USE_CLOUD_UI_URL'] = test_http_server_url
 	os.environ['BROWSER_USE_CLOUD_SYNC'] = 'true'
 

--- a/tests/ci/test_browser_session_start.py
+++ b/tests/ci/test_browser_session_start.py
@@ -996,7 +996,7 @@ class TestBrowserSessionReusePatterns:
 		# ensure all are connected and usable
 		new_tab_tasks = []
 		for browser_session in browser_sessions:
-			assert browser_session.is_connected()
+			assert await browser_session.is_connected()
 			assert browser_session.browser_context is not None
 			new_tab_tasks.append(browser_session.create_new_tab('chrome://version'))
 		await asyncio.gather(*new_tab_tasks)
@@ -1012,7 +1012,7 @@ class TestBrowserSessionReusePatterns:
 		new_tab_tasks = []
 		screenshot_tasks = []
 		for browser_session in filter(bool, browser_sessions):
-			assert browser_session.is_connected()
+			assert await browser_session.is_connected()
 			assert browser_session.browser_context is not None
 			new_tab_tasks.append(browser_session.create_new_tab('chrome://version'))
 			screenshot_tasks.append(browser_session.take_screenshot())

--- a/tests/ci/test_browser_session_tab_management.py
+++ b/tests/ci/test_browser_session_tab_management.py
@@ -331,14 +331,14 @@ class TestTabManagement:
 		assert browser_session.browser_context is not None
 		assert browser_session.browser_context != original_context
 		assert browser_session.initialized is True
-		assert browser_session.is_connected() is True
+		assert (await browser_session.is_connected()) is True
 
 	async def test_concurrent_context_access_during_closure(self, browser_session):
 		"""Test concurrent access to browser context during closure"""
 		# logger.info('Testing concurrent context access during closure')
 
 		await browser_session.start()
-		assert browser_session.is_connected() is True
+		assert (await browser_session.is_connected()) is True
 
 		# Create a barrier to synchronize operations
 		barrier = asyncio.Barrier(3)
@@ -346,7 +346,7 @@ class TestTabManagement:
 		async def close_context():
 			await barrier.wait()
 			await browser_session.browser_context.close()
-			assert browser_session.is_connected() is False
+			assert (await browser_session.is_connected()) is False
 			return 'closed'
 
 		async def access_pages():
@@ -360,7 +360,7 @@ class TestTabManagement:
 		async def check_connection():
 			await barrier.wait()
 			await asyncio.sleep(0.01)  # Small delay to let close start
-			connected = browser_session.is_connected()
+			connected = await browser_session.is_connected()
 			return f'connected: {connected}'
 
 		# Run all operations concurrently

--- a/tests/old/sync_live.py
+++ b/tests/old/sync_live.py
@@ -77,11 +77,11 @@
 
 # 	Environment variables required:
 # 	- RUN_LIVE_TESTS=1 (to enable the test)
-# 	- BROWSER_USE_CLOUD_URL (optional, defaults to https://cloud.browser-use.com)
+# 	- BROWSER_USE_CLOUD_API_URL (optional, defaults to https://cloud.browser-use.com)
 # 	"""
 
 # 	# Configuration
-# 	backend_url = os.getenv('BROWSER_USE_CLOUD_URL', 'http://localhost:8000')
+# 	backend_url = os.getenv('BROWSER_USE_CLOUD_API_URL', 'http://localhost:8000')
 # 	logger.info(f'Running live integration test against: {backend_url}')
 
 # 	# Create mock LLM
@@ -89,7 +89,7 @@
 
 # 	# Set environment variables for cloud sync
 # 	os.environ['BROWSERUSE_CLOUD_SYNC'] = 'true'
-# 	os.environ['BROWSER_USE_CLOUD_URL'] = backend_url
+# 	os.environ['BROWSER_USE_CLOUD_API_URL'] = backend_url
 
 # 	# Create browser session with real profile
 # 	browser_session = BrowserSession(
@@ -147,7 +147,7 @@
 # 	This is a simpler test that just verifies event sending works.
 # 	"""
 
-# 	backend_url = os.getenv('BROWSER_USE_CLOUD_URL', 'http://localhost:8000')
+# 	backend_url = os.getenv('BROWSER_USE_CLOUD_API_URL', 'http://localhost:8000')
 # 	logger.info(f'Testing cloud sync against: {backend_url}')
 
 # 	# Create cloud sync service


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Made BrowserSession.is_connected() async and updated it to always ensure at least one tab exists in the browser context. Updated all usage and tests to await the new async method, and switched cloud API URL config to use BROWSER_USE_CLOUD_API_URL throughout the codebase.

<!-- End of auto-generated description by cubic. -->

