### PR TITLE
Improve judge system: filter out first image and consecutive duplicates

### DIFF
--- a/eval/judge_system.py
+++ b/eval/judge_system.py
@@ -177,6 +177,57 @@ def prepare_agent_steps(complete_history: list[dict]) -> list[str]:
 	return steps
 
 
+def are_images_identical(img_path1: str, img_path2: str) -> bool:
+	"""Check if two images are identical by comparing their content."""
+	try:
+		with Image.open(img_path1) as img1, Image.open(img_path2) as img2:
+			# Convert to same format for comparison
+			if img1.mode != img2.mode:
+				img1 = img1.convert('RGB')
+				img2 = img2.convert('RGB')
+
+			# Compare sizes first (quick check)
+			if img1.size != img2.size:
+				return False
+
+			# Compare pixel data
+			return list(img1.getdata()) == list(img2.getdata())
+	except Exception as e:
+		logger.warning(f'Failed to compare images {img_path1} and {img_path2}: {e}')
+		return False
+
+
+def filter_images(screenshot_paths: list[str], max_images: int) -> list[str]:
+	"""
+	Filter screenshot paths to:
+	1. Never include the first image (always white)
+	2. Remove consecutive duplicate images
+	3. Return up to max_images from the end
+	"""
+	if not screenshot_paths:
+		return []
+
+	# Skip the first image (always white)
+	filtered_paths = screenshot_paths[1:] if len(screenshot_paths) > 1 else []
+
+	if not filtered_paths:
+		return []
+
+	# Remove consecutive duplicates
+	deduplicated_paths = [filtered_paths[0]]  # Always include the first non-skipped image
+
+	for i in range(1, len(filtered_paths)):
+		current_path = filtered_paths[i]
+		previous_path = filtered_paths[i - 1]
+
+		# Only add if not identical to previous image
+		if not are_images_identical(current_path, previous_path):
+			deduplicated_paths.append(current_path)
+
+	# Return last max_images images
+	return deduplicated_paths[-max_images:] if len(deduplicated_paths) > max_images else deduplicated_paths
+
+
 async def comprehensive_judge(
 	task: str,
 	complete_history: list[dict],
@@ -194,8 +245,8 @@ async def comprehensive_judge(
 	final_result_truncated = truncate_text(final_result or 'No final result', 40000)
 	agent_steps = prepare_agent_steps(complete_history)
 
-	# Select last N images
-	selected_images = screenshot_paths[-max_images:] if screenshot_paths else []
+	# Select and filter images
+	selected_images = filter_images(screenshot_paths, max_images)
 
 	# Encode images
 	encoded_images = []


### PR DESCRIPTION
## Changes Made

### 🖼️ Image Filtering Improvements
- **Never include first image**: Skip the first screenshot which is always white/blank
- **Remove consecutive duplicates**: Only keep one image when multiple identical screenshots occur
- **Pixel-perfect comparison**: Compare images pixel-by-pixel to detect true duplicates

### 🎯 Benefits
- **Better Judge Accuracy**: No more white/blank images confusing evaluation
- **Reduced Token Usage**: Eliminates duplicate screenshots 
- **Focused Context**: Judge sees only meaningful, unique screenshots
- **Cost Efficiency**: Fewer tokens = lower evaluation costs

### 🔧 Technical Details
- Added `are_images_identical()` function for pixel-by-pixel comparison
- Added `filter_images()` function with intelligent filtering logic
- Updated comprehensive judge to use filtered image selection
- Maintains backwards compatibility with existing evaluation pipeline

### 📊 Database Fields
This also documents the complete set of comprehensive judge results sent to database:
- `comprehensiveJudgeEvaluationSummary`
- `comprehensiveJudgeEvaluationReasoning`
- `comprehensiveJudgeEvaluationPassed`
- `comprehensiveJudgeEvaluationScore`
- `comprehensiveJudgeEvaluationCategories`
- `comprehensiveJudgeEvaluationErrors`
- `comprehensiveJudgeEvaluationTips`
- `comprehensiveJudgeEvaluationCriticalIssues`
- `comprehensiveJudgeEvaluationScores`
- `comprehensiveJudgeEvaluationFull`

Fixes issues with judge evaluation quality and token efficiency.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved the judge system to skip the first (blank) screenshot and remove consecutive duplicate images, so only unique, meaningful screenshots are used in evaluations.

- **Bug Fixes**
  - Skips the first image, which is always blank.
  - Removes consecutive duplicate screenshots using pixel-by-pixel comparison.

<!-- End of auto-generated description by cubic. -->

