### PR TITLE
fix download memory in clicking

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -251,20 +251,20 @@ class Controller(Generic[Context]):
 				assert element_node is not None, f'Element with index {params.index} does not exist'
 				download_path = await browser_session._click_element_node(element_node)
 				if download_path:
-					msg = f'💾  Downloaded file to {download_path}'
+					emoji = '💾'
+					msg = f'Downloaded file to {download_path}'
 				else:
-					msg = f'🖱️  Clicked button with index {params.index}: {element_node.get_all_text_till_next_clickable_element(max_depth=2)}'
+					emoji = '🖱️'
+					msg = f'Clicked button with index {params.index}: {element_node.get_all_text_till_next_clickable_element(max_depth=2)}'
 
-				logger.info(msg)
+				logger.info(f'{emoji} {msg}')
 				logger.debug(f'Element xpath: {element_node.xpath}')
 				if len(browser_session.tabs) > initial_pages:
 					new_tab_msg = 'New tab opened - switching to it'
 					msg += f' - {new_tab_msg}'
 					logger.info(new_tab_msg)
 					await browser_session.switch_to_tab(-1)
-				return ActionResult(
-					extracted_content=msg, include_in_memory=True, long_term_memory=f'Clicked element {params.index}'
-				)
+				return ActionResult(extracted_content=msg, include_in_memory=True, long_term_memory=msg)
 			except Exception as e:
 				error_msg = str(e)
 				if 'Execution context was destroyed' in error_msg or 'Cannot find context with specified id' in error_msg:

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -257,14 +257,15 @@ class Controller(Generic[Context]):
 					emoji = '🖱️'
 					msg = f'Clicked button with index {params.index}: {element_node.get_all_text_till_next_clickable_element(max_depth=2)}'
 
-				logger.info(f'{emoji} {msg}')
+				log = f'{emoji} {msg}'
+				logger.info(log)
 				logger.debug(f'Element xpath: {element_node.xpath}')
 				if len(browser_session.tabs) > initial_pages:
 					new_tab_msg = 'New tab opened - switching to it'
 					msg += f' - {new_tab_msg}'
 					logger.info(new_tab_msg)
 					await browser_session.switch_to_tab(-1)
-				return ActionResult(extracted_content=msg, include_in_memory=True, long_term_memory=msg)
+				return ActionResult(extracted_content=log, include_in_memory=True, long_term_memory=msg)
 			except Exception as e:
 				error_msg = str(e)
 				if 'Execution context was destroyed' in error_msg or 'Cannot find context with specified id' in error_msg:

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -257,15 +257,15 @@ class Controller(Generic[Context]):
 					emoji = '🖱️'
 					msg = f'Clicked button with index {params.index}: {element_node.get_all_text_till_next_clickable_element(max_depth=2)}'
 
-				log = f'{emoji} {msg}'
-				logger.info(log)
+				logger.info(f'{emoji} {msg}')
 				logger.debug(f'Element xpath: {element_node.xpath}')
 				if len(browser_session.tabs) > initial_pages:
 					new_tab_msg = 'New tab opened - switching to it'
 					msg += f' - {new_tab_msg}'
-					logger.info(new_tab_msg)
+					emoji = '🔗'
+					logger.info(f'{emoji} {new_tab_msg}')
 					await browser_session.switch_to_tab(-1)
-				return ActionResult(extracted_content=log, include_in_memory=True, long_term_memory=msg)
+				return ActionResult(extracted_content=msg, include_in_memory=True, long_term_memory=msg)
 			except Exception as e:
 				error_msg = str(e)
 				if 'Execution context was destroyed' in error_msg or 'Cannot find context with specified id' in error_msg:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed the memory message when clicking to download a file so it now shows the correct action and file path.

- **Bug Fixes**
  - Updated the memory log to include the actual download message instead of a generic text.

<!-- End of auto-generated description by cubic. -->

