### PR TITLE
Add last_message parameter and anti-hallucination instruction to judge system

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -125,6 +125,7 @@ class MessageManager:
 		self.sensitive_data_description = ''
 		self.available_file_paths = available_file_paths
 		self.use_thinking = use_thinking
+		self.last_input_messages = []
 		# Only initialize messages if state is empty
 		if len(self.state.history.messages) == 0:
 			self._init_messages()
@@ -392,8 +393,8 @@ Next Goal: {model_output.current_state.next_goal}
 
 		# Log message history for debugging
 		logger.debug(self._log_history_lines())
-
-		return [m.message for m in self.state.history.messages]
+		self.last_input_messages = [m.message for m in self.state.history.messages]
+		return self.last_input_messages
 
 	def _add_message_with_type(
 		self,

--- a/eval/judge_system.py
+++ b/eval/judge_system.py
@@ -412,12 +412,13 @@ extraction, interaction, login, research, shopping, booking, comparison, qa_test
 - What's the core thing why the task failed? - What are the most important things to fix?
 
 **IMPROVEMENT TIPS:**
-- Create actionable tips for browser-use agent developers to fix common issues
+- Create actionable tips for browser-use agent developers to fix common issues 
+- Make the tips easy understandable for a developer without the specific task context
 - Tips will be aggregated across tasks to identify the most problematic patterns
 - Focus on browser-use specific architecture: DOM-to-text conversion, indexed elements, iterative loops
 - Consider improvements to: system prompt,DOM input state representation, action handling, tools
-- Always mention the error pattern first, then the specific improvement suggestion
-- If errors happen on specific websites you can mention them so the developer can fix them
+- Always mention the error pattern first, then the specific improvement suggestion. Like Login_error on sheets.google.com: build a login function for google sheets
+- If errors are related to specific websites please meention the link in the improvement tips 
 - Can the output be presented better - sometimes the agent does not output exactly what the user asked for
 
 **SCORING SCALE:**
@@ -453,8 +454,8 @@ Respond with EXACTLY this JSON structure (no additional text):
         "Critical issue that must be fixed 2"
     ],
     "improvement_tips": [
-        "Specific actionable improvement 1",
-        "Specific actionable improvement 2"
+        "Error pattern: Specific actionable improvement 1",
+        "Error pattern: Specific actionable improvement 2"
     ]
 }}"""
 

--- a/eval/judge_system.py
+++ b/eval/judge_system.py
@@ -189,11 +189,14 @@ def encode_image(image_path: str) -> str:
 		return ''
 
 
-def truncate_text(text: str, max_length: int) -> str:
+def truncate_text(text: str, max_length: int, from_beginning: bool = False) -> str:
 	"""Truncate text to maximum length with eval system indicator."""
 	if len(text) <= max_length:
 		return text
-	return text[: max_length - 23] + '...[cut for eval]...'
+	if from_beginning:
+		return '...[cut for eval]' + text[-max_length + 23 :]
+	else:
+		return text[: max_length - 23] + '...[cut for eval]...'
 
 
 def prepare_agent_steps(complete_history: list[dict]) -> list[str]:
@@ -326,7 +329,7 @@ async def comprehensive_judge(
 	# Prepare inputs with length limits
 	task_truncated = truncate_text(task, 40000)
 	final_result_truncated = truncate_text(final_result or 'No final result', 40000)
-	last_message_truncated = truncate_text(last_message or 'No last message', 40000)
+	last_message_truncated = truncate_text(last_message or 'No last message', 40000, from_beginning=True)
 	agent_steps = prepare_agent_steps(complete_history)
 
 	# Select and filter images

--- a/eval/judge_system.py
+++ b/eval/judge_system.py
@@ -120,7 +120,8 @@ class ErrorCategory(Enum):
 	EXTRACT_DATA_MISUSE = 'extract_data_misuse'  # Wrong usage of extract_structured_data
 
 	# Output & Task Completion Issues
-	WRONG_OUTPUT_FORMAT = 'partial_output'
+	PARTIAL_OUTPUT = 'partial_output'
+	WRONG_OUTPUT_FORMAT = 'wrong_output_format'
 
 
 class TaskCategory(Enum):
@@ -379,10 +380,10 @@ The browser-use agent operates in iterative loops receiving structured input:
 **EVALUATION CRITERIA:**
 
 1. **Task Satisfaction**: Understand the user intent - Is the user satisfied with the final result? - This is the most important criterion.
-2. **Tool Usage**: How well did the tools work?
+2. **Tool Usage**: How well did the tools work? - How does the trajectory of the agent look like?
 3. **Agent Reasoning**: Quality of decision-making and problem-solving  
 4. **Browser Handling**: How well did the navigation and browser interaction work?
-5. **Final Outcome**: How was the trajectory of the agent? How was the output presented and the ?
+5. **Final Output**: How does the output presented is it exactly what the user asked for?
 
 **BROWSER-USE SPECIFIC EVALUATION FOCUS:**
 - Data Extraction: Did agent properly read information from browser_state text structure?
@@ -409,7 +410,8 @@ extraction, interaction, login, research, shopping, booking, comparison, qa_test
 - Focus on browser-use specific architecture: DOM-to-text conversion, indexed elements, iterative loops
 - Consider improvements to: system prompt,DOM input state representation, action handling, tools
 - Always mention the error pattern first, then the specific improvement suggestion
-
+- If errors happen on specific websites you can mention them so the developer can fix them
+- Can the output be presented better - sometimes the agent does not output exactly what the user asked for
 
 **SCORING SCALE:**
 - 90-100: Excellent execution, human-like, minimal issues

--- a/eval/service.py
+++ b/eval/service.py
@@ -931,6 +931,7 @@ async def reformat_agent_history(
 	task_id: str,
 	run_id: str,
 	task: str,
+	last_message: str,
 	base_path: str = 'saved_trajectories',
 	include_result: bool = False,
 ) -> dict:
@@ -1033,6 +1034,7 @@ async def reformat_agent_history(
 		'action_history': action_history,
 		'screenshot_paths': screenshot_paths,
 		'final_result_response': final_result,
+		'last_message': last_message,
 		'self_report_completed': self_report_completed,
 		'self_report_success': self_report_success,
 		'complete_history': complete_history,
@@ -1316,7 +1318,7 @@ async def run_agent_with_browser(
 	validate_output: bool = False,
 	planner_llm: BaseChatModel | None = None,
 	planner_interval: int = 1,
-) -> AgentHistoryList:
+) -> tuple[AgentHistoryList, str]:
 	"""Run agent with the browser session"""
 	# Create controller, optionally with SERP search
 	controller = create_controller(use_serp=use_serp)
@@ -1341,10 +1343,10 @@ async def run_agent_with_browser(
 		source='eval_platform',
 	)
 	# get last message
+	await agent.run(max_steps=max_steps)
 	last_input_messages = agent.message_manager.last_input_messages
 	last_message = last_input_messages[-1].text
-	await agent.run(max_steps=max_steps)
-	return agent.state.history
+	return agent.state.history, last_message
 
 
 @observe(name='evaluate_task_result', span_type='EVALUATOR')  # type: ignore[arg-type]
@@ -1497,7 +1499,7 @@ async def run_task_with_semaphore(
 					try:
 						logger.info(f'Task {task.task_id}: Agent run starting.')
 
-						agent_history = await run_stage(
+						agent_history, last_message = await run_stage(
 							Stage.RUN_AGENT,
 							lambda: run_agent_with_browser(
 								browser_session,
@@ -1521,7 +1523,8 @@ async def run_task_with_semaphore(
 					except Exception as e:
 						error = StageError(Stage.RUN_AGENT, 'exception', str(e))
 						task_result.stage_failed(Stage.RUN_AGENT, error)
-						logger.error(f'Task {task.task_id}: Agent run failed: {str(e)}')
+						logger.error(f'Task {task.task_id}: Agent run failed: {str(e) + " " + str(e.__traceback__)}')
+
 						# Continue to server save instead of early return
 
 				# Stage 3: Format history
@@ -1531,7 +1534,12 @@ async def run_task_with_semaphore(
 						formatted_data = await run_stage(
 							Stage.FORMAT_HISTORY,
 							lambda: reformat_agent_history(
-								agent_history, task.task_id, run_id, task.confirmed_task, include_result=include_result
+								agent_history,
+								task.task_id,
+								run_id,
+								task.confirmed_task,
+								last_message,
+								include_result=include_result,
 							),
 						)
 						task_result.stage_completed(Stage.FORMAT_HISTORY, formatted_data)

--- a/eval/service.py
+++ b/eval/service.py
@@ -1340,7 +1340,9 @@ async def run_agent_with_browser(
 		planner_interval=planner_interval,
 		source='eval_platform',
 	)
-
+	# get last message
+	last_input_messages = agent.message_manager.last_input_messages
+	last_message = last_input_messages[-1].text
 	await agent.run(max_steps=max_steps)
 	return agent.state.history
 


### PR DESCRIPTION
## Enhancement

This PR enhances the judge system to better evaluate browser-use agent runs by including the agent's final message and preventing hallucination evaluation.

## Changes Made

### 1. Added `last_message` Parameter
- Added `last_message` parameter to `comprehensive_judge` and `judge_with_retry` functions
- Include agent's final message/output in evaluation context
- Remove dependency on separate action results since they're now available in the last message
- Updated function signatures and comprehensive docstrings

### 2. Anti-Hallucination Instruction
- Added explicit instruction for judge to NOT evaluate for hallucination
- Agent has access to more information than judge can see (browser_state text content, full DOM context)
- Focus evaluation on trajectory quality, tool usage, and task completion rather than data accuracy
- Assume agent-stated facts are correct and extracted from available information

### 3. Improved Evaluation Context
- Include agent's last message in evaluation prompt for better assessment
- Better understanding of agent's final reasoning and output
- More accurate evaluation based on complete agent communication

## Benefits

- **More Accurate Evaluations**: Judge now has complete context including agent's final thoughts
- **No False Hallucination Flags**: Prevents incorrect penalization when agent has more info than judge
- **Better Understanding**: Judge can see agent's complete reasoning process including final message
- **Cleaner Architecture**: Removes redundant action result dependency

## Impact

This will result in more accurate and fair evaluations that focus on actual agent behavior and task completion rather than incorrectly flagging hallucination when the agent simply has access to more information than the judge can see.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a last_message parameter to the judge system and updated the evaluation prompt to prevent false hallucination flags when assessing browser-use agent runs.

- **Improvements**
  - Judge now sees the agent’s final message for better context.
  - Added instruction to ignore hallucination checks, focusing on task completion and tool use.

<!-- End of auto-generated description by cubic. -->

