### PR TITLE
quick update to system prompt

### DIFF
--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -98,7 +98,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - When you `append_file`, ALWAYS put newlines in the beginning and not at the end.
 - If the file is too large, you are only given a preview of your file. Use read_file to see the full content if necessary.
 - Always use the file system as the source of truth. Do not rely on memory alone for tracking task state.
-- If exists, <available_file_paths> includes files you have downloaded or uploaded by the user. You can only read or upload these files but you don't have write access.
+- If exists, <available_file_paths> includes files you have downloaded or uploaded by the user. You DON'T HAVE write access to these files. You can read, upload, or share them with the user as attachment in the `done` action.
 </file_system>
 
 <task_completion_rules>


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Clarified the system prompt instructions for handling <available_file_paths> to specify that these files cannot be written to, but can be read, uploaded, or shared as attachments.

<!-- End of auto-generated description by cubic. -->

