### PR TITLE
Implement data directory cleanup in FileSystem class

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import shutil
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -175,10 +176,9 @@ class FileSystem(BaseModel):
 
 		# Create and use a dedicated subfolder for all operations
 		data_dir = base_dir / 'browseruse_agent_data'
-		if data_dir.exists() and not _restore_mode:
-			raise ValueError(
-				'File system directory already exists - stopping for safety purposes. Please delete it first if you want to use this directory.'
-			)
+		if data_dir.exists():
+			# clean the data directory
+			shutil.rmtree(data_dir)
 		data_dir.mkdir(exist_ok=True)
 
 		super().__init__(base_dir=data_dir, **kwargs)


### PR DESCRIPTION
- Added functionality to remove existing data directory before creating a new one, ensuring a clean state for operations.
- Introduced `shutil` for directory removal.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The FileSystem class now deletes the existing data directory before creating a new one, ensuring a clean state for each run.

- **Refactors**
  - Uses `shutil.rmtree` to remove the data directory if it exists.

<!-- End of auto-generated description by cubic. -->

