### PR TITLE
Remove kayak.gif from git lfs

### DIFF
--- a/static/kayak.gif
+++ b/static/kayak.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab32dca74aff21e80c1d05457e61204216fd50109c6c8bdd158de4231c3cdaf0
-size 3481879


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed kayak.gif from git LFS to clean up unused files.

<!-- End of auto-generated description by cubic. -->

