### PR TITLE
Remove photos.gif from git lfs

### DIFF
--- a/static/photos.gif
+++ b/static/photos.gif
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aae096e0ca557ee5add53a3cb2dd5da152ddc5282f555f41b0b689aa4b93b76b
-size 1645394


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed photos.gif from git LFS to clean up unused files.

<!-- End of auto-generated description by cubic. -->

