### PR TITLE
Screenshot timeout issue

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -335,38 +335,36 @@ class Agent(Generic[Context]):
 		# assert not (browser_session and browser_context), 'Cannot provide both browser_session and browser_context'
 		browser_profile = browser_profile or DEFAULT_BROWSER_PROFILE
 
-		# if browser_session:
-		# 	# Check if user is trying to reuse an uninitialized session
-		# 	if browser_session.browser_profile.keep_alive and not browser_session.initialized:
-		# 		self.logger.error(
-		# 			'❌ Passed a BrowserSession with keep_alive=True that is not initialized. '
-		# 			'Call await browser_session.start() before passing it to Agent() to reuse the same browser. '
-		# 			'Otherwise, each agent will launch its own browser instance.'
-		# 		)
-		# 		raise ValueError(
-		# 			'BrowserSession with keep_alive=True must be initialized before passing to Agent. '
-		# 			'Call: await browser_session.start()'
-		# 		)
+		if browser_session:
+			# Check if user is trying to reuse an uninitialized session
+			if browser_session.browser_profile.keep_alive and not browser_session.initialized:
+				self.logger.error(
+					'❌ Passed a BrowserSession with keep_alive=True that is not initialized. '
+					'Call await browser_session.start() before passing it to Agent() to reuse the same browser. '
+					'Otherwise, each agent will launch its own browser instance.'
+				)
+				raise ValueError(
+					'BrowserSession with keep_alive=True must be initialized before passing to Agent. '
+					'Call: await browser_session.start()'
+				)
 
-		# 	# always copy sessions that are passed in to avoid agents overwriting each other's agent_current_page and human_current_page by accident
-		# 	self.browser_session = browser_session.model_copy(
-		# 		# update={
-		# 		# 	'agent_current_page': None,   # dont reset these, let the next agent start on the same page as the last agent
-		# 		# 	'human_current_page': None,
-		# 		# },
-		# 	)
-		# else:
-		# 	if browser is not None:
-		# 		assert isinstance(browser, Browser), 'Browser is not set up'
-		self.browser_session = browser_session
-
-		# BrowserSession(
-		# 	browser_profile=browser_profile,
-		# 	browser=browser,
-		# 	browser_context=browser_context,
-		# 	agent_current_page=page,
-		# 	id=uuid7str()[:-4] + self.id[-4:],  # re-use the same 4-char suffix so they show up together in logs
-		# )
+			# always copy sessions that are passed in to avoid agents overwriting each other's agent_current_page and human_current_page by accident
+			self.browser_session = browser_session.model_copy(
+				# update={
+				# 	'agent_current_page': None,   # dont reset these, let the next agent start on the same page as the last agent
+				# 	'human_current_page': None,
+				# },
+			)
+		else:
+			if browser is not None:
+				assert isinstance(browser, Browser), 'Browser is not set up'
+			self.browser_session = BrowserSession(
+				browser_profile=browser_profile,
+				browser=browser,
+				browser_context=browser_context,
+				agent_current_page=page,
+				id=uuid7str()[:-4] + self.id[-4:],  # re-use the same 4-char suffix so they show up together in logs
+			)
 
 		if self.sensitive_data:
 			# Check if sensitive_data has domain-specific credentials

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -335,36 +335,38 @@ class Agent(Generic[Context]):
 		# assert not (browser_session and browser_context), 'Cannot provide both browser_session and browser_context'
 		browser_profile = browser_profile or DEFAULT_BROWSER_PROFILE
 
-		if browser_session:
-			# Check if user is trying to reuse an uninitialized session
-			if browser_session.browser_profile.keep_alive and not browser_session.initialized:
-				self.logger.error(
-					'❌ Passed a BrowserSession with keep_alive=True that is not initialized. '
-					'Call await browser_session.start() before passing it to Agent() to reuse the same browser. '
-					'Otherwise, each agent will launch its own browser instance.'
-				)
-				raise ValueError(
-					'BrowserSession with keep_alive=True must be initialized before passing to Agent. '
-					'Call: await browser_session.start()'
-				)
+		# if browser_session:
+		# 	# Check if user is trying to reuse an uninitialized session
+		# 	if browser_session.browser_profile.keep_alive and not browser_session.initialized:
+		# 		self.logger.error(
+		# 			'❌ Passed a BrowserSession with keep_alive=True that is not initialized. '
+		# 			'Call await browser_session.start() before passing it to Agent() to reuse the same browser. '
+		# 			'Otherwise, each agent will launch its own browser instance.'
+		# 		)
+		# 		raise ValueError(
+		# 			'BrowserSession with keep_alive=True must be initialized before passing to Agent. '
+		# 			'Call: await browser_session.start()'
+		# 		)
 
-			# always copy sessions that are passed in to avoid agents overwriting each other's agent_current_page and human_current_page by accident
-			self.browser_session = browser_session.model_copy(
-				# update={
-				# 	'agent_current_page': None,   # dont reset these, let the next agent start on the same page as the last agent
-				# 	'human_current_page': None,
-				# },
-			)
-		else:
-			if browser is not None:
-				assert isinstance(browser, Browser), 'Browser is not set up'
-			self.browser_session = BrowserSession(
-				browser_profile=browser_profile,
-				browser=browser,
-				browser_context=browser_context,
-				agent_current_page=page,
-				id=uuid7str()[:-4] + self.id[-4:],  # re-use the same 4-char suffix so they show up together in logs
-			)
+		# 	# always copy sessions that are passed in to avoid agents overwriting each other's agent_current_page and human_current_page by accident
+		# 	self.browser_session = browser_session.model_copy(
+		# 		# update={
+		# 		# 	'agent_current_page': None,   # dont reset these, let the next agent start on the same page as the last agent
+		# 		# 	'human_current_page': None,
+		# 		# },
+		# 	)
+		# else:
+		# 	if browser is not None:
+		# 		assert isinstance(browser, Browser), 'Browser is not set up'
+		self.browser_session = browser_session
+
+		# BrowserSession(
+		# 	browser_profile=browser_profile,
+		# 	browser=browser,
+		# 	browser_context=browser_context,
+		# 	agent_current_page=page,
+		# 	id=uuid7str()[:-4] + self.id[-4:],  # re-use the same 4-char suffix so they show up together in logs
+		# )
 
 		if self.sensitive_data:
 			# Check if sensitive_data has domain-specific credentials

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -569,6 +569,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	# --- Page load/wait timings ---
 	default_navigation_timeout: float | None = Field(default=None, description='Default page navigation timeout.')
 	default_timeout: float | None = Field(default=None, description='Default playwright call timeout.')
+	screenshot_timeout: float = Field(default=35.0, description='Timeout in seconds for screenshot operations.')
 	minimum_wait_page_load_time: float = Field(default=0.25, description='Minimum time to wait before capturing page state.')
 	wait_for_network_idle_page_load_time: float = Field(default=0.5, description='Time to wait for network idle.')
 	maximum_wait_page_load_time: float = Field(default=5.0, description='Maximum time to wait for page load.')

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -2828,7 +2828,7 @@ class BrowserSession(BaseModel):
 		self.logger.debug('🖼️ Animations: disabled')
 		self.logger.debug('🖼️ Caret: initial')
 
-		screenshot = await self.agent_current_page.screenshot(
+		screenshot = await page.screenshot(
 			full_page=full_page,
 			animations='disabled',
 			caret='initial',

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -2610,6 +2610,10 @@ class BrowserSession(BaseModel):
 			# 	)
 
 			try:
+				self.logger.debug('🖼️ Taking screenshot')
+				self.logger.debug(f'🖼️ Page URL: {page.url}')
+				self.logger.debug(f'🖼️ Page title: {await page.title()}')
+				self.logger.debug(f'🖼️ Browser PID: {self.browser_pid}')
 				screenshot_b64 = await self.take_screenshot()
 			except Exception as e:
 				self.logger.warning(f'Failed to capture screenshot: {type(e).__name__}: {e}')
@@ -2812,8 +2816,17 @@ class BrowserSession(BaseModel):
 
 		# We no longer force tabs to the foreground as it disrupts user focus
 		# await self.agent_current_page.bring_to_front()
+		self.logger.debug('🖼️ Getting current page')
 		page = await self.get_current_page()
+		self.logger.debug(f'🖼️ Page URL: {page.url}')
+		self.logger.debug(f'🖼️ Page title: {await page.title()}')
+		self.logger.debug('🖼️ Waiting for load state')
 		await page.wait_for_load_state()
+
+		self.logger.debug('🖼️ Taking screenshot')
+		self.logger.debug(f'🖼️ Full page: {full_page}')
+		self.logger.debug('🖼️ Animations: disabled')
+		self.logger.debug('🖼️ Caret: initial')
 
 		screenshot = await self.agent_current_page.screenshot(
 			full_page=full_page,


### PR DESCRIPTION
WIP
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a configurable screenshot timeout and improved error handling for screenshot operations to prevent hangs and provide clearer errors.

- **Bug Fixes**
  - Checks browser and page connection state before taking screenshots.
  - Returns specific error messages for timeouts and connection issues.
  - Uses the new screenshot_timeout setting from the browser profile.

<!-- End of auto-generated description by cubic. -->

