### PR TITLE
#FIX:Include system_prompt_no_thinking.md in package build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ include = [
     "!browser_use/**/tests/*.py",
     "!browser_use/**/tests.py",
     "browser_use/agent/system_prompt.md",
+    "browser_use/agent/system_prompt_no_thinking.md",
     "browser_use/dom/buildDomTree.js",
     "!tests/**/*.py",
 ]


### PR DESCRIPTION
Add browser_use/agent/system_prompt_no_thinking.md to the Hatch build include list so that it is distributed and installed with the package.