### PR TITLE
eval-single-task-run

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -172,7 +172,6 @@ jobs:
           TASK_ID="${{ github.event.client_payload.script_args.task_id }}"
           TASK_TEXT="${{ github.event.client_payload.script_args.task_text }}"
           TASK_WEBSITE="${{ github.event.client_payload.script_args.task_website }}"
-          BRANCH="${{ github.event.client_payload.script_args.branch }}"
 
           # Build command using array for cleaner construction
           CMD_ARGS=(
@@ -212,7 +211,6 @@ jobs:
           [[ -n "$TASK_ID" ]] && CMD_ARGS+=("--task-id" "$TASK_ID")
           [[ -n "$TASK_TEXT" ]] && CMD_ARGS+=("--task-text" "$TASK_TEXT")
           [[ -n "$TASK_WEBSITE" ]] && CMD_ARGS+=("--task-website" "$TASK_WEBSITE")
-          [[ -n "$BRANCH" ]] && CMD_ARGS+=("--branch" "$BRANCH")
 
           # Convert array to command string with proper escaping
           printf -v CMD_STRING '%q ' "${CMD_ARGS[@]}"

--- a/eval/service.py
+++ b/eval/service.py
@@ -2202,9 +2202,6 @@ if __name__ == '__main__':
 	# Single task mode arguments
 	parser.add_argument('--task-text', type=str, default=None, help='Task description for single task mode')
 	parser.add_argument('--task-website', type=str, default=None, help='Task website for single task mode')
-	parser.add_argument(
-		'--branch', type=str, default=None, help='Git branch for single task mode (defaults to current branch if not provided)'
-	)
 	# Keep task-id for backward compatibility but make it optional
 	parser.add_argument('--task-id', type=str, default=None, help='Optional task ID (auto-generated if not provided)')
 
@@ -2217,6 +2214,10 @@ if __name__ == '__main__':
 	logger.info('Running tasks...')
 	# Run tasks and evaluate
 	load_dotenv()
+
+	# --- Load Environment Variables (Always) ---
+	CONVEX_URL = os.getenv('EVALUATION_TOOL_URL') or ''
+	SECRET_KEY = os.getenv('EVALUATION_TOOL_SECRET_KEY') or ''
 
 	# --- Load Tasks (Either Single Task or from Server) ---
 	tasks = []
@@ -2239,9 +2240,6 @@ if __name__ == '__main__':
 
 	else:
 		# Original multi-task mode - fetch from server
-		CONVEX_URL = os.getenv('EVALUATION_TOOL_URL')
-		SECRET_KEY = os.getenv('EVALUATION_TOOL_SECRET_KEY')
-
 		if not CONVEX_URL or not SECRET_KEY:
 			logger.error('Error: EVALUATION_TOOL_URL or EVALUATION_TOOL_SECRET_KEY environment variables not set.')
 			exit(1)  # Exit if config is missing
@@ -2270,16 +2268,8 @@ if __name__ == '__main__':
 	else:
 		logger.info('Attempting to start a new run on the server...')
 
-	# Get git info, with special handling for single task mode
+	# Get git info
 	git_info = get_git_info()
-
-	# For single task mode, allow branch override or use current branch
-	if args.task_text:
-		if args.branch:
-			git_info['branch'] = args.branch
-			logger.info(f'Single task mode: Using specified branch {args.branch}')
-		else:
-			logger.info(f'Single task mode: Using current git branch {git_info["branch"]}')
 
 	# Collect additional data from args to store with the run
 	additional_run_data = {


### PR DESCRIPTION
Auto-generated PR for branch: eval-single-task-run
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for running a single evaluation task by passing task details directly, without needing to fetch tasks from the server.

- **New Features**
  - Accepts task ID, text, website, and branch as parameters for single task runs.
  - Skips server fetch and uses a local run ID if only a single task is provided.
  - Results are saved locally or to the server if credentials are present.

<!-- End of auto-generated description by cubic. -->

