### PR TITLE
Revert browser session setup change

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -304,10 +304,10 @@ class Agent(Generic[Context]):
 			# always copy sessions that are passed in to avoid conflicting with other agents sharing the same session
 			self.browser_session = browser_session.model_copy(
 				deep=True,
-				update={
-					'agent_current_page': None,
-					'human_current_page': None,
-				},
+				# update={
+				# 	'agent_current_page': None,
+				# 	'human_current_page': None,
+				# },
 			)
 		else:
 			self.browser_session = BrowserSession(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reverted the recent change to browser session setup, restoring the previous logic for creating or using browser sessions.

<!-- End of auto-generated description by cubic. -->

