### PR TITLE
Fix single task run ID handling for cloud execution

### DIFF
--- a/eval/service.py
+++ b/eval/service.py
@@ -2306,12 +2306,17 @@ if __name__ == '__main__':
 		'laminarEvalLink': None,  # Will be updated after evaluation creation
 	}
 
-	# For single task mode, skip server run creation unless URLs are provided
+	# For single task mode, use provided run ID if available, otherwise skip server run creation
 	if args.task_text:
-		# Single task mode - generate a local run ID (use the task_id we generated earlier)
-		safe_task_id = task_id or 'unknown'
-		run_id = f'local_single_task_{safe_task_id}_{int(time.time())}'
-		logger.info(f'Single task mode: Using local run ID {run_id}')
+		# Single task mode - use provided run_id (from GitHub Actions) or generate local one
+		if args.run_id:
+			run_id = args.run_id
+			logger.info(f'Single task mode: Using provided run ID {run_id}')
+		else:
+			# Fallback for local single task runs without server
+			safe_task_id = task_id or 'unknown'
+			run_id = f'local_single_task_{safe_task_id}_{int(time.time())}'
+			logger.info(f'Single task mode: Using local run ID {run_id}')
 	else:
 		# Multi-task mode - use server
 		run_id = start_new_run(CONVEX_URL, SECRET_KEY, run_data, existing_run_id=args.run_id)


### PR DESCRIPTION
## Problem

Single task cloud execution was failing with validation errors because the evaluation script was generating local run IDs instead of using the provided Convex run ID.

## Solution

- Modified  to respect the provided  parameter in single task mode
- Removed fragile local run ID generation that caused database validation errors  
- Now follows the same robust pattern as regular evaluation runs
- Maintains backward compatibility for local single task runs without server

## Changes

- **service.py**: Use provided run_id when available in single task mode instead of always generating a local ID

## Testing

- Single task cloud execution now works without validation errors
- Results are properly saved to the correct Convex run
- Local single task runs still work as fallback

Fixes the issue where single task runs were showing success but failing to save results due to run ID mismatch.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed single task cloud execution to use the provided Convex run ID, preventing validation errors and ensuring results are saved correctly.

- **Bug Fixes**
  - Uses the given run ID in single task mode instead of always generating a local one.
  - Keeps local single task runs working as before.

<!-- End of auto-generated description by cubic. -->

