### PR TITLE
Enable config kwargs for chatgoogle model

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -66,8 +66,7 @@ class ChatGoogle(BaseChatModel):
 		llm = ChatGoogle(
 			model='gemini-2.0-flash-exp',
 			config_kwargs={
-				'tools': [types.Tool(code_execution=types.ToolCodeExecution())],
-				'safety_settings': [types.SafetySetting(category='HARM_CATEGORY_DANGEROUS_CONTENT', threshold='BLOCK_NONE')]
+				'tools': [types.Tool(code_execution=types.ToolCodeExecution())]
 			}
 		)
 	"""


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a config_kwargs parameter to the ChatGoogle model, letting users pass advanced configuration like tools and safety settings to the Gemini chat API.

- **New Features**
  - Users can now provide extra config options, such as code execution tools, when creating a ChatGoogle instance.
  - Model-specific settings like temperature still override config_kwargs if set.

<!-- End of auto-generated description by cubic. -->

