### PR TITLE
Files are displayed by default in done text

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -125,7 +125,6 @@ class Agent(Generic[Context]):
 		# Initial agent run parameters
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		initial_actions: list[dict[str, dict[str, Any]]] | None = None,
-		display_files_in_done_text: bool = True,
 		# Cloud Callbacks
 		register_new_step_callback: (
 			Callable[['BrowserStateSummary', 'AgentOutput', int], None]  # Sync callback
@@ -182,6 +181,7 @@ class Agent(Generic[Context]):
 		task_id: str | None = None,
 		cloud_sync: CloudSync | None = None,
 		calculate_cost: bool = False,
+		display_files_in_done_text: bool = True,
 	):
 		if page_extraction_llm is None:
 			page_extraction_llm = llm

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -121,10 +121,11 @@ class Agent(Generic[Context]):
 		browser_context: BrowserContext | None = None,
 		browser_profile: BrowserProfile | None = None,
 		browser_session: BrowserSession | None = None,
-		controller: Controller[Context] = Controller(),
+		controller: Controller[Context] | None = None,
 		# Initial agent run parameters
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		initial_actions: list[dict[str, dict[str, Any]]] | None = None,
+		display_files_in_done_text: bool = True,
 		# Cloud Callbacks
 		register_new_step_callback: (
 			Callable[['BrowserStateSummary', 'AgentOutput', int], None]  # Sync callback
@@ -197,7 +198,9 @@ class Agent(Generic[Context]):
 		# Core components
 		self.task = task
 		self.llm = llm
-		self.controller = controller
+		self.controller = (
+			controller if controller is not None else Controller(display_files_in_done_text=display_files_in_done_text)
+		)
 		self.sensitive_data = sensitive_data
 
 		self.settings = AgentSettings(


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Files are now shown by default in the "done" message when actions complete, making it easier to see file contents without extra steps.

- **New Features**
  - Added a setting to control if files are displayed in the "done" text.
  - By default, files are included in the message unless turned off.

<!-- End of auto-generated description by cubic. -->

