### PR TITLE
Add upload file action

### DIFF
--- a/browser_use/controller/views.py
+++ b/browser_use/controller/views.py
@@ -57,6 +57,11 @@ class SendKeysAction(BaseModel):
 	keys: str
 
 
+class UploadFileAction(BaseModel):
+	index: int
+	path: str
+
+
 class ExtractPageContentAction(BaseModel):
 	value: str
 


### PR DESCRIPTION
Adds file upload action to browser-use
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new action to upload files to interactive elements in the browser using a file path and element index.

- **New Features**
  - Supports uploading files by specifying the file path and target element index.
  - Returns clear error messages if the file or element is not found.

<!-- End of auto-generated description by cubic. -->

