### PR TITLE
Remove save_pdf action

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -2,7 +2,6 @@ import asyncio
 import enum
 import json
 import logging
-import re
 from collections.abc import Awaitable, Callable
 from typing import Any, Generic, TypeVar, cast
 
@@ -243,21 +242,6 @@ class Controller(Generic[Context]):
 				extracted_content=msg,
 				include_in_memory=True,
 				long_term_memory=f"Input '{params.text}' into element {params.index}.",
-			)
-
-		# Save PDF
-		@self.registry.action('Save the current page as a PDF file')
-		async def save_pdf(page: Page):
-			short_url = re.sub(r'^https?://(?:www\.)?|/$', '', page.url)
-			slug = re.sub(r'[^a-zA-Z0-9]+', '-', short_url).strip('-').lower()
-			sanitized_filename = f'{slug}.pdf'
-
-			await page.emulate_media(media='screen')
-			await page.pdf(path=sanitized_filename, format='A4', print_background=False)
-			msg = f'Saving page with URL {page.url} as PDF to ./{sanitized_filename}'
-			logger.info(msg)
-			return ActionResult(
-				extracted_content=msg, include_in_memory=True, long_term_memory=f'Saved PDF to {sanitized_filename}'
 			)
 
 		# Tab Management Actions

--- a/examples/custom-functions/save_pdf.py
+++ b/examples/custom-functions/save_pdf.py
@@ -18,6 +18,7 @@ from browser_use.llm import ChatOpenAI
 controller = Controller()
 
 download_path = Path.cwd() / 'downloads'
+download_path.mkdir(parents=True, exist_ok=True)
 
 
 # Save PDF - exact copy from original controller function

--- a/examples/custom-functions/save_pdf.py
+++ b/examples/custom-functions/save_pdf.py
@@ -1,0 +1,55 @@
+import asyncio
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use import ActionResult, Agent, Controller
+from browser_use.browser.types import Page
+from browser_use.llm import ChatOpenAI
+
+# Initialize controller
+controller = Controller()
+
+download_path = Path.cwd() / 'downloads'
+
+
+# Save PDF - exact copy from original controller function
+@controller.registry.action('Save the current page as a PDF file')
+async def save_pdf(page: Page):
+	short_url = re.sub(r'^https?://(?:www\.)?|/$', '', page.url)
+	slug = re.sub(r'[^a-zA-Z0-9]+', '-', short_url).strip('-').lower()
+	sanitized_filename = f'{slug}.pdf'
+
+	await page.emulate_media(media='screen')
+	await page.pdf(path=download_path / sanitized_filename, format='A4', print_background=False)
+	msg = f'Saving page with URL {page.url} as PDF to {download_path / sanitized_filename}'
+	return ActionResult(extracted_content=msg, include_in_memory=True, long_term_memory=f'Saved PDF to {sanitized_filename}')
+
+
+async def main():
+	"""
+	Example task: Navigate to browser-use.com and save the page as a PDF
+	"""
+	task = """
+	Go to https://browser-use.com/ and save the page as a PDF file.
+	"""
+
+	# Initialize the language model
+	model = ChatOpenAI(model='gpt-4.1-mini')
+
+	# Create and run the agent
+	agent = Agent(task=task, llm=model, controller=controller)
+
+	result = await agent.run()
+	print(f'🎯 Task completed: {result}')
+
+
+if __name__ == '__main__':
+	asyncio.run(main())


### PR DESCRIPTION
Removes save_pdf action from browser-use
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the built-in save_pdf action from the main controller and moved it to a custom example script.

- **Refactors**
 - Deleted save_pdf from controller code.
 - Added save_pdf as a standalone example in examples/custom-functions/save_pdf.py.

<!-- End of auto-generated description by cubic. -->

