### PR TITLE
eval-runners-disable-cache

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -53,29 +53,12 @@ jobs:
         with:
           ref: ${{ steps.determine_ref.outputs.REF }}
 
-      - name: Debug Repository Structure
-        run: |
-          echo "=== REPOSITORY STRUCTURE DEBUG ==="
-          echo "Current working directory: $(pwd)"
-          echo "Repository contents:"
-          ls -la
-          echo ""
-          echo "Looking for uv.lock:"
-          find . -name "uv.lock" -type f || echo "No uv.lock found"
-          echo ""
-          echo "Looking for pyproject.toml:"
-          find . -name "pyproject.toml" -type f || echo "No pyproject.toml found"
-          echo ""
-          echo "Git repository info:"
-          git remote -v
-          git branch
-          echo "=================================="
-
       - name: Set up Python and uv
         uses: useblacksmith/setup-uv@v4
         with:
-          enable-cache: true
-          cache-dependency-glob: "**/uv.lock"
+          enable-cache: false
+          # Disabled cache because uv.lock doesn't exist in repository
+          # cache-dependency-glob: "**/uv.lock"
           # Alternative: disable cache if issues persist
           # enable-cache: false
 


### PR DESCRIPTION
Auto-generated PR for branch: eval-runners-disable-cache
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Disabled caching in the eval workflow setup to avoid errors since uv.lock is not present in the repository.

- **Refactors**
  - Removed unused debug steps and cache configuration for uv.

<!-- End of auto-generated description by cubic. -->

