### PR TITLE
eval-runners-cache-enable

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -56,11 +56,12 @@ jobs:
       - name: Set up Python and uv
         uses: useblacksmith/setup-uv@v4
         with:
-          enable-cache: false
-          # Disabled cache because uv.lock doesn't exist in repository
-          # cache-dependency-glob: "**/uv.lock"
-          # Alternative: disable cache if issues persist
-          # enable-cache: false
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/*requirements*.txt
+          cache-suffix: "eval-deps"
+          prune-cache: false
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Auto-generated PR for branch: eval-runners-cache-enable
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enabled caching for Python dependencies in the eval workflow to speed up installs and reduce repeated downloads.

- **Dependencies**
  - Turned on cache for pyproject.toml and requirements files.
  - Set a custom cache suffix for eval dependencies.

<!-- End of auto-generated description by cubic. -->

