### PR TITLE
Fix name not defined error in example in agent-settings.mdx

### DIFF
--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -161,8 +161,8 @@ Specify the action as a dictionary where the key is the action name and the valu
 ```python
 
 initial_actions = [
-	{'go_to_url': {'url': 'https://www.google.com', 'new_tab': true}},
-	{'go_to_url': {'url': 'https://en.wikipedia.org/wiki/Randomness', 'new_tab': true}},
+	{'go_to_url': {'url': 'https://www.google.com', 'new_tab': True}},
+	{'go_to_url': {'url': 'https://en.wikipedia.org/wiki/Randomness', 'new_tab': True}},
 	{'scroll_down': {'amount': 1000}},
 ]
 agent = Agent(


### PR DESCRIPTION
Changed
"true" to "True" to avoid name error

Error I got with old version: "name 'true' is not defined""
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a Python example in the agent-settings documentation by changing "true" to "True" to prevent a name error.

<!-- End of auto-generated description by cubic. -->

