### PR TITLE
eval-add-anchor-arg

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -196,6 +196,7 @@ jobs:
           [[ "${{ github.event.client_payload.script_args.no_vision }}" == "true" ]] && CMD_ARGS+=("--no-vision")
           [[ "$HEADLESS" == "true" ]] && CMD_ARGS+=("--headless")
           [[ "${{ github.event.client_payload.script_args.use_serp }}" == "true" ]] && CMD_ARGS+=("--use-serp")
+          [[ "${{ github.event.client_payload.script_args.use_anchor }}" == "true" ]] && CMD_ARGS+=("--use-anchor")
           [[ "${{ github.event.client_payload.script_args.enable_memory }}" == "true" ]] && CMD_ARGS+=("--enable-memory")
           [[ "${{ github.event.client_payload.script_args.validate_output }}" == "true" ]] && CMD_ARGS+=("--validate-output")
           [[ "${{ github.event.client_payload.script_args.include_result }}" == "true" ]] && CMD_ARGS+=("--include-result")


### PR DESCRIPTION
Auto-generated PR for branch: eval-add-anchor-arg
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for the --use-anchor argument in the evaluation workflow to enable anchor usage during script execution.

<!-- End of auto-generated description by cubic. -->

