### PR TITLE
eval-runner-group

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   run_evaluation:
-    runs-on: ubuntu-latest-16-core
+    runs-on: 
+      group: eval
+      labels: ubuntu-latest-16-core
     timeout-minutes: 360
     env:
       IN_DOCKER: 'true'


### PR DESCRIPTION
Auto-generated PR for branch: eval-runner-group
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the eval workflow to use a specific runner group for evaluation jobs.

- **Dependencies**
  - Set the runner group to "eval" with the "ubuntu-latest-16-core" label.

<!-- End of auto-generated description by cubic. -->

