### PR TITLE
fix: correct case for GitHub

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -26,7 +26,7 @@
   },
   "topbarLinks": [
     {
-      "name": "Github",
+      "name": "GitHub",
       "url": "https://github.com/browser-use/browser-use"
     },
     {


### PR DESCRIPTION
Use correct case for `GitHub`
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the navigation link to use the correct "GitHub" casing in the top bar.

<!-- End of auto-generated description by cubic. -->

