### PR TITLE
Add reasoning_low parameter to OpenAI chat model

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -6,6 +6,7 @@ import httpx
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.shared.chat_model import ChatModel
+from openai.types.shared_params.reasoning_effort import ReasoningEffort
 from openai.types.shared_params.response_format_json_schema import JSONSchema, ResponseFormatJSONSchema
 from pydantic import BaseModel
 
@@ -33,7 +34,7 @@ class ChatOpenAI(BaseChatModel):
 
 	# Model params
 	temperature: float | None = None
-	reasoning_effort: str = 'low'
+	reasoning_effort: ReasoningEffort = 'low'
 
 	# Client initialization parameters
 	api_key: str | None = None


### PR DESCRIPTION
Added reasoning_low parameter to OpenAI chat model to control the reasoning effort of the model.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a reasoning_effort parameter to the OpenAI chat model, defaulting to "low", to control the model's reasoning level in responses.

<!-- End of auto-generated description by cubic. -->

