### PR TITLE
Remove xpath from input text action

### DIFF
--- a/browser_use/controller/views.py
+++ b/browser_use/controller/views.py
@@ -21,7 +21,6 @@ class ClickElementAction(BaseModel):
 class InputTextAction(BaseModel):
 	index: int
 	text: str
-	xpath: str | None = None
 
 
 class DoneAction(BaseModel):


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the optional xpath field from the InputTextAction model to simplify its structure.

<!-- End of auto-generated description by cubic. -->

