### PR TITLE
Remove xpath from click_element_by_index

### DIFF
--- a/browser_use/controller/views.py
+++ b/browser_use/controller/views.py
@@ -15,7 +15,6 @@ class GoToUrlAction(BaseModel):
 
 class ClickElementAction(BaseModel):
 	index: int
-	xpath: str | None = None
 
 
 class InputTextAction(BaseModel):


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the optional xpath field from the ClickElementAction model to simplify its structure.

<!-- End of auto-generated description by cubic. -->

