### PR TITLE
Remove mem0 dependencies from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "google-api-core>=2.25.0",
     "httpx>=0.28.1",
     "markdownify==1.1.0",
-    "mem0ai>=0.1.106",
     "patchright>=1.52.5",
     "playwright>=1.52.0",
     "portalocker>=2.7.0,<3.0.0",


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the mem0ai dependency from pyproject.toml to simplify project requirements.

<!-- End of auto-generated description by cubic. -->

