### PR TITLE
Clarify new elements tagging criteria

### DIFF
--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -61,7 +61,7 @@ Examples:
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
-- Elements with <new> tags are elements that appeared on the website since the last step - an element is only tagged as "new" if it was not present in the previous step but is now visible on the page (if url has not changed)
+- Elements with <new> tags appeared on the website since the last step (if url has not changed)
 - Pure text elements without [] are not interactive.
 </browser_state>
 

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -61,7 +61,7 @@ Examples:
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
-- Elements tagged with <new> are the new clickable elements that appeared on the website since the last step - if url has not changed
+- Elements tagged with <new> are the new clickable elements that appeared on the website since the last step - if url has not changed.
 - Pure text elements without [] are not interactive.
 </browser_state>
 

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -61,7 +61,7 @@ Examples:
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
-- Elements with <new> tags appeared on the website since the last step (if url has not changed)
+- Elements tagged with <new> are the new clickable elements that appeared on the website since the last step - if url has not changed
 - Pure text elements without [] are not interactive.
 </browser_state>
 

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -61,7 +61,7 @@ Examples:
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
-- Elements with <new> tags are new elements that were added after the previous step (if url has not changed)
+- Elements with <new> tags are elements that appeared on the website since the last step - an element is only tagged as "new" if it was not present in the previous step but is now visible on the page (if url has not changed)
 - Pure text elements without [] are not interactive.
 </browser_state>
 

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -61,7 +61,7 @@ Examples:
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
-- Elements with <new> tags are elements that appeared on the website since the last step - an element is only tagged as "new" if it was not present in the previous step but is now visible on the page (if url has not changed)
+- Elements with <new> tags appeared on the website since the last step (if url has not changed)
 - Pure text elements without [] are not interactive.
 </browser_state>
 

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -61,7 +61,7 @@ Examples:
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
-- Elements tagged with <new> are the new clickable elements that appeared on the website since the last step - if url has not changed
+- Elements tagged with <new> are the new clickable elements that appeared on the website since the last step - if url has not changed.
 - Pure text elements without [] are not interactive.
 </browser_state>
 

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -61,7 +61,7 @@ Examples:
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
-- Elements with <new> tags appeared on the website since the last step (if url has not changed)
+- Elements tagged with <new> are the new clickable elements that appeared on the website since the last step - if url has not changed
 - Pure text elements without [] are not interactive.
 </browser_state>
 

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -61,7 +61,7 @@ Examples:
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
-- Elements with <new> tags are new elements that were added after the previous step (if url has not changed)
+- Elements with <new> tags are elements that appeared on the website since the last step - an element is only tagged as "new" if it was not present in the previous step but is now visible on the page (if url has not changed)
 - Pure text elements without [] are not interactive.
 </browser_state>
 


### PR DESCRIPTION
Clarify system prompt description of `<new>` tags to specify new clickable elements.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the system prompt to clarify that elements tagged with <new> are clickable elements that appeared since the last step, if the URL has not changed.

<!-- End of auto-generated description by cubic. -->

