### PR TITLE
Fix cryptography dependency issue in GitHub Actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,15 +158,15 @@ log_level = "DEBUG"
 allow-direct-references = true
 
 [tool.uv]
-# required-environments = [
-#     "sys_platform == 'darwin' and platform_machine == 'arm64'",
-#     "sys_platform == 'darwin' and platform_machine == 'x86_64'",
-#     "sys_platform == 'linux' and platform_machine == 'x86_64'",
-#     "sys_platform == 'linux' and platform_machine == 'aarch64'",
-#     # "sys_platform == 'linux' and platform_machine == 'arm64'",  # no pytorch wheels available yet
-#     "sys_platform == 'win32' and platform_machine == 'x86_64'",
-#     # "sys_platform == 'win32' and platform_machine == 'arm64'",  # no pytorch wheels available yet
-# ]
+required-environments = [
+    "sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "sys_platform == 'linux' and platform_machine == 'aarch64'",
+    # "sys_platform == 'linux' and platform_machine == 'arm64'",  # no pytorch wheels available yet
+    "sys_platform == 'win32' and platform_machine == 'x86_64'",
+    # "sys_platform == 'win32' and platform_machine == 'arm64'",  # no pytorch wheels available yet
+]
 dev-dependencies = [
     "ruff>=0.11.2",
     "tokencost>=0.1.16",


### PR DESCRIPTION
## Problem
The GitHub Actions workflow was failing with:
```
error: Distribution cryptography==45.0.5 @ registry+https://pypi.org/simple can't be installed because it doesn't have a source distribution or wheel for the current platform
```

The issue was that cryptography 45.0.5 doesn't have wheels for Linux x86_64 (used by GitHub Actions runners).

## Solution
Uncommented the `required-environments` section in `pyproject.toml` to ensure `uv` resolves packages with compatible wheels for all supported platforms, including Linux x86_64.

This forces `uv` to pick package versions that have wheels available for the target platform rather than trying to use incompatible versions.

## Note
The GitHub workflow URL tracking feature was already implemented in a recent commit, so this PR only contains the dependency fix.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a dependency issue in GitHub Actions by enabling required environment settings in pyproject.toml, so compatible cryptography wheels are used on all platforms. This prevents workflow failures on Linux x86_64 runners.

<!-- End of auto-generated description by cubic. -->

