### PR TITLE
eval-dont-go-to-the-website

### DIFF
--- a/eval/service.py
+++ b/eval/service.py
@@ -1373,9 +1373,9 @@ async def setup_browser_session(task: Task, headless: bool, highlight_elements: 
 	logger.debug(f'Browser setup: Browser session started for task {task.task_id}')
 
 	# Navigate to task starting url if provided
-	if task.website:
-		logger.debug(f'Browser setup: Navigating to {task.website} for task {task.task_id}')
-		await browser_session.navigate(task.website)
+	# if task.website:
+	# logger.debug(f'Browser setup: Navigating to {task.website} for task {task.task_id}')
+	# await browser_session.navigate(task.website)
 
 	logger.debug(f'Browser setup: Setup completed for task {task.task_id}')
 	return browser_session


### PR DESCRIPTION
Auto-generated PR for: eval-dont-go-to-the-website
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Commented out the code that automatically navigates to the website when setting up a browser session for a task.

<!-- End of auto-generated description by cubic. -->

