### PR TITLE
fix for new release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ include = [
     "!browser_use/**/tests.py",
     "browser_use/agent/system_prompt.md",
     "browser_use/agent/system_prompt_no_thinking.md",
-    "browser_use/dom/buildDomTree.js",
+    "browser_use/dom/**/*.js",
     "!tests/**/*.py",
 ]
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the release build to include all JavaScript files in browser_use/dom, not just buildDomTree.js.

<!-- End of auto-generated description by cubic. -->

