### PR TITLE
fix: fixing highlighted elements not show

### DIFF
--- a/browser_use/dom/dom_tree/index.js
+++ b/browser_use/dom/dom_tree/index.js
@@ -140,7 +140,8 @@
         container.style.left = "0";
         container.style.width = "100%";
         container.style.height = "100%";
-        container.style.zIndex = "2147483640";
+        // Make sure to use the maximum valid value in zIndex to avoid being blocked by other elements
+        container.style.zIndex = "2147483647";
         container.style.backgroundColor = 'transparent';
         document.body.appendChild(container);
       }


### PR DESCRIPTION
fix: fixing highlighted elements not show. Make sure to use the maximum valid value in zIndex to avoid being blocked by other elements
fixing: [highlighted elements not show #2292](https://github.com/browser-use/browser-use/issues/2292)

### before fixing: some interactive elements are not highlighted in the picture.
![img_v3_02ns_bba33936-14a4-42f5-a96f-e74749a5a9cg](https://github.com/user-attachments/assets/2ea83327-fd82-4386-94b8-a52f119b3a73)

### after fixing: some interactive elements are highlighted in the picture,such as "接受" highlighted with number 2.
![img_v3_02ns_18319f38-94eb-4e06-8d66-10bdc0e6ffbg](https://github.com/user-attachments/assets/9e39e293-1122-4ef6-b827-e5a5c3659953)
