### PR TITLE
fixing detection of interactive elements in Shadow DOM

### DIFF
--- a/browser_use/dom/dom_tree/index.js
+++ b/browser_use/dom/dom_tree/index.js
@@ -140,7 +140,8 @@
         container.style.left = "0";
         container.style.width = "100%";
         container.style.height = "100%";
-        container.style.zIndex = "2147483640";
+        // Make sure to use the maximum valid value in zIndex to avoid being blocked by other elements
+        container.style.zIndex = "2147483647";
         container.style.backgroundColor = 'transparent';
         document.body.appendChild(container);
       }

--- a/browser_use/dom/dom_tree/index.js
+++ b/browser_use/dom/dom_tree/index.js
@@ -140,7 +140,7 @@
         container.style.left = "0";
         container.style.width = "100%";
         container.style.height = "100%";
-        // Make sure to use the maximum valid value in zIndex to avoid being blocked by other elements
+        // Use the maximum valid value in zIndex to ensure the element is not blocked by overlapping elements.
         container.style.zIndex = "2147483647";
         container.style.backgroundColor = 'transparent';
         document.body.appendChild(container);

--- a/browser_use/dom/dom_tree/index.js
+++ b/browser_use/dom/dom_tree/index.js
@@ -1235,7 +1235,8 @@
     }
 
     // Early viewport check - only filter out elements clearly outside viewport
-    if (viewportExpansion !== -1) {
+    // The getBoundingClientRect() of the Shadow DOM host element may return width/height = 0
+    if (viewportExpansion !== -1 && !node.shadowRoot) {
       const rect = getCachedBoundingRect(node); // Keep for initial quick check
       const style = getCachedComputedStyle(node);
 


### PR DESCRIPTION
fixing detection of interactive elements in Shadow DOM.
fixing by
1. Avoiding  Early viewport check
2. Use the maximum valid value in zIndex to ensure the element is not blocked by overlapping elements.

**fixing: [Interaction Issue: Shadow DOM in axeptio cookie banner #2276](https://github.com/browser-use/browser-use/issues/2276)**

#### Before fixing: Nothing is highlighted in following picture.
![img_v3_02nt_041fa406-69ea-4fab-a2f5-780c8ec7e82g](https://github.com/user-attachments/assets/3244ff42-08ae-4efa-8890-b871bae567a2)

#### After fixing: There are  10 elements be highlighted in following picture.
![img_v3_02nt_b5b58c7f-1a35-457b-97c2-aabb0318da9g](https://github.com/user-attachments/assets/ed3711a1-12d3-4d9b-bc08-e73f000e9de2)
