### PR TITLE
feat: multiple browser support for the eval script

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -23,6 +23,7 @@ jobs:
       EVALUATION_TOOL_URL: ${{ secrets.EVALUATION_TOOL_URL }}
       EVALUATION_TOOL_SECRET_KEY: ${{ secrets.EVALUATION_TOOL_SECRET_KEY }}
       ANCHOR_BROWSER_API_KEY: ${{ secrets.ANCHOR_BROWSER_API_KEY }}
+      BRIGHTDATA_CDP_URL: ${{ secrets.BRIGHTDATA_CDP_URL }}
       SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
       LMNR_PROJECT_API_KEY: ${{ secrets.LMNR_PROJECT_API_KEY }}
       BROWSER_USE_LOGGING_LEVEL: ${{ secrets.BROWSER_USE_LOGGING_LEVEL }}
@@ -251,6 +252,7 @@ jobs:
           USER_MESSAGE="${{ github.event.client_payload.script_args.user_message }}"
           DEVELOPER_ID="${{ github.event.client_payload.script_args.developer_id }}"
           PLANNER_MODEL="${{ github.event.client_payload.script_args.planner_model }}"
+          BROWSER="${{ github.event.client_payload.script_args.browser }}"
           RUN_ID="${{ github.event.client_payload.script_args.run_id }}"
           LAMINAR_EVAL_ID="${{ github.event.client_payload.script_args.laminar_eval_id }}"
           # Pass raw GitHub Actions object to Python - no parsing in bash
@@ -282,7 +284,6 @@ jobs:
           [[ "${{ github.event.client_payload.script_args.no_vision }}" == "true" ]] && CMD_ARGS+=("--no-vision")
           [[ "$HEADLESS" == "true" ]] && CMD_ARGS+=("--headless")
           [[ "${{ github.event.client_payload.script_args.use_serp }}" == "true" ]] && CMD_ARGS+=("--use-serp")
-          [[ "${{ github.event.client_payload.script_args.use_anchor }}" == "true" ]] && CMD_ARGS+=("--use-anchor")
           [[ "${{ github.event.client_payload.script_args.enable_memory }}" == "true" ]] && CMD_ARGS+=("--enable-memory")
           [[ "${{ github.event.client_payload.script_args.validate_output }}" == "true" ]] && CMD_ARGS+=("--validate-output")
           [[ "${{ github.event.client_payload.script_args.include_result }}" == "true" ]] && CMD_ARGS+=("--include-result")
@@ -294,6 +295,7 @@ jobs:
           [[ -n "$USER_MESSAGE" ]] && CMD_ARGS+=("--user-message" "$USER_MESSAGE")
           [[ -n "$DEVELOPER_ID" ]] && CMD_ARGS+=("--developer-id" "$DEVELOPER_ID")
           [[ -n "$PLANNER_MODEL" ]] && CMD_ARGS+=("--planner-model" "$PLANNER_MODEL")
+          [[ -n "$BROWSER" ]] && CMD_ARGS+=("--browser" "$BROWSER")
           [[ -n "$RUN_ID" ]] && CMD_ARGS+=("--run-id" "$RUN_ID")
           [[ -n "$LAMINAR_EVAL_ID" ]] && CMD_ARGS+=("--laminar-eval-id" "$LAMINAR_EVAL_ID")
           

--- a/eval/service.py
+++ b/eval/service.py
@@ -96,8 +96,13 @@ else:
 def create_anchor_browser_session(headless: bool = False) -> str:
 	"""Create an Anchor Browser session and return CDP URL"""
 	browser_configuration = {
-		'session': {'proxy': {'type': 'anchor_residential', 'active': True}},
-		'browser': {'adblock': {'active': True}, 'captcha_solver': {'active': True}, 'headless': {'active': headless}},
+		'session': {'proxy': {'type': 'anchor_mobile', 'active': True, 'country_code': 'us'}},
+		'browser': {
+			'adblock': {'active': True},
+			'captcha_solver': {'active': True},
+			'headless': {'active': headless},
+			'extra_stealth': {'active': True},
+		},
 	}
 
 	try:

--- a/eval/service.py
+++ b/eval/service.py
@@ -81,9 +81,16 @@ load_dotenv()
 # Check for Anchor Browser API key
 ANCHOR_BROWSER_API_KEY = os.getenv('ANCHOR_BROWSER_API_KEY')
 if ANCHOR_BROWSER_API_KEY:
-	logger.info('ANCHOR_BROWSER_API_KEY is set. Tasks will use Anchor Browser.')
+	logger.info('ANCHOR_BROWSER_API_KEY is set. Tasks can use Anchor Browser.')
 else:
-	logger.warning('ANCHOR_BROWSER_API_KEY is not set. Tasks will use local browser.')
+	logger.warning('ANCHOR_BROWSER_API_KEY is not set. Anchor Browser will not be available.')
+
+# Check for Brightdata CDP URL
+BRIGHTDATA_CDP_URL = os.getenv('BRIGHTDATA_CDP_URL')
+if BRIGHTDATA_CDP_URL:
+	logger.info('BRIGHTDATA_CDP_URL is set. Tasks can use Brightdata browser.')
+else:
+	logger.warning('BRIGHTDATA_CDP_URL is not set. Brightdata browser will not be available.')
 
 
 def create_anchor_browser_session(headless: bool = False) -> str:
@@ -1441,27 +1448,43 @@ async def run_stage(stage: Stage, stage_func, timeout: int | None = None):
 
 
 async def setup_browser_session(
-	task: Task, headless: bool, highlight_elements: bool = True, use_anchor: bool = False
+	task: Task, headless: bool, highlight_elements: bool = True, browser: str = 'local'
 ) -> BrowserSession:
 	"""Setup browser session for the task"""
 
-	# Check for Anchor Browser API key and flag
+	# Validate browser option
+	valid_browsers = ['local', 'anchor-browser', 'brightdata', 'browser-use']
+	if browser not in valid_browsers:
+		logger.warning(f'Browser setup: Invalid browser option "{browser}". Falling back to local browser.')
+		browser = 'local'
+
 	cdp_url = None
 
-	if use_anchor and ANCHOR_BROWSER_API_KEY:
-		try:
-			logger.debug(f'Browser setup: Creating Anchor Browser session for task {task.task_id}')
-			cdp_url = await asyncio.to_thread(create_anchor_browser_session, headless)
-		except Exception as e:
-			logger.error(
-				f'Browser setup: Failed to create Anchor Browser session for task {task.task_id}: {type(e).__name__}: {e}'
+	if browser == 'anchor-browser':
+		if ANCHOR_BROWSER_API_KEY:
+			try:
+				logger.debug(f'Browser setup: Creating Anchor Browser session for task {task.task_id}')
+				cdp_url = await asyncio.to_thread(create_anchor_browser_session, headless)
+			except Exception as e:
+				logger.error(
+					f'Browser setup: Failed to create Anchor Browser session for task {task.task_id}: {type(e).__name__}: {e}'
+				)
+				logger.info(f'Browser setup: Falling back to local browser for task {task.task_id}')
+				cdp_url = None
+		else:
+			logger.warning(
+				f'Browser setup: Anchor Browser requested but ANCHOR_BROWSER_API_KEY not set. Using local browser for task {task.task_id}'
 			)
-			logger.info(f'Browser setup: Falling back to local browser for task {task.task_id}')
-			cdp_url = None
-	elif use_anchor and not ANCHOR_BROWSER_API_KEY:
-		logger.warning(
-			f'Browser setup: Anchor Browser requested but ANCHOR_BROWSER_API_KEY not set. Using local browser for task {task.task_id}'
-		)
+	elif browser == 'brightdata':
+		if BRIGHTDATA_CDP_URL:
+			logger.debug(f'Browser setup: Using Brightdata CDP URL for task {task.task_id}')
+			cdp_url = BRIGHTDATA_CDP_URL
+		else:
+			logger.warning(
+				f'Browser setup: Brightdata requested but BRIGHTDATA_CDP_URL not set. Using local browser for task {task.task_id}'
+			)
+	elif browser == 'browser-use':
+		logger.warning(f'Browser setup: Browser-use not implemented yet. Falling back to local browser for task {task.task_id}')
 
 	profile_kwargs = {
 		'user_data_dir': None,  # Incognito mode - no persistent state
@@ -1843,7 +1866,7 @@ async def run_task_with_semaphore(
 	semaphore_runs: asyncio.Semaphore,  # Pass semaphore as argument
 	github_workflow_url: str | None = None,
 	use_serp: bool = False,
-	use_anchor: bool = False,
+	browser: str = 'local',
 	enable_memory: bool = False,
 	memory_interval: int = 10,
 	max_actions_per_step: int = 10,
@@ -1940,7 +1963,7 @@ async def run_task_with_semaphore(
 
 					browser_session = await run_stage(
 						Stage.SETUP_BROWSER,
-						lambda: setup_browser_session(task, headless, highlight_elements, use_anchor),
+						lambda: setup_browser_session(task, headless, highlight_elements, browser),
 						timeout=120,
 					)
 					task_result.stage_completed(Stage.SETUP_BROWSER)
@@ -2248,7 +2271,7 @@ async def run_multiple_tasks(
 	headless: bool = False,
 	use_vision: bool = True,
 	use_serp: bool = False,
-	use_anchor: bool = False,
+	browser: str = 'local',
 	enable_memory: bool = False,
 	memory_interval: int = 10,
 	max_actions_per_step: int = 10,
@@ -2329,7 +2352,7 @@ async def run_multiple_tasks(
 					semaphore_runs=semaphore_runs,  # Pass the semaphore
 					github_workflow_url=github_workflow_url,
 					use_serp=use_serp,
-					use_anchor=use_anchor,
+					browser=browser,
 					enable_memory=enable_memory,
 					memory_interval=memory_interval,
 					max_actions_per_step=max_actions_per_step,
@@ -2689,7 +2712,7 @@ async def run_evaluation_pipeline(
 	headless: bool = False,
 	use_vision: bool = True,
 	use_serp: bool = False,
-	use_anchor: bool = False,
+	browser: str = 'local',
 	enable_memory: bool = False,
 	memory_interval: int = 10,
 	max_actions_per_step: int = 10,
@@ -2744,7 +2767,7 @@ async def run_evaluation_pipeline(
 		headless=headless,
 		use_vision=use_vision,
 		use_serp=use_serp,
-		use_anchor=use_anchor,
+		browser=browser,
 		enable_memory=enable_memory,
 		memory_interval=memory_interval,
 		max_actions_per_step=max_actions_per_step,
@@ -2877,7 +2900,12 @@ if __name__ == '__main__':
 	parser.add_argument('--eval-group', type=str, default='', help='Evaluation group to include in the run')
 	parser.add_argument('--developer-id', type=str, default=None, help='Name of the developer starting the run')
 	parser.add_argument('--use-serp', action='store_true', help='Use SERP search instead of Google search')
-	parser.add_argument('--use-anchor', action='store_true', help='Use Anchor Browser (requires ANCHOR_BROWSER_API_KEY)')
+	parser.add_argument(
+		'--browser',
+		type=str,
+		default='local',
+		help='Browser to use: local, anchor-browser, brightdata, browser-use (default: local)',
+	)
 	parser.add_argument('--enable-memory', action='store_true', help='Enable mem0 memory system for agents')
 	parser.add_argument('--memory-interval', type=int, default=10, help='Memory creation interval (default: 10 steps)')
 	parser.add_argument('--max-actions-per-step', type=int, default=10, help='Maximum number of actions per step (default: 10)')
@@ -3130,11 +3158,18 @@ if __name__ == '__main__':
 		logger.info('🔍 Using default Google search')
 
 	# Log browser mode being used
-	if args.use_anchor:
+	if args.browser == 'anchor-browser':
 		if ANCHOR_BROWSER_API_KEY:
 			logger.info('🌐 Using Anchor Browser (remote browser service)')
 		else:
-			logger.warning('⚠️ --use-anchor flag provided but ANCHOR_BROWSER_API_KEY not set. Will use local browser!')
+			logger.warning('⚠️ --browser anchor-browser provided but ANCHOR_BROWSER_API_KEY not set. Will use local browser!')
+	elif args.browser == 'brightdata':
+		if BRIGHTDATA_CDP_URL:
+			logger.info('🌐 Using Brightdata browser (remote browser service)')
+		else:
+			logger.warning('⚠️ --browser brightdata provided but BRIGHTDATA_CDP_URL not set. Will use local browser!')
+	elif args.browser == 'browser-use':
+		logger.warning('🌐 Browser-use not implemented yet. Will use local browser!')
 	else:
 		logger.info('🌐 Using local browser')
 
@@ -3235,7 +3270,7 @@ if __name__ == '__main__':
 				headless=args.headless,
 				use_vision=not args.no_vision,
 				use_serp=args.use_serp,
-				use_anchor=args.use_anchor,
+				browser=args.browser,
 				enable_memory=args.enable_memory,
 				memory_interval=args.memory_interval,
 				max_actions_per_step=args.max_actions_per_step,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for selecting different browsers (local, Anchor Browser, Brightdata) in the eval script using a new --browser argument.

- **New Features**
  - Users can choose the browser backend with --browser (local, anchor-browser, brightdata, browser-use).
  - Updated environment variable handling and logging for new browser options.

<!-- End of auto-generated description by cubic. -->

