### PR TITLE
Change step index to start at zero

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -175,7 +175,7 @@ Interactive elements from top layer of the current page inside the viewport{trun
 
 	def _get_agent_state_description(self) -> str:
 		if self.step_info:
-			step_info_description = f'Step {self.step_info.step_number + 1} of {self.step_info.max_steps} max possible steps\n'
+			step_info_description = f'Step {self.step_info.step_number} of {self.step_info.max_steps} max possible steps\n'
 		else:
 			step_info_description = ''
 		time_str = datetime.now().strftime('%Y-%m-%d %H:%M')

--- a/eval/comprehensive_judge.py
+++ b/eval/comprehensive_judge.py
@@ -133,7 +133,7 @@ def prepare_agent_steps(complete_history: list[dict]) -> list[str]:
 
 	steps = []
 	for i, step in enumerate(history_to_process):
-		step_text = f'Step {i + 1}:\n'
+		step_text = f'Step {i}:\n'
 
 		# Add model output if available
 		if step.get('model_output'):
@@ -156,15 +156,15 @@ def prepare_agent_steps(complete_history: list[dict]) -> list[str]:
 					if result.get('extracted_content'):
 						content = str(result['extracted_content'])
 						if len(content) > 500:
-							step_text += f'Result {j + 1}: {content[:500]}...[cut for eval system]\n'
+							step_text += f'Result {j}: {content[:500]}...[cut for eval system]\n'
 						else:
-							step_text += f'Result {j + 1}: {content}\n'
+							step_text += f'Result {j}: {content}\n'
 					if result.get('error'):
 						error = str(result['error'])
 						if len(error) > 500:
-							step_text += f'Error {j + 1}: {error[:500]}...[cut for eval system]\n'
+							step_text += f'Error {j}: {error[:500]}...[cut for eval system]\n'
 						else:
-							step_text += f'Error {j + 1}: {error}\n'
+							step_text += f'Error {j}: {error}\n'
 
 		steps.append(step_text)
 


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Changed step numbering to start at zero instead of one in agent state descriptions and evaluation steps. This ensures consistency across the UI and evaluation outputs.

<!-- End of auto-generated description by cubic. -->

