### PR TITLE
MCP server logging stderr redirection

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -1,6 +1,14 @@
+import os
+
 from browser_use.logging_config import setup_logging
 
-logger = setup_logging()
+# Only set up logging if not in MCP mode or if explicitly requested
+if os.environ.get('BROWSER_USE_SETUP_LOGGING', 'true').lower() != 'false':
+	logger = setup_logging()
+else:
+	import logging
+
+	logger = logging.getLogger('browser_use')
 
 # Monkeypatch BaseSubprocessTransport.__del__ to handle closed event loops gracefully
 from asyncio import base_subprocess

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -494,21 +494,6 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 		return None
 
 
-class ActionNotFoundError(ValueError):
-	"""Raised when an unknown action is attempted"""
-
-	def __init__(self, attempted_action: str | None, available_actions: list[str]):
-		self.attempted_action = attempted_action
-		self.available_actions = sorted(available_actions)
-
-		if attempted_action:
-			message = f"Unknown action '{attempted_action}' in model response. Available actions are: {', '.join(self.available_actions)}"
-		else:
-			message = f'Failed to parse action from model response. Available actions are: {", ".join(self.available_actions)}'
-
-		super().__init__(message)
-
-
 class AgentError:
 	"""Container for agent error handling"""
 
@@ -520,9 +505,6 @@ class AgentError:
 	def format_error(error: Exception, include_trace: bool = False) -> str:
 		"""Format error message based on error type and optionally include trace"""
 		message = ''
-		if isinstance(error, ActionNotFoundError):
-			# For ActionNotFoundError, use the message as-is
-			return str(error)
 		if isinstance(error, ValidationError):
 			return f'{AgentError.VALIDATION_ERROR}\nDetails: {str(error)}'
 		if isinstance(error, RateLimitError):

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -494,6 +494,21 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 		return None
 
 
+class ActionNotFoundError(ValueError):
+	"""Raised when an unknown action is attempted"""
+
+	def __init__(self, attempted_action: str | None, available_actions: list[str]):
+		self.attempted_action = attempted_action
+		self.available_actions = sorted(available_actions)
+
+		if attempted_action:
+			message = f"Unknown action '{attempted_action}' in model response. Available actions are: {', '.join(self.available_actions)}"
+		else:
+			message = f'Failed to parse action from model response. Available actions are: {", ".join(self.available_actions)}'
+
+		super().__init__(message)
+
+
 class AgentError:
 	"""Container for agent error handling"""
 
@@ -505,6 +520,9 @@ class AgentError:
 	def format_error(error: Exception, include_trace: bool = False) -> str:
 		"""Format error message based on error type and optionally include trace"""
 		message = ''
+		if isinstance(error, ActionNotFoundError):
+			# For ActionNotFoundError, use the message as-is
+			return str(error)
 		if isinstance(error, ValidationError):
 			return f'{AgentError.VALIDATION_ERROR}\nDetails: {str(error)}'
 		if isinstance(error, RateLimitError):

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1750,7 +1750,7 @@ class BrowserSession(BaseModel):
 				if self.browser_profile.downloads_path:
 					try:
 						# Try short-timeout expect_download to detect a file download has been been triggered
-						async with page.expect_download(timeout=5000) as download_info:
+						async with page.expect_download(timeout=5_000) as download_info:
 							await click_func()
 						download = await download_info.value
 						# Determine file path
@@ -1787,7 +1787,7 @@ class BrowserSession(BaseModel):
 					await self._check_and_handle_navigation(page)
 
 			try:
-				return await perform_click(lambda: element_handle and element_handle.click(timeout=1500))
+				return await perform_click(lambda: element_handle and element_handle.click(timeout=1_500))
 			except URLNotAllowedError as e:
 				raise e
 			except Exception as e:
@@ -1800,7 +1800,7 @@ class BrowserSession(BaseModel):
 						raise Exception(f'Element no longer exists in DOM after context loss: {repr(element_node)}')
 					# Try click again with fresh element
 					try:
-						return await perform_click(lambda: element_handle.click(timeout=1500))
+						return await perform_click(lambda: element_handle.click(timeout=1_500))
 					except Exception:
 						# Fall back to JavaScript click
 						return await perform_click(lambda: page.evaluate('(el) => el.click()', element_handle))
@@ -1903,7 +1903,7 @@ class BrowserSession(BaseModel):
 		except Exception as e:
 			if 'timeout' in str(e).lower():
 				self.logger.warning(
-					f"⚠️ Loading {_log_pretty_url(normalized_url)} didn't finish after {(self.browser_profile.default_navigation_timeout or 30000) / 1000}s, continuing anyway..."
+					f"⚠️ Loading {_log_pretty_url(normalized_url)} didn't finish after {(self.browser_profile.default_navigation_timeout or 30_000) / 1000}s, continuing anyway..."
 				)
 				# Don't re-raise timeout errors - the page is likely still usable and will continue to load in the background
 			else:
@@ -2462,7 +2462,7 @@ class BrowserSession(BaseModel):
 		try:
 			# 10 ms timeout
 			page = await self.get_current_page()
-			await page.go_back(timeout=10, wait_until='domcontentloaded')
+			await page.go_back(timeout=10_000, wait_until='domcontentloaded')
 
 			# await self._wait_for_page_and_frames_load(timeout_overwrite=1.0)
 		except Exception as e:
@@ -2473,7 +2473,7 @@ class BrowserSession(BaseModel):
 		"""Navigate the agent's tab forward in browser history"""
 		try:
 			page = await self.get_current_page()
-			await page.go_forward(timeout=10, wait_until='domcontentloaded')
+			await page.go_forward(timeout=10_000, wait_until='domcontentloaded')
 		except Exception as e:
 			# Continue even if its not fully loaded, because we wait later for the page to load
 			self.logger.debug(f'⏭️ Error during go_forward: {type(e).__name__}: {e}')
@@ -2821,7 +2821,7 @@ class BrowserSession(BaseModel):
 		page = await self.get_current_page()
 
 		try:
-			await page.wait_for_load_state(timeout=5000)
+			await page.wait_for_load_state(timeout=5_000)
 		except Exception:
 			pass
 
@@ -3269,10 +3269,10 @@ class BrowserSession(BaseModel):
 
 			# Ensure element is ready for input
 			try:
-				await element_handle.wait_for_element_state('stable', timeout=1000)
+				await element_handle.wait_for_element_state('stable', timeout=1_000)
 				is_visible = await self._is_visible(element_handle)
 				if is_visible:
-					await element_handle.scroll_into_view_if_needed(timeout=1000)
+					await element_handle.scroll_into_view_if_needed(timeout=1_000)
 			except Exception:
 				pass
 

--- a/browser_use/logging_config.py
+++ b/browser_use/logging_config.py
@@ -59,18 +59,25 @@ def addLoggingLevel(levelName, levelNum, methodName=None):
 	setattr(logging, methodName, logToRoot)
 
 
-def setup_logging():
+def setup_logging(stream=None, log_level=None, force_setup=False):
+	"""Setup logging configuration for browser-use.
+
+	Args:
+		stream: Output stream for logs (default: sys.stdout). Can be sys.stderr for MCP mode.
+		log_level: Override log level (default: uses CONFIG.BROWSER_USE_LOGGING_LEVEL)
+		force_setup: Force reconfiguration even if handlers already exist
+	"""
 	# Try to add RESULT level, but ignore if it already exists
 	try:
 		addLoggingLevel('RESULT', 35)  # This allows ERROR, FATAL and CRITICAL
 	except AttributeError:
 		pass  # Level already exists, which is fine
 
-	log_type = CONFIG.BROWSER_USE_LOGGING_LEVEL
+	log_type = log_level or CONFIG.BROWSER_USE_LOGGING_LEVEL
 
 	# Check if handlers are already set up
-	if logging.getLogger().hasHandlers():
-		return
+	if logging.getLogger().hasHandlers() and not force_setup:
+		return logging.getLogger('browser_use')
 
 	# Clear existing handlers
 	root = logging.getLogger()
@@ -83,7 +90,7 @@ def setup_logging():
 			return super().format(record)
 
 	# Setup single handler for all loggers
-	console = logging.StreamHandler(sys.stdout)
+	console = logging.StreamHandler(stream or sys.stdout)
 
 	# adittional setLevel here to filter logs
 	if log_type == 'result':

--- a/browser_use/observability.py
+++ b/browser_use/observability.py
@@ -39,7 +39,9 @@ def _is_debug_mode() -> bool:
 	return False
 
 
-logger.info(f'Debug mode is {_is_debug_mode()}')
+# Only log debug mode status if explicitly requested
+if os.environ.get('BROWSER_USE_VERBOSE_OBSERVABILITY', 'false').lower() == 'true':
+	logger.info(f'Debug mode is {_is_debug_mode()}')
 
 # Try to import lmnr observe
 _LMNR_AVAILABLE = False
@@ -48,10 +50,12 @@ _lmnr_observe = None
 try:
 	from lmnr import observe as _lmnr_observe  # type: ignore
 
-	logger.info('Lmnr is available for observability')
+	if os.environ.get('BROWSER_USE_VERBOSE_OBSERVABILITY', 'false').lower() == 'true':
+		logger.info('Lmnr is available for observability')
 	_LMNR_AVAILABLE = True
 except ImportError:
-	logger.info('Lmnr is not available for observability')
+	if os.environ.get('BROWSER_USE_VERBOSE_OBSERVABILITY', 'false').lower() == 'true':
+		logger.info('Lmnr is not available for observability')
 	_LMNR_AVAILABLE = False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.4.5"
+version = "0.5.0"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Redirected all server and library logging to stderr in MCP mode to prevent log output from mixing with stdout, and made logging setup more configurable.

- **Refactors**
  - Logging now uses stderr for all output in MCP server mode.
  - Added environment variables and options to control logging setup and verbosity.
  - Updated logging configuration to allow forced reconfiguration and custom streams.

<!-- End of auto-generated description by cubic. -->

