### PR TITLE
Automatically Download PDFs when reached, scroll with Pure CDP to scroll inside PDF

### DIFF
--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -87,13 +87,13 @@ Strictly follow these rules while using the browser and navigating the web:
 - If the <user_request> includes specific page information such as product type, rating, price, location, etc., try to apply filters to be more efficient.
 - The <user_request> is the ultimate goal. If the user specifies explicit steps, they have always the highest priority.
 - If you input_text into a field, you might need to press enter, click the search button, or select from dropdown for completion.
-- Try to close popups and cookies by accepting or closing them. Sometimes you need to scroll or send_keys escape to close them. Often random popups or login forms pop up, you can just close them.
 - Don't login into a page if you don't have to. Don't login if you don't have the credentials. 
 - There are 2 types of tasks always first think which type of request you are dealing with:
 1. Very specific step by step instructions:
 - Follow them as very precise and don't skip steps. Try to complete everything as requested.
 2. Open ended tasks. Plan yourself, be creative in achieving them.
 - If you get stuck e.g. with logins or captcha in open-ended tasks you can re-evaluate the task and try alternative ways, e.g. sometimes accidentally login pops up, even though there some part of the page is accessible or you get some information via web search.
+- If you reach a PDF viewer, the file is automatically downloaded and you can see its path in <available_file_paths>. You can either read the file or scroll in the page to see more.
 </browser_rules>
 
 <file_system>

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -66,7 +66,7 @@ Note that:
 </browser_state>
 
 <browser_vision>
-You will be optionally provided with a screenshot of the browser with bounding boxes. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
+You will be optionally provided with a screenshot of the browser with bounding boxes. This is your GROUND TRUTH: analyze the image to evaluate your progress.
 Bounding box labels correspond to element indexes - analyze the image to make sure you click on correct elements.
 </browser_vision>
 
@@ -136,9 +136,7 @@ If you are allowed 1 action, ALWAYS output only the most reasonable action per s
 </action_rules>
 
 <reasoning_rules>
-You must reason explicitly and systematically at every step in your `thinking` block. 
-
-Exhibit the following reasoning patterns to successfully achieve the <user_request>:
+Be clear and concise in your decision-making. Exhibit the following reasoning patterns to successfully achieve the <user_request>:
 - Reason about <agent_history> to track progress and context toward <user_request>.
 - Analyze the most recent "Next Goal" and "Action Result" in <agent_history> and clearly state what you previously tried to achieve.
 - Analyze all relevant items in <agent_history>, <browser_state>, <read_state>, <file_system>, <read_state> and the screenshot to understand your state.

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -66,7 +66,7 @@ Note that:
 </browser_state>
 
 <browser_vision>
-You will be optionally provided with a screenshot of the browser with bounding boxes. This is your GROUND TRUTH: analyze the image to evaluate your progress.
+You will be optionally provided with a screenshot of the browser with bounding boxes. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
 Bounding box labels correspond to element indexes - analyze the image to make sure you click on correct elements.
 </browser_vision>
 
@@ -81,12 +81,19 @@ Strictly follow these rules while using the browser and navigating the web:
 - If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack).
 - If expected elements are missing, try refreshing, scrolling, or navigating back.
 - If the page is not fully loaded, use the wait action.
-- You can call extract_structured_data on specific pages to gather structured semantic information from the entire page, including parts not currently visible. If you see results in your read state, these are displayed only once, so make sure to save them if necessary.
-- Call extract_structured_data only if the relevant information is not visible in your <browser_state>.
+- You can call extract_structured_data on specific pages to gather structured semantic information from the entire page, including parts not currently visible. The results of extract_structured_data are automatically saved to the file system.
+- Call extract_structured_data only if the information you are looking for is not visible in your <browser_state> otherwise always just use the needed text from the <browser_state>.
 - If you fill an input field and your action sequence is interrupted, most often something changed e.g. suggestions popped up under the field.
 - If the <user_request> includes specific page information such as product type, rating, price, location, etc., try to apply filters to be more efficient.
 - The <user_request> is the ultimate goal. If the user specifies explicit steps, they have always the highest priority.
 - If you input_text into a field, you might need to press enter, click the search button, or select from dropdown for completion.
+- Don't login into a page if you don't have to. Don't login if you don't have the credentials. 
+- There are 2 types of tasks always first think which type of request you are dealing with:
+1. Very specific step by step instructions:
+- Follow them as very precise and don't skip steps. Try to complete everything as requested.
+2. Open ended tasks. Plan yourself, be creative in achieving them.
+- If you get stuck e.g. with logins or captcha in open-ended tasks you can re-evaluate the task and try alternative ways, e.g. sometimes accidentally login pops up, even though there some part of the page is accessible or you get some information via web search.
+- If you reach a PDF viewer, the file is automatically downloaded and you can see its path in <available_file_paths>. You can either read the file or scroll in the page to see more.
 </browser_rules>
 
 <file_system>
@@ -129,21 +136,24 @@ If you are allowed 1 action, ALWAYS output only the most reasonable action per s
 </action_rules>
 
 <reasoning_rules>
-Be clear and concise in your decision-making:
-- Analyze <agent_history> to track progress and context toward <user_request>.
+You must reason explicitly and systematically at every step in your `thinking` block. 
+
+Exhibit the following reasoning patterns to successfully achieve the <user_request>:
+- Reason about <agent_history> to track progress and context toward <user_request>.
 - Analyze the most recent "Next Goal" and "Action Result" in <agent_history> and clearly state what you previously tried to achieve.
 - Analyze all relevant items in <agent_history>, <browser_state>, <read_state>, <file_system>, <read_state> and the screenshot to understand your state.
 - Explicitly judge success/failure/uncertainty of the last action.
 - If todo.md is empty and the task is multi-step, generate a stepwise plan in todo.md using file tools.
 - Analyze `todo.md` to guide and track your progress. 
 - If any todo.md items are finished, mark them as complete in the file.
-- Analyze whether you are stuck in the same goal for a few steps. If so, try alternative methods.
-- Analyze the <read_state> where one-time information are displayed due to your previous action. Decide whether you want to keep this information in memory and plan writing them into a file if applicable using the file tools.
+- Analyze whether you are stuck, e.g. when you repeat the same actions multiple times without any progress. Then consider alternative approaches e.g. scrolling for more context or send_keys to interact with keys directly or different pages.
+- Analyze the <read_state> where one-time information are displayed due to your previous action. Reason about whether you want to keep this information in memory and plan writing them into a file if applicable using the file tools.
 - If you see information relevant to <user_request>, plan saving the information into a file.
 - Before writing data into a file, analyze the <file_system> and check if the file already has some content to avoid overwriting.
 - Decide what concise, actionable context should be stored in memory to inform future reasoning.
 - When ready to finish, state you are preparing to call done and communicate completion/results to the user.
 - Before done, use read_file to verify file contents intended for user output.
+- Always reason about the <user_request>. Make sure to carefully analyze the specific steps and information required. E.g. specific filters, specific form fields, specific information to search. Make sure to always compare the current trajactory with the user request and think carefully if thats how the user requested it.
 </reasoning_rules>
 
 <examples>

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3894,7 +3894,7 @@ class BrowserSession(BaseModel):
 
 			# Check if already downloaded
 			expected_path = os.path.join(self.browser_profile.downloads_path, pdf_filename)
-			if any(pdf_filename in downloaded for downloaded in self._downloaded_files):
+			if any(os.path.basename(downloaded) == pdf_filename for downloaded in self._downloaded_files):
 				self.logger.debug(f'📄 PDF already downloaded: {pdf_filename}')
 				return None
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -4075,11 +4075,14 @@ class BrowserSession(BaseModel):
 			try:
 				self.logger.debug(f'Downloading PDF from URL: {pdf_url}')
 
+				# Properly escape the URL to prevent JavaScript injection
+				escaped_pdf_url = json.dumps(pdf_url)
+
 				download_result = await page.evaluate(f"""
 					async () => {{
 						try {{
 							// Use fetch with cache: 'force-cache' to prioritize cached version
-							const response = await fetch('{pdf_url}', {{
+							const response = await fetch({escaped_pdf_url}, {{
 								cache: 'force-cache'
 							}});
 							if (!response.ok) {{
@@ -4092,7 +4095,7 @@ class BrowserSession(BaseModel):
 							// Log whether this was served from cache
 							const fromCache = response.headers.has('age') || 
 											 !response.headers.has('date') ||
-											 performance.getEntriesByName('{pdf_url}').some(entry => 
+											 performance.getEntriesByName({escaped_pdf_url}).some(entry => 
 												 entry.transferSize === 0 || entry.transferSize < entry.encodedBodySize
 											 );
 											 

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -225,7 +225,7 @@ class FileSystem:
 
 					reader = pypdf.PdfReader(full_filename)
 					num_pages = len(reader.pages)
-					MAX_PDF_PAGES = 5
+					MAX_PDF_PAGES = 10
 					extra_pages = num_pages - MAX_PDF_PAGES
 					extracted_text = ''
 					for page in reader.pages[:MAX_PDF_PAGES]:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
PDFs are now automatically downloaded when viewed in the browser, and scrolling inside PDFs uses a more reliable CDP-based method. The maximum number of PDF pages read for text extraction is increased to 10.

<!-- End of auto-generated description by cubic. -->

