### PR TITLE
try base64 cdp screenshots directly

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -90,10 +90,10 @@ jobs:
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" --no-clobber "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
           && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
       - run: patchright install chrome --with-deps
-      - run: playwright install chrome --with-deps
+      # - run: playwright install chrome --with-deps
       # could use $(uname -m) instead of hardcoding amd64
 
       - name: Cache chromium binaries
@@ -104,7 +104,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - run: playwright install chromium --with-deps
-      - run: patchright install chromium --with-deps
+      # - run: patchright install chromium --with-deps
 
       - name: Install Xvfb for headed mode
         if: github.event.client_payload.script_args.headless == 'false'

--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            /tmp
+            /tmp/google-chrome-stable.deb
           key: ${{ runner.os }}-chrome-stable
 
       - name: Install Chrome stable binary

--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -91,7 +91,7 @@ jobs:
         run: |
           sudo apt-get update -qq \
           && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
-          && apt-get install -y "/tmp/google-chrome-stable.deb" -f
+          && sudo apt-get install -y "/tmp/google-chrome-stable.deb" -f
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
       # could use $(uname -m) instead of hardcoding amd64

--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -80,23 +80,31 @@ jobs:
         id: playwright_version
         run: echo "VERSION=$(uv pip list --format json | jq -r '.[] | select(.name == "playwright") | .version')" >> $GITHUB_OUTPUT
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
+      - name: Cache chrome binaries
+        uses: actions/cache@v3
         with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright_version.outputs.VERSION }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
+          path: |
+            /tmp
+          key: ${{ runner.os }}-chrome-stable
 
-      - name: Install Playwright browser dependencies
+      - name: Install Chrome stable binary
         run: |
-          echo "Installing Playwright browsers..."
-          # comment out some based on whether stealth=True is used for evals or not
-          playwright install --no-shell chromium --with-deps
-          patchright install --no-shell chromium --with-deps
-          playwright install --no-shell chrome --with-deps
-          patchright install --no-shell chrome --with-deps
-          echo "Playwright browsers installed successfully"
+          sudo apt-get update -qq \
+          && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && apt-get install -y "/tmp/google-chrome-stable.deb" -f
+      - run: patchright install chrome --with-deps
+      - run: playwright install chrome --with-deps
+      # could use $(uname -m) instead of hardcoding amd64
+
+      - name: Cache chromium binaries
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
+
+      - run: playwright install chromium --with-deps
+      - run: patchright install chromium --with-deps
 
       - name: Install Xvfb for headed mode
         if: github.event.client_payload.script_args.headless == 'false'

--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -85,7 +85,7 @@ jobs:
         with:
           path: |
             /tmp/google-chrome-stable_current_amd64.deb
-          key: ${{ runner.os }}-chrome-stable
+          key: ${{ runner.os }}-${{ runner.arch }}-chrome-stable
 
       - name: Install Chrome stable binary
         run: |
@@ -101,7 +101,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - run: playwright install chromium --with-deps
       - run: patchright install chromium --with-deps

--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
           && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps

--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -84,14 +84,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            /tmp/google-chrome-stable.deb
+            /tmp/google-chrome-stable_current_amd64.deb
           key: ${{ runner.os }}-chrome-stable
 
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
-          && sudo apt-get install -y "/tmp/google-chrome-stable.deb" -f
+          && curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
       # could use $(uname -m) instead of hardcoding amd64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            /tmp
+            /tmp/google-chrome-stable_current_amd64.deb
           key: ${{ runner.os }}-${{ runner.arch }}-chrome-stable
 
       - name: Install Chrome stable binary

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,10 +89,10 @@ jobs:
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" --no-clobber "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
           && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
       - run: patchright install chrome --with-deps
-      - run: playwright install chrome --with-deps
+      # - run: playwright install chrome --with-deps
 
       - name: Cache chromium binaries
         uses: actions/cache@v3
@@ -102,7 +102,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - run: playwright install chromium --with-deps
-      - run: patchright install chromium --with-deps
+      # - run: patchright install chromium --with-deps
 
       - run: pytest tests/ci/${{ matrix.test_filename }}.py
 
@@ -139,10 +139,10 @@ jobs:
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" --no-clobber "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
           && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
       - run: patchright install chrome --with-deps
-      - run: playwright install chrome --with-deps
+      # - run: playwright install chrome --with-deps
 
       - name: Cache chromium binaries
         uses: actions/cache@v3
@@ -152,7 +152,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - run: playwright install chromium --with-deps
-      - run: patchright install chromium --with-deps
+      # - run: patchright install chromium --with-deps
 
       - name: Run agent tasks evaluation and capture score
         id: eval

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
           && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
@@ -140,7 +140,7 @@ jobs:
         run: |
           sudo apt-get update -qq \
           && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
-          && curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,7 +90,7 @@ jobs:
         run: |
           sudo apt-get update -qq \
           && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
-          && apt-get install -y "/tmp/google-chrome-stable.deb" -f
+          && sudo apt-get install -y "/tmp/google-chrome-stable.deb" -f
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
 
@@ -140,7 +140,7 @@ jobs:
         run: |
           sudo apt-get update -qq \
           && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
-          && apt-get install -y "/tmp/google-chrome-stable.deb" -f
+          && sudo apt-get install -y "/tmp/google-chrome-stable.deb" -f
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,14 +133,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            /tmp
+            /tmp/google-chrome-stable.deb
           key: ${{ runner.os }}-chrome-stable
 
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
           && sudo apt-get install -y "/tmp/google-chrome-stable.deb" -f
+          && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
         with:
           path: |
             /tmp
-          key: ${{ runner.os }}-chrome-stable
+          key: ${{ runner.os }}-${{ runner.arch }}-chrome-stable
 
       - name: Install Chrome stable binary
         run: |
@@ -99,7 +99,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - run: playwright install chromium --with-deps
       - run: patchright install chromium --with-deps
@@ -134,7 +134,7 @@ jobs:
         with:
           path: |
             /tmp/google-chrome-stable_current_amd64.deb
-          key: ${{ runner.os }}-chrome-stable
+          key: ${{ runner.os }}-${{ runner.arch }}-chrome-stable
 
       - name: Install Chrome stable binary
         run: |
@@ -149,7 +149,7 @@ jobs:
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - run: playwright install chromium --with-deps
       - run: patchright install chromium --with-deps

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,8 +89,8 @@ jobs:
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
-          && sudo apt-get install -y "/tmp/google-chrome-stable.deb" -f
+          && curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
 
@@ -133,14 +133,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            /tmp/google-chrome-stable.deb
+            /tmp/google-chrome-stable_current_amd64.deb
           key: ${{ runner.os }}-chrome-stable
 
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && sudo apt-get install -y "/tmp/google-chrome-stable.deb" -f
-          && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
+          && curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -139,8 +139,8 @@ jobs:
       - name: Install Chrome stable binary
         run: |
           sudo apt-get update -qq \
-          && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
           && sudo curl -o "/tmp/google-chrome-stable_current_amd64.deb" -z "/tmp/google-chrome-stable_current_amd64.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && sudo apt-get install -y "/tmp/google-chrome-stable_current_amd64.deb" -f
       - run: patchright install chrome --with-deps
       - run: playwright install chrome --with-deps
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,7 +79,22 @@ jobs:
       - name: Detect installed Playwright version
         run: echo "PLAYWRIGHT_VERSION=$(uv pip list --format json | jq -r '.[] | select(.name == "playwright") | .version')" >> $GITHUB_ENV
 
-      - name: Cache playwright binaries
+      - name: Cache chrome binaries
+        uses: actions/cache@v3
+        with:
+          path: |
+            /tmp
+          key: ${{ runner.os }}-chrome-stable
+
+      - name: Install Chrome stable binary
+        run: |
+          sudo apt-get update -qq \
+          && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && apt-get install -y "/tmp/google-chrome-stable.deb" -f
+      - run: patchright install chrome --with-deps
+      - run: playwright install chrome --with-deps
+
+      - name: Cache chromium binaries
         uses: actions/cache@v3
         with:
           path: |
@@ -87,8 +102,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - run: playwright install chromium --with-deps
-      - run: playwright install chrome --with-deps 
-      - run: patchright install chrome --with-deps
       - run: patchright install chromium --with-deps
 
       - run: pytest tests/ci/${{ matrix.test_filename }}.py
@@ -116,7 +129,22 @@ jobs:
       - name: Detect installed Playwright version
         run: echo "PLAYWRIGHT_VERSION=$(uv pip list --format json | jq -r '.[] | select(.name == "playwright") | .version')" >> $GITHUB_ENV
 
-      - name: Cache playwright binaries
+      - name: Cache chrome binaries
+        uses: actions/cache@v3
+        with:
+          path: |
+            /tmp
+          key: ${{ runner.os }}-chrome-stable
+
+      - name: Install Chrome stable binary
+        run: |
+          sudo apt-get update -qq \
+          && curl -o "/tmp/google-chrome-stable.deb" -z "/tmp/google-chrome-stable.deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb" \
+          && apt-get install -y "/tmp/google-chrome-stable.deb" -f
+      - run: patchright install chrome --with-deps
+      - run: playwright install chrome --with-deps
+
+      - name: Cache chromium binaries
         uses: actions/cache@v3
         with:
           path: |
@@ -124,8 +152,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium
 
       - run: playwright install chromium --with-deps
-      - run: playwright install chrome --with-deps
-      - run: patchright install chrome --with-deps
       - run: patchright install chromium --with-deps
 
       - name: Run agent tasks evaluation and capture score

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -2742,7 +2742,7 @@ class BrowserSession(BaseModel):
 
 		page = await self.get_current_page()
 		try:
-			await asyncio.wait_for(page.evaluate('1'), timeout=1)
+			await asyncio.wait_for(page.evaluate('1'), timeout=3)
 		except Exception as e:
 			# new tab to recover
 			self.logger.warning(f'🚨 Page {_log_pretty_url(normalized_url)} is unresponsive, creating new tab...')

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -2741,13 +2741,6 @@ class BrowserSession(BaseModel):
 			raise BrowserError(f'Navigation to non-allowed URL: {normalized_url}')
 
 		page = await self.get_current_page()
-		try:
-			await asyncio.wait_for(page.evaluate('1'), timeout=3)
-		except Exception as e:
-			# new tab to recover
-			self.logger.warning(f'🚨 Page {_log_pretty_url(normalized_url)} is unresponsive, creating new tab...')
-			page = await self.create_new_tab(normalized_url)
-			return
 
 		try:
 			await asyncio.wait_for(page.goto(normalized_url), timeout=0.1)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched screenshot capture to use base64-encoded data directly from the Chrome DevTools Protocol instead of manual encoding.

- **Refactors**
  - Uses CDP's Page.captureScreenshot to get base64 screenshots.
  - Removes extra base64 encoding step.

<!-- End of auto-generated description by cubic. -->

