### PR TITLE
eval laminar key name

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -32,6 +32,7 @@ jobs:
       SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
       LMNR_PROJECT_API_KEY: ${{ secrets.LMNR_PROJECT_API_KEY }}
       LAMINAR_LOGGING_LEVEL: ${{ github.event.client_payload.script_args.laminar_logging_level || secrets.LAMINAR_LOGGING_LEVEL || 'info' }}
+      BROWSER_USE_LOGGING_LEVEL: ${{ secrets.BROWSER_USE_LOGGING_LEVEL || 'info' }}
       EVAL_START_INDEX: ${{ github.event.client_payload.script_args.start_index }}
       TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
     


### PR DESCRIPTION
Auto-generated PR for: eval laminar key name
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the eval workflow to use LAMINAR_LOGGING_LEVEL instead of BROWSER_LOGGING_LEVEL for logging configuration. This ensures the correct environment variable and script argument are set during evaluation runs.

<!-- End of auto-generated description by cubic. -->

