### PR TITLE
eval remove laminar args

### DIFF
--- a/.github/workflows/eval.yaml
+++ b/.github/workflows/eval.yaml
@@ -337,7 +337,7 @@ jobs:
           [[ -n "$IMAGES_PER_STEP" ]] && CMD_ARGS+=("--images-per-step" "$IMAGES_PER_STEP")
           [[ -n "$RUN_ID" ]] && CMD_ARGS+=("--run-id" "$RUN_ID")
           [[ -n "$LAMINAR_EVAL_ID" ]] && CMD_ARGS+=("--laminar-eval-id" "$LAMINAR_EVAL_ID")
-          [[ -n "$LAMINAR_LOGGING_LEVEL" ]] && CMD_ARGS+=("--laminar-logging-level" "$LAMINAR_LOGGING_LEVEL")
+
           
           # Add browser timeout parameters
           [[ -n "$DEFAULT_NAVIGATION_TIMEOUT" ]] && CMD_ARGS+=("--default-navigation-timeout" "$DEFAULT_NAVIGATION_TIMEOUT")


### PR DESCRIPTION
Auto-generated PR for: eval remove laminar args
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the laminar logging level argument from the eval workflow to simplify command arguments.

<!-- End of auto-generated description by cubic. -->

