### PR TITLE
always tell agent to not use credentials unless necessary when provid…

### DIFF
--- a/eval/server.py
+++ b/eval/server.py
@@ -152,7 +152,7 @@ def format_auth_info_for_agent(auth_distribution: dict, auth_keys: list[str]) ->
 			logger.warning(f"Auth key '{auth_key}' not found in available login info. Available keys: {list(login_info.keys())}")
 
 	if relevant_auths:
-		auth_text = f'\n\nThe following login credentials can be used to complete this task: {"; ".join(relevant_auths)}.'
+		auth_text = f"\n\nOnly log into the account if it's required to complete the task. Do not log in otherwise.\n The following login credentials can be used to complete this task: {'; '.join(relevant_auths)}."
 		logger.info(f'Formatted auth info: {auth_text}')
 		return auth_text
 	else:


### PR DESCRIPTION
…ed credentials in evals
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated agent instructions to only use provided credentials if required for the task, reducing unnecessary logins.

<!-- End of auto-generated description by cubic. -->

