### PR TITLE
fix: ensure new browser context is created for video recording in existing sessions

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1064,10 +1064,17 @@ class BrowserSession(BaseModel):
 
 		# if we have a browser object but no browser_context, use the first context discovered or make a new one
 		if self.browser and not self.browser_context:
-			# If HAR recording is requested, we need to create a new context with recording enabled
-			# Cannot reuse existing context as HAR recording must be configured at context creation
-			if self.browser_profile.record_har_path and self.browser.contexts:
-				self.logger.info('🎥 Creating new browser_context with HAR recording enabled (cannot reuse existing context)')
+			# If HAR recording or video recording is requested, we need to create a new context with recording enabled
+			# Cannot reuse existing context as recording must be configured at context creation
+			if (self.browser_profile.record_har_path or self.browser_profile.record_video_dir) and self.browser.contexts:
+				recording_types = []
+				if self.browser_profile.record_har_path:
+					recording_types.append('HAR')
+				if self.browser_profile.record_video_dir:
+					recording_types.append('video')
+				self.logger.info(
+					f'🎥 Creating new browser_context with {" and ".join(recording_types)} recording enabled (cannot reuse existing context)'
+				)
 				self.browser_context = await self.browser.new_context(
 					**self.browser_profile.kwargs_for_new_context().model_dump(mode='json')
 				)


### PR DESCRIPTION
## Fix: Ensure New Browser Context is Created for Video Recording in Existing Sessions

### What this PR does
This PR fixes a bug in the browser session management where video recording would fail when connecting to an existing browser with pre-existing contexts. The issue was that the system would reuse existing browser contexts instead of creating new ones, but video recording (like HAR recording) must be configured at context creation time.

### Why it's needed
When a browser session is started without video recording and then another session connects to the same browser WITH video recording enabled, the system was incorrectly reusing the existing context. This caused video recording to fail silently because recording settings cannot be applied to existing contexts - they must be configured when the context is created.

### Changes Made
1. **Extended context creation logic**: Updated the condition in `session.py` to check for both HAR recording AND video recording when determining if a new context should be created
2. **Improved logging**: Enhanced log messages to clearly indicate which recording types are being enabled
3. **Added comprehensive test**: Created `test_video_recording_creates_new_context_on_existing_browser()` to verify the fix works correctly

### Technical Details
- Modified the condition from checking only `record_har_path` to checking both `record_har_path` OR `record_video_dir`
- When either recording type is requested and existing contexts are present, a new context is created instead of reusing the existing one
- The fix ensures that video recording works properly in multi-session scenarios

### Tests Added
- **`test_video_recording_creates_new_context_on_existing_browser`**: Comprehensive test that:
  1. Creates a browser session without video recording
  2. Connects a second session to the same browser WITH video recording
  3. Verifies that different contexts are used (preventing the bug)
  4. Confirms video files are actually created and have reasonable file sizes

### Impact
This fix ensures that video recording works reliably in all scenarios, particularly when connecting to existing browser instances. It maintains backward compatibility while extending the robust context management that was already in place for HAR recording.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a bug where video recording would fail when connecting to an existing browser session by ensuring a new browser context is always created when video recording is enabled.

- **Bug Fixes**
  - Updated context creation logic to check for both HAR and video recording, creating a new context if either is requested.
  - Added a test to confirm that video recording works correctly when connecting to an existing browser.

<!-- End of auto-generated description by cubic. -->

