### PR TITLE
fix: use AZURE_OPENAI_KEY in code to match .env.example

### DIFF
--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -43,7 +43,7 @@ class ChatAzureOpenAI(ChatOpenAILike):
 	def _get_client_params(self) -> dict[str, Any]:
 		_client_params: dict[str, Any] = {}
 
-		self.api_key = self.api_key or os.getenv('AZURE_OPENAI_API_KEY')
+		self.api_key = self.api_key or os.getenv('AZURE_OPENAI_KEY')
 		self.azure_endpoint = self.azure_endpoint or os.getenv('AZURE_OPENAI_ENDPOINT')
 		self.azure_deployment = self.azure_deployment or os.getenv('AZURE_OPENAI_DEPLOYMENT')
 		params_mapping = {


### PR DESCRIPTION
Fix: Use AZURE_OPENAI_KEY in code to match .env.example
This pull request updates the code to reference the correct environment variable AZURE_OPENAI_KEY, aligning it with what is defined in .env.example.

✅ What’s Changed
Replaced all occurrences of process.env.AZURE_OPENAI_API_KEY with process.env.AZURE_OPENAI_KEY in the codebase

📌 Why This Matters
Maintains consistency between .env.example and actual code usage

Prevents runtime issues due to missing or misnamed environment variables

Helps new developers get started faster using the provided .env.example template

🔍 Context
Previously, the code was referencing AZURE_OPENAI_API_KEY while .env.example had AZURE_OPENAI_KEY, causing confusion and potential undefined errors.

📎 Related Issue
Fixes #2431
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the code to use AZURE_OPENAI_KEY instead of AZURE_OPENAI_API_KEY, matching the .env.example file and preventing environment variable mismatches.

<!-- End of auto-generated description by cubic. -->

