### PR TITLE
lmnr ignore input for _is_page_responsive

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3282,7 +3282,7 @@ class BrowserSession(BaseModel):
 			raise
 
 	# region - Page Health Check Helpers
-	@observe_debug(ignore_output=True)
+	@observe_debug(ignore_input=True)
 	async def _is_page_responsive(self, page: Page, timeout: float = 5.0) -> bool:
 		"""Check if a page is responsive by trying to evaluate simple JavaScript."""
 		eval_task = None


### PR DESCRIPTION
Auto-generated PR for: lmnr ignore input for _is_page_responsive
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Changed the _is_page_responsive helper to ignore input during debug observation, preventing input data from being logged or processed.

<!-- End of auto-generated description by cubic. -->

