### PR TITLE
Fix incorrect pip install prompt for CLI addon

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -24,7 +24,7 @@ try:
 	from textual.containers import Container, HorizontalGroup, VerticalScroll
 	from textual.widgets import Footer, Header, Input, Label, Link, RichLog, Static
 except ImportError:
-	print('⚠️ CLI addon is not installed. Please install it with: `pip install browser-use[cli]` and try again.')
+	print('⚠️ CLI addon is not installed. Please install it with: `pip install "browser-use[cli]"` and try again.')
 	sys.exit(1)
 
 


### PR DESCRIPTION
The install instruction for the `browser-use[cli]` addon was missing quotes, which can cause issues in some shells.

For example:

<img width="701" height="43" alt="before-screenshot" src="https://github.com/user-attachments/assets/464ddbcc-ed46-4a29-b9c7-4c0a7f19fb9c" />
<br /><br />
Updated to `pip install "browser-use[cli]"` to ensure correct behavior across environments.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the pip install prompt for the CLI addon by adding quotes to the package name, preventing errors in some shells.

<!-- End of auto-generated description by cubic. -->

