### PR TITLE
Update screenshot handling for empty pages in BrowserSession

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3562,11 +3562,13 @@ class BrowserSession(BaseModel):
 
 		if is_new_tab_page(page.url):
 			self.logger.warning(
-				f'▫️ Sending LLM 1px placeholder instead of real screenshot of: {_log_pretty_url(page.url)} (page empty)'
+				f'▫️ Sending LLM no screenshot instead of real screenshot of: {_log_pretty_url(page.url)} (page empty)'
 			)
 			# Not an exception because there's no point in retrying if we hit this, its always pointless to screenshot about:blank
 			# Originally returned a 1x1 white PNG to avoid wasting tokens, but groq LLaMa models do not accept this
 			# So we return None instead, which the LLM can handle more reliably
+			# TODO: this should be decided on an LLM level - now take_screenshot doesnt give you the screenshot if the page is empty
+			# this might be weird behavior for the library overall
 			return None
 
 		# Always bring page to front before rendering, otherwise it crashes in some cases, not sure why

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3564,10 +3564,10 @@ class BrowserSession(BaseModel):
 			self.logger.warning(
 				f'▫️ Sending LLM 1px placeholder instead of real screenshot of: {_log_pretty_url(page.url)} (page empty)'
 			)
-			# not an exception because there's no point in retrying if we hit this, its always pointless to screenshot about:blank
-			# raise ValueError('Refusing to take unneeded screenshot of empty new tab page')
-			# return a 1px*1px white png to avoid wasting tokens
-			return 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+ip1sAAAAASUVORK5CYII='
+			# Not an exception because there's no point in retrying if we hit this, its always pointless to screenshot about:blank
+			# Originally returned a 1x1 white PNG to avoid wasting tokens, but groq LLaMa models do not accept this
+			# So we return None instead, which the LLM can handle more reliably
+			return None
 
 		# Always bring page to front before rendering, otherwise it crashes in some cases, not sure why
 		try:

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3566,10 +3566,8 @@ class BrowserSession(BaseModel):
 			)
 			# not an exception because there's no point in retrying if we hit this, its always pointless to screenshot about:blank
 			# raise ValueError('Refusing to take unneeded screenshot of empty new tab page')
-			# return a 4px*4px white png to avoid wasting tokens - instead of 1px*1px white png that was not accepted by groq LLaMa models
-			return (
-				'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAFElEQVR4nGP8//8/AwwwMSAB3BwAlmMEAQBq1Aqg7XL3KQAAAABJRU5ErkJggg=='
-			)
+			# return a 4px*4px white png to avoid wasting tokens - instead of 1px*1px white png that was
+			return 'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAFElEQVR4nGP8//8/AwwwMSAB3BwAlm4DBfIlvvkAAAAASUVORK5CYII='
 
 		# Always bring page to front before rendering, otherwise it crashes in some cases, not sure why
 		try:

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3562,14 +3562,14 @@ class BrowserSession(BaseModel):
 
 		if is_new_tab_page(page.url):
 			self.logger.warning(
-				f'▫️ Sending LLM no screenshot instead of real screenshot of: {_log_pretty_url(page.url)} (page empty)'
+				f'▫️ Sending LLM 4px placeholder instead of real screenshot of: {_log_pretty_url(page.url)} (page empty)'
 			)
-			# Not an exception because there's no point in retrying if we hit this, its always pointless to screenshot about:blank
-			# Originally returned a 1x1 white PNG to avoid wasting tokens, but groq LLaMa models do not accept this
-			# So we return None instead, which the LLM can handle more reliably
-			# TODO: this should be decided on an LLM level - now take_screenshot doesnt give you the screenshot if the page is empty
-			# this might be weird behavior for the library overall
-			return None
+			# not an exception because there's no point in retrying if we hit this, its always pointless to screenshot about:blank
+			# raise ValueError('Refusing to take unneeded screenshot of empty new tab page')
+			# return a 4px*4px white png to avoid wasting tokens - instead of 1px*1px white png that was not accepted by groq LLaMa models
+			return (
+				'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAFElEQVR4nGP8//8/AwwwMSAB3BwAlmMEAQBq1Aqg7XL3KQAAAABJRU5ErkJggg=='
+			)
 
 		# Always bring page to front before rendering, otherwise it crashes in some cases, not sure why
 		try:

--- a/tests/ci/test_browser_session_ownership.py
+++ b/tests/ci/test_browser_session_ownership.py
@@ -178,6 +178,8 @@ class TestBrowserOwnership:
 		# Try to use the copy - it should recover
 		await copied_session.start()  # Should reconnect
 		screenshot = await copied_session.take_screenshot()
+		assert screenshot is not None
+		assert len(screenshot) > 0
 
 		# Clean up
 		await original_session.kill()

--- a/tests/ci/test_browser_session_ownership.py
+++ b/tests/ci/test_browser_session_ownership.py
@@ -178,8 +178,6 @@ class TestBrowserOwnership:
 		# Try to use the copy - it should recover
 		await copied_session.start()  # Should reconnect
 		screenshot = await copied_session.take_screenshot()
-		assert screenshot is not None
-		assert len(screenshot) > 0
 
 		# Clean up
 		await original_session.kill()

--- a/tests/ci/test_browser_session_reuse.py
+++ b/tests/ci/test_browser_session_reuse.py
@@ -101,8 +101,8 @@ class TestBrowserSessionReuse:
 				# Take screenshot after regeneration
 				screenshot_after = await session.take_screenshot()
 				assert screenshot_after is not None
-				assert len(screenshot_after) > 0 and len(screenshot_after) < 100, (
-					'expected white 1px screenshot of about:blank when browser is reset after disconnection'
+				assert len(screenshot_after) > 0 and len(screenshot_after) < 200, (
+					'expected white 4px screenshot of about:blank when browser is reset after disconnection'
 				)
 
 		finally:

--- a/tests/ci/test_browser_session_reuse.py
+++ b/tests/ci/test_browser_session_reuse.py
@@ -121,6 +121,7 @@ class TestBrowserSessionReuse:
 
 			# Take a screenshot to verify it works
 			screenshot1 = await session.take_screenshot()
+			assert screenshot1 is not None
 
 			# Store browser PID
 			initial_pid = session.browser_pid
@@ -145,6 +146,7 @@ class TestBrowserSessionReuse:
 				try:
 					screenshot2 = await session.take_screenshot()
 					# If it succeeded, the browser should have been regenerated
+					assert screenshot2 is not None
 				except Exception:
 					# If it failed, that's also OK - the browser state was reset
 					pass
@@ -162,6 +164,9 @@ class TestBrowserSessionReuse:
 
 			# Verify we can still use the browser after regeneration
 			await session.start()  # Ensure browser is started
+			screenshot3 = await session.take_screenshot()
+			assert screenshot3 is not None
+			assert len(screenshot3) > 0
 
 		finally:
 			await session.stop()

--- a/tests/ci/test_browser_session_reuse.py
+++ b/tests/ci/test_browser_session_reuse.py
@@ -121,7 +121,6 @@ class TestBrowserSessionReuse:
 
 			# Take a screenshot to verify it works
 			screenshot1 = await session.take_screenshot()
-			assert screenshot1 is not None
 
 			# Store browser PID
 			initial_pid = session.browser_pid
@@ -146,7 +145,6 @@ class TestBrowserSessionReuse:
 				try:
 					screenshot2 = await session.take_screenshot()
 					# If it succeeded, the browser should have been regenerated
-					assert screenshot2 is not None
 				except Exception:
 					# If it failed, that's also OK - the browser state was reset
 					pass
@@ -164,9 +162,6 @@ class TestBrowserSessionReuse:
 
 			# Verify we can still use the browser after regeneration
 			await session.start()  # Ensure browser is started
-			screenshot3 = await session.take_screenshot()
-			assert screenshot3 is not None
-			assert len(screenshot3) > 0
 
 		finally:
 			await session.stop()


### PR DESCRIPTION
Changed the behavior of the screenshot method to return None instead of a 1x1 white PNG for empty pages. This adjustment accommodates the groq LLaMa models, which does not accept 1px x 1px images.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the screenshot method in BrowserSession to return None instead of a 1x1 white PNG for empty pages, ensuring compatibility with groq LLaMa models.

<!-- End of auto-generated description by cubic. -->

