### PR TITLE
Add Kimi K2 model support to evaluations

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -27,7 +27,7 @@ from browser_use.llm.messages import BaseMessage
 from browser_use.llm.views import ChatInvokeUsage
 
 GroqVerifiedModels = Literal[
-	'meta-llama/llama-4-maverick-17b-128e-instruct', 'meta-llama/llama-4-scout-17b-16e-instruct', 'qwen/qwen3-32b'
+	'meta-llama/llama-4-maverick-17b-128e-instruct', 'meta-llama/llama-4-scout-17b-16e-instruct', 'qwen/qwen3-32b', 'moonshotai/kimi-k2-instruct'
 ]
 
 T = TypeVar('T', bound=BaseModel)

--- a/examples/models/kimi-k2-groq.py
+++ b/examples/models/kimi-k2-groq.py
@@ -1,0 +1,43 @@
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+from lmnr import Laminar
+
+load_dotenv()
+
+
+Laminar.initialize()
+
+
+from browser_use import Agent
+from browser_use.llm import ChatGroq
+
+groq_api_key = os.environ.get('GROQ_API_KEY')
+llm = ChatGroq(
+	model='moonshotai/kimi-k2-instruct',
+	# temperature=0.1,
+)
+
+# llm = ChatGroq(
+# 	model='moonshotai/kimi-k2-instruct',
+# 	api_key=os.environ.get('GROQ_API_KEY'),
+# 	temperature=0.0,
+# )
+
+task = 'Go to amazon.com, search for laptop, sort by best rating, and give me the price of the first result'
+
+
+async def main():
+	agent = Agent(
+		task=task,
+		llm=llm,
+	)
+	await agent.run()
+
+
+if __name__ == '__main__':
+	asyncio.run(main())


### PR DESCRIPTION
Add Kimi K2 model (`moonshotai/kimi-k2-instruct`) to supported Groq models and include an example.

---

[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1752594759934739?thread_ts=1752594759.934739&cid=D092QUQDC56)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added support for the Kimi K2 model (`moonshotai/kimi-k2-instruct`) to Groq evaluations and included an example script.

- **New Features**
  - Enabled Kimi K2 as a selectable model in Groq.
  - Added an example script showing how to use Kimi K2 with the evaluation agent.

<!-- End of auto-generated description by cubic. -->

