### PR TITLE
Fix: ChatOpenAI sends "temperature" parameter, that is not supported in O3 and O4-mini

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -143,19 +143,19 @@ class ChatOpenAI(BaseChatModel):
 		openai_messages = OpenAIMessageSerializer.serialize_messages(messages)
 
 		try:
-			reasoning_effort_dict: dict = {}
+			model_params: dict[str, Any] = {}
 			if self.model in ReasoningModels:
-				reasoning_effort_dict['reasoning_effort'] = self.reasoning_effort
+				model_params['reasoning_effort'] = self.reasoning_effort
 
 			if self.temperature is not None:
-				reasoning_effort_dict['temperature'] = self.temperature
+				model_params['temperature'] = self.temperature
 
 			if output_format is None:
 				# Return string response
 				response = await self.get_client().chat.completions.create(
 					model=self.model,
 					messages=openai_messages,
-					**reasoning_effort_dict,
+					**model_params,
 				)
 
 				usage = self._get_usage(response)
@@ -176,7 +176,7 @@ class ChatOpenAI(BaseChatModel):
 					model=self.model,
 					messages=openai_messages,
 					response_format=ResponseFormatJSONSchema(json_schema=response_format, type='json_schema'),
-					**reasoning_effort_dict,
+					**model_params,
 				)
 
 				if response.choices[0].message.content is None:

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -145,9 +145,7 @@ class ChatOpenAI(BaseChatModel):
 		try:
 			reasoning_effort_dict: dict = {}
 			if self.model in ReasoningModels:
-				reasoning_effort_dict = {
-					'reasoning_effort': self.reasoning_effort,
-				}
+				reasoning_effort_dict['reasoning_effort'] = self.reasoning_effort
 
 			if self.temperature is not None:
 				reasoning_effort_dict['temperature'] = self.temperature

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -28,7 +28,7 @@ class ChatOpenAI(BaseChatModel):
 	A wrapper around AsyncOpenAI that implements the BaseLLM protocol.
 
 	This class accepts all AsyncOpenAI parameters while adding model
-	and temperature parameters for the LLM interface.
+	and temperature parameters for the LLM interface (if temperature it not `None`).
 	"""
 
 	# Model configuration
@@ -149,12 +149,14 @@ class ChatOpenAI(BaseChatModel):
 					'reasoning_effort': self.reasoning_effort,
 				}
 
+			if self.temperature is not None:
+				reasoning_effort_dict['temperature'] = self.temperature
+
 			if output_format is None:
 				# Return string response
 				response = await self.get_client().chat.completions.create(
 					model=self.model,
 					messages=openai_messages,
-					temperature=self.temperature,
 					**reasoning_effort_dict,
 				)
 
@@ -175,7 +177,6 @@ class ChatOpenAI(BaseChatModel):
 				response = await self.get_client().chat.completions.create(
 					model=self.model,
 					messages=openai_messages,
-					temperature=self.temperature,
 					response_format=ResponseFormatJSONSchema(json_schema=response_format, type='json_schema'),
 					**reasoning_effort_dict,
 				)


### PR DESCRIPTION
Fix Issue https://github.com/browser-use/browser-use/issues/2467 where the `ChatOpenAI` class always sends temperature, which is unsupported in some models like `o3` and `o4-mini`.

Lint and test completed successfully.