### PR TITLE
Resolve markdown-pdf licensing issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "google-auth-oauthlib>=1.2.2",
     "mcp>=1.10.1",
     "pypdf>=5.7.0",
-    "markdown-pdf>=1.7",
+    "markdown-pdf==1.5",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
Lock markdown-pdf dependency to version 1.5 to resolve AGPL-3.0 license conflict.

Versions of `markdown-pdf` from 1.6 onwards are licensed under AGPL-3.0, which is incompatible with the project's MIT license. Pinning the dependency to version 1.5 avoids this conflict.

---

[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1752830754000909?thread_ts=1752830754.000909&cid=D092QUQDC56)