### PR TITLE
Update docs custom action page type

### DIFF
--- a/docs/customize/custom-functions.mdx
+++ b/docs/customize/custom-functions.mdx
@@ -116,7 +116,7 @@ For example, actions that need to run playwright code to interact with the brows
 #### Example: Action uses the current `page`
 
 ```python
-from playwright.async_api import Page
+from browser_use.browser.types import Page
 from browser_use import Controller, ActionResult
 
 controller = Controller()

--- a/examples/custom-functions/drag_and_drop.py
+++ b/examples/custom-functions/drag_and_drop.py
@@ -9,10 +9,10 @@ making it useful for canvas drawing, sortable lists, sliders, file uploads, and 
 import asyncio
 from typing import cast
 
-from playwright.async_api import ElementHandle, Page
 from pydantic import BaseModel, Field
 
 from browser_use import ActionResult, Agent, Controller
+from browser_use.browser.types import ElementHandle, Page
 from browser_use.llm import ChatOpenAI
 
 


### PR DESCRIPTION
Update `Page` type imports in documentation and examples to resolve type conflicts.

The `browser_use` controller injects a union type for `Page` (supporting both Playwright and Patchright pages for normal and stealth modes). Previous examples imported `Page` directly from `playwright.async_api`, leading to `ValueError` due to type mismatch. This PR updates imports to `browser_use.browser.types.Page` for correct type resolution.

---

[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1752831634841859?thread_ts=1752831634.841859&cid=D092QUQDC56)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated `Page` and `ElementHandle` imports in docs and examples to use `browser_use.browser.types` for correct type resolution and to prevent type conflicts.

<!-- End of auto-generated description by cubic. -->

