### PR TITLE
Update docs

### DIFF
--- a/docs/customize/custom-functions.mdx
+++ b/docs/customize/custom-functions.mdx
@@ -116,7 +116,7 @@ For example, actions that need to run playwright code to interact with the brows
 #### Example: Action uses the current `page`
 
 ```python
-from playwright.async_api import Page
+from browser_use.browser.types import Page
 from browser_use import Controller, ActionResult
 
 controller = Controller()

--- a/examples/custom-functions/drag_and_drop.py
+++ b/examples/custom-functions/drag_and_drop.py
@@ -9,10 +9,10 @@ making it useful for canvas drawing, sortable lists, sliders, file uploads, and 
 import asyncio
 from typing import cast
 
-from playwright.async_api import ElementHandle, Page
 from pydantic import BaseModel, Field
 
 from browser_use import ActionResult, Agent, Controller
+from browser_use.browser.types import ElementHandle, Page
 from browser_use.llm import ChatOpenAI
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "google-auth-oauthlib>=1.2.2",
     "mcp>=1.10.1",
     "pypdf>=5.7.0",
-    "markdown-pdf>=1.7",
+    "markdown-pdf==1.5",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed ChatOpenAI sending the temperature parameter to models that do not support it, and updated docs and examples to use the correct Page and ElementHandle import paths. Pinned markdown-pdf to version 1.5 to avoid license conflicts.

- **Bug Fixes**
  - Only include temperature in model params if set, ensuring compatibility with all supported models.
  - Updated import paths in docs and examples to prevent type conflicts.
  - Locked markdown-pdf to version 1.5 to resolve licensing issues.

<!-- End of auto-generated description by cubic. -->

