### PR TITLE
Make vision model screenshot quality customizable

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -94,6 +94,8 @@ def _log_format_message_line(message: BaseMessage, content: str, is_last_message
 
 
 class MessageManager:
+	vision_detail_level: Literal['auto', 'low', 'high']
+
 	def __init__(
 		self,
 		task: str,
@@ -106,6 +108,7 @@ class MessageManager:
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		max_history_items: int | None = None,
 		images_per_step: int = 1,
+		vision_detail_level: Literal['auto', 'low', 'high'] = 'auto',
 		include_tool_call_examples: bool = False,
 	):
 		self.task = task
@@ -116,6 +119,7 @@ class MessageManager:
 		self.use_thinking = use_thinking
 		self.max_history_items = max_history_items
 		self.images_per_step = images_per_step
+		self.vision_detail_level = vision_detail_level
 		self.include_tool_call_examples = include_tool_call_examples
 
 		assert max_history_items is None or max_history_items > 5, 'max_history_items must be None or greater than 5'
@@ -290,6 +294,7 @@ class MessageManager:
 			sensitive_data=self.sensitive_data_description,
 			available_file_paths=available_file_paths,
 			screenshots=screenshots,
+			vision_detail_level=self.vision_detail_level,
 		).get_user_message(use_vision)
 
 		self._add_message_with_type(state_message, 'state')

--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -1,6 +1,6 @@
 import importlib.resources
 from datetime import datetime
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 from browser_use.llm.messages import ContentPartImageParam, ContentPartTextParam, ImageURL, SystemMessage, UserMessage
 from browser_use.observability import observe_debug
@@ -75,6 +75,8 @@ class SystemPrompt:
 
 
 class AgentMessagePrompt:
+	vision_detail_level: Literal['auto', 'low', 'high']
+
 	def __init__(
 		self,
 		browser_state_summary: 'BrowserStateSummary',
@@ -89,6 +91,7 @@ class AgentMessagePrompt:
 		sensitive_data: str | None = None,
 		available_file_paths: list[str] | None = None,
 		screenshots: list[str] | None = None,
+		vision_detail_level: Literal['auto', 'low', 'high'] = 'auto',
 	):
 		self.browser_state: 'BrowserStateSummary' = browser_state_summary
 		self.file_system: 'FileSystem | None' = file_system
@@ -102,6 +105,7 @@ class AgentMessagePrompt:
 		self.sensitive_data: str | None = sensitive_data
 		self.available_file_paths: list[str] | None = available_file_paths
 		self.screenshots = screenshots or []
+		self.vision_detail_level = vision_detail_level
 		assert self.browser_state
 
 	@observe_debug(ignore_input=True, ignore_output=True, name='_deduplicate_screenshots')
@@ -288,6 +292,7 @@ Interactive elements from top layer of the current page inside the viewport{trun
 						image_url=ImageURL(
 							url=f'data:image/png;base64,{screenshot}',
 							media_type='image/png',
+							detail=self.vision_detail_level,
 						),
 					)
 				)

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -10,7 +10,7 @@ import tempfile
 import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Literal, TypeVar
 
 from dotenv import load_dotenv
 
@@ -182,6 +182,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		calculate_cost: bool = False,
 		display_files_in_done_text: bool = True,
 		include_tool_call_examples: bool = False,
+		vision_detail_level: Literal['auto', 'low', 'high'] = 'auto',
 		**kwargs,
 	):
 		# Check for deprecated planner parameters
@@ -235,6 +236,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		self.settings = AgentSettings(
 			use_vision=use_vision,
+			vision_detail_level=vision_detail_level,
 			use_vision_for_planner=False,  # Always False now (deprecated)
 			save_conversation_path=save_conversation_path,
 			save_conversation_path_encoding=save_conversation_path_encoding,
@@ -326,6 +328,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			sensitive_data=sensitive_data,
 			max_history_items=self.settings.max_history_items,
 			images_per_step=self.settings.images_per_step,
+			vision_detail_level=self.settings.vision_detail_level,
 			include_tool_call_examples=self.settings.include_tool_call_examples,
 		)
 

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -4,7 +4,7 @@ import json
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Generic
+from typing import Any, Generic, Literal
 
 from openai import RateLimitError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model, model_validator
@@ -29,6 +29,7 @@ class AgentSettings(BaseModel):
 	"""Configuration options for the Agent"""
 
 	use_vision: bool = True
+	vision_detail_level: Literal['auto', 'low', 'high'] = 'auto'
 	use_vision_for_planner: bool = False
 	save_conversation_path: str | Path | None = None
 	save_conversation_path_encoding: str | None = 'utf-8'

--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -46,6 +46,7 @@ agent = Agent(
   - When enabled, the model processes visual information from web pages
   - Disable to reduce costs or use models without vision support
   - For GPT-4o, image processing costs approximately 800-1000 tokens (~$0.002 USD) per image (but this depends on the defined screen size)
+- `vision_detail_level`: Controls the detail level of screenshots sent to the vision model. Can be `'low'`, `'high'`, or `'auto'` (default). Using `'low'` can significantly reduce token consumption and cost for simpler visual tasks, while `'high'` provides more detail for complex visual analysis.
 - `save_conversation_path`: Path to save the complete conversation history. Useful for debugging.
 - `override_system_message`: Completely replace the default system prompt with a custom one.
 - `extend_system_message`: Add additional instructions to the default system prompt.


### PR DESCRIPTION
This PR proposes a `vision_detail_level` parameter. Users can now pass `vision_detail_level='low'` to the Agent constructor to save on tokens for tasks where high-resolution vision is not critical. The default remains `'auto'`, ensuring backward compatibility. 
While disabling vision (`use_vision=False`) is the cheapest option, it makes the agent completely "blind," relying solely on the structured DOM representation of the page. Using `vision_detail_level='low'` provides a crucial middle ground that offers significant benefits for a minimal token cost.