### PR TITLE
hot-fix/azure-endless-llm-generation

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -65,6 +65,7 @@ class AgentSettings(BaseModel):
 	calculate_cost: bool = False
 	include_tool_call_examples: bool = False
 	llm_timeout: int = 60  # Timeout in seconds for LLM calls
+	step_timeout: int = 180  # Timeout in seconds for each step
 
 
 class AgentState(BaseModel):

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -64,6 +64,7 @@ class AgentSettings(BaseModel):
 	extend_planner_system_message: str | None = None
 	calculate_cost: bool = False
 	include_tool_call_examples: bool = False
+	llm_timeout: int = 60  # Timeout in seconds for LLM calls
 
 
 class AgentState(BaseModel):

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -50,6 +50,8 @@ class ChatOpenAI(BaseChatModel):
 	default_query: Mapping[str, object] | None = None
 	http_client: httpx.AsyncClient | None = None
 	_strict_response_validation: bool = False
+	max_completion_tokens: int | None = None
+	top_p: float | None = None
 
 	# Static
 	@property
@@ -149,6 +151,12 @@ class ChatOpenAI(BaseChatModel):
 
 			if self.temperature is not None:
 				model_params['temperature'] = self.temperature
+
+			if self.max_completion_tokens is not None:
+				model_params['max_completion_tokens'] = self.max_completion_tokens
+
+			if self.top_p is not None:
+				model_params['top_p'] = self.top_p
 
 			if output_format is None:
 				# Return string response


### PR DESCRIPTION
Auto-generated PR for branch: hot-fix/azure-endless-llm-generation
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added timeouts for LLM calls and agent steps to prevent endless generation, and enabled support for max tokens and top_p parameters in OpenAI chat.

- **Bug Fixes**
  - LLM calls now timeout after 60 seconds.
  - Each agent step now has a 180-second timeout to avoid hanging.

- **New Features**
  - Added support for max_completion_tokens and top_p in OpenAI chat settings.

<!-- End of auto-generated description by cubic. -->

