### PR TITLE
feat: add typed.py to mark the package as typed for type-checkers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ include = [
     "browser_use/agent/system_prompt.md",
     "browser_use/agent/system_prompt_no_thinking.md",
     "browser_use/agent/system_prompt_flash.md",
+    "browser_use/py.typed",
     "browser_use/dom/**/*.js",
     "!tests/**/*.py",
 ]


### PR DESCRIPTION
https://github.com/browser-use/browser-use/issues/2508