### PR TITLE
fix: remove exposed credentials from shopping example

### DIFF
--- a/examples/use-cases/shopping.py
+++ b/examples/use-cases/shopping.py
@@ -97,8 +97,8 @@ At this stage, check the basket on the top right (indicates the price) and check
 - Select **TWINT** as the payment method.
 - Check out.
 - 
-- if it's needed the username is: nikoskalio.dev@gmail.com 
-- and the password is : TheCircuit.Migros.dev!
+- if it's needed the username is: <your-email@example.com>
+- and the password is : <your-password>
 ---
 
 ### Step 7: Confirm Order & Output Summary


### PR DESCRIPTION
## Summary
This PR removes exposed credentials from the shopping.py example file for security reasons.

## Changes
- Replaced hardcoded email (`nikoskalio.dev@gmail.com`) with placeholder `<your-email@example.com>`
- Replaced hardcoded password with placeholder `<your-password>`

## Security Impact
This removes potentially sensitive information from the public repository. The exposed credentials should be rotated if they are still in use.

## Test plan
This is a documentation/example change only - no functional code was modified.

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed hardcoded email and password from the shopping.py example and replaced them with placeholder values to prevent exposing credentials.

<!-- End of auto-generated description by cubic. -->

