### PR TITLE
Inform llm about pdf viewer limitation

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -197,11 +197,16 @@ class AgentMessagePrompt:
 
 		current_tab_text = f'Current tab: {current_tab_id}' if current_tab_id is not None else ''
 
+		# Check if this is a PDF viewer and show appropriate message
+		pdf_message = ''
+		if self.browser_state.is_pdf_viewer:
+			pdf_message = 'PDF viewer cannot be rendered. Use the read_file action on the downloaded PDF in available_file_paths to read the full content.\n'
+
 		browser_state = f"""{current_tab_text}
 Available tabs:
 {tabs_text}
 {page_info_text}
-Interactive elements from top layer of the current page inside the viewport{truncated_text}:
+{pdf_message}Interactive elements from top layer of the current page inside the viewport{truncated_text}:
 {elements_text}
 """
 		return browser_state

--- a/browser_use/browser/views.py
+++ b/browser_use/browser/views.py
@@ -59,6 +59,7 @@ class BrowserStateSummary(DOMState):
 	pixels_above: int = 0
 	pixels_below: int = 0
 	browser_errors: list[str] = field(default_factory=list)
+	is_pdf_viewer: bool = False  # Track if current page is a PDF viewer
 
 
 @dataclass


### PR DESCRIPTION
Add a message to the browser state when a PDF viewer is detected, guiding the LLM to use `read_file` on downloaded PDFs.

---

[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1753371574742759?thread_ts=1753371574.742759&cid=D092QUQDC56) • [Open in Web](https://www.cursor.com/agents?id=bc-c84efc88-96e4-4628-98eb-2f81935ca489) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c84efc88-96e4-4628-98eb-2f81935ca489)