### PR TITLE
Handle pdf viewer content with read file

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -197,11 +197,16 @@ class AgentMessagePrompt:
 
 		current_tab_text = f'Current tab: {current_tab_id}' if current_tab_id is not None else ''
 
+		# Check if current page is a PDF viewer and add appropriate message
+		pdf_message = ''
+		if self.browser_state.is_pdf_viewer:
+			pdf_message = 'PDF viewer cannot be rendered. In this page, DO NOT use the extract_structured_data action as PDF content cannot be rendered. Use the read_file action on the downloaded PDF in available_file_paths to read the full content.\n\n'
+
 		browser_state = f"""{current_tab_text}
 Available tabs:
 {tabs_text}
 {page_info_text}
-Interactive elements from top layer of the current page inside the viewport{truncated_text}:
+{pdf_message}Interactive elements from top layer of the current page inside the viewport{truncated_text}:
 {elements_text}
 """
 		return browser_state

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3175,6 +3175,9 @@ class BrowserSession(BaseModel):
 			parent=None,
 		)
 
+		# Check if current page is a PDF viewer
+		is_pdf_viewer = await self._is_pdf_viewer(page)
+
 		return BrowserStateSummary(
 			element_tree=minimal_element_tree,  # Minimal DOM tree
 			selector_map={},  # Empty selector map
@@ -3184,6 +3187,7 @@ class BrowserSession(BaseModel):
 			pixels_above=0,
 			pixels_below=0,
 			browser_errors=[f'Page state retrieval failed, minimal recovery applied for {url}'],
+			is_pdf_viewer=is_pdf_viewer,
 		)
 
 	@observe_debug(ignore_input=True, ignore_output=True, name='get_updated_state')
@@ -3301,6 +3305,9 @@ class BrowserSession(BaseModel):
 					f'DOM processing timed out for {page.url} - using minimal state. Basic navigation still available via go_to_url, scroll, and search actions.'
 				)
 
+			# Check if current page is a PDF viewer
+			is_pdf_viewer = await self._is_pdf_viewer(page)
+
 			self.browser_state_summary = BrowserStateSummary(
 				element_tree=content.element_tree,
 				selector_map=content.selector_map,
@@ -3312,6 +3319,7 @@ class BrowserSession(BaseModel):
 				pixels_above=pixels_above,
 				pixels_below=pixels_below,
 				browser_errors=browser_errors,
+				is_pdf_viewer=is_pdf_viewer,
 			)
 
 			self.logger.debug('✅ get_state_summary completed successfully')

--- a/browser_use/browser/views.py
+++ b/browser_use/browser/views.py
@@ -59,6 +59,7 @@ class BrowserStateSummary(DOMState):
 	pixels_above: int = 0
 	pixels_below: int = 0
 	browser_errors: list[str] = field(default_factory=list)
+	is_pdf_viewer: bool = False  # Whether the current page is a PDF viewer
 
 
 @dataclass

--- a/examples/file_system/alphabet_earnings.py
+++ b/examples/file_system/alphabet_earnings.py
@@ -6,16 +6,15 @@ import shutil
 from dotenv import load_dotenv
 
 from browser_use import Agent
+from browser_use.browser import BrowserProfile, BrowserSession
 from browser_use.llm import ChatOpenAI
 
 load_dotenv()
 
-
+''
 SCRIPT_DIR = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
-agent_dir = SCRIPT_DIR / 'file_system'
+agent_dir = SCRIPT_DIR / 'alphabet_earnings'
 agent_dir.mkdir(exist_ok=True)
-conversation_dir = agent_dir / 'conversations' / 'conversation'
-print(f'Agent logs directory: {agent_dir}')
 
 try:
 	from lmnr import Laminar
@@ -24,30 +23,30 @@ try:
 except Exception as e:
 	print(f'Error initializing Laminar: {e}')
 
+llm = ChatOpenAI(
+	model='o4-mini',
+)
+
+browser_session = BrowserSession(
+	browser_profile=BrowserProfile(downloads_path=str(agent_dir / 'downloads')),
+)
+
 task = """
-Go to https://mertunsall.github.io/posts/post1.html
-Save the title of the article in "data.md"
-Then, use append_file to add the first sentence of the article to "data.md"
-Then, read the file to see its content and make sure it's correct.
-Finally, share the file with me.
-
-NOTE: DO NOT USE extract_structured_data action - everything is visible in browser state.
+Go to https://abc.xyz/assets/cc/27/3ada14014efbadd7a58472f1f3f4/2025q2-alphabet-earnings-release.pdf.
+Read the PDF and save 3 interesting data points in "alphabet_earnings.pdf" and share it with me!
 """.strip('\n')
-
-llm = ChatOpenAI(model='gpt-4.1-mini')
 
 agent = Agent(
 	task=task,
 	llm=llm,
-	save_conversation_path=str(conversation_dir),
+	browser_session=browser_session,
 	file_system_path=str(agent_dir / 'fs'),
+	flash_mode=True,
 )
 
 
 async def main():
 	agent_history = await agent.run()
-	print(f'Final result: {agent_history.final_result()}', flush=True)
-
 	input('Press Enter to clean the file system...')
 	# clean the file system
 	shutil.rmtree(str(agent_dir / 'fs'))


### PR DESCRIPTION
Add PDF viewer detection to browser state to guide LLM on content extraction.

The LLM needs to be informed when a page is a PDF viewer because `extract_structured_data` cannot process PDF content. This change adds a flag to the browser state and injects a specific message, directing the LLM to use `read_file` on downloaded PDFs instead.

---

[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1753371679560089?thread_ts=1753371679.560089&cid=D092QUQDC56) • [Open in Web](https://www.cursor.com/agents?id=bc-cd9c3490-5d80-43d9-af68-fe403eb60f98) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cd9c3490-5d80-43d9-af68-fe403eb60f98)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added PDF viewer detection to browser state and updated prompts to guide the LLM to use read_file for PDFs instead of extract_structured_data.

- **New Features**
  - Added is_pdf_viewer flag to browser state summary.
  - Injected a prompt message when a PDF viewer is detected, instructing the LLM to use read_file for PDF content.

<!-- End of auto-generated description by cubic. -->

