### PR TITLE
Make separate tab for cloud sdk in docs

### DIFF
--- a/docs/cloud/custom-sdk.mdx
+++ b/docs/cloud/custom-sdk.mdx
@@ -1,0 +1,49 @@
+---
+title: "Cloud SDK"
+description: "Learn how to set up your own Browser Use Cloud SDK"
+icon: "code"
+---
+
+This guide walks you through setting up your own Browser Use Cloud SDK.
+
+## Building your own client (OpenAPI)
+
+<Note>
+  This approach is recommended **only** if you need to run simple tasks and
+  **don’t require fine-grained control**.
+</Note>
+
+The best way to build your own client is to use our [OpenAPI specification](http://api.browser-use.com/openapi.json) to generate a type-safe client library.
+
+### Python
+
+Use [openapi-python-client](https://github.com/openapi-generators/openapi-python-client) to generate a modern Python client:
+
+```bash
+# Install the generator
+pipx install openapi-python-client --include-deps
+
+# Generate the client
+openapi-python-client generate --url http://api.browser-use.com/openapi.json
+```
+
+This will create a Python package with full type hints, modern dataclasses, and async support.
+
+### TypeScript/JavaScript
+
+For TypeScript projects, use [openapi-typescript](https://www.npmjs.com/package/openapi-typescript) to generate type definitions:
+
+```bash
+# Install the generator
+npm install -D openapi-typescript
+
+# Generate the types
+npx openapi-typescript http://api.browser-use.com/openapi.json -o browser-use-api.ts
+```
+
+This will create TypeScript definitions you can use with your preferred HTTP client.
+
+<Note>
+  Need help? Contact our support team at support@browser-use.com or join our
+  [Discord community](https://link.browser-use.com/discord)
+</Note>

--- a/docs/cloud/quickstart.mdx
+++ b/docs/cloud/quickstart.mdx
@@ -87,43 +87,6 @@ Control running tasks with these operations:
 
 For detailed API documentation, see the tabs on the left, which include the full coverage of the API.
 
-## Building your own client (OpenAPI)
-
-<Note>
-  We recommend this only if you don't need control and only need to run simple
-  tasks.
-</Note>
-
-The best way to build your own client is to use our [OpenAPI specification](http://api.browser-use.com/openapi.json) to generate a type-safe client library.
-
-### Python
-
-Use [openapi-python-client](https://github.com/openapi-generators/openapi-python-client) to generate a modern Python client:
-
-```bash
-# Install the generator
-pipx install openapi-python-client --include-deps
-
-# Generate the client
-openapi-python-client generate --url http://api.browser-use.com/openapi.json
-```
-
-This will create a Python package with full type hints, modern dataclasses, and async support.
-
-### TypeScript/JavaScript
-
-For TypeScript projects, use [openapi-typescript](https://www.npmjs.com/package/openapi-typescript) to generate type definitions:
-
-```bash
-# Install the generator
-npm install -D openapi-typescript
-
-# Generate the types
-npx openapi-typescript http://api.browser-use.com/openapi.json -o browser-use-api.ts
-```
-
-This will create TypeScript definitions you can use with your preferred HTTP client.
-
 <Note>
   Need help? Contact our support team at support@browser-use.com or join our
   [Discord community](https://link.browser-use.com/discord)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -59,6 +59,7 @@
             "pages": [
               "cloud/quickstart",
               "cloud/implementation",
+              "cloud/custom-sdk",
               "cloud/webhooks",
               "cloud/authentication"
             ]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved the Cloud SDK setup guide to its own tab in the docs for easier access and better organization.

- **Docs Update**
  - Added a new "Cloud SDK" page with setup instructions for Python and TypeScript clients.
  - Removed duplicate SDK setup content from the quickstart page.

<!-- End of auto-generated description by cubic. -->

