### PR TITLE
Bump browser-use library to 0.5.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.5.5"
+version = "0.5.6"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [


### PR DESCRIPTION
Bump the `browser-use` library version to 0.5.6 in `pyproject.toml`.

---

[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1753532702828209?thread_ts=1753532702.828209&cid=D092QUQDC56) • [Open in Web](https://cursor.com/agents?id=bc-2a9d19a2-6ee9-430d-8f74-d00d494d877a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2a9d19a2-6ee9-430d-8f74-d00d494d877a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated the browser-use library version to 0.5.6 in pyproject.toml.

<!-- End of auto-generated description by cubic. -->

