### PR TITLE
feat: added docs for metadata field

### DIFF
--- a/docs/api-reference/create-scheduled-task.mdx
+++ b/docs/api-reference/create-scheduled-task.mdx
@@ -73,6 +73,10 @@ This endpoint requires an active subscription.
   Whether to enable public sharing of task executions
 </ParamField>
 
+<ParamField body="metadata" type="object">
+  Optional dictionary of string key-value pairs for custom tagging. Max 10 pairs. Keys: strings (max 100 chars, non-empty). Values: strings (max 1000 chars).
+</ParamField>
+
 *Either `interval_minutes` or `cron_expression` is required depending on the `schedule_type`.
 
 ## Response
@@ -100,7 +104,11 @@ task_data = {
   "interval_minutes": 60,
   "start_at": start_time,
   "end_at": end_time,
-  "use_adblock": True
+  "use_adblock": True,
+  "metadata": {
+    "campaign": "q4-automation",
+    "team": "marketing"
+  }
 }
 
 response = requests.post(f'{BASE_URL}/scheduled-task', headers=HEADERS, json=task_data)
@@ -117,7 +125,11 @@ curl --request POST \
     "task": "Visit example.com and check if the site is up",
     "schedule_type": "interval",
     "interval_minutes": 60,
-    "use_adblock": true
+    "use_adblock": true,
+    "metadata": {
+      "campaign": "q4-automation",
+      "team": "marketing"
+    }
   }'
 ```
 

--- a/docs/api-reference/get-scheduled-task.mdx
+++ b/docs/api-reference/get-scheduled-task.mdx
@@ -82,6 +82,10 @@ Returns detailed information about a specific scheduled task, including its sche
   When the scheduled task was last updated
 </ResponseField>
 
+<ResponseField name="metadata" type="object | null">
+  Custom metadata key-value pairs associated with the scheduled task
+</ResponseField>
+
 <RequestExample>
 
 ```python python
@@ -124,7 +128,11 @@ curl --request GET \
   "end_at": "2023-12-31T23:59:59Z",
   "is_active": true,
   "created_at": "2023-01-01T00:00:00Z",
-  "updated_at": "2023-01-01T00:00:00Z"
+  "updated_at": "2023-01-01T00:00:00Z",
+  "metadata": {
+    "campaign": "q4-automation",
+    "team": "marketing"
+  }
 }
 ```
 

--- a/docs/api-reference/get-task.mdx
+++ b/docs/api-reference/get-task.mdx
@@ -99,6 +99,10 @@ Returns comprehensive information about a task, including its current status, st
   Public URL for sharing the task (if public sharing was enabled)
 </ResponseField>
 
+<ResponseField name="metadata" type="object | null">
+  Custom metadata key-value pairs associated with the task
+</ResponseField>
+
 <RequestExample>
 
 ```python python
@@ -159,7 +163,11 @@ fetch('https://api.browser-use.com/api/v1/task/{task_id}', options)
   "output_files": [
     "<string>"
   ],
-  "public_share_url": "<string>"
+  "public_share_url": "<string>",
+  "metadata": {
+    "campaign": "q4-automation",
+    "team": "marketing"
+  }
 }
     ```
 

--- a/docs/api-reference/run-task.mdx
+++ b/docs/api-reference/run-task.mdx
@@ -75,6 +75,10 @@ Creates a new browser automation task and returns the task ID that can be used t
   If set to True, enables public sharing of the task execution. When enabled, a public_share_url will be generated that allows others to view the task results without authentication.
 </ParamField>
 
+<ParamField body="metadata" type="object">
+  Optional dictionary of string key-value pairs for custom tagging. Max 10 pairs. Keys: strings (max 100 chars, non-empty). Values: strings (max 1000 chars).
+</ParamField>
+
 ## Response
 
 <ResponseField name="id" type="string">
@@ -104,7 +108,11 @@ payload = {
     "browser_viewport_width": 123,
     "browser_viewport_height": 123,
     "max_agent_steps": 123,
-    "enable_public_share": True
+    "enable_public_share": True,
+    "metadata": {
+        "campaign": "q4-automation",
+        "team": "marketing"
+    }
 }
 headers = {
     "Authorization": "Bearer <token>",
@@ -140,7 +148,11 @@ curl --request POST \
   "browser_viewport_width": 123,
   "browser_viewport_height": 123,
   "max_agent_steps": 123,
-  "enable_public_share": true
+  "enable_public_share": true,
+  "metadata": {
+    "campaign": "q4-automation",
+    "team": "marketing"
+  }
 }'
 ```
 
@@ -148,7 +160,7 @@ curl --request POST \
 const options = {
   method: 'POST',
   headers: {Authorization: 'Bearer <token>', 'Content-Type': 'application/json'},
-  body: '{"task":"<string>","secrets":{},"allowed_domains":["<string>"],"save_browser_data":true,"structured_output_json":"<string>","llm_model":"gpt-4o","use_adblock":true,"use_proxy":true,"proxy_country_code":"us","highlight_elements":true,"included_file_names":["<string>"],"browser_viewport_width":123,"browser_viewport_height":123,"max_agent_steps":123,"enable_public_share":true}'
+  body: '{"task":"<string>","secrets":{},"allowed_domains":["<string>"],"save_browser_data":true,"structured_output_json":"<string>","llm_model":"gpt-4o","use_adblock":true,"use_proxy":true,"proxy_country_code":"us","highlight_elements":true,"included_file_names":["<string>"],"browser_viewport_width":123,"browser_viewport_height":123,"max_agent_steps":123,"enable_public_share":true,"metadata":{"campaign":"q4-automation","team":"marketing"}}'
 };
 
 fetch('https://api.browser-use.com/api/v1/run-task', options)

--- a/docs/api-reference/update-scheduled-task.mdx
+++ b/docs/api-reference/update-scheduled-task.mdx
@@ -54,6 +54,10 @@ Updates a scheduled task with partial updates. You can update any combination of
   JSON schema for structured output
 </ParamField>
 
+<ParamField body="metadata" type="object">
+  Optional dictionary of string key-value pairs for custom tagging. Max 10 pairs. Keys: strings (max 100 chars, non-empty). Values: strings (max 1000 chars).
+</ParamField>
+
 ## Response
 
 Returns the updated scheduled task object with the same format as the Get Scheduled Task response.
@@ -126,6 +130,10 @@ Returns the updated scheduled task object with the same format as the Get Schedu
   When the scheduled task was last updated
 </ResponseField>
 
+<ResponseField name="metadata" type="object | null">
+  Custom metadata key-value pairs associated with the scheduled task
+</ResponseField>
+
 <RequestExample>
 
 ```python python
@@ -137,7 +145,11 @@ headers = {"Authorization": "Bearer <token>"}
 
 payload = {
     "task": "Updated task description",
-    "is_active": False
+    "is_active": False,
+    "metadata": {
+        "campaign": "q4-automation",
+        "team": "marketing"
+    }
 }
 
 response = requests.request("PUT", url, headers=headers, json=payload)
@@ -152,7 +164,11 @@ curl --request PUT \
   --header 'Content-Type: application/json' \
   --data '{
     "task": "Updated task description",
-    "is_active": false
+    "is_active": false,
+    "metadata": {
+      "campaign": "q4-automation",
+      "team": "marketing"
+    }
   }'
 ```
 
@@ -178,7 +194,11 @@ curl --request PUT \
   "end_at": "2023-12-31T23:59:59Z",
   "is_active": false,
   "created_at": "2023-01-01T00:00:00Z",
-  "updated_at": "2023-01-01T00:30:00Z"
+  "updated_at": "2023-01-01T00:30:00Z",
+  "metadata": {
+    "campaign": "q4-automation",
+    "team": "marketing"
+  }
 }
 ```
 

--- a/docs/cloud/webhooks.mdx
+++ b/docs/cloud/webhooks.mdx
@@ -67,10 +67,16 @@ The payload follows this structure:
   "payload": {
     "session_id": "cd9cc7bf-e3af-4181-80a2-73f083bc94b4",
     "task_id": "5b73fb3f-a3cb-4912-be40-17ce9e9e1a45",
-    "status": "finished"
+    "status": "finished",
+    "metadata": {
+      "campaign": "q4-automation",
+      "team": "marketing"
+    }
   }
 }
 ```
+
+The webhook payload now includes a `metadata` field containing any custom key-value pairs that were provided when the task was created. This allows you to correlate webhook events with your internal tracking systems.
 
 ## Implementing Webhook Verification
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added documentation for the new metadata field in task and scheduled task APIs, showing how to use custom key-value pairs for tagging and tracking.

- **Docs Updates**
  - Described the metadata field in request and response sections for create, update, get, and run task endpoints.
  - Updated code examples and webhook docs to show metadata usage and payloads.

<!-- End of auto-generated description by cubic. -->

