### PR TITLE
Separate Remote Browser from Local Browser logic

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3599,11 +3599,11 @@ class BrowserSession(BaseModel):
 		retries=1,  # try up to 1 time to take the screenshot (2 total attempts)
 		timeout=30,  # allow up to 30s for each attempt (includes recovery time)
 		wait=1,  # wait 1s between each attempt
-		semaphore_limit=2,  # Allow 2 screenshots at a time to better utilize resources
-		semaphore_name='screenshot_global',
-		semaphore_scope='multiprocess',
-		semaphore_lax=True,  # Continue without semaphore if it can't be acquired
-		semaphore_timeout=15,  # Wait up to 15s for semaphore acquisition
+		# semaphore_limit=2,  # Allow 2 screenshots at a time to better utilize resources
+		# semaphore_name='screenshot_global',
+		# semaphore_scope='multiprocess',
+		# semaphore_lax=True,  # Continue without semaphore if it can't be acquired
+		# semaphore_timeout=15,  # Wait up to 15s for semaphore acquisition
 	)
 	@require_healthy_browser(usable_page=True, reopen_page=True)
 	@time_execution_async('--take_screenshot')

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -74,8 +74,8 @@ class DomService:
 		if await self.page.evaluate('1+1') != 2:
 			raise ValueError('The page cannot evaluate javascript code properly')
 
-		if is_new_tab_page(self.page.url):
-			# short-circuit if the page is a new empty tab for speed, no need to inject buildDomTree.js
+		if is_new_tab_page(self.page.url) or self.page.url.startswith('chrome://'):
+			# short-circuit if the page is a new empty tab or chrome:// page for speed, no need to inject buildDomTree.js
 			return (
 				DOMElementNode(
 					tag_name='body',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 dependencies = [
     "aiofiles>=24.1.0",
     "anyio>=4.9.0",
-    "bubus>=1.4.5",
+    "bubus>=1.4.7",
     "google-api-core>=2.25.0",
     "httpx>=0.28.1",
     "markdownify==1.1.0",

--- a/tests/ci/test_fill_fallback.py
+++ b/tests/ci/test_fill_fallback.py
@@ -1,0 +1,73 @@
+from browser_use import BrowserProfile, BrowserSession
+
+
+async def test_input_text_fallback_for_non_standard_elements(httpserver):
+	"""Test that input text works on elements that don't support fill() by using type() as fallback."""
+
+	# Create a test page with various input elements
+	httpserver.expect_request('/').respond_with_data("""
+	<html>
+	<body>
+		<!-- Standard input - should work with fill() -->
+		<input id="standard-input" type="text" placeholder="Standard input">
+		
+		<!-- Contenteditable div - should NOT work with fill(), needs fallback -->
+		<div id="contenteditable" contenteditable="true" style="border: 1px solid #ccc; padding: 5px;">
+			Click here to edit
+		</div>
+		
+		<!-- Custom element that might not support fill() -->
+		<custom-element id="custom" tabindex="0" style="border: 1px solid #ccc; padding: 5px;">
+			Custom element
+		</custom-element>
+	</body>
+	</html>
+	""")
+
+	async with BrowserSession(browser_profile=BrowserProfile(user_data_dir=None, headless=True)) as session:
+		page = await session.get_current_page()
+		await page.goto(httpserver.url_for('/'))
+
+		# Get the DOM state
+		state = await session.get_browser_state_with_recovery()
+
+		# Find elements by their text/attributes
+		standard_input_index = None
+		contenteditable_index = None
+		custom_element_index = None
+
+		for index, element in state.selector_map.items():
+			if element.attributes.get('id') == 'standard-input':
+				standard_input_index = index
+			elif element.attributes.get('id') == 'contenteditable':
+				contenteditable_index = index
+			elif element.attributes.get('id') == 'custom':
+				custom_element_index = index
+
+		# Test standard input (should work normally)
+		if standard_input_index is not None:
+			element = state.selector_map[standard_input_index]
+			await session._input_text_element_node(element, 'Test text for input')
+
+			# Verify the text was entered
+			value = await page.locator('#standard-input').input_value()
+			assert value == 'Test text for input'
+
+		# Test contenteditable div (should use fallback)
+		if contenteditable_index is not None:
+			element = state.selector_map[contenteditable_index]
+			await session._input_text_element_node(element, 'Test text for contenteditable')
+
+			# Verify the text was entered
+			text = await page.locator('#contenteditable').text_content()
+			assert 'Test text for contenteditable' in (text or '')
+
+		# Test custom element (might use fallback)
+		if custom_element_index is not None:
+			element = state.selector_map[custom_element_index]
+			# This might fail for truly custom elements, but should at least not crash
+			try:
+				await session._input_text_element_node(element, 'Test text for custom')
+			except Exception:
+				# It's okay if custom elements fail, as long as standard ones work
+				pass

--- a/tests/ci/test_gif_generation_with_navigation.py
+++ b/tests/ci/test_gif_generation_with_navigation.py
@@ -1,0 +1,130 @@
+"""Test that GIF generation works properly when real navigation happens."""
+
+import asyncio
+
+from browser_use import Agent, AgentHistoryList
+from browser_use.browser import BrowserProfile, BrowserSession
+from tests.ci.conftest import create_mock_llm
+
+
+async def test_gif_generation_with_real_navigation(httpserver, tmp_path):
+	"""Test that GIF is properly generated when agent navigates to a real page."""
+	# Set up a test page with visible content
+	httpserver.expect_request('/').respond_with_data(
+		"""
+		<!DOCTYPE html>
+		<html>
+		<head>
+			<title>Test Page for GIF</title>
+			<style>
+				body {
+					background-color: #f0f0f0;
+					font-family: Arial, sans-serif;
+					padding: 50px;
+				}
+				h1 {
+					color: #333;
+					font-size: 48px;
+				}
+				.content {
+					background: white;
+					padding: 30px;
+					border-radius: 10px;
+					box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+				}
+			</style>
+		</head>
+		<body>
+			<div class="content">
+				<h1>Test Page for GIF Generation</h1>
+				<p>This page has real content that should appear in the GIF.</p>
+				<button id="test-button">Click Me</button>
+			</div>
+		</body>
+		</html>
+		""",
+		content_type='text/html',
+	)
+
+	# Create a mock LLM that navigates then completes
+	navigate_action = f'{{"action": [{{"go_to_url": {{"url": "{httpserver.url_for("/")}"}}}}]}}'
+	done_action = '{"action": [{"done": {"text": "Navigated successfully", "success": true}}]}'
+	llm_with_navigation = create_mock_llm(actions=[navigate_action, done_action])
+
+	# Set up output path
+	gif_path = tmp_path / 'test_agent.gif'
+
+	browser_session = BrowserSession(browser_profile=BrowserProfile(headless=True, disable_security=True, user_data_dir=None))
+	await browser_session.start()
+
+	try:
+		agent = Agent(
+			task=f'Navigate to {httpserver.url_for("/")} and verify the page loads',
+			llm=llm_with_navigation,
+			browser_session=browser_session,
+			generate_gif=str(gif_path),
+		)
+
+		history: AgentHistoryList = await agent.run(max_steps=3)
+
+		# Verify the task completed
+		result = history.final_result()
+		assert result is not None
+		# result is a string, not an object with success attribute
+
+		# Give a moment for GIF to be written
+		await asyncio.sleep(0.1)
+
+		# Verify GIF was created
+		assert gif_path.exists(), f'GIF was not created at {gif_path}'
+
+		# Verify GIF has substantial content (not just placeholders)
+		gif_size = gif_path.stat().st_size
+		assert gif_size > 10000, f'GIF file is too small ({gif_size} bytes), likely only contains placeholders'
+
+		# Verify history contains real screenshots (not placeholders)
+		has_real_screenshot = False
+		for item in history.history:
+			if (
+				item.state.screenshot
+				and item.state.screenshot
+				!= 'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAFElEQVR4nGP8//8/AwwwMSAB3BwAlm4DBfIlvvkAAAAASUVORK5CYII='
+			):
+				has_real_screenshot = True
+				break
+
+		assert has_real_screenshot, 'No real screenshots found in history, only placeholders'
+
+	finally:
+		await browser_session.kill()
+
+
+async def test_gif_not_created_when_only_placeholders(tmp_path):
+	"""Test that no GIF is created when all screenshots are placeholders."""
+	# Use default mock LLM that just returns done without navigation
+	llm = create_mock_llm()
+
+	gif_path = tmp_path / 'should_not_exist.gif'
+
+	browser_session = BrowserSession(browser_profile=BrowserProfile(headless=True, disable_security=True, user_data_dir=None))
+	await browser_session.start()
+
+	try:
+		agent = Agent(
+			task='Just complete without navigation',
+			llm=llm,
+			browser_session=browser_session,
+			generate_gif=str(gif_path),
+		)
+
+		history: AgentHistoryList = await agent.run(max_steps=2)
+
+		# Task should complete
+		result = history.final_result()
+		assert result is not None
+
+		# GIF should NOT be created
+		assert not gif_path.exists(), 'GIF should not be created when all screenshots are placeholders'
+
+	finally:
+		await browser_session.kill()


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Separated remote browser logic from local browser logic and added new tests to cover input fallback and GIF generation with navigation.

- **Dependencies**
  - Updated bubus to version 1.4.7.

- **Tests**
  - Added tests for input fallback on non-standard elements.
  - Added tests for GIF generation with real navigation and placeholder-only scenarios.

<!-- End of auto-generated description by cubic. -->

