### PR TITLE
never relaunch local browser when cdp url is provided, never run JS on special `about:blank` and `chrome://` urls, improve mcp cli examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add browser-use to your Claude Desktop configuration:
   "mcpServers": {
     "browser-use": {
       "command": "uvx",
-      "args": ["browser-use", "--mcp"],
+      "args": ["browser-use[cli]", "--mcp"],
       "env": {
         "OPENAI_API_KEY": "sk-..."
       }

--- a/browser_use/agent/gif.py
+++ b/browser_use/agent/gif.py
@@ -56,9 +56,9 @@ def create_history_gif(
 
 	images = []
 
-	# if history is empty or first screenshot is None, we can't create a gif
-	if not history.history or not history.history[0].state.screenshot:
-		logger.warning('No history or first screenshot to create GIF from')
+	# if history is empty, we can't create a gif
+	if not history.history:
+		logger.warning('No history to create GIF from')
 		return
 
 	# Find the first non-placeholder screenshot

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1084,6 +1084,8 @@ class BrowserSession(BaseModel):
 	async def _unsafe_setup_new_browser_context(self) -> None:
 		"""Unsafe browser context setup without retry protection."""
 
+		assert self.cdp_url is None, 'Should never try to set up a new local browser when a cdp_url is provided'
+
 		# if we have a browser object but no browser_context, use the first context discovered or make a new one
 		if self.browser and not self.browser_context:
 			# If HAR recording or video recording is requested, we need to create a new context with recording enabled
@@ -1760,7 +1762,6 @@ class BrowserSession(BaseModel):
 		self.human_current_page = None
 		self._cached_clickable_element_hashes = None
 		# Reset CDP connection info when browser is stopped
-		self.cdp_url = None
 		self.browser_pid = None
 		self._cached_browser_state_summary = None
 		# Don't clear self.playwright here - it should be cleared explicitly in kill()

--- a/browser_use/mcp/__init__.py
+++ b/browser_use/mcp/__init__.py
@@ -6,7 +6,7 @@ This module provides integration with MCP servers and clients for browser automa
 from browser_use.mcp.client import MCPClient
 from browser_use.mcp.controller import MCPToolWrapper
 
-__all__ = ['MCPClient', 'MCPToolWrapper', 'BrowserUseServer']
+__all__ = ['MCPClient', 'MCPToolWrapper', 'BrowserUseServer']  # type: ignore
 
 
 def __getattr__(name):

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -14,7 +14,7 @@ Or as an MCP server in Claude Desktop or other MCP clients:
         "mcpServers": {
             "browser-use": {
                 "command": "uvx",
-                "args": ["browser-use", "--mcp"],
+                "args": ["browser-use[cli]", "--mcp"],
                 "env": {
                     "OPENAI_API_KEY": "sk-proj-1234567890",
                 }

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -13,7 +13,7 @@ The `browser-use` command-line interface provides multiple modes of operation fo
 Get started with browser-use immediately using `uvx`:
 
 ```bash
-uvx browser-use --help
+uvx 'browser-use[cli]' --help
 ```
 
 Or install it globally:
@@ -29,7 +29,7 @@ uv tool install 'browser-use[cli]'
 Launch an interactive terminal UI where you can chat with the browser automation agent:
 
 ```bash
-uvx browser-use
+uvx 'browser-use[cli]'
 ```
 
 This opens a chat interface where you can:
@@ -55,7 +55,7 @@ Options:
 Run browser-use as a Model Context Protocol server:
 
 ```bash
-uvx browser-use --mcp   # exoects MCP JSON RPC over stdio
+uvx 'browser-use[cli]' --mcp   # exoects MCP JSON RPC over stdio
 ```
 
 This mode exposes browser automation capabilities as MCP tools that can be used by:
@@ -166,36 +166,36 @@ Each profile directory contains Chrome user data, allowing you to:
 
 ```bash
 # Interactive mode
-uvx browser-use
+uvx 'browser-use[cli]'
 
 # One-shot task
-uvx browser-use -p "Go to github.com and search for browser-use"
+uvx 'browser-use[cli]' -p "Go to github.com and search for browser-use"
 
 # Headless one-shot
-uvx browser-use --headless -p "Extract prices from example.com/products"
+uvx 'browser-use[cli]' --headless -p "Extract prices from example.com/products"
 ```
 
 ### With Configuration
 
 ```bash
 # Use specific config file
-BROWSER_USE_CONFIG_PATH=~/my-config.json uvx browser-use
+BROWSER_USE_CONFIG_PATH=~/my-config.json uvx 'browser-use[cli]'
 
 # Override settings via environment
-BROWSER_USE_HEADLESS=true OPENAI_API_KEY=sk-... uvx browser-use -p "Check my email"
+BROWSER_USE_HEADLESS=true OPENAI_API_KEY=sk-... uvx 'browser-use[cli]' -p "Check my email"
 
 # Use different LLM model
-BROWSER_USE_LLM_MODEL=gpt-4-turbo uvx browser-use
+BROWSER_USE_LLM_MODEL=gpt-4-turbo uvx 'browser-use[cli]'
 ```
 
 ### MCP Server Usage
 
 ```bash
 # Start MCP server
-uvx browser-use --mcp
+uvx 'browser-use[cli]' --mcp
 
 # With custom settings
-BROWSER_USE_HEADLESS=false OPENAI_API_KEY=sk-... uvx browser-use --mcp
+BROWSER_USE_HEADLESS=false OPENAI_API_KEY=sk-... uvx 'browser-use[cli]' --mcp
 ```
 
 For Claude Desktop integration, add to your Claude Desktop config:
@@ -205,7 +205,7 @@ For Claude Desktop integration, add to your Claude Desktop config:
   "mcpServers": {
     "browser-use": {
       "command": "uvx",
-      "args": ["browser-use", "--mcp"],
+      "args": ["browser-use[cli]", "--mcp"],
       "env": {
         "OPENAI_API_KEY": "sk-...",
         "BROWSER_USE_HEADLESS": "false"
@@ -228,7 +228,7 @@ For Claude Desktop integration, add to your Claude Desktop config:
 Enable debug logging for troubleshooting:
 
 ```bash
-BROWSER_USE_LOGGING_LEVEL=debug uvx browser-use
+BROWSER_USE_LOGGING_LEVEL=debug uvx 'browser-use[cli]'
 ```
 
 ## See Also

--- a/docs/customize/mcp-server.mdx
+++ b/docs/customize/mcp-server.mdx
@@ -320,7 +320,7 @@ Test the MCP server without Claude Desktop:
 
 ```bash
 # Run server (reads from stdin, writes to stdout)
-uvx browser-use --mcp
+uvx 'browser-use[cli]' --mcp
 
 # The server communicates via JSON-RPC on stdio
 ```
@@ -364,8 +364,8 @@ uvx browser-use --mcp
 
 2. **Verify Python installation:**
    ```bash
-   uvx browser-use --version
-   uvx browser-use --mcp --help
+   uvx 'browser-use[cli]' --version
+   uvx 'browser-use[cli]' --mcp --help
    ```
 
 3. **Check Claude logs:**
@@ -388,7 +388,7 @@ If you see "MCP server connection failed":
 
 1. Test the server directly:
    ```bash
-   uvx browser-use --mcp
+   uvx 'browser-use[cli]' --mcp
    ```
 
 2. Check all dependencies:

--- a/examples/mcp/advanced_server.py
+++ b/examples/mcp/advanced_server.py
@@ -12,7 +12,7 @@ Prerequisites:
    pip install 'browser-use[cli]'
 
 2. Start the browser-use MCP server:
-   uvx browser-use --mcp
+   uvx 'browser-use[cli]' --mcp
 
 3. Run this example:
    python advanced_server.py
@@ -241,7 +241,7 @@ async def main():
 
 	try:
 		# Connect to browser-use MCP server
-		await assistant.connect_server(name='browser', command='uvx', args=['browser-use', '--mcp'])
+		await assistant.connect_server(name='browser', command='uvx', args=['browser-use[cli]', '--mcp'])
 
 		# Optionally connect to filesystem server
 		# Note: Uncomment to enable file operations

--- a/examples/mcp/simple_server.py
+++ b/examples/mcp/simple_server.py
@@ -131,7 +131,7 @@ async def main():
 	except Exception as e:
 		print(f'\n❌ Error: {e}')
 		print('\nMake sure the browser-use MCP server is running:')
-		print('  uvx browser-use --mcp')
+		print("  uvx 'browser-use[cli]' --mcp")
 
 
 if __name__ == '__main__':

--- a/tests/ci/test_browser_session_start.py
+++ b/tests/ci/test_browser_session_start.py
@@ -73,7 +73,7 @@ class TestBrowserSessionStart:
 		browser_pids = []
 		original_setup = browser_session._unsafe_setup_new_browser_context
 
-		async def tracking_setup():
+		async def tracking_setup(self):
 			await original_setup()
 			if browser_session.browser_pid:
 				browser_pids.append(browser_session.browser_pid)

--- a/tests/ci/test_dom_service_chrome_urls.py
+++ b/tests/ci/test_dom_service_chrome_urls.py
@@ -1,0 +1,85 @@
+"""Test DomService behavior with chrome:// URLs and new tab pages."""
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+from browser_use.dom.service import DomService
+
+
+class TestDomServiceChromeURLs:
+	"""Test that DomService returns empty DOM for chrome:// URLs and new tabs."""
+
+	@pytest.fixture
+	async def browser_session(self):
+		"""Create a browser session for testing."""
+		profile = BrowserProfile(headless=True, user_data_dir=None, keep_alive=False)
+		session = BrowserSession(browser_profile=profile)
+		await session.start()
+		yield session
+		await session.kill()
+
+	async def test_about_blank_returns_empty_dom(self, browser_session):
+		"""Test that about:blank returns an empty DOM."""
+		page = await browser_session.get_current_page()
+		await page.goto('about:blank')
+
+		dom_service = DomService(page)
+		dom_state = await dom_service.get_clickable_elements()
+
+		# Verify empty DOM is returned
+		assert dom_state.element_tree.tag_name == 'body'
+		assert dom_state.element_tree.xpath == ''
+		assert dom_state.element_tree.attributes == {}
+		assert dom_state.element_tree.children == []
+		assert dom_state.element_tree.is_visible is False
+		assert dom_state.selector_map == {}
+
+	async def test_chrome_new_tab_page_returns_empty_dom(self, browser_session):
+		"""Test that chrome://new-tab-page returns an empty DOM."""
+		page = await browser_session.get_current_page()
+		await page.goto('chrome://new-tab-page')
+
+		dom_service = DomService(page)
+		dom_state = await dom_service.get_clickable_elements()
+
+		# Verify empty DOM
+		assert dom_state.element_tree.tag_name == 'body'
+		assert len(dom_state.element_tree.children) == 0
+		assert dom_state.selector_map == {}
+
+	async def test_chrome_version_returns_empty_dom(self, browser_session):
+		"""Test that chrome://version returns an empty DOM."""
+		page = await browser_session.get_current_page()
+		await page.goto('chrome://version')
+
+		dom_service = DomService(page)
+		dom_state = await dom_service.get_clickable_elements()
+
+		# Verify empty DOM
+		assert dom_state.element_tree.tag_name == 'body'
+		assert len(dom_state.element_tree.children) == 0
+		assert dom_state.selector_map == {}
+
+	async def test_regular_url_returns_populated_dom(self, browser_session, httpserver):
+		"""Test that regular URLs still return a populated DOM."""
+		# Set up test HTML
+		httpserver.expect_request('/').respond_with_data("""
+			<html>
+				<body>
+					<h1>Test Page</h1>
+					<button id="test-button">Click me</button>
+					<a href="#link">Test Link</a>
+				</body>
+			</html>
+		""")
+
+		page = await browser_session.get_current_page()
+		await page.goto(httpserver.url_for('/'))
+
+		dom_service = DomService(page)
+		dom_state = await dom_service.get_clickable_elements()
+
+		# Verify DOM is populated (either root is not body, or body has children)
+		has_content = dom_state.element_tree.tag_name != 'body' or len(dom_state.element_tree.children) > 0
+		assert has_content, f'Expected populated DOM but got empty tree with tag {dom_state.element_tree.tag_name}'


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Prevented launching a local browser when a CDP URL is provided to avoid conflicts and ensure correct remote browser usage.

<!-- End of auto-generated description by cubic. -->

