### PR TITLE
fix: handle unexpected response types in ChatAnthropic

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -145,6 +145,14 @@ class ChatAnthropic(BaseChatModel):
 					**self._get_client_params_for_invoke(),
 				)
 
+				# Ensure we have a valid Message object before accessing attributes
+				if not isinstance(response, Message):
+					raise ModelProviderError(
+						message=f'Unexpected response type from Anthropic API: {type(response).__name__}. Response: {str(response)[:200]}',
+						status_code=502,
+						model=self.name,
+					)
+
 				usage = self._get_usage(response)
 
 				# Extract text from the first content block
@@ -188,6 +196,14 @@ class ChatAnthropic(BaseChatModel):
 					tool_choice=tool_choice,
 					**self._get_client_params_for_invoke(),
 				)
+
+				# Ensure we have a valid Message object before accessing attributes
+				if not isinstance(response, Message):
+					raise ModelProviderError(
+						message=f'Unexpected response type from Anthropic API: {type(response).__name__}. Response: {str(response)[:200]}',
+						status_code=502,
+						model=self.name,
+					)
 
 				usage = self._get_usage(response)
 

--- a/tests/ci/test_anthropic_502_error.py
+++ b/tests/ci/test_anthropic_502_error.py
@@ -1,0 +1,86 @@
+"""Test for handling Anthropic 502 errors"""
+
+import pytest
+from anthropic import APIStatusError
+from httpx import Response
+from browser_use.llm.anthropic.chat import ChatAnthropic
+from browser_use.llm.messages import UserMessage
+from browser_use.llm.exceptions import ModelProviderError
+
+
+@pytest.mark.asyncio
+async def test_anthropic_502_error_handling():
+	"""Test that ChatAnthropic properly handles 502 errors from the API"""
+	# Create a ChatAnthropic instance
+	chat = ChatAnthropic(
+		model="claude-3-5-sonnet-20240620",
+		api_key="test-key"
+	)
+	
+	# Create test messages
+	messages = [UserMessage(content="Test message")]
+	
+	# Mock the client to raise a 502 error
+	class MockClient:
+		class Messages:
+			async def create(self, **kwargs):
+				# Simulate a 502 error from Anthropic API
+				import httpx
+				request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+				response = httpx.Response(
+					status_code=502,
+					headers={},
+					content=b"Bad Gateway",
+					request=request
+				)
+				raise APIStatusError(
+					message="Bad Gateway", 
+					response=response,
+					body={"error": {"message": "Bad Gateway", "type": "server_error"}}
+				)
+		
+		messages = Messages()
+	
+	# Replace the client with our mock
+	chat.get_client = lambda: MockClient()
+	
+	# Test that the error is properly caught and re-raised as ModelProviderError
+	with pytest.raises(ModelProviderError) as exc_info:
+		await chat.ainvoke(messages)
+	
+	# Verify the error details
+	assert exc_info.value.args[0] == "Bad Gateway"
+	assert exc_info.value.args[1] == 502
+	assert str(exc_info.value) == "('Bad Gateway', 502)"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_error_does_not_access_usage():
+	"""Test that error handling doesn't try to access usage attribute on error responses"""
+	chat = ChatAnthropic(
+		model="claude-3-5-sonnet-20240620",
+		api_key="test-key"
+	)
+	
+	messages = [UserMessage(content="Test message")]
+	
+	# Mock the client to return a string instead of a proper response
+	class MockClient:
+		class Messages:
+			async def create(self, **kwargs):
+				# This simulates what might happen if the API returns an unexpected response
+				# that gets parsed as a string
+				return "Error: Bad Gateway"
+		
+		messages = Messages()
+	
+	chat.get_client = lambda: MockClient()
+	
+	# This should raise a ModelProviderError with a clear message
+	with pytest.raises(ModelProviderError) as exc_info:
+		await chat.ainvoke(messages)
+	
+	# The error should be about unexpected response type, not missing 'usage' attribute
+	assert "'str' object has no attribute 'usage'" not in str(exc_info.value)
+	assert "Unexpected response type from Anthropic API" in str(exc_info.value)
+	assert exc_info.value.args[1] == 502


### PR DESCRIPTION
Fixes #2559

## Summary
- Add type checking before accessing response.usage attribute
- Raise clear ModelProviderError when response is not a Message object
- Prevents AttributeError when API returns string errors instead of proper response

## Test plan
- [x] Added new test file `tests/ci/test_anthropic_502_error.py`
- [x] Tests verify that 502 errors are handled properly
- [x] Tests confirm no AttributeError about missing 'usage'

🤖 Generated with [Claude Code](https://claude.ai/code)