### PR TITLE
Update real-browser.mdx

### DIFF
--- a/docs/customize/real-browser.mdx
+++ b/docs/customize/real-browser.mdx
@@ -365,11 +365,11 @@ shared_profile = BrowserProfile(
     keep_alive=True,                  # don't close the browser after the agent finishes
 )
 
-window1 = BrowserSession(browser_profile=profile_a)
+window1 = BrowserSession(browser_profile=shared_profile)
 await window1.start()
 agent1 = Agent(browser_session=window1)
 
-window2 = BrowserSession(browser_profile=profile_a)
+window2 = BrowserSession(browser_profile=shared_profile)
 await window2.start()
 agent2 = Agent(browser_session=window2)
 


### PR DESCRIPTION
feat: Use `shared_profile` for parallel BrowserSession instances in browser use docs

This PR addresses an issue where the `BrowserSession` instances were incorrectly
initialized with an undefined `profile_a` instead of the intended `shared_profile`.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the browser usage docs to use the correct shared_profile for parallel BrowserSession examples. This prevents confusion by showing the intended profile in both session initializations.

<!-- End of auto-generated description by cubic. -->

