### PR TITLE
Remove message_context parameter and docs

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -103,7 +103,6 @@ class MessageManager:
 		state: MessageManagerState = MessageManagerState(),
 		use_thinking: bool = True,
 		include_attributes: list[str] | None = None,
-		message_context: str | None = None,
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		max_history_items: int | None = None,
 		vision_detail_level: Literal['auto', 'low', 'high'] = 'auto',
@@ -123,7 +122,6 @@ class MessageManager:
 
 		# Store settings as direct attributes instead of in a settings object
 		self.include_attributes = include_attributes or []
-		self.message_context = message_context
 		self.sensitive_data = sensitive_data
 		self.last_input_messages = []
 		# Only initialize messages if state is empty

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -162,7 +162,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		override_system_message: str | None = None,
 		extend_system_message: str | None = None,
 		validate_output: bool = False,
-		message_context: str | None = None,
 		generate_gif: bool | str = False,
 		available_file_paths: list[str] | None = None,
 		include_attributes: list[str] = DEFAULT_INCLUDE_ATTRIBUTES,
@@ -251,7 +250,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			override_system_message=override_system_message,
 			extend_system_message=extend_system_message,
 			validate_output=validate_output,
-			message_context=message_context,
 			generate_gif=generate_gif,
 			include_attributes=include_attributes,
 			max_actions_per_step=max_actions_per_step,
@@ -342,7 +340,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			use_thinking=self.settings.use_thinking,
 			# Settings that were previously in MessageManagerSettings
 			include_attributes=self.settings.include_attributes,
-			message_context=self.settings.message_context,
 			sensitive_data=sensitive_data,
 			max_history_items=self.settings.max_history_items,
 			vision_detail_level=self.settings.vision_detail_level,
@@ -602,8 +599,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			logger.error('💾 File system is not set up. Cannot save state.')
 			raise ValueError('File system is not set up. Cannot save state.')
 
-	def _set_message_context(self) -> str | None:
-		return self.settings.message_context
+
 
 	def _set_browser_use_version_and_source(self, source_override: str | None = None) -> None:
 		"""Get the version from pyproject.toml and determine the source of the browser-use package"""

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -36,7 +36,6 @@ class AgentSettings(BaseModel):
 	max_failures: int = 3
 	retry_delay: int = 10
 	validate_output: bool = False
-	message_context: str | None = None
 	generate_gif: bool | str = False
 	override_system_message: str | None = None
 	extend_system_message: str | None = None

--- a/docs/customize/agent-settings.mdx
+++ b/docs/customize/agent-settings.mdx
@@ -173,19 +173,7 @@ agent = Agent(
 )
 ```
 
-## Run with message context
 
-You can configure the agent and provide a separate message to help the LLM understand the task better.
-
-```python
-from browser_use.llm import ChatOpenAI
-
-agent = Agent(
-    task="your task",
-    message_context="Additional information about the task",
-    llm = ChatOpenAI(model='gpt-4o')
-)
-```
 
 ## Run with planner model
 
@@ -226,7 +214,6 @@ Using a separate planner model can help:
 
 ### Optional Parameters
 
-- `message_context`: Additional information about the task to help the LLM understand the task better.
 - `initial_actions`: List of initial actions to run before the main task.
 - `max_actions_per_step`: Maximum number of actions to run in a step. Defaults to `10`.
 - `max_failures`: Maximum number of failures before giving up. Defaults to `3`.

--- a/examples/models/deepseek-chat.py
+++ b/examples/models/deepseek-chat.py
@@ -28,7 +28,7 @@ async def main():
 		task='What should we pay attention to in the recent new rules on tariffs in China-US trade?',
 		llm=llm,
 		use_vision=False,
-		message_context=extend_system_message,
+		extend_system_message=extend_system_message,
 	)
 	await agent.run()
 


### PR DESCRIPTION
Remove the deprecated `message_context` parameter and its associated code and documentation.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1754229509777919?thread_ts=1754229509.777919&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-4a8ba375-0a35-4ef5-bc02-0fbaab39da64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a8ba375-0a35-4ef5-bc02-0fbaab39da64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>