### PR TITLE
Add gpt-oss models to groq tool calling

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -32,6 +32,8 @@ GroqVerifiedModels = Literal[
 	'meta-llama/llama-4-scout-17b-16e-instruct',
 	'qwen/qwen3-32b',
 	'moonshotai/kimi-k2-instruct',
+	'openai/gpt-oss-20b',
+	'openai/gpt-oss-120b',
 ]
 
 JsonSchemaModels = [
@@ -41,6 +43,8 @@ JsonSchemaModels = [
 
 ToolCallingModels = [
 	'moonshotai/kimi-k2-instruct',
+	'openai/gpt-oss-20b',
+	'openai/gpt-oss-120b',
 ]
 
 T = TypeVar('T', bound=BaseModel)


### PR DESCRIPTION
Add `openai/gpt-oss-20b` and `openai/gpt-oss-120b` to Groq's verified and tool-calling models.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1754424531570719?thread_ts=1754424531.570719&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-5b9414ce-c81e-4e49-aa16-9d7f9ec4514e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b9414ce-c81e-4e49-aa16-9d7f9ec4514e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added `openai/gpt-oss-20b` and `openai/gpt-oss-120b` to Groq's verified and tool-calling model lists.

<!-- End of auto-generated description by cubic. -->

