### PR TITLE
Replace markdown-pdf with md2pdf for Licensing

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-from markdown_pdf import MarkdownPdf, Section
+from md2pdf.core import md2pdf
 from pydantic import BaseModel, Field
 
 INVALID_FILENAME_ERROR_MESSAGE = 'Error: Invalid filename format. Must be alphanumeric with supported extension.'
@@ -120,9 +120,7 @@ class PdfFile(BaseFile):
 	def sync_to_disk_sync(self, path: Path) -> None:
 		file_path = path / self.full_name
 		try:
-			md_pdf = MarkdownPdf()
-			md_pdf.add_section(Section(self.content))
-			md_pdf.save(file_path)
+			md2pdf(pdf_file_path=file_path, md_content=self.content)
 		except Exception as e:
 			raise FileSystemError(f"Error: Could not write to file '{self.full_name}'. {str(e)}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "google-auth-oauthlib>=1.2.2",
     "mcp>=1.10.1",
     "pypdf>=5.7.0",
-    "markdown-pdf==1.5",
+    "md2pdf>=0.1.0",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
`markdown-pdf` has AGPL-3.0 license, while `md2pdf` is MIT licensed.

closes #2610