### PR TITLE
Add gpt-5 models to openai llm

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -19,7 +19,7 @@ from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
 
-ReasoningModels: list[ChatModel | str] = ['o4-mini', 'o3', 'o3-mini', 'o1', 'o1-pro', 'o3-pro']
+ReasoningModels: list[ChatModel | str] = ['o4-mini', 'o3', 'o3-mini', 'o1', 'o1-pro', 'o3-pro', 'gpt-5', 'gpt-5-mini', 'gpt-5-nano']
 
 
 @dataclass


### PR DESCRIPTION
Add `gpt-5`, `gpt-5-mini`, and `gpt-5-nano` to the list of reasoning models in `llm/openai/chat.py` to enable their use with enhanced reasoning configurations.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1754602720140689?thread_ts=1754602720.140689&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-ff352cf1-c32f-4da3-a963-14d138086580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff352cf1-c32f-4da3-a963-14d138086580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

