### PR TITLE
Update groq chat models list

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -39,12 +39,12 @@ GroqVerifiedModels = Literal[
 JsonSchemaModels = [
 	'meta-llama/llama-4-maverick-17b-128e-instruct',
 	'meta-llama/llama-4-scout-17b-16e-instruct',
+	'openai/gpt-oss-20b',
+	'openai/gpt-oss-120b',
 ]
 
 ToolCallingModels = [
 	'moonshotai/kimi-k2-instruct',
-	'openai/gpt-oss-20b',
-	'openai/gpt-oss-120b',
 ]
 
 T = TypeVar('T', bound=BaseModel)


### PR DESCRIPTION
Move `openai/gpt-oss-20b` and `openai/gpt-oss-120b` to `JsonSchemaModels` list to reflect their JSON schema capabilities.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1754736020863129?thread_ts=1754736020.863129&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-d4cbb89b-9974-4d6d-99ea-5d7090242ae9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4cbb89b-9974-4d6d-99ea-5d7090242ae9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved `openai/gpt-oss-20b` and `openai/gpt-oss-120b` to the JSON schema models list to better reflect their capabilities.

<!-- End of auto-generated description by cubic. -->

