### PR TITLE
Fix: Decouple use_vision and generate_gif settings

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -710,8 +710,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		assert self.browser_session is not None, 'BrowserSession is not set up'
 
 		self.logger.debug(f'🌐 Step {self.state.n_steps}: Getting browser state...')
+		# Capture screenshots if needed for either vision (LLM input) or GIF generation
+		should_capture_screenshot = self.settings.use_vision or bool(self.settings.generate_gif)
 		browser_state_summary = await self.browser_session.get_browser_state_with_recovery(
-			cache_clickable_elements_hashes=True, include_screenshot=self.settings.use_vision
+			cache_clickable_elements_hashes=True, include_screenshot=should_capture_screenshot
 		)
 		current_page = await self.browser_session.get_current_page()
 

--- a/tests/ci/test_gif_generation_with_navigation.py
+++ b/tests/ci/test_gif_generation_with_navigation.py
@@ -170,16 +170,20 @@ async def test_gif_generation_without_vision(httpserver, tmp_path):
 
 		# Verify GIF was created even without vision
 		assert gif_path.exists(), f'GIF was not created at {gif_path} when use_vision=False'
-		
+
 		# Verify GIF has content (non-zero size)
 		assert gif_path.stat().st_size > 0, f'GIF file is empty at {gif_path}'
-		
+
 		# Verify we have screenshots in history for GIF generation
 		screenshots = history.screenshots(return_none_if_not_screenshot=True)
 		assert screenshots, 'No screenshots found in history for GIF generation'
-		
+
 		# Verify at least one valid screenshot exists (not all placeholders)
-		valid_screenshots = [s for s in screenshots if s and s != 'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAE0lEQVR42mP8/5+BgYGBgYGBgQEAAP//AwMC/wE=']
+		valid_screenshots = [
+			s
+			for s in screenshots
+			if s and s != 'iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAE0lEQVR42mP8/5+BgYGBgYGBgQEAAP//AwMC/wE='
+		]
 		assert valid_screenshots, 'No valid screenshots found for GIF generation'
 
 	finally:


### PR DESCRIPTION
Fixes #2615 
  Problem

  When use_vision=False, GIF generation failed because screenshot capture was tied to the vision setting, preventing non-vision models (like DeepSeek) from generating GIFs.

  Solution

  Modified screenshot capture logic to consider both settings independently:
  # Before: only capture for vision
  include_screenshot=self.settings.use_vision

  # After: capture for either vision OR gif generation
  include_screenshot=self.settings.use_vision or bool(self.settings.generate_gif)

  Result

  - ✅ use_vision=False + generate_gif=True now works
  - ✅ Backward compatible - all existing behavior preserved
  - ✅ Performance optimized - screenshots only when needed
  - ✅ Added test coverage for the fix
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where GIF generation failed if use_vision was disabled by decoupling the screenshot logic from the vision setting.

- **Bug Fixes**
  - Screenshots are now captured if either use_vision or generate_gif is enabled.
  - Added a test to confirm GIFs generate correctly when use_vision is False.

<!-- End of auto-generated description by cubic. -->

