### PR TITLE
Change agent_obj.browser_context to agent_obj.browser_session in custom-functions/custom_hooks_before_after_step.py

### DIFF
--- a/examples/custom-functions/custom_hooks_before_after_step.py
+++ b/examples/custom-functions/custom_hooks_before_after_step.py
@@ -148,8 +148,8 @@ async def record_activity(agent_obj):
 	extracted_content_json_last_elem = None
 
 	print('--- ON_STEP_START HOOK ---')
-	website_html = await agent_obj.browser_context.get_page_html()
-	website_screenshot = await agent_obj.browser_context.take_screenshot()
+	website_html = await agent_obj.browser_session.get_page_html()
+	website_screenshot = await agent_obj.browser_session.take_screenshot()
 
 	print('--> History:')
 	# Assert agent has state to satisfy type checker


### PR DESCRIPTION
https://github.com/browser-use/browser-use/blob/a48e3914fa07f85093e5bed27990a0ee83fc66cc/examples/custom-functions/custom_hooks_before_after_step.py#L151-L152

browser_context does not have functions `get_page_html` and `take_screenshot`.
Instead, the two referenced lines need to be changed to `[...] agent_obj.browser_session. [...]`.

see Issue #2641
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated custom_hooks_before_after_step.py to use agent_obj.browser_session instead of agent_obj.browser_context for page HTML and screenshot functions, fixing compatibility issues from Issue #2641.

<!-- End of auto-generated description by cubic. -->

