### PR TITLE
Chat ollama using gpt oss

### DIFF
--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -21,9 +21,12 @@ T = TypeVar('T', bound=BaseModel)
 class ChatOllama(BaseChatModel):
 	"""
 	A wrapper around Ollama's chat model.
-	Handles custom logic for gpt-oss models.
 	"""
+	# # Model params
+	# TODO (matic): Why is this commented out?
+	# temperature: float | None = None
 
+	# Client initialization parameters
 	model: str
 	host: str | None = None
 	timeout: float | httpx.Timeout | None = None

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -11,6 +11,7 @@ from browser_use.llm.exceptions import ModelProviderError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
 from browser_use.llm.views import ChatInvokeCompletion
+import json, re
 
 T = TypeVar('T', bound=BaseModel)
 
@@ -67,7 +68,7 @@ class ChatOllama(BaseChatModel):
 			content = response.message.content or ''
 			# gpt-oss needs manual structured output handling
 			if output_format is not None and self.model.startswith("gpt-oss"):
-				import json, re
+				
 				processed = content.strip()
 				if not processed.startswith('{'):
 					json_match = re.search(r'\{.*\}', processed, re.DOTALL)

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,3 +1,4 @@
+
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
@@ -13,31 +14,26 @@ from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
 
+@dataclass
 
 @dataclass
 class ChatOllama(BaseChatModel):
 	"""
 	A wrapper around Ollama's chat model.
+	Handles custom logic for gpt-oss models.
 	"""
 
 	model: str
-
-	# # Model params
-	# TODO (matic): Why is this commented out?
-	# temperature: float | None = None
-
-	# Client initialization parameters
 	host: str | None = None
 	timeout: float | httpx.Timeout | None = None
 	client_params: dict[str, Any] | None = None
 
-	# Static
 	@property
 	def provider(self) -> str:
 		return 'ollama'
 
 	def _get_client_params(self) -> dict[str, Any]:
-		"""Prepare client parameters dictionary."""
+		# Bundle client params for Ollama
 		return {
 			'host': self.host,
 			'timeout': self.timeout,
@@ -45,9 +41,6 @@ class ChatOllama(BaseChatModel):
 		}
 
 	def get_client(self) -> OllamaAsyncClient:
-		"""
-		Returns an OllamaAsyncClient client.
-		"""
 		return OllamaAsyncClient(host=self.host, timeout=self.timeout, **self.client_params or {})
 
 	@property
@@ -63,30 +56,34 @@ class ChatOllama(BaseChatModel):
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: type[T] | None = None
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		# For gpt-oss, we have to extract structured output ourselves
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
-
 		try:
-			if output_format is None:
-				response = await self.get_client().chat(
-					model=self.model,
-					messages=ollama_messages,
-				)
-
-				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
-			else:
-				schema = output_format.model_json_schema()
-
-				response = await self.get_client().chat(
-					model=self.model,
-					messages=ollama_messages,
-					format=schema,
-				)
-
-				completion = response.message.content or ''
-				if output_format is not None:
-					completion = output_format.model_validate_json(completion)
-
+			response = await self.get_client().chat(
+				model=self.model,
+				messages=ollama_messages,
+				**({'format': output_format.model_json_schema()} if output_format is not None and not self.model.startswith("gpt-oss") else {})
+			)
+			content = response.message.content or ''
+			# gpt-oss needs manual structured output handling
+			if output_format is not None and self.model.startswith("gpt-oss"):
+				import json, re
+				processed = content.strip()
+				if not processed.startswith('{'):
+					json_match = re.search(r'\{.*\}', processed, re.DOTALL)
+					if json_match:
+						processed = json_match.group(0)
+				try:
+					parsed_json = json.loads(processed)
+					structured_output = output_format.model_validate(parsed_json)
+					return ChatInvokeCompletion(completion=structured_output, usage=None)
+				except Exception:
+					return ChatInvokeCompletion(completion=content, usage=None)
+			elif output_format is not None and not self.model.startswith("gpt-oss"):
+				completion = output_format.model_validate_json(content)
 				return ChatInvokeCompletion(completion=completion, usage=None)
-
+			else:
+				return ChatInvokeCompletion(completion=content, usage=None)
 		except Exception as e:
+			# Always wrap errors so we know which model failed
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -15,7 +15,7 @@ import json, re
 
 T = TypeVar('T', bound=BaseModel)
 
-@dataclass
+
 
 @dataclass
 class ChatOllama(BaseChatModel):

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -22,12 +22,14 @@ class ChatOllama(BaseChatModel):
 	"""
 	A wrapper around Ollama's chat model.
 	"""
+
+	model: str
 	# # Model params
 	# TODO (matic): Why is this commented out?
 	# temperature: float | None = None
 
 	# Client initialization parameters
-	model: str
+	
 	host: str | None = None
 	timeout: float | httpx.Timeout | None = None
 	client_params: dict[str, Any] | None = None

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -15,7 +15,7 @@ from browser_use import Agent
 
 # Initialize the model
 llm = ChatOpenAI(
-	model='gpt-5-mini',
+	model='gpt-oss:20b',
 )
 
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -15,7 +15,8 @@ from browser_use import Agent
 
 # Initialize the model
 llm = ChatOpenAI(
-	model='gpt-oss:20b',
+	model='gpt-5-mini',
+	#model="gpt-oss:20b"
 )
 
 


### PR DESCRIPTION
Title:
Integrated structured output handling for gpt-oss models in ChatOllama

Description:
This PR refactors the ChatOllama class (ollama/chat.py) to improve support for structured output (e.g., JSON) when using gpt-oss models.

For most models, structured output is handled natively by passing a schema and validating the response.
For gpt-oss models, which do not reliably support structured output, the response is post-processed: attempts to extract and validate a JSON object from the model’s output.
This ensures consistent behavior and robust parsing for all models, minimizing code changes and keeping the flow unified.
Why:

gpt-oss models do not natively support structured output, so manual post-processing is required.
The change makes the code more robust and user-friendly for all supported models.
Summary of changes:

Unified response handling for all models.
Added special post-processing for gpt-oss when structured output is requested.
Minimal changes to the original code structure.

Contributors: @arham-729 @Saadia-Naeem123
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added structured output support for gpt-oss models in ChatOllama by post-processing responses to extract and validate JSON, ensuring consistent behavior across all models.

- **Refactors**
 - Unified response handling for structured output.
 - Added manual JSON extraction for gpt-oss models when a schema is provided.

<!-- End of auto-generated description by cubic. -->

