### PR TITLE
Integrated structured output handling for gpt-oss models in ChatOllama.

### DIFF
--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,3 +1,4 @@
+
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
@@ -13,31 +14,24 @@ from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
 
-
 @dataclass
 class ChatOllama(BaseChatModel):
 	"""
 	A wrapper around Ollama's chat model.
+	Handles custom logic for gpt-oss models.
 	"""
 
 	model: str
-
-	# # Model params
-	# TODO (matic): Why is this commented out?
-	# temperature: float | None = None
-
-	# Client initialization parameters
 	host: str | None = None
 	timeout: float | httpx.Timeout | None = None
 	client_params: dict[str, Any] | None = None
 
-	# Static
 	@property
 	def provider(self) -> str:
 		return 'ollama'
 
 	def _get_client_params(self) -> dict[str, Any]:
-		"""Prepare client parameters dictionary."""
+		# Bundle client params for Ollama
 		return {
 			'host': self.host,
 			'timeout': self.timeout,
@@ -45,9 +39,6 @@ class ChatOllama(BaseChatModel):
 		}
 
 	def get_client(self) -> OllamaAsyncClient:
-		"""
-		Returns an OllamaAsyncClient client.
-		"""
 		return OllamaAsyncClient(host=self.host, timeout=self.timeout, **self.client_params or {})
 
 	@property
@@ -63,30 +54,34 @@ class ChatOllama(BaseChatModel):
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: type[T] | None = None
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		# For gpt-oss, we have to extract structured output ourselves
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
-
 		try:
-			if output_format is None:
-				response = await self.get_client().chat(
-					model=self.model,
-					messages=ollama_messages,
-				)
-
-				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
-			else:
-				schema = output_format.model_json_schema()
-
-				response = await self.get_client().chat(
-					model=self.model,
-					messages=ollama_messages,
-					format=schema,
-				)
-
-				completion = response.message.content or ''
-				if output_format is not None:
-					completion = output_format.model_validate_json(completion)
-
+			response = await self.get_client().chat(
+				model=self.model,
+				messages=ollama_messages,
+				**({'format': output_format.model_json_schema()} if output_format is not None and not self.model.startswith("gpt-oss") else {})
+			)
+			content = response.message.content or ''
+			# gpt-oss needs manual structured output handling
+			if output_format is not None and self.model.startswith("gpt-oss"):
+				import json, re
+				processed = content.strip()
+				if not processed.startswith('{'):
+					json_match = re.search(r'\{.*\}', processed, re.DOTALL)
+					if json_match:
+						processed = json_match.group(0)
+				try:
+					parsed_json = json.loads(processed)
+					structured_output = output_format.model_validate(parsed_json)
+					return ChatInvokeCompletion(completion=structured_output, usage=None)
+				except Exception:
+					return ChatInvokeCompletion(completion=content, usage=None)
+			elif output_format is not None and not self.model.startswith("gpt-oss"):
+				completion = output_format.model_validate_json(content)
 				return ChatInvokeCompletion(completion=completion, usage=None)
-
+			else:
+				return ChatInvokeCompletion(completion=content, usage=None)
 		except Exception as e:
+			# Always wrap errors so we know which model failed
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,4 +1,3 @@
-
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
@@ -14,74 +13,119 @@ from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
 
+
 @dataclass
 class ChatOllama(BaseChatModel):
-	"""
-	A wrapper around Ollama's chat model.
-	Handles custom logic for gpt-oss models.
-	"""
+    """
+    A wrapper around Ollama's chat model.
+    """
 
-	model: str
-	host: str | None = None
-	timeout: float | httpx.Timeout | None = None
-	client_params: dict[str, Any] | None = None
+    model: str
 
-	@property
-	def provider(self) -> str:
-		return 'ollama'
+    # # Model params
+    # TODO (matic): Why is this commented out?
+    # temperature: float | None = None
 
-	def _get_client_params(self) -> dict[str, Any]:
-		# Bundle client params for Ollama
-		return {
-			'host': self.host,
-			'timeout': self.timeout,
-			'client_params': self.client_params,
-		}
+    # Client initialization parameters
+    host: str | None = None
+    timeout: float | httpx.Timeout | None = None
+    client_params: dict[str, Any] | None = None
 
-	def get_client(self) -> OllamaAsyncClient:
-		return OllamaAsyncClient(host=self.host, timeout=self.timeout, **self.client_params or {})
+    # Static
+    @property
+    def provider(self) -> str:
+        return 'ollama'
 
-	@property
-	def name(self) -> str:
-		return self.model
+    def _get_client_params(self) -> dict[str, Any]:
+        """Prepare client parameters dictionary."""
+        return {
+            'host': self.host,
+            'timeout': self.timeout,
+            'client_params': self.client_params,
+        }
 
-	@overload
-	async def ainvoke(self, messages: list[BaseMessage], output_format: None = None) -> ChatInvokeCompletion[str]: ...
+    def get_client(self) -> OllamaAsyncClient:
+        """
+        Returns an OllamaAsyncClient client.
+        """
+        return OllamaAsyncClient(host=self.host, timeout=self.timeout, **self.client_params or {})
 
-	@overload
-	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T]) -> ChatInvokeCompletion[T]: ...
+    @property
+    def name(self) -> str:
+        return self.model
 
-	async def ainvoke(
-		self, messages: list[BaseMessage], output_format: type[T] | None = None
-	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
-		# For gpt-oss, we have to extract structured output ourselves
-		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
-		try:
-			response = await self.get_client().chat(
-				model=self.model,
-				messages=ollama_messages,
-				**({'format': output_format.model_json_schema()} if output_format is not None and not self.model.startswith("gpt-oss") else {})
-			)
-			content = response.message.content or ''
-			# gpt-oss needs manual structured output handling
-			if output_format is not None and self.model.startswith("gpt-oss"):
-				import json, re
-				processed = content.strip()
-				if not processed.startswith('{'):
-					json_match = re.search(r'\{.*\}', processed, re.DOTALL)
-					if json_match:
-						processed = json_match.group(0)
-				try:
-					parsed_json = json.loads(processed)
-					structured_output = output_format.model_validate(parsed_json)
-					return ChatInvokeCompletion(completion=structured_output, usage=None)
-				except Exception:
-					return ChatInvokeCompletion(completion=content, usage=None)
-			elif output_format is not None and not self.model.startswith("gpt-oss"):
-				completion = output_format.model_validate_json(content)
-				return ChatInvokeCompletion(completion=completion, usage=None)
-			else:
-				return ChatInvokeCompletion(completion=content, usage=None)
-		except Exception as e:
-			# Always wrap errors so we know which model failed
-			raise ModelProviderError(message=str(e), model=self.name) from e
+    @overload
+    async def ainvoke(self, messages: list[BaseMessage], output_format: None = None) -> ChatInvokeCompletion[str]: ...
+
+    @overload
+    async def ainvoke(self, messages: list[BaseMessage], output_format: type[T]) -> ChatInvokeCompletion[T]: ...
+
+    async def ainvoke(
+        self, messages: list[BaseMessage], output_format: type[T] | None = None
+    ) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+        ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
+
+        try:
+            # Special handling for gpt-oss models
+            if self.model.startswith("gpt-oss"):
+                print(f"\n🔍 DEBUG: Sending {len(messages)} messages to {self.model}")
+                print(f"🔍 DEBUG: output_format = {output_format}")
+                for i, msg in enumerate(messages):
+                    print(f"Message {i+1} ({getattr(msg, 'role', 'unknown')}): {str(msg)[:200]}...")
+
+                # Always get unstructured output
+                response = await self.get_client().chat(
+                    model=self.model,
+                    messages=ollama_messages,
+                )
+                content = response.message.content or ''
+                print(f"🔍 DEBUG: Got unstructured response:")
+                print(f"Response content: '{content}'")
+                print(f"Response length: {len(content)}")
+
+                if output_format is not None and content:
+                    import json
+                    try:
+                        raw = content.strip()
+                        if not raw.startswith('{'):
+                            import re
+                            json_match = re.search(r'\{.*\}', raw, re.DOTALL)
+                            if json_match:
+                                raw = json_match.group(0)
+                        parsed_json = json.loads(raw)
+                        print(f"✅ DEBUG: Successfully parsed JSON: {list(parsed_json.keys())}")
+                        structured_output = output_format.model_validate(parsed_json)
+                        return ChatInvokeCompletion(completion=structured_output, usage=None)
+                    except (json.JSONDecodeError, Exception) as e:
+                        print(f"❌ DEBUG: Failed to parse JSON: {e}")
+                        print(f"Raw content: {raw}")
+                        return ChatInvokeCompletion(completion=raw, usage=None)
+                elif not content:
+                    raise Exception(f"Empty response from {self.model}")
+                else:
+                    return ChatInvokeCompletion(completion=content, usage=None)
+            else:
+                # Default behavior for other models
+                if output_format is None:
+                    response = await self.get_client().chat(
+                        model=self.model,
+                        messages=ollama_messages,
+                    )
+                    return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
+                else:
+                    schema = output_format.model_json_schema()
+                    response = await self.get_client().chat(
+                        model=self.model,
+                        messages=ollama_messages,
+                        format=schema,
+                    )
+                    completion = response.message.content or ''
+                    if output_format is not None:
+                        completion = output_format.model_validate_json(completion)
+                    return ChatInvokeCompletion(completion=completion, usage=None)
+
+        except Exception as e:
+            print(f"🔍 DEBUG: Exception in ainvoke: {e}")
+            import traceback
+            traceback.print_exc()
+            raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/tests/test_ollama_gpt-oss.py
+++ b/browser_use/llm/tests/test_ollama_gpt-oss.py
@@ -1,0 +1,101 @@
+#Tests for the gpt-oss:20b
+import pytest
+import json
+from pydantic import BaseModel
+from browser_use import Agent
+from browser_use.llm.ollama.chat import ChatOllama
+from browser_use.llm.messages import UserMessage
+from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.llm.exceptions import ModelProviderError
+
+
+class ExampleOutput(BaseModel):
+    name: str
+
+
+@pytest.mark.asyncio
+async def test_gptoss_plain_text(monkeypatch):
+    """GPT-OSS without output_format returns plain string."""
+    async def mock_chat(*args, **kwargs):
+        class MockResp:
+            message = type("m", (), {"content": "Hello GPT-OSS"})
+        return MockResp()
+
+    monkeypatch.setattr(ChatOllama, "get_client", lambda self: type("c", (), {"chat": mock_chat})())
+
+    llm = ChatOllama(model="qwen3:8b", host="http://...") #replace wth actual host and change the model name to gpt-oss:20b
+    result = await llm.ainvoke([UserMessage(content="Hello")])
+    assert isinstance(result, ChatInvokeCompletion)
+    assert result.completion == "Hello GPT-OSS"
+
+
+@pytest.mark.asyncio
+async def test_gptoss_with_valid_json(monkeypatch):
+    """GPT-OSS with output_format and valid JSON parses correctly."""
+    async def mock_chat(*args, **kwargs):
+        class MockResp:
+            message = type("m", (), {"content": '{"name": "Browser Use"}'})
+        return MockResp()
+
+    monkeypatch.setattr(ChatOllama, "get_client", lambda self: type("c", (), {"chat": mock_chat})())
+
+    llm = ChatOllama(model="qwen3:8b", host="http://...") #replace with actual host and change the model name to gpt-oss:20b
+    result = await llm.ainvoke([UserMessage(content="Hello")], output_format=ExampleOutput)
+    assert result.completion.name == "Browser Use"
+
+
+@pytest.mark.asyncio
+async def test_gptoss_with_invalid_json(monkeypatch):
+    """GPT-OSS with output_format but invalid JSON returns raw string."""
+    async def mock_chat(*args, **kwargs):
+        class MockResp:
+            message = type("m", (), {"content": "Not JSON output"})
+        return MockResp()
+
+    monkeypatch.setattr(ChatOllama, "get_client", lambda self: type("c", (), {"chat": mock_chat})())
+
+    llm = ChatOllama(model="qwen3:8b", host="http://...") # replace with actual host and change the model name to gpt-oss:20b
+    result = await llm.ainvoke([UserMessage(content="Hello")], output_format=ExampleOutput)
+    assert result.completion == "Not JSON output"
+
+
+@pytest.mark.asyncio
+async def test_non_gptoss_with_output_format(monkeypatch):
+    """Non-GPT-OSS with output_format should use Pydantic JSON parsing."""
+    data = ExampleOutput(name="Normal Ollama").model_dump_json()
+
+    async def mock_chat(*args, **kwargs):
+        class MockResp:
+            message = type("m", (), {"content": data})
+        return MockResp()
+
+    monkeypatch.setattr(ChatOllama, "get_client", lambda self: type("c", (), {"chat": mock_chat})())
+
+    llm = ChatOllama(model="llama2:7b", host="http://...") # replace with actual host and no change in model name
+    result = await llm.ainvoke([UserMessage(content="Hello")], output_format=ExampleOutput)
+    assert result.completion.name == "Normal Ollama"
+
+
+@pytest.mark.asyncio
+async def test_model_provider_error(monkeypatch):
+    """If chat() raises exception, ModelProviderError should be raised."""
+    async def mock_chat(*args, **kwargs):
+        raise RuntimeError("Connection failed")
+
+    monkeypatch.setattr(ChatOllama, "get_client", lambda self: type("c", (), {"chat": mock_chat})())
+
+    llm = ChatOllama(model="qwen3:8b", host="http://...") #replace with actual host and change the model name to gpt-oss:20b
+    with pytest.raises(ModelProviderError) as excinfo:
+        await llm.ainvoke([UserMessage(content="Hello")])
+    assert "Connection failed" in str(excinfo.value)
+
+
+def test_provider_and_name_and_client_params():
+    """Test provider, name, and _get_client_params output."""
+    llm = ChatOllama(model="qwen3:8b", host="http://...", timeout=5, client_params={"a": 1}) #replace with actual host and change the model name to gpt-oss:20b
+    assert llm.provider == "ollama"
+    assert llm.name == "gpt-oss:20b"
+    params = llm._get_client_params()
+    assert params["host"] == "http://10.20.20.100:11434"
+    assert params["timeout"] == 5
+    assert params["client_params"] == {"a": 1}

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -16,6 +16,8 @@ from browser_use import Agent
 # Initialize the model
 llm = ChatOpenAI(
 	model='gpt-5-mini',
+	#model="gpt-oss:20b",  # or any Ollama model you want
+    #host="http://..."
 )
 
 


### PR DESCRIPTION
This PR refactors the ChatOllama class to improve support for structured output (e.g., JSON) when using gpt-oss models.

For most models, structured output is handled natively by passing a schema and validating the response.
For gpt-oss models, which do not reliably support structured output, the response is post-processed: attempts to extract and validate a JSON object from the model’s output.
This ensures consistent behavior and robust parsing for all models, minimizing code changes and keeping the flow unified.
Why:

gpt-oss models do not natively support structured output, so manual post-processing is required.
The change makes the code more robust and user-friendly for all supported models.
Summary of changes:

Unified response handling for all models.
Added special post-processing for gpt-oss when structured output is requested.
Minimal changes to the original code structure

Co-authored by: @Saadia-Naeem123, @arham-729
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added structured output support for gpt-oss models in ChatOllama by post-processing responses to extract and validate JSON, ensuring consistent behavior across all models.

- **Refactors**
 - Unified response handling for structured output.
 - Added manual JSON extraction for gpt-oss models.
 - Updated and added tests for gpt-oss output scenarios.

<!-- End of auto-generated description by cubic. -->

