### PR TITLE
hot-fix/error-count-only-for-single-steps

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -799,7 +799,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		await self._check_and_update_downloads('after executing actions')
 
 		# check for action errors  and len more than 1
-		if self.state.last_result and len(self.state.last_result) > 1 and self.state.last_result[-1].error:
+		if self.state.last_result and len(self.state.last_result) == 1 and self.state.last_result[-1].error:
 			self.state.consecutive_failures += 1
 			self.logger.debug(f'🔄 Step {self.state.n_steps}: Consecutive failures: {self.state.consecutive_failures}')
 			return


### PR DESCRIPTION
Auto-generated PR for: hot-fix/error-count-only-for-single-steps
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed error counting logic so consecutive failures are only tracked for single-step results, preventing incorrect failure counts for multi-step actions.

<!-- End of auto-generated description by cubic. -->

