### PR TITLE
Record exceptions and rename span context

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -1685,7 +1685,7 @@ Provide the extracted information in a clear, structured format."""
 			if params is not None:
 				# Use Laminar span if available, otherwise use no-op context manager
 				if Laminar is not None:
-					span_context = Laminar.start_as_current_span(
+					span = Laminar.start_as_current_span(
 						name=action_name,
 						input={
 							'action': action_name,
@@ -1697,9 +1697,9 @@ Provide the extracted information in a clear, structured format."""
 					# No-op context manager when lmnr is not available
 					from contextlib import nullcontext
 
-					span_context = nullcontext()
+					span = nullcontext()
 
-				with span_context:
+				with span:
 					try:
 						result = await self.registry.execute_action(
 							action_name=action_name,
@@ -1712,6 +1712,8 @@ Provide the extracted information in a clear, structured format."""
 							context=context,
 						)
 					except Exception as e:
+						if Laminar is not None:
+							span.record_exception(e)
 						result = ActionResult(error=str(e))
 
 					if Laminar is not None:


### PR DESCRIPTION
Rename `span_context` to `span` and record exceptions in the span within the `act()` method for clearer tracing.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1755091910842529?thread_ts=1755091910.842529&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-5b3b7f1a-266b-483e-bd6a-ee3e9c10be88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b3b7f1a-266b-483e-bd6a-ee3e9c10be88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the `span_context` variable to `span` and added exception recording to Laminar spans in the `act()` method for clearer tracing.

<!-- End of auto-generated description by cubic. -->

