### PR TITLE
increase-frequency_penalty

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -48,7 +48,7 @@ class ChatOpenAI(BaseChatModel):
 	# Model params
 	# set to 0.1 because browser-use aims to be more reliable and deterministic
 	temperature: float | None = 0.2
-	frequency_penalty: float | None = 0.1
+	frequency_penalty: float | None = 0.2
 	reasoning_effort: ReasoningEffort = 'low'
 	seed: int | None = None
 	service_tier: Literal['auto', 'default', 'flex', 'priority', 'scale'] | None = None


### PR DESCRIPTION
Auto-generated PR for: increase-frequency_penalty
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Raised the default frequency_penalty for OpenAI chat models from 0.1 to 0.2 to reduce repeated phrases and improve response variety.

<!-- End of auto-generated description by cubic. -->

