### PR TITLE
Revert "Record exceptions and rename span context"

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -1685,7 +1685,7 @@ Provide the extracted information in a clear, structured format."""
 			if params is not None:
 				# Use Laminar span if available, otherwise use no-op context manager
 				if Laminar is not None:
-					span = Laminar.start_as_current_span(
+					span_context = Laminar.start_as_current_span(
 						name=action_name,
 						input={
 							'action': action_name,
@@ -1697,9 +1697,9 @@ Provide the extracted information in a clear, structured format."""
 					# No-op context manager when lmnr is not available
 					from contextlib import nullcontext
 
-					span = nullcontext()
+					span_context = nullcontext()
 
-				with span:
+				with span_context:
 					try:
 						result = await self.registry.execute_action(
 							action_name=action_name,
@@ -1712,8 +1712,6 @@ Provide the extracted information in a clear, structured format."""
 							context=context,
 						)
 					except Exception as e:
-						if Laminar is not None:
-							span.record_exception(e)
 						result = ActionResult(error=str(e))
 
 					if Laminar is not None:


### PR DESCRIPTION
Reverts browser-use/browser-use#2668
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed exception recording and reverted the span context variable name in the service controller to restore previous behavior.

<!-- End of auto-generated description by cubic. -->

