### PR TITLE
Revert prompt changes

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -535,7 +535,6 @@ class Controller(Generic[Context]):
 
 			# Simple prompt
 			prompt = f"""Extract the requested information from this webpage content.
-If you get a query which does not make sense given the content - explain briefly whats on the page, and that you don't have access to the requested information.
 			
 Query: {query}
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restored the previous prompt in the extract_structured_data function by removing guidance for handling unclear queries.

<!-- End of auto-generated description by cubic. -->

