### PR TITLE
feat: disable debugger enable CDP call

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -183,7 +183,9 @@ class MessageManager:
 		read_state_idx = 0
 		for idx, action_result in enumerate(result):
 			if action_result.include_extracted_content_only_once and action_result.extracted_content:
-				self.state.read_state_description += f'<read_state_{read_state_idx}>\n{action_result.extracted_content}\n</read_state_{read_state_idx}>\n'
+				self.state.read_state_description += (
+					f'<read_state_{read_state_idx}>\n{action_result.extracted_content}\n</read_state_{read_state_idx}>\n'
+				)
 				read_state_idx += 1
 				logger.debug(f'Added extracted_content to read_state_description: {action_result.extracted_content}')
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -120,7 +120,7 @@ class CDPSession(BaseModel):
 		self.session_id = result['sessionId']
 
 		# Use specified domains or default domains
-		domains = domains or ['Page', 'DOM', 'DOMSnapshot', 'Accessibility', 'Runtime', 'Inspector', 'Debugger']
+		domains = domains or ['Page', 'DOM', 'DOMSnapshot', 'Accessibility', 'Runtime', 'Inspector']
 
 		# Enable all domains in parallel
 		enable_tasks = []
@@ -137,16 +137,6 @@ class CDPSession(BaseModel):
 		results = await asyncio.gather(*enable_tasks, return_exceptions=True)
 		if any(isinstance(result, Exception) for result in results):
 			raise RuntimeError(f'Failed to enable requested CDP domain: {results}')
-
-		# disable breakpoints on the page so it doesnt pause on crashes / debugger statements
-		try:
-			await self.cdp_client.send.Debugger.setSkipAllPauses(params={'skip': True}, session_id=self.session_id)
-			# if 'Debugger' not in domains:
-			# 	await self.cdp_client.send.Debugger.disable()
-			# await cdp_session.cdp_client.send.EventBreakpoints.disable(session_id=cdp_session.session_id)
-		except Exception as e:
-			# self.logger.warning(f'Failed to disable page JS breakpoints: {e}')
-			pass
 
 		target_info = await self.get_target_info()
 		self.title = target_info['title']

--- a/browser_use/browser/watchdog_base.py
+++ b/browser_use/browser/watchdog_base.py
@@ -21,10 +21,10 @@ class BaseWatchdog(BaseModel):
 	"""
 
 	model_config = ConfigDict(
-		arbitrary_types_allowed=True, # allow non-serializable objects like EventBus/BrowserSession in fields
+		arbitrary_types_allowed=True,  # allow non-serializable objects like EventBus/BrowserSession in fields
 		extra='forbid',  # dont allow implicit class/instance state, everything must be a properly typed Field or PrivateAttr
 		validate_assignment=False,  # avoid re-triggering  __init__ / validators on values on every assignment
-		revalidate_instances='never', # avoid re-triggering __init__ / validators and erasing private attrs
+		revalidate_instances='never',  # avoid re-triggering __init__ / validators and erasing private attrs
 	)
 
 	# Class variables to statically define the list of events relevant to each watchdog


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed automatic enabling of the Debugger domain and skipped breakpoint configuration in the session attach process to prevent unwanted pause behavior.

<!-- End of auto-generated description by cubic. -->

