### PR TITLE
Add default cdp_use warning env variable

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -59,6 +59,10 @@ class OldConfig:
 		return os.getenv('ANONYMIZED_TELEMETRY', 'true').lower()[:1] in 'ty1'
 
 	@property
+	def CDP_USE_WARNING_LOGGING(self) -> bool:
+		return os.getenv('CDP_USE_WARNING_LOGGING', 'true').lower()[:1] in 'ty1'
+
+	@property
 	def BROWSER_USE_CLOUD_SYNC(self) -> bool:
 		return os.getenv('BROWSER_USE_CLOUD_SYNC', str(self.ANONYMIZED_TELEMETRY)).lower()[:1] in 'ty1'
 
@@ -189,6 +193,9 @@ class FlatEnvConfig(BaseSettings):
 	XDG_CACHE_HOME: str = Field(default='~/.cache')
 	XDG_CONFIG_HOME: str = Field(default='~/.config')
 	BROWSER_USE_CONFIG_DIR: str | None = Field(default=None)
+
+	# CDP configuration
+	CDP_USE_WARNING_LOGGING: bool = Field(default=True)
 
 	# LLM API keys
 	OPENAI_API_KEY: str = Field(default='')


### PR DESCRIPTION
Add `CDP_USE_WARNING_LOGGING` environment variable to control CDP warning log verbosity.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1755312494679419?thread_ts=1755312494.679419&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-a07a2324-95d2-4bc5-b2b9-ec573975222c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a07a2324-95d2-4bc5-b2b9-ec573975222c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds the CDP_USE_WARNING_LOGGING env var to control CDP warning verbosity. When set to false, CDP logs emit only errors, reducing noise in console and pipe logs.

- **New Features**
  - CDP_USE_WARNING_LOGGING (default: true) added to Config and FlatEnvConfig.
  - CDP log level now respects this flag in setup_cdp_logging and for websockets.client/cdp_use.client.
  - cdp.pipe handler also respects the flag (DEBUG when true, ERROR when false).

<!-- End of auto-generated description by cubic. -->

