### PR TITLE
Set cdp_use logging level env variable

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -180,6 +180,7 @@ class FlatEnvConfig(BaseSettings):
 
 	# Logging and telemetry
 	BROWSER_USE_LOGGING_LEVEL: str = Field(default='info')
+	CDP_LOGGING_LEVEL: str = Field(default='warning')
 	ANONYMIZED_TELEMETRY: bool = Field(default=True)
 	BROWSER_USE_CLOUD_SYNC: bool | None = Field(default=None)
 	BROWSER_USE_CLOUD_API_URL: str = Field(default='https://api.browser-use.com')

--- a/browser_use/logging_config.py
+++ b/browser_use/logging_config.py
@@ -127,14 +127,29 @@ def setup_logging(stream=None, log_level=None, force_setup=False):
 	bubus_logger.addHandler(console)
 	bubus_logger.setLevel(logging.INFO if log_type == 'result' else log_level)
 
-	# Configure CDP logging using cdp_use's setup function
-	# This enables the formatted CDP output at the same level as browser_use
+	# Configure CDP logging using separate CDP_LOGGING_LEVEL
+	cdp_log_type = CONFIG.CDP_LOGGING_LEVEL.lower()
+	
+	# Determine the CDP log level to use
+	if cdp_log_type == 'result':
+		cdp_log_level = 35  # RESULT level value
+	elif cdp_log_type == 'debug':
+		cdp_log_level = logging.DEBUG
+	elif cdp_log_type == 'info':
+		cdp_log_level = logging.INFO
+	elif cdp_log_type == 'warning':
+		cdp_log_level = logging.WARNING
+	elif cdp_log_type == 'error':
+		cdp_log_level = logging.ERROR
+	else:
+		cdp_log_level = logging.WARNING  # Default to WARNING
+
 	try:
 		from cdp_use.logging import setup_cdp_logging  # type: ignore
 
-		# Use the same stream and level as browser_use
+		# Use CDP-specific level instead of browser_use level
 		setup_cdp_logging(
-			level=log_level,
+			level=cdp_log_level,
 			stream=stream or sys.stdout,
 			format_string='%(levelname)-8s [%(name)s] %(message)s' if log_type != 'result' else '%(message)s',
 		)
@@ -149,7 +164,7 @@ def setup_logging(stream=None, log_level=None, force_setup=False):
 		]
 		for logger_name in cdp_loggers:
 			cdp_logger = logging.getLogger(logger_name)
-			cdp_logger.setLevel(log_level)
+			cdp_logger.setLevel(cdp_log_level)
 			cdp_logger.addHandler(console)
 			cdp_logger.propagate = False
 


### PR DESCRIPTION
Add `CDP_LOGGING_LEVEL` environment variable to control `cdp_use` logger verbosity independently, defaulting to 'warning' to suppress verbose logs.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1755374640005529?thread_ts=1755374640.005529&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-18c8a685-6dd2-4bb2-aaec-dc20c51a6ce2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18c8a685-6dd2-4bb2-aaec-dc20c51a6ce2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a CDP_LOGGING_LEVEL env var to control cdp_use logging independently of browser_use. Defaults to warning to reduce noisy CDP logs.

- New Features
  - Supported levels: debug, info, warning, error, result.
  - Shares the same output stream as browser_use; only the level is separate.

<!-- End of auto-generated description by cubic. -->

