### PR TITLE
Move highlight labels to lower right corner

### DIFF
--- a/browser_use/dom/debug/highlights.py
+++ b/browser_use/dom/debug/highlights.py
@@ -193,8 +193,8 @@ async def inject_highlighting_script(dom_service: DomService, interactive_elemen
 				// Enhanced label with interactive index
 				const label = createTextElement('div', element.interactive_index, `
 					position: absolute;
-					top: -20px;
-					left: 0;
+					bottom: -20px;
+					right: 0;
 					background-color: #4a90e2;
 					color: white;
 					padding: 2px 6px;


### PR DESCRIPTION
Move highlight labels from the top-left to the bottom-right corner to prevent text occlusion.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1755383142256389?thread_ts=1755383142.256389&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-1d8ff748-1032-4019-8ce8-b8a30ace41a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d8ff748-1032-4019-8ce8-b8a30ace41a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Moved interactive element index labels from the top-left to the bottom-right of the highlight box. This prevents covering element text and improves readability during DOM inspection.

<!-- End of auto-generated description by cubic. -->

