### PR TITLE
Speed up type text event

### DIFF
--- a/browser_use/browser/default_action_watchdog.py
+++ b/browser_use/browser/default_action_watchdog.py
@@ -584,8 +584,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 					},
 					session_id=cdp_session.session_id,
 				)
-				# Add 18ms delay between keystrokes
-				await asyncio.sleep(0.018)
+				# Add 1.8ms delay between keystrokes
+				await asyncio.sleep(0.0018)
 
 		except Exception as e:
 			raise Exception(f'Failed to type to page: {str(e)}')
@@ -832,8 +832,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 					},
 					session_id=cdp_session.session_id,
 				)
-				# Small delay between characters
-				await asyncio.sleep(0.09)
+				# Small delay between characters (9ms)
+				await asyncio.sleep(0.009)
 
 		except Exception as e:
 			self.logger.error(f'Failed to input text via CDP: {type(e).__name__}: {e}')


### PR DESCRIPTION
Reduce typing delays in `type_text` event by 10x to prevent timeouts on long forms.

---
[Slack Thread](https://browser-use.slack.com/archives/C08SZRT860M/p1755650134186159?thread_ts=1755650134.186159&cid=C08SZRT860M)

<a href="https://cursor.com/background-agent?bcId=bc-4a5faed8-b421-4ac0-b4b5-c1b02cc072a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a5faed8-b421-4ac0-b4b5-c1b02cc072a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Speed up typing in type_text by ~10x to prevent timeouts on long forms.

- **Performance**
  - Reduced per-keystroke delay from 18ms to 1.8ms in _type_to_page.
  - Reduced per-character delay from 90ms to 9ms in _input_text_element_node_impl.

<!-- End of auto-generated description by cubic. -->

