### PR TITLE
fix clicking and typing in iframes

### DIFF
--- a/browser_use/browser/views.py
+++ b/browser_use/browser/views.py
@@ -141,8 +141,10 @@ class BrowserError(Exception):
 	def __str__(self) -> str:
 		if self.details:
 			return f'{self.message} ({self.details}) during: {self.while_handling_event}'
+		elif self.while_handling_event:
+			return f'{self.message} (while handling: {self.while_handling_event})'
 		else:
-			return f'{self.message} (while handling event: {self.while_handling_event})'
+			return self.message
 
 
 class URLNotAllowedError(BrowserError):


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes clicking and typing inside iframes by using the correct CDP session for the element’s frame/target and adding a safe click fallback before page typing. Interactions in nested and cross-origin iframes are now reliable.

- Bug Fixes
  - Use cdp_client_for_node to resolve and operate in the element’s frame/target, with fallback to main session.
  - Remove Target.activateTarget; scroll and click via the correct session context.
  - On typing failure, attempt a short-timeout element click to focus before page typing; cleaner error messages when no event is present.

<!-- End of auto-generated description by cubic. -->

