### PR TITLE
Authenticated Proxy Server Support

### DIFF
--- a/browser_use/browser/__init__.py
+++ b/browser_use/browser/__init__.py
@@ -2,11 +2,12 @@ from typing import TYPE_CHECKING
 
 # Type stubs for lazy imports
 if TYPE_CHECKING:
-	from .profile import BrowserProfile
+	from .profile import BrowserProfile, ProxySettings
 	from .session import BrowserSession
 
 # Lazy imports mapping for heavy browser components
 _LAZY_IMPORTS = {
+	'ProxySettings': ('.profile', 'ProxySettings'),
 	'BrowserProfile': ('.profile', 'BrowserProfile'),
 	'BrowserSession': ('.session', 'BrowserSession'),
 }
@@ -35,4 +36,5 @@ def __getattr__(name: str):
 __all__ = [
 	'BrowserSession',
 	'BrowserProfile',
+	'ProxySettings',
 ]

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1049,8 +1049,9 @@ class BrowserSession(BaseModel):
 		"""
 
 		try:
-			username = getattr(self.browser_profile, 'proxy_username', None)
-			password = getattr(self.browser_profile, 'proxy_password', None)
+			proxy_cfg = self.browser_profile.proxy
+			username = proxy_cfg.username if proxy_cfg else None
+			password = proxy_cfg.password if proxy_cfg else None
 			if not username or not password:
 				self.logger.debug('Proxy credentials not provided; skipping proxy auth setup')
 				return

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1052,24 +1052,26 @@ class BrowserSession(BaseModel):
 			username = getattr(self.browser_profile, 'proxy_username', None)
 			password = getattr(self.browser_profile, 'proxy_password', None)
 			if not username or not password:
+				self.logger.debug('Proxy credentials not provided; skipping proxy auth setup')
 				return
 
-			# Enable Fetch domain with auth handling
-			# Try enabling globally
+			# Enable Fetch domain with auth handling (do not pause all requests)
 			try:
-				await self._cdp_client_root.send.Fetch.enable(params={'handleAuthRequests': True, 'patterns': [{'urlPattern': '*'}]})
-			except Exception:
-				pass
+				await self._cdp_client_root.send.Fetch.enable(params={'handleAuthRequests': True})
+				self.logger.debug('Fetch.enable(handleAuthRequests=True) enabled on root client')
+			except Exception as e:
+				self.logger.debug(f'Fetch.enable on root failed: {type(e).__name__}: {e}')
 
-			# Also try enabling on current session if available
+			# Also enable on the focused session if available to ensure events are delivered
 			try:
 				if self.agent_focus:
 					await self.agent_focus.cdp_client.send.Fetch.enable(
-						params={'handleAuthRequests': True, 'patterns': [{'urlPattern': '*'}]},
+						params={'handleAuthRequests': True},
 						session_id=self.agent_focus.session_id,
 					)
-			except Exception:
-				pass
+					self.logger.debug('Fetch.enable(handleAuthRequests=True) enabled on focused session')
+			except Exception as e:
+				self.logger.debug(f'Fetch.enable on focused session failed: {type(e).__name__}: {e}')
 
 			def _on_auth_required(event: dict, session_id: SessionID | None = None):
 				# event keys may be snake_case or camelCase depending on generator; handle both
@@ -1092,7 +1094,7 @@ class BrowserSession(BaseModel):
 								session_id=session_id,
 							)
 						except Exception as e:
-							self.logger.debug(f'Proxy auth respond failed: {e}')
+							self.logger.debug(f'Proxy auth respond failed: {type(e).__name__}: {e}')
 					# schedule
 					asyncio.create_task(_respond())
 				else:
@@ -1103,37 +1105,19 @@ class BrowserSession(BaseModel):
 								params={'requestId': request_id, 'authChallengeResponse': {'response': 'Default'}},
 								session_id=session_id,
 							)
-						except Exception:
-							pass
+						except Exception as e:
+							self.logger.debug(f'Default auth respond failed: {type(e).__name__}: {e}')
 					if request_id:
 						asyncio.create_task(_default())
 
-			def _on_request_paused(event: dict, session_id: SessionID | None = None):
-				# Continue all paused requests to avoid stalling the network
-				request_id = event.get('requestId') or event.get('request_id')
-				if not request_id:
-					return
-
-				async def _continue():
-					try:
-						await self._cdp_client_root.send.Fetch.continueRequest(
-							params={'requestId': request_id},
-							session_id=session_id,
-						)
-					except Exception:
-						pass
-
-				asyncio.create_task(_continue())
-
-			# Register event handler on root client
+			# Register event handler on root client (and focused session if present)
 			try:
 				self._cdp_client_root.register.Fetch.authRequired(_on_auth_required)
-				self._cdp_client_root.register.Fetch.requestPaused(_on_request_paused)
 				if self.agent_focus:
 					self.agent_focus.cdp_client.register.Fetch.authRequired(_on_auth_required)
-					self.agent_focus.cdp_client.register.Fetch.requestPaused(_on_request_paused)
-			except Exception:
-				pass
+				self.logger.debug('Registered Fetch.authRequired handlers')
+			except Exception as e:
+				self.logger.debug(f'Failed to register authRequired handlers: {type(e).__name__}: {e}')
 
 			# Auto-enable Fetch on every newly attached target to ensure auth callbacks fire
 			def _on_attached(event: dict, session_id: SessionID | None = None):
@@ -1144,31 +1128,23 @@ class BrowserSession(BaseModel):
 				async def _enable():
 					try:
 						await self._cdp_client_root.send.Fetch.enable(
-							params={'handleAuthRequests': True, 'patterns': [{'urlPattern': '*'}]},
+							params={'handleAuthRequests': True},
 							session_id=sid,
 						)
-					except Exception:
-						pass
+						self.logger.debug(f'Fetch.enable(handleAuthRequests=True) enabled on attached session {sid}')
+					except Exception as e:
+						self.logger.debug(f'Fetch.enable on attached session failed: {type(e).__name__}: {e}')
 
 				asyncio.create_task(_enable())
 
 			try:
 				self._cdp_client_root.register.Target.attachedToTarget(_on_attached)
-			except Exception:
-				pass
-
-			# Ensure Fetch is enabled for the current focused session, too
-			try:
-				if self.agent_focus:
-					await self.agent_focus.cdp_client.send.Fetch.enable(
-						params={'handleAuthRequests': True, 'patterns': [{'urlPattern': '*'}]},
-						session_id=self.agent_focus.session_id,
-					)
-			except Exception:
-				pass
+				self.logger.debug('Registered Target.attachedToTarget handler for Fetch.enable')
+			except Exception as e:
+				self.logger.debug(f'Failed to register attachedToTarget handler: {type(e).__name__}: {e}')
 
 		except Exception as e:
-			self.logger.debug(f'Skipping proxy auth setup: {e}')
+			self.logger.debug(f'Skipping proxy auth setup: {type(e).__name__}: {e}')
 
 	async def get_tabs(self) -> list[TabInfo]:
 		"""Get information about all open tabs using CDP Target.getTargetInfo for speed."""

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -177,14 +177,20 @@ def update_config_with_click_args(config: dict[str, Any], ctx: click.Context) ->
 		config['browser']['profile_directory'] = ctx.params['profile_directory']
 	if ctx.params.get('cdp_url'):
 		config['browser']['cdp_url'] = ctx.params['cdp_url']
+
+	# Consolidated proxy dict
+	proxy: dict[str, str] = {}
 	if ctx.params.get('proxy_url'):
-		config['browser']['proxy_server'] = ctx.params['proxy_url']
+		proxy['server'] = ctx.params['proxy_url']
 	if ctx.params.get('no_proxy'):
-		config['browser']['proxy_bypass_list'] = [p.strip() for p in ctx.params['no_proxy'].split(',') if p.strip()]
+		# Store as comma-separated list string to match Chrome flag
+		proxy['bypass'] = ','.join([p.strip() for p in ctx.params['no_proxy'].split(',') if p.strip()])
 	if ctx.params.get('proxy_username'):
-		config['browser']['proxy_username'] = ctx.params['proxy_username']
+		proxy['username'] = ctx.params['proxy_username']
 	if ctx.params.get('proxy_password'):
-		config['browser']['proxy_password'] = ctx.params['proxy_password']
+		proxy['password'] = ctx.params['proxy_password']
+	if proxy:
+		config['browser']['proxy'] = proxy
 
 	return config
 

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -177,6 +177,14 @@ def update_config_with_click_args(config: dict[str, Any], ctx: click.Context) ->
 		config['browser']['profile_directory'] = ctx.params['profile_directory']
 	if ctx.params.get('cdp_url'):
 		config['browser']['cdp_url'] = ctx.params['cdp_url']
+	if ctx.params.get('proxy_url'):
+		config['browser']['proxy_server'] = ctx.params['proxy_url']
+	if ctx.params.get('no_proxy'):
+		config['browser']['proxy_bypass_list'] = [p.strip() for p in ctx.params['no_proxy'].split(',') if p.strip()]
+	if ctx.params.get('proxy_username'):
+		config['browser']['proxy_username'] = ctx.params['proxy_username']
+	if ctx.params.get('proxy_password'):
+		config['browser']['proxy_password'] = ctx.params['proxy_password']
 
 	return config
 
@@ -1573,6 +1581,10 @@ async def textual_interface(config: dict[str, Any]):
 )
 @click.option('--profile-directory', type=str, help='Chrome profile directory name (e.g. "Default", "Profile 1")')
 @click.option('--cdp-url', type=str, help='Connect to existing Chrome via CDP URL (e.g. http://localhost:9222)')
+@click.option('--proxy-url', type=str, help='Proxy server for Chromium traffic (e.g. http://host:8080 or socks5://host:1080)')
+@click.option('--no-proxy', type=str, help='Comma-separated hosts to bypass proxy (e.g. localhost,127.0.0.1,*.internal)')
+@click.option('--proxy-username', type=str, help='Proxy auth username')
+@click.option('--proxy-password', type=str, help='Proxy auth password')
 @click.option('-p', '--prompt', type=str, help='Run a single task without the TUI (headless mode)')
 @click.option('--mcp', is_flag=True, help='Run as MCP server (exposes JSON RPC via stdin/stdout)')
 @click.pass_context

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -213,6 +213,12 @@ class FlatEnvConfig(BaseSettings):
 	BROWSER_USE_ALLOWED_DOMAINS: str | None = Field(default=None)
 	BROWSER_USE_LLM_MODEL: str | None = Field(default=None)
 
+	# Proxy env vars
+	BROWSER_USE_PROXY_URL: str | None = Field(default=None)
+	BROWSER_USE_NO_PROXY: str | None = Field(default=None)
+	BROWSER_USE_PROXY_USERNAME: str | None = Field(default=None)
+	BROWSER_USE_PROXY_PASSWORD: str | None = Field(default=None)
+
 
 class DBStyleEntry(BaseModel):
 	"""Database-style entry with UUID and metadata."""
@@ -446,6 +452,17 @@ class Config:
 		if env_config.BROWSER_USE_ALLOWED_DOMAINS:
 			domains = [d.strip() for d in env_config.BROWSER_USE_ALLOWED_DOMAINS.split(',') if d.strip()]
 			config['browser_profile']['allowed_domains'] = domains
+
+		# Proxy settings (Chromium)
+		if env_config.BROWSER_USE_PROXY_URL:
+			config['browser_profile']['proxy_server'] = env_config.BROWSER_USE_PROXY_URL
+		if env_config.BROWSER_USE_NO_PROXY:
+			bypass = [d.strip() for d in env_config.BROWSER_USE_NO_PROXY.split(',') if d.strip()]
+			config['browser_profile']['proxy_bypass_list'] = bypass
+		if env_config.BROWSER_USE_PROXY_USERNAME:
+			config['browser_profile']['proxy_username'] = env_config.BROWSER_USE_PROXY_USERNAME
+		if env_config.BROWSER_USE_PROXY_PASSWORD:
+			config['browser_profile']['proxy_password'] = env_config.BROWSER_USE_PROXY_PASSWORD
 
 		if env_config.OPENAI_API_KEY:
 			config['llm']['api_key'] = env_config.OPENAI_API_KEY

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -453,16 +453,23 @@ class Config:
 			domains = [d.strip() for d in env_config.BROWSER_USE_ALLOWED_DOMAINS.split(',') if d.strip()]
 			config['browser_profile']['allowed_domains'] = domains
 
-		# Proxy settings (Chromium)
+		# Proxy settings (Chromium) -> consolidated `proxy` dict
+		proxy_dict: dict[str, Any] = {}
 		if env_config.BROWSER_USE_PROXY_URL:
-			config['browser_profile']['proxy_server'] = env_config.BROWSER_USE_PROXY_URL
+			proxy_dict['server'] = env_config.BROWSER_USE_PROXY_URL
 		if env_config.BROWSER_USE_NO_PROXY:
-			bypass = [d.strip() for d in env_config.BROWSER_USE_NO_PROXY.split(',') if d.strip()]
-			config['browser_profile']['proxy_bypass_list'] = bypass
+			# store bypass as comma-separated string to match Chrome flag
+			proxy_dict['bypass'] = ','.join(
+				[d.strip() for d in env_config.BROWSER_USE_NO_PROXY.split(',') if d.strip()]
+			)
 		if env_config.BROWSER_USE_PROXY_USERNAME:
-			config['browser_profile']['proxy_username'] = env_config.BROWSER_USE_PROXY_USERNAME
+			proxy_dict['username'] = env_config.BROWSER_USE_PROXY_USERNAME
 		if env_config.BROWSER_USE_PROXY_PASSWORD:
-			config['browser_profile']['proxy_password'] = env_config.BROWSER_USE_PROXY_PASSWORD
+			proxy_dict['password'] = env_config.BROWSER_USE_PROXY_PASSWORD
+		if proxy_dict:
+			# ensure section exists
+			config.setdefault('browser_profile', {})
+			config['browser_profile']['proxy'] = proxy_dict
 
 		if env_config.OPENAI_API_KEY:
 			config['llm']['api_key'] = env_config.OPENAI_API_KEY

--- a/docs/customize/browser-settings.mdx
+++ b/docs/customize/browser-settings.mdx
@@ -488,10 +488,14 @@ Whether to automatically accept all downloads.
 #### `proxy`
 
 ```python
-proxy: dict | None = None
+proxy: ProxySettings | None = None
 ```
 
-Proxy settings. Example: `{"server": "http://proxy.com:8080", "username": "user", "password": "pass"}`. 
+Proxy settings (typed). Example:
+
+```python
+proxy=ProxySettings(server="http://proxy.com:8080", username="user", password="pass")
+```
 
 #### `permissions`
 

--- a/tests/ci/test_proxy_smoke.py
+++ b/tests/ci/test_proxy_smoke.py
@@ -19,6 +19,26 @@ def test_chromium_args_include_proxy_flags():
     assert any(a == '--proxy-bypass-list=localhost,127.0.0.1' for a in args), args
 
 
+def test_chromium_args_include_pac_url_flag_and_exclusivity():
+    # PAC URL should produce --proxy-pac-url and not --proxy-server
+    profile = BrowserProfile(
+        headless=True,
+        user_data_dir=str(CONFIG.BROWSER_USE_PROFILES_DIR / 'proxy-smoke-pac'),
+        proxy_pac_url='http://proxy.local/proxy.pac',
+    )
+    args = profile.get_args()
+    assert any(a == '--proxy-pac-url=http://proxy.local/proxy.pac' for a in args), args
+    assert all(not a.startswith('--proxy-server=') for a in args), args
+
+    # Setting both PAC URL and server should raise
+    with pytest.raises(ValueError):
+        BrowserProfile(
+            headless=True,
+            user_data_dir=str(CONFIG.BROWSER_USE_PROFILES_DIR / 'proxy-smoke-bad'),
+            proxy_server='http://proxy.local:8080',
+            proxy_pac_url='http://proxy.local/proxy.pac',
+        )
+
 @pytest.mark.asyncio
 async def test_cdp_proxy_auth_handler_registers_and_responds():
     # Create profile with proxy auth credentials
@@ -35,7 +55,9 @@ async def test_cdp_proxy_auth_handler_registers_and_responds():
         def __init__(self) -> None:
             self.enabled = False
             self.last_auth: dict[str, Any] | None = None
+            self.last_default: dict[str, Any] | None = None
             self.auth_callback = None
+            self.request_paused_callback = None
 
             class _FetchSend:
                 def __init__(self, outer: 'StubCDP') -> None:
@@ -47,6 +69,10 @@ async def test_cdp_proxy_auth_handler_registers_and_responds():
                 async def continueWithAuth(self, params: dict, session_id: str | None = None) -> None:
                     self._outer.last_auth = {'params': params, 'session_id': session_id}
 
+                async def continueRequest(self, params: dict, session_id: str | None = None) -> None:
+                    # no-op; included to mirror CDP API surface used by impl
+                    pass
+
             class _Send:
                 def __init__(self, outer: 'StubCDP') -> None:
                     self.Fetch = _FetchSend(outer)
@@ -57,6 +83,9 @@ async def test_cdp_proxy_auth_handler_registers_and_responds():
 
                 def authRequired(self, callback) -> None:
                     self._outer.auth_callback = callback
+
+                def requestPaused(self, callback) -> None:
+                    self._outer.request_paused_callback = callback
 
             class _Register:
                 def __init__(self, outer: 'StubCDP') -> None:
@@ -82,10 +111,21 @@ async def test_cdp_proxy_auth_handler_registers_and_responds():
     root.auth_callback(ev, session_id='s1')  # type: ignore[misc]
 
     # Let scheduled task run
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)
 
     assert root.last_auth is not None
     params = root.last_auth['params']
     assert params['authChallengeResponse']['response'] == 'ProvideCredentials'
     assert params['authChallengeResponse']['username'] == 'user'
     assert params['authChallengeResponse']['password'] == 'pass'
+    assert root.last_auth['session_id'] == 's1'
+
+    # Now simulate a non-proxy auth challenge and ensure default handling
+    ev2 = {'requestId': 'r2', 'authChallenge': {'source': 'Server'}}
+    root.auth_callback(ev2, session_id='s2')  # type: ignore[misc]
+    await asyncio.sleep(0.05)
+    # After non-proxy challenge, last_auth should reflect Default response
+    assert root.last_auth is not None
+    params2 = root.last_auth['params']
+    assert params2['requestId'] == 'r2'
+    assert params2['authChallengeResponse']['response'] == 'Default'

--- a/tests/ci/test_proxy_smoke.py
+++ b/tests/ci/test_proxy_smoke.py
@@ -11,33 +11,15 @@ def test_chromium_args_include_proxy_flags():
     profile = BrowserProfile(
         headless=True,
         user_data_dir=str(CONFIG.BROWSER_USE_PROFILES_DIR / 'proxy-smoke'),
-        proxy_server='http://proxy.local:8080',
-        proxy_bypass_list=['localhost', '127.0.0.1'],
+        proxy={
+            'server': 'http://proxy.local:8080',
+            'bypass': 'localhost,127.0.0.1',
+        },
     )
     args = profile.get_args()
     assert any(a == '--proxy-server=http://proxy.local:8080' for a in args), args
     assert any(a == '--proxy-bypass-list=localhost,127.0.0.1' for a in args), args
 
-
-def test_chromium_args_include_pac_url_flag_and_exclusivity():
-    # PAC URL should produce --proxy-pac-url and not --proxy-server
-    profile = BrowserProfile(
-        headless=True,
-        user_data_dir=str(CONFIG.BROWSER_USE_PROFILES_DIR / 'proxy-smoke-pac'),
-        proxy_pac_url='http://proxy.local/proxy.pac',
-    )
-    args = profile.get_args()
-    assert any(a == '--proxy-pac-url=http://proxy.local/proxy.pac' for a in args), args
-    assert all(not a.startswith('--proxy-server=') for a in args), args
-
-    # Setting both PAC URL and server should raise
-    with pytest.raises(ValueError):
-        BrowserProfile(
-            headless=True,
-            user_data_dir=str(CONFIG.BROWSER_USE_PROFILES_DIR / 'proxy-smoke-bad'),
-            proxy_server='http://proxy.local:8080',
-            proxy_pac_url='http://proxy.local/proxy.pac',
-        )
 
 @pytest.mark.asyncio
 async def test_cdp_proxy_auth_handler_registers_and_responds():
@@ -45,8 +27,7 @@ async def test_cdp_proxy_auth_handler_registers_and_responds():
     profile = BrowserProfile(
         headless=True,
         user_data_dir=str(CONFIG.BROWSER_USE_PROFILES_DIR / 'proxy-smoke'),
-        proxy_username='user',
-        proxy_password='pass',
+        proxy={'username': 'user', 'password': 'pass'},
     )
     session = BrowserSession(browser_profile=profile)
 

--- a/tests/ci/test_proxy_smoke.py
+++ b/tests/ci/test_proxy_smoke.py
@@ -1,0 +1,91 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.config import CONFIG
+
+
+def test_chromium_args_include_proxy_flags():
+    profile = BrowserProfile(
+        headless=True,
+        user_data_dir=str(CONFIG.BROWSER_USE_PROFILES_DIR / 'proxy-smoke'),
+        proxy_server='http://proxy.local:8080',
+        proxy_bypass_list=['localhost', '127.0.0.1'],
+    )
+    args = profile.get_args()
+    assert any(a == '--proxy-server=http://proxy.local:8080' for a in args), args
+    assert any(a == '--proxy-bypass-list=localhost,127.0.0.1' for a in args), args
+
+
+@pytest.mark.asyncio
+async def test_cdp_proxy_auth_handler_registers_and_responds():
+    # Create profile with proxy auth credentials
+    profile = BrowserProfile(
+        headless=True,
+        user_data_dir=str(CONFIG.BROWSER_USE_PROFILES_DIR / 'proxy-smoke'),
+        proxy_username='user',
+        proxy_password='pass',
+    )
+    session = BrowserSession(browser_profile=profile)
+
+    # Stub CDP client with minimal Fetch support
+    class StubCDP:
+        def __init__(self) -> None:
+            self.enabled = False
+            self.last_auth: dict[str, Any] | None = None
+            self.auth_callback = None
+
+            class _FetchSend:
+                def __init__(self, outer: 'StubCDP') -> None:
+                    self._outer = outer
+
+                async def enable(self, params: dict, session_id: str | None = None) -> None:
+                    self._outer.enabled = True
+
+                async def continueWithAuth(self, params: dict, session_id: str | None = None) -> None:
+                    self._outer.last_auth = {'params': params, 'session_id': session_id}
+
+            class _Send:
+                def __init__(self, outer: 'StubCDP') -> None:
+                    self.Fetch = _FetchSend(outer)
+
+            class _FetchRegister:
+                def __init__(self, outer: 'StubCDP') -> None:
+                    self._outer = outer
+
+                def authRequired(self, callback) -> None:
+                    self._outer.auth_callback = callback
+
+            class _Register:
+                def __init__(self, outer: 'StubCDP') -> None:
+                    self.Fetch = _FetchRegister(outer)
+
+            self.send = _Send(self)
+            self.register = _Register(self)
+
+    root = StubCDP()
+
+    # Attach stubs to session
+    session._cdp_client_root = root  # type: ignore[attr-defined]
+    # No need to attach a real CDPSession; _setup_proxy_auth works with root client
+
+    # Should register Fetch handler and enable auth handling without raising
+    await session._setup_proxy_auth()
+
+    assert root.enabled is True
+    assert callable(root.auth_callback)
+
+    # Simulate proxy auth required event
+    ev = {'requestId': 'r1', 'authChallenge': {'source': 'Proxy'}}
+    root.auth_callback(ev, session_id='s1')  # type: ignore[misc]
+
+    # Let scheduled task run
+    await asyncio.sleep(0.01)
+
+    assert root.last_auth is not None
+    params = root.last_auth['params']
+    assert params['authChallengeResponse']['response'] == 'ProvideCredentials'
+    assert params['authChallengeResponse']['username'] == 'user'
+    assert params['authChallengeResponse']['password'] == 'pass'


### PR DESCRIPTION
Add support for configuring and handling proxy settings in the CDP browser automation stack. CDP does not support command line arguments for proxy server credentials, so credential authorization needs to be done by hooking into Fetch events.

**Proxy Configuration and Handling**

* Added new proxy-related fields to `BrowserProfile` (`proxy_server`, `proxy_bypass_list`, `proxy_pac_url`, `proxy_username`, `proxy_password`) and validated exclusivity between `proxy_server` and `proxy_pac_url`. 
* Updated Chromium launch argument generation in `BrowserProfile.get_args` to include proxy flags based on configuration.
* Implemented proxy authentication handling in `BrowserSession` via a new `_setup_proxy_auth` method, enabling CDP Fetch domain and responding to proxy auth challenges with configured credentials.

**Testing**

* Smoke tests are in `test_proxy_smoke.py` to verify Chromium proxy flags, PAC URL exclusivity, and proxy authentication handler logic.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add full proxy support, including authenticated proxies, for CDP-based browsing. Configure proxy server/PAC/bypass and credentials; sessions now handle proxy auth challenges via CDP Fetch.

- **New Features**
  - BrowserProfile: added proxy_server, proxy_pac_url (mutually exclusive), proxy_bypass_list, proxy_username, proxy_password; generates Chromium proxy flags.
  - BrowserSession: handles proxy auth via Fetch.authRequired with provided credentials; continues paused requests to avoid stalls; enables Fetch on root, focused, and newly attached targets.
  - CLI: added --proxy-url, --no-proxy, --proxy-username, --proxy-password.
  - Env vars: BROWSER_USE_PROXY_URL, BROWSER_USE_NO_PROXY, BROWSER_USE_PROXY_USERNAME, BROWSER_USE_PROXY_PASSWORD.
  - Tests: smoke tests cover Chromium args, PAC/server exclusivity, and proxy auth handler behavior.

<!-- End of auto-generated description by cubic. -->

