### PR TITLE
set default_llm

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -1,7 +1,11 @@
 import os
 from typing import TYPE_CHECKING
 
+# Default model - users can change this
+from browser_use.llm.openai.chat import ChatOpenAI
 from browser_use.logging_config import setup_logging
+
+default_llm = ChatOpenAI(model='gpt-4.1-mini')
 
 # Only set up logging if not in MCP mode or if explicitly requested
 if os.environ.get('BROWSER_USE_SETUP_LOGGING', 'true').lower() != 'false':

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -8,21 +8,11 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from browser_use import Agent, ChatOpenAI
+from browser_use import Agent, default_llm
 
 
 async def main():
-	# Choose your model
-	llm = ChatOpenAI(model='gpt-4.1-mini')
-
-	# Define your task
-	task = 'Go and find the founders of browser-use'
-
-	# Create the agent
-	agent = Agent(task=task, llm=llm)
-
-	# Start
-	await agent.run(max_steps=2)
+	await Agent('Find the founders of browser-use', default_llm).run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Auto-generated PR for: set default_llm
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Expose default_llm = ChatOpenAI(model='gpt-4.1-mini') from browser_use to provide a sensible default. Update examples/simple.py to use it, reducing boilerplate while still allowing custom models.

<!-- End of auto-generated description by cubic. -->

