### PR TITLE
Updated the api docs with available models

### DIFF
--- a/docs/api-reference/create-scheduled-task.mdx
+++ b/docs/api-reference/create-scheduled-task.mdx
@@ -42,8 +42,8 @@ This endpoint requires an active subscription.
 <ParamField body="structured_output_json" type="string">
   JSON schema for structured output
 </ParamField>
-<ParamField body="llm_model" type="string" default="gpt-4o">
-  LLM model to use. Available options: gpt-4o, gpt-4o-mini, gpt-4.1, gpt-4.1-mini, o4-mini, o3, gemini-2.0-flash, gemini-2.0-flash-lite, gemini-2.5-flash-preview-04-17, gemini-2.5-flash, gemini-2.5-pro, claude-3-7-sonnet-20250219, claude-sonnet-4-20250514, llama-4-maverick-17b-128e-instruct
+<ParamField body="llm_model" type="string" default="gpt-4.1">
+  LLM model to use. Available options: gpt-4.1, gpt-4.1-mini, o4-mini, o3, gemini-2.5-flash, gemini-2.5-pro, claude-sonnet-4-20250514
 </ParamField>
 <ParamField body="use_adblock" type="boolean" default="true">
   Whether to use an adblocker

--- a/docs/api-reference/run-task.mdx
+++ b/docs/api-reference/run-task.mdx
@@ -37,11 +37,12 @@ Creates a new browser automation task and returns the task ID that can be used t
 <ParamField body="llm_model" type="string" default="gpt-4.1">
   LLM model to use. 
   Available options: 
-  - gpt-4o
-  - gpt-4o-mini
   - gpt-4.1
   - gpt-4.1-mini
+  - o4-mini
+  - o3
   - gemini-2.5-flash
+  - gemini-2.5-pro
   - claude-sonnet-4-20250514
 </ParamField>
 

--- a/docs/api-reference/update-scheduled-task.mdx
+++ b/docs/api-reference/update-scheduled-task.mdx
@@ -45,7 +45,7 @@ Updates a scheduled task with partial updates. You can update any combination of
   Whether to highlight elements on the page
 </ParamField>
 <ParamField body="llm_model" type="string">
-  LLM model to use. Available options: gpt-4o, gpt-4o-mini, gpt-4.1, gpt-4.1-mini, o4-mini, o3, gemini-2.0-flash, gemini-2.0-flash-lite, gemini-2.5-flash-preview-04-17, gemini-2.5-flash, gemini-2.5-pro, claude-3-7-sonnet-20250219, claude-sonnet-4-20250514, llama-4-maverick-17b-128e-instruct
+  LLM model to use. Available options: gpt-4.1, gpt-4.1-mini, o4-mini, o3, gemini-2.5-flash, gemini-2.5-pro, claude-sonnet-4-20250514
 </ParamField>
 <ParamField body="save_browser_data" type="boolean">
   Whether to save browser cookies and data between runs


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated API docs to show the current supported LLM models and set gpt-4.1 as the default. Applies to create-scheduled-task, run-task, and update-scheduled-task.

- **Migration**
  - Default llm_model for create-scheduled-task is now gpt-4.1.
  - Removed unsupported models (e.g., gpt-4o variants, older Gemini/Claude/Llama). If you used one, switch to a supported model and set llm_model explicitly.

<!-- End of auto-generated description by cubic. -->

