### PR TITLE
Save Click and Input Text Coordinates

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -109,6 +109,9 @@ class ActionResult(BaseModel):
 	extracted_content: str | None = None
 	include_extracted_content_only_once: bool = False  # Whether the extracted content should be used to update the read_state
 
+	# Metadata for observability (e.g., click coordinates)
+	metadata: dict | None = None
+
 	# Deprecated
 	include_in_memory: bool = False  # whether to include in extracted_content inside long_term_memory
 

--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -90,7 +90,7 @@ class NavigateToUrlEvent(BaseEvent[None]):
 	event_timeout: float | None = 15.0  # seconds
 
 
-class ClickElementEvent(ElementSelectedEvent[dict | None]):
+class ClickElementEvent(ElementSelectedEvent[dict[str, Any] | None]):
 	"""Click an element."""
 
 	node: 'EnhancedDOMTreeNode'

--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -90,7 +90,7 @@ class NavigateToUrlEvent(BaseEvent[None]):
 	event_timeout: float | None = 15.0  # seconds
 
 
-class ClickElementEvent(ElementSelectedEvent[None]):
+class ClickElementEvent(ElementSelectedEvent[dict | None]):
 	"""Click an element."""
 
 	node: 'EnhancedDOMTreeNode'

--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -105,7 +105,7 @@ class ClickElementEvent(ElementSelectedEvent[dict | None]):
 	event_timeout: float | None = 15.0  # seconds
 
 
-class TypeTextEvent(ElementSelectedEvent[None]):
+class TypeTextEvent(ElementSelectedEvent[dict | None]):
 	"""Type text into an element."""
 
 	node: 'EnhancedDOMTreeNode'

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -329,13 +329,16 @@ class Controller(Generic[Context]):
 					TypeTextEvent(node=node, text=params.text, clear_existing=params.clear_existing)
 				)
 				await event
-				await event.event_result(raise_if_any=True, raise_if_none=False)
+				input_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
 				msg = f"Input '{params.text}' into element {params.index}."
 				logger.info(msg)
+				
+				# Include input coordinates in metadata if available
 				return ActionResult(
 					extracted_content=msg,
 					include_in_memory=True,
 					long_term_memory=f"Input '{params.text}' into element {params.index}.",
+					metadata=input_metadata if isinstance(input_metadata, dict) else None
 				)
 			except Exception as e:
 				# Log the full error for debugging

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -282,12 +282,19 @@ class Controller(Generic[Context]):
 					ClickElementEvent(node=node, while_holding_ctrl=params.while_holding_ctrl)
 				)
 				await event
-				# Wait for handler to complete and get any exception (None is expected on success)
-				await event.event_result(raise_if_any=True, raise_if_none=False)
+				# Wait for handler to complete and get any exception or metadata
+				click_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
 				memory = f'Clicked element with index {params.index}'
 				msg = f'🖱️ {memory}'
 				logger.info(msg)
-				return ActionResult(extracted_content=memory, include_in_memory=True, long_term_memory=memory)
+				
+				# Include click coordinates in metadata if available
+				return ActionResult(
+					extracted_content=memory, 
+					include_in_memory=True, 
+					long_term_memory=memory,
+					metadata=click_metadata if isinstance(click_metadata, dict) else None
+				)
 			except Exception as e:
 				logger.error(f'Failed to execute ClickElementEvent: {type(e).__name__}: {e}')
 				clean_msg = extract_llm_error_message(e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ examples = [
     "langchain-openai>=0.3.26",
 ]
 eval = [
-    "lmnr[all]>=0.6.11",
+    "lmnr[all]==0.7.6",
     "anyio>=4.9.0",
     "Pillow>=11.2.1",
     "psutil>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ dev-dependencies = [
     "ty>=0.0.1a1",
     "pytest-xdist>=3.7.0",
     "pillow>=11.2.1",
-    "lmnr[all]>=0.6.13",
+    "lmnr[all]==0.7.6",
     # "pytest-playwright-asyncio>=0.7.0",  # not actually needed I think
     "pytest-timeout>=2.4.0",
 ]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add coordinate capture for clicks and text input and surface them on ActionResult.metadata for better observability. Also pins lmnr to 0.7.6.

- **New Features**
  - ActionResult now includes a metadata dict.
  - ClickElementEvent and TypeTextEvent return dict | None with element-center coordinates (click_x/click_y, input_x/input_y). Service attaches this to ActionResult.metadata.

- **Dependencies**
  - Pin lmnr[all]==0.7.6.

<!-- End of auto-generated description by cubic. -->

