### PR TITLE
Extract structured data -> get page as markdown

### DIFF
--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -21,7 +21,7 @@ At every step, your input will consist of:
 2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
 4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements.
-5. <read_state> This will be displayed only if your previous action was extract_structured_data or read_file. This data is only shown in the current step.
+5. <read_state> This will be displayed only if your previous action was read_entire_page_as_markdown or read_file. This data is only shown in the current step.
 </input>
 
 <agent_history>
@@ -76,13 +76,12 @@ Strictly follow these rules while using the browser and navigating the web:
 - Only use indexes that are explicitly provided.
 - If research is needed, open a **new tab** instead of reusing the current one.
 - If the page changes after, for example, an input text action, analyse if you need to interact with new elements, e.g. selecting the right option from the list.
-- By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page. The extract_structured_data action gets the full loaded page content.
+- By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page.
+- You can use read_entire_page_as_markdown to read the entire page as markdown including parts not currently visible. Call this tool only if the information you are looking for is not in the current <browser_state>.
 - You can scroll by a specific number of pages using the num_pages parameter (e.g., 0.5 for half page, 2.0 for two pages).
 - If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack).
 - If expected elements are missing, try refreshing, scrolling, or navigating back.
 - If the page is not fully loaded, use the wait action.
-- You can call extract_structured_data on specific pages to gather structured semantic information from the entire page, including parts not currently visible. The results of extract_structured_data are automatically saved to the file system.
-- Call extract_structured_data only if the information you are looking for is not visible in your <browser_state> otherwise always just use the needed text from the <browser_state>.
 - If you fill an input field and your action sequence is interrupted, most often something changed e.g. suggestions popped up under the field.
 - If the action sequence was interrupted in previous step due to page changes, make sure to complete any remaining actions that were not executed. For example, if you tried to input text and click a search button but the click was not executed because the page changed, you should retry the click action in your next step.
 - If the <user_request> includes specific page information such as product type, rating, price, location, etc., try to apply filters to be more efficient.
@@ -138,8 +137,6 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 Maximize efficiency by combining related actions in one step instead of doing them separately:
 
 **Highly Recommended Action Combinations:**
-- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
-- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
 - `click_element_by_index` + `input_text` → Click input field and fill it immediately
 - `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
@@ -148,22 +145,8 @@ Maximize efficiency by combining related actions in one step instead of doing th
 **Examples of Efficient Combinations:**
 ```json
 "action": [
-  {{"click_element_by_index": {{"index": 15}}}},
-  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
-]
-```
-
-```json
-"action": [
   {{"input_text": {{"index": 23, "text": "laptop"}}}},
   {{"click_element_by_index": {{"index": 24}}}}
-]
-```
-
-```json
-"action": [
-  {{"go_to_url": {{"url": "https://example.com/search"}}}},
-  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
 ]
 ```
 

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -77,6 +77,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - If research is needed, open a **new tab** instead of reusing the current one.
 - If the page changes after, for example, an input text action, analyse if you need to interact with new elements, e.g. selecting the right option from the list.
 - By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page.
+- If you see <page_markdown> in your state, it means that you requested to get the whole page as markdown in the previous step. Read the content carefully to extract the information you were seeking in the page.
 - You can use read_entire_page_as_markdown to read the entire page as markdown including parts not currently visible. Call this tool only if the information you are looking for is not in the current <browser_state>.
 - You can scroll by a specific number of pages using the num_pages parameter (e.g., 0.5 for half page, 2.0 for two pages).
 - If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack).

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -75,6 +75,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - If research is needed, open a **new tab** instead of reusing the current one.
 - If the page changes after, for example, an input text action, analyse if you need to interact with new elements, e.g. selecting the right option from the list.
 - By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page.
+- If you see <page_markdown> in your state, it means that you requested to get the whole page as markdown in the previous step. Read the content carefully to extract the information you were seeking in the page.
 - You can use read_entire_page_as_markdown to read the entire page as markdown including parts not currently visible. Call this tool only if the information you are looking for is not in the current <browser_state>.
 - You can scroll by a specific number of pages using the num_pages parameter (e.g., 0.5 for half page, 2.0 for two pages).
 - If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack).

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -21,7 +21,7 @@ At every step, your input will consist of:
 2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
 4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements.
-5. <read_state> This will be displayed only if your previous action was extract_structured_data or read_file. This data is only shown in the current step.
+5. <read_state> This will be displayed only if your previous action was read_entire_page_as_markdown or read_file. This data is only shown in the current step.
 </input>
 
 <agent_history>
@@ -74,13 +74,12 @@ Strictly follow these rules while using the browser and navigating the web:
 - Only use indexes that are explicitly provided.
 - If research is needed, open a **new tab** instead of reusing the current one.
 - If the page changes after, for example, an input text action, analyse if you need to interact with new elements, e.g. selecting the right option from the list.
-- By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page. The extract_structured_data action gets the full loaded page content.
+- By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page.
+- You can use read_entire_page_as_markdown to read the entire page as markdown including parts not currently visible. Call this tool only if the information you are looking for is not in the current <browser_state>.
 - You can scroll by a specific number of pages using the num_pages parameter (e.g., 0.5 for half page, 2.0 for two pages).
 - If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack).
 - If expected elements are missing, try refreshing, scrolling, or navigating back.
 - If the page is not fully loaded, use the wait action.
-- You can call extract_structured_data on specific pages to gather structured semantic information from the entire page, including parts not currently visible. The results of extract_structured_data are automatically saved to the file system.
-- Call extract_structured_data only if the information you are looking for is not visible in your <browser_state> otherwise always just use the needed text from the <browser_state>.
 - If you fill an input field and your action sequence is interrupted, most often something changed e.g. suggestions popped up under the field.
 - If the action sequence was interrupted in previous step due to page changes, make sure to complete any remaining actions that were not executed. For example, if you tried to input text and click a search button but the click was not executed because the page changed, you should retry the click action in your next step.
 - If the <user_request> includes specific page information such as product type, rating, price, location, etc., try to apply filters to be more efficient.
@@ -129,15 +128,12 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 - If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
 </action_rules>
 
-
 <efficiency_guidelines>
 **IMPORTANT: Be More Efficient with Multi-Action Outputs**
 
 Maximize efficiency by combining related actions in one step instead of doing them separately:
 
 **Highly Recommended Action Combinations:**
-- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
-- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
 - `click_element_by_index` + `input_text` → Click input field and fill it immediately
 - `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
@@ -146,22 +142,8 @@ Maximize efficiency by combining related actions in one step instead of doing th
 **Examples of Efficient Combinations:**
 ```json
 "action": [
-  {{"click_element_by_index": {{"index": 15}}}},
-  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
-]
-```
-
-```json
-"action": [
   {{"input_text": {{"index": 23, "text": "laptop"}}}},
   {{"click_element_by_index": {{"index": 24}}}}
-]
-```
-
-```json
-"action": [
-  {{"go_to_url": {{"url": "https://example.com/search"}}}},
-  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
 ]
 ```
 
@@ -171,6 +153,7 @@ Maximize efficiency by combining related actions in one step instead of doing th
 
 **Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
 </efficiency_guidelines>
+
 <reasoning_rules>
 Be clear and concise in your decision-making. Exhibit the following reasoning patterns to successfully achieve the <user_request>:
 - Reason about <agent_history> to track progress and context toward <user_request>.

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -77,6 +77,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - If research is needed, open a **new tab** instead of reusing the current one.
 - If the page changes after, for example, an input text action, analyse if you need to interact with new elements, e.g. selecting the right option from the list.
 - By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page.
+- If you see <page_markdown> in your state, it means that you requested to get the whole page as markdown in the previous step. Read the content carefully to extract the information you were seeking in the page.
 - You can use read_entire_page_as_markdown to read the entire page as markdown including parts not currently visible. Call this tool only if the information you are looking for is not in the current <browser_state>.
 - You can scroll by a specific number of pages using the num_pages parameter (e.g., 0.5 for half page, 2.0 for two pages).
 - If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack).

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -21,7 +21,7 @@ At every step, your input will consist of:
 2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
 4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements.
-5. <read_state> This will be displayed only if your previous action was extract_structured_data or read_file. This data is only shown in the current step.
+5. <read_state> This will be displayed only if your previous action was read_entire_page_as_markdown or read_file. This data is only shown in the current step.
 </input>
 
 <agent_history>
@@ -76,13 +76,12 @@ Strictly follow these rules while using the browser and navigating the web:
 - Only use indexes that are explicitly provided.
 - If research is needed, open a **new tab** instead of reusing the current one.
 - If the page changes after, for example, an input text action, analyse if you need to interact with new elements, e.g. selecting the right option from the list.
-- By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page. The extract_structured_data action gets the full loaded page content.
+- By default, only elements in the visible viewport are listed. Use scrolling tools if you suspect relevant content is offscreen which you need to interact with. Scroll ONLY if there are more pixels below or above the page.
+- You can use read_entire_page_as_markdown to read the entire page as markdown including parts not currently visible. Call this tool only if the information you are looking for is not in the current <browser_state>.
 - You can scroll by a specific number of pages using the num_pages parameter (e.g., 0.5 for half page, 2.0 for two pages).
 - If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack).
 - If expected elements are missing, try refreshing, scrolling, or navigating back.
 - If the page is not fully loaded, use the wait action.
-- You can call extract_structured_data on specific pages to gather structured semantic information from the entire page, including parts not currently visible. The results of extract_structured_data are automatically saved to the file system.
-- Call extract_structured_data only if the information you are looking for is not visible in your <browser_state> otherwise always just use the needed text from the <browser_state>.
 - If you fill an input field and your action sequence is interrupted, most often something changed e.g. suggestions popped up under the field.
 - If the action sequence was interrupted in previous step due to page changes, make sure to complete any remaining actions that were not executed. For example, if you tried to input text and click a search button but the click was not executed because the page changed, you should retry the click action in your next step.
 - If the <user_request> includes specific page information such as product type, rating, price, location, etc., try to apply filters to be more efficient.
@@ -137,8 +136,6 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 Maximize efficiency by combining related actions in one step instead of doing them separately:
 
 **Highly Recommended Action Combinations:**
-- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
-- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
 - `click_element_by_index` + `input_text` → Click input field and fill it immediately
 - `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
@@ -147,22 +144,8 @@ Maximize efficiency by combining related actions in one step instead of doing th
 **Examples of Efficient Combinations:**
 ```json
 "action": [
-  {{"click_element_by_index": {{"index": 15}}}},
-  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
-]
-```
-
-```json
-"action": [
   {{"input_text": {{"index": 23, "text": "laptop"}}}},
   {{"click_element_by_index": {{"index": 24}}}}
-]
-```
-
-```json
-"action": [
-  {{"go_to_url": {{"url": "https://example.com/search"}}}},
-  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
 ]
 ```
 

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -595,14 +595,15 @@ Not recommended to:
 				content = re.sub(r'Primary: UNKNOWN\n\nNo specific evidence found', '', content, flags=re.MULTILINE | re.DOTALL)
 				content = re.sub(r'UNKNOWN CONFIDENCE', '', content, flags=re.MULTILINE | re.DOTALL)
 				content = re.sub(r'!\[\]\(\)', '', content, flags=re.MULTILINE | re.DOTALL)
+				# Compress consecutive newlines (4+ newlines become 3 newlines)
+				content = re.sub(r'\n{4,}', '\n' * MAX_NEWLINES, content)
 				# Strip all whitespace (newlines, spaces, tabs) from beginning and end
 				content = content.strip()
-				content = "<page_content>\n" + content + "\n</page_content>"
 			except Exception as e:
 				raise RuntimeError(f'Could not convert html to markdown: {type(e).__name__}')
-
-			# Compress consecutive newlines (4+ newlines become 3 newlines)
-			content = re.sub(r'\n{4,}', '\n' * MAX_NEWLINES, content)
+			
+			content_begin = "<page_markdown>\nIn the previous step, you asked to read the entire page as markdown. Here is the markdown of the page:\n"
+			content = content_begin + content + "\n</page_markdown>"
 
 			# Truncate if content is too long
 			if len(content) > MAX_CHAR_LIMIT:

--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -602,8 +602,9 @@ Not recommended to:
 			except Exception as e:
 				raise RuntimeError(f'Could not convert html to markdown: {type(e).__name__}')
 			
-			content_begin = "<page_markdown>\nIn the previous step, you asked to read the entire page as markdown. Here is the markdown of the page:\n"
-			content = content_begin + content + "\n</page_markdown>"
+			content_begin = "In the previous step, you asked to read the entire page as markdown - you can find the page markdown below.\n<page_markdown>\n"
+			content_end = "\n</page_markdown>\nThis content will disappear in the next step. You should read the content carefully to extract all the information you need from the page."
+			content = content_begin + content + content_end
 
 			# Truncate if content is too long
 			if len(content) > MAX_CHAR_LIMIT:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replace extract_structured_data with read_entire_page_as_markdown to capture the full page as markdown and surface it in read_state in the next step. This removes in-step LLM extraction, improves reliability, and clarifies when to read vs. interact.

- **Refactors**
  - Added read_entire_page_as_markdown(include_links) that converts the entire HTML to markdown, cleans artifacts, compresses blank lines, wraps in <page_content>, and truncates at 30k chars.
  - Removed extract_structured_data and its usage examples; updated all system prompts to reference read_entire_page_as_markdown and explain when to use it vs. scrolling or interacting.

- **Migration**
  - Replace extract_structured_data(...) with read_entire_page_as_markdown(include_links=[true|false]).
  - Read the result from <read_state> in the next step. Do not use this tool to find interactive elements; rely on browser_state and scrolling for that.

<!-- End of auto-generated description by cubic. -->

