### PR TITLE
Add docker telemetry conditionally

### DIFF
--- a/browser_use/telemetry/views.py
+++ b/browser_use/telemetry/views.py
@@ -3,6 +3,8 @@ from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from browser_use.config import is_running_in_docker
+
 
 @dataclass
 class BaseTelemetryEvent(ABC):
@@ -13,7 +15,10 @@ class BaseTelemetryEvent(ABC):
 
 	@property
 	def properties(self) -> dict[str, Any]:
-		return {k: v for k, v in asdict(self).items() if k != 'name'}
+		props = {k: v for k, v in asdict(self).items() if k != 'name'}
+		# Add Docker context if running in Docker
+		props['is_docker'] = is_running_in_docker()
+		return props
 
 
 @dataclass

--- a/tests/ci/test_telemetry.py
+++ b/tests/ci/test_telemetry.py
@@ -111,6 +111,8 @@ def test_cli_telemetry_event():
 	assert 'version' in props
 	assert 'action' in props
 	assert 'mode' in props
+	assert 'is_docker' in props  # Docker context should be included
+	assert isinstance(props['is_docker'], bool)  # Should be a boolean
 	assert 'name' not in props  # name should not be in properties
 
 
@@ -259,6 +261,8 @@ def test_mcp_server_telemetry_event_with_parent_process():
 	props = event.properties
 	assert 'parent_process_cmdline' in props
 	assert props['parent_process_cmdline'] == 'python -m browser_use.mcp.server'
+	assert 'is_docker' in props  # Docker context should be included
+	assert isinstance(props['is_docker'], bool)  # Should be a boolean
 
 
 def test_telemetry_device_id_uses_config_dir():


### PR DESCRIPTION
Add `is_docker` property to all telemetry events to track if the application is running in a Docker environment.

The `is_docker` property is automatically added to all telemetry events by modifying the `BaseTelemetryEvent` and leverages the existing `is_running_in_docker()` utility function for detection. This ensures consistent Docker context without affecting interactive terminal usage.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1756061011025009?thread_ts=1756061011.025009&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-6bd6782a-7f97-4170-a992-d7bd2e5a1c87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6bd6782a-7f97-4170-a992-d7bd2e5a1c87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an is_docker boolean to all telemetry events to indicate if the app is running in Docker, enabling environment-based analytics. Implemented in BaseTelemetryEvent.properties using is_running_in_docker, with tests updated to assert presence and boolean type.

<!-- End of auto-generated description by cubic. -->

