### PR TITLE
Add example for follow-up tasks without session termination

### DIFF
--- a/examples/features/README_follow_up_tasks.md
+++ b/examples/features/README_follow_up_tasks.md
@@ -1,0 +1,122 @@
+# Follow-up Tasks Examples
+
+This directory contains examples demonstrating how to use follow-up tasks with persistent browser sessions in browser-use.
+
+## Key Concept: `keep_alive=True`
+
+The critical setting for follow-up tasks is `keep_alive=True` in the `BrowserProfile`. This prevents the browser from closing when a task completes, allowing you to add new tasks to the same session.
+
+## Examples
+
+### 1. `reddit_follow_up_example.py`
+**Perfect recreation of your CLI scenario:**
+- Go to Reddit → agent calls `done()` → browser stays open
+- Add follow-up task: "What's the first post?"
+- Agent continues with same session
+
+```python
+# Key pattern:
+browser_session = BrowserSession(
+    browser_profile=BrowserProfile(keep_alive=True)
+)
+
+# First task
+agent = Agent(task="go to reddit", browser_session=browser_session)
+await agent.run()  # Completes, browser stays open
+
+# Follow-up task
+agent.add_new_task("what's the first post")
+await agent.run()  # Continues with same browser
+```
+
+### 2. `interactive_session.py`
+**Build your own interactive loop:**
+- User types tasks one by one
+- Browser persists between all tasks
+- Great for custom chat interfaces
+
+### 3. `follow_up_tasks.py` (existing)
+**Basic follow-up example** (existing file)
+
+## CLI Already Supports This!
+
+The **CLI interactive mode already does exactly what you want**:
+
+```bash
+$ browser-use
+> go to reddit
+[Agent works and calls done(), browser stays open]
+✅ Task completed!
+
+> what's the first post
+[Agent continues with same browser session]
+✅ Task completed!
+```
+
+The CLI uses `keep_alive=True` by default and calls `agent.add_new_task()` for subsequent tasks.
+
+## How It Works
+
+1. **Browser Session with `keep_alive=True`**
+   ```python
+   browser_session = BrowserSession(
+       browser_profile=BrowserProfile(keep_alive=True)
+   )
+   ```
+
+2. **First Task**
+   ```python
+   agent = Agent(task="initial task", browser_session=browser_session)
+   await agent.run()  # Browser stays open after completion
+   ```
+
+3. **Follow-up Tasks**
+   ```python
+   agent.add_new_task("follow-up task")
+   await agent.run()  # Same browser, new task
+   ```
+
+4. **Cleanup** (when done with all tasks)
+   ```python
+   await browser_session.kill()  # Manually close browser
+   ```
+
+## Key Points
+
+- ✅ **CLI already supports this pattern** - no changes needed
+- ✅ **`agent.add_new_task()` exists** - programmatic API available  
+- ✅ **`keep_alive=True`** - browser persistence is built-in
+- ✅ **Session reuse** - all cookies, localStorage, DOM state preserved
+- ✅ **Same tab or new tabs** - depends on actions taken
+
+## Use Cases
+
+- **Interactive chat interfaces** - User asks follow-up questions
+- **Multi-step automation** - Complete workflows across multiple tasks
+- **Testing scenarios** - Set up state, then test different paths
+- **Data extraction pipelines** - Navigate to site, then extract different data points
+- **Research workflows** - Go to site, then explore different aspects
+
+## Running the Examples
+
+```bash
+# Reddit follow-up example (demonstrates exact CLI pattern)
+python examples/features/reddit_follow_up_example.py
+
+# Interactive session (type your own tasks)
+python examples/features/interactive_session.py
+
+# Original follow-up example  
+python examples/features/follow_up_tasks.py
+```
+
+## Configuration Tips
+
+```python
+# Recommended browser profile for follow-up tasks
+BrowserProfile(
+    keep_alive=True,        # Essential: don't close browser after tasks
+    headless=False,         # True for server environments
+    user_data_dir='~/.config/browseruse/profiles/persistent',  # Reuse profiles
+)
+```

--- a/examples/features/interactive_session.py
+++ b/examples/features/interactive_session.py
@@ -1,0 +1,182 @@
+"""
+Example: Interactive session with follow-up tasks
+
+This example shows how to build your own interactive loop where:
+1. Browser session stays alive between tasks
+2. User can input multiple tasks sequentially
+3. Each task builds on the previous browser state
+
+This pattern is useful for:
+- Building custom chat interfaces
+- Scripted automation with multiple steps
+- Testing scenarios where you need session persistence
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use import Agent
+from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.llm import ChatOpenAI
+
+
+async def interactive_browser_session():
+    """
+    Create an interactive browser session that accepts multiple tasks.
+    """
+    
+    # Set up LLM
+    llm = ChatOpenAI(model='gpt-4o-mini', temperature=0.0)
+    
+    # Create persistent browser session
+    browser_session = BrowserSession(
+        browser_profile=BrowserProfile(
+            headless=False,  # Set to True for headless mode
+            keep_alive=True,  # Critical: keeps browser alive between tasks
+            user_data_dir='~/.config/browseruse/profiles/interactive',
+        )
+    )
+    
+    print("🚀 Starting browser session...")
+    await browser_session.start()
+    
+    agent = None
+    task_count = 0
+    
+    print("""
+🌟 Interactive Browser Session Started!
+Type your tasks one by one. The browser will stay open between tasks.
+Type 'exit' or 'quit' to end the session.
+
+Example tasks:
+- "go to reddit.com"
+- "what's the first post about?"
+- "go to github.com and search for browser-use"
+- "click on the first result"
+""")
+    
+    try:
+        while True:
+            # Get task from user
+            task = input(f"\n📝 Task #{task_count + 1}: ").strip()
+            
+            if task.lower() in ['exit', 'quit', '']:
+                print("👋 Ending session...")
+                break
+                
+            task_count += 1
+            print(f"🏃 Running task: {task}")
+            
+            if agent is None:
+                # First task: create new agent
+                agent = Agent(
+                    task=task,
+                    llm=llm,
+                    browser_session=browser_session,
+                )
+            else:
+                # Subsequent tasks: add to existing agent
+                agent.add_new_task(task)
+            
+            # Run the task
+            try:
+                history = await agent.run()
+                
+                if history.is_successful():
+                    print(f"✅ Task completed successfully!")
+                    if history.final_result():
+                        print(f"📄 Result: {history.final_result()}")
+                else:
+                    print(f"❌ Task failed or was incomplete")
+                    
+            except Exception as e:
+                print(f"💥 Error running task: {e}")
+                
+    except KeyboardInterrupt:
+        print("\n🛑 Session interrupted by user")
+        
+    finally:
+        # Clean up
+        print("🧹 Cleaning up browser session...")
+        await browser_session.kill()
+        print("✅ Session ended")
+
+
+async def automated_follow_up_demo():
+    """
+    Demonstration with predefined follow-up tasks.
+    """
+    
+    llm = ChatOpenAI(model='gpt-4o-mini', temperature=0.0)
+    
+    browser_session = BrowserSession(
+        browser_profile=BrowserProfile(
+            headless=False,
+            keep_alive=True,
+            user_data_dir='~/.config/browseruse/profiles/demo',
+        )
+    )
+    
+    await browser_session.start()
+    
+    # Define a sequence of related tasks
+    tasks = [
+        "Navigate to reddit.com",
+        "What is the title of the first post on the homepage?",
+        "Scroll down to see more posts",
+        "How many posts are visible on the page now?",
+    ]
+    
+    agent = None
+    
+    try:
+        for i, task in enumerate(tasks, 1):
+            print(f"\n📝 Task {i}/{len(tasks)}: {task}")
+            
+            if agent is None:
+                agent = Agent(
+                    task=task,
+                    llm=llm,
+                    browser_session=browser_session,
+                )
+            else:
+                agent.add_new_task(task)
+            
+            history = await agent.run()
+            
+            print(f"✅ Task {i} completed: {history.is_successful()}")
+            if history.final_result():
+                print(f"📄 Result: {history.final_result()}")
+                
+            # Brief pause between tasks
+            await asyncio.sleep(1)
+            
+    finally:
+        await browser_session.kill()
+
+
+if __name__ == '__main__':
+    print("🌟 Interactive Session Examples")
+    print("="*50)
+    
+    mode = input("""
+Choose mode:
+1. Interactive (you type tasks)
+2. Automated demo (predefined tasks)
+
+Enter 1 or 2: """).strip()
+    
+    if mode == "1":
+        asyncio.run(interactive_browser_session())
+    elif mode == "2":
+        print("\n🤖 Running automated demo...")
+        asyncio.run(automated_follow_up_demo())
+    else:
+        print("Invalid choice. Please run again and choose 1 or 2.")

--- a/examples/features/reddit_follow_up_example.py
+++ b/examples/features/reddit_follow_up_example.py
@@ -1,0 +1,138 @@
+"""
+Example: Follow-up tasks without killing the session
+
+This example demonstrates how to:
+1. Go to Reddit (agent completes and calls done())
+2. Browser stays open (keep_alive=True)
+3. Add a follow-up task: "What's the first post?"
+4. Agent continues with the same session
+
+This is the exact pattern you'd get with CLI interactive mode.
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use import Agent
+from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.llm import ChatOpenAI
+
+
+async def main():
+    """
+    Demonstrate follow-up tasks with persistent browser session.
+    """
+    
+    # Set up LLM
+    llm = ChatOpenAI(model='gpt-4o-mini', temperature=0.0)
+    
+    # Create a browser session with keep_alive=True
+    # This prevents the browser from closing when the first task completes
+    browser_session = BrowserSession(
+        browser_profile=BrowserProfile(
+            headless=False,  # Set to True if you don't want to see the browser
+            keep_alive=True,  # This is the key setting for follow-up tasks
+            user_data_dir='~/.config/browseruse/profiles/reddit_demo',  # Reuse profile
+        )
+    )
+    
+    print("🚀 Starting browser session...")
+    await browser_session.start()
+    
+    # Initial task: Go to Reddit
+    initial_task = "Navigate to reddit.com and wait for the page to load"
+    
+    agent = Agent(
+        task=initial_task,
+        llm=llm,
+        browser_session=browser_session,  # Pass the existing session
+    )
+    
+    print(f"📝 Running initial task: {initial_task}")
+    history1 = await agent.run()
+    
+    print(f"✅ Initial task completed! Success: {history1.is_successful()}")
+    print(f"📍 Current URL: {history1.final_result()}")
+    print("\n" + "="*50)
+    print("🔄 Browser session is still alive! Adding follow-up task...")
+    print("="*50 + "\n")
+    
+    # Follow-up task: Analyze the first post
+    # The browser stays open and we can continue working
+    follow_up_task = "Look at the first post on the Reddit homepage and tell me what it's about"
+    
+    print(f"📝 Adding follow-up task: {follow_up_task}")
+    agent.add_new_task(follow_up_task)
+    
+    # Run the follow-up task
+    history2 = await agent.run()
+    
+    print(f"✅ Follow-up task completed! Success: {history2.is_successful()}")
+    print(f"📄 Result: {history2.final_result()}")
+    
+    # You could add more follow-up tasks here...
+    # agent.add_new_task("Click on the first post and read the comments")
+    # await agent.run()
+    
+    print("\n" + "="*50)
+    print("🧹 Cleaning up...")
+    print("="*50)
+    
+    # Clean up: manually kill the browser session
+    # Note: This is necessary because we set keep_alive=True
+    await browser_session.kill()
+    print("✅ Browser session closed")
+
+
+def simulate_cli_interaction():
+    """
+    This simulates what happens in the CLI interactive mode:
+    
+    1. User types: "go to reddit"
+    2. Agent runs and completes task (calls done())
+    3. Browser stays open because CLI uses keep_alive=True by default
+    4. User types: "what's the first post"
+    5. CLI calls agent.add_new_task() and agent.run() again
+    6. Agent continues with the same browser session
+    """
+    print("""
+    🖥️  CLI Simulation:
+    
+    $ browser-use
+    > go to reddit
+    [Agent works and completes task...]
+    ✅ Task completed! Browser stays open.
+    
+    > what's the first post
+    [Agent continues with same browser session...]
+    ✅ Task completed!
+    
+    > exit
+    [Browser closes]
+    """)
+
+
+if __name__ == '__main__':
+    print("🌟 Reddit Follow-up Tasks Example")
+    print("="*50)
+    print("This demonstrates the same pattern as CLI interactive mode:")
+    print("1. Complete initial task (browser stays open)")
+    print("2. Add follow-up task without restarting browser")
+    print("3. Continue working in the same session")
+    print("="*50 + "\n")
+    
+    # Show what CLI does
+    simulate_cli_interaction()
+    
+    print("🏃 Running actual example...")
+    print("-" * 30 + "\n")
+    
+    # Run the actual example
+    asyncio.run(main())


### PR DESCRIPTION
Add new examples and documentation to clarify follow-up tasks with persistent browser sessions.

While the CLI already supports follow-up tasks, the existing programmatic example was not illustrative enough. These new examples demonstrate `keep_alive=True` and `agent.add_new_task()` for building custom interactive loops and replicating the CLI's behavior.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1756061834508129?thread_ts=1756061834.508129&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-ba7163e1-bc65-4979-9bbb-3758677faf9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba7163e1-bc65-4979-9bbb-3758677faf9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

