### PR TITLE
Organize tool documentation into subpages

### DIFF
--- a/docs/customize/tools-basic.mdx
+++ b/docs/customize/tools-basic.mdx
@@ -1,0 +1,85 @@
+---
+title: "Tools Overview"
+description: "Extend default agent with custom action functions to accomplish specific tasks"
+icon: "wrench"
+mode: "wide"
+---
+
+Custom actions are functions *you* provide, that are added to our [default actions](https://github.com/browser-use/browser-use/blob/main/browser_use/controller/service.py) the agent can use to accomplish tasks.
+
+Action functions can request [arbitrary parameters](/customize/tools-parameters#action-parameters-via-pydantic-model) that the LLM has to come up with + a fixed set of [framework-provided arguments](/customize/tools-parameters#framework-provided-parameters) for browser APIs / `Agent(context=...)` / etc.
+
+<Note>
+  Our default set of actions is already quite powerful, the built-in `Controller` provides basics like `go_to_url`, `scroll_down`, `extract_content`, [and more](https://github.com/browser-use/browser-use/blob/main/browser_use/controller/service.py).
+</Note>
+
+It's easy to add your own actions to implement additional custom behaviors, integrations with other apps, or performance optimizations.
+
+For examples of custom actions (e.g. uploading files, asking a human-in-the-loop for help, drawing a polygon with the mouse, and more), see [examples/custom-functions](https://github.com/browser-use/browser-use/tree/main/examples/custom-functions).
+
+## Quick Example
+
+Here's a simple custom action that asks a human for help:
+
+```python
+from browser_use import Controller, ActionResult
+
+controller = Controller()
+
+@controller.action('Ask human for help with a question')
+def ask_human(question: str) -> ActionResult:
+    answer = input(f'{question} > ')
+    return ActionResult(extracted_content=f'The human responded with: {answer}', include_in_memory=True)
+
+# Then pass your controller to the agent to use it
+agent = Agent(
+    task='...',
+    llm=llm,
+    controller=controller,
+)
+```
+
+<Note>
+  Keep your action function names and descriptions short and concise:
+  - The LLM chooses between actions to run solely based on the function name and description
+  - The LLM decides how to fill action params based on their names, type hints, & defaults
+</Note>
+
+## What You Can Do With Custom Actions
+
+Custom actions enable you to:
+
+- **Integrate with external services** - Call APIs, databases, or other systems
+- **Add domain-specific logic** - Implement business rules or specialized workflows
+- **Optimize performance** - Create faster alternatives to default actions for specific use cases
+- **Handle file operations** - Upload, download, or process files
+- **Enable human-in-the-loop** - Ask for user input or approval when needed
+- **Access browser internals** - Use Chrome DevTools Protocol for advanced browser control
+
+## Browser Interaction Context
+
+<Note>
+Browser Use has moved from Playwright to Chrome DevTools Protocol (CDP) for browser interaction. The `browser_session` provides access to CDP through `browser_session.agent_focus.cdp_client` or `await browser_session.get_or_create_cdp_session()`. Playwright is only used internally to install the browser binary, but all browser interaction is done via CDP.
+</Note>
+
+Your custom actions can interact with the browser in several ways:
+
+- **Direct CDP access** for low-level browser control
+- **Event-based actions** for structured browser interactions  
+- **High-level browser session methods** for common operations
+
+Learn more about these approaches in the [Tools Parameters](/customize/tools-parameters) section.
+
+## Important Rules
+
+1. **Return an [`ActionResult`](https://github.com/search?q=repo%3Abrowser-use%2Fbrowser-use+%22class+ActionResult%28BaseModel%29%22&type=code)**: All actions should return an `ActionResult | str | None`. The stringified version of the result is passed back to the LLM, and optionally persisted in the long-term memory when `ActionResult(..., include_in_memory=True)`.
+
+2. **Type hints on arguments are required**: They are used to verify that action params don't conflict with special arguments injected by the controller (e.g. `browser_session`)
+
+3. **Actions functions called directly must be passed kwargs**: When calling actions from other actions or python code, you must **pass all parameters as kwargs only**, even though the actions are usually defined using positional args.
+
+## Next Steps
+
+- Learn how to [register actions and manage controllers](/customize/tools-register)
+- Explore [parameter types and patterns](/customize/tools-parameters)
+- Check out [real examples](https://github.com/browser-use/browser-use/tree/main/examples/custom-functions)

--- a/docs/customize/tools-parameters.mdx
+++ b/docs/customize/tools-parameters.mdx
@@ -1,59 +1,13 @@
 ---
-title: "Tools"
-description: "Extend default agent and write custom action functions to do certain tasks"
-icon: "wrench"
+title: "Action Parameters"
+description: "Define parameters for custom actions using function arguments or Pydantic models"
+icon: "gear"
 mode: "wide"
 ---
 
-Custom actions are functions *you* provide, that are added to our [default actions](https://github.com/browser-use/browser-use/blob/main/browser_use/controller/service.py) the agent can use to accomplish tasks.
-Action functions can request [arbitrary parameters](#action-parameters-via-pydantic-model) that the LLM has to come up with + a fixed set of [framework-provided arguments](#framework-provided-parameters) for browser APIs / `Agent(context=...)` / etc.
-
-<Note>
-  Our default set of actions is already quite powerful, the built-in `Controller` provides basics like `go_to_url`, `scroll_down`, `extract_content`, [and more](https://github.com/browser-use/browser-use/blob/main/browser_use/controller/service.py).
-</Note>
-
-It's easy to add your own actions to implement additional custom behaviors, integrations with other apps, or performance optimizations.
-
-For examples of custom actions (e.g. uploading files, asking a human-in-the-loop for help, drawing a polygon with the mouse, and more), see [examples/custom-functions](https://github.com/browser-use/browser-use/tree/main/examples/custom-functions).
-
-
-## Action Function Registration
-
-To register your own custom functions (which can be `sync` or `async`), decorate them with the `@controller.action(...)` decorator. This saves them into the `controller.registry`.
-
-```python
-from browser_use import Controller, ActionResult
-
-controller = Controller()
-
-@controller.action('Ask human for help with a question', domains=['example.com'])   # pass allowed_domains= or page_filter= to limit actions to certain pages
-def ask_human(question: str) -> ActionResult:
-    answer = input(f'{question} > ')
-    return ActionResult(extracted_content=f'The human responded with: {answer}', include_in_memory=True)
-```
-
-```python
-# Then pass your controller to the agent to use it
-agent = Agent(
-    task='...',
-    llm=llm,
-    controller=controller,
-)
-```
-
-<Note>
-  Keep your action function names and descriptions short and concise:
-  - The LLM chooses between actions to run solely based on the function name and description
-  - The LLM decides how to fill action params based on their names, type hints, & defaults
-</Note>
-
----
-
-## Action Parameters
-
 Browser Use supports two patterns for defining action parameters: normal function arguments, or a Pydantic model.
 
-### Function Arguments
+## Function Arguments
 
 For simple actions that don't need default values, you can define the action parameters directly as arguments to the function. This one takes a single string argument, `css_selector`.
 When the LLM calls an action, it sees its argument names & types, and will provide values that fit.
@@ -75,7 +29,7 @@ async def click_element(css_selector: str, browser_session: Browser) -> ActionRe
     return ActionResult(extracted_content=f"Clicked element {css_selector}")
 ```
 
-### Pydantic Model
+## Pydantic Model
 
 You can define a pydantic model for the parameters your action expects by setting a `@controller.action(..., param_model=MyParams)`.
 This allows you to use optional parameters, default values, `Annotated[...]` types with custom validation, field descriptions, and other features offered by pydantic.
@@ -85,10 +39,9 @@ When the agent calls calls your agent function, an instance of your model with t
 Using a pydantic model is helpful because it allows more flexibility and power to enforce the schema of the values the LLM should provide.
 The LLM gets the entire pydantic JSON schema for your `param_model`, it will see the function name & description + individual field names, types, descriptions, and default values.
 
-
 ```python
 from typing import Annotated
-from pydantic import BaseModel, AfterValidator
+from pydantic import BaseModel, AfterValidator, Field
 from browser_use import ActionResult
 
 class MyParams(BaseModel):
@@ -124,7 +77,7 @@ Any special framework-provided arguments (e.g. `browser_session`) will be passed
 To use a `BaseModel` the arg *must* be called `params`. Action function args are matched and filled like named arguments; arg order doesn't matter but names and types do.
 </Important>
 
-### Framework-Provided Parameters
+## Framework-Provided Parameters
 
 These special action parameters are injected by the `Controller` and are passed as extra args to any actions that expect them.
 
@@ -140,11 +93,11 @@ For example, actions that need to interact with the browser should take the `bro
 Browser Use has moved from Playwright to Chrome DevTools Protocol (CDP) for browser interaction. The `browser_session` provides access to CDP through `browser_session.agent_focus.cdp_client` or `await browser_session.get_or_create_cdp_session()`. Playwright is only used internally to install the browser binary, but all browser interaction is done via CDP.
 </Note>
 
-### Understanding the Browser Session Context
+## Understanding the Browser Session Context
 
 The `Browser` object provides multiple ways to interact with the browser:
 
-#### 1. Direct CDP Access
+### 1. Direct CDP Access
 ```python
 # Get the current CDP session
 cdp_session = await browser_session.get_or_create_cdp_session()
@@ -177,7 +130,7 @@ await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
 )
 ```
 
-#### 2. Event-Based Actions
+### 2. Event-Based Actions
 ```python
 from browser_use.browser.events import ClickElementEvent, TypeTextEvent, NavigateToUrlEvent
 
@@ -195,7 +148,7 @@ navigate_event = browser_session.event_bus.dispatch(NavigateToUrlEvent(url="http
 await navigate_event
 ```
 
-#### 3. High-Level Browser Session Methods
+### 3. High-Level Browser Session Methods
 ```python
 # Get current page information
 state = await browser_session.get_browser_state_summary()
@@ -212,7 +165,9 @@ html = await browser_session.get_page_html()
 tabs = await browser_session.get_tabs()
 ```
 
-#### Example: Action uses the current browser session
+## Browser Session Examples
+
+### Example: Basic Browser Interaction
 
 ```python
 from browser_use import Browser, Controller, ActionResult
@@ -232,7 +187,7 @@ async def input_text_into_page(text: str, browser_session: Browser) -> ActionRes
     return ActionResult(extracted_content='Text input completed')
 ```
 
-#### Example: Action uses browser session for tab management
+### Example: Tab Management
 
 ```python
 from browser_use import Browser, Controller, ActionResult
@@ -259,88 +214,84 @@ async def open_website(url: str, browser_session: Browser) -> ActionResult:
     return ActionResult(extracted_content=f'Opened new tab with url {url}')
 ```
 
+## Parameter Validation Rules
 
----
+1. **Type hints on arguments are required**: They are used to verify that action params don't conflict with special arguments injected by the controller (e.g. `browser_session`)
 
+2. **Actions functions called directly must be passed kwargs**: When calling actions from other actions or python code, you must **pass all parameters as kwargs only**, even though the actions are usually defined using positional args (for the same reasons as [pluggy](https://pluggy.readthedocs.io/en/stable/index.html#calling-hooks)).
+   Action arguments are always matched by name and type, **not** positional order, so this helps prevent ambiguity / reordering issues while keeping action signatures short.
+   ```python
+   @controller.action('Fill in the country form field')
+   async def input_country_field(country: str, browser_session: Browser) -> ActionResult:
+       await some_action(123, browser_session=browser_session)                                # ❌ not allowed: positional args, use kwarg syntax when calling
+       await some_action(abc=123, browser_session=browser_session)                            # ✅ allowed: action params & special kwargs
+       await some_other_action(params=OtherAction(abc=123), browser_session=browser_session)  # ✅ allowed: params=model & special kwargs
+   ```
 
-## Important Rules
+## Parameter Pattern Examples
 
-1. **Return an [`ActionResult`](https://github.com/search?q=repo%3Abrowser-use%2Fbrowser-use+%22class+ActionResult%28BaseModel%29%22&type=code)**: All actions should return an `ActionResult | str | None`. The stringified version of the result is passed back to the LLM, and optionally persisted in the long-term memory when `ActionResult(..., include_in_memory=True)`.
-2. **Type hints on arguments are required**: They are used to verify that action params don't conflict with special arguments injected by the controller (e.g. `browser_session`)
-3. **Actions functions called directly must be passed kwargs**: When calling actions from other actions or python code, you must **pass all parameters as kwargs only**, even though the actions are usually defined using positional args (for the same reasons as [pluggy](https://pluggy.readthedocs.io/en/stable/index.html#calling-hooks)).
-    Action arguments are always matched by name and type, **not** positional order, so this helps prevent ambiguity / reordering issues while keeping action signatures short.
-    ```python
-    @controller.action('Fill in the country form field')
-    async def input_country_field(country: str, browser_session: Browser) -> ActionResult:
-        await some_action(123, browser_session=browser_session)                                # ❌ not allowed: positional args, use kwarg syntax when calling
-        await some_action(abc=123, browser_session=browser_session)                            # ✅ allowed: action params & special kwargs
-        await some_other_action(params=OtherAction(abc=123), browser_session=browser_session)  # ✅ allowed: params=model & special kwargs
-    ```
-
+### Using Pydantic Model (Recommended)
 ```python
-# Using Pydantic Model to define action params (recommended)
 class PinCodeParams(BaseModel):
     code: int
     retries: int = 3                                               # ✅ supports optional/defaults
 
 @controller.action('...', param_model=PinCodeParams)
 async def input_pin_code(params: PinCodeParams, browser_session: Browser): ...   # ✅ special params at the end
+```
 
-# Using function arguments to define action params
+### Using Function Arguments
+```python
 async def input_pin_code(code: int, retries: int, browser_session: Browser): ... # ✅ params first, special params second, no defaults
 async def input_pin_code(code: int, retries: int=3): ...           # ✅ defaults ok only if no special params needed
 async def input_pin_code(code: int, retries: int=3, browser_session: Browser): ... # ❌ Python SyntaxError! not allowed
 ```
 
+## Advanced Parameter Patterns
 
----
-
-
-## Reusing Custom Actions Across Agents
-
-You can use the same controller for multiple agents.
+### Complex Validation with Pydantic
 
 ```python
-controller = Controller()
+from typing import Annotated, Literal
+from pydantic import BaseModel, Field, validator
 
-# ... register actions to the controller
+class SearchParams(BaseModel):
+    query: str = Field(min_length=1, description="Search query (required)")
+    category: Literal["electronics", "books", "clothing"] = Field(default="electronics")
+    price_range: tuple[float, float] = Field(default=(0.0, 1000.0))
+    
+    @validator('price_range')
+    def validate_price_range(cls, v):
+        if v[0] > v[1]:
+            raise ValueError('Min price must be less than max price')
+        return v
 
-agent = Agent(
-    task="Go to website X and find the latest news",
-    llm=llm,
-    controller=controller
-)
-
-# Run the agent
-await agent.run()
-
-agent2 = Agent(
-    task="Go to website Y and find the latest news",
-    llm=llm,
-    controller=controller
-)
-
-await agent2.run()
+@controller.action('Search products with advanced filters', param_model=SearchParams)
+async def search_products(params: SearchParams, browser_session: Browser) -> ActionResult:
+    # LLM will receive full schema including validation rules
+    ...
 ```
 
-<Note>
-  The controller is stateless and can be used to register multiple actions and
-  multiple agents.
-</Note>
+### Context-Aware Actions
 
-
-
-## Exclude functions
-
-If you want to exclude some registered actions and make them unavailable to the agent, you can do:
 ```python
-controller = Controller(exclude_actions=['search_google'])
-agent = Agent(controller=controller, ...)
+@controller.action('Process user data based on context')
+async def process_user_data(
+    user_id: str,
+    context: AgentContext,  # Access to agent context
+    browser_session: Browser
+) -> ActionResult:
+    # Use context data passed to Agent
+    if hasattr(context, 'user_permissions'):
+        if 'admin' not in context.user_permissions:
+            return ActionResult(extracted_content="Access denied")
+    
+    # Process with permissions
+    ...
 ```
 
+## Next Steps
 
-
-@controller.action('Fill out secret_form', allowed_domains=['https://*.example.com'])
-def fill_out_form(...) -> ActionResult:
-    ... will only be runnable by LLM on pages that match https://*.example.com
-```
+- Check out [real examples](https://github.com/browser-use/browser-use/tree/main/examples/custom-functions)
+- Learn about [action registration patterns](/customize/tools-register)
+- Read the [tools overview](/customize/tools-basic)

--- a/docs/customize/tools-register.mdx
+++ b/docs/customize/tools-register.mdx
@@ -1,0 +1,218 @@
+---
+title: "Action Registration"
+description: "Register custom actions, manage controllers, and configure domain restrictions"
+icon: "plus"
+mode: "wide"
+---
+
+## Action Function Registration
+
+To register your own custom functions (which can be `sync` or `async`), decorate them with the `@controller.action(...)` decorator. This saves them into the `controller.registry`.
+
+```python
+from browser_use import Controller, ActionResult
+
+controller = Controller()
+
+@controller.action('Ask human for help with a question', domains=['example.com'])   # pass allowed_domains= or page_filter= to limit actions to certain pages
+def ask_human(question: str) -> ActionResult:
+    answer = input(f'{question} > ')
+    return ActionResult(extracted_content=f'The human responded with: {answer}', include_in_memory=True)
+```
+
+```python
+# Then pass your controller to the agent to use it
+agent = Agent(
+    task='...',
+    llm=llm,
+    controller=controller,
+)
+```
+
+<Note>
+  Keep your action function names and descriptions short and concise:
+  - The LLM chooses between actions to run solely based on the function name and description
+  - The LLM decides how to fill action params based on their names, type hints, & defaults
+</Note>
+
+## Controller Management
+
+### Creating Controllers
+
+Controllers are stateless and can be reused across multiple agents:
+
+```python
+from browser_use import Controller
+
+controller = Controller()
+
+# Register multiple actions
+@controller.action('First action')
+def action_one(param: str) -> ActionResult:
+    return ActionResult(extracted_content=f"Result: {param}")
+
+@controller.action('Second action')
+def action_two(param: int) -> ActionResult:
+    return ActionResult(extracted_content=f"Number: {param}")
+```
+
+### Excluding Actions
+
+If you want to exclude some registered actions and make them unavailable to the agent, you can do:
+
+```python
+controller = Controller(exclude_actions=['search_google'])
+agent = Agent(controller=controller, ...)
+```
+
+## Reusing Custom Actions Across Agents
+
+You can use the same controller for multiple agents.
+
+```python
+controller = Controller()
+
+# ... register actions to the controller
+
+agent = Agent(
+    task="Go to website X and find the latest news",
+    llm=llm,
+    controller=controller
+)
+
+# Run the agent
+await agent.run()
+
+agent2 = Agent(
+    task="Go to website Y and find the latest news",
+    llm=llm,
+    controller=controller
+)
+
+await agent2.run()
+```
+
+<Note>
+  The controller is stateless and can be used to register multiple actions and
+  multiple agents.
+</Note>
+
+## Domain Restrictions
+
+You can restrict actions to only run on specific domains or pages using the `allowed_domains` or `page_filter` parameters:
+
+### Domain-Based Restrictions
+
+```python
+@controller.action('Fill out secret_form', allowed_domains=['https://*.example.com'])
+def fill_out_form(...) -> ActionResult:
+    # This action will only be runnable by LLM on pages that match https://*.example.com
+    ...
+```
+
+### Custom Page Filters
+
+For more complex restrictions, you can use custom page filters:
+
+```python
+def is_secure_page(url: str) -> bool:
+    return url.startswith('https://') and 'login' not in url
+
+@controller.action('Safe action', page_filter=is_secure_page)
+def safe_action(...) -> ActionResult:
+    # This action will only run on HTTPS pages without 'login' in the URL
+    ...
+```
+
+## Action Organization Best Practices
+
+### Grouping Related Actions
+
+Organize related actions together:
+
+```python
+# E-commerce actions
+@controller.action('Add item to cart')
+def add_to_cart(product_id: str, quantity: int) -> ActionResult:
+    ...
+
+@controller.action('Remove item from cart')
+def remove_from_cart(product_id: str) -> ActionResult:
+    ...
+
+@controller.action('Proceed to checkout')
+def checkout() -> ActionResult:
+    ...
+```
+
+### Using Descriptive Names
+
+Choose clear, descriptive names that help the LLM understand when to use each action:
+
+```python
+# Good: Clear and specific
+@controller.action('Extract product price from e-commerce page')
+def extract_product_price() -> ActionResult:
+    ...
+
+# Bad: Too vague
+@controller.action('Get data')
+def get_data() -> ActionResult:
+    ...
+```
+
+### Action Documentation
+
+Include helpful descriptions and type hints:
+
+```python
+@controller.action('Search for products with filters and return results')
+def search_products(
+    query: str,           # Search term
+    category: str = '',   # Optional product category
+    max_price: float = 0  # Maximum price filter (0 = no limit)
+) -> ActionResult:
+    """
+    Search for products with optional filtering.
+    Returns a list of matching products with details.
+    """
+    ...
+```
+
+## Action Registration Patterns
+
+### Simple Function Registration
+
+```python
+@controller.action('Simple action description')
+def simple_action(param: str) -> ActionResult:
+    return ActionResult(extracted_content=f"Processed: {param}")
+```
+
+### Async Function Registration
+
+```python
+@controller.action('Async action description')
+async def async_action(param: str, browser_session: Browser) -> ActionResult:
+    # Perform async operations
+    result = await some_async_operation(param)
+    return ActionResult(extracted_content=result)
+```
+
+### Registration with Domain Restrictions
+
+```python
+@controller.action(
+    'Bank-specific action',
+    allowed_domains=['https://mybank.com', 'https://*.mybank.com']
+)
+def bank_action(account_id: str) -> ActionResult:
+    # This action only works on bank domains
+    ...
+```
+
+## Next Steps
+
+- Learn about [parameter types and patterns](/customize/tools-parameters)
+- Explore [real examples](https://github.com/browser-use/browser-use/tree/main/examples/custom-functions)
+- Read about [browser session context](/customize/tools-parameters#framework-provided-parameters)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,6 +61,16 @@
                 ]
               },
               {
+                "group": "Tools",
+                "icon": "wrench",
+                "isDefaultOpen": false,
+                "pages": [
+                  "customize/tools-basic",
+                  "customize/tools-register",
+                  "customize/tools-parameters"
+                ]
+              },
+              {
                 "group": "Examples",
                 "icon": "folder-open",
                 "pages": [
@@ -71,8 +81,7 @@
                   "customize/secure",
                   "customize/more-examples"
                 ]
-              },
-              "customize/custom-functions"
+              }
             ]
           },
           {


### PR DESCRIPTION
Splits the 'Tools' documentation into subpages for better organization and consistency with existing 'Browser' and 'Agent' sections.

The original `custom-functions.mdx` was a single, large file covering multiple aspects of custom actions. This PR refactors it into three distinct pages: `tools-basic.mdx` for an overview, `tools-register.mdx` for action registration and controller management, and `tools-parameters.mdx` for detailed parameter information. This improves discoverability and readability, aligning the structure with other documentation sections.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1756190436730499?thread_ts=1756190436.730499&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-397c23bb-ba85-4142-ba1a-41f2d73c40a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-397c23bb-ba85-4142-ba1a-41f2d73c40a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Split the large Tools docs into three focused pages to improve readability and match the structure of the Browser and Agent sections. Navigation now groups these pages under a new Tools section.

- **Refactors**
  - Replaced customize/custom-functions.mdx with:
    - customize/tools-basic.mdx (overview and quick start)
    - customize/tools-register.mdx (action registration, controller reuse, domain/page filters)
    - customize/tools-parameters.mdx (function vs Pydantic params, framework-provided args, CDP-based browser session examples)
  - Clarified ActionResult returns and kwargs-only calling rule; added CDP guidance for browser interaction.
  - Updated docs.json: added Tools group with the three pages; removed customize/custom-functions from nav.

- **Migration**
  - Update links from /customize/custom-functions to:
    - /customize/tools-basic, /customize/tools-register, or /customize/tools-parameters
  - Check deep links (e.g., framework-provided-parameters, browser session context) now live under Tools Parameters.
  - No runtime or API changes.

<!-- End of auto-generated description by cubic. -->

