### PR TITLE
fix-browser-start

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1229,10 +1229,13 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			# Start browser session and attach watchdogs
 			assert self.browser_session is not None, 'Browser session must be initialized before starting'
 			self.logger.debug('🌐 Starting browser session...')
+
 			from browser_use.browser.events import BrowserStartEvent
 
 			event = self.browser_session.event_bus.dispatch(BrowserStartEvent())
 			await event
+			# Check if browser startup actually succeeded by getting the result
+			await event.event_result(raise_if_any=True, raise_if_none=False)
 
 			self.logger.debug('🔧 Browser session started with watchdogs attached')
 

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -536,11 +536,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	# Session/connection configuration
 	cdp_url: str | None = Field(default=None, description='CDP URL for connecting to existing browser instance')
-	is_local: bool = Field(default=True, description='Whether this is a local browser instance')
+	is_local: bool = Field(default=False, description='Whether this is a local browser instance')
 	# label: str = 'default'
 
 	# custom options we provide that aren't native playwright kwargs
-	stealth: bool = Field(default=False, description='Use stealth mode to avoid detection by anti-bot systems.')
 	disable_security: bool = Field(default=False, description='Disable browser security features.')
 	deterministic_rendering: bool = Field(default=False, description='Enable deterministic rendering flags.')
 	allowed_domains: list[str] | None = Field(

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -203,7 +203,6 @@ class BrowserSession(BaseModel):
 
 	# Access session fields directly, browser settings via profile or property
 	print(session.id)  # Session field
-	print(session.browser_profile.stealth)  # Direct browser_profile access
 	```
 	"""
 
@@ -219,7 +218,7 @@ class BrowserSession(BaseModel):
 		# Core configuration
 		id: str | None = None,
 		cdp_url: str | None = None,
-		is_local: bool = True,
+		is_local: bool = False,
 		browser_profile: BrowserProfile | None = None,
 		# BrowserProfile fields that can be passed directly
 		# From BrowserConnectArgs
@@ -252,7 +251,6 @@ class BrowserSession(BaseModel):
 		# From BrowserNewContextArgs
 		storage_state: str | Path | dict[str, Any] | None = None,
 		# BrowserProfile specific fields
-		stealth: bool | None = None,
 		disable_security: bool | None = None,
 		deterministic_rendering: bool | None = None,
 		allowed_domains: list[str] | None = None,
@@ -272,6 +270,10 @@ class BrowserSession(BaseModel):
 		# Following the same pattern as AgentSettings in service.py
 		# Only pass non-None values to avoid validation errors
 		profile_kwargs = {k: v for k, v in locals().items() if k not in ['self', 'browser_profile', 'id'] and v is not None}
+
+		# if is_local is False but executable_path is provided, set is_local to True
+		if is_local is False and executable_path is not None:
+			profile_kwargs['is_local'] = True
 
 		# Create browser profile from direct parameters or use provided one
 		if browser_profile is not None:

--- a/docs/customize/browser/all-parameters.mdx
+++ b/docs/customize/browser/all-parameters.mdx
@@ -7,7 +7,6 @@ mode: "wide"
 
 ## Core Settings
 - `cdp_url`: CDP URL for connecting to existing browser instance (e.g., `"http://localhost:9222"`)
-- `is_local` (default: `True`): Whether this is a local browser instance. Set to `False` for remote browsers
 
 ## Display & Appearance
 - `headless` (default: `None`): Run browser without UI. Auto-detects based on display availability (`True`/`False`/`None`)
@@ -20,7 +19,6 @@ mode: "wide"
 
 
 ## Browser Behavior
-- `stealth` (default: `False`): Use stealth techniques to avoid bot detection
 - `keep_alive` (default: `None`): Keep browser running after agent completes
 - `allowed_domains`: Restrict navigation to specific domains. Domain pattern formats:
   - `'example.com'` - Matches only `https://example.com/*`  
@@ -31,6 +29,7 @@ mode: "wide"
   - Use list like `['*.google.com', 'https://example.com', 'chrome-extension://*']`
 - `enable_default_extensions` (default: `True`): Load automation extensions (uBlock Origin, cookie handlers, ClearURLs)
 - `cross_origin_iframes` (default: `False`): Enable cross-origin iframe support (may cause complexity)
+- `is_local` (default: `True`): Whether this is a local browser instance. Set to `False` for remote browsers. If we have a `executable_path` set, it will be automatically set to `True`. This can effect your download behavior.
 
 ## User Data & Profiles
 - `user_data_dir` (default: auto-generated temp): Directory for browser profile data. Use `None` for incognito mode
@@ -90,7 +89,7 @@ mode: "wide"
 For backward compatibility, you can pass all the parameters from above to the `BrowserProfile` and then to the `Browser`.
 ```python
 from browser_use import BrowserProfile
-profile = BrowserProfile(headless=False, stealth=True)
+profile = BrowserProfile(headless=False)
 browser = Browser(browser_profile=profile)
 ```
 

--- a/docs/customize/browser/remote.mdx
+++ b/docs/customize/browser/remote.mdx
@@ -10,8 +10,7 @@ from browser_use import Agent, Browser, ChatOpenAI
 
 # Connect to remote browser
 browser = Browser(
-    cdp_url='http://remote-server:9222',
-    is_local=False,  # set to True if you want to use a local browser
+    cdp_url='http://remote-server:9222'
 )
 
 
@@ -44,8 +43,7 @@ browser = Browser(
             username="proxy-user",
             password="proxy-pass"
         )
-        cdp_url="http://remote-server:9222",
-        is_local=False  # set to True if you want to use a local browser
+        cdp_url="http://remote-server:9222"
 )
 
 

--- a/examples/browser/using_cdp.py
+++ b/examples/browser/using_cdp.py
@@ -2,11 +2,15 @@
 Simple demonstration of the CDP feature.
 
 To test this locally, follow these steps:
-1. Create a shortcut for the executable Chrome file.
-2. Add the following argument to the shortcut:
-   - On Windows: `--remote-debugging-port=9222`
-3. Open a web browser and navigate to `http://localhost:9222/json/version` to verify that the Remote Debugging Protocol (CDP) is running.
-4. Launch this example.
+1. Find the chrome executable file.
+2. On mac by default, the chrome is in `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`
+3. Add the following argument to the shortcut:
+   `--remote-debugging-port=9222`
+4. Open a web browser and navigate to `http://localhost:9222/json/version` to verify that the Remote Debugging Protocol (CDP) is running.
+5. Launch this example.
+
+Full command Mac:
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222
 
 @dev You need to set the `OPENAI_API_KEY` environment variable before proceeding.
 """
@@ -25,13 +29,7 @@ from browser_use import Agent, Tools
 from browser_use.browser import BrowserProfile, BrowserSession
 from browser_use.llm import ChatOpenAI
 
-browser_session = BrowserSession(
-	browser_profile=BrowserProfile(
-		headless=False,
-		cdp_url='http://localhost:9222',
-		is_local=False,
-	)
-)
+browser_session = BrowserSession(browser_profile=BrowserProfile(cdp_url='http://localhost:9222', is_local=True))
 tools = Tools()
 
 

--- a/tests/ci/evaluate_tasks.py
+++ b/tests/ci/evaluate_tasks.py
@@ -71,7 +71,6 @@ async def run_single_task(task_file):
 			headless=True,
 			user_data_dir=None,
 			chromium_sandbox=False,  # Disable sandbox for CI environment (GitHub Actions)
-			stealth=True,  #
 		)
 		session = BrowserSession(browser_profile=profile)
 		print('[DEBUG] Browser session created', file=sys.stderr)


### PR DESCRIPTION
Auto-generated PR for branch: fix-browser-start
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fail fast on browser startup and simplify configuration. BrowserStartEvent now raises on startup errors, is_local defaults to False with auto-detection when executable_path is set, and the deprecated stealth option is removed.

- **Bug Fixes**
  - Agent awaits BrowserStartEvent result and raises if the browser fails to start.

- **Migration**
  - Remove stealth from configs and tests (no longer supported).
  - Remote browsers: you can omit is_local (now defaults to False).
  - Local browsers: set is_local=True, or provide executable_path (auto-sets is_local to True).

<!-- End of auto-generated description by cubic. -->

