### PR TITLE
hot-fix-local-true-if-no-cdp-url

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -274,6 +274,8 @@ class BrowserSession(BaseModel):
 		# if is_local is False but executable_path is provided, set is_local to True
 		if is_local is False and executable_path is not None:
 			profile_kwargs['is_local'] = True
+		if not cdp_url:
+			profile_kwargs['is_local'] = True
 
 		# Create browser profile from direct parameters or use provided one
 		if browser_profile is not None:


### PR DESCRIPTION
Auto-generated PR for: hot-fix-local-true-if-no-cdp-url
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Default to local browser mode when no CDP URL is provided by setting profile_kwargs['is_local'] = True. This prevents remote connection attempts and fixes session startup when running without a CDP endpoint.

<!-- End of auto-generated description by cubic. -->

