### PR TITLE
Update gif.py

### DIFF
--- a/browser_use/agent/gif.py
+++ b/browser_use/agent/gif.py
@@ -245,7 +245,12 @@ def _create_task_frame(
 	else:
 		font_size = base_font_size
 
-	larger_font = ImageFont.truetype(regular_font.path, font_size)  # type: ignore
+	# Try to create a larger font, but fall back to regular font if it fails
+	try:
+		larger_font = ImageFont.truetype(regular_font.path, font_size)  # type: ignore
+	except (OSError, AttributeError):
+		# Fall back to regular font if .path is not available or font loading fails
+		larger_font = regular_font
 
 	# Generate wrapped text with the calculated font size
 	wrapped_text = _wrap_text(task, larger_font, max_width)


### PR DESCRIPTION
fixes os related font error at gif creation
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes GIF creation crashes on some OSes by adding a safe fallback when loading fonts. If loading a TrueType font fails, we now use the existing regular font.

- **Bug Fixes**
  - Catch OSError/AttributeError from ImageFont.truetype and fall back to regular_font.
  - Prevents failures when regular_font has no .path or the font cannot be loaded.

<!-- End of auto-generated description by cubic. -->

