### PR TITLE
fix: Add sensitive data placeholder names to LLM prompts

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -237,7 +237,7 @@ class MessageManager:
 		for key, value in sensitive_data.items():
 			if isinstance(value, dict):
 				# New format: {domain: {key: value}}
-				if match_url_with_domain_pattern(current_page_url, key, True):
+				if current_page_url and match_url_with_domain_pattern(current_page_url, key, True):
 					placeholders.update(value.keys())
 			else:
 				# Old format: {key: value}
@@ -271,7 +271,12 @@ class MessageManager:
 
 		# First, update the agent history items with the latest step results
 		self._update_agent_history_description(model_output, result, step_info)
-		if sensitive_data:
+
+		# Use the passed sensitive_data parameter, falling back to instance variable
+		effective_sensitive_data = sensitive_data if sensitive_data is not None else self.sensitive_data
+		if effective_sensitive_data:
+			# Update instance variable to keep it in sync
+			self.sensitive_data = effective_sensitive_data
 			self.sensitive_data_description = self._get_sensitive_data_description(browser_state_summary.url)
 
 		# Use only the current screenshot

--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -274,7 +274,7 @@ class MessageManager:
 
 		# Use the passed sensitive_data parameter, falling back to instance variable
 		effective_sensitive_data = sensitive_data if sensitive_data is not None else self.sensitive_data
-		if effective_sensitive_data:
+		if effective_sensitive_data is not None:
 			# Update instance variable to keep it in sync
 			self.sensitive_data = effective_sensitive_data
 			self.sensitive_data_description = self._get_sensitive_data_description(browser_state_summary.url)


### PR DESCRIPTION
Problem

The agent service was passing sensitive_data parameter to create_state_messages(), but the message manager was ignoring this parameter and only checking its instance variable. This meant placeholder names were never added to prompts, so the LLM didn't know what sensitive data keys were available.

Solution

Fixed parameter usage: Use the passed sensitive_data parameter instead of ignoring it
Added null safety: Prevent crashes when current_page_url is None
Enhanced prompts: LLM now receives explicit list of available placeholder keys
Impact

Before: LLM had no knowledge of available sensitive data placeholders

After: LLM gets clear guidance on available placeholders
<sensitive_data>
Here are placeholders for sensitive data:
['password', 'username']
To use them, write the placeholder name
</sensitive_data>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Pass sensitive-data placeholder names to LLM prompts and add a null check for current_page_url. The LLM now gets a clear list of available placeholder keys.

- **Bug Fixes**
  - Use the sensitive_data argument when creating state messages; fall back to the instance field and keep it in sync.
  - Add a null check before matching current_page_url to a domain.

<!-- End of auto-generated description by cubic. -->

