### PR TITLE
fix: improve StorageStateWatchdog lifecycle management

### DIFF
--- a/browser_use/browser/watchdogs/storage_state_watchdog.py
+++ b/browser_use/browser/watchdogs/storage_state_watchdog.py
@@ -12,6 +12,7 @@ from pydantic import Field, PrivateAttr
 
 from browser_use.browser.events import (
 	BrowserConnectedEvent,
+	BrowserStopEvent,
 	LoadStorageStateEvent,
 	SaveStorageStateEvent,
 	StorageStateLoadedEvent,
@@ -26,6 +27,7 @@ class StorageStateWatchdog(BaseWatchdog):
 	# Event contracts
 	LISTENS_TO: ClassVar[list[type[BaseEvent]]] = [
 		BrowserConnectedEvent,
+		BrowserStopEvent,
 		SaveStorageStateEvent,
 		LoadStorageStateEvent,
 	]
@@ -51,7 +53,12 @@ class StorageStateWatchdog(BaseWatchdog):
 		await self._start_monitoring()
 
 		# Automatically load storage state after browser start
-		self.event_bus.dispatch(LoadStorageStateEvent())
+		await self.event_bus.dispatch(LoadStorageStateEvent())
+
+	async def on_BrowserStopEvent(self, event: BrowserStopEvent) -> None:
+		"""Stop monitoring when browser stops."""
+		self.logger.debug('[StorageStateWatchdog] Stopping storage_state monitoring')
+		await self._stop_monitoring()
 
 	async def on_SaveStorageStateEvent(self, event: SaveStorageStateEvent) -> None:
 		"""Handle storage state save request."""


### PR DESCRIPTION
## Fix StorageStateWatchdog lifecycle management

### Problem
StorageStateWatchdog continues monitoring after browser closes, causing CDP connection errors in logs.

### Solution
- Add `BrowserStopEvent` handler to cleanly stop monitoring when browser closes
- Await `LoadStorageStateEvent` dispatch to ensure storage loads before navigation
- Properly cancel monitoring task to prevent post-close errors

### Impact
- No impact while `StorageStateWatchdog` is commented out in `attach_all_watchdogs()`
- No more error logs after browser session ends
- Ensures authentication/cookies are fully loaded before navigation begins