### PR TITLE
remove-efficiency-rules

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1139,23 +1139,21 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		"""Extract URL from task string using naive pattern matching."""
 		import re
 
+		# Remove email addresses from task before looking for URLs
+		task_without_emails = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', '', task)
+
 		# Look for common URL patterns
 		patterns = [
 			r'https?://[^\s<>"\']+',  # Full URLs with http/https
 			r'(?:www\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}(?:/[^\s<>"\']*)?',  # Domain names with subdomains and optional paths
 		]
 
-		# Email pattern to exclude
-		email_pattern = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
-
 		found_urls = []
 		for pattern in patterns:
-			matches = re.finditer(pattern, task)
+			matches = re.finditer(pattern, task_without_emails)
 			for match in matches:
 				url = match.group(0)
-				# Skip if this looks like an email address
-				if re.search(email_pattern, url):
-					continue
+
 				# Remove trailing punctuation that's not part of URLs
 				url = re.sub(r'[.,;:!?()\[\]]+$', '', url)
 				# Add https:// if missing

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -136,16 +136,17 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 <efficiency_guidelines>
 You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
 
-
 **Recommended Action Combinations:**
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
-- `input_text` + `input_text` → Fill form fields
-- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
+- `input_text` + `input_text` → Fill multiple form fields
+- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when the page does not navigate between clicks)
 - `scroll` with num_pages 10 + `extract_structured_data` → Scroll to the bottom of the page to load more content before extracting structured data
 - File operations + browser actions 
 
 Do not try multiple different paths in one step. Always have one clear goal per step. 
-Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, like do not use click and then go to url, because you would not see if the click was successful or not. 
+Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, e.g. 
+- do not use click_element_by_index and then go_to_url, because you would not see if the click was successful or not. 
+- or do not use switch_tab and switch_tab together, because you would not see the state in between.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -135,12 +135,17 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 <efficiency_guidelines>
 You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
 
+
 **Recommended Action Combinations:**
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
 - `input_text` + `input_text` → Fill form fields
 - `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
 - File operations + browser actions 
-Think "What's the logical sequence of actions I would do?" and group them together when safe.
+
+Do not try multiple different paths in one step. Always have one clear goal per step. 
+Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, like do not use click and then go to url, because you would not see if the click was successful or not. 
+
+Scroll allows you with num_pages to directly execute it multiple times.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -128,50 +128,19 @@ The `done` action is your opportunity to terminate and share your findings with 
 - You are allowed to use a maximum of {max_actions} actions per step.
 
 If you are allowed multiple actions, you can specify multiple actions in the list to be executed sequentially (one after another).
-- If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
+- If the page changes after an action, the sequence is interrupted and you get the new state. 
 </action_rules>
 
 
 <efficiency_guidelines>
-**IMPORTANT: Be More Efficient with Multi-Action Outputs**
+You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
 
-Maximize efficiency by combining related actions in one step instead of doing them separately:
-
-**Highly Recommended Action Combinations:**
-- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
-- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
+**Recommended Action Combinations:**
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
-- `click_element_by_index` + `input_text` → Click input field and fill it immediately
-- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
+- `input_text` + `input_text` → Fill form fields
+- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
 - File operations + browser actions 
-
-**Examples of Efficient Combinations:**
-```json
-"action": [
-  {{"click_element_by_index": {{"index": 15}}}},
-  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
-]
-```
-
-```json
-"action": [
-  {{"input_text": {{"index": 23, "text": "laptop"}}}},
-  {{"click_element_by_index": {{"index": 24}}}}
-]
-```
-
-```json
-"action": [
-  {{"go_to_url": {{"url": "https://example.com/search"}}}},
-  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
-]
-```
-
-**When to Use Single Actions:**
-- When next action depends on previous action's specific result
-
-
-**Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
+Think "What's the logical sequence of actions I would do?" and group them together when safe.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -131,6 +131,49 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 - If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
 </action_rules>
 
+
+<efficiency_guidelines>
+**IMPORTANT: Be More Efficient with Multi-Action Outputs**
+
+Maximize efficiency by combining related actions in one step instead of doing them separately:
+
+**Highly Recommended Action Combinations:**
+- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
+- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
+- `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
+- `click_element_by_index` + `input_text` → Click input field and fill it immediately
+- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
+- File operations + browser actions 
+
+**Examples of Efficient Combinations:**
+```json
+"action": [
+  {{"click_element_by_index": {{"index": 15}}}},
+  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
+]
+```
+
+```json
+"action": [
+  {{"input_text": {{"index": 23, "text": "laptop"}}}},
+  {{"click_element_by_index": {{"index": 24}}}}
+]
+```
+
+```json
+"action": [
+  {{"go_to_url": {{"url": "https://example.com/search"}}}},
+  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
+]
+```
+
+**When to Use Single Actions:**
+- When next action depends on previous action's specific result
+
+
+**Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
+</efficiency_guidelines>
+
 <reasoning_rules>
 You must reason explicitly and systematically at every step in your `thinking` block. 
 

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -140,12 +140,11 @@ You can output multiple actions in one step. Try to be efficient where it makes 
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
 - `input_text` + `input_text` → Fill form fields
 - `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
+- `scroll` with num_pages 10 + `extract_structured_data` → Scroll to the bottom of the page to load more content before extracting structured data
 - File operations + browser actions 
 
 Do not try multiple different paths in one step. Always have one clear goal per step. 
 Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, like do not use click and then go to url, because you would not see if the click was successful or not. 
-
-Scroll allows you with num_pages to directly execute it multiple times.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -131,49 +131,6 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 - If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
 </action_rules>
 
-
-<efficiency_guidelines>
-**IMPORTANT: Be More Efficient with Multi-Action Outputs**
-
-Maximize efficiency by combining related actions in one step instead of doing them separately:
-
-**Highly Recommended Action Combinations:**
-- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
-- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
-- `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
-- `click_element_by_index` + `input_text` → Click input field and fill it immediately
-- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
-- File operations + browser actions 
-
-**Examples of Efficient Combinations:**
-```json
-"action": [
-  {{"click_element_by_index": {{"index": 15}}}},
-  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
-]
-```
-
-```json
-"action": [
-  {{"input_text": {{"index": 23, "text": "laptop"}}}},
-  {{"click_element_by_index": {{"index": 24}}}}
-]
-```
-
-```json
-"action": [
-  {{"go_to_url": {{"url": "https://example.com/search"}}}},
-  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
-]
-```
-
-**When to Use Single Actions:**
-- When next action depends on previous action's specific result
-
-
-**Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
-</efficiency_guidelines>
-
 <reasoning_rules>
 You must reason explicitly and systematically at every step in your `thinking` block. 
 

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -129,16 +129,20 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 - If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
 </action_rules>
 
-
 <efficiency_guidelines>
 You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
+
 
 **Recommended Action Combinations:**
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
 - `input_text` + `input_text` → Fill form fields
 - `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
 - File operations + browser actions 
-Think "What's the logical sequence of actions I would do?" and group them together when safe.
+
+Do not try multiple different paths in one step. Always have one clear goal per step. 
+Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, like do not use click and then go to url, because you would not see if the click was successful or not. 
+
+Scroll allows you with num_pages to directly execute it multiple times.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -137,12 +137,11 @@ You can output multiple actions in one step. Try to be efficient where it makes 
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
 - `input_text` + `input_text` → Fill form fields
 - `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
+- `scroll` with num_pages 10 + `extract_structured_data` → Scroll to the bottom of the page to load more content before extracting structured data
 - File operations + browser actions 
 
 Do not try multiple different paths in one step. Always have one clear goal per step. 
 Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, like do not use click and then go to url, because you would not see if the click was successful or not. 
-
-Scroll allows you with num_pages to directly execute it multiple times.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -133,16 +133,17 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 <efficiency_guidelines>
 You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
 
-
 **Recommended Action Combinations:**
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
-- `input_text` + `input_text` → Fill form fields
-- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
+- `input_text` + `input_text` → Fill multiple form fields
+- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when the page does not navigate between clicks)
 - `scroll` with num_pages 10 + `extract_structured_data` → Scroll to the bottom of the page to load more content before extracting structured data
 - File operations + browser actions 
 
 Do not try multiple different paths in one step. Always have one clear goal per step. 
-Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, like do not use click and then go to url, because you would not see if the click was successful or not. 
+Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, e.g. 
+- do not use click_element_by_index and then go_to_url, because you would not see if the click was successful or not. 
+- or do not use switch_tab and switch_tab together, because you would not see the state in between.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -129,48 +129,6 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 - If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
 </action_rules>
 
-
-<efficiency_guidelines>
-**IMPORTANT: Be More Efficient with Multi-Action Outputs**
-
-Maximize efficiency by combining related actions in one step instead of doing them separately:
-
-**Highly Recommended Action Combinations:**
-- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
-- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
-- `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
-- `click_element_by_index` + `input_text` → Click input field and fill it immediately
-- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
-- File operations + browser actions 
-
-**Examples of Efficient Combinations:**
-```json
-"action": [
-  {{"click_element_by_index": {{"index": 15}}}},
-  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
-]
-```
-
-```json
-"action": [
-  {{"input_text": {{"index": 23, "text": "laptop"}}}},
-  {{"click_element_by_index": {{"index": 24}}}}
-]
-```
-
-```json
-"action": [
-  {{"go_to_url": {{"url": "https://example.com/search"}}}},
-  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
-]
-```
-
-**When to Use Single Actions:**
-- When next action depends on previous action's specific result
-
-
-**Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
-</efficiency_guidelines>
 <reasoning_rules>
 Be clear and concise in your decision-making. Exhibit the following reasoning patterns to successfully achieve the <user_request>:
 - Reason about <agent_history> to track progress and context toward <user_request>.

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -129,6 +129,48 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 - If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
 </action_rules>
 
+
+<efficiency_guidelines>
+**IMPORTANT: Be More Efficient with Multi-Action Outputs**
+
+Maximize efficiency by combining related actions in one step instead of doing them separately:
+
+**Highly Recommended Action Combinations:**
+- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
+- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
+- `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
+- `click_element_by_index` + `input_text` → Click input field and fill it immediately
+- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
+- File operations + browser actions 
+
+**Examples of Efficient Combinations:**
+```json
+"action": [
+  {{"click_element_by_index": {{"index": 15}}}},
+  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
+]
+```
+
+```json
+"action": [
+  {{"input_text": {{"index": 23, "text": "laptop"}}}},
+  {{"click_element_by_index": {{"index": 24}}}}
+]
+```
+
+```json
+"action": [
+  {{"go_to_url": {{"url": "https://example.com/search"}}}},
+  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
+]
+```
+
+**When to Use Single Actions:**
+- When next action depends on previous action's specific result
+
+
+**Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
+</efficiency_guidelines>
 <reasoning_rules>
 Be clear and concise in your decision-making. Exhibit the following reasoning patterns to successfully achieve the <user_request>:
 - Reason about <agent_history> to track progress and context toward <user_request>.

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -131,46 +131,16 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 
 
 <efficiency_guidelines>
-**IMPORTANT: Be More Efficient with Multi-Action Outputs**
+You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
 
-Maximize efficiency by combining related actions in one step instead of doing them separately:
-
-**Highly Recommended Action Combinations:**
-- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
-- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
+**Recommended Action Combinations:**
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
-- `click_element_by_index` + `input_text` → Click input field and fill it immediately
-- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
+- `input_text` + `input_text` → Fill form fields
+- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
 - File operations + browser actions 
-
-**Examples of Efficient Combinations:**
-```json
-"action": [
-  {{"click_element_by_index": {{"index": 15}}}},
-  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
-]
-```
-
-```json
-"action": [
-  {{"input_text": {{"index": 23, "text": "laptop"}}}},
-  {{"click_element_by_index": {{"index": 24}}}}
-]
-```
-
-```json
-"action": [
-  {{"go_to_url": {{"url": "https://example.com/search"}}}},
-  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
-]
-```
-
-**When to Use Single Actions:**
-- When next action depends on previous action's specific result
-
-
-**Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
+Think "What's the logical sequence of actions I would do?" and group them together when safe.
 </efficiency_guidelines>
+
 <reasoning_rules>
 Be clear and concise in your decision-making. Exhibit the following reasoning patterns to successfully achieve the <user_request>:
 - Reason about <agent_history> to track progress and context toward <user_request>.

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -139,12 +139,11 @@ You can output multiple actions in one step. Try to be efficient where it makes 
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
 - `input_text` + `input_text` → Fill form fields
 - `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
+- `scroll` with num_pages 10 + `extract_structured_data` → Scroll to the bottom of the page to load more content before extracting structured data
 - File operations + browser actions 
 
 Do not try multiple different paths in one step. Always have one clear goal per step. 
 Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, like do not use click and then go to url, because you would not see if the click was successful or not. 
-
-Scroll allows you with num_pages to directly execute it multiple times.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -131,47 +131,6 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 - If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
 </action_rules>
 
-<efficiency_guidelines>
-**IMPORTANT: Be More Efficient with Multi-Action Outputs**
-
-Maximize efficiency by combining related actions in one step instead of doing them separately:
-
-**Highly Recommended Action Combinations:**
-- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
-- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
-- `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
-- `click_element_by_index` + `input_text` → Click input field and fill it immediately
-- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
-- File operations + browser actions 
-
-**Examples of Efficient Combinations:**
-```json
-"action": [
-  {{"click_element_by_index": {{"index": 15}}}},
-  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
-]
-```
-
-```json
-"action": [
-  {{"input_text": {{"index": 23, "text": "laptop"}}}},
-  {{"click_element_by_index": {{"index": 24}}}}
-]
-```
-
-```json
-"action": [
-  {{"go_to_url": {{"url": "https://example.com/search"}}}},
-  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
-]
-```
-
-**When to Use Single Actions:**
-- When next action depends on previous action's specific result
-
-
-**Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
-</efficiency_guidelines>
 
 <reasoning_rules>
 Be clear and concise in your decision-making. Exhibit the following reasoning patterns to successfully achieve the <user_request>:

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -135,16 +135,17 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 <efficiency_guidelines>
 You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
 
-
 **Recommended Action Combinations:**
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
-- `input_text` + `input_text` → Fill form fields
-- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
+- `input_text` + `input_text` → Fill multiple form fields
+- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when the page does not navigate between clicks)
 - `scroll` with num_pages 10 + `extract_structured_data` → Scroll to the bottom of the page to load more content before extracting structured data
 - File operations + browser actions 
 
 Do not try multiple different paths in one step. Always have one clear goal per step. 
-Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, like do not use click and then go to url, because you would not see if the click was successful or not. 
+Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, e.g. 
+- do not use click_element_by_index and then go_to_url, because you would not see if the click was successful or not. 
+- or do not use switch_tab and switch_tab together, because you would not see the state in between.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -132,45 +132,14 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 </action_rules>
 
 <efficiency_guidelines>
-**IMPORTANT: Be More Efficient with Multi-Action Outputs**
+You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
 
-Maximize efficiency by combining related actions in one step instead of doing them separately:
-
-**Highly Recommended Action Combinations:**
-- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
-- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
+**Recommended Action Combinations:**
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
-- `click_element_by_index` + `input_text` → Click input field and fill it immediately
-- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
+- `input_text` + `input_text` → Fill form fields
+- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
 - File operations + browser actions 
-
-**Examples of Efficient Combinations:**
-```json
-"action": [
-  {{"click_element_by_index": {{"index": 15}}}},
-  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
-]
-```
-
-```json
-"action": [
-  {{"input_text": {{"index": 23, "text": "laptop"}}}},
-  {{"click_element_by_index": {{"index": 24}}}}
-]
-```
-
-```json
-"action": [
-  {{"go_to_url": {{"url": "https://example.com/search"}}}},
-  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
-]
-```
-
-**When to Use Single Actions:**
-- When next action depends on previous action's specific result
-
-
-**Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
+Think "What's the logical sequence of actions I would do?" and group them together when safe.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -134,12 +134,17 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 <efficiency_guidelines>
 You can output multiple actions in one step. Try to be efficient where it makes sense. Do not predict actions which do not make sense for the current page.
 
+
 **Recommended Action Combinations:**
 - `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
 - `input_text` + `input_text` → Fill form fields
 - `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows
 - File operations + browser actions 
-Think "What's the logical sequence of actions I would do?" and group them together when safe.
+
+Do not try multiple different paths in one step. Always have one clear goal per step. 
+Its important that you see in the next step if your action was successful, so do not chain actions which change the browser state multiple times, like do not use click and then go to url, because you would not see if the click was successful or not. 
+
+Scroll allows you with num_pages to directly execute it multiple times.
 </efficiency_guidelines>
 
 <reasoning_rules>

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -131,6 +131,47 @@ If you are allowed multiple actions, you can specify multiple actions in the lis
 - If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.
 </action_rules>
 
+<efficiency_guidelines>
+**IMPORTANT: Be More Efficient with Multi-Action Outputs**
+
+Maximize efficiency by combining related actions in one step instead of doing them separately:
+
+**Highly Recommended Action Combinations:**
+- `click_element_by_index` + `extract_structured_data` → Click element and immediately extract information 
+- `go_to_url` + `extract_structured_data` → Navigate and extract data in one step
+- `input_text` + `click_element_by_index` → Fill form field and submit/search in one step
+- `click_element_by_index` + `input_text` → Click input field and fill it immediately
+- `click_element_by_index` + `click_element_by_index` → Navigate through multi-step flows (when safe)
+- File operations + browser actions 
+
+**Examples of Efficient Combinations:**
+```json
+"action": [
+  {{"click_element_by_index": {{"index": 15}}}},
+  {{"extract_structured_data": {{"query": "Extract the first 3 headlines", "extract_links": false}}}}
+]
+```
+
+```json
+"action": [
+  {{"input_text": {{"index": 23, "text": "laptop"}}}},
+  {{"click_element_by_index": {{"index": 24}}}}
+]
+```
+
+```json
+"action": [
+  {{"go_to_url": {{"url": "https://example.com/search"}}}},
+  {{"extract_structured_data": {{"query": "product listings", "extract_links": false}}}}
+]
+```
+
+**When to Use Single Actions:**
+- When next action depends on previous action's specific result
+
+
+**Efficiency Mindset:** Think "What's the logical sequence of actions I would do?" and group them together when safe.
+</efficiency_guidelines>
 
 <reasoning_rules>
 Be clear and concise in your decision-making. Exhibit the following reasoning patterns to successfully achieve the <user_request>:

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -759,11 +759,11 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 				'id': 'cjpalhdlnbpafiamejdnhcphjbkeiagm',
 				'url': 'https://clients2.google.com/service/update2/crx?response=redirect&prodversion=130&acceptformat=crx3&x=id%3Dcjpalhdlnbpafiamejdnhcphjbkeiagm%26uc',
 			},
-			{
-				'name': "I still don't care about cookies",
-				'id': 'edibdbjcniadpccecjdfdjjppcpchdlm',
-				'url': 'https://clients2.google.com/service/update2/crx?response=redirect&prodversion=130&acceptformat=crx3&x=id%3Dedibdbjcniadpccecjdfdjjppcpchdlm%26uc',
-			},
+			# {
+			# 	'name': "I still don't care about cookies",
+			# 	'id': 'edibdbjcniadpccecjdfdjjppcpchdlm',
+			# 	'url': 'https://clients2.google.com/service/update2/crx?response=redirect&prodversion=130&acceptformat=crx3&x=id%3Dedibdbjcniadpccecjdfdjjppcpchdlm%26uc',
+			# },
 			{
 				'name': 'ClearURLs',
 				'id': 'lckanjgmijmafbedllaakclkaicjfmnk',
@@ -774,11 +774,11 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			# 	'id': 'pgojnojmmhpofjgdmaebadhbocahppod',
 			# 	'url': 'https://clients2.google.com/service/update2/crx?response=redirect&prodversion=130&acceptformat=crx3&x=id%3Dpgojnojmmhpofjgdmaebadhbocahppod%26uc',
 			# },
-			# {
-			# 	'name': 'Consent-O-Matic',
-			# 	'id': 'mdjildafknihdffpkfmmpnpoiajfjnjd',
-			# 	'url': 'https://clients2.google.com/service/update2/crx?response=redirect&prodversion=130&acceptformat=crx3&x=id%3Dmdjildafknihdffpkfmmpnpoiajfjnjd%26uc',
-			# },
+			{
+				'name': 'Consent-O-Matic',
+				'id': 'mdjildafknihdffpkfmmpnpoiajfjnjd',
+				'url': 'https://clients2.google.com/service/update2/crx?response=redirect&prodversion=130&acceptformat=crx3&x=id%3Dmdjildafknihdffpkfmmpnpoiajfjnjd%26uc',
+			},
 			# {
 			# 	'name': 'Privacy | Protect Your Payments',
 			# 	'id': 'hmgpakheknboplhmlicfkkgjipfabmhp',

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -850,7 +850,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			if not bg_path.exists():
 				return
 
-			with open(bg_path, 'r', encoding='utf-8') as f:
+			with open(bg_path, encoding='utf-8') as f:
 				content = f.read()
 
 			# Create the whitelisted domains object for JavaScript with proper indentation

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -268,6 +268,7 @@ class BrowserSession(BaseModel):
 		filter_highlight_ids: bool | None = None,
 		auto_download_pdfs: bool | None = None,
 		profile_directory: str | None = None,
+		cookie_whitelist_domains: list[str] | None = None,
 	):
 		# Following the same pattern as AgentSettings in service.py
 		# Only pass non-None values to avoid validation errors

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -255,16 +255,16 @@ class DOMWatchdog(BaseWatchdog):
 			# Get target title safely
 			try:
 				self.logger.debug('🔍 DOMWatchdog.on_BrowserStateRequestEvent: Getting page title...')
-				title = await asyncio.wait_for(self.browser_session.get_current_page_title(), timeout=2.0)
+				title = await asyncio.wait_for(self.browser_session.get_current_page_title(), timeout=1.0)
 				self.logger.debug(f'🔍 DOMWatchdog.on_BrowserStateRequestEvent: Got title: {title}')
 			except Exception as e:
 				self.logger.debug(f'🔍 DOMWatchdog.on_BrowserStateRequestEvent: Failed to get title: {e}')
 				title = 'Page'
 
-			# Get comprehensive page info from CDP
+			# Get comprehensive page info from CDP with timeout
 			try:
 				self.logger.debug('🔍 DOMWatchdog.on_BrowserStateRequestEvent: Getting page info from CDP...')
-				page_info = await self._get_page_info()
+				page_info = await asyncio.wait_for(self._get_page_info(), timeout=1.0)
 				self.logger.debug(f'🔍 DOMWatchdog.on_BrowserStateRequestEvent: Got page info from CDP: {page_info}')
 			except Exception as e:
 				self.logger.debug(

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -263,7 +263,7 @@ class Tools(Generic[Context]):
 		# Element Interaction Actions
 
 		@self.registry.action(
-			'Click element by index. Only indices from your browser_state are allowed. Never use and index that is not inside your current browser_state. Set while_holding_ctrl=True to open any resulting navigation in a new tab.',
+			'Click element by index. Only indices from your browser_state are allowed. Never use an index that is not inside your current browser_state. Set while_holding_ctrl=True to open any resulting navigation in a new tab.',
 			param_model=ClickElementAction,
 		)
 		async def click_element_by_index(params: ClickElementAction, browser_session: BrowserSession):

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -263,7 +263,7 @@ class Tools(Generic[Context]):
 		# Element Interaction Actions
 
 		@self.registry.action(
-			'Click element by index, set while_holding_ctrl=True to open any resulting navigation in a new tab. Only click on indices that are inside your current browser_state. Never click or assume not existing indices.',
+			'Click element by index. Only indices from your browser_state are allowed. Never use and index that is not inside your current browser_state. Set while_holding_ctrl=True to open any resulting navigation in a new tab.',
 			param_model=ClickElementAction,
 		)
 		async def click_element_by_index(params: ClickElementAction, browser_session: BrowserSession):
@@ -314,7 +314,7 @@ class Tools(Generic[Context]):
 				return ActionResult(error=error_msg)
 
 		@self.registry.action(
-			'Click and input text into a input interactive element. Only input text into indices that are inside your current browser_state. Never input text into indices that are not inside your current browser_state.',
+			'Input text into an input interactive element. Only input text into indices that are inside your current browser_state. Never input text into indices that are not inside your current browser_state.',
 			param_model=InputTextAction,
 		)
 		async def input_text(params: InputTextAction, browser_session: BrowserSession, has_sensitive_data: bool = False):

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -647,8 +647,8 @@ Provide the extracted information in a clear, structured format."""
 				raise RuntimeError(str(e))
 
 		@self.registry.action(
-			"""Scroll the page by specified number of pages (set down=True to scroll down, down=False to scroll up, num_pages=number of pages to scroll like 0.5 for half page, 3.0 for three pages, etc.). Optional index parameter to scroll within a specific element or its scroll container (works well for dropdowns and custom UI components). Don't use index to scroll the entire page.
-			Instead of scrolling multiple step after step, use a high number of pages at once like 10 to get to the bottom of the page.
+			"""Scroll the page by specified number of pages (set down=True to scroll down, down=False to scroll up, num_pages=number of pages to scroll like 0.5 for half page, 10.0 for ten pages, etc.). Optional index parameter to scroll within a specific element or its scroll container (works well for dropdowns and custom UI components). If you want to scroll the entire page, don't use index.
+			Instead of scrolling step after step, use a high number of pages at once like 10 to get to the bottom of the page.
 			""",
 			param_model=ScrollAction,
 		)

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -647,7 +647,9 @@ Provide the extracted information in a clear, structured format."""
 				raise RuntimeError(str(e))
 
 		@self.registry.action(
-			'Scroll the page by specified number of pages (set down=True to scroll down, down=False to scroll up, num_pages=number of pages to scroll like 0.5 for half page, 1.0 for one page, etc.). Optional index parameter to scroll within a specific element or its scroll container (works well for dropdowns and custom UI components). Use index=0 or omit index to scroll the entire page.',
+			"""Scroll the page by specified number of pages (set down=True to scroll down, down=False to scroll up, num_pages=number of pages to scroll like 0.5 for half page, 3.0 for three pages, etc.). Optional index parameter to scroll within a specific element or its scroll container (works well for dropdowns and custom UI components). Don't use index to scroll the entire page.
+			Instead of scrolling multiple step after step, use a high number of pages at once like 10 to get to the bottom of the page.
+			""",
 			param_model=ScrollAction,
 		)
 		async def scroll(params: ScrollAction, browser_session: BrowserSession):


### PR DESCRIPTION
Auto-generated PR for branch: remove-efficiency-rules
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Streamlined efficiency guidelines and action docs to make multi‑action steps safer and clearer. Fixed URL detection by stripping emails before matching, and improved scroll guidance to prefer larger jumps and omit index for full‑page scrolling.

- **Bug Fixes**
  - Remove emails from task text before URL matching to prevent false positives.

- **Refactors**
  - Simplified efficiency_guidelines in all prompts; added clear do/don’t for chaining and updated recommended combos (including scroll + extract).
  - Clarified click_element_by_index and input_text descriptions to only allow indices from the current browser_state.
  - Updated scroll action docs to favor high num_pages (e.g., 10) and to omit index when scrolling the entire page.

<!-- End of auto-generated description by cubic. -->

