### PR TITLE
Re-enable auto download pdfs

### DIFF
--- a/examples/file_system/alphabet_earnings.py
+++ b/examples/file_system/alphabet_earnings.py
@@ -6,23 +6,12 @@ import shutil
 from dotenv import load_dotenv
 
 from browser_use import Agent, ChatOpenAI
-from browser_use.browser import BrowserProfile, BrowserSession
 
 load_dotenv()
 
-''
 SCRIPT_DIR = pathlib.Path(os.path.dirname(os.path.abspath(__file__)))
 agent_dir = SCRIPT_DIR / 'alphabet_earnings'
 agent_dir.mkdir(exist_ok=True)
-
-
-llm = ChatOpenAI(
-	model='o4-mini',
-)
-
-browser_session = BrowserSession(
-	browser_profile=BrowserProfile(downloads_path=str(agent_dir / 'downloads')),
-)
 
 task = """
 Go to https://abc.xyz/assets/cc/27/3ada14014efbadd7a58472f1f3f4/2025q2-alphabet-earnings-release.pdf.
@@ -31,16 +20,15 @@ Read the PDF and save 3 interesting data points in "alphabet_earnings.pdf" and s
 
 agent = Agent(
 	task=task,
-	llm=llm,
-	browser_session=browser_session,
+	llm=ChatOpenAI(model='o4-mini'),
 	file_system_path=str(agent_dir / 'fs'),
 	flash_mode=True,
 )
 
 
 async def main():
-	agent_history = await agent.run()
-	input('Press Enter to clean the file system...')
+	await agent.run()
+	input(f'Press Enter to clean the file system at {agent_dir}...')
 	# clean the file system
 	shutil.rmtree(str(agent_dir / 'fs'))
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Re-enabled automatic PDF downloads by default and switched downloads to a unique, pre-created directory under /tmp. Updated the Alphabet earnings example to rely on the default browser profile for simpler setup.

- **New Features**
  - auto_download_pdfs now defaults to true.
  - Downloads path is created as /tmp/browser-use-downloads-<uuid>, ensured unique and created upfront.

<!-- End of auto-generated description by cubic. -->

