### PR TITLE
disable highlights by default

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -596,7 +596,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	# --- UI/viewport/DOM ---
 
-	highlight_elements: bool = Field(default=True, description='Highlight interactive elements on the page.')
+	highlight_elements: bool = Field(default=False, description='Highlight interactive elements on the page.')
 	filter_highlight_ids: bool = Field(
 		default=True, description='Only show element IDs in highlights if llm_representation is less than 10 characters.'
 	)

--- a/docs/customize/browser/all-parameters.mdx
+++ b/docs/customize/browser/all-parameters.mdx
@@ -61,7 +61,7 @@ mode: "wide"
 - `wait_between_actions` (default: `0.5`): Time to wait between agent actions in seconds
 
 ## AI Integration
-- `highlight_elements` (default: `True`): Highlight interactive elements for AI vision
+- `highlight_elements` (default: `False`): Highlight interactive elements for AI vision
 
 ## Downloads & Files
 - `accept_downloads` (default: `True`): Automatically accept all downloads


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Disable element highlights by default to reduce visual noise and make the UI cleaner. Updated BrowserProfile.highlight_elements default to False and synced the docs.

- **Migration**
  - If you relied on highlights, explicitly set highlight_elements=True in BrowserProfile or your config.
  - No other changes required.

<!-- End of auto-generated description by cubic. -->

