### PR TITLE
smaller-highlights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,4 @@ token.json
 
 temp-profile-*
 
-*.png
+screenshot.png

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ token.json
 
 
 temp-profile-*
+
+*.png

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -66,8 +66,8 @@ Note that:
 </browser_state>
 
 <browser_vision>
-You will be optionally provided with a screenshot of the browser with bounding boxes. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
-Bounding box labels correspond to element indexes - analyze the image to make sure you click on correct elements.
+You will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
+If an interactive index inside your browser_state does not have text information, then the interactive index is written at the top center of it's element in the screenshot.
 </browser_vision>
 
 <browser_rules>

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -64,8 +64,8 @@ Note that:
 </browser_state>
 
 <browser_vision>
-You will be optionally provided with a screenshot of the browser with bounding boxes. This is your GROUND TRUTH: analyze the image to evaluate your progress.
-Bounding box labels correspond to element indexes - analyze the image to make sure you click on correct elements.
+You will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
+If an interactive index inside your browser_state does not have text information, then the interactive index is written at the top center of it's element in the screenshot.
 </browser_vision>
 
 <browser_rules>

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -66,8 +66,8 @@ Note that:
 </browser_state>
 
 <browser_vision>
-You will be optionally provided with a screenshot of the browser with bounding boxes. This is your GROUND TRUTH: analyze the image to evaluate your progress.
-Bounding box labels correspond to element indexes - analyze the image to make sure you click on correct elements.
+You will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
+If an interactive index inside your browser_state does not have text information, then the interactive index is written at the top center of it's element in the screenshot.
 </browser_vision>
 
 <browser_rules>

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -596,7 +596,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	# --- UI/viewport/DOM ---
 
-	highlight_elements: bool = Field(default=False, description='Highlight interactive elements on the page.')
+	highlight_elements: bool = Field(default=True, description='Highlight interactive elements on the page.')
 	filter_highlight_ids: bool = Field(
 		default=True, description='Only show element IDs in highlights if llm_representation is less than 10 characters.'
 	)

--- a/browser_use/browser/python_highlights.py
+++ b/browser_use/browser/python_highlights.py
@@ -481,10 +481,13 @@ async def create_highlighted_screenshot_async(
 	filename = os.getenv('BROWSER_USE_SCREENSHOT_FILE')
 	if filename:
 
-		async def _write_screenshot():
-			with open(filename, 'wb') as f:
-				f.write(base64.b64decode(final_screenshot))
-			logger.debug('Saved screenshot to ' + str(filename))
+		def _write_screenshot():
+			try:
+				with open(filename, 'wb') as f:
+					f.write(base64.b64decode(final_screenshot))
+				logger.debug('Saved screenshot to ' + str(filename))
+			except Exception as e:
+				logger.warning(f'Failed to save screenshot to {filename}: {e}')
 
 		await asyncio.to_thread(_write_screenshot)
 	return final_screenshot

--- a/browser_use/browser/python_highlights.py
+++ b/browser_use/browser/python_highlights.py
@@ -342,7 +342,7 @@ def process_element_highlight(
 				# Use the meaningful text that matches what the LLM sees
 				meaningful_text = element.get_meaningful_text_for_llm()
 				# Show ID only if meaningful text is less than 5 characters
-				if len(meaningful_text) < 5:
+				if len(meaningful_text) < 3:
 					index_text = str(element_index)
 			else:
 				# Always show ID when filter is disabled

--- a/browser_use/browser/python_highlights.py
+++ b/browser_use/browser/python_highlights.py
@@ -95,8 +95,8 @@ def draw_enhanced_bounding_box_with_text(
 		try:
 			# Scale font size based on image dimensions for consistent appearance across viewports
 			img_width, img_height = image_size
-			# Base font size scales with viewport width (36px for 1200px viewport)
-			base_font_size = max(16, min(48, int(img_width * 0.03)))  # 3% of viewport width
+			# Base font size scales with viewport width (24px for 1200px viewport) - smaller numbers
+			base_font_size = max(12, min(32, int(img_width * 0.02)))  # 2% of viewport width
 			big_font = None
 			try:
 				big_font = ImageFont.truetype('/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf', base_font_size)
@@ -121,8 +121,8 @@ def draw_enhanced_bounding_box_with_text(
 				text_width = bbox_text[2] - bbox_text[0]
 				text_height = bbox_text[3] - bbox_text[1]
 
-			# Scale padding based on viewport size for consistent appearance
-			padding = max(4, int(img_width * 0.005))  # 0.5% of viewport width
+			# Scale padding based on viewport size for consistent appearance - reduced for tighter fit
+			padding = max(2, int(img_width * 0.002))  # 0.2% of viewport width - smaller padding
 			element_width = x2 - x1
 			element_height = y2 - y1
 

--- a/browser_use/browser/python_highlights.py
+++ b/browser_use/browser/python_highlights.py
@@ -131,15 +131,17 @@ def draw_enhanced_bounding_box_with_text(
 			container_width = text_width + padding * 2
 			container_height = text_height + padding * 2
 
-			# Position in top-left corner (inside if fits, outside if too small)
-			if element_width >= container_width and element_height >= container_height:
-				# Place inside top-left corner
-				bg_x1 = x1 + 2  # Small offset from edge
-				bg_y1 = y1 + 2
+			# Position in top center - for small elements, place further up to avoid blocking content
+			# Center horizontally within the element
+			bg_x1 = x1 + (element_width - container_width) // 2
+
+			# Simple rule: if element is small, place index further up to avoid blocking icons
+			if element_width < 60 or element_height < 30:
+				# Small element: place well above to avoid blocking content
+				bg_y1 = max(0, y1 - container_height - 5)
 			else:
-				# Place outside top-left corner
-				bg_x1 = x1
-				bg_y1 = max(0, y1 - container_height)
+				# Regular element: place inside with small offset
+				bg_y1 = y1 + 2
 
 			bg_x2 = bg_x1 + container_width
 			bg_y2 = bg_y1 + container_height
@@ -482,7 +484,7 @@ async def create_highlighted_screenshot_async(
 		async def _write_screenshot():
 			with open(filename, 'wb') as f:
 				f.write(base64.b64decode(final_screenshot))
-			logger.debug('Saved screenshot to screenshot.png')
+			logger.debug('Saved screenshot to ' + str(filename))
 
 		await asyncio.to_thread(_write_screenshot)
 	return final_screenshot

--- a/docs/customize/browser/all-parameters.mdx
+++ b/docs/customize/browser/all-parameters.mdx
@@ -61,7 +61,7 @@ mode: "wide"
 - `wait_between_actions` (default: `0.5`): Time to wait between agent actions in seconds
 
 ## AI Integration
-- `highlight_elements` (default: `False`): Highlight interactive elements for AI vision
+- `highlight_elements` (default: `True`): Highlight interactive elements for AI vision
 
 ## Downloads & Files
 - `accept_downloads` (default: `True`): Automatically accept all downloads

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,7 +1,7 @@
 from browser_use import Agent, ChatOpenAI
 
 agent = Agent(
-	task='Find founders of browser-use',
+	task='Give me a csv of 20 collage football games season 2025 ',
 	llm=ChatOpenAI(model='gpt-4.1-mini'),
 )
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,7 +1,7 @@
 from browser_use import Agent, ChatOpenAI
 
 agent = Agent(
-	task='Give me a csv of 20 collage football games season 2025 ',
+	task='Find founders of browser-use',
 	llm=ChatOpenAI(model='gpt-4.1-mini'),
 )
 


### PR DESCRIPTION
Auto-generated PR for branch: smaller-highlights
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make highlight index boxes a fixed, smaller size across viewports and add an opt-in, async screenshot save path.

- New Features
  - Save highlighted screenshot when BROWSER_USE_SCREENSHOT_FILE is set; file write runs off-thread.

- Refactors
  - Fixed font size (20) and padding (10) for index overlays for a consistent look.
  - Add *.png to .gitignore and update example task text.

<!-- End of auto-generated description by cubic. -->

