### PR TITLE
reduce frequency_penalty

### DIFF
--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -196,7 +196,7 @@ Here are examples of good output patterns. Use them as reference but never copy 
 </memory_examples>
 
 <next_goal_examples>
-"next_goal": "Click on the 'Add to Cart' button (index 23) to proceed with the purchase flow."
+"next_goal": "Click on the 'Add to Cart' button to proceed with the purchase flow."
 "next_goal": "Extract details from the first item on the page."
 </next_goal_examples>
 </examples>

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -193,7 +193,7 @@ Here are examples of good output patterns. Use them as reference but never copy 
 </memory_examples>
 
 <next_goal_examples>
-"next_goal": "Click on the 'Add to Cart' button (index 23) to proceed with the purchase flow."
+"next_goal": "Click on the 'Add to Cart' button to proceed with the purchase flow."
 "next_goal": "Extract details from the first item on the page."
 </next_goal_examples>
 </examples>

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1349,7 +1349,6 @@ class BrowserSession(BaseModel):
 		except Exception as e:
 			self.logger.debug(f'Skipping proxy auth setup: {type(e).__name__}: {e}')
 
-	@observe_debug(ignore_input=True, ignore_output=True, name='get_tabs')
 	async def get_tabs(self) -> list[TabInfo]:
 		"""Get information about all open tabs using CDP Target.getTargetInfo for speed."""
 		tabs = []

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -455,7 +455,6 @@ class DOMWatchdog(BaseWatchdog):
 		elapsed = time.time() - start_time
 		self.logger.debug(f'✅ Page stability wait completed in {elapsed:.2f}s')
 
-	@observe_debug(ignore_input=True, ignore_output=True, name='get_page_info')
 	async def _get_page_info(self) -> 'PageInfo':
 		"""Get comprehensive page information using a single CDP call.
 

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -47,7 +47,7 @@ class ChatOpenAI(BaseChatModel):
 
 	# Model params
 	temperature: float | None = 0.2
-	frequency_penalty: float | None = 0.3  # this avoids infinite generation of \t for models like 4.1-mini
+	frequency_penalty: float | None = 0.15  # this avoids infinite generation of \t for models like 4.1-mini
 	reasoning_effort: ReasoningEffort = 'low'
 	seed: int | None = None
 	service_tier: Literal['auto', 'default', 'flex', 'priority', 'scale'] | None = None


### PR DESCRIPTION
Auto-generated PR for: reduce frequency_penalty
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Lowered the model’s frequency_penalty to 0.15 to allow necessary repetition while still preventing runaway repeats, and cleaned up prompts and debug tracing for less noise.

- **Refactors**
  - Reduce ChatOpenAI frequency_penalty from 0.3 → 0.15 to balance repetition control.
  - Remove hardcoded index from next_goal prompt examples.
  - Drop observe_debug decorators from get_tabs and _get_page_info to cut trace noise.

<!-- End of auto-generated description by cubic. -->

