### PR TITLE
reduce-frequency_penalty-more

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -46,8 +46,8 @@ class ChatOpenAI(BaseChatModel):
 	model: ChatModel | str
 
 	# Model params
-	temperature: float | None = 0.2
-	frequency_penalty: float | None = 0.15  # this avoids infinite generation of \t for models like 4.1-mini
+	temperature: float | None = 0.1
+	frequency_penalty: float | None = 0.05  # this avoids infinite generation of \t for models like 4.1-mini
 	reasoning_effort: ReasoningEffort = 'low'
 	seed: int | None = None
 	service_tier: Literal['auto', 'default', 'flex', 'priority', 'scale'] | None = None


### PR DESCRIPTION
Auto-generated PR for: reduce-frequency_penalty-more
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Lowered ChatOpenAI defaults to temperature=0.1 and frequency_penalty=0.05. This reduces output noise while keeping a small penalty to avoid tab-loop artifacts in models like 4.1-mini.

<!-- End of auto-generated description by cubic. -->

