### PR TITLE
edit-quickstart-docs

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -753,10 +753,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			success = self.state.last_result[-1].success
 			if success:
 				# Green color for success
-				self.logger.info(f'📄 \033[32m Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
+				self.logger.info(f'\n📄 \033[32m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
 			else:
 				# Red color for failure
-				self.logger.info(f'📄 \033[31m Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
+				self.logger.info(f'\n📄 \033[31m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
 			if self.state.last_result[-1].attachments:
 				total_attachments = len(self.state.last_result[-1].attachments)
 				for i, file_path in enumerate(self.state.last_result[-1].attachments):

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -9,12 +9,12 @@ icon: "rocket"
 
 <Tabs>
 <Tab title="uv">
-```bash
+```bash create environment
 uv venv --python 3.12
 ```
 </Tab>
 <Tab title="pip">
-```bash
+```bash create environment
 python -m venv .venv
 ```
 </Tab>
@@ -22,28 +22,26 @@ python -m venv .venv
 
 <Tabs>
 <Tab title="Mac/Linux">
-```bash
+```bash activate environment
 source .venv/bin/activate
 ```
 </Tab>
 <Tab title="Windows">
-```bash
+```bash activate environment
 .venv\Scripts\activate
 ```
 </Tab>
 </Tabs>
 
-Install browser-use & chromium:
-
 <Tabs>
 <Tab title="uv">
-```bash
+```bash install browser-use & chromium
 uv pip install browser-use
 uvx playwright install chromium --with-deps 
 ```
 </Tab>
 <Tab title="pip">
-```bash
+```bash install browser-use & chromium
 pip install browser-use
 playwright install chromium --with-deps
 ```
@@ -55,12 +53,12 @@ Create a `.env` file and add your API key. Don't have one? Start with a [free Ge
 
 <Tabs>
 <Tab title="Mac/Linux">
-```bash
+```bash create .env file
 touch .env
 ```
 </Tab>
 <Tab title="Windows">
-```cmd
+```cmd create .env file
 echo. > .env
 ```
 </Tab>
@@ -68,17 +66,17 @@ echo. > .env
 
 <Tabs>
 <Tab title="Google">
-```bash .env
+```bash add your key to .env file
 GEMINI_API_KEY=
 ```
 </Tab>
 <Tab title="OpenAI">
-```bash .env
+```bash add your key to .env file
 OPENAI_API_KEY=
 ```
 </Tab>
 <Tab title="Anthropic">
-```bash .env
+```bash add your key to .env file
 ANTHROPIC_API_KEY=
 ```
 </Tab>
@@ -116,7 +114,7 @@ import asyncio
 load_dotenv()
 
 async def main():
-    llm = ChatOpenAI(model="gpt-4o")
+    llm = ChatOpenAI(model="gpt-4.1-mini")
     task = "Find the number 1 post on Show HN"
     agent = Agent(task=task, llm=llm)
     await agent.run()
@@ -134,7 +132,7 @@ import asyncio
 load_dotenv()
 
 async def main():
-    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    llm = ChatAnthropic(model='claude-sonnet-4-0', temperature=0.0)
     task = "Find the number 1 post on Show HN"
     agent = Agent(task=task, llm=llm)
     await agent.run()

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,45 +5,109 @@ icon: "rocket"
 ---
 
 
-## 1. Easy setup
+## 1. Fast setup
 
-Use [uv](https://docs.astral.sh/uv/) to create and activate the environment:
-
+<Tabs>
+<Tab title="uv">
 ```bash
 uv venv --python 3.12
 ```
-
+</Tab>
+<Tab title="pip">
 ```bash
-# For Mac/Linux:
-source .venv/bin/activate
+python -m venv .venv
+```
+</Tab>
+</Tabs>
 
-# For Windows:
+<Tabs>
+<Tab title="Mac/Linux">
+```bash
+source .venv/bin/activate
+```
+</Tab>
+<Tab title="Windows">
+```bash
 .venv\Scripts\activate
 ```
+</Tab>
+</Tabs>
 
-Install browser-use:
+Install browser-use & chromium:
 
+<Tabs>
+<Tab title="uv">
 ```bash
 uv pip install browser-use
+uvx playwright install chromium --with-deps 
 ```
-
-Install Chromium:
-
+</Tab>
+<Tab title="pip">
 ```bash
-uvx playwright install chromium --with-deps
+pip install browser-use
+playwright install chromium --with-deps
 ```
+</Tab>
+</Tabs>
 
 ## 2. Choose your favorite LLM
-Create a `.env` file and add your API key:
+Create a `.env` file and add your API key. Don't have one? Start with a [free Gemini key](https://aistudio.google.com/app/u/1/apikey?pli=1).
 
+<Tabs>
+<Tab title="Mac/Linux">
+```bash
+touch .env
+```
+</Tab>
+<Tab title="Windows">
+```cmd
+echo. > .env
+```
+</Tab>
+</Tabs>
+
+<Tabs>
+<Tab title="Google">
+```bash .env
+GEMINI_API_KEY=
+```
+</Tab>
+<Tab title="OpenAI">
 ```bash .env
 OPENAI_API_KEY=
 ```
+</Tab>
+<Tab title="Anthropic">
+```bash .env
+ANTHROPIC_API_KEY=
+```
+</Tab>
+</Tabs>
 
-See [Supported Models](/customize/supported-models) for other models.
+See [Supported Models](/customize/supported-models) for more.
 
 ## 3. Run your first agent
 
+<Tabs>
+<Tab title="Google">
+```python agent.py
+from browser_use import Agent, ChatGoogle
+from dotenv import load_dotenv
+import asyncio
+
+load_dotenv()
+
+async def main():
+    llm = ChatGoogle(model="gemini-2.5-flash")
+    task = "Find the number 1 post on Show HN"
+    agent = Agent(task=task, llm=llm)
+    await agent.run()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+</Tab>
+<Tab title="OpenAI">
 ```python agent.py
 from browser_use import Agent, ChatOpenAI
 from dotenv import load_dotenv
@@ -52,7 +116,7 @@ import asyncio
 load_dotenv()
 
 async def main():
-    llm = ChatOpenAI(model="gpt-4.1-mini")
+    llm = ChatOpenAI(model="gpt-4o")
     task = "Find the number 1 post on Show HN"
     agent = Agent(task=task, llm=llm)
     await agent.run()
@@ -60,3 +124,23 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+</Tab>
+<Tab title="Anthropic">
+```python agent.py
+from browser_use import Agent, ChatAnthropic
+from dotenv import load_dotenv
+import asyncio
+
+load_dotenv()
+
+async def main():
+    llm = ChatAnthropic(model="claude-3-5-sonnet-20241022")
+    task = "Find the number 1 post on Show HN"
+    agent = Agent(task=task, llm=llm)
+    await agent.run()
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+</Tab>
+</Tabs>


### PR DESCRIPTION
Auto-generated PR for: edit-quickstart-docs
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Revamped the Quickstart to streamline setup across uv/pip and Mac/Windows, and added ready-to-run agent examples for Google, OpenAI, and Anthropic. This helps users install Chromium correctly and run an agent in minutes with sensible default models.

- **New Features**
  - Tabbed setup for uv vs. pip and Mac/Linux vs. Windows activation.
  - Combined install steps for browser-use and Playwright Chromium (--with-deps).
  - Guided .env creation with keys for Google, OpenAI, and Anthropic; link to Supported Models.
  - Three agent.py examples: ChatGoogle (gemini-2.5-flash), ChatOpenAI (gpt-4o), ChatAnthropic (claude-3-5-sonnet-20241022).

<!-- End of auto-generated description by cubic. -->

