### PR TITLE
added back the executable builds for cli and mcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ all = [
 [project.urls]
 Repository = "https://github.com/browser-use/browser-use"
 
+[project.scripts]
+browseruse = "browser_use.cli:main"
+browser-use = "browser_use.cli:main"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restored the CLI executables by defining entry points in pyproject.toml so installations include the browseruse and browser-use commands. This fixes the packaging issue that broke the CLI and MCP integrations.

<!-- End of auto-generated description by cubic. -->

