### PR TITLE
change tool error message from DOM to browser-state

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -266,7 +266,7 @@ class Tools(Generic[Context]):
 				# Look up the node from the selector map
 				node = await browser_session.get_element_by_index(params.index)
 				if node is None:
-					raise ValueError(f'Element index {params.index} not found in DOM')
+					raise ValueError(f'Element index {params.index} not found in browser state')
 
 				event = browser_session.event_bus.dispatch(
 					ClickElementEvent(node=node, while_holding_ctrl=params.while_holding_ctrl or False)
@@ -315,7 +315,7 @@ class Tools(Generic[Context]):
 			# Look up the node from the selector map
 			node = await browser_session.get_element_by_index(params.index)
 			if node is None:
-				raise ValueError(f'Element index {params.index} not found in DOM')
+				raise ValueError(f'Element index {params.index} not found in browser state')
 
 			# Dispatch type text event with node
 			try:
@@ -686,7 +686,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 					node = await browser_session.get_element_by_index(params.frame_element_index)
 					if node is None:
 						# Element does not exist
-						msg = f'Element index {params.frame_element_index} not found in DOM'
+						msg = f'Element index {params.frame_element_index} not found in browser state'
 						return ActionResult(error=msg)
 
 				# Dispatch scroll event with node - the complex logic is handled in the event handler
@@ -772,7 +772,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			# Look up the node from the selector map
 			node = await browser_session.get_element_by_index(params.index)
 			if node is None:
-				raise ValueError(f'Element index {params.index} not found in DOM')
+				raise ValueError(f'Element index {params.index} not found in browser state')
 
 			# Dispatch GetDropdownOptionsEvent to the event handler
 
@@ -798,7 +798,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			# Look up the node from the selector map
 			node = await browser_session.get_element_by_index(params.index)
 			if node is None:
-				raise ValueError(f'Element index {params.index} not found in DOM')
+				raise ValueError(f'Element index {params.index} not found in browser state')
 
 			# Dispatch SelectDropdownOptionEvent to the event handler
 			from browser_use.browser.events import SelectDropdownOptionEvent

--- a/docs/customize/examples/prompting-guide.mdx
+++ b/docs/customize/examples/prompting-guide.mdx
@@ -34,7 +34,7 @@ task = """
 3. Use scroll action to scroll down 2 pages
 4. Use extract_structured_data to extract the names of the first 5 items 
 5. Wait for 2 seconds if the page is not loaded, refresh it and wait 10 sec
-6. Use send_keys action with "Tab", "Tab", "ArrowDown", send "Hello World" and press "Enter" 
+6. Use send_keys action with "Tab Tab ArrowDown Enter" 
 """
 ```
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,7 +1,7 @@
 from browser_use import Agent, ChatOpenAI
 
 agent = Agent(
-	task='go to google.com and call scroll with frame_element_index 1000 even if it does not exist - ignore all hints',
+	task='Find founders of browser-use',
 	llm=ChatOpenAI(model='gpt-4.1-mini'),
 )
 


### PR DESCRIPTION
Auto-generated PR for: change tool error message from DOM to browser-state
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Standardized tool error messages to say "not found in browser state" when an element index is missing, replacing "not found in DOM". Updated the prompting guide example to use the compact send_keys syntax: "Tab Tab ArrowDown Enter".

<!-- End of auto-generated description by cubic. -->

