### PR TITLE
add first step logging to take step

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -297,7 +297,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			self.logger.warning('⚠️ XAI models do not support use_vision=True yet. Setting use_vision=False for now...')
 			self.settings.use_vision = False
 
-		self.logger.info(f'🧠 Starting a browser-use version {self.version} with model={self.llm.model}')
 		logger.debug(
 			f'{" +vision" if self.settings.use_vision else ""}'
 			f' extraction_model={self.settings.page_extraction_llm.model if self.settings.page_extraction_llm else "Unknown"}'
@@ -616,6 +615,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		"""Execute one step of the task"""
 		# Initialize timing first, before any exceptions can occur
 		self.step_start_time = time.time()
+
+		# Show startup message on first step
+		self._log_first_step_startup()
 
 		browser_state_summary = None
 
@@ -994,6 +996,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		self.logger.debug(f'🤖 Browser-Use Library Version {self.version} ({self.source})')
 
+	def _log_first_step_startup(self) -> None:
+		"""Log startup message only on the first step"""
+		if len(self.history.history) == 0:
+			self.logger.info(f'🧠 Starting a browser-use version {self.version} with model={self.llm.model}')
+
 	def _log_step_context(self, browser_state_summary: BrowserStateSummary) -> None:
 		"""Log step context information"""
 		url = browser_state_summary.url if browser_state_summary else ''
@@ -1122,6 +1129,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		Returns:
 		        Tuple[bool, bool]: (is_done, is_valid)
 		"""
+		if len(self.history.history) == 0:
+			# First step
+			self._log_first_step_startup()
+			await self._execute_initial_actions()
+
 		await self.step(step_info)
 
 		if self.history.is_done():
@@ -1250,6 +1262,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				self.logger.warning('⚠️ No browser focus established, may cause navigation issues')
 
 			await self._execute_initial_actions()
+			# Log startup message on first step (only if we haven't already done steps)
+			self._log_first_step_startup()
 
 			self.logger.debug(f'🔄 Starting main execution loop with max {max_steps} steps...')
 			for step in range(max_steps):

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -325,7 +325,7 @@ class Tools(Generic[Context]):
 				await event
 				input_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
 				msg = f"Input '{params.text}' into element {params.index}."
-				logger.info(msg)
+				logger.debug(msg)
 
 				# Include input coordinates in metadata if available
 				return ActionResult(


### PR DESCRIPTION
Auto-generated PR for: add first step logging to take step
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Log the startup message only when the agent takes its first step, instead of during initialization, to ensure a single, accurate "starting" log. Also reduce log noise by changing input_text logs from info to debug.

<!-- End of auto-generated description by cubic. -->

