### PR TITLE
change parameter chat google

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -73,11 +73,11 @@ class ChatGoogle(BaseChatModel):
 
 	# Model configuration
 	model: VerifiedGeminiModels | str
-	temperature: float | None = 0.2  # Match OpenAI default
+	temperature: float | None = 0.2
 	top_p: float | None = None
 	seed: int | None = None
 	thinking_budget: int | None = None
-	max_output_tokens: int | None = 4096  # Match OpenAI default
+	max_output_tokens: int | None = 4096
 	config: types.GenerateContentConfigDict | None = None
 
 	# Client initialization parameters

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -73,10 +73,11 @@ class ChatGoogle(BaseChatModel):
 
 	# Model configuration
 	model: VerifiedGeminiModels | str
-	temperature: float | None = None
+	temperature: float | None = 0.2  # Match OpenAI default
 	top_p: float | None = None
 	seed: int | None = None
 	thinking_budget: int | None = None
+	max_output_tokens: int | None = 4096  # Match OpenAI default
 	config: types.GenerateContentConfigDict | None = None
 
 	# Client initialization parameters
@@ -192,6 +193,9 @@ class ChatGoogle(BaseChatModel):
 		if self.thinking_budget is not None:
 			thinking_config_dict: types.ThinkingConfigDict = {'thinking_budget': self.thinking_budget}
 			config['thinking_config'] = thinking_config_dict
+
+		if self.max_output_tokens is not None:
+			config['max_output_tokens'] = self.max_output_tokens
 
 		async def _make_api_call():
 			if output_format is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,4 +199,5 @@ dev-dependencies = [
     "lmnr[all]==0.7.6",
     # "pytest-playwright-asyncio>=0.7.0",  # not actually needed I think
     "pytest-timeout>=2.4.0",
+    "pydantic_settings>=2.10.1"
 ]


### PR DESCRIPTION
Auto-generated PR for: change parameter chat google
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Aligns Google chat model defaults with OpenAI and adds output token control for more predictable behavior across providers.

- **New Features**
  - Set default temperature to 0.2 and add max_output_tokens (default 4096).
  - Pass max_output_tokens to the GenerateContent config in ainvoke.

- **Dependencies**
  - Add pydantic_settings>=2.10.1 to dev dependencies.

<!-- End of auto-generated description by cubic. -->

