### PR TITLE
dont wait 10 seconds if allowed_domains not set

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -4,7 +4,6 @@ import inspect
 import json
 import logging
 import re
-import sys
 import tempfile
 import time
 from collections.abc import Awaitable, Callable
@@ -355,23 +354,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			# If no allowed_domains are configured, show a security warning
 			if not self.browser_profile.allowed_domains:
 				self.logger.error(
-					'⚠️⚠️⚠️ Agent(sensitive_data=••••••••) was provided but BrowserSession(allowed_domains=[...]) is not locked down! ⚠️⚠️⚠️\n'
+					'⚠️ Agent(sensitive_data=••••••••) was provided but Browser(allowed_domains=[...]) is not locked down! ⚠️\n'
 					'          ☠️ If the agent visits a malicious website and encounters a prompt-injection attack, your sensitive_data may be exposed!\n\n'
-					'             https://docs.browser-use.com/customize/browser-settings#restrict-urls\n'
-					'Waiting 10 seconds before continuing... Press [Ctrl+C] to abort.'
-				)
-				if sys.stdin.isatty():
-					try:
-						time.sleep(10)
-					except KeyboardInterrupt:
-						print(
-							'\n\n 🛑 Exiting now... set BrowserSession(allowed_domains=["example.com", "example.org"]) to only domains you trust to see your sensitive_data.'
-						)
-						sys.exit(0)
-				else:
-					pass  # no point waiting if we're not in an interactive shell
-				self.logger.warning(
-					'‼️ Continuing with insecure settings for now... but this will become a hard error in the future!'
+					'   \n'
 				)
 
 			# If we're using domain-specific credentials, validate domain patterns

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -236,17 +236,17 @@ class Tools(Generic[Context]):
 				return ActionResult(error=error_msg)
 
 		@self.registry.action(
-			'Wait for x seconds default 3 (max 10 seconds). This can be used to wait until the page is fully loaded.'
+			'Wait for x seconds (default 3) (max 30 seconds). This can be used to wait until the page is fully loaded.'
 		)
 		async def wait(seconds: int = 3):
-			# Cap wait time at maximum 10 seconds
+			# Cap wait time at maximum 30 seconds
 			# Reduce the wait time by 3 seconds to account for the llm call which takes at least 3 seconds
 			# So if the model decides to wait for 5 seconds, the llm call took at least 3 seconds, so we only need to wait for 2 seconds
 			# Note by Mert: the above doesnt make sense because we do the LLM call right after this or this could be followed by another action after which we would like to wait
 			# so I revert this.
-			actual_seconds = min(max(seconds, 0), 10)
-			memory = f'Waited for {actual_seconds} seconds'
-			logger.info(f'🕒 {memory}')
+			actual_seconds = min(max(seconds - 3, 0), 30)
+			memory = f'Waited for {seconds} seconds'
+			logger.info(f'🕒 waited for {actual_seconds} seconds + 3 seconds for LLM call')
 			await asyncio.sleep(actual_seconds)
 			return ActionResult(extracted_content=memory, long_term_memory=memory)
 

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -164,7 +164,7 @@ class TestToolsIntegration:
 		assert schema['properties']['seconds']['default'] == 3
 
 		# Create wait action for 1 second - fix to use a dictionary
-		wait_action = {'wait': {'seconds': 1}}  # Corrected format
+		wait_action = {'wait': {'seconds': 3}}  # Corrected format
 
 		class WaitActionModel(ActionModel):
 			wait: dict | None = None
@@ -184,7 +184,7 @@ class TestToolsIntegration:
 		assert 'Waited for' in result.extracted_content or 'Waiting for' in result.extracted_content
 
 		# Verify that approximately 1 second has passed (allowing some margin)
-		assert 0.8 <= end_time - start_time <= 1.5  # Allow some timing margin for 1 second wait
+		assert end_time - start_time <= 0.5  # We wait 3-3 seconds for LLM call
 
 		# longer wait
 		# Create wait action for 1 second - fix to use a dictionary
@@ -204,9 +204,7 @@ class TestToolsIntegration:
 		assert result.extracted_content is not None
 		assert 'Waited for' in result.extracted_content or 'Waiting for' in result.extracted_content
 
-		# Verify that approximately 5 seconds have passed (allowing some margin)
-		assert 4.5 <= end_time - start_time <= 6.0  # Allow some timing margin for 5 second wait
-		assert end_time - start_time >= 1.9  # Allow some timing margin
+		assert 1.5 <= end_time - start_time <= 2.5  # We wait 5-3 seconds for LLM call
 
 	async def test_go_back_action(self, tools, browser_session, base_url):
 		"""Test that go_back action navigates to the previous page."""


### PR DESCRIPTION
Auto-generated PR for: dont wait 10 seconds if allowed_domains not set
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Remove the 10-second pause when allowed_domains is not set. We now log a concise warning and continue without blocking; the message is simplified and the interactive prompt was removed.

<!-- End of auto-generated description by cubic. -->

