### PR TITLE
remove lmnr from examples

### DIFF
--- a/browser_use/llm/tests/test_gemini_image.py
+++ b/browser_use/llm/tests/test_gemini_image.py
@@ -3,7 +3,6 @@ import base64
 import io
 import random
 
-from lmnr import Laminar
 from PIL import Image, ImageDraw, ImageFont
 
 from browser_use.llm.google.chat import ChatGoogle
@@ -16,8 +15,6 @@ from browser_use.llm.messages import (
 	SystemMessage,
 	UserMessage,
 )
-
-Laminar.initialize()
 
 
 def create_random_text_image(text: str = 'hello world', width: int = 4000, height: int = 4000) -> str:

--- a/docs/development/monitoring/observability.mdx
+++ b/docs/development/monitoring/observability.mdx
@@ -31,7 +31,7 @@ import asyncio
 
 from lmnr import Laminar, Instruments
 # this line auto-instruments Browser Use and any browser you use (local or remote)
-Laminar.initialize(project_api_key="...")
+Laminar.initialize(project_api_key="...", disabled_instruments={Instruments.BROWSER_USE})
 
 async def main():
     agent = Agent(

--- a/examples/custom-functions/cua.py
+++ b/examples/custom-functions/cua.py
@@ -28,13 +28,6 @@ from browser_use import Agent, ChatOpenAI, Tools
 from browser_use.agent.views import ActionResult
 from browser_use.browser import BrowserSession
 
-try:
-	from lmnr import Laminar
-
-	Laminar.initialize(project_api_key=os.getenv('LMNR_PROJECT_API_KEY'))
-except ImportError:
-	pass
-
 
 class OpenAICUAAction(BaseModel):
 	"""Parameters for OpenAI Computer Use Assistant action."""

--- a/examples/models/aws.py
+++ b/examples/models/aws.py
@@ -14,12 +14,8 @@ Requirements:
 
 import asyncio
 
-from lmnr import Laminar
-
 from browser_use import Agent
 from browser_use.llm import ChatAnthropicBedrock, ChatAWSBedrock
-
-Laminar.initialize()
 
 
 async def example_anthropic_bedrock():

--- a/examples/models/claude-4-sonnet.py
+++ b/examples/models/claude-4-sonnet.py
@@ -10,10 +10,8 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from dotenv import load_dotenv
-from lmnr import Laminar
 
 load_dotenv()
-Laminar.initialize()
 
 from browser_use import Agent
 from browser_use.llm import ChatAnthropic

--- a/examples/models/gemini.py
+++ b/examples/models/gemini.py
@@ -5,14 +5,10 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from dotenv import load_dotenv
-from lmnr import Laminar
-
-load_dotenv()
-
 
 from browser_use import Agent, ChatGoogle
 
-Laminar.initialize()
+load_dotenv()
 
 api_key = os.getenv('GOOGLE_API_KEY')
 if not api_key:

--- a/examples/models/gpt-4.1.py
+++ b/examples/models/gpt-4.1.py
@@ -7,14 +7,10 @@ Simple try of the agent.
 import asyncio
 
 from dotenv import load_dotenv
-from lmnr import Laminar
 
 from browser_use import Agent, ChatOpenAI
 
 load_dotenv()
-
-
-Laminar.initialize()
 
 # All the models are type safe from OpenAI in case you need a list of supported models
 llm = ChatOpenAI(model='gpt-4.1-mini')

--- a/examples/models/gpt-5-mini.py
+++ b/examples/models/gpt-5-mini.py
@@ -7,14 +7,10 @@ Simple try of the agent.
 import asyncio
 
 from dotenv import load_dotenv
-from lmnr import Laminar
 
 from browser_use import Agent, ChatOpenAI
 
 load_dotenv()
-
-
-Laminar.initialize()
 
 # All the models are type safe from OpenAI in case you need a list of supported models
 llm = ChatOpenAI(model='gpt-5-mini')

--- a/examples/models/langchain/example.py
+++ b/examples/models/langchain/example.py
@@ -12,12 +12,9 @@ This example demonstrates how to:
 import asyncio
 
 from langchain_openai import ChatOpenAI  # pyright: ignore
-from lmnr import Laminar
 
 from browser_use import Agent
 from examples.models.langchain.chat import ChatLangchain
-
-Laminar.initialize()
 
 
 async def main():

--- a/examples/models/llama4-groq.py
+++ b/examples/models/llama4-groq.py
@@ -5,12 +5,8 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from dotenv import load_dotenv
-from lmnr import Laminar
 
 load_dotenv()
-
-
-Laminar.initialize()
 
 
 from browser_use import Agent

--- a/examples/models/openrouter.py
+++ b/examples/models/openrouter.py
@@ -8,14 +8,10 @@ import asyncio
 import os
 
 from dotenv import load_dotenv
-from lmnr import Laminar
 
 from browser_use import Agent, ChatOpenAI
 
 load_dotenv()
-
-
-Laminar.initialize()
 
 # All the models are type safe from OpenAI in case you need a list of supported models
 llm = ChatOpenAI(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ examples = [
     "langchain-openai>=0.3.26",
 ]
 eval = [
-    "lmnr[all]==0.7.6",
+    "lmnr[all]==0.7.10",
     "anyio>=4.9.0",
     "psutil>=7.0.0",
     "datamodel-code-generator>=0.26.0",
@@ -196,7 +196,7 @@ dev-dependencies = [
     "pyright>=1.1.403",
     "ty>=0.0.1a1",
     "pytest-xdist>=3.7.0",
-    "lmnr[all]==0.7.6",
+    "lmnr[all]==0.7.10",
     # "pytest-playwright-asyncio>=0.7.0",  # not actually needed I think
     "pytest-timeout>=2.4.0",
     "pydantic_settings>=2.10.1"


### PR DESCRIPTION
Auto-generated PR for: remove lmnr from examples
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed Laminar from example scripts and a test to reduce setup friction and prevent unintended instrumentation. Updated docs to show how to disable Browser Use instrumentation, and bumped lmnr to 0.7.10 for dev/eval.

- **Refactors**
  - Removed lmnr imports/initialize from example scripts and the Gemini image test.
  - Examples now rely only on browser_use and their respective LLM SDKs.
  - Docs: Laminar.initialize now shows disabled_instruments={Instruments.BROWSER_USE}.

- **Dependencies**
  - Updated lmnr[all] to 0.7.10 in eval and dev dependencies.

<!-- End of auto-generated description by cubic. -->

