### PR TITLE
Fallback to forced output on consecutive failures

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -49,6 +49,7 @@ class AgentSettings(BaseModel):
 	include_tool_call_examples: bool = False
 	llm_timeout: int = 60  # Timeout in seconds for LLM calls
 	step_timeout: int = 180  # Timeout in seconds for each step
+	enable_final_recovery: bool = True  # If True, attempt one final recovery call after max_failures
 
 
 class AgentState(BaseModel):


### PR DESCRIPTION
Add a final recovery attempt to generate a 'done' output with intermediate results after consecutive failures.

This feature improves robustness by attempting to provide a final, forced 'done' output with intermediate results when the agent hits its maximum consecutive failures, instead of immediately stopping. This gives users more context on task failure, and it is enabled by default but can be deactivated.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1757001432352429?thread_ts=1757001432.352429&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-1e6b8ad3-ae0f-4e50-a61a-b8ac058a28a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e6b8ad3-ae0f-4e50-a61a-b8ac058a28a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a final recovery step that forces a “done” output with intermediate results when the agent hits max consecutive failures, so users get context instead of a hard stop. Enabled by default and can be turned off.

- **New Features**
  - Final recovery on max_failures: forces a done action, sets success=False, and returns recent intermediate results.
  - New setting: AgentSettings.enable_final_recovery (default True); also available as a constructor param.
  - If the model doesn’t return done, we force it; respects llm_timeout and logs outcomes. On failure, we still return a final error with intermediate results.

- **Migration**
  - No changes required.
  - To disable: set enable_final_recovery=False in AgentSettings or when constructing the agent.

<!-- End of auto-generated description by cubic. -->

