### PR TITLE
fix-popup-handling

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -510,7 +510,7 @@ class DialogOpenedEvent(BaseEvent):
 	dialog_type: str  # 'alert', 'confirm', 'prompt', or 'beforeunload'
 	message: str
 	url: str
-	frame_id: str
+	frame_id: str | None = None  # Can be None when frameId is not provided by CDP
 	# target_id: TargetID   # TODO: add this to avoid needing target_id_from_frame() later
 
 


### PR DESCRIPTION
Auto-generated PR for branch: fix-popup-handling
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes JavaScript popup handling by auto-dismissing alerts/confirm/prompts immediately via CDP across all frames. Simplifies the flow to prevent crashes and focus issues, and makes DialogOpenedEvent.frame_id optional for missing CDP frameIds.

- **Bug Fixes**
  - Register Page.javascriptDialogOpening on both session and root CDP clients to catch dialogs from any frame.
  - Dismiss dialogs with Page.handleJavaScriptDialog using session fallbacks (detected session → agent focus) with short timeouts.
  - PopupsWatchdog no longer listens to or emits DialogOpenedEvent; it only listens to TabCreatedEvent.

- **Migration**
  - If you relied on DialogOpenedEvent from PopupsWatchdog, remove those listeners; dialogs are now dismissed silently.
  - DialogOpenedEvent.frame_id is now optional (can be None); update any strict type checks.

<!-- End of auto-generated description by cubic. -->

