### PR TITLE
Optimize sync data sending for authentication

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1952,6 +1952,28 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			},
 		}
 
+	async def authenticate_and_sync_logs(self, show_instructions: bool = True) -> bool:
+		"""
+		Authenticate with cloud service and sync all logs after task completion.
+		
+		This is useful when users want to view their logs in the cloud after 
+		a task has already completed and the agent is no longer running.
+		
+		Args:
+			show_instructions: Whether to show authentication instructions to user
+			
+		Returns:
+			bool: True if authentication and sync was successful
+		"""
+		if not hasattr(self, 'cloud_sync') or self.cloud_sync is None:
+			self.logger.warning('Cloud sync is not enabled for this agent')
+			return False
+		
+		return await self.cloud_sync.authenticate_and_sync_pending(
+			agent_session_id=self.session_id,
+			show_instructions=show_instructions
+		)
+
 	def run_sync(
 		self,
 		max_steps: int = 100,


### PR DESCRIPTION
Queue sync events until authentication is complete and enable post-task log synchronization to prevent unauthenticated data leaks.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1757034838869459?thread_ts=1757034838.869459&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-a0f0ac89-610e-4708-ac06-bbcfd3d14512">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0f0ac89-610e-4708-ac06-bbcfd3d14512">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Queues sync events until the user is authenticated to prevent unauthenticated data from being sent. Adds a post-task auth-and-sync flow so users can authenticate later and upload all logs.

- **New Features**
  - Start authentication immediately when the agent session is created (background task).
  - Queue events before auth and resend them after auth; no pre-auth network calls.
  - Add SyncService.authenticate_and_sync_pending and AgentService.authenticate_and_sync_logs for post-task log sync.

<!-- End of auto-generated description by cubic. -->

