### PR TITLE
Exclude previous input value from hash

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -659,6 +659,9 @@ class EnhancedDOMTreeNode:
 	def __hash__(self) -> int:
 		"""
 		Hash the element based on its parent branch path and attributes.
+		
+		Note: Excludes 'value' attribute from hash calculation to prevent multiact 
+		from breaking when input field values change.
 
 		TODO: migrate this to use only backendNodeId + current SessionId
 		"""
@@ -667,8 +670,8 @@ class EnhancedDOMTreeNode:
 		parent_branch_path = self._get_parent_branch_path()
 		parent_branch_path_string = '/'.join(parent_branch_path)
 
-		# Get attributes hash
-		attributes_string = ''.join(f'{key}={value}' for key, value in self.attributes.items())
+		# Get attributes hash (excluding 'value' to prevent multiact issues)
+		attributes_string = ''.join(f'{key}={value}' for key, value in self.attributes.items() if key != 'value')
 
 		# Combine both for final hash
 		combined_string = f'{parent_branch_path_string}|{attributes_string}'


### PR DESCRIPTION
Exclude 'value' attribute from `EnhancedDOMTreeNode` hash calculation to prevent multiact from breaking when input field values change.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1757035098494109?thread_ts=1757035098.494109&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-9de6263d-d2f4-4f7f-8ed9-681678723685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9de6263d-d2f4-4f7f-8ed9-681678723685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

