### PR TITLE
fix-timeouts-long-websites-only-hashmap

### DIFF
--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -82,10 +82,12 @@ def build_snapshot_lookup(
 				backend_node_to_snapshot_index[backend_node_id] = i
 
 		# PERFORMANCE: Pre-build layout index map to eliminate O(n²) double lookups
+		# Preserve original behavior: use FIRST occurrence for duplicates
 		layout_index_map = {}
 		if layout and 'nodeIndex' in layout:
 			for layout_idx, node_index in enumerate(layout['nodeIndex']):
-				layout_index_map[node_index] = layout_idx
+				if node_index not in layout_index_map:  # Only store first occurrence
+					layout_index_map[node_index] = layout_idx
 
 		# Build snapshot lookup for each backend node id
 		for backend_node_id, snapshot_index in backend_node_to_snapshot_index.items():

--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -25,12 +25,27 @@ REQUIRED_COMPUTED_STYLES = [
 	'pointer-events',
 	'cursor',
 	'overflow',
+	'overflow-x',
+	'overflow-y',
+	'width',
+	'height',
+	'top',
+	'left',
+	'right',
+	'bottom',
+	'transform',
+	'clip',
+	'clip-path',
+	'user-select',
+	'background-color',
+	'color',
+	'border',
+	'margin',
+	'padding',
 ]
 
-# PERFORMANCE: Reduced from 19 to 8 styles (58% reduction)
-# Removed non-essential styles: width, height, top, left, right, bottom, transform,
-# clip, clip-path, user-select, background-color, color, border, margin, padding
-# These can be computed from bounds/rects when actually needed
+# PERFORMANCE NOTE: The layout index map O(1) optimization was the real fix, not style reduction
+# Keeping full computed styles for quality - the O(n²) → O(1) gives us all the performance we need
 
 # Full style set for fallback scenarios
 FULL_COMPUTED_STYLES = [

--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -25,6 +25,23 @@ REQUIRED_COMPUTED_STYLES = [
 	'pointer-events',
 	'cursor',
 	'overflow',
+]
+
+# PERFORMANCE: Reduced from 19 to 8 styles (58% reduction)
+# Removed non-essential styles: width, height, top, left, right, bottom, transform,
+# clip, clip-path, user-select, background-color, color, border, margin, padding
+# These can be computed from bounds/rects when actually needed
+
+# Full style set for fallback scenarios
+FULL_COMPUTED_STYLES = [
+	'display',
+	'visibility',
+	'opacity',
+	'position',
+	'z-index',
+	'pointer-events',
+	'cursor',
+	'overflow',
 	'overflow-x',
 	'overflow-y',
 	'width',
@@ -62,12 +79,25 @@ def _parse_computed_styles(strings: list[str], style_indices: list[int]) -> dict
 def build_snapshot_lookup(
 	snapshot: CaptureSnapshotReturns,
 	device_pixel_ratio: float = 1.0,
+	viewport_bounds: dict | None = None,  # Your ±2000px viewport filtering
 ) -> dict[int, EnhancedSnapshotNode]:
 	"""Build a lookup table of backend node ID to enhanced snapshot data with everything calculated upfront."""
+	import logging
+
+	logger = logging.getLogger(__name__)
+
 	snapshot_lookup: dict[int, EnhancedSnapshotNode] = {}
 
 	if not snapshot['documents']:
+		logger.debug('🔍 SNAPSHOT: No documents in snapshot')
 		return snapshot_lookup
+
+	if viewport_bounds:
+		logger.debug(
+			f'🔍 SNAPSHOT: Using viewport bounds: top={viewport_bounds["top"]}, bottom={viewport_bounds["bottom"]}, height={viewport_bounds["total_height"]}'
+		)
+	else:
+		logger.debug('🔍 SNAPSHOT: No viewport bounds - processing all elements')
 
 	strings = snapshot['strings']
 
@@ -82,7 +112,47 @@ def build_snapshot_lookup(
 				backend_node_to_snapshot_index[backend_node_id] = i
 
 		# Build snapshot lookup for each backend node id
+		total_nodes = len(backend_node_to_snapshot_index)
+		processed_nodes = 0
+		filtered_out_nodes = 0
+
+		logger.debug(f'🔍 SNAPSHOT: Starting early filtering on {total_nodes} nodes...')
+		import time
+
+		processing_start = time.time()
+
+		# PERFORMANCE: Pre-build layout index map to eliminate O(n²) double lookups
+		layout_index_map = {}
+		if layout and 'nodeIndex' in layout:
+			for layout_idx, node_index in enumerate(layout['nodeIndex']):
+				layout_index_map[node_index] = layout_idx
+
+		layout_map_time = time.time() - processing_start
+		logger.debug(f'🔍 SNAPSHOT: Built layout index map with {len(layout_index_map)} entries in {layout_map_time:.3f}s')
+
 		for backend_node_id, snapshot_index in backend_node_to_snapshot_index.items():
+			# PERFORMANCE OPTIMIZATION: Quick bounds check FIRST using cached layout map (O(1) lookup)
+			should_skip = False
+			if viewport_bounds and snapshot_index in layout_index_map:
+				layout_idx = layout_index_map[snapshot_index]
+				if layout_idx < len(layout.get('bounds', [])):
+					bounds = layout['bounds'][layout_idx]
+					if len(bounds) >= 4:
+						# Quick viewport check using raw coordinates (device pixels)
+						raw_x, raw_y, raw_width, raw_height = bounds[0], bounds[1], bounds[2], bounds[3]
+						# Convert to CSS pixels for viewport comparison
+						element_top = raw_y / device_pixel_ratio
+						element_bottom = element_top + (raw_height / device_pixel_ratio)
+
+						# Skip elements that don't intersect with viewport bounds
+						if element_bottom < viewport_bounds['top'] or element_top > viewport_bounds['bottom']:
+							filtered_out_nodes += 1
+							should_skip = True
+
+			if should_skip:
+				continue  # Skip expensive processing entirely
+
+			# Now do the expensive processing only for elements in viewport
 			is_clickable = None
 			if 'isClickable' in nodes:
 				is_clickable = _parse_rare_boolean_data(nodes['isClickable'], snapshot_index)
@@ -93,14 +163,15 @@ def build_snapshot_lookup(
 			bounding_box = None
 			computed_styles = {}
 
-			# Look for layout tree node that corresponds to this snapshot node
+			# PERFORMANCE: Use cached layout map instead of expensive enumerate loop
 			paint_order = None
 			client_rects = None
 			scroll_rects = None
 			stacking_contexts = None
-			for layout_idx, node_index in enumerate(layout.get('nodeIndex', [])):
-				if node_index == snapshot_index and layout_idx < len(layout.get('bounds', [])):
-					# Parse bounding box
+			if snapshot_index in layout_index_map:
+				layout_idx = layout_index_map[snapshot_index]
+				if layout_idx < len(layout.get('bounds', [])):
+					# Parse bounding box (we already did bounds check above for viewport filtering)
 					bounds = layout['bounds'][layout_idx]
 					if len(bounds) >= 4:
 						# IMPORTANT: CDP coordinates are in device pixels, convert to CSS pixels
@@ -153,8 +224,6 @@ def build_snapshot_lookup(
 					if layout_idx < len(layout.get('stackingContexts', [])):
 						stacking_contexts = layout.get('stackingContexts', {}).get('index', [])[layout_idx]
 
-					break
-
 			snapshot_lookup[backend_node_id] = EnhancedSnapshotNode(
 				is_clickable=is_clickable,
 				cursor_style=cursor_style,
@@ -164,6 +233,30 @@ def build_snapshot_lookup(
 				computed_styles=computed_styles if computed_styles else None,
 				paint_order=paint_order,
 				stacking_contexts=stacking_contexts,
+			)
+			processed_nodes += 1
+
+	# Log filtering results with timing
+	processing_end = time.time()
+	processing_time = processing_end - processing_start
+
+	logger.debug(
+		f'🔍 SNAPSHOT: Processed {processed_nodes} nodes, skipped {filtered_out_nodes} nodes early (total: {total_nodes}) in {processing_time:.2f}s'
+	)
+	if viewport_bounds and total_nodes > 0:
+		filter_percentage = (filtered_out_nodes / total_nodes) * 100
+		process_percentage = (processed_nodes / total_nodes) * 100
+		logger.debug(
+			f'⚡ SNAPSHOT: Early viewport filtering skipped {filter_percentage:.1f}% of elements, processed only {process_percentage:.1f}%'
+		)
+
+		# Show performance improvement estimate
+		if processed_nodes > 0:
+			time_per_processed_node = processing_time / processed_nodes
+			estimated_full_time = time_per_processed_node * total_nodes
+			time_saved = estimated_full_time - processing_time
+			logger.debug(
+				f'⚡ SNAPSHOT: Estimated time saved: {time_saved:.2f}s (would have taken {estimated_full_time:.2f}s for all nodes)'
 			)
 
 	return snapshot_lookup

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -257,13 +257,9 @@ class DomService:
 		# Collect all frame IDs recursively
 		all_frame_ids = collect_all_frame_ids(frame_tree['frameTree'])
 
-		# Process all frames for full quality (layout index map gives us the performance we need)
-		frame_ids_to_process = all_frame_ids
-		self.logger.debug(f'🔍 AX tree: processing all {len(all_frame_ids)} frames')
-
-		# Get accessibility tree for selected frames
+		# Get accessibility tree for each frame
 		ax_tree_requests = []
-		for frame_id in frame_ids_to_process:
+		for frame_id in all_frame_ids:
 			ax_tree_request = cdp_session.cdp_client.send.Accessibility.getFullAXTree(
 				params={'frameId': frame_id}, session_id=cdp_session.session_id
 			)
@@ -349,14 +345,8 @@ class DomService:
 			)
 
 		start = time.time()
-		self.logger.debug('🔍 CDP: Starting all CDP tasks...')
 
 		# Create initial tasks
-		snapshot_start = time.time()
-		dom_tree_start = time.time()
-		ax_tree_start = time.time()
-		device_ratio_start = time.time()
-
 		tasks = {
 			'snapshot': asyncio.create_task(create_snapshot_request()),
 			'dom_tree': asyncio.create_task(create_dom_tree_request()),
@@ -364,30 +354,11 @@ class DomService:
 			'device_pixel_ratio': asyncio.create_task(self._get_viewport_ratio(target_id)),
 		}
 
-		task_start_times = {
-			'snapshot': snapshot_start,
-			'dom_tree': dom_tree_start,
-			'ax_tree': ax_tree_start,
-			'device_pixel_ratio': device_ratio_start,
-		}
-
-		self.logger.debug('🔍 CDP: All tasks created, waiting for completion (timeout=10s)...')
-
 		# Wait for all tasks with timeout
 		done, pending = await asyncio.wait(tasks.values(), timeout=10.0)
 
-		# Log completed tasks
-		for task_name, task in tasks.items():
-			if task in done:
-				elapsed = time.time() - task_start_times[task_name]
-				self.logger.debug(f'✅ CDP: {task_name} completed in {elapsed:.2f}s')
-			elif task in pending:
-				elapsed = time.time() - task_start_times[task_name]
-				self.logger.warning(f'⏰ CDP: {task_name} TIMED OUT after {elapsed:.2f}s (timeout=10s)')
-
 		# Retry any failed or timed out tasks
 		if pending:
-			self.logger.debug(f'🔍 CDP: {len(pending)} tasks timed out, retrying...')
 			for task in pending:
 				task.cancel()
 
@@ -400,61 +371,33 @@ class DomService:
 			}
 
 			# Create new tasks only for the ones that didn't complete
-			retry_start = time.time()
-			retry_task_names = []
 			for key, task in tasks.items():
-				if task in pending and key in retry_map:
+				if task in pending and task in retry_map:
 					tasks[key] = retry_map[task]()
-					retry_task_names.append(key)
-					self.logger.debug(f'🔄 CDP: Retrying {key}...')
 
 			# Wait again with shorter timeout
-			self.logger.debug(f'🔍 CDP: Waiting for {len(retry_task_names)} retry tasks (timeout=2s)...')
 			done2, pending2 = await asyncio.wait([t for t in tasks.values() if not t.done()], timeout=2.0)
 
-			# Log retry results
-			for task_name in retry_task_names:
-				task = tasks[task_name]
-				if task in done2:
-					elapsed = time.time() - retry_start
-					self.logger.debug(f'✅ CDP: {task_name} retry completed in {elapsed:.2f}s')
-				elif task in pending2:
-					elapsed = time.time() - retry_start
-					self.logger.warning(f'⏰ CDP: {task_name} retry TIMED OUT after {elapsed:.2f}s (timeout=2s)')
-
 			if pending2:
-				self.logger.warning(f'🔍 CDP: {len(pending2)} tasks failed after retry, cancelling...')
 				for task in pending2:
 					task.cancel()
 
 		# Extract results, tracking which ones failed
-		self.logger.debug(f'🔍 CDP: Extracting results from {len(tasks)} tasks...')
-		extract_start = time.time()
-
 		results = {}
 		failed = []
 		for key, task in tasks.items():
-			task_extract_start = time.time()
 			if task.done() and not task.cancelled():
 				try:
 					results[key] = task.result()
-					task_extract_end = time.time()
-					self.logger.debug(f'✅ CDP: Extracted {key} result in {task_extract_end - task_extract_start:.2f}s')
 				except Exception as e:
-					task_extract_end = time.time()
-					self.logger.warning(f'❌ CDP: Task {key} failed after {task_extract_end - task_extract_start:.2f}s: {e}')
+					self.logger.warning(f'CDP request {key} failed with exception: {e}')
 					failed.append(key)
 			else:
-				task_extract_end = time.time()
-				self.logger.warning(f'⏰ CDP: Task {key} timed out after {task_extract_end - task_extract_start:.2f}s')
+				self.logger.warning(f'CDP request {key} timed out')
 				failed.append(key)
-
-		extract_end = time.time()
-		self.logger.debug(f'🔍 CDP: All results extracted in {extract_end - extract_start:.2f}s')
 
 		# If any required tasks failed, raise an exception
 		if failed:
-			self.logger.error(f'❌ CDP: {len(failed)} tasks failed: {", ".join(failed)}')
 			raise TimeoutError(f'CDP requests failed or timed out: {", ".join(failed)}')
 
 		snapshot = results['snapshot']
@@ -462,10 +405,7 @@ class DomService:
 		ax_tree = results['ax_tree']
 		device_pixel_ratio = results['device_pixel_ratio']
 		end = time.time()
-		total_cdp_time = end - start
-		cdp_timing = {'cdp_calls_total': total_cdp_time}
-
-		self.logger.debug(f'🔍 CDP: TOTAL CDP processing completed in {total_cdp_time:.2f}s')
+		cdp_timing = {'cdp_calls_total': end - start}
 
 		# DEBUG: Log snapshot info
 		if snapshot and 'documents' in snapshot:
@@ -514,17 +454,8 @@ class DomService:
 		enhanced_dom_tree_node_lookup: dict[int, EnhancedDOMTreeNode] = {}
 		""" NodeId (NOT backend node id) -> enhanced dom tree node"""  # way to get the parent/content node
 
-		# Parse snapshot data with everything calculated upfront (O(1) hash map optimized!)
-		snapshot_processing_start = time.time()
-		self.logger.debug('🔍 DOM: Starting snapshot lookup processing...')
-
+		# Parse snapshot data with everything calculated upfront
 		snapshot_lookup = build_snapshot_lookup(snapshot, device_pixel_ratio)
-
-		snapshot_processing_end = time.time()
-		self.logger.debug(
-			f'🔍 DOM: Snapshot lookup processing completed in {snapshot_processing_end - snapshot_processing_start:.2f}s'
-		)
-		self.logger.debug(f'🔍 DOM: Snapshot lookup contains {len(snapshot_lookup)} elements')
 
 		async def _construct_enhanced_node(
 			node: Node, html_frames: list[EnhancedDOMTreeNode] | None, total_frame_offset: DOMRect | None
@@ -720,13 +651,7 @@ class DomService:
 
 			return dom_tree_node
 
-		dom_construction_start = time.time()
-		self.logger.debug('🔍 DOM: Starting DOM tree construction...')
-
 		enhanced_dom_tree_node = await _construct_enhanced_node(dom_tree['root'], initial_html_frames, initial_total_frame_offset)
-
-		dom_construction_end = time.time()
-		self.logger.debug(f'🔍 DOM: DOM tree construction completed in {dom_construction_end - dom_construction_start:.2f}s')
 
 		return enhanced_dom_tree_node
 
@@ -741,23 +666,15 @@ class DomService:
 
 		# Use current target (None means use current)
 		assert self.browser_session.current_target_id is not None
-
-		dom_tree_start = time.time()
-		self.logger.debug('🔍 SERIALIZER: Getting DOM tree...')
 		enhanced_dom_tree = await self.get_dom_tree(target_id=self.browser_session.current_target_id)
-		dom_tree_end = time.time()
-		self.logger.debug(f'🔍 SERIALIZER: DOM tree retrieved in {dom_tree_end - dom_tree_start:.2f}s')
 
-		serializer_start = time.time()
-		self.logger.debug('🔍 SERIALIZER: Starting DOM serialization...')
+		start = time.time()
 		serialized_dom_state, serializer_timing = DOMTreeSerializer(
 			enhanced_dom_tree, previous_cached_state
 		).serialize_accessible_elements()
-		serializer_end = time.time()
-		self.logger.debug(f'🔍 SERIALIZER: DOM serialization completed in {serializer_end - serializer_start:.2f}s')
 
-		serialize_total_timing = {'serialize_dom_tree_total': serializer_end - serializer_start}
-		serialize_total_timing['get_dom_tree_time'] = dom_tree_end - dom_tree_start
+		end = time.time()
+		serialize_total_timing = {'serialize_dom_tree_total': end - start}
 
 		# Combine all timing info
 		all_timing = {**serializer_timing, **serialize_total_timing}


### PR DESCRIPTION
Auto-generated PR for branch: fix-timeouts-long-websites-only-hashmap
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes timeouts on very long pages by replacing the O(n²) layout scan with an O(1) hashmap and tightening CDP task handling. Keeps full computed styles and processes all frames without a performance hit.

- **Bug Fixes**
  - Prevents snapshot/AX timeouts with per-task 10s timeouts, targeted 2s retries, and cancellations.
  - Raises clear errors with failing task names and logs per-task completion/timeout.

- **Performance**
  - Pre-builds a layout index map for snapshot lookup (O(1) node-to-layout access).
  - Processes all frames and retains full computed styles; adds detailed timing for snapshot, DOM construction, serialization, and total CDP time.

<!-- End of auto-generated description by cubic. -->

