### PR TITLE
timeouts-remove-unused-styles

### DIFF
--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -16,32 +16,16 @@ from browser_use.dom.views import DOMRect, EnhancedSnapshotNode
 
 # Only the ESSENTIAL computed styles for interactivity and visibility detection
 REQUIRED_COMPUTED_STYLES = [
-	# Essential for visibility
-	'display',
-	'visibility',
-	'opacity',
-	'position',
-	'z-index',
-	'pointer-events',
-	'cursor',
-	'overflow',
-	'overflow-x',
-	'overflow-y',
-	'width',
-	'height',
-	'top',
-	'left',
-	'right',
-	'bottom',
-	'transform',
-	'clip',
-	'clip-path',
-	'user-select',
-	'background-color',
-	'color',
-	'border',
-	'margin',
-	'padding',
+	# Only styles actually accessed in the codebase (prevents Chrome crashes on heavy sites)
+	'display',  # Used in service.py visibility detection
+	'visibility',  # Used in service.py visibility detection
+	'opacity',  # Used in service.py visibility detection
+	'overflow',  # Used in views.py scrollability detection
+	'overflow-x',  # Used in views.py scrollability detection
+	'overflow-y',  # Used in views.py scrollability detection
+	'cursor',  # Used in enhanced_snapshot.py cursor extraction
+	'pointer-events',  # Used for clickability logic
+	'position',  # Used for visibility logic
 ]
 
 


### PR DESCRIPTION
Auto-generated PR for branch: timeouts-remove-unused-styles
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Trimmed computed styles in enhanced_snapshot.py to only the 9 properties we actually use, reducing snapshot overhead and avoiding Chrome crashes/timeouts on heavy pages. Speeds up DOM capture without changing visibility or clickability logic.

- **Refactors**
  - Limited REQUIRED_COMPUTED_STYLES to: display, visibility, opacity, overflow, overflow-x, overflow-y, cursor, pointer-events, position.
  - Added inline notes mapping each style to its usage in service.py/views.py for easier audits.

<!-- End of auto-generated description by cubic. -->

