### PR TITLE
Implement cli auth flow for data sync

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -60,7 +60,19 @@ class OldConfig:
 
 	@property
 	def BROWSER_USE_CLOUD_SYNC(self) -> bool:
-		return os.getenv('BROWSER_USE_CLOUD_SYNC', str(self.ANONYMIZED_TELEMETRY)).lower()[:1] in 'ty1'
+		# If explicitly set via env var, use that value
+		env_value = os.getenv('BROWSER_USE_CLOUD_SYNC')
+		if env_value is not None:
+			return env_value.lower()[:1] in 'ty1'
+		
+		# Otherwise, default to true if authenticated, false if not
+		try:
+			from browser_use.sync.auth import DeviceAuthClient
+			auth_client = DeviceAuthClient()
+			return auth_client.is_authenticated
+		except Exception:
+			# Fallback to ANONYMIZED_TELEMETRY if auth check fails
+			return str(self.ANONYMIZED_TELEMETRY).lower()[:1] in 'ty1'
 
 	@property
 	def BROWSER_USE_CLOUD_API_URL(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
     "markdown-pdf==1.5",
     "html2text>=2025.4.15",
     "pillow>=11.2.1",
+    "rich>=14.0.0",
+    "click>=8.1.8",
+    "textual>=3.2.0",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
Implement a CLI authentication flow and gate cloud sync on authentication to ensure data is only sent by authenticated users.

Previously, the agent would attempt to send sync data even if the user was not authenticated, which could lead to an unclear user experience and potential privacy concerns. This change ensures that cloud sync is explicitly opt-in via a new `browser-use auth` command and is only enabled for authenticated users, while providing clear instructions in the agent logs for unauthenticated users.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1757104264661669?thread_ts=1757104264.661669&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-c1387400-e7a2-4b08-bcfe-d5eb16486d4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1387400-e7a2-4b08-bcfe-d5eb16486d4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a CLI auth flow and gate cloud sync behind authentication so only verified users can sync data. Adds a simple browser-use auth command with a status check and a built-in sync test.

- **New Features**
  - New CLI: browser-use auth [--check] to authenticate via device flow or view status.
  - Agent only enables cloud sync when authenticated (or when a custom cloud_sync is passed); unauthenticated runs show clear instructions.
  - Config defaults BROWSER_USE_CLOUD_SYNC to true only when authenticated, unless overridden by env.
  - Auth flow sends a dummy event to verify sync and prints a session URL.

- **Dependencies**
  - Add rich, click, textual.

<!-- End of auto-generated description by cubic. -->

