### PR TITLE
Implement cli auth flow for unauthenticated users

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -60,7 +60,20 @@ class OldConfig:
 
 	@property
 	def BROWSER_USE_CLOUD_SYNC(self) -> bool:
-		return os.getenv('BROWSER_USE_CLOUD_SYNC', str(self.ANONYMIZED_TELEMETRY)).lower()[:1] in 'ty1'
+		# Default to True if authenticated, otherwise follow ANONYMIZED_TELEMETRY setting
+		default_value = str(self.ANONYMIZED_TELEMETRY)
+		
+		# Check if user is authenticated
+		try:
+			from browser_use.sync.auth import DeviceAuthClient
+			auth_client = DeviceAuthClient()
+			if auth_client.is_authenticated:
+				default_value = 'true'
+		except Exception:
+			# If there's any error checking auth, use the original default
+			pass
+			
+		return os.getenv('BROWSER_USE_CLOUD_SYNC', default_value).lower()[:1] in 'ty1'
 
 	@property
 	def BROWSER_USE_CLOUD_API_URL(self) -> str:


### PR DESCRIPTION
Implement a CLI authentication command and gate cloud sync on user authentication status to prevent unauthenticated data transmission.

This change introduces a `browser-use auth` CLI command for explicit user authentication, ensuring that sync data is only sent after successful authentication. It also defaults cloud sync to 'on' for authenticated users and provides a clear CLI instruction for unauthenticated users to initiate the authentication flow.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1757106950850849?thread_ts=1757106950.850849&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-1e36918c-0c2e-4f38-b8e8-81cd31111efa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e36918c-0c2e-4f38-b8e8-81cd31111efa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add a browser-use auth command and block cloud sync until the user is authenticated to prevent unauthenticated data from being sent. For authenticated users, cloud sync now defaults to on.

- **New Features**
  - New CLI command: browser-use auth starts device auth in the terminal and enables cloud sync.
  - Cloud sync is gated by auth; unauthenticated runs show “browser-use auth” and hold events.
  - Config change: BROWSER_USE_CLOUD_SYNC defaults to true when authenticated; otherwise follows ANONYMIZED_TELEMETRY or the env var.
  - CLI entry now supports subcommands (click group) while keeping existing flags (e.g., --mcp, --prompt).

- **Migration**
  - Run browser-use auth once to enable cloud sync.
  - Existing env overrides still work.

<!-- End of auto-generated description by cubic. -->

