### PR TITLE
Remove unused screenshot constants

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -44,9 +44,6 @@ from browser_use.utils import _log_pretty_url, is_new_tab_page
 
 DEFAULT_BROWSER_PROFILE = BrowserProfile()
 
-MAX_SCREENSHOT_HEIGHT = 2000
-MAX_SCREENSHOT_WIDTH = 1920
-
 _LOGGED_UNIQUE_SESSION_IDS = set()  # track unique session IDs that have been logged to make sure we always assign a unique enough id to new sessions and avoid ambiguity in logs
 red = '\033[91m'
 reset = '\033[0m'


### PR DESCRIPTION
## Summary
• Removed `MAX_SCREENSHOT_HEIGHT` and `MAX_SCREENSHOT_WIDTH` constants from `browser_use/browser/session.py`
• These constants were declared but never used anywhere in the codebase

## Test plan
- [x] Verified constants are not referenced elsewhere in the codebase
- [x] Code cleanup with no functional changes

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed unused MAX_SCREENSHOT_HEIGHT and MAX_SCREENSHOT_WIDTH constants from browser_use/browser/session.py to eliminate dead code. No behavior changes; verified they aren’t referenced anywhere.

<!-- End of auto-generated description by cubic. -->

