### PR TITLE
hotfix numpy missing

### DIFF
--- a/browser_use/browser/video_recorder.py
+++ b/browser_use/browser/video_recorder.py
@@ -7,13 +7,12 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
-import numpy as np
-
 from browser_use.browser.profile import ViewportSize
 
 try:
 	import imageio.v2 as iio
 	import imageio_ffmpeg
+	import numpy as np
 	from imageio.core.format import Format
 
 	IMAGEIO_AVAILABLE = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,8 @@ aws = [
     "boto3>=1.38.45"
 ]
 video = [
-    "imageio[ffmpeg]>=2.37.0"
+    "imageio[ffmpeg]>=2.37.0",
+    "numpy>=2.3.2",
 ]
 examples = [
     "agentmail>=0.0.53",


### PR DESCRIPTION
Auto-generated PR for: hotfix numpy missing
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes missing NumPy for video recording. Adds NumPy to the video extra and defers import so non-video environments don’t break.

- **Bug Fixes**
  - Add numpy>=2.3.2 to the [video] extra in pyproject.toml.
  - Move numpy import inside the imageio try block in video_recorder.py to avoid ModuleNotFoundError when video deps aren’t installed.

<!-- End of auto-generated description by cubic. -->

