### PR TITLE
enable-cross_origin_iframes

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -587,7 +587,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		description='Window position to use for the browser x,y from the top left when headless=False.',
 	)
 	cross_origin_iframes: bool = Field(
-		default=False,
+		default=True,
 		description='Enable cross-origin iframe support (OOPIF/Out-of-Process iframes). When False, only same-origin frames are processed to avoid complexity and hanging.',
 	)
 


### PR DESCRIPTION
Auto-generated PR for: enable-cross_origin_iframes
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Enable cross-origin iframe support (OOPIF) by default by setting BrowserProfile.cross_origin_iframes to true. This processes third-party iframes out of the box and improves site coverage.

- **Migration**
  - To restore previous behavior, set cross_origin_iframes=False in BrowserProfile or your config.

<!-- End of auto-generated description by cubic. -->

