### PR TITLE
fix newline input text

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1007,48 +1007,75 @@ class DefaultActionWatchdog(BaseWatchdog):
 			self.logger.debug(f'🎯 Typing text character by character: "{text}"')
 
 			for i, char in enumerate(text):
-				# Get proper modifiers, VK code, and base key for the character
-				modifiers, vk_code, base_key = self._get_char_modifiers_and_vk(char)
-				key_code = self._get_key_code_for_char(base_key)
+				# Special handling for newline characters - convert to Enter key press
+				if char == '\n':
+					# Send Enter key sequence (same as SendKeysEvent handler for 'enter'/'return')
+					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
+						params={
+							'type': 'rawKeyDown',
+							'windowsVirtualKeyCode': 13,
+							'code': 'Enter',
+							'key': 'Enter',
+						},
+						session_id=cdp_session.session_id,
+					)
+					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
+						params={'type': 'char', 'text': '\r', 'unmodifiedText': '\r'},
+						session_id=cdp_session.session_id,
+					)
+					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
+						params={
+							'type': 'keyUp',
+							'windowsVirtualKeyCode': 13,
+							'code': 'Enter',
+							'key': 'Enter',
+						},
+						session_id=cdp_session.session_id,
+					)
+				else:
+					# Regular character handling
+					# Get proper modifiers, VK code, and base key for the character
+					modifiers, vk_code, base_key = self._get_char_modifiers_and_vk(char)
+					key_code = self._get_key_code_for_char(base_key)
 
-				# self.logger.debug(f'🎯 Typing character {i + 1}/{len(text)}: "{char}" (base_key: {base_key}, code: {key_code}, modifiers: {modifiers}, vk: {vk_code})')
+					# self.logger.debug(f'🎯 Typing character {i + 1}/{len(text)}: "{char}" (base_key: {base_key}, code: {key_code}, modifiers: {modifiers}, vk: {vk_code})')
 
-				# Step 1: Send keyDown event (NO text parameter)
-				await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
-					params={
-						'type': 'keyDown',
-						'key': base_key,
-						'code': key_code,
-						'modifiers': modifiers,
-						'windowsVirtualKeyCode': vk_code,
-					},
-					session_id=cdp_session.session_id,
-				)
+					# Step 1: Send keyDown event (NO text parameter)
+					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
+						params={
+							'type': 'keyDown',
+							'key': base_key,
+							'code': key_code,
+							'modifiers': modifiers,
+							'windowsVirtualKeyCode': vk_code,
+						},
+						session_id=cdp_session.session_id,
+					)
 
-				# Small delay to emulate human typing speed
-				await asyncio.sleep(0.001)
+					# Small delay to emulate human typing speed
+					await asyncio.sleep(0.001)
 
-				# Step 2: Send char event (WITH text parameter) - this is crucial for text input
-				await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
-					params={
-						'type': 'char',
-						'text': char,
-						'key': char,
-					},
-					session_id=cdp_session.session_id,
-				)
+					# Step 2: Send char event (WITH text parameter) - this is crucial for text input
+					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
+						params={
+							'type': 'char',
+							'text': char,
+							'key': char,
+						},
+						session_id=cdp_session.session_id,
+					)
 
-				# Step 3: Send keyUp event (NO text parameter)
-				await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
-					params={
-						'type': 'keyUp',
-						'key': base_key,
-						'code': key_code,
-						'modifiers': modifiers,
-						'windowsVirtualKeyCode': vk_code,
-					},
-					session_id=cdp_session.session_id,
-				)
+					# Step 3: Send keyUp event (NO text parameter)
+					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
+						params={
+							'type': 'keyUp',
+							'key': base_key,
+							'code': key_code,
+							'modifiers': modifiers,
+							'windowsVirtualKeyCode': vk_code,
+						},
+						session_id=cdp_session.session_id,
+					)
 
 				# Small delay between characters to look human (realistic typing speed)
 				await asyncio.sleep(0.001)


### PR DESCRIPTION
Auto-generated PR for: fix newline input text
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes newline handling by translating '\n' into an Enter key sequence via CDP, so new lines insert reliably in textareas and contenteditable fields.

- **Bug Fixes**
  - Map '\n' to Enter: dispatch rawKeyDown (VK 13), char '\r', then keyUp.
  - Keep handling for other characters unchanged, including typing delays.

<!-- End of auto-generated description by cubic. -->

