### PR TITLE
make reasoning_models a parameter

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar, overload
 
 import httpx
@@ -55,17 +55,19 @@ class ChatOpenAI(BaseChatModel):
 	http_client: httpx.AsyncClient | None = None
 	_strict_response_validation: bool = False
 	max_completion_tokens: int | None = 4096
-	reasoning_models: list[ChatModel | str] | None = [
-		'o4-mini',
-		'o3',
-		'o3-mini',
-		'o1',
-		'o1-pro',
-		'o3-pro',
-		'gpt-5',
-		'gpt-5-mini',
-		'gpt-5-nano',
-	]
+	reasoning_models: list[ChatModel | str] | None = field(
+		default_factory=lambda: [
+			'o4-mini',
+			'o3',
+			'o3-mini',
+			'o1',
+			'o1-pro',
+			'o3-pro',
+			'gpt-5',
+			'gpt-5-mini',
+			'gpt-5-nano',
+		]
+	)
 
 	# Static
 	@property

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -20,18 +20,6 @@ from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
 
-ReasoningModels: list[ChatModel | str] = [
-	'o4-mini',
-	'o3',
-	'o3-mini',
-	'o1',
-	'o1-pro',
-	'o3-pro',
-	'gpt-5',
-	'gpt-5-mini',
-	'gpt-5-nano',
-]
-
 
 @dataclass
 class ChatOpenAI(BaseChatModel):
@@ -67,6 +55,17 @@ class ChatOpenAI(BaseChatModel):
 	http_client: httpx.AsyncClient | None = None
 	_strict_response_validation: bool = False
 	max_completion_tokens: int | None = 4096
+	reasoning_models: list[ChatModel | str] | None = [
+		'o4-mini',
+		'o3',
+		'o3-mini',
+		'o1',
+		'o1-pro',
+		'o3-pro',
+		'gpt-5',
+		'gpt-5-mini',
+		'gpt-5-nano',
+	]
 
 	# Static
 	@property
@@ -180,7 +179,7 @@ class ChatOpenAI(BaseChatModel):
 			if self.service_tier is not None:
 				model_params['service_tier'] = self.service_tier
 
-			if any(str(m).lower() in str(self.model).lower() for m in ReasoningModels):
+			if any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
 				model_params['reasoning_effort'] = self.reasoning_effort
 				del model_params['temperature']
 				del model_params['frequency_penalty']

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -179,7 +179,7 @@ class ChatOpenAI(BaseChatModel):
 			if self.service_tier is not None:
 				model_params['service_tier'] = self.service_tier
 
-			if any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
 				model_params['reasoning_effort'] = self.reasoning_effort
 				del model_params['temperature']
 				del model_params['frequency_penalty']


### PR DESCRIPTION
Auto-generated PR for: make reasoning_models a parameter
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Made reasoning_models configurable on ChatOpenAI so users can control which models are treated as “reasoning” models. Defaults to the previous list, so behavior is unchanged unless overridden.

- **New Features**
  - Added reasoning_models parameter with the prior default values.
  - ainvoke now checks self.reasoning_models to set reasoning_effort and drop temperature/frequency_penalty when matched.

<!-- End of auto-generated description by cubic. -->

