### PR TITLE
Update serializer.py to assign indices to scrollable elements

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -236,8 +236,8 @@ class DOMTreeSerializer:
 			return
 
 		# Skip assigning index to excluded nodes, or ignored by paint order
-		if not node.excluded_by_parent and not node.ignored_by_paint_order:
-			# Assign index to clickable elements that are also visible
+		if (is_interactive_assign or node.original_node.is_actually_scrollable) and is_visible:
+			# Assign index to clickable and scrollable elements that are also visible
 			is_interactive_assign = self._is_interactive_cached(node.original_node)
 			is_visible = node.original_node.snapshot_node and node.original_node.is_visible
 


### PR DESCRIPTION
SCROLL Elements Sometimes Don't Get Index Numbers

The Current Logic

1. SCROLL Display: Elements with |SCROLL| are displayed when:
  - The element is scrollable (is_actually_scrollable or is_scrollable)
  - AND should_show_scroll is true (element is scrollable and doesn't have a scrollable parent)
2. Index Assignment: Indices are ONLY assigned in _assign_interactive_indices_and_mark_new_nodes when:
  - The element is interactive (passes ClickableElementDetector.is_interactive())
  - AND the element is visible

The Problem

There's a mismatch between display and indexing logic:

- Line 477-479: Shows |SCROLL| for scrollable elements that are NOT interactive (no index)
- Line 483: Shows |SCROLL+[index]| for scrollable elements that ARE interactive (has index)

Why SCROLL Elements Don't Get Indices

Scrollable elements only get indices if they are ALSO considered "interactive" by ClickableElementDetector. Many
scrollable containers (like <div> with overflow) are NOT considered interactive because they:
- Don't have interactive tags (button, input, select, etc.)
- Don't have onclick handlers
- Don't have interactive ARIA roles
- Don't have tabindex

What Needs to Change

To ensure ALL scrollable elements get indices, you need to modify line 271 in
_assign_interactive_indices_and_mark_new_nodes:

Current logic:
if is_interactive_assign and is_visible:  # Only interactive elements get indices

Should be:
if (is_interactive_assign or node.original_node.is_actually_scrollable) and is_visible:  # Interactive OR 
scrollable elements get indices

This would ensure that:
1. All scrollable elements that are visible get an index number
2. The |SCROLL+[index]| format would be used instead of just |SCROLL|
3. Users can interact with scrollable containers even if they're not traditionally "interactive"

The key insight is that scrollability should be treated as a form of interactivity since users need to be able to target scrollable containers with the scroll action.