### PR TITLE
Make iframe limit configurable

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -606,6 +606,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	)
 	paint_order_filtering: bool = Field(default=True, description='Enable paint order filtering. Slightly experimental.')
 
+	# --- DOM/iframe processing limits ---
+	max_total_iframes: int = Field(default=3, description='Maximum number of iframe documents to process to prevent crashes.')
+	max_iframe_depth: int = Field(default=1, description='Maximum depth for cross-origin iframe recursion.')
+
 	# --- Downloads ---
 	auto_download_pdfs: bool = Field(default=True, description='Automatically download PDFs when navigating to PDF viewer pages.')
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -270,6 +270,9 @@ class BrowserSession(BaseModel):
 		cross_origin_iframes: bool | None = None,
 		highlight_elements: bool | None = None,
 		paint_order_filtering: bool | None = None,
+		# DOM/iframe processing limits
+		max_total_iframes: int | None = None,
+		max_iframe_depth: int | None = None,
 	):
 		# Following the same pattern as AgentSettings in service.py
 		# Only pass non-None values to avoid validation errors

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -361,6 +361,8 @@ class DOMWatchdog(BaseWatchdog):
 					logger=self.logger,
 					cross_origin_iframes=self.browser_session.browser_profile.cross_origin_iframes,
 					paint_order_filtering=self.browser_session.browser_profile.paint_order_filtering,
+					max_total_iframes=self.browser_session.browser_profile.max_total_iframes,
+					max_iframe_depth=self.browser_session.browser_profile.max_iframe_depth,
 				)
 
 			# Get serialized DOM tree using the service

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -226,6 +226,10 @@ class FlatEnvConfig(BaseSettings):
 	BROWSER_USE_PROXY_USERNAME: str | None = Field(default=None)
 	BROWSER_USE_PROXY_PASSWORD: str | None = Field(default=None)
 
+	# DOM/iframe processing limits
+	BROWSER_USE_MAX_TOTAL_IFRAMES: int | None = Field(default=None)
+	BROWSER_USE_MAX_IFRAME_DEPTH: int | None = Field(default=None)
+
 
 class DBStyleEntry(BaseModel):
 	"""Database-style entry with UUID and metadata."""
@@ -481,6 +485,13 @@ class Config:
 
 		if env_config.BROWSER_USE_LLM_MODEL:
 			config['llm']['model'] = env_config.BROWSER_USE_LLM_MODEL
+
+		# DOM/iframe processing limits
+		if env_config.BROWSER_USE_MAX_TOTAL_IFRAMES is not None:
+			config['browser_profile']['max_total_iframes'] = env_config.BROWSER_USE_MAX_TOTAL_IFRAMES
+		
+		if env_config.BROWSER_USE_MAX_IFRAME_DEPTH is not None:
+			config['browser_profile']['max_iframe_depth'] = env_config.BROWSER_USE_MAX_IFRAME_DEPTH
 
 		return config
 


### PR DESCRIPTION
Make iframe processing limits configurable via environment variables and agent arguments to prevent crashes and allow processing of more complex pages.

The previous hardcoded limits (e.g., `MAX_TOTAL_IFRAMES=3`) would issue a warning and truncate iframe processing on pages with many iframes, potentially hindering the agent's ability to interact with content. This change allows users to override these limits to suit their specific use cases.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1757343033724149?thread_ts=1757343033.724149&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-345948bc-3943-43a9-9caa-3abf9ea79bc0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-345948bc-3943-43a9-9caa-3abf9ea79bc0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Makes iframe processing limits configurable to prevent crashes on pages with many iframes and support deeper traversal when needed. Defaults remain unchanged (3 total iframes, depth 1).

- New Features
  - Added max_total_iframes and max_iframe_depth to AgentService → BrowserSession → DOMService.
  - Read BROWSER_USE_MAX_TOTAL_IFRAMES and BROWSER_USE_MAX_IFRAME_DEPTH from env into BrowserProfile.
  - DOMService now enforces per-instance limits and logs warnings with the configured values.

- Migration
  - No action needed if defaults are fine.
  - To override: set env vars BROWSER_USE_MAX_TOTAL_IFRAMES and/or BROWSER_USE_MAX_IFRAME_DEPTH, or pass max_total_iframes/max_iframe_depth to the Agent.

<!-- End of auto-generated description by cubic. -->

