### PR TITLE
Make iframe limit configurable

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -590,6 +590,14 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		default=True,
 		description='Enable cross-origin iframe support (OOPIF/Out-of-Process iframes). When False, only same-origin frames are processed to avoid complexity and hanging.',
 	)
+	max_iframes: int = Field(
+		default_factory=lambda: CONFIG.BROWSER_USE_MAX_IFRAMES or 100,
+		description='Maximum number of iframe documents to process to prevent crashes (default: 100, previous default was 3). Can be set via BROWSER_USE_MAX_IFRAMES environment variable.',
+	)
+	max_iframe_depth: int = Field(
+		default=1,
+		description='Maximum depth for cross-origin iframe recursion (default: 1 level deep).',
+	)
 
 	# --- Page load/wait timings ---
 

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -591,12 +591,12 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		description='Enable cross-origin iframe support (OOPIF/Out-of-Process iframes). When False, only same-origin frames are processed to avoid complexity and hanging.',
 	)
 	max_iframes: int = Field(
-		default_factory=lambda: CONFIG.BROWSER_USE_MAX_IFRAMES or 100,
-		description='Maximum number of iframe documents to process to prevent crashes (default: 100, previous default was 3). Can be set via BROWSER_USE_MAX_IFRAMES environment variable.',
+		default=100,
+		description='Maximum number of iframe documents to process to prevent crashes (default: 100, previous default was 3).',
 	)
 	max_iframe_depth: int = Field(
-		default=1,
-		description='Maximum depth for cross-origin iframe recursion (default: 1 level deep).',
+		default=5,
+		description='Maximum depth for cross-origin iframe recursion (default: 5 levels deep).',
 	)
 
 	# --- Page load/wait timings ---

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -592,7 +592,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	)
 	max_iframes: int = Field(
 		default=100,
-		description='Maximum number of iframe documents to process to prevent crashes (default: 100, previous default was 3).',
+		description='Maximum number of iframe documents to process to prevent crashes.',
 	)
 	max_iframe_depth: int = Field(
 		default=5,

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -296,8 +296,6 @@ class BrowserSession(BaseModel):
 		super().__init__(
 			id=id or str(uuid7str()),
 			browser_profile=resolved_browser_profile,
-			max_iframes=max_iframes if max_iframes is not None else resolved_browser_profile.max_iframes,
-			max_iframe_depth=max_iframe_depth if max_iframe_depth is not None else resolved_browser_profile.max_iframe_depth,
 		)
 
 	# Session configuration (session identity only)
@@ -309,9 +307,16 @@ class BrowserSession(BaseModel):
 		description='BrowserProfile() options to use for the session, otherwise a default profile will be used',
 	)
 	
-	# Iframe processing configuration (can override profile defaults)
-	max_iframes: int = Field(default=100, description='Maximum number of iframe documents to process')
-	max_iframe_depth: int = Field(default=5, description='Maximum depth for cross-origin iframe recursion')
+	# Iframe processing configuration (gets values from browser_profile)
+	@property
+	def max_iframes(self) -> int:
+		"""Maximum number of iframe documents to process."""
+		return self.browser_profile.max_iframes
+	
+	@property
+	def max_iframe_depth(self) -> int:
+		"""Maximum depth for cross-origin iframe recursion."""
+		return self.browser_profile.max_iframe_depth
 
 	# Convenience properties for common browser settings
 	@property

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -270,6 +270,9 @@ class BrowserSession(BaseModel):
 		cross_origin_iframes: bool | None = None,
 		highlight_elements: bool | None = None,
 		paint_order_filtering: bool | None = None,
+		# Iframe processing limits
+		max_iframes: int | None = None,
+		max_iframe_depth: int | None = None,
 	):
 		# Following the same pattern as AgentSettings in service.py
 		# Only pass non-None values to avoid validation errors
@@ -293,6 +296,8 @@ class BrowserSession(BaseModel):
 		super().__init__(
 			id=id or str(uuid7str()),
 			browser_profile=resolved_browser_profile,
+			max_iframes=max_iframes if max_iframes is not None else resolved_browser_profile.max_iframes,
+			max_iframe_depth=max_iframe_depth if max_iframe_depth is not None else resolved_browser_profile.max_iframe_depth,
 		)
 
 	# Session configuration (session identity only)
@@ -303,6 +308,10 @@ class BrowserSession(BaseModel):
 		default_factory=lambda: DEFAULT_BROWSER_PROFILE,
 		description='BrowserProfile() options to use for the session, otherwise a default profile will be used',
 	)
+	
+	# Iframe processing configuration (can override profile defaults)
+	max_iframes: int = Field(default=100, description='Maximum number of iframe documents to process')
+	max_iframe_depth: int = Field(default=5, description='Maximum depth for cross-origin iframe recursion')
 
 	# Convenience properties for common browser settings
 	@property

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -361,6 +361,8 @@ class DOMWatchdog(BaseWatchdog):
 					logger=self.logger,
 					cross_origin_iframes=self.browser_session.browser_profile.cross_origin_iframes,
 					paint_order_filtering=self.browser_session.browser_profile.paint_order_filtering,
+					max_iframes=self.browser_session.browser_profile.max_iframes,
+					max_iframe_depth=self.browser_session.browser_profile.max_iframe_depth,
 				)
 
 			# Get serialized DOM tree using the service

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -361,8 +361,8 @@ class DOMWatchdog(BaseWatchdog):
 					logger=self.logger,
 					cross_origin_iframes=self.browser_session.browser_profile.cross_origin_iframes,
 					paint_order_filtering=self.browser_session.browser_profile.paint_order_filtering,
-					max_iframes=self.browser_session.browser_profile.max_iframes,
-					max_iframe_depth=self.browser_session.browser_profile.max_iframe_depth,
+					max_iframes=self.browser_session.max_iframes,
+					max_iframe_depth=self.browser_session.max_iframe_depth,
 				)
 
 			# Get serialized DOM tree using the service

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -225,6 +225,9 @@ class FlatEnvConfig(BaseSettings):
 	BROWSER_USE_NO_PROXY: str | None = Field(default=None)
 	BROWSER_USE_PROXY_USERNAME: str | None = Field(default=None)
 	BROWSER_USE_PROXY_PASSWORD: str | None = Field(default=None)
+	
+	# DOM processing limits
+	BROWSER_USE_MAX_IFRAMES: int | None = Field(default=None)
 
 
 class DBStyleEntry(BaseModel):

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -225,9 +225,6 @@ class FlatEnvConfig(BaseSettings):
 	BROWSER_USE_NO_PROXY: str | None = Field(default=None)
 	BROWSER_USE_PROXY_USERNAME: str | None = Field(default=None)
 	BROWSER_USE_PROXY_PASSWORD: str | None = Field(default=None)
-	
-	# DOM processing limits
-	BROWSER_USE_MAX_IFRAMES: int | None = Field(default=None)
 
 
 class DBStyleEntry(BaseModel):

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -27,9 +27,7 @@ from browser_use.dom.views import (
 if TYPE_CHECKING:
 	from browser_use.browser.session import BrowserSession
 
-# Global limits to prevent iframe explosion
-MAX_TOTAL_IFRAMES = 3  # Maximum number of iframe documents to process (very conservative to prevent explosions)
-MAX_IFRAME_DEPTH = 1  # Maximum depth for cross-origin iframe recursion (only 1 level deep)
+# Note: iframe limits are now configurable via BrowserProfile.max_iframes and BrowserProfile.max_iframe_depth
 
 
 class DomService:
@@ -49,11 +47,15 @@ class DomService:
 		logger: logging.Logger | None = None,
 		cross_origin_iframes: bool = False,
 		paint_order_filtering: bool = True,
+		max_iframes: int = 100,
+		max_iframe_depth: int = 1,
 	):
 		self.browser_session = browser_session
 		self.logger = logger or browser_session.logger
 		self.cross_origin_iframes = cross_origin_iframes
 		self.paint_order_filtering = paint_order_filtering
+		self.max_iframes = max_iframes
+		self.max_iframe_depth = max_iframe_depth
 
 	async def __aenter__(self):
 		return self
@@ -419,12 +421,12 @@ class DomService:
 		# DEBUG: Log snapshot info and limit documents to prevent explosion
 		if snapshot and 'documents' in snapshot:
 			original_doc_count = len(snapshot['documents'])
-			# Limit to MAX_TOTAL_IFRAMES documents to prevent iframe explosion
-			if original_doc_count > MAX_TOTAL_IFRAMES:
+			# Limit to max_iframes documents to prevent iframe explosion
+			if original_doc_count > self.max_iframes:
 				self.logger.warning(
-					f'⚠️ Limiting processing of {original_doc_count} iframes on page to only first {MAX_TOTAL_IFRAMES} to prevent crashes!'
+					f'⚠️ Limiting processing of {original_doc_count} iframes on page to only first {self.max_iframes} to prevent crashes!'
 				)
-				snapshot['documents'] = snapshot['documents'][:MAX_TOTAL_IFRAMES]
+				snapshot['documents'] = snapshot['documents'][:self.max_iframes]
 
 			total_nodes = sum(len(doc.get('nodes', [])) for doc in snapshot['documents'])
 			self.logger.debug(f'🔍 DEBUG: Snapshot contains {len(snapshot["documents"])} frames with {total_nodes} total nodes')
@@ -641,9 +643,9 @@ class DomService:
 				self.cross_origin_iframes and node['nodeName'].upper() == 'IFRAME' and node.get('contentDocument', None) is None
 			):  # None meaning there is no content
 				# Check iframe depth to prevent infinite recursion
-				if iframe_depth >= MAX_IFRAME_DEPTH:
+				if iframe_depth >= self.max_iframe_depth:
 					self.logger.debug(
-						f'Skipping iframe at depth {iframe_depth} to prevent infinite recursion (max depth: {MAX_IFRAME_DEPTH})'
+						f'Skipping iframe at depth {iframe_depth} to prevent infinite recursion (max depth: {self.max_iframe_depth})'
 					)
 				else:
 					# Check if iframe is visible and large enough (>= 200px in both dimensions)


### PR DESCRIPTION
Make iframe processing limits configurable via environment variables and `BrowserProfile`, and increase the default `max_iframes` to 100.

The previous hardcoded limit of 3 iframes was too restrictive for many modern web pages, causing warnings and incomplete processing. This change allows users to adjust the limit and sets a more reasonable default.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1757343080938439?thread_ts=1757343080.938439&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-6a08e590-c58d-4a72-a807-22096f4000e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a08e590-c58d-4a72-a807-22096f4000e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Made iframe processing limits configurable and raised the default max_iframes from 3 to 100 for more complete DOM processing on modern pages. Replaces hardcoded limits with env and BrowserProfile settings.

- **New Features**
  - Added BrowserProfile.max_iframes (default 100, configurable via BROWSER_USE_MAX_IFRAMES) and BrowserProfile.max_iframe_depth (default 1).
  - DomService now takes max_iframes and max_iframe_depth; removed previous global constants.
  - dom_watchdog passes profile limits through to DomService.
  - Added BROWSER_USE_MAX_IFRAMES to env config and improved log warnings to reflect the active limit.

- **Migration**
  - Default behavior now processes up to 100 iframes. Set BROWSER_USE_MAX_IFRAMES or BrowserProfile.max_iframes to lower or raise this as needed.
  - No breaking changes; configuration is optional.

<!-- End of auto-generated description by cubic. -->

