### PR TITLE
Mark custom selectors as interactive elements

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -182,6 +182,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		sample_images: list[ContentPartTextParam | ContentPartImageParam] | None = None,
 		final_response_after_failure: bool = True,
 		_url_shortening_limit: int = 25,
+		custom_interactive_selectors: list[str] | None = None,
 		**kwargs,
 	):
 		if llm is None:
@@ -216,6 +217,14 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if browser and browser_session:
 			raise ValueError('Cannot specify both "browser" and "browser_session" parameters. Use "browser" for the cleaner API.')
 		browser_session = browser or browser_session
+
+		# Update browser profile with custom interactive selectors if provided
+		if custom_interactive_selectors and browser_profile:
+			# Merge custom selectors into existing browser profile
+			browser_profile = browser_profile.model_copy(update={'custom_interactive_selectors': custom_interactive_selectors})
+		elif custom_interactive_selectors:
+			# Create new browser profile with custom selectors
+			browser_profile = (browser_profile or DEFAULT_BROWSER_PROFILE).model_copy(update={'custom_interactive_selectors': custom_interactive_selectors})
 
 		self.browser_session = browser_session or BrowserSession(
 			browser_profile=browser_profile,

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -599,6 +599,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		default=5,
 		description='Maximum depth for cross-origin iframe recursion (default: 5 levels deep).',
 	)
+	custom_interactive_selectors: list[str] | None = Field(
+		default=None,
+		description='List of CSS selectors that should always be marked as interactive elements'
+	)
 
 	# --- Page load/wait timings ---
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -273,6 +273,8 @@ class BrowserSession(BaseModel):
 		# Iframe processing limits
 		max_iframes: int | None = None,
 		max_iframe_depth: int | None = None,
+		# Custom interactive selectors
+		custom_interactive_selectors: list[str] | None = None,
 	):
 		# Following the same pattern as AgentSettings in service.py
 		# Only pass non-None values to avoid validation errors

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -363,6 +363,7 @@ class DOMWatchdog(BaseWatchdog):
 					paint_order_filtering=self.browser_session.browser_profile.paint_order_filtering,
 					max_iframes=self.browser_session.browser_profile.max_iframes,
 					max_iframe_depth=self.browser_session.browser_profile.max_iframe_depth,
+					custom_interactive_selectors=self.browser_session.browser_profile.custom_interactive_selectors,
 				)
 
 			# Get serialized DOM tree using the service

--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -42,6 +42,7 @@ class DOMTreeSerializer:
 		enable_bbox_filtering: bool = True,
 		containment_threshold: float | None = None,
 		paint_order_filtering: bool = True,
+		custom_interactive_selectors: list[str] | None = None,
 	):
 		self.root_node = root_node
 		self._interactive_counter = 1
@@ -56,6 +57,9 @@ class DOMTreeSerializer:
 		self.containment_threshold = containment_threshold or self.DEFAULT_CONTAINMENT_THRESHOLD
 		# Paint order filtering configuration
 		self.paint_order_filtering = paint_order_filtering
+		
+		# Custom interactive selectors configuration
+		self.custom_interactive_selectors = custom_interactive_selectors or []
 
 	def serialize_accessible_elements(self) -> tuple[SerializedDOMState, dict[str, float]]:
 		import time
@@ -113,7 +117,7 @@ class DOMTreeSerializer:
 			import time
 
 			start_time = time.time()
-			result = ClickableElementDetector.is_interactive(node)
+			result = ClickableElementDetector.is_interactive(node, self.custom_interactive_selectors)
 			end_time = time.time()
 
 			if 'clickable_detection_time' not in self.timing_info:

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -49,6 +49,7 @@ class DomService:
 		paint_order_filtering: bool = True,
 		max_iframes: int = 100,
 		max_iframe_depth: int = 5,
+		custom_interactive_selectors: list[str] | None = None,
 	):
 		self.browser_session = browser_session
 		self.logger = logger or browser_session.logger
@@ -56,6 +57,7 @@ class DomService:
 		self.paint_order_filtering = paint_order_filtering
 		self.max_iframes = max_iframes
 		self.max_iframe_depth = max_iframe_depth
+		self.custom_interactive_selectors = custom_interactive_selectors
 
 	async def __aenter__(self):
 		return self
@@ -725,7 +727,10 @@ class DomService:
 
 		start = time.time()
 		serialized_dom_state, serializer_timing = DOMTreeSerializer(
-			enhanced_dom_tree, previous_cached_state, paint_order_filtering=self.paint_order_filtering
+			enhanced_dom_tree, 
+			previous_cached_state, 
+			paint_order_filtering=self.paint_order_filtering,
+			custom_interactive_selectors=self.custom_interactive_selectors
 		).serialize_accessible_elements()
 
 		end = time.time()

--- a/examples/features/custom_interactive_selectors.py
+++ b/examples/features/custom_interactive_selectors.py
@@ -1,0 +1,58 @@
+"""
+Example: Custom Interactive Selectors
+
+This example demonstrates how to use custom_interactive_selectors to force
+certain elements to be marked as interactive, even if they wouldn't normally
+be detected as clickable by the browser-use agent.
+
+This is useful for:
+- Custom UI components that don't use standard interactive tags
+- Elements with non-standard click handlers
+- Complex web applications with custom interaction patterns
+"""
+
+import asyncio
+from browser_use import Agent, ChatOpenAI
+
+
+async def main():
+    """
+    Example showing how to specify custom selectors that should always be
+    treated as interactive elements.
+    """
+    
+    # Define custom selectors that should always be marked as interactive
+    custom_selectors = [
+        '.custom-button',           # Any element with class "custom-button"
+        '[data-action]',           # Any element with a "data-action" attribute
+        '#special-element',        # Element with ID "special-element"
+        'div.interactive-card',    # Div elements with class "interactive-card"
+        '[role="custom-button"]',  # Elements with custom role attribute
+    ]
+    
+    # Create agent with custom interactive selectors
+    agent = Agent(
+        task="Navigate to a webpage and interact with custom UI components that might not be automatically detected as clickable",
+        llm=ChatOpenAI(model="gpt-4o-mini"),
+        custom_interactive_selectors=custom_selectors,
+        # You can also pass other browser configuration options
+        headless=False,  # Set to True for headless mode
+    )
+    
+    print("🎯 Agent created with custom interactive selectors:")
+    for selector in custom_selectors:
+        print(f"  - {selector}")
+    
+    print("\n🚀 Running agent...")
+    print("The agent will now treat elements matching the custom selectors as interactive,")
+    print("even if they wouldn't normally be detected as clickable.")
+    
+    # Run the agent
+    result = await agent.run(max_steps=10)
+    
+    print("✅ Agent completed!")
+    return result
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/features/custom_interactive_selectors_demo.py
+++ b/examples/features/custom_interactive_selectors_demo.py
@@ -1,0 +1,231 @@
+"""
+Example: Custom Interactive Selectors Demo
+
+This example creates a simple HTML page with custom interactive elements
+and demonstrates how the custom_interactive_selectors feature allows the
+agent to interact with elements that wouldn't normally be detected.
+"""
+
+import asyncio
+import tempfile
+import os
+from pathlib import Path
+from browser_use import Agent, ChatOpenAI
+
+
+def create_demo_html():
+    """Create a demo HTML page with custom interactive elements."""
+    html_content = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Custom Interactive Elements Demo</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f5f5f5;
+        }
+        .container {
+            background: white;
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        
+        /* Standard interactive elements */
+        .standard-button {
+            background: #007bff;
+            color: white;
+            padding: 10px 20px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            margin: 10px;
+        }
+        
+        /* Custom elements that look interactive but aren't standard */
+        .custom-card {
+            background: #e9ecef;
+            padding: 20px;
+            margin: 10px 0;
+            border-radius: 8px;
+            border-left: 4px solid #28a745;
+            transition: background-color 0.3s;
+        }
+        
+        .special-widget {
+            background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+            color: white;
+            padding: 15px;
+            margin: 10px 0;
+            border-radius: 10px;
+            text-align: center;
+            font-weight: bold;
+        }
+        
+        .interactive-icon {
+            display: inline-block;
+            width: 40px;
+            height: 40px;
+            background: #ffc107;
+            border-radius: 50%;
+            margin: 5px;
+            text-align: center;
+            line-height: 40px;
+            font-weight: bold;
+        }
+        
+        .result {
+            margin-top: 20px;
+            padding: 15px;
+            background: #d4edda;
+            border: 1px solid #c3e6cb;
+            border-radius: 5px;
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Custom Interactive Elements Demo</h1>
+        <p>This page demonstrates elements that might not be automatically detected as interactive.</p>
+        
+        <h2>Standard Interactive Elements</h2>
+        <button class="standard-button" onclick="showResult('Standard button clicked!')">Standard Button</button>
+        <a href="#" onclick="showResult('Standard link clicked!'); return false;">Standard Link</a>
+        
+        <h2>Custom Interactive Elements</h2>
+        <p>These elements have click handlers but might not be detected automatically:</p>
+        
+        <div class="custom-card" data-action="click" onclick="showResult('Custom card clicked!')">
+            <h3>Custom Card Component</h3>
+            <p>This looks like a card but has a click handler (data-action attribute)</p>
+        </div>
+        
+        <div class="special-widget" id="special-element" onclick="showResult('Special widget clicked!')">
+            <p>Special Widget (ID: special-element)</p>
+        </div>
+        
+        <div>
+            <span class="interactive-icon" data-action="icon1" onclick="showResult('Icon 1 clicked!')">1</span>
+            <span class="interactive-icon" data-action="icon2" onclick="showResult('Icon 2 clicked!')">2</span>
+            <span class="interactive-icon" data-action="icon3" onclick="showResult('Icon 3 clicked!')">3</span>
+        </div>
+        
+        <div role="custom-button" onclick="showResult('Custom role button clicked!')" 
+             style="background: #6f42c1; color: white; padding: 12px; margin: 10px 0; text-align: center; border-radius: 5px;">
+            Element with Custom Role
+        </div>
+        
+        <div id="result" class="result"></div>
+    </div>
+    
+    <script>
+        function showResult(message) {
+            const resultDiv = document.getElementById('result');
+            resultDiv.textContent = message;
+            resultDiv.style.display = 'block';
+            setTimeout(() => {
+                resultDiv.style.display = 'none';
+            }, 3000);
+        }
+    </script>
+</body>
+</html>
+    """
+    
+    # Create a temporary HTML file
+    temp_file = tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False)
+    temp_file.write(html_content)
+    temp_file.close()
+    
+    return temp_file.name
+
+
+async def demo_without_custom_selectors():
+    """Run the demo without custom selectors to show the difference."""
+    print("🔍 Demo 1: Running WITHOUT custom selectors")
+    print("=" * 50)
+    
+    html_file = create_demo_html()
+    file_url = f"file://{os.path.abspath(html_file)}"
+    
+    try:
+        agent = Agent(
+            task=f"Open {file_url} and try to click on the 'Custom Card Component' and the 'Special Widget'",
+            llm=ChatOpenAI(model="gpt-4o-mini"),
+            headless=True,
+        )
+        
+        result = await agent.run(max_steps=5)
+        print("✅ Demo 1 completed")
+        
+    finally:
+        # Clean up
+        os.unlink(html_file)
+
+
+async def demo_with_custom_selectors():
+    """Run the demo with custom selectors to show the improvement."""
+    print("\n🎯 Demo 2: Running WITH custom selectors")
+    print("=" * 50)
+    
+    html_file = create_demo_html()
+    file_url = f"file://{os.path.abspath(html_file)}"
+    
+    # Define the custom selectors that match our demo page elements
+    custom_selectors = [
+        '.custom-card',              # The custom card component
+        '#special-element',          # The special widget
+        '[data-action]',            # Any element with data-action attribute
+        '[role="custom-button"]',   # Elements with custom role
+    ]
+    
+    try:
+        agent = Agent(
+            task=f"Open {file_url} and click on the 'Custom Card Component', the 'Special Widget', and one of the numbered icons",
+            llm=ChatOpenAI(model="gpt-4o-mini"),
+            custom_interactive_selectors=custom_selectors,
+            headless=True,
+        )
+        
+        print("Custom selectors being used:")
+        for selector in custom_selectors:
+            print(f"  - {selector}")
+        
+        result = await agent.run(max_steps=8)
+        print("✅ Demo 2 completed")
+        
+    finally:
+        # Clean up
+        os.unlink(html_file)
+
+
+async def main():
+    """Run both demos to show the difference."""
+    print("🚀 Custom Interactive Selectors Demo")
+    print("This demo shows the difference between running with and without custom selectors")
+    print()
+    
+    # Run demo without custom selectors first
+    await demo_without_custom_selectors()
+    
+    # Run demo with custom selectors
+    await demo_with_custom_selectors()
+    
+    print("\n📊 Summary:")
+    print("- Demo 1 (without custom selectors): May have trouble finding non-standard interactive elements")
+    print("- Demo 2 (with custom selectors): Can interact with custom elements that match the specified selectors")
+    print("\n💡 Use custom_interactive_selectors when working with:")
+    print("  • Custom UI frameworks (React, Vue, Angular components)")
+    print("  • Web apps with non-standard interactive patterns")
+    print("  • Elements that have click handlers but don't look like standard buttons/links")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Add `custom_interactive_selectors` to the Agent to mark specified elements as interactive.

This feature (ENG-497) allows users to explicitly define CSS selectors for elements that should always be considered interactive, addressing cases where default detection heuristics might miss custom UI components or non-standard interactive patterns.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1757376184591849?thread_ts=1757376184.591849&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-ac002e64-0f83-42c8-af76-0c445f6e6cb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ac002e64-0f83-42c8-af76-0c445f6e6cb2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

