### PR TITLE
fix take step

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1312,7 +1312,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		Returns:
 		        Tuple[bool, bool]: (is_done, is_valid)
 		"""
-		if len(self.history.history) == 0:
+		if step_info is not None and step_info.step_number == 1:
 			# First step
 			self._log_first_step_startup()
 			await self._execute_initial_actions()


### PR DESCRIPTION
Auto-generated PR for: fix take step
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes first-step detection in take_step by checking step_info.step_number == 1 instead of relying on empty history. This ensures initial actions run only on the true first step.

- **Bug Fixes**
  - Run initial startup only when step_number is 1, preventing accidental re-runs on resumed or cleared histories.

<!-- End of auto-generated description by cubic. -->

