### PR TITLE
fix: save initial actions to history and fix serialization

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -145,6 +145,14 @@ class DOMRect:
 	y: float
 	width: float
 	height: float
+	
+	def to_dict(self) -> dict[str, Any]:
+		return {
+			'x': self.x,
+			'y': self.y,
+			'width': self.width,
+			'height': self.height,
+		}
 
 
 @dataclass(slots=True)
@@ -758,11 +766,16 @@ class DOMInteractedElement:
 
 	def to_dict(self) -> dict[str, Any]:
 		return {
+			'node_id': self.node_id,
+			'backend_node_id': self.backend_node_id,
+			'frame_id': self.frame_id,
 			'node_type': self.node_type.value,
 			'node_value': self.node_value,
 			'node_name': self.node_name,
 			'attributes': self.attributes,
+			'bounds': self.bounds.to_dict() if self.bounds else None,
 			'x_path': self.x_path,
+			'element_hash': self.element_hash,
 		}
 
 	@classmethod


### PR DESCRIPTION
- Save go_to_url initial actions to history file
- Add DOMRect.to_dict() for JSON serialization
- Complete DOMInteractedElement.to_dict() with all required fields
- Fix history replay validation errors
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Saves initial go_to_url actions to history and completes DOM serialization. This fixes history replay validation errors and ensures consistent JSON output.

- **New Features**
  - Save initial actions as step 0 with metadata and a browser state snapshot (screenshot, recent events).

- **Bug Fixes**
  - Add DOMRect.to_dict and include bounds in serialization.
  - Complete DOMInteractedElement.to_dict with node_id, backend_node_id, frame_id, element_hash.

<!-- End of auto-generated description by cubic. -->

