### PR TITLE
include-js-tool

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -913,7 +913,6 @@ Return:
 JSON.stringify(Array.from(document.querySelectorAll('a')).map(el => el.textContent.trim()))
 - execute_js can only return strings/numbers/booleans that are readable
 - Objects return "Executed successfully (returned object)" - useless!
-- If you get `{}` or `[]` results, your selectors are WRONG. Use shadow DOM detection (#5) first.
 
 """,
 		)
@@ -927,15 +926,15 @@ JSON.stringify(Array.from(document.querySelectorAll('a')).map(el => el.textConte
 					params={'expression': code, 'returnByValue': True}, session_id=cdp_session.session_id
 				)
 				result_text = result.get('result', {}).get('value', '')
-				description = result.get('result', {}).get('description', '')
+
 				if len(result_text) > 20000:
 					result_text = result_text[:20000] + ' Truncated after 20000 characters ...'
 				# Return the result (could be empty string, which is valid)
 				return ActionResult(extracted_content=f'Code: {code}\n\nResult: {result_text}')
 
 			except Exception as e:
-				result = f'Failed to execute JavaScript {code}: {e} '
-				return ActionResult(error=result)
+				result_text = f'Failed to execute JavaScript {code}: {e} '
+				return ActionResult(error=result_text)
 
 	# Custom done action for structured output
 	async def extract_clean_markdown(

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -926,7 +926,7 @@ JSON.stringify(Array.from(document.querySelectorAll('a')).map(el => el.textConte
 					params={'expression': code, 'returnByValue': True}, session_id=cdp_session.session_id
 				)
 				result_text = result.get('result', {}).get('value', '')
-
+				result_text = str(result_text)
 				if len(result_text) > 20000:
 					result_text = result_text[:20000] + ' Truncated after 20000 characters ...'
 				# Return the result (could be empty string, which is valid)

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -37,7 +37,6 @@ from browser_use.tools.views import (
 	ClickElementAction,
 	CloseTabAction,
 	DoneAction,
-	ExecuteCDPAction,
 	GetDropdownOptionsAction,
 	GoToUrlAction,
 	InputTextAction,
@@ -893,34 +892,50 @@ You will be given a query and the markdown of a webpage that has been filtered t
 				include_extracted_content_only_once=True,
 			)
 
-			# General CDP execution tool
-
 		@self.registry.action(
 			"""This JavaScript code gets executed with Runtime.evaluate
-			 - Write code to solve problems you could not solve with other tools.
-			 - Don't write comments in here, no human reads that.
-			 - Write only valid code. 
 EXAMPLES:
-Clicking on coordinates, using when other tools fail, filling a form all at once, hovering, dragging, extracting only links, extracting query, zooming ....
+Using when other tools fail, filling a form all at once, hovering, dragging, extracting only links, extracting content from the page, Clicking on coordinates, zooming, use this if the user provides custom selecotrs which you can otherwise not interact with ....
 You can also use it to explore the website.
+- Write code to solve problems you could not solve with other tools.
+- Don't write comments in here, no human reads that.
+- Write only valid js code. 
+- use this to e.g. extract + filter links, convert the page to json into the format you need etc...
+- wrap your code in a function(){{ ... }})() 
+- wrap your code in a try catch block
+- limit the output otherwise your context will explode
+- think if you deal with special elements like iframes / shadow roots etc
+- Adopt your strategy for React Native Web, React, Angular, Vue, MUI pages etc.
+- e.g. with  synthetic events, keyboard simulation, shadow DOM, etc.
+
+## Basic DOM interaction (single line preferred):
+Return: 
+JSON.stringify(Array.from(document.querySelectorAll('a')).map(el => el.textContent.trim()))
+- execute_js can only return strings/numbers/booleans that are readable
+- Objects return "Executed successfully (returned object)" - useless!
+- If you get `{}` or `[]` results, your selectors are WRONG. Use shadow DOM detection (#5) first.
+
 """,
-			param_model=ExecuteCDPAction,
 		)
-		async def execute_js(params: ExecuteCDPAction, browser_session: BrowserSession):
-			# Pre-process JavaScript to fix common issues
-			code = params.js_code
+		async def execute_js(code: str, browser_session: BrowserSession):
+			# Pre-process JavaScript to fix common issues and add error handling
+
 			cdp_session = await browser_session.get_or_create_cdp_session()
+			result_text = ''
 			try:
 				result = await cdp_session.cdp_client.send.Runtime.evaluate(
-					params={'expression': code}, session_id=cdp_session.session_id
+					params={'expression': code, 'returnByValue': True}, session_id=cdp_session.session_id
 				)
 				result_text = result.get('result', {}).get('value', '')
 				description = result.get('result', {}).get('description', '')
-				error_message = result.get('exceptionDetails', {}).get('text', '')
-				return ActionResult(extracted_content=result_text)
+				if len(result_text) > 20000:
+					result_text = result_text[:20000] + ' Truncated after 20000 characters ...'
+				# Return the result (could be empty string, which is valid)
+				return ActionResult(extracted_content=f'Code: {code}\n\nResult: {result_text}')
 
 			except Exception as e:
-				return ActionResult(error=f'Failed to execute JavaScript: {e}')
+				result = f'Failed to execute JavaScript {code}: {e} '
+				return ActionResult(error=result)
 
 	# Custom done action for structured output
 	async def extract_clean_markdown(

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -91,7 +91,3 @@ class GetDropdownOptionsAction(BaseModel):
 class SelectDropdownOptionAction(BaseModel):
 	index: int = Field(ge=1, description='index of the dropdown element to select an option for')
 	text: str = Field(description='the text or exact value of the option to select')
-
-
-class ExecuteCDPAction(BaseModel):
-	js_code: str = Field(description='JavaScript code to execute via CDP Runtime.evaluate')

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -91,3 +91,7 @@ class GetDropdownOptionsAction(BaseModel):
 class SelectDropdownOptionAction(BaseModel):
 	index: int = Field(ge=1, description='index of the dropdown element to select an option for')
 	text: str = Field(description='the text or exact value of the option to select')
+
+
+class ExecuteCDPAction(BaseModel):
+	js_code: str = Field(description='JavaScript code to execute via CDP Runtime.evaluate')


### PR DESCRIPTION
Auto-generated PR for: include-js-tool
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a general-purpose JavaScript execution tool via CDP Runtime.evaluate to handle interactions and extraction when other tools fall short. Enables actions like coordinate clicks, bulk form fill, hover/drag, link scraping, and page exploration.

- **New Features**
  - New ExecuteCDPAction(js_code) model and execute_js action.
  - Runs code via an existing CDP session using Runtime.evaluate.
  - Returns the evaluation value as extracted_content; errors include a clear message.

<!-- End of auto-generated description by cubic. -->

