### PR TITLE
Ensure js_result is defined

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1531,6 +1531,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 		]
 
 		found = False
+		js_result = None
 		for query in search_queries:
 			try:
 				# Perform search
@@ -1587,18 +1588,18 @@ class DefaultActionWatchdog(BaseWatchdog):
 				session_id=session_id,
 			)
 
-		if js_result.get('result', {}).get('value'):
-			self.logger.debug(f'📜 Scrolled to text: "{event.text}" (via JS)')
-			return None
-		else:
-			self.logger.warning(f'⚠️ Text not found: "{event.text}"')
-			raise BrowserError(f'Text not found: "{event.text}"', details={'text': event.text})
-
-		# If we got here and found is True, return None (success)
+		# Check if text was found via XPath search
 		if found:
 			return None
-		else:
-			raise BrowserError(f'Text not found: "{event.text}"', details={'text': event.text})
+		
+		# Check if JavaScript fallback found the text
+		if js_result and js_result.get('result', {}).get('value'):
+			self.logger.debug(f'📜 Scrolled to text: "{event.text}" (via JS)')
+			return None
+		
+		# Text not found by either method
+		self.logger.warning(f'⚠️ Text not found: "{event.text}"')
+		raise BrowserError(f'Text not found: "{event.text}"', details={'text': event.text})
 
 	async def on_GetDropdownOptionsEvent(self, event: GetDropdownOptionsEvent) -> dict[str, str]:
 		"""Handle get dropdown options request with CDP."""


### PR DESCRIPTION
Initialize `js_result` and refactor `on_ScrollToTextEvent` logic to fix `UnboundLocalError` when text is found via XPath.

The `UnboundLocalError` occurred because `js_result` was only defined if the XPath search failed and the JavaScript fallback was used. If the text was found by the initial XPath search, `js_result` was never assigned, leading to an error when the code later attempted to access it. This PR ensures `js_result` is always defined and the logic correctly handles both XPath and JavaScript success paths.

---
[Slack Thread](https://browser-use.slack.com/archives/C093BKWATV1/p1757598106936189?thread_ts=1757598106.936189&cid=C093BKWATV1)

<a href="https://cursor.com/background-agent?bcId=bc-402e1592-f22e-4593-ba14-926d49004df7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-402e1592-f22e-4593-ba14-926d49004df7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix UnboundLocalError in on_ScrollToTextEvent by always initializing js_result and correcting the success checks. XPath now returns early on success, JS runs only as a fallback, and we error only if both fail.

- **Bug Fixes**
  - Initialize js_result = None before the search loop.
  - Return on XPath success; otherwise check JS result; else raise BrowserError.
  - Streamlined logs for JS and not-found cases.

<!-- End of auto-generated description by cubic. -->

