### PR TITLE
updated pricing on old docs

### DIFF
--- a/docs/cloud/v1/pricing.mdx
+++ b/docs/cloud/v1/pricing.mdx
@@ -12,29 +12,30 @@ The Browser Use Cloud API pricing consists of two components:
 
 ## LLM Model Step Pricing
 
+> **Limited Time Offer**: O3 model pricing reduced from $0.03 to $0.01 per step!
+
 The following table shows the total cost per step for each available LLM model:
 
 | Model                            | Cost per Step |
 | -------------------------------- | ------------- |
-| GPT-4o                           | $0.03         |
-| GPT-4o mini                      | $0.01         |
-| GPT-4.1                          | $0.03         |
-| GPT-4.1 mini                     | $0.01         |
+| GPT-4.1                          | $0.025        |
+| GPT-4.1 mini                     | $0.0075       |
 | O4 mini                          | $0.02         |
-| O3                               | $0.03         |
-| Gemini 2.0 Flash                 | $0.01         |
-| Gemini 2.0 Flash Lite            | $0.01         |
-| Gemini 2.5 Flash Preview (04/17) | $0.01         |
-| Gemini 2.5 Flash                 | $0.01         |
-| Gemini 2.5 Pro                   | $0.03         |
+| O3                               | $0.01         |
+| Gemini 2.5 Flash                 | $0.0075       |
+| Gemini 2.5 Pro                   | $0.025        |
 | Claude 3.7 Sonnet (2025-02-19)   | $0.03         |
 | Claude Sonnet 4 (2025-05-14)     | $0.03         |
 | Llama 4 Maverick 17B Instruct    | $0.01         |
 
-## Example Cost Calculation
+## Example Cost Calculations
 
-For example, using GPT-4.1 for a 10 step task:
-
+**Using GPT-4.1 for a 10 step task:**
 - Task initialization: $0.01
-- 10 steps x \$0.03 per step = \$0.30
-- **Total cost: $0.31**
+- 10 steps × $0.025 per step = $0.25
+- **Total cost: $0.26**
+
+**Using O3 for a 10 step task (Limited Time Offer):**
+- Task initialization: $0.01
+- 10 steps × $0.01 per step = $0.10
+- **Total cost: $0.11**


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the Cloud v1 pricing page to reflect current model step prices and add a limited-time O3 discount.
Refreshed the table and examples (e.g., GPT-4.1 $0.025/step, GPT-4.1 mini $0.0075, Gemini 2.5 Flash $0.0075, Pro $0.025; O3 $0.01) and removed outdated models.

<!-- End of auto-generated description by cubic. -->

