### PR TITLE
fix-pixel-prompt

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -148,16 +148,12 @@ class AgentMessagePrompt:
 					pi = self.browser_state.page_info
 					pages_above = pi.pixels_above / pi.viewport_height if pi.viewport_height > 0 else 0
 					elements_text = f'... {pages_above:.1f} pages above - scroll to see more or extract structured data if you are looking for specific information ...\n{elements_text}'
-				else:
-					elements_text = f'... {pages_above:.1f} pages above - scroll to see more or extract structured data if you are looking for specific information ...\n{elements_text}'
 			else:
 				elements_text = f'[Start of page]\n{elements_text}'
 			if has_content_below:
 				if self.browser_state.page_info:
 					pi = self.browser_state.page_info
 					pages_below = pi.pixels_below / pi.viewport_height if pi.viewport_height > 0 else 0
-					elements_text = f'{elements_text}\n... {pages_below:.1f} pages below - scroll to see more or extract structured data if you are looking for specific information ...'
-				else:
 					elements_text = f'{elements_text}\n... {pages_below:.1f} pages below - scroll to see more or extract structured data if you are looking for specific information ...'
 			else:
 				elements_text = f'{elements_text}\n[End of page]'

--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -122,9 +122,8 @@ class AgentMessagePrompt:
 		else:
 			truncated_text = ''
 
-		has_content_above = (self.browser_state.pixels_above or 0) > 0
-		has_content_below = (self.browser_state.pixels_below or 0) > 0
-
+		has_content_above = False
+		has_content_below = False
 		# Enhanced page information for the model
 		page_info_text = ''
 		if self.browser_state.page_info:
@@ -132,6 +131,8 @@ class AgentMessagePrompt:
 			# Compute page statistics dynamically
 			pages_above = pi.pixels_above / pi.viewport_height if pi.viewport_height > 0 else 0
 			pages_below = pi.pixels_below / pi.viewport_height if pi.viewport_height > 0 else 0
+			has_content_above = pages_above > 0
+			has_content_below = pages_below > 0
 			total_pages = pi.page_height / pi.viewport_height if pi.viewport_height > 0 else 0
 			current_page_position = pi.scroll_y / max(pi.page_height - pi.viewport_height, 1)
 			page_info_text = '<page_info>'
@@ -146,18 +147,18 @@ class AgentMessagePrompt:
 				if self.browser_state.page_info:
 					pi = self.browser_state.page_info
 					pages_above = pi.pixels_above / pi.viewport_height if pi.viewport_height > 0 else 0
-					elements_text = f'... {self.browser_state.pixels_above} pixels above ({pages_above:.1f} pages) - scroll to see more or extract structured data if you are looking for specific information ...\n{elements_text}'
+					elements_text = f'... {pages_above:.1f} pages above - scroll to see more or extract structured data if you are looking for specific information ...\n{elements_text}'
 				else:
-					elements_text = f'... {self.browser_state.pixels_above} pixels above - scroll to see more or extract structured data if you are looking for specific information ...\n{elements_text}'
+					elements_text = f'... {pages_above:.1f} pages above - scroll to see more or extract structured data if you are looking for specific information ...\n{elements_text}'
 			else:
 				elements_text = f'[Start of page]\n{elements_text}'
 			if has_content_below:
 				if self.browser_state.page_info:
 					pi = self.browser_state.page_info
 					pages_below = pi.pixels_below / pi.viewport_height if pi.viewport_height > 0 else 0
-					elements_text = f'{elements_text}\n... {self.browser_state.pixels_below} pixels below ({pages_below:.1f} pages) - scroll to see more or extract structured data if you are looking for specific information ...'
+					elements_text = f'{elements_text}\n... {pages_below:.1f} pages below - scroll to see more or extract structured data if you are looking for specific information ...'
 				else:
-					elements_text = f'{elements_text}\n... {self.browser_state.pixels_below} pixels below - scroll to see more or extract structured data if you are looking for specific information ...'
+					elements_text = f'{elements_text}\n... {pages_below:.1f} pages below - scroll to see more or extract structured data if you are looking for specific information ...'
 			else:
 				elements_text = f'{elements_text}\n[End of page]'
 		else:


### PR DESCRIPTION
Auto-generated PR for branch: fix-pixel-prompt
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes the browser prompt to show scroll context in pages instead of raw pixels and correctly detect content above/below the viewport. This makes the page summary clearer and avoids misleading pixel counts.

- **Bug Fixes**
  - Compute has_content_above/below from page_info using viewport-height ratios.
  - Replace "N pixels above/below" with "{pages:.1f} pages above/below".
  - Guard against divide-by-zero when calculating page counts.

<!-- End of auto-generated description by cubic. -->

