### PR TITLE
improve-prompt-dom-meta-data

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -19,6 +19,8 @@ DEFAULT_INCLUDE_ATTRIBUTES = [
 	'title',
 	'type',
 	'checked',
+	# 'class',
+	'id',
 	'name',
 	'role',
 	'value',
@@ -138,6 +140,7 @@ class SimplifiedNode:
 
 	ignored_by_paint_order: bool = False  # More info in dom/serializer/paint_order.py
 	excluded_by_parent: bool = False  # New field for bbox filtering
+	is_shadow_host: bool = False  # New field for shadow DOM hosts
 
 	def _clean_original_node_json(self, node_json: dict) -> dict:
 		"""Recursively remove children_nodes and shadow_roots from original_node JSON."""


### PR DESCRIPTION
Auto-generated PR for branch: improve-prompt-dom-meta-data
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add DOM metadata and clear shadow DOM markers to the prompt to improve element targeting, especially on SPAs and widget-based sites. This helps the agent understand page structure and interact with elements inside shadow roots.

- **New Features**
  - Injects <page_stats> into the prompt with counts for links, interactive elements, iframes, scroll containers, shadow roots (open/closed), images, and total elements; warns when the page looks empty (<10 elements).
  - Always includes shadow DOM fragments and shadow hosts in the simplified tree, even when not visible; adds is_shadow_host flag.
  - Serializer shows shadow details: prefixes lines with |SHADOW(open)| or |SHADOW(closed)|, and renders “Shadow Content (Open/Closed)” blocks, integrated with existing SCROLL/IFRAME/clickable markers.
  - Adds id to the attribute whitelist for clearer element identification.

<!-- End of auto-generated description by cubic. -->

