### PR TITLE
Use the ratio of the text border size to the element size to determine the position.

### DIFF
--- a/browser_use/browser/python_highlights.py
+++ b/browser_use/browser/python_highlights.py
@@ -183,8 +183,13 @@ def draw_enhanced_bounding_box_with_text(
 			bg_x1 = x1 + (element_width - container_width) // 2
 
 			# Simple rule: if element is small, place index further up to avoid blocking icons
-			if element_width < 60 or element_height < 30:
-				# Small element: place well above to avoid blocking content
+			# Calculate ratio of text container to element size for smart positioning
+			width_ratio = container_width / element_width if element_width > 0 else 1.0
+			height_ratio = container_height / element_height if element_height > 0 else 1.0
+
+			# If text container takes up too much space relative to element, place it outside
+			if width_ratio > 0.3 or height_ratio > 0.3:
+				# Text container is too large relative to element: place above to avoid blocking content
 				bg_y1 = max(0, y1 - container_height - 5)
 			else:
 				# Regular element: place inside with small offset


### PR DESCRIPTION
If only the element size is used, the index label box may cover the content of the element.

Here is a bad case：
<img width="356" height="206" alt="image" src="https://github.com/user-attachments/assets/6cc06ffd-63b9-4077-8993-7607cf8732d1" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Changed index label placement to use the text container-to-element size ratio. This prevents labels from covering element content, especially on small or dense UI elements.

- **Bug Fixes**
  - If width_ratio or height_ratio > 0.3, place the label above the element; otherwise keep it inside with a small offset.

<!-- End of auto-generated description by cubic. -->

