### PR TITLE
updated docs and added link to signup for a api key

### DIFF
--- a/browser_use/browser/cloud.py
+++ b/browser_use/browser/cloud.py
@@ -110,7 +110,8 @@ class CloudBrowserClient:
 
 			logger.info(f'🌤️ Cloud browser created successfully: {browser_response.id}')
 			logger.debug(f'🌤️ CDP URL: {browser_response.cdpUrl}')
-			logger.debug(f'🌤️ Live URL: {browser_response.liveUrl}')
+			# Cyan color for live URL
+			logger.info(f'\033[36m🔗 Live URL: {browser_response.liveUrl}\033[0m')
 
 			return browser_response
 

--- a/browser_use/browser/cloud.py
+++ b/browser_use/browser/cloud.py
@@ -73,7 +73,7 @@ class CloudBrowserClient:
 
 		if not api_token:
 			raise CloudBrowserAuthError(
-				'No authentication token found. Please set BROWSER_USE_API_KEY environment variable to authenticate with the cloud service.'
+				'No authentication token found. Please set BROWSER_USE_API_KEY environment variable to authenticate with the cloud service. You can also create an API key at https://cloud.browser-use.com'
 			)
 
 		headers = {'X-Browser-Use-API-Key': api_token, 'Content-Type': 'application/json'}
@@ -88,7 +88,7 @@ class CloudBrowserClient:
 
 			if response.status_code == 401:
 				raise CloudBrowserAuthError(
-					'Authentication failed. Please make sure you have set BROWSER_USE_API_KEY environment variable to authenticate with the cloud service.'
+					'Authentication failed. Please make sure you have set BROWSER_USE_API_KEY environment variable to authenticate with the cloud service. You can also create an API key at https://cloud.browser-use.com'
 				)
 			elif response.status_code == 403:
 				raise CloudBrowserAuthError('Access forbidden. Please check your browser-use cloud subscription status.')
@@ -157,7 +157,7 @@ class CloudBrowserClient:
 
 		if not api_token:
 			raise CloudBrowserAuthError(
-				'No authentication token found. Please set BROWSER_USE_API_KEY environment variable to authenticate with the cloud service.'
+				'No authentication token found. Please set BROWSER_USE_API_KEY environment variable to authenticate with the cloud service. You can also create an API key at https://cloud.browser-use.com'
 			)
 
 		headers = {'X-Browser-Use-API-Key': api_token, 'Content-Type': 'application/json'}

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import tempfile
 from collections.abc import Iterable
@@ -731,15 +730,6 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		"""Ensure proxy configuration is consistent."""
 		if self.proxy and (self.proxy.bypass and not self.proxy.server):
 			logger.warning('BrowserProfile.proxy.bypass provided but proxy has no server; bypass will be ignored.')
-		return self
-
-	@model_validator(mode='after')
-	def set_use_cloud_from_env(self) -> Self:
-		"""Set use_cloud=True if BROWSER_USE_API_KEY environment variable is present and use_cloud wasn't explicitly set."""
-		# Only auto-enable if use_cloud is still the default (False) and API key is present
-		if not self.use_cloud and bool(os.getenv('BROWSER_USE_API_KEY')):
-			self.use_cloud = True
-			logger.debug('🌤️ Auto-enabled cloud browser due to BROWSER_USE_API_KEY environment variable')
 		return self
 
 	def model_post_init(self, __context: Any) -> None:

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -520,7 +520,7 @@ class BrowserSession(BaseModel):
 						self.logger.info('🌤️ Successfully connected to cloud browser service')
 					except CloudBrowserAuthError:
 						raise CloudBrowserAuthError(
-							'Authentication failed for cloud browser service. Set BROWSER_USE_API_KEY environment variable'
+							'Authentication failed for cloud browser service. Set BROWSER_USE_API_KEY environment variable. You can also create an API key at https://cloud.browser-use.com'
 						)
 					except CloudBrowserError as e:
 						raise CloudBrowserError(f'Failed to create cloud browser: {e}')

--- a/docs/customize/browser/remote.mdx
+++ b/docs/customize/browser/remote.mdx
@@ -5,23 +5,6 @@ icon: "cloud"
 mode: "wide"
 ---
 
-```python
-from browser_use import Agent, Browser, ChatOpenAI
-
-# Connect to remote browser
-browser = Browser(
-    cdp_url='http://remote-server:9222'
-)
-
-
-agent = Agent(
-    task="Your task here",
-    llm=ChatOpenAI(model='gpt-4.1-mini'),
-    browser=browser,
-)
-```
-
-
 ## Get a CDP URL
 
 ### Browser-Use Cloud Browser
@@ -33,7 +16,8 @@ from browser_use import Agent, Browser, ChatOpenAI
 
 # Use Browser-Use cloud browser service
 browser = Browser(
-    cloud_browser=True  # Automatically provisions a cloud browser
+    use_cloud=True,  # Automatically provisions a cloud browser
+    # cdp_url="http://remote-server:9222" # CDP URL from your favorite browser provider like AnchorBrowser, HyperBrowser, BrowserBase, Steel.dev, etc.
 )
 
 agent = Agent(

--- a/docs/customize/browser/remote.mdx
+++ b/docs/customize/browser/remote.mdx
@@ -5,9 +5,8 @@ icon: "cloud"
 mode: "wide"
 ---
 
-## Get a CDP URL
 
-### Browser-Use Cloud Browser
+### Browser-Use Cloud Browser or CDP URL
 
 The easiest way to use a cloud browser is with the built-in Browser-Use cloud service:
 

--- a/examples/browser/cloud_browser.py
+++ b/examples/browser/cloud_browser.py
@@ -34,7 +34,9 @@ async def main():
 	except Exception as e:
 		print(f'❌ Error: {e}')
 		if 'Authentication' in str(e):
-			print('💡 Set BROWSER_USE_API_KEY environment variable')
+			print(
+				'💡 Set BROWSER_USE_API_KEY environment variable. You can also create an API key at https://cloud.browser-use.com'
+			)
 
 
 if __name__ == '__main__':

--- a/examples/cloud/01_basic_task.py
+++ b/examples/cloud/01_basic_task.py
@@ -23,7 +23,9 @@ from requests.exceptions import RequestException
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:
-	raise ValueError('Please set BROWSER_USE_API_KEY environment variable')
+	raise ValueError(
+		'Please set BROWSER_USE_API_KEY environment variable. You can also create an API key at https://cloud.browser-use.com'
+	)
 
 BASE_URL = os.getenv('BROWSER_USE_BASE_URL', 'https://api.browser-use.com/api/v1')
 TIMEOUT = int(os.getenv('BROWSER_USE_TIMEOUT', '30'))

--- a/examples/cloud/02_fast_mode_gemini.py
+++ b/examples/cloud/02_fast_mode_gemini.py
@@ -27,7 +27,9 @@ from requests.exceptions import RequestException
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:
-	raise ValueError('Please set BROWSER_USE_API_KEY environment variable')
+	raise ValueError(
+		'Please set BROWSER_USE_API_KEY environment variable. You can also create an API key at https://cloud.browser-use.com'
+	)
 
 BASE_URL = os.getenv('BROWSER_USE_BASE_URL', 'https://api.browser-use.com/api/v1')
 TIMEOUT = int(os.getenv('BROWSER_USE_TIMEOUT', '30'))
@@ -220,15 +222,15 @@ def main():
 
 		task = """
         Go to Hacker News (news.ycombinator.com) and get the top 3 articles from the front page.
-        
+
         Then, write a funny tech news segment in the style of Fireship YouTube channel:
         - Be sarcastic and witty about tech trends
-        - Use developer humor and memes  
+        - Use developer humor and memes
         - Make fun of common programming struggles
         - Include phrases like "And yes, it runs on JavaScript" or "Plot twist: it's written in Rust"
         - Keep it under 250 words but make it entertaining
         - Structure it like a news anchor delivering breaking tech news
-        
+
         Make each story sound dramatic but also hilarious, like you're reporting on the most important events in human history.
         """
 		task_id = create_fast_task(task)

--- a/examples/cloud/03_structured_output.py
+++ b/examples/cloud/03_structured_output.py
@@ -26,7 +26,9 @@ from requests.exceptions import RequestException
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:
-	raise ValueError('Please set BROWSER_USE_API_KEY environment variable')
+	raise ValueError(
+		'Please set BROWSER_USE_API_KEY environment variable. You can also create an API key at https://cloud.browser-use.com'
+	)
 
 BASE_URL = os.getenv('BROWSER_USE_BASE_URL', 'https://api.browser-use.com/api/v1')
 TIMEOUT = int(os.getenv('BROWSER_USE_TIMEOUT', '30'))
@@ -233,8 +235,8 @@ def demo_news_extraction():
 	print('-' * 40)
 
 	task = """
-    Go to a major news website (like BBC, CNN, or Reuters) and extract information 
-    about the top 3 news articles. For each article, get the title, summary, URL, 
+    Go to a major news website (like BBC, CNN, or Reuters) and extract information
+    about the top 3 news articles. For each article, get the title, summary, URL,
     and any other available metadata.
     """
 
@@ -264,8 +266,8 @@ def demo_product_extraction():
 	print('-' * 40)
 
 	task = """
-    Go to Amazon and search for 'wireless headphones'. Find the first product result 
-    and extract detailed information including name, price, rating, availability, 
+    Go to Amazon and search for 'wireless headphones'. Find the first product result
+    and extract detailed information including name, price, rating, availability,
     and description.
     """
 
@@ -295,8 +297,8 @@ def demo_company_extraction():
 	print('-' * 40)
 
 	task = """
-    Go to a financial website and look up information about Apple Inc. 
-    Extract company details including name, stock symbol, market cap, 
+    Go to a financial website and look up information about Apple Inc.
+    Extract company details including name, stock symbol, market cap,
     industry, headquarters, and founding year.
     """
 

--- a/examples/cloud/04_proxy_usage.py
+++ b/examples/cloud/04_proxy_usage.py
@@ -25,7 +25,9 @@ from requests.exceptions import RequestException
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:
-	raise ValueError('Please set BROWSER_USE_API_KEY environment variable')
+	raise ValueError(
+		'Please set BROWSER_USE_API_KEY environment variable. You can also create an API key at https://cloud.browser-use.com'
+	)
 
 BASE_URL = os.getenv('BROWSER_USE_BASE_URL', 'https://api.browser-use.com/api/v1')
 TIMEOUT = int(os.getenv('BROWSER_USE_TIMEOUT', '30'))
@@ -94,7 +96,7 @@ def test_ip_location(country_code: str) -> dict[str, Any]:
     2. The detected country/location
     3. The ISP/organization
     4. Any other location details shown
-    
+
     Please be specific about what you see on the page.
     """
 
@@ -106,11 +108,11 @@ def test_geo_restricted_content(country_code: str) -> dict[str, Any]:
 	"""Test access to geo-restricted content."""
 	task = """
     Go to a major news website (like BBC, CNN, or local news) and check:
-    1. What content is available 
+    1. What content is available
     2. Any geo-restriction messages
     3. Local/regional content differences
     4. Language or currency preferences shown
-    
+
     Note any differences from what you might expect.
     """
 
@@ -121,15 +123,15 @@ def test_geo_restricted_content(country_code: str) -> dict[str, Any]:
 def test_streaming_service_access(country_code: str) -> dict[str, Any]:
 	"""Test access to region-specific streaming content."""
 	task = """
-    Go to a major streaming service website (like Netflix, YouTube, or BBC iPlayer) 
+    Go to a major streaming service website (like Netflix, YouTube, or BBC iPlayer)
     and check what content or messaging appears.
-    
+
     Report:
     1. What homepage content is shown
     2. Any geo-restriction messages or content differences
     3. Available content regions or language options
     4. Any pricing or availability differences
-    
+
     Note: Don't try to log in, just observe the publicly available content.
     """
 
@@ -141,13 +143,13 @@ def test_search_results_by_location(country_code: str) -> dict[str, Any]:
 	"""Test how search results vary by location."""
 	task = """
     Go to Google and search for "best restaurants near me" or "local news".
-    
+
     Report:
     1. What local results appear
     2. The detected location in search results
     3. Any location-specific content or ads
     4. Language preferences
-    
+
     This will show how search results change based on proxy location.
     """
 

--- a/examples/cloud/05_search_api.py
+++ b/examples/cloud/05_search_api.py
@@ -23,7 +23,9 @@ import aiohttp
 # Configuration
 API_KEY = os.getenv('BROWSER_USE_API_KEY')
 if not API_KEY:
-	raise ValueError('Please set BROWSER_USE_API_KEY environment variable')
+	raise ValueError(
+		'Please set BROWSER_USE_API_KEY environment variable. You can also create an API key at https://cloud.browser-use.com.'
+	)
 
 BASE_URL = os.getenv('BROWSER_USE_BASE_URL', 'https://api.browser-use.com/api/v1')
 TIMEOUT = int(os.getenv('BROWSER_USE_TIMEOUT', '30'))


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a direct signup link for the Browser-Use API key to auth errors and examples, and updates docs to use the correct use_cloud flag. Clarifies how to supply a CDP URL from external providers and cleans up wording/formatting in cloud examples.

<!-- End of auto-generated description by cubic. -->

