### PR TITLE
fix framework_events_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Check out the [library docs](https://docs.browser-use.com) and [cloud docs](http
 https://github.com/user-attachments/assets/171fb4d6-0355-46f2-863e-edb04a828d04
 
 <br/><br/>
-See more [examples in the docs](https://docs.browser-use.com/examples). 
 
+See [more examples](https://docs.browser-use.com/examples) in the docs and give us a star!
 
 
 <br/><br/>

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1179,8 +1179,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 			# Execute JavaScript to trigger comprehensive event sequence
 			framework_events_script = """
 			(function() {
-				// Find the target element
-				const element = arguments[0];
+				// Find the target element (available as 'this' when using objectId)
+				const element = this;
 				if (!element) return false;
 
 				// Ensure element is focused
@@ -1255,7 +1255,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 				}
 
 				return success;
-			})(arguments[0]);
+			})();
 			"""
 
 			# Execute the framework events script
@@ -1263,7 +1263,6 @@ class DefaultActionWatchdog(BaseWatchdog):
 				params={
 					'objectId': object_id,
 					'functionDeclaration': framework_events_script,
-					'arguments': [{'objectId': object_id}],
 					'returnByValue': True,
 				},
 				session_id=cdp_session.session_id,


### PR DESCRIPTION
Auto-generated PR for: fix framework_events_script
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes framework event triggering by binding to the element via this in CDP Runtime.callFunctionOn, improving reliable focus/click/input dispatch in SPAs. Also tweaks README example link copy.

- **Bug Fixes**
  - Use this instead of arguments[0] in framework_events_script and stop passing arguments to callFunctionOn, ensuring correct element binding and consistent event firing.

<!-- End of auto-generated description by cubic. -->

