### PR TITLE
Log browser-use pip version on agent start

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -13,6 +13,7 @@ from sys import stderr
 from typing import Any, ParamSpec, TypeVar
 from urllib.parse import urlparse
 
+import httpx
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -576,6 +577,24 @@ def get_browser_use_version() -> str:
 	except Exception as e:
 		logger.debug(f'Error detecting browser-use version: {type(e).__name__}: {e}')
 		return 'unknown'
+
+
+async def check_latest_browser_use_version() -> str | None:
+	"""Check the latest version of browser-use from PyPI asynchronously.
+
+	Returns:
+		The latest version string if successful, None if failed
+	"""
+	try:
+		async with httpx.AsyncClient(timeout=3.0) as client:
+			response = await client.get('https://pypi.org/pypi/browser-use/json')
+			if response.status_code == 200:
+				data = response.json()
+				return data['info']['version']
+	except Exception:
+		# Silently fail - we don't want to break agent startup due to network issues
+		pass
+	return None
 
 
 @cache


### PR DESCRIPTION
Add an info log message at agent startup to display the newest `browser-use` pip version and encourage users to upgrade.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1758246823746979?thread_ts=1758246823.746979&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-7249ebf3-45c9-499f-9ad9-d70f953790eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7249ebf3-45c9-499f-9ad9-d70f953790eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
On agent startup, we now check PyPI for the latest browser-use version and log an upgrade hint if a newer release is available. This keeps users up to date without blocking startup.

- **New Features**
  - Fetch latest version from PyPI with a 3s timeout; failures are ignored.
  - Log an info message when a newer version exists, including the upgrade command: uv add browser-use@<latest_version>.

<!-- End of auto-generated description by cubic. -->

