### PR TITLE
Update system message override check

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -28,7 +28,7 @@ class SystemPrompt:
 		self.use_thinking = use_thinking
 		self.flash_mode = flash_mode
 		prompt = ''
-		if override_system_message:
+		if override_system_message is not None:
 			prompt = override_system_message
 		else:
 			self._load_prompt_template()


### PR DESCRIPTION
Change `if override_system_message:` to `if override_system_message is not None:` to make the condition more explicit.

This change ensures that empty strings or other falsy values for `override_system_message` are still considered valid, rather than being treated as `False`.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1758425416164869?thread_ts=1758425416.164869&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-d818c3d4-3596-4b10-b4f1-7cd5cc4fe538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d818c3d4-3596-4b10-b4f1-7cd5cc4fe538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Use an explicit None check for override_system_message so empty strings and other falsy values are treated as valid overrides. Only None now falls back to the default prompt template.

<!-- End of auto-generated description by cubic. -->

