### PR TITLE
Remove unused parameter

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1884,9 +1884,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 	async def _execute_history_step(self, history_item: AgentHistory, delay: float) -> list[ActionResult]:
 		"""Execute a single step from history with element validation"""
 		assert self.browser_session is not None, 'BrowserSession is not set up'
-		state = await self.browser_session.get_browser_state_summary(
-			include_screenshot=False
-		)
+		state = await self.browser_session.get_browser_state_summary(include_screenshot=False)
 		if not state or not history_item.model_output:
 			raise ValueError('Invalid state or model output')
 		updated_actions = []

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -679,7 +679,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Always take screenshots for all steps
 		self.logger.debug('📸 Requesting browser state with include_screenshot=True')
 		browser_state_summary = await self.browser_session.get_browser_state_summary(
-			cache_clickable_elements_hashes=True,
 			include_screenshot=True,  # always capture even if use_vision=False so that cloud sync is useful (it's fast now anyway)
 			include_recent_events=self.include_recent_events,
 		)
@@ -1660,7 +1659,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			# This prevents stale element detection but doesn't refresh before execution
 			if action.get_index() is not None and i != 0:
 				new_browser_state_summary = await self.browser_session.get_browser_state_summary(
-					cache_clickable_elements_hashes=False,
 					include_screenshot=False,
 				)
 				new_selector_map = new_browser_state_summary.dom_state.selector_map
@@ -1887,7 +1885,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		"""Execute a single step from history with element validation"""
 		assert self.browser_session is not None, 'BrowserSession is not set up'
 		state = await self.browser_session.get_browser_state_summary(
-			cache_clickable_elements_hashes=False, include_screenshot=False
+			include_screenshot=False
 		)
 		if not state or not history_item.model_output:
 			raise ValueError('Invalid state or model output')

--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -190,7 +190,6 @@ class BrowserStateRequestEvent(BaseEvent[BrowserStateSummary]):
 
 	include_dom: bool = True
 	include_screenshot: bool = True
-	cache_clickable_elements_hashes: bool = True
 	include_recent_events: bool = False
 
 	event_timeout: float | None = _get_timeout('TIMEOUT_BrowserStateRequestEvent', 30.0)  # seconds

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1045,7 +1045,6 @@ class BrowserSession(BaseModel):
 	@observe_debug(ignore_input=True, ignore_output=True, name='get_browser_state_summary')
 	async def get_browser_state_summary(
 		self,
-		cache_clickable_elements_hashes: bool = True,
 		include_screenshot: bool = True,
 		cached: bool = False,
 		include_recent_events: bool = False,
@@ -1072,7 +1071,6 @@ class BrowserSession(BaseModel):
 				BrowserStateRequestEvent(
 					include_dom=True,
 					include_screenshot=include_screenshot,
-					cache_clickable_elements_hashes=cache_clickable_elements_hashes,
 					include_recent_events=include_recent_events,
 				)
 			),

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -768,7 +768,7 @@ class BrowserUseServer:
 		if not self.browser_session:
 			return 'Error: No browser session active'
 
-		state = await self.browser_session.get_browser_state_summary(cache_clickable_elements_hashes=False)
+		state = await self.browser_session.get_browser_state_summary()
 
 		result = {
 			'url': state.url,

--- a/tests/ci/test_browser_event_ClickElementEvent.py
+++ b/tests/ci/test_browser_event_ClickElementEvent.py
@@ -143,7 +143,7 @@ class TestClickElementEvent:
 		await asyncio.sleep(0.5)  # Give page time to load
 
 		# Initialize the DOM state to populate the selector map
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map
 		selector_map = await browser_session.get_selector_map()
@@ -406,7 +406,7 @@ class TestClickElementEvent:
 		await asyncio.sleep(0.5)
 
 		# Get the clickable elements
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 		selector_map = await browser_session.get_selector_map()
 
 		# Find the inline element
@@ -488,7 +488,7 @@ class TestClickElementEvent:
 		await asyncio.sleep(0.5)
 
 		# Get the clickable elements
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 		selector_map = await browser_session.get_selector_map()
 
 		# Find the block element inside inline
@@ -576,7 +576,7 @@ class TestClickElementEvent:
 		await asyncio.sleep(0.5)
 
 		# Get the clickable elements
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 		selector_map = await browser_session.get_selector_map()
 
 		# Find the target element
@@ -636,7 +636,7 @@ class TestClickElementEvent:
 		await asyncio.sleep(0.5)
 
 		# Get the clickable elements
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 		selector_map = await browser_session.get_selector_map()
 
 		# Find the file input
@@ -699,7 +699,7 @@ class TestClickElementEvent:
 		await asyncio.sleep(0.5)
 
 		# Get the clickable elements
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 		selector_map = await browser_session.get_selector_map()
 
 		# Find the select element
@@ -1098,7 +1098,7 @@ class TestClickElementEvent:
 			await asyncio.sleep(0.5)
 
 			# Initialize the DOM state to populate the selector map
-			await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+			await browser_session.get_browser_state_summary()
 
 			# Get the selector map
 			selector_map = await browser_session.get_selector_map()

--- a/tests/ci/test_browser_event_GetDropdownOptionsEvent.py
+++ b/tests/ci/test_browser_event_GetDropdownOptionsEvent.py
@@ -286,7 +286,7 @@ class TestGetDropdownOptionsEvent:
 		await tools.act(GoToUrlActionModel(**goto_action), browser_session)
 
 		# Initialize the DOM state to populate the selector map
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map and find the select element
 		selector_map = await browser_session.get_selector_map()
@@ -344,7 +344,7 @@ class TestGetDropdownOptionsEvent:
 		await tools.act(GoToUrlActionModel(**goto_action), browser_session)
 
 		# Initialize the DOM state
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map and find the ARIA menu
 		selector_map = await browser_session.get_selector_map()
@@ -406,7 +406,7 @@ class TestGetDropdownOptionsEvent:
 		await tools.act(GoToUrlActionModel(**goto_action), browser_session)
 
 		# Initialize the DOM state
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map and find the custom dropdown
 		selector_map = await browser_session.get_selector_map()
@@ -495,7 +495,7 @@ class TestSelectDropdownOptionEvent:
 		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map and find the select element
 		selector_map = await browser_session.get_selector_map()
@@ -543,7 +543,7 @@ class TestSelectDropdownOptionEvent:
 		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map and find the ARIA menu
 		selector_map = await browser_session.get_selector_map()
@@ -595,7 +595,7 @@ class TestSelectDropdownOptionEvent:
 		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map and find the custom dropdown
 		selector_map = await browser_session.get_selector_map()
@@ -643,7 +643,7 @@ class TestSelectDropdownOptionEvent:
 		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map and find the select element
 		selector_map = await browser_session.get_selector_map()

--- a/tests/ci/test_browser_event_GetDropdownOptionsEvent_aria_menus.py
+++ b/tests/ci/test_browser_event_GetDropdownOptionsEvent_aria_menus.py
@@ -165,7 +165,7 @@ class TestARIAMenuDropdown:
 		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state to populate the selector map
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map
 		selector_map = await browser_session.get_selector_map()
@@ -232,7 +232,7 @@ class TestARIAMenuDropdown:
 		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state to populate the selector map
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map
 		selector_map = await browser_session.get_selector_map()
@@ -302,7 +302,7 @@ class TestARIAMenuDropdown:
 		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state to populate the selector map
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map
 		selector_map = await browser_session.get_selector_map()

--- a/tests/ci/test_browser_event_NavigateToUrlEvent.py
+++ b/tests/ci/test_browser_event_NavigateToUrlEvent.py
@@ -97,7 +97,7 @@ class TestNavigateToUrlEvent:
 
 		# Test that get_state_summary works
 		try:
-			await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+			await browser_session.get_browser_state_summary()
 			assert False, 'Expected throw error when navigating to non-existent page'
 		except Exception as e:
 			pass

--- a/tests/ci/test_browser_session_element_cache.py
+++ b/tests/ci/test_browser_session_element_cache.py
@@ -88,7 +88,7 @@ async def test_assumption_1_dom_processing_works(browser_session, httpserver):
 	await event.event_result(raise_if_any=True, raise_if_none=False)
 
 	# Trigger DOM processing
-	state = await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=False)
+	state = await browser_session.get_browser_state_summary()
 
 	print('DOM processing result:')
 	print(f'  - Elements found: {len(state.dom_state.selector_map)}')
@@ -109,7 +109,7 @@ async def test_assumption_2_cached_selector_map_persists(browser_session, httpse
 	await event.event_result(raise_if_any=True, raise_if_none=False)
 
 	# Trigger DOM processing and cache
-	state = await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=False)
+	state = await browser_session.get_browser_state_summary()
 	initial_selector_map = dict(state.dom_state.selector_map)
 
 	# Check if cached selector map is still available
@@ -136,7 +136,7 @@ async def test_assumption_3_action_gets_same_selector_map(browser_session, tools
 	await event.event_result(raise_if_any=True, raise_if_none=False)
 
 	# Trigger DOM processing and cache
-	await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=False)
+	await browser_session.get_browser_state_summary()
 	cached_selector_map = await browser_session.get_selector_map()
 
 	print('Pre-action state:')
@@ -174,7 +174,7 @@ async def test_assumption_4_click_action_specific_issue(browser_session, tools, 
 	await event.event_result(raise_if_any=True, raise_if_none=False)
 
 	# Trigger DOM processing and cache
-	await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=False)
+	await browser_session.get_browser_state_summary()
 	cached_selector_map = await browser_session.get_selector_map()
 
 	print('Pre-click state:')
@@ -224,7 +224,7 @@ async def test_assumption_5_multiple_get_selector_map_calls(browser_session, htt
 	await event.event_result(raise_if_any=True, raise_if_none=False)
 
 	# Trigger DOM processing and cache
-	await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=False)
+	await browser_session.get_browser_state_summary()
 
 	# Call get_selector_map multiple times
 	map1 = await browser_session.get_selector_map()

--- a/tests/ci/test_browser_watchdog_screenshots.py
+++ b/tests/ci/test_browser_watchdog_screenshots.py
@@ -104,7 +104,7 @@ class TestHeadlessScreenshots:
 			await event.event_result(raise_if_any=True, raise_if_none=False)
 
 			# Get state summary
-			state = await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=False)
+			state = await browser_session.get_browser_state_summary()
 
 			# Verify screenshot is included
 			assert state.screenshot is not None
@@ -143,7 +143,7 @@ class TestHeadlessScreenshots:
 
 			# Browser should auto-create a new page on about:blank with animation
 			# With AboutBlankWatchdog, about:blank pages now have animated content, so they should have screenshots
-			state = await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=False)
+			state = await browser_session.get_browser_state_summary()
 			assert state.screenshot is not None, 'Screenshot should not be None for animated about:blank pages'
 			assert state.url == 'about:blank' or state.url.startswith('chrome://'), f'Expected empty page but got {state.url}'
 
@@ -153,7 +153,7 @@ class TestHeadlessScreenshots:
 			await event.event_result(raise_if_any=True, raise_if_none=False)
 
 			# Get state with screenshot
-			state = await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=False)
+			state = await browser_session.get_browser_state_summary()
 			# Should have a screenshot now
 			assert state.screenshot is not None, 'Screenshot should not be None for real pages'
 			assert isinstance(state.screenshot, str)

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -413,7 +413,7 @@ class TestToolsIntegration:
 			await asyncio.sleep(1.0)
 
 		# Initialize the DOM state to populate the selector map
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Get the selector map
 		selector_map = await browser_session.get_selector_map()
@@ -540,7 +540,7 @@ class TestToolsIntegration:
 			await asyncio.sleep(1.0)
 
 		# populate the selector map with highlight indices
-		await browser_session.get_browser_state_summary(cache_clickable_elements_hashes=True)
+		await browser_session.get_browser_state_summary()
 
 		# Now get the selector map which should contain our dropdown
 		selector_map = await browser_session.get_selector_map()

--- a/tests/scripts/debug_iframe_scrolling.py
+++ b/tests/scripts/debug_iframe_scrolling.py
@@ -131,9 +131,7 @@ async def debug_iframe_scrolling():
 			"""Capture DOM state and return analysis"""
 			print(f'\n📸 Capturing DOM state: {label}')
 			state_event = browser_session.event_bus.dispatch(
-				BrowserStateRequestEvent(
-					include_dom=True, include_screenshot=False, include_recent_events=False
-				)
+				BrowserStateRequestEvent(include_dom=True, include_screenshot=False, include_recent_events=False)
 			)
 			browser_state = await state_event.event_result()
 

--- a/tests/scripts/debug_iframe_scrolling.py
+++ b/tests/scripts/debug_iframe_scrolling.py
@@ -132,7 +132,7 @@ async def debug_iframe_scrolling():
 			print(f'\n📸 Capturing DOM state: {label}')
 			state_event = browser_session.event_bus.dispatch(
 				BrowserStateRequestEvent(
-					include_dom=True, include_screenshot=False, cache_clickable_elements_hashes=True, include_recent_events=False
+					include_dom=True, include_screenshot=False, include_recent_events=False
 				)
 			)
 			browser_state = await state_event.event_result()


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed the unused cache_clickable_elements_hashes parameter from BrowserSession.get_browser_state_summary and BrowserStateRequestEvent, and updated all call sites. This simplifies the API with no behavior change.

- **Refactors**
  - Dropped cache_clickable_elements_hashes from BrowserStateRequestEvent and get_browser_state_summary.
  - Updated service/mcp layers, tests, and scripts to call without the parameter.

- **Migration**
  - Remove the cache_clickable_elements_hashes argument from any calls to get_browser_state_summary or BrowserStateRequestEvent.
  - No other changes needed; behavior is unchanged.

<!-- End of auto-generated description by cubic. -->

