### PR TITLE
fix scroll to text action bug

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1808,12 +1808,12 @@ class DefaultActionWatchdog(BaseWatchdog):
 				session_id=session_id,
 			)
 
-		if js_result.get('result', {}).get('value'):
-			self.logger.debug(f'📜 Scrolled to text: "{event.text}" (via JS)')
-			return None
-		else:
-			self.logger.warning(f'⚠️ Text not found: "{event.text}"')
-			raise BrowserError(f'Text not found: "{event.text}"', details={'text': event.text})
+			if js_result.get('result', {}).get('value'):
+				self.logger.debug(f'📜 Scrolled to text: "{event.text}" (via JS)')
+				return None
+			else:
+				self.logger.warning(f'⚠️ Text not found: "{event.text}"')
+				raise BrowserError(f'Text not found: "{event.text}"', details={'text': event.text})
 
 		# If we got here and found is True, return None (success)
 		if found:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes ScrollToText so JS result handling only runs in the JS path. This prevents false “Text not found” errors and crashes when js_result wasn’t set.

- **Bug Fixes**
  - Move js_result checks inside the JS execution block.
  - Preserve native path behavior (uses found) without unintended exceptions.

<!-- End of auto-generated description by cubic. -->

