### PR TITLE
feat(realtimex): load environment variables from realtimex

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -93,6 +93,7 @@ from browser_use.browser import BrowserProfile, BrowserSession
 from browser_use.config import get_default_llm, get_default_profile, load_browser_use_config
 from browser_use.filesystem.file_system import FileSystem
 from browser_use.llm.openai.chat import ChatOpenAI
+from browser_use.realtimex import load_realtimex_env
 from browser_use.tools.service import Tools
 
 logger = logging.getLogger(__name__)
@@ -188,6 +189,9 @@ class BrowserUseServer:
 	def __init__(self, session_timeout_minutes: int = 10):
 		# Ensure all logging goes to stderr (in case new loggers were created)
 		_ensure_all_loggers_use_stderr()
+
+		# Load RealTimeX environment variables
+		load_realtimex_env()
 
 		self.server = Server('browser-use')
 		self.config = load_browser_use_config()

--- a/browser_use/realtimex/__init__.py
+++ b/browser_use/realtimex/__init__.py
@@ -1,0 +1,5 @@
+"""RealTimeX integration helpers for browser-use."""
+
+from browser_use.realtimex.env_loader import load_realtimex_env
+
+__all__ = ['load_realtimex_env']

--- a/browser_use/realtimex/env_loader.py
+++ b/browser_use/realtimex/env_loader.py
@@ -1,0 +1,70 @@
+"""RealTimeX environment variable loader for browser-use integration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Iterable
+
+from dotenv import dotenv_values
+
+
+def _get_realtimex_server_dir() -> Path:
+	"""Return the RealTimeX server directory using platform-safe joins."""
+	user_home = os.path.expanduser('~')
+	absolute_path = os.path.join(user_home, '.realtimex.ai', 'Resources', 'server')
+	return Path(absolute_path)
+
+
+# Default RealTimeX configuration directory
+_REALTIMEX_SERVER_DIR = _get_realtimex_server_dir()
+
+# Candidate environment filenames in priority order
+_ENV_FILENAMES: tuple[str, ...] = ('.env', '.env.production', '.env.development')
+
+# Mapping from RealTimeX-specific variables to browser-use expectations
+_ENV_MAPPING: dict[str, str] = {
+	'REALTIMEX_AI_API_KEY': 'OPENAI_API_KEY',
+	'REALTIMEX_AI_BASE_PATH': 'OPENAI_BASE_URL',
+}
+
+
+def _first_existing_env_file(
+	directory: Path = _REALTIMEX_SERVER_DIR,
+	filenames: Iterable[str] = _ENV_FILENAMES,
+) -> Path | None:
+	"""Return the first existing .env file in the RealTimeX directory."""
+	for name in filenames:
+		candidate = directory / name
+		if candidate.exists():
+			return candidate
+	return None
+
+
+def load_realtimex_env() -> None:
+	"""Load RealTimeX environment variables into the current process."""
+	env_file = _first_existing_env_file()
+	if not env_file:
+		return
+
+	env_values = dotenv_values(env_file)
+	if not env_values:
+		return
+
+	for source_key, target_key in _ENV_MAPPING.items():
+		raw_value = env_values.get(source_key)
+		if not raw_value:
+			continue
+
+		value = raw_value.strip() if isinstance(raw_value, str) else raw_value
+		if not value:
+			continue
+
+		# Preserve explicitly-set environment variables
+		if os.getenv(target_key):
+			continue
+
+		os.environ[target_key] = str(value)
+
+
+__all__ = ['load_realtimex_env']


### PR DESCRIPTION
Adds a new 'realtimex' integration that automatically loads environment variables from the RealTimeX server configuration.

This simplifies setup for users who have both 'browser-use' and RealTimeX installed by mapping the RealTimeX API key and base path to the corresponding OpenAI environment variables.

The integration:

- Looks for '.env' files in the default RealTimeX server directory ('~/.realtimex.ai/Resources/server').
- Maps 'REALTIMEX_AI_API_KEY' to 'OPENAI_API_KEY'.
- Maps 'REALTIMEX_AI_BASE_PATH' to 'OPENAI_BASE_URL'.
- Avoids overwriting any explicitly set environment variables.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Automatically loads OpenAI environment variables from the RealTimeX server config to simplify setup when both are installed. Runs during MCP server startup and preserves any variables already set.

- **New Features**
  - Reads .env, .env.production, or .env.development from ~/.realtimex.ai/Resources/server
  - Maps REALTIMEX_AI_API_KEY -> OPENAI_API_KEY
  - Maps REALTIMEX_AI_BASE_PATH -> OPENAI_BASE_URL
  - Skips mapping if target vars are already set

<!-- End of auto-generated description by cubic. -->

