### PR TITLE
LLM call telemetry event

### DIFF
--- a/browser_use/telemetry/__init__.py
+++ b/browser_use/telemetry/__init__.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 	from browser_use.telemetry.views import (
 		BaseTelemetryEvent,
 		CLITelemetryEvent,
+		LLMCallTelemetryEvent,
 		MCPClientTelemetryEvent,
 		MCPServerTelemetryEvent,
 	)
@@ -19,6 +20,7 @@ _LAZY_IMPORTS = {
 	'ProductTelemetry': ('browser_use.telemetry.service', 'ProductTelemetry'),
 	'BaseTelemetryEvent': ('browser_use.telemetry.views', 'BaseTelemetryEvent'),
 	'CLITelemetryEvent': ('browser_use.telemetry.views', 'CLITelemetryEvent'),
+	'LLMCallTelemetryEvent': ('browser_use.telemetry.views', 'LLMCallTelemetryEvent'),
 	'MCPClientTelemetryEvent': ('browser_use.telemetry.views', 'MCPClientTelemetryEvent'),
 	'MCPServerTelemetryEvent': ('browser_use.telemetry.views', 'MCPServerTelemetryEvent'),
 }
@@ -46,6 +48,7 @@ __all__ = [
 	'BaseTelemetryEvent',
 	'ProductTelemetry',
 	'CLITelemetryEvent',
+	'LLMCallTelemetryEvent',
 	'MCPClientTelemetryEvent',
 	'MCPServerTelemetryEvent',
 ]

--- a/browser_use/telemetry/views.py
+++ b/browser_use/telemetry/views.py
@@ -91,3 +91,32 @@ class CLITelemetryEvent(BaseTelemetryEvent):
 	error_message: str | None = None
 
 	name: str = 'cli_event'
+
+
+@dataclass
+class LLMCallTelemetryEvent(BaseTelemetryEvent):
+	"""Telemetry event for individual LLM calls"""
+
+	# Session context
+	session_id: str  # Links to agent.session_id
+	task_id: str
+	step_number: int  # Which step in the agent flow
+
+	# LLM details
+	model: str
+	model_provider: str
+
+	# Call data (serialized for transmission)
+	input_messages: str  # JSON serialized messages
+	output_response: str  # JSON serialized response
+
+	# Metrics
+	prompt_tokens: int
+	completion_tokens: int
+	total_tokens: int
+	duration_ms: float
+
+	# Optional
+	error_message: str | None = None
+
+	name: str = 'llm_call_event'


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add telemetry for each LLM call to track model usage, latency, and payloads. This helps debug agent steps and analyze cost/performance without affecting the main flow.

- **New Features**
  - Added LLMCallTelemetryEvent capturing session/task/step, model/provider, serialized input/output, token counts, and duration (ms).
  - Agent now records and sends this event after each LLM invocation, non-blocking, with safe error logging.
  - Exported LLMCallTelemetryEvent in telemetry package for external use.

<!-- End of auto-generated description by cubic. -->

