### PR TITLE
fix the spelling mistakes in the using_cdp example

### DIFF
--- a/examples/browser/using_cdp.py
+++ b/examples/browser/using_cdp.py
@@ -36,7 +36,7 @@ tools = Tools()
 async def main():
 	agent = Agent(
 		task='Visit https://duckduckgo.com and search for "browser-use founders"',
-		lllm=ChatOpenAI(model='gpt-4.1-mini'),
+		llm=ChatOpenAI(model='gpt-4.1-mini'),
 		tools=tools,
 		browser_session=browser_session,
 	)

--- a/examples/features/blocked_domains.py
+++ b/examples/features/blocked_domains.py
@@ -17,13 +17,13 @@ llm = ChatOpenAI(model='gpt-4o-mini')
 task = 'Navigate to example.com, then try to go to x.com, then facebook.com, and finally visit google.com. Tell me which sites you were able to access.'
 
 prohibited_domains = [
-	'x.com',                         # Block X (formerly Twitter) - "locked the f in" 
-	'twitter.com',                   # Block Twitter (redirects to x.com anyway)
-	'facebook.com',                  # Lock the F in Facebook too
-	'*.meta.com',                    # Block all Meta properties
-	'*.adult-site.com',              # Block all subdomains of adult sites
+	'x.com',  # Block X (formerly Twitter) - "locked the f in"
+	'twitter.com',  # Block Twitter (redirects to x.com anyway)
+	'facebook.com',  # Lock the F in Facebook too
+	'*.meta.com',  # Block all Meta properties
+	'*.adult-site.com',  # Block all subdomains of adult sites
 	'https://explicit-content.org',  # Block specific protocol/domain
-	'gambling-site.net',             # Block gambling sites
+	'gambling-site.net',  # Block gambling sites
 ]
 
 browser_session = BrowserSession(
@@ -43,7 +43,7 @@ agent = Agent(
 
 async def main():
 	print('Demo: Blocked Domains Feature - "Lock the F in" Edition')
-	print('We\'re literally locking the F in Facebook and X!')
+	print("We're literally locking the F in Facebook and X!")
 	print(f'Prohibited domains: {prohibited_domains}')
 	print('The agent will try to visit various sites, but blocked domains will be prevented.')
 	print()


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixed a typo in the using_cdp example by renaming the Agent parameter from lllm to llm. This ensures the ChatOpenAI model is passed correctly and the example runs without errors.

<!-- End of auto-generated description by cubic. -->

