### PR TITLE
change gemini 2.5 flash to gemini latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ load_dotenv()
 
 agent = Agent(
     task="Find the number of stars of the browser-use repo",
-    llm=ChatGoogle(model="gemini-2.5-flash"),
+    llm=ChatGoogle(model="gemini-flash-latest"),
     # browser=Browser(use_cloud=True),  # Uses Browser-Use cloud for the browser
 )
 agent.run_sync()

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -707,6 +707,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		# Page-specific actions will be included directly in the browser_state message
 		self.logger.debug(f'💬 Step {self.state.n_steps}: Creating state messages for context...')
+
 		self._message_manager.create_state_messages(
 			browser_state_summary=browser_state_summary,
 			model_output=self.state.last_model_output,

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -28,6 +28,8 @@ VerifiedGeminiModels = Literal[
 	'Gemini-2.0-exp',
 	'gemini-2.5-flash',
 	'gemini-2.5-flash-lite',
+	'gemini-flash-latest',
+	'gemini-flash-lite-latest',
 	'gemini-2.5-pro',
 	'gemma-3-27b-it',
 	'gemma-3-4b',

--- a/docs/customize/agent/supported-models.mdx
+++ b/docs/customize/agent/supported-models.mdx
@@ -9,7 +9,7 @@ icon: "robot"
 
 - Best accuracy: `O3`
 - Fastest: `llama4` on groq
-- Balanced: fast + cheap + clever: `gemini-2.5-flash` or `gpt-4.1-mini`
+- Balanced: fast + cheap + clever: `gemini-flash-latest` or `gpt-4.1-mini`
 
 
 ### OpenAI [example](https://github.com/browser-use/browser-use/blob/main/examples/models/gpt-4.1.py)
@@ -104,7 +104,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Initialize the model
-llm = ChatGoogle(model='gemini-2.5-flash')
+llm = ChatGoogle(model='gemini-flash-latest')
 
 # Create agent with the model
 agent = Agent(

--- a/docs/examples/templates/fast-agent.mdx
+++ b/docs/examples/templates/fast-agent.mdx
@@ -31,7 +31,7 @@ async def main():
 	)
 	# from browser_use import ChatGoogle
 
-	# llm = ChatGoogle(model='gemini-2.5-flash')
+	# llm = ChatGoogle(model='gemini-flash-lite-latest')
 
 	# 2. Create speed-optimized browser profile
 	browser_profile = BrowserProfile(
@@ -74,7 +74,7 @@ llm = ChatGroq(model='meta-llama/llama-4-maverick-17b-128e-instruct')
 
 # Google Gemini Flash - Optimized for speed
 from browser_use import ChatGoogle
-llm = ChatGoogle(model='gemini-2.5-flash')
+llm = ChatGoogle(model='gemini-flash-lite-latest')
 ```
 
 ### 2. Browser Optimizations

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -96,7 +96,7 @@ import asyncio
 load_dotenv()
 
 async def main():
-    llm = ChatGoogle(model="gemini-2.5-flash")
+    llm = ChatGoogle(model="gemini-flash-latest")
     task = "Find the number 1 post on Show HN"
     agent = Agent(task=task, llm=llm)
     await agent.run()

--- a/examples/features/blocked_domains.py
+++ b/examples/features/blocked_domains.py
@@ -17,13 +17,13 @@ llm = ChatOpenAI(model='gpt-4o-mini')
 task = 'Navigate to example.com, then try to go to x.com, then facebook.com, and finally visit google.com. Tell me which sites you were able to access.'
 
 prohibited_domains = [
-	'x.com',                         # Block X (formerly Twitter) - "locked the f in" 
-	'twitter.com',                   # Block Twitter (redirects to x.com anyway)
-	'facebook.com',                  # Lock the F in Facebook too
-	'*.meta.com',                    # Block all Meta properties
-	'*.adult-site.com',              # Block all subdomains of adult sites
+	'x.com',  # Block X (formerly Twitter) - "locked the f in"
+	'twitter.com',  # Block Twitter (redirects to x.com anyway)
+	'facebook.com',  # Lock the F in Facebook too
+	'*.meta.com',  # Block all Meta properties
+	'*.adult-site.com',  # Block all subdomains of adult sites
 	'https://explicit-content.org',  # Block specific protocol/domain
-	'gambling-site.net',             # Block gambling sites
+	'gambling-site.net',  # Block gambling sites
 ]
 
 browser_session = BrowserSession(
@@ -43,7 +43,7 @@ agent = Agent(
 
 async def main():
 	print('Demo: Blocked Domains Feature - "Lock the F in" Edition')
-	print('We\'re literally locking the F in Facebook and X!')
+	print("We're literally locking the F in Facebook and X!")
 	print(f'Prohibited domains: {prohibited_domains}')
 	print('The agent will try to visit various sites, but blocked domains will be prevented.')
 	print()

--- a/examples/getting_started/05_fast_agent.py
+++ b/examples/getting_started/05_fast_agent.py
@@ -31,7 +31,7 @@ async def main():
 	)
 	# from browser_use import ChatGoogle
 
-	# llm = ChatGoogle(model='gemini-flash-latest')
+	# llm = ChatGoogle(model='gemini-flash-lite-latest')
 
 	# 2. Create speed-optimized browser profile
 	browser_profile = BrowserProfile(

--- a/examples/getting_started/05_fast_agent.py
+++ b/examples/getting_started/05_fast_agent.py
@@ -31,7 +31,7 @@ async def main():
 	)
 	# from browser_use import ChatGoogle
 
-	# llm = ChatGoogle(model='gemini-2.5-flash')
+	# llm = ChatGoogle(model='gemini-flash-latest')
 
 	# 2. Create speed-optimized browser profile
 	browser_profile = BrowserProfile(

--- a/examples/models/gemini.py
+++ b/examples/models/gemini.py
@@ -14,7 +14,7 @@ api_key = os.getenv('GOOGLE_API_KEY')
 if not api_key:
 	raise ValueError('GOOGLE_API_KEY is not set')
 
-llm = ChatGoogle(model='gemini-2.5-flash', api_key=api_key, temperature=0.0)
+llm = ChatGoogle(model='gemini-flash-latest', api_key=api_key, temperature=0.0)
 
 
 async def run_search():

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -6,7 +6,7 @@ load_dotenv()
 
 agent = Agent(
 	task='Find the number of stars of the browser-use repo',
-	llm=ChatGoogle(model='gemini-2.5-flash'),
+	llm=ChatGoogle(model='gemini-flash-latest'),
 	# browser=Browser(use_cloud=True),  # Uses Browser-Use cloud for the browser
 )
 agent.run_sync()


### PR DESCRIPTION
Auto-generated PR for: change gemini 2.5 flash to gemini latest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for `gemini-flash-latest` and `gemini-flash-lite-latest` and updates docs/examples to use these models instead of `gemini-2.5-flash`.
> 
> - **LLM (Google Gemini)**:
>   - Add `gemini-flash-latest` and `gemini-flash-lite-latest` to `VerifiedGeminiModels` in `browser_use/llm/google/chat.py`.
> - **Docs & Examples**:
>   - Replace `gemini-2.5-flash` with `gemini-flash-latest` across `README.md`, `docs/quickstart.mdx`, `docs/customize/agent/supported-models.mdx`, `examples/models/gemini.py`, and `examples/simple.py`.
>   - Use `gemini-flash-lite-latest` in speed-focused examples: `docs/examples/templates/fast-agent.mdx`, `examples/getting_started/05_fast_agent.py`.
>   - Update recommendation bullet to prefer `gemini-flash-latest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a6181afd70636402fec6bb05691e5d15cfb1774. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->