### PR TITLE
redirect for get-browser-profile and v2/quickstart

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -117,7 +117,7 @@
     },
     {
       "source":"/api-reference/browser-profiles/get-browser-profile",
-      "destination":"/api-reference/profiles/get-browser-profile"
+      "destination":"https://docs.cloud.browser-use.com/api-reference/v-2-api-current/profiles/get-profile-profiles-profile-id-get"
     },
     {
       "source": "/cloud/v2/quickstart",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -114,6 +114,14 @@
     {
       "source": "/customize/examples/prompting-guide",
       "destination": "/customize/agent/prompting-guide"
+    },
+    {
+      "source":"/api-reference/browser-profiles/get-browser-profile",
+      "destination":"/api-reference/profiles/get-browser-profile"
+    },
+    {
+      "source": "/cloud/v2/quickstart",
+      "destination": "/cloud/v1/quickstart"
     }
   ],
   "navigation": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -121,7 +121,7 @@
     },
     {
       "source": "/cloud/v2/quickstart",
-      "destination": "/cloud/v1/quickstart"
+      "destination": "https://docs.cloud.browser-use.com/get-started/quickstart"
     }
   ],
   "navigation": {


### PR DESCRIPTION
the top google links point to deprecated docs, so redirect:
"/api-reference/browser-profiles/get-browser-profile" -> "/api-reference/profiles/get-browser-profile"
"/cloud/v2/quickstart" -> "/cloud/v1/quickstart"
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update docs redirects so popular Google links point to current pages and avoid deprecated content.
- /api-reference/browser-profiles/get-browser-profile -> /api-reference/profiles/get-browser-profile
- /cloud/v2/quickstart -> /cloud/v1/quickstart

<!-- End of auto-generated description by cubic. -->

