### PR TITLE
Update import statement for GetCookiesParameters

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -973,7 +973,7 @@ class BrowserSession(BaseModel):
 
 	async def cookies(self, urls: list[str] | None = None) -> list['Cookie']:
 		"""Get cookies, optionally filtered by URLs."""
-		from cdp_use.cdp.network.library import GetCookiesParameters
+		from cdp_use.cdp.network.commands import GetCookiesParameters
 
 		params: GetCookiesParameters = {}
 		if urls:


### PR DESCRIPTION
`GetCookiesParameters` was imported from `cdp_use.cdp.network.library`, but that's only available if `TYPE_CHECKING` is `True`. During runtime, that's not the case, which makes the function throw

```
ImportError: cannot import name 'GetCookiesParameters' from 'cdp_use.cdp.network.library' (.../.venv/lib/python3.11/site-packages/cdp_use/cdp/network/library.py)
```

`GetCookiesParameters` is always available from `cdp_use.cdp.network` and `cdp_use.cdp.network.commands`

Alternative solution would be to wrap this too in an `if TYPE_CHECKING`, but I think this is cleaner