### PR TITLE
[Issue 3217] Add ElementDetector to BrowserProfile for customization of interactive element selection

### DIFF
--- a/browser_use/actor/page.py
+++ b/browser_use/actor/page.py
@@ -360,7 +360,7 @@ class Page:
 	@property
 	def dom_service(self) -> 'DomService':
 		"""Get the DOM service for this target."""
-		return DomService(self._browser_session)
+		return DomService(self._browser_session, element_detector=self._browser_session.browser_profile.element_detector)
 
 	async def get_element_by_prompt(self, prompt: str, llm: 'BaseChatModel | None' = None) -> 'Element | None':
 		"""Get an element by a prompt."""
@@ -375,7 +375,7 @@ class Page:
 		enhanced_dom_tree = await dom_service.get_dom_tree(target_id=self._target_id)
 
 		serialized_dom_state, _ = DOMTreeSerializer(
-			enhanced_dom_tree, None, paint_order_filtering=True
+			enhanced_dom_tree, None, paint_order_filtering=True, element_detector=self._browser_session.browser_profile.element_detector
 		).serialize_accessible_elements()
 
 		llm_representation = serialized_dom_state.llm_representation()

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -4,13 +4,16 @@ from collections.abc import Iterable
 from enum import Enum
 from functools import cache
 from pathlib import Path
-from typing import Annotated, Any, Literal, Self
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Self
 from urllib.parse import urlparse
 
 from pydantic import AfterValidator, AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from browser_use.config import CONFIG
 from browser_use.utils import _log_pretty_path, logger
+
+if TYPE_CHECKING:
+	from browser_use.dom.serializer.clickable_elements import ElementDetector
 
 CHROME_DEBUG_PORT = 9242  # use a non-default port to avoid conflicts with other tools / devs using 9222
 CHROME_DISABLED_COMPONENTS = [
@@ -626,6 +629,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		default=True, description='Only show element IDs in highlights if llm_representation is less than 10 characters.'
 	)
 	paint_order_filtering: bool = Field(default=True, description='Enable paint order filtering. Slightly experimental.')
+	element_detector: 'ElementDetector | None' = Field(default=None, description='Custom element detector for interactive element detection.')
 
 	# --- Downloads ---
 	auto_download_pdfs: bool = Field(default=True, description='Automatically download PDFs when navigating to PDF viewer pages.')

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -46,6 +46,7 @@ from browser_use.utils import _log_pretty_url, is_new_tab_page
 
 if TYPE_CHECKING:
 	from browser_use.actor.page import Page
+	from browser_use.dom.serializer.clickable_elements import ElementDetector
 
 DEFAULT_BROWSER_PROFILE = BrowserProfile()
 
@@ -277,6 +278,7 @@ class BrowserSession(BaseModel):
 		cross_origin_iframes: bool | None = None,
 		highlight_elements: bool | None = None,
 		paint_order_filtering: bool | None = None,
+		element_detector: 'ElementDetector | None' = None,
 		# Iframe processing limits
 		max_iframes: int | None = None,
 		max_iframe_depth: int | None = None,

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -362,6 +362,7 @@ class DOMWatchdog(BaseWatchdog):
 					logger=self.logger,
 					cross_origin_iframes=self.browser_session.browser_profile.cross_origin_iframes,
 					paint_order_filtering=self.browser_session.browser_profile.paint_order_filtering,
+					element_detector=self.browser_session.browser_profile.element_detector,
 					max_iframes=self.browser_session.browser_profile.max_iframes,
 					max_iframe_depth=self.browser_session.browser_profile.max_iframe_depth,
 				)

--- a/browser_use/dom/serializer/clickable_elements.py
+++ b/browser_use/dom/serializer/clickable_elements.py
@@ -1,9 +1,19 @@
+from abc import ABC, abstractmethod
+
 from browser_use.dom.views import EnhancedDOMTreeNode, NodeType
 
 
-class ClickableElementDetector:
-	@staticmethod
-	def is_interactive(node: EnhancedDOMTreeNode) -> bool:
+class ElementDetector(ABC):
+	"""Abstract base class for element detection strategies."""
+	
+	@abstractmethod
+	def is_interactive(self, node: EnhancedDOMTreeNode) -> bool:
+		"""Check if this node is interactive/clickable."""
+		pass
+
+
+class ClickableElementDetector(ElementDetector):
+	def is_interactive(self, node: EnhancedDOMTreeNode) -> bool:
 		"""Check if this node is clickable/interactive using enhanced scoring."""
 
 		# Skip non-element nodes

--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from browser_use.dom.serializer.clickable_elements import ClickableElementDetector
+from browser_use.dom.serializer.clickable_elements import ClickableElementDetector, ElementDetector
 from browser_use.dom.serializer.paint_order import PaintOrderRemover
 from browser_use.dom.utils import cap_text_length
 from browser_use.dom.views import (
@@ -22,7 +22,7 @@ class DOMTreeSerializer:
 	"""Serializes enhanced DOM trees to string format."""
 
 	# Configuration - elements that propagate bounds to their children
-	PROPAGATING_ELEMENTS = [
+	PROPAGATING_ELEMENTS: list[dict[str, str | None]] = [
 		{'tag': 'a', 'role': None},  # Any <a> tag
 		{'tag': 'button', 'role': None},  # Any <button> tag
 		{'tag': 'div', 'role': 'button'},  # <div role="button">
@@ -43,6 +43,7 @@ class DOMTreeSerializer:
 		enable_bbox_filtering: bool = True,
 		containment_threshold: float | None = None,
 		paint_order_filtering: bool = True,
+		element_detector: ElementDetector | None = None,
 	):
 		self.root_node = root_node
 		self._interactive_counter = 1
@@ -57,6 +58,8 @@ class DOMTreeSerializer:
 		self.containment_threshold = containment_threshold or self.DEFAULT_CONTAINMENT_THRESHOLD
 		# Paint order filtering configuration
 		self.paint_order_filtering = paint_order_filtering
+		# Element detector configuration
+		self.element_detector: ElementDetector = element_detector or ClickableElementDetector()
 
 	def _safe_parse_number(self, value_str: str, default: float) -> float:
 		"""Parse string to float, handling negatives and decimals."""
@@ -410,7 +413,7 @@ class DOMTreeSerializer:
 			import time
 
 			start_time = time.time()
-			result = ClickableElementDetector.is_interactive(node)
+			result = self.element_detector.is_interactive(node)
 			end_time = time.time()
 
 			if 'clickable_detection_time' not in self.timing_info:

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -27,6 +27,7 @@ from browser_use.observability import observe_debug
 
 if TYPE_CHECKING:
 	from browser_use.browser.session import BrowserSession
+	from browser_use.dom.serializer.clickable_elements import ElementDetector
 
 # Note: iframe limits are now configurable via BrowserProfile.max_iframes and BrowserProfile.max_iframe_depth
 
@@ -48,6 +49,7 @@ class DomService:
 		logger: logging.Logger | None = None,
 		cross_origin_iframes: bool = False,
 		paint_order_filtering: bool = True,
+		element_detector: 'ElementDetector | None' = None,
 		max_iframes: int = 100,
 		max_iframe_depth: int = 5,
 	):
@@ -55,6 +57,7 @@ class DomService:
 		self.logger = logger or browser_session.logger
 		self.cross_origin_iframes = cross_origin_iframes
 		self.paint_order_filtering = paint_order_filtering
+		self.element_detector = element_detector
 		self.max_iframes = max_iframes
 		self.max_iframe_depth = max_iframe_depth
 
@@ -729,7 +732,7 @@ class DomService:
 
 		start = time.time()
 		serialized_dom_state, serializer_timing = DOMTreeSerializer(
-			enhanced_dom_tree, previous_cached_state, paint_order_filtering=self.paint_order_filtering
+			enhanced_dom_tree, previous_cached_state, paint_order_filtering=self.paint_order_filtering, element_detector=self.element_detector
 		).serialize_accessible_elements()
 
 		end = time.time()


### PR DESCRIPTION
Implements the enhancement requested in https://github.com/browser-use/browser-use/issues/3217

Adds an abstract class ElementDetector with method is_interactive for overriding is_interactive behavior. Consumers can either implement their own ElementDetector or extend ClickableElementDetector. This can be configured in the `BrowserProfile`