### PR TITLE
[fix] type checking in CI

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -5,12 +5,12 @@ from typing import Any, TypeVar, overload
 
 import httpx
 from anthropic import (
-	NOT_GIVEN,
 	APIConnectionError,
 	APIStatusError,
 	AsyncAnthropic,
 	NotGiven,
 	RateLimitError,
+	omit,
 )
 from anthropic.types import CacheControlEphemeralParam, Message, ToolParam
 from anthropic.types.model_param import ModelParam
@@ -141,7 +141,7 @@ class ChatAnthropic(BaseChatModel):
 				response = await self.get_client().messages.create(
 					model=self.model,
 					messages=anthropic_messages,
-					system=system_prompt or NOT_GIVEN,
+					system=system_prompt or omit,
 					**self._get_client_params_for_invoke(),
 				)
 
@@ -192,7 +192,7 @@ class ChatAnthropic(BaseChatModel):
 					model=self.model,
 					messages=anthropic_messages,
 					tools=[tool],
-					system=system_prompt or NOT_GIVEN,
+					system=system_prompt or omit,
 					tool_choice=tool_choice,
 					**self._get_client_params_for_invoke(),
 				)

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 from anthropic import (
-	NOT_GIVEN,
 	APIConnectionError,
 	APIStatusError,
 	AsyncAnthropicBedrock,
 	RateLimitError,
+	omit,
 )
 from anthropic.types import CacheControlEphemeralParam, Message, ToolParam
 from anthropic.types.text_block import TextBlock
@@ -163,7 +163,7 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 				response = await self.get_client().messages.create(
 					model=self.model,
 					messages=anthropic_messages,
-					system=system_prompt or NOT_GIVEN,
+					system=system_prompt or omit,
 					**self._get_client_params_for_invoke(),
 				)
 
@@ -206,7 +206,7 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 					model=self.model,
 					messages=anthropic_messages,
 					tools=[tool],
-					system=system_prompt or NOT_GIVEN,
+					system=system_prompt or omit,
 					tool_choice=tool_choice,
 					**self._get_client_params_for_invoke(),
 				)

--- a/examples/integrations/agentmail/email_tools.py
+++ b/examples/integrations/agentmail/email_tools.py
@@ -99,7 +99,7 @@ class EmailTools(Tools):
 		"""
 		Wait for a message to be received in the inbox
 		"""
-		async with self.email_client.websockets.connect() as ws:  # type: ignore[attr-defined]
+		async with self.email_client.websockets.connect() as ws:
 			await ws.send_subscribe(message=Subscribe(inbox_ids=[inbox_id]))
 
 			try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ video = [
     "numpy>=2.3.2",
 ]
 examples = [
-    "agentmail>=0.0.66",
+    "agentmail==0.0.59",
     # botocore: only needed for Bedrock Claude boto3 examples/models/bedrock_claude.py
     "botocore>=1.37.23",
     "imgcat>=0.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ video = [
     "numpy>=2.3.2",
 ]
 examples = [
-    "agentmail>=0.0.53",
+    "agentmail>=0.0.66",
     # botocore: only needed for Bedrock Claude boto3 examples/models/bedrock_claude.py
     "botocore>=1.37.23",
     "imgcat>=0.6.0",


### PR DESCRIPTION
This PR fixes the currently failing `code-style` and `type-checker` jobs in CI.

For the files related to Anthropic, the system argument is expected to be an instance of `Omit` instead of `NotGiven`, so I've changed it.

For the issue related to AgentMail, I've had to pin its dependency to `0.0.59`. I bisected their commits and realized that the `websockets` attribute isn't present within the `AsyncAgentMail` class after this version. Here's the exact commit: https://github.com/agentmail-to/agentmail-python/commit/57121f9b790141cbae6f6090d3b7a3372c407c2c. This is potentially unintentional on their part, however, their readme still shows an example of using the `websockets` property within the class.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix failing CI type-checker and code-style jobs by correcting Anthropic client type usage and pinning AgentMail to a compatible version. This unblocks CI and keeps examples working.

- **Bug Fixes**
  - Use anthropic.omit for system prompt instead of NOT_GIVEN in Anthropic and Bedrock chat clients to satisfy SDK typing.

- **Dependencies**
  - Pin agentmail to 0.0.59 to keep AsyncAgentMail.websockets available and prevent type-check errors.

<!-- End of auto-generated description by cubic. -->

