### PR TITLE
linter

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -141,7 +141,7 @@ class ChatAnthropic(BaseChatModel):
 				response = await self.get_client().messages.create(
 					model=self.model,
 					messages=anthropic_messages,
-					system=system_prompt or NOT_GIVEN,
+					system=system_prompt if system_prompt else NOT_GIVEN,
 					**self._get_client_params_for_invoke(),
 				)
 
@@ -192,7 +192,7 @@ class ChatAnthropic(BaseChatModel):
 					model=self.model,
 					messages=anthropic_messages,
 					tools=[tool],
-					system=system_prompt or NOT_GIVEN,
+					system=system_prompt if system_prompt else NOT_GIVEN,
 					tool_choice=tool_choice,
 					**self._get_client_params_for_invoke(),
 				)

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -163,7 +163,7 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 				response = await self.get_client().messages.create(
 					model=self.model,
 					messages=anthropic_messages,
-					system=system_prompt or NOT_GIVEN,
+					system=system_prompt if system_prompt else NOT_GIVEN,
 					**self._get_client_params_for_invoke(),
 				)
 
@@ -206,7 +206,7 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 					model=self.model,
 					messages=anthropic_messages,
 					tools=[tool],
-					system=system_prompt or NOT_GIVEN,
+					system=system_prompt if system_prompt else NOT_GIVEN,
 					tool_choice=tool_choice,
 					**self._get_client_params_for_invoke(),
 				)

--- a/examples/integrations/agentmail/email_tools.py
+++ b/examples/integrations/agentmail/email_tools.py
@@ -99,7 +99,7 @@ class EmailTools(Tools):
 		"""
 		Wait for a message to be received in the inbox
 		"""
-		async with self.email_client.websockets.connect() as ws:
+		async with self.email_client.websockets.connect() as ws:  # type: ignore[attr-defined]
 			await ws.send_subscribe(message=Subscribe(inbox_ids=[inbox_id]))
 
 			try:


### PR DESCRIPTION
Auto-generated PR for: linter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use explicit conditional when passing `system` to Anthropic clients and add a `type: ignore` for `websockets.connect` in email tools.
> 
> - **LLM**:
>   - **Anthropic clients** (`browser_use/llm/anthropic/chat.py`, `browser_use/llm/aws/chat_anthropic.py`): use `system=system_prompt if system_prompt else NOT_GIVEN` for both normal and tool-invocation paths.
> - **Examples**:
>   - **Email tools** (`examples/integrations/agentmail/email_tools.py`): add `# type: ignore[attr-defined]` on `websockets.connect()` context manager.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cd7846b14ae59af43a2b89b5db88b38ec9d57fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->