### PR TITLE
Functionality to stop the agent externally

### DIFF
--- a/examples/features/stop_externally.py
+++ b/examples/features/stop_externally.py
@@ -1,0 +1,43 @@
+import asyncio
+import os
+import random
+import sys
+
+from browser_use.llm.google.chat import ChatGoogle
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use import Agent
+
+llm = ChatGoogle(model='gemini-flash-latest', temperature=1.0)
+
+
+def check_is_task_stopped():
+	async def _internal_check_is_task_stopped() -> bool:
+		if random.random() < 0.1:
+			print('[TASK STOPPER] Task is stopped')
+			return True
+		else:
+			print('[TASK STOPPER] Task is not stopped')
+			return False
+
+	return _internal_check_is_task_stopped
+
+
+task = """
+Go to https://browser-use.github.io/stress-tests/challenges/wufoo-style-form.html and complete the Wufoo-style form by filling in all required fields and submitting.
+"""
+
+agent = Agent(task=task, llm=llm, flash_mode=True, register_should_stop_callback=check_is_task_stopped(), max_actions_per_step=1)
+
+
+async def main():
+	await agent.run(max_steps=30)
+
+
+if __name__ == '__main__':
+	asyncio.run(main())


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add an external stop callback to let callers halt the agent gracefully. The agent now checks this callback during steps/actions, sets a stopped state, and exits without counting as a failure.

- **New Features**
  - Added register_should_stop_callback to Agent; if it returns True, the agent sets state.stopped and interrupts the run.
  - Included examples/features/stop_externally.py showing how to supply a stop callback.

- **Refactors**
  - Replaced _raise_if_stopped_or_paused with _check_stop_or_pause and wired it into key execution points (context prep, post-LLM, before history commit, and action execution).
  - Treat InterruptedError as a clean stop: don’t increment failure count and swallow during initial actions.
  - Tweaked logs: simpler action error logs, model parse issues now log at error level, and a clearer startup message.

<!-- End of auto-generated description by cubic. -->

