### PR TITLE
try to make actions shorter

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -23,8 +23,8 @@ from browser_use.agent.cloud_events import (
 )
 from browser_use.agent.message_manager.utils import save_conversation
 from browser_use.llm.base import BaseChatModel
+from browser_use.llm.google.chat import ChatGoogle
 from browser_use.llm.messages import BaseMessage, ContentPartImageParam, ContentPartTextParam, UserMessage
-from browser_use.llm.openai.chat import ChatOpenAI
 from browser_use.tokens.service import TokenCost
 
 load_dotenv()
@@ -196,12 +196,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				except (ImportError, ValueError) as e:
 					# Use the logger that's already imported at the top of the module
 					logger.warning(
-						f'Failed to create default LLM "{default_llm_name}": {e}. Falling back to ChatOpenAI(model="gpt-4.1-mini")'
+						f'Failed to create default LLM "{default_llm_name}": {e}. Falling back to ChatGoogle(model="gemini-flash-latest")'
 					)
-					llm = ChatOpenAI(model='gpt-4.1-mini')
+					llm = ChatGoogle(model='gemini-flash-latest')
 			else:
 				# No default LLM specified, use the original default
-				llm = ChatOpenAI(model='gpt-4.1-mini')
+				llm = ChatGoogle(model='gemini-flash-latest')
 
 		if page_extraction_llm is None:
 			page_extraction_llm = llm

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -48,7 +48,7 @@ USER REQUEST: This is your ultimate objective and always remains visible.
 1. Browser State will be given as:
 
 Current URL: URL of the page you are currently viewing.
-Open Tabs: Open tabs with their indexes.
+Open Tabs: Open tabs with their ids.
 Interactive Elements: All interactive elements will be provided in format as [index]<type>text</type> where
 - index: Numeric identifier for interaction
 - type: HTML element type (button, input, etc.)

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -46,7 +46,7 @@ USER REQUEST: This is your ultimate objective and always remains visible.
 1. Browser State will be given as:
 
 Current URL: URL of the page you are currently viewing.
-Open Tabs: Open tabs with their indexes.
+Open Tabs: Open tabs with their ids.
 Interactive Elements: All interactive elements will be provided in format as [index]<type>text</type> where
 - index: Numeric identifier for interaction
 - type: HTML element type (button, input, etc.)

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -48,7 +48,7 @@ USER REQUEST: This is your ultimate objective and always remains visible.
 1. Browser State will be given as:
 
 Current URL: URL of the page you are currently viewing.
-Open Tabs: Open tabs with their indexes.
+Open Tabs: Open tabs with their ids.
 Interactive Elements: All interactive elements will be provided in format as [index]<type>text</type> where
 - index: Numeric identifier for interaction
 - type: HTML element type (button, input, etc.)

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -179,6 +179,10 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
+		# Allow data: and blob: URLs (they don't have hostnames)
+		if parsed.scheme in ['data', 'blob']:
+			return True
+
 		# Get the actual host (domain)
 		host = parsed.hostname
 		if not host:

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -20,7 +20,7 @@ class GoToUrlAction(BaseModel):
 
 class ClickElementAction(BaseModel):
 	index: int = Field(ge=1, description='index of the element to click')
-	while_holding_ctrl: bool | None = Field(
+	ctrl: bool | None = Field(
 		default=None,
 		description='Set to True to open the navigation in a new background tab (Ctrl+Click behavior). Optional.',
 	)
@@ -52,17 +52,19 @@ class SwitchTabAction(BaseModel):
 	tab_id: str = Field(
 		min_length=4,
 		max_length=4,
-		description='Last 4 chars of TargetID',
+		description="tab_id to switch to which is displayed as 'Tab <tab_id>' in the browser_state.",
 	)  # last 4 chars of TargetID
 
 
 class CloseTabAction(BaseModel):
-	tab_id: str = Field(min_length=4, max_length=4, description='4 character Tab ID')  # last 4 chars of TargetID
+	tab_id: str = Field(
+		min_length=4, max_length=4, description="tab_id to close which is displayed as 'Tab <tab_id>' in the browser_state."
+	)  # last 4 chars of TargetID
 
 
 class ScrollAction(BaseModel):
 	down: bool  # True to scroll down, False to scroll up
-	num_pages: float  # Number of pages to scroll (0.5 = half page, 1.0 = one page, etc.)
+	num_pages: float = 1.0  # Number of pages to scroll (0.5 = half page, 1.0 = one page, etc.)
 	frame_element_index: int | None = None  # Optional element index to find scroll container for
 
 

--- a/tests/ci/test_browser_event_ClickElementEvent.py
+++ b/tests/ci/test_browser_event_ClickElementEvent.py
@@ -70,17 +70,17 @@ def tools():
 
 
 class TestClickElementEvent:
-	"""Test cases for ClickElementEvent and click_element_by_index action."""
+	"""Test cases for ClickElementEvent and click action."""
 
 	async def test_error_handling(self, tools, browser_session):
 		"""Test error handling when an action fails."""
 		# Create an action with an invalid index
-		invalid_action = {'click_element_by_index': ClickElementAction(index=999)}  # doesn't exist on page
+		invalid_action = {'click': ClickElementAction(index=999)}  # doesn't exist on page
 
 		from browser_use.agent.views import ActionModel
 
 		class ClickActionModel(ActionModel):
-			click_element_by_index: ClickElementAction | None = None
+			click: ClickElementAction | None = None
 
 		# This should fail since the element doesn't exist
 		result: ActionResult = await tools.act(ClickActionModel(**invalid_action), browser_session)
@@ -88,7 +88,7 @@ class TestClickElementEvent:
 		assert result.error is not None
 
 	async def test_click_element_by_index(self, tools, browser_session, base_url, http_server):
-		"""Test that click_element_by_index correctly clicks an element and handles different outcomes."""
+		"""Test that click correctly clicks an element and handles different outcomes."""
 		# Add route for clickable elements test page
 		http_server.expect_request('/clickable').respond_with_data(
 			"""
@@ -173,14 +173,12 @@ class TestClickElementEvent:
 			f"Expected button text '{expected_button_text}' not found in '{button_text}'"
 		)
 
-		# Create a model for the click_element_by_index action
+		# Create a model for the click action
 		class ClickElementActionModel(ActionModel):
-			click_element_by_index: ClickElementAction | None = None
+			click: ClickElementAction | None = None
 
 		# Execute the action with the button index
-		result = await tools.act(
-			ClickElementActionModel(click_element_by_index=ClickElementAction(index=button_index)), browser_session
-		)
+		result = await tools.act(ClickElementActionModel(click=ClickElementAction(index=button_index)), browser_session)
 
 		# Verify the result structure
 		assert isinstance(result, ActionResult), 'Result should be an ActionResult instance'
@@ -201,7 +199,7 @@ class TestClickElementEvent:
 		assert result_text == expected_result_text, f"Expected result text '{expected_result_text}', got '{result_text}'"
 
 	async def test_click_element_new_tab(self, tools, browser_session, base_url, http_server):
-		"""Test that click_element_by_index with while_holding_ctrl=True opens links in new tabs."""
+		"""Test that click with ctrl=True opens links in new tabs."""
 		# Add route for new tab test page
 		http_server.expect_request('/newTab').respond_with_data(
 			"""
@@ -247,11 +245,11 @@ class TestClickElementEvent:
 
 		assert link_index is not None, 'Could not find link element'
 
-		# Click the link with while_holding_ctrl=True
-		click_action = {'click_element_by_index': ClickElementAction(index=link_index, while_holding_ctrl=True)}
+		# Click the link with ctrl=True
+		click_action = {'click': ClickElementAction(index=link_index, ctrl=True)}
 
 		class ClickActionModel(ActionModel):
-			click_element_by_index: ClickElementAction | None = None
+			click: ClickElementAction | None = None
 
 		result = await tools.act(ClickActionModel(**click_action), browser_session)
 		await asyncio.sleep(1)  # Wait for new tab to open
@@ -288,7 +286,7 @@ class TestClickElementEvent:
 
 	@pytest.mark.skip(reason='Tab count assertion failures - tab management logic changed')
 	async def test_click_element_normal_vs_new_tab(self, tools, browser_session, base_url, http_server):
-		"""Test that click_element_by_index behaves differently with while_holding_ctrl=False vs while_holding_ctrl=True."""
+		"""Test that click behaves differently with ctrl=False vs ctrl=True."""
 		# Add route for comparison test page
 		http_server.expect_request('/comparison').respond_with_data(
 			"""
@@ -330,11 +328,11 @@ class TestClickElementEvent:
 
 		assert len(link_indices) >= 2, 'Need at least 2 links for comparison test'
 
-		# Test normal click (while_holding_ctrl=False) - should navigate in current tab
-		click_action_normal = {'click_element_by_index': ClickElementAction(index=link_indices[0], while_holding_ctrl=False)}
+		# Test normal click (ctrl=False) - should navigate in current tab
+		click_action_normal = {'click': ClickElementAction(index=link_indices[0], ctrl=False)}
 
 		class ClickActionModel(ActionModel):
-			click_element_by_index: ClickElementAction | None = None
+			click: ClickElementAction | None = None
 
 		result = await tools.act(ClickActionModel(**click_action_normal), browser_session)
 		await asyncio.sleep(1)
@@ -347,8 +345,8 @@ class TestClickElementEvent:
 		await tools.act(GoToUrlActionModel(**goto_action), browser_session)
 		await asyncio.sleep(1)
 
-		# Test new tab click (while_holding_ctrl=True) - should open in new background tab
-		click_action_new_tab = {'click_element_by_index': ClickElementAction(index=link_indices[1], while_holding_ctrl=True)}
+		# Test new tab click (ctrl=True) - should open in new background tab
+		click_action_new_tab = {'click': ClickElementAction(index=link_indices[1], ctrl=True)}
 		result = await tools.act(ClickActionModel(**click_action_new_tab), browser_session)
 		await asyncio.sleep(1)
 
@@ -420,9 +418,9 @@ class TestClickElementEvent:
 
 		# Click the element - should click the visible portion
 		class ClickActionModel(ActionModel):
-			click_element_by_index: ClickElementAction | None = None
+			click: ClickElementAction | None = None
 
-		result = await tools.act(ClickActionModel(click_element_by_index=ClickElementAction(index=inline_index)), browser_session)
+		result = await tools.act(ClickActionModel(click=ClickElementAction(index=inline_index)), browser_session)
 
 		assert result.error is None, f'Click failed: {result.error}'
 
@@ -502,9 +500,9 @@ class TestClickElementEvent:
 
 		# Click the block element
 		class ClickActionModel(ActionModel):
-			click_element_by_index: ClickElementAction | None = None
+			click: ClickElementAction | None = None
 
-		result = await tools.act(ClickActionModel(click_element_by_index=ClickElementAction(index=block_index)), browser_session)
+		result = await tools.act(ClickActionModel(click=ClickElementAction(index=block_index)), browser_session)
 
 		assert result.error is None, f'Click failed: {result.error}'
 
@@ -590,9 +588,9 @@ class TestClickElementEvent:
 
 		# Click should still work on the visible portion
 		class ClickActionModel(ActionModel):
-			click_element_by_index: ClickElementAction | None = None
+			click: ClickElementAction | None = None
 
-		result = await tools.act(ClickActionModel(click_element_by_index=ClickElementAction(index=target_index)), browser_session)
+		result = await tools.act(ClickActionModel(click=ClickElementAction(index=target_index)), browser_session)
 
 		assert result.error is None, f'Click failed: {result.error}'
 
@@ -651,11 +649,9 @@ class TestClickElementEvent:
 
 		# Attempt to click should raise an exception
 		class ClickActionModel(ActionModel):
-			click_element_by_index: ClickElementAction | None = None
+			click: ClickElementAction | None = None
 
-		result = await tools.act(
-			ClickActionModel(click_element_by_index=ClickElementAction(index=file_input_index)), browser_session
-		)
+		result = await tools.act(ClickActionModel(click=ClickElementAction(index=file_input_index)), browser_session)
 
 		# Should have an error about file inputs
 		assert result.error is not None, 'Expected error for file input click'
@@ -713,9 +709,9 @@ class TestClickElementEvent:
 
 		# Attempt to click should raise an exception
 		class ClickActionModel(ActionModel):
-			click_element_by_index: ClickElementAction | None = None
+			click: ClickElementAction | None = None
 
-		result = await tools.act(ClickActionModel(click_element_by_index=ClickElementAction(index=select_index)), browser_session)
+		result = await tools.act(ClickActionModel(click=ClickElementAction(index=select_index)), browser_session)
 
 		# Should automatically provide dropdown options instead of an error
 		assert result.error is None, 'Should not have error - should provide dropdown options automatically'
@@ -1114,7 +1110,7 @@ class TestClickElementEvent:
 
 			# Create action model for file upload
 			class UploadFileActionModel(ActionModel):
-				upload_file_to_element: UploadFileAction | None = None
+				upload_file: UploadFileAction | None = None
 
 			# Create a temporary FileSystem for the test
 			import tempfile
@@ -1126,7 +1122,7 @@ class TestClickElementEvent:
 
 				# Upload the file using the label index (should find the associated file input)
 				result = await tools.act(
-					UploadFileActionModel(upload_file_to_element=UploadFileAction(index=label_index, path=temp_file_path)),
+					UploadFileActionModel(upload_file=UploadFileAction(index=label_index, path=temp_file_path)),
 					browser_session,
 					available_file_paths=[temp_file_path],  # Pass the file path as available
 					file_system=file_system,  # Pass the required file_system parameter
@@ -1248,9 +1244,9 @@ class TestClickElementEvent:
 
 			# Test 1: Try to upload a file that's not in available_file_paths - should fail
 			class UploadActionModel(ActionModel):
-				upload_file_to_element: UploadFileAction | None = None
+				upload_file: UploadFileAction | None = None
 
-			upload_action = UploadActionModel(upload_file_to_element=UploadFileAction(index=1, path=test_file_path))
+			upload_action = UploadActionModel(upload_file=UploadFileAction(index=1, path=test_file_path))
 
 			# Create a temporary FileSystem for all tests
 			with tempfile.TemporaryDirectory() as temp_dir:
@@ -1283,7 +1279,7 @@ class TestClickElementEvent:
 				fs_file_path = str(file_system.get_dir() / 'test.txt')
 
 				# Try to upload using just the filename (should check FileSystem)
-				upload_action_fs = UploadActionModel(upload_file_to_element=UploadFileAction(index=1, path='test.txt'))
+				upload_action_fs = UploadActionModel(upload_file=UploadFileAction(index=1, path='test.txt'))
 
 				result = await tools.act(
 					upload_action_fs,

--- a/tests/ci/test_browser_session_element_cache.py
+++ b/tests/ci/test_browser_session_element_cache.py
@@ -165,7 +165,7 @@ async def test_assumption_3_action_gets_same_selector_map(browser_session, tools
 
 @pytest.mark.asyncio
 async def test_assumption_4_click_action_specific_issue(browser_session, tools, httpserver):
-	"""Test assumption 4: Specific issue with click_element_by_index action."""
+	"""Test assumption 4: Specific issue with click action."""
 	# Go to a simple page using CDP events
 	from browser_use.browser.events import NavigateToUrlEvent
 
@@ -181,12 +181,12 @@ async def test_assumption_4_click_action_specific_issue(browser_session, tools, 
 	print(f'  - Cached elements: {len(cached_selector_map)}')
 	print(f'  - Element 0 exists: {0 in cached_selector_map}')
 
-	# Create a test action that replicates click_element_by_index logic
+	# Create a test action that replicates click logic
 	@tools.registry.action('Test: Debug click logic')
 	async def test_debug_click_logic(index: int, browser_session: BrowserSession):
 		from browser_use import ActionResult
 
-		# This is the exact logic from click_element_by_index
+		# This is the exact logic from click
 		selector_map = await browser_session.get_selector_map()
 
 		print(f'  - Action selector map size: {len(selector_map)}')

--- a/tests/ci/test_browser_session_output_paths.py
+++ b/tests/ci/test_browser_session_output_paths.py
@@ -72,16 +72,16 @@ def interactive_llm(httpserver_url):
 		"""
 		{
 			"thinking": "null",
-			"evaluation_previous_goal": "Successfully navigated to the page",
-			"memory": "Page loaded, can see search box and submit button",
-			"next_goal": "Click on the search box to focus it",
-			"action": [
-				{
-					"click_element_by_index": {
-						"index": 0
-					}
+		"evaluation_previous_goal": "Successfully navigated to the page",
+		"memory": "Page loaded, can see search box and submit button",
+		"next_goal": "Click on the search box to focus it",
+		"action": [
+			{
+				"click": {
+					"index": 0
 				}
-			]
+			}
+		]
 		}
 		""",
 		# Third action: Type text in the search box
@@ -105,16 +105,16 @@ def interactive_llm(httpserver_url):
 		"""
 		{
 			"thinking": "null",
-			"evaluation_previous_goal": "Typed 'test' in search box",
-			"memory": "Text 'test' has been entered successfully",
-			"next_goal": "Click the submit button to complete the task",
-			"action": [
-				{
-					"click_element_by_index": {
-						"index": 1
-					}
+		"evaluation_previous_goal": "Typed 'test' in search box",
+		"memory": "Text 'test' has been entered successfully",
+		"next_goal": "Click the submit button to complete the task",
+		"action": [
+			{
+				"click": {
+					"index": 1
 				}
-			]
+			}
+		]
 		}
 		""",
 		# Fifth action: Done - task completed

--- a/tests/ci/test_browser_watchdog_downloads_upload_full_circle.py
+++ b/tests/ci/test_browser_watchdog_downloads_upload_full_circle.py
@@ -189,12 +189,10 @@ class TestDownloadUploadFullCircle:
 
 				# Step 2: Click download link and wait for download
 				class ClickActionModel(ActionModel):
-					click_element_by_index: ClickElementAction | None = None
+					click: ClickElementAction | None = None
 
 				# Click the download link
-				result = await tools.act(
-					ClickActionModel(click_element_by_index=ClickElementAction(index=download_link_index)), browser_session
-				)
+				result = await tools.act(ClickActionModel(click=ClickElementAction(index=download_link_index)), browser_session)
 				assert result.error is None, f'Click on download link failed: {result.error}'
 
 				# Wait for the download event
@@ -272,11 +270,11 @@ class TestDownloadUploadFullCircle:
 
 				# Step 4: Upload the downloaded file
 				class UploadActionModel(ActionModel):
-					upload_file_to_element: UploadFileAction | None = None
+					upload_file: UploadFileAction | None = None
 
 				# The downloaded file should be automatically available for upload
 				result = await tools.act(
-					UploadActionModel(upload_file_to_element=UploadFileAction(index=file_input_index, path=downloaded_file_path)),
+					UploadActionModel(upload_file=UploadFileAction(index=file_input_index, path=downloaded_file_path)),
 					browser_session,
 					available_file_paths=[],  # Empty, but file is in downloaded_files
 					file_system=file_system,
@@ -304,9 +302,7 @@ class TestDownloadUploadFullCircle:
 				assert submit_button_index is not None, 'Submit button not found'
 
 				# Click the submit button
-				result = await tools.act(
-					ClickActionModel(click_element_by_index=ClickElementAction(index=submit_button_index)), browser_session
-				)
+				result = await tools.act(ClickActionModel(click=ClickElementAction(index=submit_button_index)), browser_session)
 				assert result.error is None, f'Click on submit button failed: {result.error}'
 
 				# Wait for JavaScript to process the upload

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -98,7 +98,7 @@ class TestToolsIntegration:
 		common_actions = [
 			'go_to_url',
 			'search',
-			'click_element_by_index',
+			'click',
 			'input_text',
 			'scroll',
 			'go_back',
@@ -294,7 +294,7 @@ class TestToolsIntegration:
 
 		# But other actions are still there
 		assert 'go_to_url' in excluded_tools.registry.registry.actions
-		assert 'click_element_by_index' in excluded_tools.registry.registry.actions
+		assert 'click' in excluded_tools.registry.registry.actions
 
 	async def test_search_action(self, tools, browser_session, base_url):
 		"""Test the search action."""


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Simplified tool action descriptions and naming to make actions shorter and easier to use. Renamed a few actions/params and set a default for scrolling to reduce boilerplate without changing behavior.

- **Refactors**
  - Shorter, clearer descriptions across actions (search, go_to_url, click, input_text, upload_file, switch_tab, scroll, scroll_to_text, execute_js).
  - Renamed actions: click_element_by_index → click, upload_file_to_element → upload_file.
  - Renamed ClickElementAction param: while_holding_ctrl → ctrl.
  - Set ScrollAction.num_pages default to 1.0.

- **Migration**
  - Update ClickElementAction payloads to use ctrl instead of while_holding_ctrl.
  - If actions are referenced by function name, switch to click and upload_file.
  - Scroll now defaults to one page when num_pages is omitted.

<!-- End of auto-generated description by cubic. -->

