### PR TITLE
added option to interactive elements

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -677,7 +677,7 @@ class DOMTreeSerializer:
 		# 5. Keep if has role suggesting interactivity
 		if node.original_node.attributes:
 			role = node.original_node.attributes.get('role')
-			if role in ['button', 'link', 'checkbox', 'radio', 'tab', 'menuitem']:
+			if role in ['button', 'link', 'checkbox', 'radio', 'tab', 'menuitem', 'option']:
 				return False
 
 		# Default: exclude this child


### PR DESCRIPTION
### 🐛 Summary
Fixes [#3238](https://github.com/browser-use/browser-use/issues/3238)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added role="option" to the interactive roles in the DOM serializer so these nodes are kept instead of excluded. This fixes missing bounding boxes for option-like items in listboxes/selects.

<!-- End of auto-generated description by cubic. -->

