### PR TITLE
screenshot-tool

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal, Union
+from typing import Literal
 
 from browser_use.agent.message_manager.views import (
 	HistoryItem,
@@ -285,7 +285,7 @@ class MessageManager:
 		model_output: AgentOutput | None = None,
 		result: list[ActionResult] | None = None,
 		step_info: AgentStepInfo | None = None,
-		use_vision: Union[bool, Literal['auto']] = 'auto',
+		use_vision: bool | Literal['auto'] = 'auto',
 		page_filtered_actions: str | None = None,
 		sensitive_data=None,
 		available_file_paths: list[str] | None = None,  # Always pass current available_file_paths

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeVar, Union
 from urllib.parse import urlparse
 
 from dotenv import load_dotenv
@@ -154,7 +154,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		register_should_stop_callback: Callable[[], Awaitable[bool]] | None = None,
 		# Agent settings
 		output_model_schema: type[AgentStructuredOutput] | None = None,
-		use_vision: bool = True,
+		use_vision: Union[bool, Literal['auto']] = 'auto',
 		save_conversation_path: str | Path | None = None,
 		save_conversation_path_encoding: str | None = 'utf-8',
 		max_failures: int = 3,
@@ -255,7 +255,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		elif controller is not None:
 			self.tools = controller
 		else:
-			self.tools = Tools(display_files_in_done_text=display_files_in_done_text)
+			# Exclude take_screenshot tool when use_vision=False
+			exclude_actions = ['take_screenshot'] if use_vision is False else []
+			self.tools = Tools(exclude_actions=exclude_actions, display_files_in_done_text=display_files_in_done_text)
 
 		# Structured output
 		self.output_model_schema = output_model_schema

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Generic, Literal, TypeVar, Union
+from typing import Any, Generic, Literal, TypeVar
 from urllib.parse import urlparse
 
 from dotenv import load_dotenv
@@ -154,7 +154,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		register_should_stop_callback: Callable[[], Awaitable[bool]] | None = None,
 		# Agent settings
 		output_model_schema: type[AgentStructuredOutput] | None = None,
-		use_vision: Union[bool, Literal['auto']] = 'auto',
+		use_vision: bool | Literal['auto'] = 'auto',
 		save_conversation_path: str | Path | None = None,
 		save_conversation_path_encoding: str | None = 'utf-8',
 		max_failures: int = 3,

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -20,7 +20,7 @@ At every step, your input will consist of:
 1. <agent_history>: A chronological event stream including your previous actions and their results.
 2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
-4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements.
+4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used take_screenshot before
 5. <read_state> This will be displayed only if your previous action was extract_structured_data or read_file. This data is only shown in the current step.
 </input>
 
@@ -66,8 +66,9 @@ Note that:
 </browser_state>
 
 <browser_vision>
-You will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
+If you used take_screenshot before, you will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
 If an interactive index inside your browser_state does not have text information, then the interactive index is written at the top center of it's element in the screenshot.
+Use take_screenshot if you are unsure or simply want more information. 
 </browser_vision>
 
 <browser_rules>

--- a/browser_use/agent/system_prompt.md
+++ b/browser_use/agent/system_prompt.md
@@ -20,7 +20,7 @@ At every step, your input will consist of:
 1. <agent_history>: A chronological event stream including your previous actions and their results.
 2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
-4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used take_screenshot before
+4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used take_screenshot before, this will contain a screenshot.
 5. <read_state> This will be displayed only if your previous action was extract_structured_data or read_file. This data is only shown in the current step.
 </input>
 

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -20,7 +20,7 @@ At every step, your input will consist of:
 1. <agent_history>: A chronological event stream including your previous actions and their results.
 2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
-4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements.
+4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used take_screenshot before
 5. <read_state> This will be displayed only if your previous action was extract_structured_data or read_file. This data is only shown in the current step.
 </input>
 
@@ -64,9 +64,13 @@ Note that:
 </browser_state>
 
 <browser_vision>
-You will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
+If you used take_screenshot before, you will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
 If an interactive index inside your browser_state does not have text information, then the interactive index is written at the top center of it's element in the screenshot.
+Use take_screenshot if you are unsure or simply want more information. 
 </browser_vision>
+
+
+
 
 <browser_rules>
 Strictly follow these rules while using the browser and navigating the web:

--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -20,7 +20,7 @@ At every step, your input will consist of:
 1. <agent_history>: A chronological event stream including your previous actions and their results.
 2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
-4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used take_screenshot before
+4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used take_screenshot before, this will contain a screenshot.
 5. <read_state> This will be displayed only if your previous action was extract_structured_data or read_file. This data is only shown in the current step.
 </input>
 

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -20,7 +20,7 @@ At every step, your input will consist of:
 1. <agent_history>: A chronological event stream including your previous actions and their results.
 2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
-4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements.
+4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used take_screenshot before
 5. <read_state> This will be displayed only if your previous action was extract_structured_data or read_file. This data is only shown in the current step.
 </input>
 
@@ -66,8 +66,9 @@ Note that:
 </browser_state>
 
 <browser_vision>
-You will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
+If you used take_screenshot before, you will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
 If an interactive index inside your browser_state does not have text information, then the interactive index is written at the top center of it's element in the screenshot.
+Use take_screenshot if you are unsure or simply want more information. 
 </browser_vision>
 
 <browser_rules>

--- a/browser_use/agent/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompt_no_thinking.md
@@ -20,7 +20,7 @@ At every step, your input will consist of:
 1. <agent_history>: A chronological event stream including your previous actions and their results.
 2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
-4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used take_screenshot before
+4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used take_screenshot before, this will contain a screenshot.
 5. <read_state> This will be displayed only if your previous action was extract_structured_data or read_file. This data is only shown in the current step.
 </input>
 

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -5,7 +5,7 @@ import logging
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Generic, Literal
+from typing import Any, Generic, Literal, Union
 
 from openai import RateLimitError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model, model_validator
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class AgentSettings(BaseModel):
 	"""Configuration options for the Agent"""
 
-	use_vision: bool = True
+	use_vision: Union[bool, Literal['auto']] = 'auto'
 	vision_detail_level: Literal['auto', 'low', 'high'] = 'auto'
 	save_conversation_path: str | Path | None = None
 	save_conversation_path_encoding: str | None = 'utf-8'

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -5,7 +5,7 @@ import logging
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Generic, Literal, Union
+from typing import Any, Generic, Literal
 
 from openai import RateLimitError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model, model_validator
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class AgentSettings(BaseModel):
 	"""Configuration options for the Agent"""
 
-	use_vision: Union[bool, Literal['auto']] = 'auto'
+	use_vision: bool | Literal['auto'] = 'auto'
 	vision_detail_level: Literal['auto', 'low', 'high'] = 'auto'
 	save_conversation_path: str | Path | None = None
 	save_conversation_path_encoding: str | None = 'utf-8'

--- a/browser_use/telemetry/views.py
+++ b/browser_use/telemetry/views.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
-from typing import Any
+from typing import Any, Literal, Union
 
 from browser_use.config import is_running_in_docker
 
@@ -29,7 +29,7 @@ class AgentTelemetryEvent(BaseTelemetryEvent):
 	model_provider: str
 	max_steps: int
 	max_actions_per_step: int
-	use_vision: bool
+	use_vision: Union[bool, Literal['auto']]
 	version: str
 	source: str
 	cdp_url: str | None

--- a/browser_use/telemetry/views.py
+++ b/browser_use/telemetry/views.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
-from typing import Any, Literal, Union
+from typing import Any, Literal
 
 from browser_use.config import is_running_in_docker
 
@@ -29,7 +29,7 @@ class AgentTelemetryEvent(BaseTelemetryEvent):
 	model_provider: str
 	max_steps: int
 	max_actions_per_step: int
-	use_vision: Union[bool, Literal['auto']]
+	use_vision: bool | Literal['auto']
 	version: str
 	source: str
 	cdp_url: str | None

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -844,6 +844,21 @@ Note: For multiple pages (>=1.0), scrolls are performed one page at a time to en
 					long_term_memory=f"Tried scrolling to text '{text}' but it was not found",
 				)
 
+		@self.registry.action(
+			'Request to include a screenshot in your next browser state. Use this when you need visual confirmation or when the page contains complex visual information that is hard to understand from the DOM alone.'
+		)
+		async def take_screenshot():
+			"""Request that a screenshot be included in the next observation"""
+			memory = 'Requested screenshot for next observation'
+			msg = f'📸 {memory}'
+			logger.info(msg)
+
+			# Return flag in metadata to signal that screenshot should be included
+			return ActionResult(
+				extracted_content=memory,
+				metadata={'include_screenshot': True},
+			)
+
 		# Dropdown Actions
 
 		@self.registry.action(

--- a/docs/customize/agent/all-parameters.mdx
+++ b/docs/customize/agent/all-parameters.mdx
@@ -13,7 +13,7 @@ mode: "wide"
 - `output_model_schema`: Pydantic model class for structured output validation. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/custom_output.py)
 
 ### Vision & Processing
-- `use_vision` (default: `True`): Enable/disable vision capabilities for processing screenshots
+- `use_vision` (default: `"auto"`): Vision mode - `"auto"` includes take_screenshot tool but only uses vision when requested, `True` always includes screenshots, `False` never includes screenshots and excludes take_screenshot tool
 - `vision_detail_level` (default: `'auto'`): Screenshot detail level - `'low'`, `'high'`, or `'auto'`
 - `page_extraction_llm`: Separate LLM model for page content extraction. You can choose a small & fast model because it only needs to extract text from the page (default: same as `llm`)
 

--- a/docs/customize/tools/available.mdx
+++ b/docs/customize/tools/available.mdx
@@ -32,6 +32,9 @@ mode: "wide"
 ### Content Extraction
 - **`extract_structured_data`** - Extract data from webpages using LLM
 
+### Visual Analysis
+- **`take_screenshot`** - Request a screenshot in your next browser state for visual confirmation
+
 ### Form Controls
 - **`get_dropdown_options`** - Get dropdown option values
 - **`select_dropdown_option`** - Select dropdown options


### PR DESCRIPTION
Auto-generated PR for branch: screenshot-tool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an auto vision mode that includes screenshots only when requested via a new take_screenshot action, updating agent logic, prompts, telemetry, and docs.
> 
> - **Vision behavior**:
>   - Add `use_vision` mode `"auto"` (default) across `Agent`, `MessageManager`, `AgentSettings`, and telemetry; supports `bool | Literal['auto']`.
>   - Conditionally include `browser_state_summary.screenshot` only when requested via action metadata `{"include_screenshot": true}` or when `use_vision=True`; pass `effective_use_vision` to `.get_user_message()`.
>   - Exclude `take_screenshot` tool from `Tools` when `use_vision=False`.
> - **New tool**:
>   - Add `take_screenshot` action in `browser_use/tools/service.py` that returns metadata to request a screenshot in the next observation.
> - **Prompts**:
>   - Update system prompts to note `browser_vision` screenshot is present only after `take_screenshot`; instruct to use `take_screenshot` when unsure.
> - **Telemetry**:
>   - Update `AgentTelemetryEvent.use_vision` type to `bool | Literal['auto']`.
> - **Docs**:
>   - Update `use_vision` parameter docs (default `"auto"` and behavior) and add `take_screenshot` to available tools.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ee687fd2d9645a370890ebaab516095ee1710e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->