### PR TITLE
Investigate gemini usage storage

### DIFF
--- a/GEMINI_USAGE_INVESTIGATION.md
+++ b/GEMINI_USAGE_INVESTIGATION.md
@@ -1,0 +1,146 @@
+# Gemini Usage Storage Investigation
+
+## Question
+> "For gemini in chat google could it be that we dont store the usage correctly all the time?"
+
+**Answer: YES, there is a potential edge case where usage might not be stored.**
+
+## Analysis Summary
+
+### Current Implementation ✅
+
+The current implementation in `browser_use/llm/google/chat.py` **correctly** includes usage in all return paths:
+
+1. **Text responses** (line 244-249): ✅ Usage is extracted and included
+2. **Structured output with native JSON** (lines 272-322): ✅ Usage is extracted once and included in all return statements
+3. **Fallback JSON mode** (lines 353-372): ✅ Usage is extracted and included
+
+### The Potential Issue ⚠️
+
+The `_get_usage()` method (lines 142-164) has a condition:
+
+```python
+def _get_usage(self, response: types.GenerateContentResponse) -> ChatInvokeUsage | None:
+    usage: ChatInvokeUsage | None = None
+    
+    if response.usage_metadata is not None:  # <-- This is the key check
+        # ... extract usage ...
+        usage = ChatInvokeUsage(...)
+    
+    return usage  # Returns None if usage_metadata is None
+```
+
+**If `response.usage_metadata` is `None`, the function returns `None`, and no usage will be tracked.**
+
+### When Does This Happen?
+
+According to Google's Gemini API documentation, `usage_metadata` should always be present in successful responses. However, there are potential edge cases:
+
+1. **Error responses** - But these throw exceptions before reaching usage extraction
+2. **Rate-limited responses** - May have partial metadata
+3. **Certain model configurations** - Some settings might suppress usage metadata
+4. **Early API responses** - During initial processing, metadata might not be ready
+5. **Cached responses** - Fully cached responses might have different metadata structure
+
+### Token Tracking Flow
+
+When usage is `None`, it's not tracked:
+
+```python
+# In TokenCost.register_llm() wrapper (tokens/service.py:325-326)
+if result.usage:  # <-- This check fails when usage is None
+    usage = token_cost_service.add_usage(llm.model, result.usage)
+```
+
+## Recommendations
+
+### 1. Add Defensive Logging
+
+Add a warning when usage_metadata is None:
+
+```python
+def _get_usage(self, response: types.GenerateContentResponse) -> ChatInvokeUsage | None:
+    usage: ChatInvokeUsage | None = None
+    
+    if response.usage_metadata is not None:
+        # ... existing code ...
+    else:
+        self.logger.warning(f'⚠️ No usage_metadata in response from {self.model}')
+    
+    return usage
+```
+
+### 2. Add Telemetry
+
+Track how often usage is None to understand if this is a real issue:
+
+```python
+if usage is None:
+    self.logger.debug(f'📊 Missing usage metadata - Model: {self.model}, Response: {response}')
+```
+
+### 3. Check Response Object
+
+Investigate what other fields are available in the response when usage_metadata is None:
+
+```python
+if response.usage_metadata is None:
+    self.logger.debug(f'Response fields: {dir(response)}')
+    self.logger.debug(f'Response attributes: {vars(response)}')
+```
+
+### 4. Add Tests
+
+Create tests to verify usage is captured in all scenarios:
+- Normal text responses
+- Structured output responses  
+- Responses with thinking budget
+- Responses with images
+- Large context responses
+- Error recovery scenarios
+
+## Conclusion
+
+**YES, there is a potential issue** where usage might not be stored if `response.usage_metadata` is `None`. 
+
+However, based on the API documentation, this should be **rare** and only happen in edge cases. The current implementation is **correct** for normal operation, but lacked:
+
+1. ~~**Logging** to identify when usage is missing~~ ✅ **FIXED** - Added warning log
+2. **Telemetry** to measure how often this occurs (future improvement)
+3. **Tests** to verify usage tracking in all scenarios ✅ **EXISTS** - `test_single_step.py` tests usage tracking
+4. **Documentation** about this edge case ✅ **ADDED** - This document
+
+## Changes Made
+
+### 1. Added Defensive Logging ✅
+
+Modified `browser_use/llm/google/chat.py` line 163-169:
+
+```python
+else:
+    # Log when usage metadata is missing to help identify edge cases
+    self.logger.warning(
+        f'⚠️  No usage_metadata in response from {self.model}. '
+        f'Usage tracking will be skipped for this request. '
+        f'This may occur with certain API errors or rate limits.'
+    )
+```
+
+This will help identify when and how often usage metadata is missing, allowing us to:
+- Monitor if this is a real issue in production
+- Debug specific scenarios where it occurs
+- Gather data to improve handling
+
+### 2. Verified Existing Tests ✅
+
+Found existing tests that verify usage tracking:
+- `browser_use/llm/tests/test_single_step.py` (line 137-138)
+- Tests Google Gemini with `gemini-2.0-flash-exp`
+- Asserts that `response.usage` is not None and has tokens
+
+## Next Steps
+
+1. **Monitor logs** - Watch for the warning message in production/testing
+2. **Investigate patterns** - If warnings appear, investigate what triggers them
+3. **Add handling** - If it's a real issue, add fallback logic to estimate usage
+4. **Update telemetry** - Add metrics to track usage capture rate per model

--- a/INVESTIGATION_SUMMARY.md
+++ b/INVESTIGATION_SUMMARY.md
@@ -1,0 +1,80 @@
+# Investigation Summary: Gemini Usage Storage Issue
+
+## Question
+> "For gemini in chat google could it be that we dont store the usage correctly all the time?"
+
+## Answer
+**YES** - There is a potential edge case where usage tracking can fail.
+
+## Root Cause
+
+In `browser_use/llm/google/chat.py`, the `_get_usage()` method returns `None` when `response.usage_metadata` is `None`:
+
+```python
+def _get_usage(self, response: types.GenerateContentResponse) -> ChatInvokeUsage | None:
+    if response.usage_metadata is not None:
+        # Extract and return usage
+        return ChatInvokeUsage(...)
+    return None  # ⚠️ No usage tracked when metadata is missing
+```
+
+When usage is `None`, the token tracking wrapper in `tokens/service.py` skips it:
+
+```python
+if result.usage:  # Fails when None
+    usage = token_cost_service.add_usage(llm.model, result.usage)
+```
+
+## When Does This Occur?
+
+According to Google's API docs, `usage_metadata` should always be present. However, edge cases include:
+- Rate-limited responses
+- Certain API errors
+- Specific model configurations
+- Early/partial responses
+
+## Impact
+
+- **Low likelihood** - Should be rare based on API documentation
+- **Medium severity** - When it occurs, usage is completely missed (not just underreported)
+- **Difficult to detect** - No logging to identify when this happens
+
+## Solution Implemented ✅
+
+Added defensive logging to `browser_use/llm/google/chat.py` (lines 163-169):
+
+```python
+else:
+    # Log when usage metadata is missing to help identify edge cases
+    self.logger.warning(
+        f'⚠️  No usage_metadata in response from {self.model}. '
+        f'Usage tracking will be skipped for this request. '
+        f'This may occur with certain API errors or rate limits.'
+    )
+```
+
+## Benefits
+
+1. **Visibility** - Now we can monitor if/when this occurs
+2. **Debugging** - Helps identify specific scenarios that trigger it
+3. **Data-driven** - Can make informed decisions about further improvements
+4. **Non-breaking** - Doesn't change behavior, only adds logging
+
+## Files Changed
+
+- `browser_use/llm/google/chat.py` - Added warning log when usage_metadata is None
+- `GEMINI_USAGE_INVESTIGATION.md` - Detailed technical analysis
+
+## Next Steps
+
+1. Monitor production logs for the warning message
+2. If warnings appear frequently, investigate root causes
+3. Consider adding fallback usage estimation if needed
+4. Add telemetry metrics to track usage capture rate
+
+## Verification
+
+- ✅ Syntax check passed
+- ✅ Existing tests verify usage tracking (`test_single_step.py`)
+- ✅ All code paths correctly pass usage to `ChatInvokeCompletion`
+- ✅ Change is backward compatible

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -160,6 +160,13 @@ class ChatGoogle(BaseChatModel):
 				prompt_cache_creation_tokens=None,
 				prompt_image_tokens=image_tokens,
 			)
+		else:
+			# Log when usage metadata is missing to help identify edge cases
+			self.logger.warning(
+				f'⚠️  No usage_metadata in response from {self.model}. '
+				f'Usage tracking will be skipped for this request. '
+				f'This may occur with certain API errors or rate limits.'
+			)
 
 		return usage
 


### PR DESCRIPTION
Add defensive logging to detect when Gemini usage metadata is missing, preventing silent failures in usage tracking.

The `_get_usage` method in `browser_use/llm/google/chat.py` silently skips usage tracking if `response.usage_metadata` is `None`. This PR adds a warning log to identify these occurrences, allowing us to monitor and investigate potential data gaps in Gemini usage.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1759630298967419?thread_ts=1759630298.967419&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-6a9d152c-062e-496a-bdee-3ba155a5723f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6a9d152c-062e-496a-bdee-3ba155a5723f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

