### PR TITLE
Fix gemini-flash-latest token tracking

### DIFF
--- a/browser_use/tokens/tests/test_gemini_flash_latest_pricing.py
+++ b/browser_use/tokens/tests/test_gemini_flash_latest_pricing.py
@@ -1,0 +1,54 @@
+"""
+Test to verify that gemini-flash-latest and gemini-flash-lite-latest can be looked up correctly.
+
+This test ensures the token cost service correctly handles model names that require
+provider prefixes in the LiteLLM pricing data.
+"""
+
+import pytest
+
+from browser_use.tokens.service import TokenCost
+
+
+@pytest.mark.asyncio
+async def test_gemini_flash_latest_pricing():
+	"""Test that gemini-flash-latest pricing is found"""
+	tc = TokenCost(include_cost=True)
+	await tc.initialize()
+	
+	# Test gemini-flash-latest (requires 'gemini/' prefix in pricing data)
+	pricing = await tc.get_model_pricing('gemini-flash-latest')
+	assert pricing is not None, 'Could not find pricing for gemini-flash-latest'
+	assert pricing.model == 'gemini/gemini-flash-latest', f'Expected model key to be "gemini/gemini-flash-latest", got "{pricing.model}"'
+	assert pricing.input_cost_per_token is not None, 'Input cost should not be None'
+	assert pricing.output_cost_per_token is not None, 'Output cost should not be None'
+	assert pricing.input_cost_per_token > 0, 'Input cost should be positive'
+	assert pricing.output_cost_per_token > 0, 'Output cost should be positive'
+
+
+@pytest.mark.asyncio
+async def test_gemini_flash_lite_latest_pricing():
+	"""Test that gemini-flash-lite-latest pricing is found"""
+	tc = TokenCost(include_cost=True)
+	await tc.initialize()
+	
+	# Test gemini-flash-lite-latest (requires 'gemini/' prefix in pricing data)
+	pricing = await tc.get_model_pricing('gemini-flash-lite-latest')
+	assert pricing is not None, 'Could not find pricing for gemini-flash-lite-latest'
+	assert pricing.model == 'gemini/gemini-flash-lite-latest', f'Expected model key to be "gemini/gemini-flash-lite-latest", got "{pricing.model}"'
+	assert pricing.input_cost_per_token is not None, 'Input cost should not be None'
+	assert pricing.output_cost_per_token is not None, 'Output cost should not be None'
+
+
+@pytest.mark.asyncio
+async def test_regular_gemini_model_pricing():
+	"""Test that regular gemini models (without requiring prefix) still work"""
+	tc = TokenCost(include_cost=True)
+	await tc.initialize()
+	
+	# Test gemini-2.0-flash (should work without prefix requirement)
+	pricing = await tc.get_model_pricing('gemini-2.0-flash')
+	assert pricing is not None, 'Could not find pricing for gemini-2.0-flash'
+	assert pricing.model == 'gemini-2.0-flash', f'Expected model key to be "gemini-2.0-flash", got "{pricing.model}"'
+	assert pricing.input_cost_per_token is not None, 'Input cost should not be None'
+	assert pricing.output_cost_per_token is not None, 'Output cost should not be None'


### PR DESCRIPTION
Add fallback logic to `get_model_pricing` to correctly track token usage for Gemini models like `gemini-flash-latest` that use a `gemini/` prefix in pricing data.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1759648839367329?thread_ts=1759648839.367329&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-8bf25362-b43f-4c27-bfa0-b8e347075a73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8bf25362-b43f-4c27-bfa0-b8e347075a73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix token tracking for Gemini models by resolving pricing keys that use the "gemini/" prefix. Models like gemini-flash-latest now report accurate input/output costs.

- **Bug Fixes**
  - Added fallback in get_model_pricing to try "gemini/{model_name}" for Gemini models when exact match is missing.
  - Return pricing using the resolved key (prefixed or exact) to align with LiteLLM data.
  - Added tests for gemini-flash-latest, gemini-flash-lite-latest, and confirmed regular models still work.

<!-- End of auto-generated description by cubic. -->

