### PR TITLE
Add moon shot provider

### DIFF
--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -9,81 +9,83 @@ from typing import TYPE_CHECKING
 # Lightweight imports that are commonly used
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.messages import (
-	AssistantMessage,
-	BaseMessage,
-	SystemMessage,
-	UserMessage,
+    AssistantMessage,
+    BaseMessage,
+    SystemMessage,
+    UserMessage,
 )
 from browser_use.llm.messages import (
-	ContentPartImageParam as ContentImage,
+    ContentPartImageParam as ContentImage,
 )
 from browser_use.llm.messages import (
-	ContentPartRefusalParam as ContentRefusal,
+    ContentPartRefusalParam as ContentRefusal,
 )
 from browser_use.llm.messages import (
-	ContentPartTextParam as ContentText,
+    ContentPartTextParam as ContentText,
 )
 
 # Type stubs for lazy imports
 if TYPE_CHECKING:
-	from browser_use.llm.anthropic.chat import ChatAnthropic
-	from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
-	from browser_use.llm.aws.chat_bedrock import ChatAWSBedrock
-	from browser_use.llm.azure.chat import ChatAzureOpenAI
-	from browser_use.llm.deepseek.chat import ChatDeepSeek
-	from browser_use.llm.google.chat import ChatGoogle
-	from browser_use.llm.groq.chat import ChatGroq
-	from browser_use.llm.ollama.chat import ChatOllama
-	from browser_use.llm.openai.chat import ChatOpenAI
-	from browser_use.llm.openrouter.chat import ChatOpenRouter
+    from browser_use.llm.anthropic.chat import ChatAnthropic
+    from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
+    from browser_use.llm.aws.chat_bedrock import ChatAWSBedrock
+    from browser_use.llm.azure.chat import ChatAzureOpenAI
+    from browser_use.llm.deepseek.chat import ChatDeepSeek
+    from browser_use.llm.google.chat import ChatGoogle
+    from browser_use.llm.groq.chat import ChatGroq
+    from browser_use.llm.moonshot.chat import ChatMoonshot
+    from browser_use.llm.ollama.chat import ChatOllama
+    from browser_use.llm.openai.chat import ChatOpenAI
+    from browser_use.llm.openrouter.chat import ChatOpenRouter
 
-	# Type stubs for model instances - enables IDE autocomplete
-	openai_gpt_4o: ChatOpenAI
-	openai_gpt_4o_mini: ChatOpenAI
-	openai_gpt_4_1_mini: ChatOpenAI
-	openai_o1: ChatOpenAI
-	openai_o1_mini: ChatOpenAI
-	openai_o1_pro: ChatOpenAI
-	openai_o3: ChatOpenAI
-	openai_o3_mini: ChatOpenAI
-	openai_o3_pro: ChatOpenAI
-	openai_o4_mini: ChatOpenAI
-	openai_gpt_5: ChatOpenAI
-	openai_gpt_5_mini: ChatOpenAI
-	openai_gpt_5_nano: ChatOpenAI
+    # Type stubs for model instances - enables IDE autocomplete
+    openai_gpt_4o: ChatOpenAI
+    openai_gpt_4o_mini: ChatOpenAI
+    openai_gpt_4_1_mini: ChatOpenAI
+    openai_o1: ChatOpenAI
+    openai_o1_mini: ChatOpenAI
+    openai_o1_pro: ChatOpenAI
+    openai_o3: ChatOpenAI
+    openai_o3_mini: ChatOpenAI
+    openai_o3_pro: ChatOpenAI
+    openai_o4_mini: ChatOpenAI
+    openai_gpt_5: ChatOpenAI
+    openai_gpt_5_mini: ChatOpenAI
+    openai_gpt_5_nano: ChatOpenAI
 
-	azure_gpt_4o: ChatAzureOpenAI
-	azure_gpt_4o_mini: ChatAzureOpenAI
-	azure_gpt_4_1_mini: ChatAzureOpenAI
-	azure_o1: ChatAzureOpenAI
-	azure_o1_mini: ChatAzureOpenAI
-	azure_o1_pro: ChatAzureOpenAI
-	azure_o3: ChatAzureOpenAI
-	azure_o3_mini: ChatAzureOpenAI
-	azure_o3_pro: ChatAzureOpenAI
-	azure_gpt_5: ChatAzureOpenAI
-	azure_gpt_5_mini: ChatAzureOpenAI
+    azure_gpt_4o: ChatAzureOpenAI
+    azure_gpt_4o_mini: ChatAzureOpenAI
+    azure_gpt_4_1_mini: ChatAzureOpenAI
+    azure_o1: ChatAzureOpenAI
+    azure_o1_mini: ChatAzureOpenAI
+    azure_o1_pro: ChatAzureOpenAI
+    azure_o3: ChatAzureOpenAI
+    azure_o3_mini: ChatAzureOpenAI
+    azure_o3_pro: ChatAzureOpenAI
+    azure_gpt_5: ChatAzureOpenAI
+    azure_gpt_5_mini: ChatAzureOpenAI
 
-	google_gemini_2_0_flash: ChatGoogle
-	google_gemini_2_0_pro: ChatGoogle
-	google_gemini_2_5_pro: ChatGoogle
-	google_gemini_2_5_flash: ChatGoogle
-	google_gemini_2_5_flash_lite: ChatGoogle
+    google_gemini_2_0_flash: ChatGoogle
+    google_gemini_2_0_pro: ChatGoogle
+    google_gemini_2_5_pro: ChatGoogle
+    google_gemini_2_5_flash: ChatGoogle
+    google_gemini_2_5_flash_lite: ChatGoogle
 
 # Models are imported on-demand via __getattr__
 
 # Lazy imports mapping for heavy chat models
 _LAZY_IMPORTS = {
-	'ChatAnthropic': ('browser_use.llm.anthropic.chat', 'ChatAnthropic'),
-	'ChatAnthropicBedrock': ('browser_use.llm.aws.chat_anthropic', 'ChatAnthropicBedrock'),
-	'ChatAWSBedrock': ('browser_use.llm.aws.chat_bedrock', 'ChatAWSBedrock'),
-	'ChatAzureOpenAI': ('browser_use.llm.azure.chat', 'ChatAzureOpenAI'),
-	'ChatDeepSeek': ('browser_use.llm.deepseek.chat', 'ChatDeepSeek'),
-	'ChatGoogle': ('browser_use.llm.google.chat', 'ChatGoogle'),
-	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
-	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
-	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
-	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
+    'ChatAnthropic': ('browser_use.llm.anthropic.chat', 'ChatAnthropic'),
+    'ChatAnthropicBedrock': ('browser_use.llm.aws.chat_anthropic', 'ChatAnthropicBedrock'),
+    'ChatAWSBedrock': ('browser_use.llm.aws.chat_bedrock', 'ChatAWSBedrock'),
+    'ChatAzureOpenAI': ('browser_use.llm.azure.chat', 'ChatAzureOpenAI'),
+    'ChatDeepSeek': ('browser_use.llm.deepseek.chat', 'ChatDeepSeek'),
+    'ChatGoogle': ('browser_use.llm.google.chat', 'ChatGoogle'),
+    'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
+    'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
+    'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
+    'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
+    'ChatMoonshot': ('browser_use.llm.moonshot.chat', 'ChatMoonshot'),
 }
 
 # Cache for model instances - only created when accessed
@@ -91,56 +93,58 @@ _model_cache: dict[str, 'BaseChatModel'] = {}
 
 
 def __getattr__(name: str):
-	"""Lazy import mechanism for heavy chat model imports and model instances."""
-	if name in _LAZY_IMPORTS:
-		module_path, attr_name = _LAZY_IMPORTS[name]
-		try:
-			from importlib import import_module
+    """Lazy import mechanism for heavy chat model imports and model instances."""
+    if name in _LAZY_IMPORTS:
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        try:
+            from importlib import import_module
 
-			module = import_module(module_path)
-			attr = getattr(module, attr_name)
-			return attr
-		except ImportError as e:
-			raise ImportError(f'Failed to import {name} from {module_path}: {e}') from e
+            module = import_module(module_path)
+            attr = getattr(module, attr_name)
+            return attr
+        except ImportError as e:
+            raise ImportError(
+                f'Failed to import {name} from {module_path}: {e}') from e
 
-	# Check cache first for model instances
-	if name in _model_cache:
-		return _model_cache[name]
+    # Check cache first for model instances
+    if name in _model_cache:
+        return _model_cache[name]
 
-	# Try to get model instances from models module on-demand
-	try:
-		from browser_use.llm.models import __getattr__ as models_getattr
+    # Try to get model instances from models module on-demand
+    try:
+        from browser_use.llm.models import __getattr__ as models_getattr
 
-		attr = models_getattr(name)
-		# Cache in our clean cache dict
-		_model_cache[name] = attr
-		return attr
-	except (AttributeError, ImportError):
-		pass
+        attr = models_getattr(name)
+        # Cache in our clean cache dict
+        _model_cache[name] = attr
+        return attr
+    except (AttributeError, ImportError):
+        pass
 
-	raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
 __all__ = [
-	# Message types -> for easier transition from langchain
-	'BaseMessage',
-	'UserMessage',
-	'SystemMessage',
-	'AssistantMessage',
-	# Content parts with better names
-	'ContentText',
-	'ContentRefusal',
-	'ContentImage',
-	# Chat models
-	'BaseChatModel',
-	'ChatOpenAI',
-	'ChatDeepSeek',
-	'ChatGoogle',
-	'ChatAnthropic',
-	'ChatAnthropicBedrock',
-	'ChatAWSBedrock',
-	'ChatGroq',
-	'ChatAzureOpenAI',
-	'ChatOllama',
-	'ChatOpenRouter',
+    # Message types -> for easier transition from langchain
+    'BaseMessage',
+    'UserMessage',
+    'SystemMessage',
+    'AssistantMessage',
+    # Content parts with better names
+    'ContentText',
+    'ContentRefusal',
+    'ContentImage',
+    # Chat models
+    'BaseChatModel',
+    'ChatOpenAI',
+    'ChatDeepSeek',
+    'ChatMoonshot',
+    'ChatGoogle',
+    'ChatAnthropic',
+    'ChatAnthropicBedrock',
+    'ChatAWSBedrock',
+    'ChatGroq',
+    'ChatAzureOpenAI',
+    'ChatOllama',
+    'ChatOpenRouter',
 ]

--- a/browser_use/llm/moonshot/chat.py
+++ b/browser_use/llm/moonshot/chat.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, TypeVar, overload
+
+import httpx
+from openai import (
+    APIConnectionError,
+    APIError,
+    APIStatusError,
+    APITimeoutError,
+    AsyncOpenAI,
+    RateLimitError,
+)
+from pydantic import BaseModel
+
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.moonshot.serializer import MoonshotMessageSerializer
+from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.views import ChatInvokeCompletion
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+@dataclass
+class ChatMoonshot(BaseChatModel):
+    """Moonshot AI (Kimi) /chat/completions wrapper (OpenAI-compatible)."""
+
+    model: str = 'moonshot-v1-8k'
+
+    # Generation parameters
+    max_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    seed: int | None = None
+
+    # Connection parameters
+    api_key: str | None = None
+    base_url: str | httpx.URL | None = 'https://api.moonshot.cn/v1'
+    timeout: float | httpx.Timeout | None = None
+    client_params: dict[str, Any] | None = None
+
+    @property
+    def provider(self) -> str:
+        return 'moonshot'
+
+    def _client(self) -> AsyncOpenAI:
+        return AsyncOpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url,
+            timeout=self.timeout,
+            **(self.client_params or {}),
+        )
+
+    @property
+    def name(self) -> str:
+        return self.model
+
+    @overload
+    async def ainvoke(
+        self,
+        messages: list[BaseMessage],
+        output_format: None = None,
+        tools: list[dict[str, Any]] | None = None,
+        stop: list[str] | None = None,
+    ) -> ChatInvokeCompletion[str]: ...
+
+    @overload
+    async def ainvoke(
+        self,
+        messages: list[BaseMessage],
+        output_format: type[T],
+        tools: list[dict[str, Any]] | None = None,
+        stop: list[str] | None = None,
+    ) -> ChatInvokeCompletion[T]: ...
+
+    async def ainvoke(
+            self,
+            messages: list[BaseMessage],
+            output_format: type[T] | None = None,
+            tools: list[dict[str, Any]] | None = None,
+            stop: list[str] | None = None,
+    ) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+        """
+        Moonshot AI (Kimi) ainvoke supports:
+        1. Regular text/multi-turn conversation
+        2. Function Calling
+        3. JSON Output (response_format)
+        """
+        client = self._client()
+        ms_messages = MoonshotMessageSerializer.serialize_messages(messages)
+        common: dict[str, Any] = {}
+
+        if self.temperature is not None:
+            common['temperature'] = self.temperature
+        if self.max_tokens is not None:
+            common['max_tokens'] = self.max_tokens
+        if self.top_p is not None:
+            common['top_p'] = self.top_p
+        if self.seed is not None:
+            common['seed'] = self.seed
+
+        # ① Regular multi-turn conversation/text output
+        if output_format is None and not tools:
+            try:
+                resp = await client.chat.completions.create(  # type: ignore
+                    model=self.model,
+                    messages=ms_messages,  # type: ignore
+                    **common,
+                )
+                return ChatInvokeCompletion(
+                    completion=resp.choices[0].message.content or '',
+                    usage=None,
+                )
+            except RateLimitError as e:
+                raise ModelRateLimitError(str(e), model=self.name) from e
+            except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
+                raise ModelProviderError(str(e), model=self.name) from e
+            except Exception as e:
+                raise ModelProviderError(str(e), model=self.name) from e
+
+        # ② Function Calling path (with tools or output_format)
+        if tools or (output_format is not None and hasattr(output_format, 'model_json_schema')):
+            try:
+                call_tools = tools
+                tool_choice = None
+                if output_format is not None and hasattr(output_format, 'model_json_schema'):
+                    tool_name = output_format.__name__
+                    schema = SchemaOptimizer.create_optimized_json_schema(
+                        output_format)
+                    schema.pop('title', None)
+                    call_tools = [
+                        {
+                            'type': 'function',
+                            'function': {
+                                'name': tool_name,
+                                'description': f'Return a JSON object of type {tool_name}',
+                                'parameters': schema,
+                            },
+                        }
+                    ]
+                    tool_choice = {'type': 'function',
+                                   'function': {'name': tool_name}}
+
+                # Log request details
+                logger.info("[Moonshot] Making request with:")
+                logger.info(f"  - model: {self.model}")
+                logger.info(
+                    f"  - output_format: {output_format.__name__ if output_format else None}")
+                logger.info(f"  - tools provided: {bool(tools)}")
+                logger.info(
+                    f"  - call_tools count: {len(call_tools) if call_tools else 0}")
+                logger.info(f"  - tool_choice: {tool_choice}")
+                logger.info(f"  - messages count: {len(ms_messages)}")
+                if call_tools:
+                    logger.info(
+                        f"  - tool schemas: {json.dumps(call_tools, indent=2)}")
+
+                resp = await client.chat.completions.create(  # type: ignore
+                    model=self.model,
+                    messages=ms_messages,  # type: ignore
+                    tools=call_tools,  # type: ignore
+                    tool_choice=tool_choice,  # type: ignore
+                    **common,
+                )
+                msg = resp.choices[0].message
+
+                # Log response details
+                logger.info("[Moonshot] Response received:")
+                logger.info(f"  - has tool_calls: {bool(msg.tool_calls)}")
+                logger.info(
+                    f"  - tool_calls count: {len(msg.tool_calls) if msg.tool_calls else 0}")
+                logger.info(
+                    f"  - content: {msg.content[:200] if msg.content else None}")
+                logger.info(
+                    f"  - finish_reason: {resp.choices[0].finish_reason}")
+
+                if msg.tool_calls:
+                    for i, tc in enumerate(msg.tool_calls):
+                        logger.info(
+                            f"  - tool_call[{i}].name: {tc.function.name}")
+                        logger.info(
+                            f"  - tool_call[{i}].arguments: {tc.function.arguments[:200] if isinstance(tc.function.arguments, str) else str(tc.function.arguments)[:200]}")
+
+                # If no tool calls, handle based on whether output_format is required
+                if not msg.tool_calls:
+                    # If output_format is specified, try to parse JSON from content as fallback
+                    if output_format is not None:
+                        logger.warning(
+                            f"[Moonshot] No tool_calls returned, attempting to parse JSON from content...")  # noqa: F541
+                        logger.info(
+                            f"[Moonshot] Response content: {msg.content}")
+
+                        # Moonshot may return JSON directly in content instead of tool_calls
+                        if msg.content:
+                            try:
+                                # Try to parse the content as JSON
+                                parsed = json.loads(msg.content)
+                                logger.info(
+                                    "[Moonshot] Successfully parsed JSON from content!")
+                                return ChatInvokeCompletion(
+                                    completion=output_format.model_validate(
+                                        parsed),
+                                    usage=None,
+                                )
+                            except (json.JSONDecodeError, Exception) as parse_error:
+                                logger.error(
+                                    f"[Moonshot] Failed to parse JSON from content: {parse_error}")
+                                logger.error(
+                                    f"[Moonshot] Content was: {msg.content[:500]}")
+
+                        logger.error(
+                            f"[Moonshot] ERROR: output_format={output_format.__name__} was specified but no tool_calls in response and content is not valid JSON!")
+                        logger.error(
+                            f"[Moonshot] Finish reason: {resp.choices[0].finish_reason}")
+                        raise ValueError(
+                            'Expected tool_calls in response but got none and content is not parseable JSON')
+                    # Otherwise, return the text content (model chose not to call tools)
+                    return ChatInvokeCompletion(
+                        completion=msg.content or '',
+                        usage=None,
+                    )
+
+                raw_args = msg.tool_calls[0].function.arguments
+                if isinstance(raw_args, str):
+                    parsed = json.loads(raw_args)
+                else:
+                    parsed = raw_args
+                # --------- Fix: only use model_validate when output_format is not None ----------
+                if output_format is not None:
+                    return ChatInvokeCompletion(
+                        completion=output_format.model_validate(parsed),
+                        usage=None,
+                    )
+                else:
+                    # If no output_format, return dict directly
+                    return ChatInvokeCompletion(
+                        completion=parsed,
+                        usage=None,
+                    )
+            except RateLimitError as e:
+                raise ModelRateLimitError(str(e), model=self.name) from e
+            except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
+                raise ModelProviderError(str(e), model=self.name) from e
+            except Exception as e:
+                raise ModelProviderError(str(e), model=self.name) from e
+
+        # ③ JSON Output path (official response_format)
+        if output_format is not None and hasattr(output_format, 'model_json_schema'):
+            try:
+                resp = await client.chat.completions.create(  # type: ignore
+                    model=self.model,
+                    messages=ms_messages,  # type: ignore
+                    response_format={'type': 'json_object'},
+                    **common,
+                )
+                content = resp.choices[0].message.content
+                if not content:
+                    raise ModelProviderError(
+                        'Empty JSON content in Moonshot response', model=self.name)
+                parsed = output_format.model_validate_json(content)
+                return ChatInvokeCompletion(
+                    completion=parsed,
+                    usage=None,
+                )
+            except RateLimitError as e:
+                raise ModelRateLimitError(str(e), model=self.name) from e
+            except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
+                raise ModelProviderError(str(e), model=self.name) from e
+            except Exception as e:
+                raise ModelProviderError(str(e), model=self.name) from e
+
+        raise ModelProviderError(
+            'No valid ainvoke execution path for Moonshot LLM', model=self.name)

--- a/browser_use/llm/moonshot/chat.py
+++ b/browser_use/llm/moonshot/chat.py
@@ -32,7 +32,7 @@ T = TypeVar('T', bound=BaseModel)
 class ChatMoonshot(BaseChatModel):
     """Moonshot AI (Kimi) /chat/completions wrapper (OpenAI-compatible)."""
 
-    model: str = 'moonshot-v1-8k'
+    model: str = 'kimi-k2-0905-preview'
 
     # Generation parameters
     max_tokens: int | None = None

--- a/browser_use/llm/moonshot/serializer.py
+++ b/browser_use/llm/moonshot/serializer.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import json
+from typing import Any, overload
+
+from browser_use.llm.messages import (
+    AssistantMessage,
+    BaseMessage,
+    ContentPartImageParam,
+    ContentPartTextParam,
+    SystemMessage,
+    ToolCall,
+    UserMessage,
+)
+
+MessageDict = dict[str, Any]
+
+
+class MoonshotMessageSerializer:
+    """Serializer for converting browser-use messages to Moonshot messages."""
+
+    @staticmethod
+    def _serialize_text_part(part: ContentPartTextParam) -> str:
+        return part.text
+
+    @staticmethod
+    def _serialize_image_part(part: ContentPartImageParam) -> dict[str, Any]:
+        url = part.image_url.url
+        if url.startswith('data:'):
+            return {'type': 'image_url', 'image_url': {'url': url}}
+        return {'type': 'image_url', 'image_url': {'url': url}}
+
+    @staticmethod
+    def _serialize_content(content: Any) -> str | list[dict[str, Any]]:
+        if content is None:
+            return ''
+        if isinstance(content, str):
+            return content
+        serialized: list[dict[str, Any]] = []
+        for part in content:
+            if part.type == 'text':
+                serialized.append(
+                    {'type': 'text', 'text': MoonshotMessageSerializer._serialize_text_part(part)})
+            elif part.type == 'image_url':
+                serialized.append(
+                    MoonshotMessageSerializer._serialize_image_part(part))
+            elif part.type == 'refusal':
+                serialized.append(
+                    {'type': 'text', 'text': f'[Refusal] {part.refusal}'})
+        return serialized
+
+    @staticmethod
+    def _serialize_tool_calls(tool_calls: list[ToolCall]) -> list[dict[str, Any]]:
+        moonshot_tool_calls: list[dict[str, Any]] = []
+        for tc in tool_calls:
+            try:
+                arguments = json.loads(tc.function.arguments)
+            except json.JSONDecodeError:
+                arguments = {'arguments': tc.function.arguments}
+            moonshot_tool_calls.append(
+                {
+                    'id': tc.id,
+                    'type': 'function',
+                            'function': {
+                                'name': tc.function.name,
+                                'arguments': arguments,
+                            },
+                }
+            )
+        return moonshot_tool_calls
+
+    @overload
+    @staticmethod
+    def serialize(message: UserMessage) -> MessageDict: ...
+
+    @overload
+    @staticmethod
+    def serialize(message: SystemMessage) -> MessageDict: ...
+
+    @overload
+    @staticmethod
+    def serialize(message: AssistantMessage) -> MessageDict: ...
+
+    @staticmethod
+    def serialize(message: BaseMessage) -> MessageDict:
+        if isinstance(message, UserMessage):
+            return {
+                'role': 'user',
+                'content': MoonshotMessageSerializer._serialize_content(message.content),
+            }
+        if isinstance(message, SystemMessage):
+            return {
+                'role': 'system',
+                'content': MoonshotMessageSerializer._serialize_content(message.content),
+            }
+        if isinstance(message, AssistantMessage):
+            msg: MessageDict = {
+                'role': 'assistant',
+                'content': MoonshotMessageSerializer._serialize_content(message.content),
+            }
+            if message.tool_calls:
+                msg['tool_calls'] = MoonshotMessageSerializer._serialize_tool_calls(
+                    message.tool_calls)
+            return msg
+        raise ValueError(f'Unknown message type: {type(message)}')
+
+    @staticmethod
+    def serialize_messages(messages: list[BaseMessage]) -> list[MessageDict]:
+        return [MoonshotMessageSerializer.serialize(m) for m in messages]

--- a/examples/models/moonshot-chat.py
+++ b/examples/models/moonshot-chat.py
@@ -1,0 +1,36 @@
+import asyncio
+import os
+
+from browser_use import Agent
+from browser_use.llm import ChatMoonshot
+
+# Add your custom instructions
+extend_system_message = """
+Remember the most important rules: 
+1. When performing a search task, open https://www.google.com/ first for search. 
+2. Final output.
+"""
+moonshot_api_key = os.getenv('MOONSHOT_API_KEY')
+if moonshot_api_key is None:
+    print('Make sure you have MOONSHOT_API_KEY:')
+    print('export MOONSHOT_API_KEY=your_key')
+    exit(0)
+
+
+async def main():
+    llm = ChatMoonshot(
+        base_url='https://api.moonshot.cn/v1',
+        model='kimi-k2-0905-preview',
+        api_key=moonshot_api_key,
+    )
+
+    agent = Agent(
+        task='What should we pay attention to in the recent new rules on tariffs in China-US trade?',
+        llm=llm,
+        use_vision=False,
+        extend_system_message=extend_system_message,
+    )
+    await agent.run()
+
+
+asyncio.run(main())


### PR DESCRIPTION
##  Summary
This PR adds support for Moonshot AI's Kimi models to browser-use. Expands LLM provider options for users in regions where Moonshot/Kimi is preferred

### New Files
- **`browser_use/llm/moonshot/chat.py`** - Main ChatMoonshot implementation with OpenAI-compatible API wrapper
- **`browser_use/llm/moonshot/serializer.py`** - Message serialization for converting browser-use messages to Moonshot format
- **`examples/models/moonshot-chat.py`** - Example demonstrating Moonshot integration

### Modified Files
- **`browser_use/llm/__init__.py`** - Added ChatMoonshot to lazy imports and exports