### PR TITLE
Implement agent fallback llm option

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -48,6 +48,7 @@ class AgentSettings(BaseModel):
 	max_history_items: int | None = None
 
 	page_extraction_llm: BaseChatModel | None = None
+	fallback_llm: list[BaseChatModel] | None = None  # List of fallback LLMs to use if main LLM fails
 	calculate_cost: bool = False
 	include_tool_call_examples: bool = False
 	llm_timeout: int = 60  # Timeout in seconds for LLM calls (auto-detected: 30s for gemini, 90s for o3, 60s default)

--- a/docs/customize/agent/all-parameters.mdx
+++ b/docs/customize/agent/all-parameters.mdx
@@ -16,6 +16,7 @@ mode: "wide"
 - `use_vision` (default: `"auto"`): Vision mode - `"auto"` includes screenshot tool but only uses vision when requested, `True` always includes screenshots, `False` never includes screenshots and excludes screenshot tool
 - `vision_detail_level` (default: `'auto'`): Screenshot detail level - `'low'`, `'high'`, or `'auto'`
 - `page_extraction_llm`: Separate LLM model for page content extraction. You can choose a small & fast model because it only needs to extract text from the page (default: same as `llm`)
+- `fallback_llm`: List of fallback LLM models to use if the main LLM fails. When an LLM error occurs, the agent will try the next fallback in the list, still counting it as an error. If the fallback fails, it switches back to the main LLM and rotates to the next fallback for future failures
 
 ### Actions & Behavior
 - `initial_actions`: List of actions to run before the main task without LLM. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/initial_actions.py)


### PR DESCRIPTION
Add `fallback_llm` to the Agent to provide resilience against LLM errors during `get_model_output` calls.

When the primary LLM fails, the agent will attempt to use a fallback LLM from the provided list. This process rotates through the fallback LLMs on each failure, and if a fallback also fails, the agent reverts to the primary LLM for the next attempt. Failures, whether from the primary or fallback LLMs, are still counted towards the agent's `max_failures` limit.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1759796741127949?thread_ts=1759796741.127949&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-17e85cab-ba4d-44eb-890c-0d232ab64740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17e85cab-ba4d-44eb-890c-0d232ab64740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a fallback_llm option to keep the agent running when the primary LLM errors. On failure, the agent tries the next fallback, then reverts to the main model; failures still count toward max_failures.

- New Features
  - Added fallback_llm: list[BaseChatModel] to AgentSettings and wired it into service.
  - Implemented rotation through fallbacks in get_model_output with automatic switch-back to the main LLM.
  - Registered fallback models with TokenCost for accurate cost tracking and updated docs to explain usage.

<!-- End of auto-generated description by cubic. -->

