### PR TITLE
remove prompt_description

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -73,14 +73,10 @@ class ChatBrowserUse(BaseChatModel):
 		return f'browser-use/{self.model}'
 
 	@overload
-	async def ainvoke(
-		self, messages: list[BaseMessage], output_format: None = None
-	) -> ChatInvokeCompletion[str]: ...
+	async def ainvoke(self, messages: list[BaseMessage], output_format: None = None) -> ChatInvokeCompletion[str]: ...
 
 	@overload
-	async def ainvoke(
-		self, messages: list[BaseMessage], output_format: type[T]
-	) -> ChatInvokeCompletion[T]: ...
+	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T]) -> ChatInvokeCompletion[T]: ...
 
 	@observe(name='chat_browser_use_ainvoke')
 	async def ainvoke(


### PR DESCRIPTION
Auto-generated PR for: remove prompt_description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes prompt_description from ChatBrowserUse.ainvoke, deleting related payload handling and debug logging.
> 
> - **LLM Client (`browser_use/llm/browser_use/chat.py`)**:
>   - **API change**: Remove `prompt_description` parameter from `ChatBrowserUse.ainvoke` (all overloads and implementation).
>   - **Payload**: Drop adding `prompt_description` to request body.
>   - **Logging**: Remove debug logs related to `prompt_description`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c836fd8b58edc2c578a4d7b6f320eddc8668b15e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->