### PR TITLE
feat: Add close_after_run parameter to agent.run()

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1434,11 +1434,13 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 	@observe(name='agent.run', metadata={'task': '{{task}}', 'debug': '{{debug}}'})
 	@time_execution_async('--run')
 	async def run(
-		self,
-		max_steps: int = 100,
-		on_step_start: AgentHookFunc | None = None,
-		on_step_end: AgentHookFunc | None = None,
-	) -> AgentHistoryList[AgentStructuredOutput]:
+    self,
+    max_steps: int = 100,
+    on_step_start: AgentHookFunc | None = None,
+    on_step_end: AgentHookFunc | None = None,
+    *,
+    close_after_run: bool = True,
+) -> AgentHistoryList[AgentStructuredOutput]:
 		"""Execute the task with maximum number of steps"""
 
 		loop = asyncio.get_event_loop()
@@ -1661,7 +1663,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			# Use longer timeout to avoid deadlocks in tests with multiple agents
 			await self.eventbus.stop(timeout=3.0)
 
-			await self.close()
+			if close_after_run:
+				await self.close()
 
 	@observe_debug(ignore_input=True, ignore_output=True)
 	@time_execution_async('--multi_act')

--- a/tests/ci/test_config.py
+++ b/tests/ci/test_config.py
@@ -84,7 +84,7 @@ class TestLazyConfig:
 
 			# Test default path expansion
 			os.environ.pop('XDG_CACHE_HOME', None)
-			assert '/.cache' in str(CONFIG.XDG_CACHE_HOME)
+			assert f'{os.sep}.cache' in str(CONFIG.XDG_CACHE_HOME)
 		finally:
 			if original_value:
 				os.environ['XDG_CACHE_HOME'] = original_value


### PR DESCRIPTION
I'm happy to post this pull request, which improves the project's developer experience on two fronts. First, while testing on Windows, I identified and resolved two platform-specific bugs in the CI suite, which will now allow for smoother contributions from other Windows developers. Second, I implemented the originally requested feature for issue #3213—a backwards-compatible "close_after_run" parameter—to provide more granular control over the agent's browser session. All tests are now passing, and I'm ready for your review.  
<img width="1919" height="1018" alt="Screenshot 2025-10-14 101857" src="https://github.com/user-attachments/assets/a8333e02-bdc4-4084-9576-50fb29f7a42d" />
<img width="1909" height="1020" alt="Screenshot 2025-10-14 101934" src="https://github.com/user-attachments/assets/bf311969-5659-4080-83fc-d0e6fb0f2cd1" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a close_after_run option to agent.run() to control whether the agent closes its browser session after a run. Also fixes a Windows-specific path test to stabilize CI. Addresses #3213.

- **New Features**
  - agent.run(): added keyword-only close_after_run (default True) to keep the session open when needed.

- **Bug Fixes**
  - Made cache path assertion OS-agnostic using os.sep to pass on Windows.

<!-- End of auto-generated description by cubic. -->

