### PR TITLE
Add chatbrowseruse to browser use library

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
 	from browser_use.llm import models
 	from browser_use.llm.anthropic.chat import ChatAnthropic
 	from browser_use.llm.azure.chat import ChatAzureOpenAI
+	from browser_use.llm.browser_use.chat import ChatBrowserUse
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
 	from browser_use.llm.oci_raw.chat import ChatOCIRaw
@@ -88,6 +89,7 @@ _LAZY_IMPORTS = {
 	'ChatAzureOpenAI': ('browser_use.llm.azure.chat', 'ChatAzureOpenAI'),
 	'ChatOCIRaw': ('browser_use.llm.oci_raw.chat', 'ChatOCIRaw'),
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
+	'ChatBrowserUse': ('browser_use.llm.browser_use.chat', 'ChatBrowserUse'),
 	# LLM models module
 	'models': ('browser_use.llm.models', None),
 }
@@ -134,6 +136,7 @@ __all__ = [
 	'ChatAzureOpenAI',
 	'ChatOCIRaw',
 	'ChatOllama',
+	'ChatBrowserUse',
 	'Tools',
 	'Controller',
 	# LLM models module


### PR DESCRIPTION
Add `ChatBrowserUse` to the main `browser_use` library exports to enable direct top-level import.

---
[Slack Thread](https://browser-use.slack.com/archives/C08SZRT860M/p1760149235469519?thread_ts=1760149235.469519&cid=C08SZRT860M)

<a href="https://cursor.com/background-agent?bcId=bc-95a73b9d-a56d-413a-81f3-0ac8e1b3aeb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-95a73b9d-a56d-413a-81f3-0ac8e1b3aeb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added ChatBrowserUse to the top-level browser_use exports, enabling direct import: from browser_use import ChatBrowserUse. This aligns it with other chat clients and removes the need for deep module imports.

<!-- End of auto-generated description by cubic. -->

