### PR TITLE
model-eval-google

### DIFF
--- a/tests/ci/evaluate_tasks.py
+++ b/tests/ci/evaluate_tasks.py
@@ -17,7 +17,7 @@ import anyio
 import yaml
 from pydantic import BaseModel
 
-from browser_use import Agent, AgentHistoryList, BrowserProfile, BrowserSession, ChatOpenAI
+from browser_use import Agent, AgentHistoryList, BrowserProfile, BrowserSession, ChatGoogle
 from browser_use.llm.messages import UserMessage
 
 # --- CONFIG ---
@@ -56,8 +56,8 @@ async def run_single_task(task_file):
 		print(f'[DEBUG] Task: {task[:100]}...', file=sys.stderr)
 		print(f'[DEBUG] Max steps: {max_steps}', file=sys.stderr)
 
-		agent_llm = ChatOpenAI(model='gpt-4.1-mini')
-		judge_llm = ChatOpenAI(model='gpt-4.1-mini')
+		agent_llm = ChatGoogle(model='gemini-flash-latest')
+		judge_llm = ChatGoogle(model='gemini-flash-latest')
 		print('[DEBUG] LLMs initialized', file=sys.stderr)
 
 		# Each subprocess gets its own profile and session


### PR DESCRIPTION
Auto-generated PR for branch: model-eval-google

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches CI evaluation script to use ChatGoogle with gemini-flash-latest instead of ChatOpenAI gpt-4.1-mini.
> 
> - **CI tests**:
>   - Replace `ChatOpenAI` with `ChatGoogle` in `tests/ci/evaluate_tasks.py`.
>   - Update models from `gpt-4.1-mini` to `gemini-flash-latest` for both agent and judge.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a463675ffc0e9b28d0a7630c8178cac89a9494a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->