### PR TITLE
Validate agent output for user satisfaction

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -72,6 +72,7 @@ class AgentState(BaseModel):
 	stopped: bool = False
 	session_initialized: bool = False  # Track if session events have been dispatched
 	follow_up_task: bool = False  # Track if the agent is a follow-up task
+	validation_attempted: bool = False  # Track if output validation has been attempted
 
 	message_manager_state: MessageManagerState = Field(default_factory=MessageManagerState)
 	file_system_state: FileSystemState | None = None

--- a/tests/ci/test_agent_output_validation.py
+++ b/tests/ci/test_agent_output_validation.py
@@ -1,0 +1,258 @@
+"""Test agent output validation feature"""
+import asyncio
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from browser_use import Agent, BrowserProfile
+from browser_use.agent.views import ActionResult, AgentOutput
+from browser_use.llm.base import BaseLLMResponse
+from tests.conftest import FakeLLM
+
+
+@pytest.fixture
+def browser_profile():
+	"""Return a browser profile for testing"""
+	return BrowserProfile(headless=True, disable_security=True, extra_chromium_args=['--no-sandbox'])
+
+
+async def test_validation_when_output_unsatisfactory(setup_html_server, browser_profile):
+	"""Test that validation triggers continuation when output is unsatisfactory"""
+	
+	# Set up test page
+	server = setup_html_server
+	html_content = """
+	<html>
+		<body>
+			<h1>Test Page</h1>
+			<p>Simple test content</p>
+		</body>
+	</html>
+	"""
+	server.expect_request('/test').respond_with_data(html_content, content_type='text/html')
+	test_url = server.url_for('/test')
+	
+	# Track how many times LLM is called
+	call_count = {'count': 0}
+	validation_call_count = {'count': 0}
+	
+	async def fake_llm_output(messages, **kwargs):
+		"""Generate fake LLM responses"""
+		call_count['count'] += 1
+		
+		# Check if this is a validation call by looking at message content
+		last_message = messages[-1].content if messages else ''
+		if 'validating an AI agent' in str(last_message).lower():
+			validation_call_count['count'] += 1
+			# First validation: say user is NOT satisfied
+			if validation_call_count['count'] == 1:
+				return BaseLLMResponse(
+					completion={
+						'satisfied': False,
+						'reason': 'The output is incomplete and missing key information'
+					},
+					raw_message=AIMessage(content='validation response'),
+				)
+			# Second validation after extra step: say satisfied
+			else:
+				return BaseLLMResponse(
+					completion={
+						'satisfied': True,
+						'reason': 'The output now looks complete'
+					},
+					raw_message=AIMessage(content='validation response'),
+				)
+		
+		# Regular agent steps
+		if call_count['count'] == 1:
+			# First step: navigate
+			action = [{'navigate': {'url': test_url, 'new_tab': False}}]
+		elif call_count['count'] == 2:
+			# Second step: done with incomplete result
+			action = [{'done': {'success': True, 'text': 'Incomplete result'}}]
+		else:
+			# Third step (after validation): done with complete result
+			action = [{'done': {'success': True, 'text': 'Complete result with all details'}}]
+		
+		return BaseLLMResponse(
+			completion=AgentOutput(
+				evaluation_previous_goal='Making progress',
+				memory='Working on task',
+				next_goal='Complete the task',
+				action=action,
+			),
+			raw_message=AIMessage(content='test response'),
+		)
+	
+	# Create agent with fake LLM
+	llm = FakeLLM(fake_llm_output)
+	agent = Agent(
+		task='Get information from the test page',
+		llm=llm,
+		browser_profile=browser_profile,
+	)
+	
+	# Run agent with max 2 steps
+	history = await agent.run(max_steps=2)
+	
+	# Verify validation was called
+	assert validation_call_count['count'] >= 1, 'Validation should have been called at least once'
+	
+	# Verify that agent took more than 2 steps due to validation
+	assert len(history.history) >= 2, 'Agent should have executed at least 2 steps'
+	
+	# Verify validation_attempted flag was set
+	assert agent.state.validation_attempted is True, 'validation_attempted should be True'
+	
+	await agent.close()
+
+
+async def test_validation_when_output_satisfactory(setup_html_server, browser_profile):
+	"""Test that validation doesn't trigger continuation when output is good"""
+	
+	# Set up test page
+	server = setup_html_server
+	html_content = """
+	<html>
+		<body>
+			<h1>Test Page</h1>
+			<p>Simple test content</p>
+		</body>
+	</html>
+	"""
+	server.expect_request('/test').respond_with_data(html_content, content_type='text/html')
+	test_url = server.url_for('/test')
+	
+	# Track how many times LLM is called
+	call_count = {'count': 0}
+	validation_call_count = {'count': 0}
+	
+	async def fake_llm_output(messages, **kwargs):
+		"""Generate fake LLM responses"""
+		call_count['count'] += 1
+		
+		# Check if this is a validation call
+		last_message = messages[-1].content if messages else ''
+		if 'validating an AI agent' in str(last_message).lower():
+			validation_call_count['count'] += 1
+			# Say user IS satisfied
+			return BaseLLMResponse(
+				completion={
+					'satisfied': True,
+					'reason': 'The output is complete and satisfactory'
+				},
+				raw_message=AIMessage(content='validation response'),
+			)
+		
+		# Regular agent steps
+		if call_count['count'] == 1:
+			# First step: navigate
+			action = [{'navigate': {'url': test_url, 'new_tab': False}}]
+		else:
+			# Second step: done with good result
+			action = [{'done': {'success': True, 'text': 'Complete result with all the required details'}}]
+		
+		return BaseLLMResponse(
+			completion=AgentOutput(
+				evaluation_previous_goal='Making progress',
+				memory='Working on task',
+				next_goal='Complete the task',
+				action=action,
+			),
+			raw_message=AIMessage(content='test response'),
+		)
+	
+	# Create agent with fake LLM
+	llm = FakeLLM(fake_llm_output)
+	agent = Agent(
+		task='Get information from the test page',
+		llm=llm,
+		browser_profile=browser_profile,
+	)
+	
+	# Run agent with max 2 steps
+	history = await agent.run(max_steps=2)
+	
+	# Verify validation was called
+	assert validation_call_count['count'] == 1, 'Validation should have been called once'
+	
+	# Verify that agent took exactly 2 steps (no extra step from validation)
+	assert len(history.history) == 2, 'Agent should have executed exactly 2 steps'
+	
+	# Verify validation_attempted flag was set
+	assert agent.state.validation_attempted is True, 'validation_attempted should be True'
+	
+	await agent.close()
+
+
+async def test_validation_not_triggered_on_failure(setup_html_server, browser_profile):
+	"""Test that validation is skipped when agent reports failure"""
+	
+	# Set up test page
+	server = setup_html_server
+	html_content = """
+	<html>
+		<body>
+			<h1>Test Page</h1>
+		</body>
+	</html>
+	"""
+	server.expect_request('/test').respond_with_data(html_content, content_type='text/html')
+	test_url = server.url_for('/test')
+	
+	# Track how many times LLM is called
+	call_count = {'count': 0}
+	validation_call_count = {'count': 0}
+	
+	async def fake_llm_output(messages, **kwargs):
+		"""Generate fake LLM responses"""
+		call_count['count'] += 1
+		
+		# Check if this is a validation call
+		last_message = messages[-1].content if messages else ''
+		if 'validating an AI agent' in str(last_message).lower():
+			validation_call_count['count'] += 1
+			return BaseLLMResponse(
+				completion={
+					'satisfied': False,
+					'reason': 'Should not be called'
+				},
+				raw_message=AIMessage(content='validation response'),
+			)
+		
+		# Regular agent steps
+		if call_count['count'] == 1:
+			# First step: navigate
+			action = [{'navigate': {'url': test_url, 'new_tab': False}}]
+		else:
+			# Second step: done with FAILURE
+			action = [{'done': {'success': False, 'text': 'Task failed'}}]
+		
+		return BaseLLMResponse(
+			completion=AgentOutput(
+				evaluation_previous_goal='Making progress',
+				memory='Working on task',
+				next_goal='Complete the task',
+				action=action,
+			),
+			raw_message=AIMessage(content='test response'),
+		)
+	
+	# Create agent with fake LLM
+	llm = FakeLLM(fake_llm_output)
+	agent = Agent(
+		task='Get information from the test page',
+		llm=llm,
+		browser_profile=browser_profile,
+	)
+	
+	# Run agent
+	history = await agent.run(max_steps=2)
+	
+	# Verify validation was NOT called (we skip validation on failure)
+	assert validation_call_count['count'] == 0, 'Validation should not be called when agent reports failure'
+	
+	# Verify validation_attempted flag was set
+	assert agent.state.validation_attempted is True, 'validation_attempted should be True'
+	
+	await agent.close()


### PR DESCRIPTION
Add a post-completion LLM-based validation step to agent runs, allowing for a single self-correction iteration if the output is deemed unsatisfactory.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1760451341971679?thread_ts=1760451341.971679&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-c91a9f50-526e-4b58-95cf-591aa6f46247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c91a9f50-526e-4b58-95cf-591aa6f46247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an LLM-based output validation after an agent finishes and triggers one extra step if the result likely won’t satisfy the user. Skips validation on explicit failures or missing final results, and tracks the attempt in agent state.

- **New Features**
  - Added AgentState.validation_attempted to prevent repeated checks.
  - Implemented _validate_output_satisfaction() to ask the LLM for a JSON verdict on user satisfaction.
  - When unsatisfied, runs a single extra iteration with timeout and exception handling; logs completion and invokes done callbacks as needed.
  - Added CI tests covering unsatisfactory, satisfactory, and failure paths.

<!-- End of auto-generated description by cubic. -->

