### PR TITLE
reduce max_output_tokens gemini

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -78,7 +78,7 @@ class ChatGoogle(BaseChatModel):
 	top_p: float | None = None
 	seed: int | None = None
 	thinking_budget: int | None = None  # for gemini-2.5 flash and flash-lite models, default will be set to 0
-	max_output_tokens: int | None = 8192
+	max_output_tokens: int | None = 4096
 	config: types.GenerateContentConfigDict | None = None
 	include_system_in_user: bool = False
 	supports_structured_output: bool = True  # New flag


### PR DESCRIPTION
Auto-generated PR for: reduce max_output_tokens gemini
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Lowered the default max_output_tokens for Gemini chat models from 8192 to 4096 to align with model limits and reduce generation errors. Override max_output_tokens if you need longer outputs.

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers the default `max_output_tokens` in `ChatGoogle` from 8192 to 4096.
> 
> - **LLM (Google/Gemini)**:
>   - Reduce default `max_output_tokens` in `browser_use/llm/google/chat.py` (`ChatGoogle`) from `8192` to `4096`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98995449c2c0072966bcee4406af316f99b09ce3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->