### PR TITLE
get_state_as_text

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1160,6 +1160,13 @@ class BrowserSession(BaseModel):
 		assert result is not None and result.dom_state is not None
 		return result
 
+	async def get_state_as_text(self) -> str:
+		"""Get the browser state as text."""
+		state = await self.get_browser_state_summary()
+		assert state.dom_state is not None
+		dom_state = state.dom_state
+		return dom_state.llm_representation()
+
 	async def attach_all_watchdogs(self) -> None:
 		"""Initialize and attach all watchdogs with explicit handler registration."""
 		# Prevent duplicate watchdog attachment


### PR DESCRIPTION
Auto-generated PR for branch: get_state_as_text

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `BrowserSession.get_state_as_text()` to return the current DOM state text via `llm_representation()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c7cf16042044496d6b04eae72a8862a5ff5b464. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->