### PR TITLE
Add flag to disable version check

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1215,11 +1215,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self.logger.debug(f'🤖 Browser-Use Library Version {self.version} ({self.source})')
 
 		# Check for latest version and log upgrade message if needed
-		latest_version = await check_latest_browser_use_version()
-		if latest_version and latest_version != self.version:
-			self.logger.info(
-				f'📦 Newer version available: {latest_version} (current: {self.version}). Upgrade with: uv add browser-use@{latest_version}'
-			)
+		if CONFIG.BROWSER_USE_VERSION_CHECK:
+			latest_version = await check_latest_browser_use_version()
+			if latest_version and latest_version != self.version:
+				self.logger.info(
+					f'📦 Newer version available: {latest_version} (current: {self.version}). Upgrade with: uv add browser-use@{latest_version}'
+				)
 
 	def _log_first_step_startup(self) -> None:
 		"""Log startup message only on the first step"""

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -76,6 +76,10 @@ class OldConfig:
 			raise AssertionError('BROWSER_USE_CLOUD_UI_URL must be a valid URL if set')
 		return url
 
+	@property
+	def BROWSER_USE_VERSION_CHECK(self) -> bool:
+		return os.getenv('BROWSER_USE_VERSION_CHECK', 'true').lower()[:1] in 'ty1'
+
 	# Path configuration
 	@property
 	def XDG_CACHE_HOME(self) -> Path:
@@ -191,6 +195,7 @@ class FlatEnvConfig(BaseSettings):
 	BROWSER_USE_CLOUD_SYNC: bool | None = Field(default=None)
 	BROWSER_USE_CLOUD_API_URL: str = Field(default='https://api.browser-use.com')
 	BROWSER_USE_CLOUD_UI_URL: str = Field(default='')
+	BROWSER_USE_VERSION_CHECK: bool = Field(default=True)
 
 	# Path configuration
 	XDG_CACHE_HOME: str = Field(default='~/.cache')

--- a/tests/ci/test_config.py
+++ b/tests/ci/test_config.py
@@ -2,6 +2,8 @@
 
 import os
 
+import pytest
+
 from browser_use.config import CONFIG
 
 
@@ -30,24 +32,25 @@ class TestLazyConfig:
 			else:
 				os.environ.pop('BROWSER_USE_LOGGING_LEVEL', None)
 
-	def test_boolean_env_vars(self):
+	@pytest.mark.parametrize('env_var', ['ANONYMIZED_TELEMETRY', 'BROWSER_USE_VERSION_CHECK'])
+	def test_boolean_env_vars(self, env_var):
 		"""Test boolean environment variables are parsed correctly."""
-		original_value = os.environ.get('ANONYMIZED_TELEMETRY', '')
+		original_value = os.environ.get(env_var, '')
 		try:
 			# Test true values
 			for true_val in ['true', 'True', 'TRUE', 'yes', 'Yes', '1']:
-				os.environ['ANONYMIZED_TELEMETRY'] = true_val
-				assert CONFIG.ANONYMIZED_TELEMETRY is True, f'Failed for value: {true_val}'
+				os.environ[env_var] = true_val
+				assert getattr(CONFIG, env_var) is True, f'Failed for value: {true_val}'
 
 			# Test false values
 			for false_val in ['false', 'False', 'FALSE', 'no', 'No', '0']:
-				os.environ['ANONYMIZED_TELEMETRY'] = false_val
+				os.environ[env_var] = false_val
 				assert CONFIG.ANONYMIZED_TELEMETRY is False, f'Failed for value: {false_val}'
 		finally:
 			if original_value:
-				os.environ['ANONYMIZED_TELEMETRY'] = original_value
+				os.environ[env_var] = original_value
 			else:
-				os.environ.pop('ANONYMIZED_TELEMETRY', None)
+				os.environ.pop(env_var, None)
 
 	def test_api_keys_lazy_loading(self):
 		"""Test API keys are loaded lazily."""


### PR DESCRIPTION
The latest version check adds ~900ms of startup latency for us
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a flag to disable the latest version check, reducing startup latency by ~900ms. The check is on by default and can be turned off via an env var.

- **New Features**
  - Gate the version check behind CONFIG.BROWSER_USE_VERSION_CHECK.
  - Add BROWSER_USE_VERSION_CHECK env/config (default true) with robust true/false parsing.
  - Update tests to cover boolean parsing for this flag.

- **Migration**
  - Set BROWSER_USE_VERSION_CHECK=false to skip the version check at startup.

<!-- End of auto-generated description by cubic. -->

