### PR TITLE
Perform an additional occlusion check between mouse move -> click

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -476,6 +476,11 @@ class DefaultActionWatchdog(BaseWatchdog):
 				)
 				await asyncio.sleep(0.05)
 
+				# Check for occlusion again, as the mouse move may have opened a popover
+				is_occluded = await self._check_element_occlusion(backend_node_id, center_x, center_y, cdp_session)
+				if is_occluded:
+					raise Exception('Click target is occluded by another element after mouse move, must use JS-based click')
+
 				# Mouse down
 				self.logger.debug(f'👆🏾 Clicking x: {center_x}px y: {center_y}px ...')
 				try:


### PR DESCRIPTION
This cart button is a bit funky; the mouse move triggers the popover and then the popover ends up intercepting the click.

https://github.com/user-attachments/assets/48dcbbda-c1ee-486a-be5d-a8b5d5d27933

Adding an additional occlusion check between the mouse move -> click event solves the problem.

<img width="1257" height="234" alt="Screenshot 2025-10-15 at 10 19 44" src="https://github.com/user-attachments/assets/2146619b-b0ae-4a6d-a3dc-d18302e9fa1d" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add an extra occlusion check after mouse move and before click to prevent newly opened popovers from intercepting clicks. If the target is occluded, we abort the native click and use a JS-based click instead.

<!-- End of auto-generated description by cubic. -->

