### PR TITLE
add model names to ChatBrowserUse()

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -32,31 +32,37 @@ class ChatBrowserUse(BaseChatModel):
 	Usage:
 		agent = Agent(
 			task="Find the number of stars of the browser-use repo",
-			llm=ChatBrowserUse(),
+			llm=ChatBrowserUse(model='bu-latest'),
 		)
 	"""
 
 	def __init__(
 		self,
-		fast: bool = False,
+		model: str = 'bu-latest',
 		api_key: str | None = None,
 		base_url: str | None = None,
 		timeout: float = 120.0,
+		**kwargs,
 	):
 		"""
 		Initialize ChatBrowserUse client.
 
 		Args:
-			fast: If True, uses fast model. If False, uses smart model.
+			model: Model name to use. Options: 'bu-latest', 'bu-1-0'. Defaults to 'bu-latest'.
 			api_key: API key for browser-use cloud. Defaults to BROWSER_USE_API_KEY env var.
 			base_url: Base URL for the API. Defaults to BROWSER_USE_LLM_URL env var or production URL.
 			timeout: Request timeout in seconds.
 		"""
-		self.fast = fast
+		# Validate model name
+		valid_models = ['bu-latest', 'bu-1-0']
+		if model not in valid_models:
+			raise ValueError(f"Invalid model: '{model}'. Must be one of {valid_models}")
+
+		self.model = 'bu-1-0' if model == 'bu-latest' else model  # must update on new model releases
+		self.fast = False
 		self.api_key = api_key or os.getenv('BROWSER_USE_API_KEY')
 		self.base_url = base_url or os.getenv('BROWSER_USE_LLM_URL', 'https://llm.api.browser-use.com')
 		self.timeout = timeout
-		self.model = 'fast' if fast else 'smart'
 
 		if not self.api_key:
 			raise ValueError(
@@ -70,7 +76,7 @@ class ChatBrowserUse(BaseChatModel):
 
 	@property
 	def name(self) -> str:
-		return f'browser-use/{self.model}'
+		return self.model
 
 	@overload
 	async def ainvoke(self, messages: list[BaseMessage], output_format: None = None) -> ChatInvokeCompletion[str]: ...

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -8,12 +8,14 @@ Usage:
     model = llm.azure_gpt_4_1_mini
     model = llm.openai_gpt_4o
     model = llm.google_gemini_2_5_pro
+    model = llm.bu_latest
 """
 
 import os
 from typing import TYPE_CHECKING
 
 from browser_use.llm.azure.chat import ChatAzureOpenAI
+from browser_use.llm.browser_use.chat import ChatBrowserUse
 from browser_use.llm.cerebras.chat import ChatCerebras
 from browser_use.llm.google.chat import ChatGoogle
 from browser_use.llm.openai.chat import ChatOpenAI
@@ -72,6 +74,9 @@ cerebras_qwen_3_32b: 'BaseChatModel'
 cerebras_qwen_3_235b_a22b_instruct_2507: 'BaseChatModel'
 cerebras_qwen_3_235b_a22b_thinking_2507: 'BaseChatModel'
 cerebras_qwen_3_coder_480b: 'BaseChatModel'
+
+bu_latest: 'BaseChatModel'
+bu_1_0: 'BaseChatModel'
 
 
 def get_llm_by_name(model_name: str):
@@ -163,8 +168,15 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('CEREBRAS_API_KEY')
 		return ChatCerebras(model=model, api_key=api_key)
 
+	# Browser Use Models
+	elif provider == 'bu':
+		# Handle bu_latest -> bu-latest conversion (need to prepend 'bu-' back)
+		model = f'bu-{model_part.replace("_", "-")}'
+		api_key = os.getenv('BROWSER_USE_API_KEY')
+		return ChatBrowserUse(model=model, api_key=api_key)
+
 	else:
-		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras']
+		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu']
 		raise ValueError(f"Unknown provider: '{provider}'. Available providers: {', '.join(available_providers)}")
 
 
@@ -184,6 +196,8 @@ def __getattr__(name: str) -> 'BaseChatModel':
 		return ChatOCIRaw  # type: ignore
 	elif name == 'ChatCerebras':
 		return ChatCerebras  # type: ignore
+	elif name == 'ChatBrowserUse':
+		return ChatBrowserUse  # type: ignore
 
 	# Handle model instances - these are the main use case
 	try:
@@ -198,6 +212,7 @@ __all__ = [
 	'ChatAzureOpenAI',
 	'ChatGoogle',
 	'ChatCerebras',
+	'ChatBrowserUse',
 ]
 
 if OCI_AVAILABLE:
@@ -247,6 +262,9 @@ __all__ += [
 	'cerebras_qwen_3_235b_a22b_instruct_2507',
 	'cerebras_qwen_3_235b_a22b_thinking_2507',
 	'cerebras_qwen_3_coder_480b',
+	# Browser Use instances - created on demand
+	'bu_latest',
+	'bu_1_0',
 ]
 
 # NOTE: OCI backend is optional. The try/except ImportError and conditional __all__ are required


### PR DESCRIPTION
## Summary

Add browser-use cloud model support with new model naming convention

### Details
- Removed fast: bool parameter
- Supports bu-latest and bu-1-0 model names (bu-latest currently
 maps to bu-1-0)
- Added to llm.models module for unified access:
llm.browser_use_bu_latest and llm.browser_use_bu_1_0
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add Browser Use cloud model support to ChatBrowserUse with explicit model names, replacing the fast/smart toggle. Unified access via llm.models with easy imports.

- **New Features**
  - ChatBrowserUse now accepts model='bu-latest' or 'bu-1-0' (bu-latest maps to bu-1-0).
  - API payload sends model instead of fast; name returns the resolved model.
  - llm.models exposes llm.browser_use_bu_latest and llm.browser_use_bu_1_0; get_llm_by_name resolves browser_use_* to ChatBrowserUse.

- **Migration**
  - Replace ChatBrowserUse(fast=True|False) with ChatBrowserUse(model='bu-latest'|'bu-1-0').
  - Prefer llm.browser_use_bu_latest for default usage.
  - Ensure BROWSER_USE_API_KEY is set.

<!-- End of auto-generated description by cubic. -->

