### PR TITLE
docs: fix typo "trasticly" → "drastically"

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -329,7 +329,7 @@ Source: (go to or request this content to learn more) https://docs.browser-use.c
 
 Tips and tricks 
 
-Prompting can trasticly improve performance and solve existing limitations of the library.
+Prompting can drastically improve performance and solve existing limitations of the library.
 
 ### 1. Be Specific vs Open-Ended
 

--- a/docs/customize/agent/prompting-guide.mdx
+++ b/docs/customize/agent/prompting-guide.mdx
@@ -4,7 +4,7 @@ description: "Tips and tricks "
 icon: "lightbulb"
 ---
 
-Prompting can trasticly improve performance and solve existing limitations of the library.
+Prompting can drastically improve performance and solve existing limitations of the library.
 
 ### 1. Be Specific vs Open-Ended
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fix typo “trasticly” → “drastically” in AGENTS.MD and the prompting guide to improve docs clarity.

<!-- End of auto-generated description by cubic. -->

