### PR TITLE
Corrected The Typo trastical -> Drastically

### DIFF
--- a/docs/customize/agent/prompting-guide.mdx
+++ b/docs/customize/agent/prompting-guide.mdx
@@ -4,7 +4,7 @@ description: "Tips and tricks "
 icon: "lightbulb"
 ---
 
-Prompting can trasticly improve performance and solve existing limitations of the library.
+Prompting can Drastically improve performance and solve existing limitations of the library.
 
 ### 1. Be Specific vs Open-Ended
 


### PR DESCRIPTION
So i have made changes in the documentation part which can be found here 

https://docs.browser-use.com/customize/agent/prompting-guide#2-name-actions-directly

trastical -> Drastically 

it's typo in the documentation is what i think 

issue no. #3364  
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a typo in the prompting guide: “trasticly” → “drastically” to improve clarity.

<!-- End of auto-generated description by cubic. -->

