### PR TITLE
Fix framework events not triggering

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1265,6 +1265,10 @@ class DefaultActionWatchdog(BaseWatchdog):
 			)
 
 			success = result.get('result', {}).get('value', False)
+			if success:
+				self.logger.debug('✅ Framework events triggered successfully')
+			else:
+				self.logger.warning('⚠️ Failed to trigger framework events')
 
 		except Exception as e:
 			self.logger.warning(f'⚠️ Failed to trigger framework events: {type(e).__name__}: {e}')


### PR DESCRIPTION
Can't pass an IIFE to `Runtime.callFunctionOn`; doing so fails with a syntax error:

<img width="1706" height="60" alt="Screenshot 2025-10-21 at 11 40 23" src="https://github.com/user-attachments/assets/2a49b13a-60b5-4d9b-82f5-9b01f2f3e2a2" />

This caused some inputs to clear after the agent blurred them due to framework events never firing.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes framework events not triggering by replacing the IIFE with a regular function for Runtime.callFunctionOn, preventing syntax errors and ensuring change/blur events fire correctly. Inputs no longer clear after the agent blurs them.

- **Bug Fixes**
  - Replace IIFE with a function executed via objectId to avoid CDP syntax error.
  - Add success/failure logs to help diagnose event triggering.

<!-- End of auto-generated description by cubic. -->

