### PR TITLE
Update cloud_events.py

### DIFF
--- a/browser_use/agent/cloud_events.py
+++ b/browser_use/agent/cloud_events.py
@@ -8,10 +8,10 @@ from bubus import BaseEvent
 from pydantic import Field, field_validator
 from uuid_extensions import uuid7str
 
-MAX_STRING_LENGTH = 100000  # 100K chars ~ 25k tokens should be enough
+MAX_STRING_LENGTH = 10000  # 100K chars ~ 25k tokens should be enough
 MAX_URL_LENGTH = 100000
 MAX_TASK_LENGTH = 100000
-MAX_COMMENT_LENGTH = 2000
+MAX_COMMENT_LENGTH = 200
 MAX_FILE_CONTENT_SIZE = 50 * 1024 * 1024  # 50MB
 
 


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Reduced cloud event payload limits to prevent oversized messages and improve stability. Set MAX_STRING_LENGTH to 10,000 (was 100,000) and MAX_COMMENT_LENGTH to 200 (was 2,000).

<!-- End of auto-generated description by cubic. -->

