### PR TITLE
Update link to Available Tools documentation

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -365,7 +365,7 @@ task = """
 """
 ```
 
-See [Available Tools](/customize/tools/available) for the complete list of actions.
+See [Available Tools](https://docs.browser-use.com/customize/tools/available) for the complete list of actions.
 
 ### 3. Handle interaction problems via keyboard navigation
 


### PR DESCRIPTION
Issue with relative link caught in https://github.com/browser-use/browser-use/issues/3387
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix broken "Available Tools" link in AGENTS.MD by replacing the relative path with the absolute docs URL. This ensures the link works in GitHub and other contexts.

<!-- End of auto-generated description by cubic. -->

