### PR TITLE
Fix issue #3155

### DIFF
--- a/browser_use/browser/watchdogs/screenshot_watchdog.py
+++ b/browser_use/browser/watchdogs/screenshot_watchdog.py
@@ -11,52 +11,119 @@ from browser_use.browser.watchdog_base import BaseWatchdog
 from browser_use.observability import observe_debug
 
 if TYPE_CHECKING:
-	pass
+    pass
 
 
 class ScreenshotWatchdog(BaseWatchdog):
-	"""Handles screenshot requests using CDP."""
+    """Handles screenshot requests using CDP."""
 
-	# Events this watchdog listens to
-	LISTENS_TO: ClassVar[list[type[BaseEvent[Any]]]] = [ScreenshotEvent]
+    # Events this watchdog listens to
+    LISTENS_TO: ClassVar[list[type[BaseEvent[Any]]]] = [ScreenshotEvent]
 
-	# Events this watchdog emits
-	EMITS: ClassVar[list[type[BaseEvent[Any]]]] = []
+    # Events this watchdog emits
+    EMITS: ClassVar[list[type[BaseEvent[Any]]]] = []
 
-	@observe_debug(ignore_input=True, ignore_output=True, name='screenshot_event_handler')
-	async def on_ScreenshotEvent(self, event: ScreenshotEvent) -> str:
-		"""Handle screenshot request using CDP.
+    @observe_debug(
+        ignore_input=True, ignore_output=True, name="screenshot_event_handler"
+    )
+    async def on_ScreenshotEvent(self, event: ScreenshotEvent) -> str:
+        """Handle screenshot request using CDP.
 
-		Args:
-			event: ScreenshotEvent with optional full_page and clip parameters
+        Args:
+                event: ScreenshotEvent with optional full_page and clip parameters
 
-		Returns:
-			Dict with 'screenshot' key containing base64-encoded screenshot or None
-		"""
-		self.logger.debug('[ScreenshotWatchdog] Handler START - on_ScreenshotEvent called')
-		try:
-			# Get CDP client and session for current target
-			cdp_session = await self.browser_session.get_or_create_cdp_session()
+        Returns:
+                Dict with 'screenshot' key containing base64-encoded screenshot or None
+        """
+        self.logger.debug(
+            "[ScreenshotWatchdog] Handler START - on_ScreenshotEvent called"
+        )
+        cdp_session = None
+        try:
+            # Get CDP client and session for current target
+            cdp_session = await self.browser_session.get_or_create_cdp_session()
 
-			# Prepare screenshot parameters
-			params = CaptureScreenshotParameters(format='jpeg', quality=60, captureBeyondViewport=False)
+            # Prepare screenshot parameters
+            params = CaptureScreenshotParameters(
+                format="jpeg", quality=60, captureBeyondViewport=False
+            )
 
-			# Take screenshot using CDP
-			self.logger.debug(f'[ScreenshotWatchdog] Taking screenshot with params: {params}')
-			result = await cdp_session.cdp_client.send.Page.captureScreenshot(params=params, session_id=cdp_session.session_id)
+            # Take screenshot using CDP
+            self.logger.debug(
+                f"[ScreenshotWatchdog] Taking screenshot with params: {params}"
+            )
+            result = await cdp_session.cdp_client.send.Page.captureScreenshot(
+                params=params, session_id=cdp_session.session_id
+            )
 
-			# Return base64-encoded screenshot data
-			if result and 'data' in result:
-				self.logger.debug('[ScreenshotWatchdog] Screenshot captured successfully')
-				return result['data']
+            # Return base64-encoded screenshot data
+            if result and "data" in result:
+                self.logger.debug(
+                    "[ScreenshotWatchdog] Screenshot captured successfully"
+                )
+                return result["data"]
 
-			raise BrowserError('[ScreenshotWatchdog] Screenshot result missing data')
-		except Exception as e:
-			self.logger.error(f'[ScreenshotWatchdog] Screenshot failed: {e}')
-			raise
-		finally:
-			# Try to remove highlights even on failure
-			try:
-				await self.browser_session.remove_highlights()
-			except Exception:
-				pass
+            raise BrowserError("[ScreenshotWatchdog] Screenshot result missing data")
+        except Exception as e:
+            self.logger.error(f"[ScreenshotWatchdog] Screenshot failed: {e}")
+            # Retry once against a confirmed top-level page target if available
+            if "top-level targets" in str(e):
+                try:
+                    current_session = cdp_session
+                    top_level_session = await self._get_top_level_page_session(
+                        fallback=current_session
+                    )
+                    if top_level_session and top_level_session is not current_session:
+                        self.logger.info(
+                            "[ScreenshotWatchdog] Retrying screenshot after refocusing top-level target"
+                        )
+                        params = CaptureScreenshotParameters(
+                            format="jpeg", quality=60, captureBeyondViewport=False
+                        )
+                        result = await top_level_session.cdp_client.send.Page.captureScreenshot(
+                            params=params,
+                            session_id=top_level_session.session_id,
+                        )
+                        if result and "data" in result:
+                            self.logger.info(
+                                "[ScreenshotWatchdog] Screenshot captured successfully on retry"
+                            )
+                            return result["data"]
+                except Exception as retry_error:
+                    self.logger.error(
+                        f"[ScreenshotWatchdog] Retry after top-level refocus failed: {retry_error}"
+                    )
+            raise BrowserError(f"[ScreenshotWatchdog] Screenshot failed: {e}") from e
+        finally:
+            # Try to remove highlights even on failure
+            try:
+                await self.browser_session.remove_highlights()
+            except Exception:
+                pass
+
+    async def _get_top_level_page_session(self, fallback=None):
+        """Return a CDP session that is guaranteed to target a top-level page."""
+        candidates = []
+
+        # Start with the agent focus if available
+        if self.browser_session.agent_focus:
+            candidates.append(self.browser_session.agent_focus)
+
+        # Add any pooled sessions we know about
+        if hasattr(self.browser_session, "_cdp_session_pool"):
+            candidates.extend(self.browser_session._cdp_session_pool.values())
+
+        for session in candidates:
+            if session is None or session is fallback:
+                continue
+            try:
+                info = await session.get_target_info()
+                if info.get("type") == "page":
+                    return session
+            except Exception as e:
+                self.logger.debug(
+                    f"[ScreenshotWatchdog] Failed to inspect session {getattr(session, 'target_id', '?')}: {e}"
+                )
+
+        # Fall back to the original session if nothing better was found
+        return fallback


### PR DESCRIPTION
For some websites, we get this error when attempting to grab a screenshot:

```
ERROR    [cdp_use.client] CDP Error for request 49: {'code': -32000, 'message': 'Command can only be executed on top-level targets'}                                                                                                                                                                                                                                                          
```

This PR fixes this by falling back to taking a screenshot of the top-level target.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes screenshot failures by retrying against the top-level CDP target when the page returns "Command can only be executed on top-level targets." This makes screenshot capture reliable on sites with nested targets or iframes.

- **Bug Fixes**
  - Retry once using a confirmed top-level page session when the specific CDP error is hit.
  - Added a helper to select a top-level CDP session from agent focus or the session pool.
  - Better error wrapping and logging; highlight cleanup still runs on exit.

<!-- End of auto-generated description by cubic. -->

