### PR TITLE
Fix laminar bug

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1461,7 +1461,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		return False
 
-	@observe(name='agent.run', metadata={'task': '{{task}}', 'debug': '{{debug}}'})
+	@observe(name='agent.run', ignore_input=True, ignore_output=True)
 	@time_execution_async('--run')
 	async def run(
 		self,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the observe decorator on agent.run to ignore input and output. This fixes Laminar instrumentation errors caused by serializing task/debug metadata.

<!-- End of auto-generated description by cubic. -->

