### PR TITLE
Remove translation links from README as they are now outdated and not…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,6 @@
 
 </br>
 
-<div align="center">
-
-<!-- Keep these links. Translations will automatically update with the README. -->
-[Deutsch](https://www.readme-i18n.com/browser-use/browser-use?lang=de) |
-[Español](https://www.readme-i18n.com/browser-use/browser-use?lang=es) |
-[français](https://www.readme-i18n.com/browser-use/browser-use?lang=fr) |
-[日本語](https://www.readme-i18n.com/browser-use/browser-use?lang=ja) |
-[한국어](https://www.readme-i18n.com/browser-use/browser-use?lang=ko) |
-[Português](https://www.readme-i18n.com/browser-use/browser-use?lang=pt) |
-[Русский](https://www.readme-i18n.com/browser-use/browser-use?lang=ru) |
-[中文](https://www.readme-i18n.com/browser-use/browser-use?lang=zh)
-
-</div>
-
 ---
 
 <div align="center">


### PR DESCRIPTION
… working

Removed language translation links from the README.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed outdated translation links from the README that no longer work. This prevents sending users to broken pages and simplifies the docs.

<!-- End of auto-generated description by cubic. -->

