### PR TITLE
add tool example browser session

### DIFF
--- a/docs/customize/tools/add.mdx
+++ b/docs/customize/tools/add.mdx
@@ -52,6 +52,45 @@ Your function has access to these objects:
 - **`available_file_paths: list[str]`** - Available files for upload/processing
 - **`has_sensitive_data: bool`** - Whether action contains sensitive data
 
+
+## Browser Interaction Examples
+
+You can use `browser_session` to directly interact with page elements using CSS selectors:
+
+```python
+from browser_use import Tools, Agent, ActionResult, BrowserSession
+
+tools = Tools()
+
+@tools.action(description='Click the submit button using CSS selector')
+async def click_submit_button(browser_session: BrowserSession):
+    # Get the current page
+    page = await browser_session.must_get_current_page()
+
+    # Get element(s) by CSS selector
+    elements = await page.get_elements_by_css_selector('button[type="submit"]')
+
+    if not elements:
+        return ActionResult(extracted_content='No submit button found')
+
+    # Click the first matching element
+    await elements[0].click()
+
+    return ActionResult(extracted_content='Submit button clicked!')
+```
+
+
+Available methods on `Page`:
+- `get_elements_by_css_selector(selector: str)` - Returns list of matching elements
+- `get_element_by_prompt(prompt: str, llm)` - Returns element or None using LLM
+- `must_get_element_by_prompt(prompt: str, llm)` - Returns element or raises error
+
+Available methods on `Element`:
+- `click()` - Click the element
+- `type(text: str)` - Type text into the element
+- `get_text()` - Get element text content
+- See `browser_use/actor/element.py` for more methods
+
 ## Pydantic Input
 
 You can use Pydantic for the tool parameters:


### PR DESCRIPTION
Auto-generated PR for: add tool example browser session

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a browser_session example with CSS selector interactions and lists available Page/Element methods in the tools documentation.
> 
> - **Docs (Customize > Tools > Add)**
>   - Add "Browser Interaction Examples" section demonstrating `browser_session` usage to click a submit button via CSS selector.
>   - Document available `Page` methods: `get_elements_by_css_selector`, `get_element_by_prompt`, `must_get_element_by_prompt`.
>   - Document available `Element` methods: `click`, `type`, `get_text` (referencing `browser_use/actor/element.py` for more).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02e14b71e2616983e6c50955013a7fcd2df69a87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->