### PR TITLE
reset state stopped after new task

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -626,6 +626,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self._message_manager.add_new_task(new_task)
 		# Mark as follow-up task and recreate eventbus (gets shut down after each run)
 		self.state.follow_up_task = True
+		# Reset control flags so agent can continue
+		self.state.stopped = False
+		self.state.paused = False
 		agent_id_suffix = str(self.id)[-4:].replace('-', '_')
 		if agent_id_suffix and agent_id_suffix[0].isdigit():
 			agent_id_suffix = 'a' + agent_id_suffix


### PR DESCRIPTION
Auto-generated PR for: reset state stopped after new task

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clears `state.stopped` and `state.paused` in `add_new_task` so the agent resumes properly on follow-up tasks.
> 
> - **Agent control flow**
>   - In `browser_use/agent/service.py`, `add_new_task` now resets `state.stopped` and `state.paused` to `False` before recreating the event bus, ensuring follow-up tasks can proceed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3240b13501c791c3bcdc55ec367d3d1e88d77df5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->