### PR TITLE
weekly-cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,13 +31,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
 
+      - name: Get week number for cache key
+        id: week
+        run: echo "number=$(date +%Y-W%U)" >> $GITHUB_OUTPUT
+
       - name: Cache chromium binaries
         id: cache-chromium
         uses: actions/cache@v4
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ hashFiles('uv.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ steps.week.outputs.number }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-chromium-
 
@@ -122,13 +126,17 @@ jobs:
 
       - run: uv sync --dev --all-extras
 
+      - name: Get week number for cache key
+        id: week
+        run: echo "number=$(date +%Y-W%U)" >> $GITHUB_OUTPUT
+
       - name: Cache chromium binaries
         id: cache-chromium
         uses: actions/cache@v4
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ hashFiles('uv.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ steps.week.outputs.number }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-chromium-
 
@@ -163,7 +171,7 @@ jobs:
         if: steps.check-file.outputs.exists == 'true'
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 2
+          timeout_minutes: 4
           max_attempts: 2
           retry_on: error
           command: pytest "tests/ci/${{ matrix.test_filename }}.py"
@@ -171,7 +179,7 @@ jobs:
   evaluate-tasks:
     needs: setup-chromium
     runs-on: ubuntu-latest
-    timeout-minutes: 4  # Allow more time for agent eval tasks
+    timeout-minutes: 8  # Allow more time for agent eval tasks
     env:
       IN_DOCKER: 'true'
       BROWSER_USE_CLOUD_SYNC: 'false'
@@ -200,13 +208,17 @@ jobs:
 
       - run: uv sync --dev --all-extras
 
+      - name: Get week number for cache key
+        id: week
+        run: echo "number=$(date +%Y-W%U)" >> $GITHUB_OUTPUT
+
       - name: Cache chromium binaries
         id: cache-chromium
         uses: actions/cache@v4
         with:
           path: |
             ~/.cache/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ hashFiles('uv.lock') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ steps.week.outputs.number }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-chromium-
 


### PR DESCRIPTION
Auto-generated PR for branch: weekly-cache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Playwright Chromium cache to a week-based key and increases timeouts for tests and agent evaluation.
> 
> - **CI workflow (`.github/workflows/test.yaml`)**:
>   - **Caching**:
>     - Add step to compute weekly cache key (`steps.week.outputs.number`).
>     - Change Chromium cache key from `hashFiles('uv.lock')` to weekly key across `setup-chromium`, `tests`, and `evaluate-tasks`.
>   - **Timeouts**:
>     - Increase retry step timeout for tests from `2` to `4` minutes.
>     - Increase `evaluate-tasks` job timeout from `4` to `8` minutes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1abe880484a53b05aa2b0e04de232dee6696b72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->