### PR TITLE
Fix issue #3373

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -7,7 +7,7 @@ This server provides tools for:
 - File system operations
 
 Usage:
-    uvx browser-use --mcp
+    uvx 'browser-use[cli]' --mcp
 
 Or as an MCP server in Claude Desktop or other MCP clients:
     {

--- a/docs/customize/integrations/mcp-server.mdx
+++ b/docs/customize/integrations/mcp-server.mdx
@@ -13,8 +13,10 @@ The MCP (Model Context Protocol) Server allows you to expose browser-use's brows
 
 ### Start MCP Server
 
+**Prerequisite:** `browser-use` requires Python 3.11 or newer. Please ensure your Python version is up to date before proceeding.
+
 ```bash
-uvx browser-use --mcp
+uvx 'browser-use[cli]' --mcp
 ```
 
 The server will start in stdio mode, ready to accept MCP connections.
@@ -174,7 +176,7 @@ uv pip install 'browser-use'
 Enable debug logging by setting:
 ```bash
 export BROWSER_USE_LOG_LEVEL=DEBUG
-uvx browser-use --mcp
+uvx 'browser-use[cli]' --mcp
 ```
 
 ## Security Considerations

--- a/examples/mcp/simple_server.py
+++ b/examples/mcp/simple_server.py
@@ -9,7 +9,7 @@ Prerequisites:
    pip install 'browser-use[cli]'
 
 2. Start the browser-use MCP server in a separate terminal:
-   uvx browser-use --mcp
+   uvx 'browser-use[cli]' --mcp
 
 3. Run this client example:
    python simple_server.py


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated MCP Server docs to add the Python 3.11+ prerequisite and correct the start command to uvx 'browser-use[cli]' --mcp. This fixes issue #3373 where the old command failed to start the server.

<!-- End of auto-generated description by cubic. -->

