### PR TITLE
eval on pr

### DIFF
--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -55,25 +55,4 @@ jobs:
             exit 1
           fi
 
-      - name: Post initial comment
-        if: always()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const triggerSuccess = '${{ steps.trigger.outcome }}' === 'success';
-            const commitSha = '${{ github.event.pull_request.head.sha }}';
-            const workflowUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
 
-            let body;
-            if (triggerSuccess) {
-              body = `🚀 **Eval started** `;
-            } else {
-              body = `**Trigger failed**. Check [workflow logs](${workflowUrl}).`;
-            }
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            });


### PR DESCRIPTION
Auto-generated PR for: eval on pr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add GitHub Actions workflow to trigger external PR evaluation for authorized authors and fail the job if the API response indicates failure.
> 
> - **CI**:
>   - **New workflow** `/.github/workflows/eval-on-pr.yml` to trigger external evaluation on PR events (`opened`, `synchronize`, `reopened`).
>     - Runs only for PR authors with `OWNER`/`MEMBER`/`COLLABORATOR` association.
>     - Calls `POST ${EVAL_PLATFORM_URL}/api/triggerInteractionTasksV6` with `commitSha`, `prNumber`, `branchName`, `testCase` (from `vars.EVAL_TEST_CASE` or default `InteractionTasks_v6`), and `githubRepo`.
>     - Uses `EVAL_PLATFORM_KEY` for auth; logs response and fails if `.success` is not `true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67a0919fe1b6ede59fece1c96733d9176213eb0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->