### PR TITLE
Feature/chatgpt UI

### DIFF
--- a/examples/ui/README.md
+++ b/examples/ui/README.md
@@ -5,3 +5,69 @@
 | `command_line.py`      | **Terminal**      | Parses arguments for command-line execution. | `python command_line.py`                  |
 | `gradio_demo.py`       | **Gradio**        | Provides a Gradio-based interactive UI.  | `python gradio_demo.py`                   |
 | `streamlit_demo.py`    | **Streamlit**     | Runs a Streamlit-based web interface.    | `python -m streamlit run streamlit_demo.py` |
+| `chatgpt_backend.py`   | **ChatGPT-Style** | FastAPI backend with WebSocket streaming | See below for full setup                  |
+
+---
+
+## 🚀 ChatGPT-Style Frontend (NEW!)
+
+Frontend web moderno inspirado no ChatGPT para interagir com browser-use via texto e comandos de voz.
+
+### Features
+
+- ✨ Interface ChatGPT-style moderna
+- 🎤 Reconhecimento de voz (Web Speech API)
+- 📸 Preview do browser em tempo real
+- ⚡ Streaming via WebSocket
+- 🎮 Controles pause/resume/stop
+- 📊 Timeline de ações expandível
+- 🌙 Suporte a dark mode
+
+### Quick Start
+
+#### Backend
+
+```bash
+# Instalar dependências
+pip install "browser-use[chatgpt-ui]"
+
+# Configurar API keys
+export OPENAI_API_KEY=your_key_here
+
+# Iniciar backend
+cd examples/ui
+python chatgpt_backend.py
+```
+
+Backend: http://localhost:8000
+
+#### Frontend
+
+```bash
+cd examples/ui/chatgpt-frontend
+
+# Instalar e rodar
+npm install
+npm run dev
+```
+
+Frontend: http://localhost:3000
+
+### Documentação Completa
+
+Veja [chatgpt-frontend/README.md](chatgpt-frontend/README.md) para documentação detalhada, arquitetura, troubleshooting e exemplos de uso.
+
+### Arquivos
+
+```
+examples/ui/
+├── chatgpt_backend.py       # API FastAPI + WebSocket
+├── session_manager.py        # Gerenciador de sessões
+├── voice_services.py         # STT/TTS com OpenAI
+└── chatgpt-frontend/         # Frontend Next.js
+    ├── components/           # Componentes React
+    ├── hooks/                # Custom hooks
+    ├── app/                  # Pages Next.js
+    └── README.md             # Docs completa
+```
+

--- a/examples/ui/chatgpt-frontend/.gitignore
+++ b/examples/ui/chatgpt-frontend/.gitignore
@@ -1,0 +1,40 @@
+node_modules/
+.next/
+out/
+dist/
+build/
+
+# Dependencies
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Testing
+coverage/
+
+# Env
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Next.js
+.next/
+out/
+
+# Production
+build/
+dist/

--- a/examples/ui/chatgpt-frontend/README.md
+++ b/examples/ui/chatgpt-frontend/README.md
@@ -1,0 +1,250 @@
+# Browser-Use ChatGPT Frontend
+
+Interface web moderna estilo ChatGPT para controlar o browser-use através de comandos de texto e voz.
+
+## 🎯 Features
+
+- ✨ **Interface ChatGPT-style** - Design moderno e intuitivo
+- 🎤 **Comandos de Voz** - Reconhecimento de fala via Web Speech API
+- 📸 **Preview em Tempo Real** - Visualização de screenshots durante execução
+- ⚡ **WebSocket Streaming** - Atualizações em tempo real de cada step
+- 🎮 **Controles Interativos** - Pause, resume e stop do agente
+- 📊 **Timeline de Ações** - Histórico completo expandível
+- 🌙 **Dark Mode** - Tema escuro automático
+
+## 🚀 Quick Start
+
+### 1. Instalar Dependências do Backend
+
+```bash
+cd /workspaces/browser-use
+pip install fastapi uvicorn websockets openai
+```
+
+### 2. Configurar Variáveis de Ambiente
+
+Crie um arquivo `.env` na raiz do projeto:
+
+```bash
+# OpenAI (obrigatório para LLM e serviços de voz)
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Opcional: Outros provedores LLM
+ANTHROPIC_API_KEY=your_anthropic_key
+GOOGLE_API_KEY=your_google_key
+```
+
+### 3. Iniciar Backend
+
+```bash
+cd examples/ui
+python chatgpt_backend.py
+```
+
+O backend estará rodando em `http://localhost:8000`
+
+### 4. Instalar Dependências do Frontend
+
+```bash
+cd examples/ui/chatgpt-frontend
+npm install
+```
+
+### 5. Iniciar Frontend
+
+```bash
+npm run dev
+```
+
+O frontend estará rodando em `http://localhost:3000`
+
+## 📖 Como Usar
+
+### Via Texto
+
+1. Digite sua tarefa no campo de input
+2. Pressione Enter ou clique no botão enviar
+3. Acompanhe a execução em tempo real no chat e no preview do browser
+
+**Exemplos de tarefas:**
+
+```
+- Vá para google.com e pesquise por "automação web"
+- Encontre o número de estrelas do repositório browser-use no GitHub
+- Entre no site amazon.com e busque por "notebook"
+- Extraia os títulos das notícias principais do g1.com
+```
+
+### Via Voz
+
+1. Clique no ícone do microfone 🎤
+2. Fale sua tarefa claramente
+3. Clique novamente para parar a gravação
+4. O texto será transcrito automaticamente e você pode enviá-lo
+
+### Controles Durante Execução
+
+- **⏸️ Pause** - Pausa a execução do agente
+- **▶️ Resume** - Retoma a execução pausada
+- **⏹️ Stop** - Para completamente a execução
+- **🖥️ Toggle Preview** - Mostra/esconde o preview do browser
+
+## 🏗️ Arquitetura
+
+```
+┌─────────────────────────────────────┐
+│  Frontend (Next.js + React)         │
+│  - Chat Interface                   │
+│  - Voice Recognition (Web API)      │
+│  - Browser Preview                  │
+│  - Action Timeline                  │
+└─────────────┬───────────────────────┘
+              │ WebSocket + REST API
+┌─────────────▼───────────────────────┐
+│  Backend (FastAPI)                  │
+│  - chatgpt_backend.py               │
+│  - session_manager.py               │
+│  - voice_services.py                │
+└─────────────┬───────────────────────┘
+              │ Agent Control
+┌─────────────▼───────────────────────┐
+│  Browser-Use Agent                  │
+│  - Browser Automation               │
+│  - LLM Integration                  │
+│  - Screenshot Capture               │
+└─────────────────────────────────────┘
+```
+
+## 🔧 Configuração Avançada
+
+### Mudar Provedor LLM
+
+Edite a requisição em `ChatInterface.tsx`:
+
+```typescript
+llm_provider: 'anthropic',  // openai, anthropic, google, groq
+llm_model: 'claude-3-5-sonnet-20241022',
+```
+
+### Ajustar Número de Steps
+
+```typescript
+max_steps: 20,  // Padrão: 10
+```
+
+### Usar OpenAI Whisper para Transcrição
+
+Se preferir usar a API do Whisper ao invés da Web Speech API nativa:
+
+1. Desabilite o reconhecimento nativo no frontend
+2. Grave áudio e envie para o endpoint `/api/voice/transcribe`
+3. O backend processará via OpenAI Whisper
+
+## 📁 Estrutura de Arquivos
+
+```
+examples/ui/
+├── chatgpt_backend.py       # API FastAPI principal
+├── session_manager.py        # Gerenciamento de sessões
+├── voice_services.py         # Serviços STT/TTS
+└── chatgpt-frontend/
+    ├── app/
+    │   ├── layout.tsx        # Layout principal
+    │   ├── page.tsx          # Página home
+    │   └── globals.css       # Estilos globais
+    ├── components/
+    │   ├── Sidebar.tsx       # Lista de conversas
+    │   ├── ChatInterface.tsx # Interface principal
+    │   ├── MessageBubble.tsx # Componente de mensagem
+    │   ├── BrowserPreview.tsx# Preview do browser
+    │   └── ActionTimeline.tsx# Timeline de ações
+    ├── hooks/
+    │   ├── useWebSocket.ts   # Hook WebSocket
+    │   └── useSpeechRecognition.ts
+    ├── package.json
+    ├── tsconfig.json
+    ├── tailwind.config.js
+    └── next.config.js
+```
+
+## 🐛 Troubleshooting
+
+### Backend não conecta
+
+- Verifique se o backend está rodando: `curl http://localhost:8000`
+- Confira as variáveis de ambiente no `.env`
+- Veja os logs do terminal onde o backend está rodando
+
+### WebSocket não conecta
+
+- Certifique-se que CORS está configurado corretamente
+- Verifique se a porta 8000 está liberada
+- Confira o console do browser para erros
+
+### Reconhecimento de voz não funciona
+
+- Web Speech API só funciona em HTTPS ou localhost
+- Alguns browsers não suportam (use Chrome/Edge)
+- Verifique permissões de microfone no browser
+
+### Screenshots não aparecem
+
+- Verifique se o diretório `/tmp/browser-use-sessions/` existe
+- Confira se o agente tem permissões de escrita
+- Veja logs do backend para erros de captura
+
+## 🚢 Deploy em Produção
+
+### Backend
+
+```bash
+# Instalar dependências
+pip install -r requirements.txt
+
+# Rodar com Gunicorn
+gunicorn chatgpt_backend:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000
+```
+
+### Frontend
+
+```bash
+# Build de produção
+npm run build
+
+# Servir build
+npm run start
+```
+
+### Docker (TODO)
+
+```bash
+docker-compose up
+```
+
+## 📝 Notas
+
+- **Custos**: Cada execução consome tokens do LLM escolhido
+- **Rate Limits**: Respeite os limites da API do provedor LLM
+- **Segurança**: Não exponha suas API keys publicamente
+- **Browser**: Chromium será baixado automaticamente pelo Playwright
+
+## 🤝 Contribuindo
+
+Contribuições são bem-vindas! Por favor:
+
+1. Fork o repositório
+2. Crie uma branch para sua feature
+3. Commit suas mudanças
+4. Push para a branch
+5. Abra um Pull Request
+
+## 📄 Licença
+
+MIT License - veja LICENSE para detalhes
+
+## 🙏 Agradecimentos
+
+- Browser-Use team pelo framework incrível
+- OpenAI pela API de LLM e Whisper
+- Next.js e React pela base do frontend
+- Tailwind CSS pelo sistema de design

--- a/examples/ui/chatgpt-frontend/app/globals.css
+++ b/examples/ui/chatgpt-frontend/app/globals.css
@@ -1,0 +1,86 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --bg-primary: #fff;
+  --bg-secondary: #f7f7f8;
+  --text-primary: #202123;
+  --text-secondary: #565869;
+  --border-color: #d9d9e3;
+}
+
+[data-theme='dark'] {
+  --bg-primary: #343541;
+  --bg-secondary: #444654;
+  --text-primary: #ececf1;
+  --text-secondary: #c5c5d2;
+  --border-color: #565869;
+}
+
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+/* Scrollbar customizado */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #565869;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #6e6e80;
+}
+
+/* Animações */
+@keyframes pulse-subtle {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.animate-pulse-subtle {
+  animation: pulse-subtle 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+/* Markdown styles */
+.markdown-content {
+  @apply text-base leading-relaxed;
+}
+
+.markdown-content p {
+  @apply mb-4;
+}
+
+.markdown-content ul, .markdown-content ol {
+  @apply mb-4 ml-6;
+}
+
+.markdown-content li {
+  @apply mb-2;
+}
+
+.markdown-content code {
+  @apply bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded text-sm font-mono;
+}
+
+.markdown-content pre {
+  @apply bg-gray-900 text-gray-100 p-4 rounded-lg mb-4 overflow-x-auto;
+}
+
+.markdown-content pre code {
+  @apply bg-transparent p-0;
+}

--- a/examples/ui/chatgpt-frontend/app/layout.tsx
+++ b/examples/ui/chatgpt-frontend/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+import { Inter } from 'next/font/google'
+import './globals.css'
+
+const inter = Inter({ subsets: ['latin'] })
+
+export const metadata: Metadata = {
+  title: 'Browser-Use Chat',
+  description: 'ChatGPT-style interface for browser automation',
+}
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="pt-BR">
+      <body className={inter.className}>{children}</body>
+    </html>
+  )
+}

--- a/examples/ui/chatgpt-frontend/app/page.tsx
+++ b/examples/ui/chatgpt-frontend/app/page.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+import Sidebar from '@/components/Sidebar'
+import ChatInterface from '@/components/ChatInterface'
+import BrowserPreview from '@/components/BrowserPreview'
+
+export default function Home() {
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null)
+  const [showBrowserPreview, setShowBrowserPreview] = useState(true)
+
+  return (
+    <main className="flex h-screen bg-chatgpt-gray-50 dark:bg-chatgpt-gray-900">
+      {/* Sidebar */}
+      <Sidebar 
+        currentSessionId={currentSessionId}
+        onSessionSelect={setCurrentSessionId}
+      />
+
+      {/* Chat Area */}
+      <div className="flex-1 flex flex-col">
+        <ChatInterface 
+          sessionId={currentSessionId}
+          onSessionCreated={setCurrentSessionId}
+          onToggleBrowserPreview={() => setShowBrowserPreview(!showBrowserPreview)}
+        />
+      </div>
+
+      {/* Browser Preview (collapsible) */}
+      {showBrowserPreview && (
+        <BrowserPreview 
+          sessionId={currentSessionId}
+          onClose={() => setShowBrowserPreview(false)}
+        />
+      )}
+    </main>
+  )
+}

--- a/examples/ui/chatgpt-frontend/components/ActionTimeline.tsx
+++ b/examples/ui/chatgpt-frontend/components/ActionTimeline.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+
+interface Step {
+  stepNumber: number
+  action: string
+  thought?: string
+  screenshot?: string
+  timestamp: string
+}
+
+interface ActionTimelineProps {
+  steps: Step[]
+}
+
+export default function ActionTimeline({ steps }: ActionTimelineProps) {
+  const [expandedSteps, setExpandedSteps] = useState<Set<number>>(new Set())
+
+  const toggleStep = (stepNumber: number) => {
+    const newExpanded = new Set(expandedSteps)
+    if (newExpanded.has(stepNumber)) {
+      newExpanded.delete(stepNumber)
+    } else {
+      newExpanded.add(stepNumber)
+    }
+    setExpandedSteps(newExpanded)
+  }
+
+  if (steps.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="mt-6 border-t border-chatgpt-gray-200 dark:border-chatgpt-gray-700 pt-4">
+      <h3 className="text-sm font-semibold mb-3 text-chatgpt-gray-200">
+        Timeline de Ações ({steps.length} steps)
+      </h3>
+
+      <div className="space-y-2">
+        {steps.map((step) => {
+          const isExpanded = expandedSteps.has(step.stepNumber)
+
+          return (
+            <div
+              key={step.stepNumber}
+              className="border border-chatgpt-gray-200 dark:border-chatgpt-gray-700 rounded-lg overflow-hidden"
+            >
+              {/* Step Header */}
+              <button
+                onClick={() => toggleStep(step.stepNumber)}
+                className="w-full flex items-center gap-3 px-4 py-3 hover:bg-chatgpt-gray-50 dark:hover:bg-chatgpt-gray-800 transition-colors"
+              >
+                {isExpanded ? (
+                  <ChevronDown size={16} className="flex-shrink-0" />
+                ) : (
+                  <ChevronRight size={16} className="flex-shrink-0" />
+                )}
+
+                <div className="flex-1 text-left">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs font-mono text-chatgpt-gray-200">
+                      Step {step.stepNumber}
+                    </span>
+                    <span className="text-sm font-medium">{step.action}</span>
+                  </div>
+                  <div className="text-xs text-chatgpt-gray-200 mt-0.5">
+                    {new Date(step.timestamp).toLocaleTimeString('pt-BR')}
+                  </div>
+                </div>
+              </button>
+
+              {/* Step Details (expandible) */}
+              {isExpanded && (
+                <div className="px-4 pb-4 border-t border-chatgpt-gray-200 dark:border-chatgpt-gray-700">
+                  {/* Thought */}
+                  {step.thought && (
+                    <div className="mt-3">
+                      <div className="text-xs font-semibold text-chatgpt-gray-200 mb-1">
+                        Pensamento:
+                      </div>
+                      <div className="text-sm bg-chatgpt-gray-50 dark:bg-chatgpt-gray-900 rounded p-3">
+                        {step.thought}
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Screenshot */}
+                  {step.screenshot && (
+                    <div className="mt-3">
+                      <div className="text-xs font-semibold text-chatgpt-gray-200 mb-1">
+                        Screenshot:
+                      </div>
+                      <img
+                        src={`data:image/png;base64,${step.screenshot}`}
+                        alt={`Step ${step.stepNumber}`}
+                        className="rounded border border-chatgpt-gray-200 dark:border-chatgpt-gray-700 max-w-full h-auto cursor-pointer hover:opacity-90"
+                        onClick={() => {
+                          const win = window.open()
+                          if (win) {
+                            win.document.write(
+                              `<img src="data:image/png;base64,${step.screenshot}" />`
+                            )
+                          }
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/examples/ui/chatgpt-frontend/components/BrowserPreview.tsx
+++ b/examples/ui/chatgpt-frontend/components/BrowserPreview.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { X, ExternalLink, Maximize2 } from 'lucide-react'
+
+interface BrowserPreviewProps {
+  sessionId: string | null
+  onClose: () => void
+}
+
+export default function BrowserPreview({ sessionId, onClose }: BrowserPreviewProps) {
+  const [currentUrl, setCurrentUrl] = useState<string>('')
+  const [currentTitle, setCurrentTitle] = useState<string>('')
+  const [screenshot, setScreenshot] = useState<string | null>(null)
+  const [stepNumber, setStepNumber] = useState<number>(0)
+
+  useEffect(() => {
+    if (!sessionId) return
+
+    // Conectar ao WebSocket para receber atualizações
+    const ws = new WebSocket(`ws://localhost:8000/ws/${sessionId}`)
+
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data)
+      
+      if (data.type === 'step') {
+        setCurrentUrl(data.url || '')
+        setCurrentTitle(data.title || '')
+        setScreenshot(data.screenshot || null)
+        setStepNumber(data.step_number || 0)
+      }
+    }
+
+    return () => {
+      ws.close()
+    }
+  }, [sessionId])
+
+  const openInNewTab = () => {
+    if (currentUrl) {
+      window.open(currentUrl, '_blank')
+    }
+  }
+
+  return (
+    <div className="w-96 bg-white dark:bg-chatgpt-gray-800 border-l border-chatgpt-gray-200 dark:border-chatgpt-gray-700 flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-chatgpt-gray-200 dark:border-chatgpt-gray-700">
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-sm">Browser Preview</h3>
+          {stepNumber > 0 && (
+            <p className="text-xs text-chatgpt-gray-200">Step {stepNumber}</p>
+          )}
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1.5 rounded hover:bg-chatgpt-gray-100 dark:hover:bg-chatgpt-gray-700"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      {/* URL Bar */}
+      {currentUrl && (
+        <div className="px-4 py-2 border-b border-chatgpt-gray-200 dark:border-chatgpt-gray-700">
+          <div className="flex items-center gap-2">
+            <div className="flex-1 min-w-0 px-3 py-1.5 rounded bg-chatgpt-gray-100 dark:bg-chatgpt-gray-900 text-sm truncate">
+              {currentUrl}
+            </div>
+            <button
+              onClick={openInNewTab}
+              className="p-1.5 rounded hover:bg-chatgpt-gray-100 dark:hover:bg-chatgpt-gray-700"
+              title="Abrir em nova aba"
+            >
+              <ExternalLink size={16} />
+            </button>
+          </div>
+          {currentTitle && (
+            <div className="mt-1 text-xs text-chatgpt-gray-200 truncate">
+              {currentTitle}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Screenshot */}
+      <div className="flex-1 overflow-y-auto p-4">
+        {screenshot ? (
+          <div className="relative group">
+            <img
+              src={`data:image/png;base64,${screenshot}`}
+              alt="Browser Screenshot"
+              className="w-full h-auto rounded-lg border border-chatgpt-gray-200 dark:border-chatgpt-gray-700"
+            />
+            <button
+              onClick={() => {
+                const win = window.open()
+                if (win) {
+                  win.document.write(`
+                    <html>
+                      <head><title>Screenshot - Step ${stepNumber}</title></head>
+                      <body style="margin:0;background:#000;display:flex;align-items:center;justify-content:center;">
+                        <img src="data:image/png;base64,${screenshot}" style="max-width:100%;max-height:100vh;" />
+                      </body>
+                    </html>
+                  `)
+                }
+              }}
+              className="absolute top-2 right-2 p-2 rounded bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity"
+              title="Ampliar"
+            >
+              <Maximize2 size={16} />
+            </button>
+          </div>
+        ) : (
+          <div className="h-full flex items-center justify-center text-chatgpt-gray-200">
+            <div className="text-center">
+              <Monitor size={48} className="mx-auto mb-4 opacity-50" />
+              <p className="text-sm">Aguardando navegação...</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Monitor({ size, className }: { size: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  )
+}

--- a/examples/ui/chatgpt-frontend/components/ChatInterface.tsx
+++ b/examples/ui/chatgpt-frontend/components/ChatInterface.tsx
@@ -1,0 +1,345 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { Send, Mic, MicOff, Monitor, Pause, Play, Square } from 'lucide-react'
+import MessageBubble from './MessageBubble'
+import ActionTimeline from './ActionTimeline'
+import { useWebSocket } from '@/hooks/useWebSocket'
+import { useSpeechRecognition } from '@/hooks/useSpeechRecognition'
+
+interface Message {
+  id: string
+  type: 'user' | 'assistant' | 'system'
+  content: string
+  timestamp: string
+  screenshot?: string
+  action?: string
+  thought?: string
+  stepNumber?: number
+}
+
+interface ChatInterfaceProps {
+  sessionId: string | null
+  onSessionCreated: (sessionId: string) => void
+  onToggleBrowserPreview: () => void
+}
+
+export default function ChatInterface({ 
+  sessionId, 
+  onSessionCreated,
+  onToggleBrowserPreview 
+}: ChatInterfaceProps) {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [isPaused, setIsPaused] = useState(false)
+  const [currentStep, setCurrentStep] = useState(0)
+  const [maxSteps, setMaxSteps] = useState(10)
+  
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const { isListening, transcript, startListening, stopListening, isSupported } = useSpeechRecognition()
+  const { sendMessage, agentStatus } = useWebSocket(sessionId, (event) => {
+    handleWebSocketEvent(event)
+  })
+
+  // Auto-scroll para última mensagem
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  // Atualizar input com transcrição de voz
+  useEffect(() => {
+    if (transcript) {
+      setInput(transcript)
+    }
+  }, [transcript])
+
+  const handleWebSocketEvent = (event: any) => {
+    switch (event.type) {
+      case 'agent_started':
+        setIsLoading(true)
+        setMaxSteps(event.max_steps)
+        addSystemMessage(`Agente iniciado: ${event.task}`)
+        break
+
+      case 'step':
+        setCurrentStep(event.step_number)
+        addAssistantMessage({
+          content: event.thought || `Executando: ${event.action}`,
+          screenshot: event.screenshot,
+          action: event.action,
+          thought: event.thought,
+          stepNumber: event.step_number,
+        })
+        break
+
+      case 'done':
+        setIsLoading(false)
+        addSystemMessage(`Tarefa concluída! ${event.total_steps} steps executados.`)
+        if (event.final_result) {
+          addAssistantMessage({ content: event.final_result })
+        }
+        break
+
+      case 'error':
+        setIsLoading(false)
+        addSystemMessage(`Erro: ${event.error}`, 'error')
+        break
+
+      case 'control':
+        if (event.action === 'paused') {
+          setIsPaused(true)
+          addSystemMessage('Agente pausado')
+        } else if (event.action === 'resumed') {
+          setIsPaused(false)
+          addSystemMessage('Agente resumido')
+        } else if (event.action === 'stopped') {
+          setIsLoading(false)
+          addSystemMessage('Agente parado')
+        }
+        break
+    }
+  }
+
+  const addUserMessage = (content: string) => {
+    const message: Message = {
+      id: Date.now().toString(),
+      type: 'user',
+      content,
+      timestamp: new Date().toISOString(),
+    }
+    setMessages((prev) => [...prev, message])
+  }
+
+  const addAssistantMessage = (data: {
+    content: string
+    screenshot?: string
+    action?: string
+    thought?: string
+    stepNumber?: number
+  }) => {
+    const message: Message = {
+      id: Date.now().toString(),
+      type: 'assistant',
+      ...data,
+      timestamp: new Date().toISOString(),
+    }
+    setMessages((prev) => [...prev, message])
+  }
+
+  const addSystemMessage = (content: string, variant: 'info' | 'error' = 'info') => {
+    const message: Message = {
+      id: Date.now().toString(),
+      type: 'system',
+      content,
+      timestamp: new Date().toISOString(),
+    }
+    setMessages((prev) => [...prev, message])
+  }
+
+  const handleSendMessage = async () => {
+    if (!input.trim()) return
+
+    const messageText = input.trim()
+    setInput('')
+    addUserMessage(messageText)
+    setIsLoading(true)
+
+    try {
+      const response = await fetch('http://localhost:8000/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: messageText,
+          session_id: sessionId,
+          llm_provider: 'openai',
+          llm_model: 'gpt-4o-mini',
+          max_steps: 10,
+        }),
+      })
+
+      const data = await response.json()
+      
+      if (!sessionId) {
+        onSessionCreated(data.session_id)
+      }
+    } catch (error) {
+      console.error('Erro ao enviar mensagem:', error)
+      addSystemMessage('Erro ao enviar mensagem', 'error')
+      setIsLoading(false)
+    }
+  }
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSendMessage()
+    }
+  }
+
+  const handleToggleMic = () => {
+    if (isListening) {
+      stopListening()
+    } else {
+      startListening()
+    }
+  }
+
+  const handleControlAgent = async (action: 'pause' | 'resume' | 'stop') => {
+    if (!sessionId) return
+
+    try {
+      await fetch(`http://localhost:8000/api/session/${sessionId}/control`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action }),
+      })
+    } catch (error) {
+      console.error(`Erro ao ${action} agente:`, error)
+    }
+  }
+
+  return (
+    <div className="flex-1 flex flex-col h-full">
+      {/* Header */}
+      <div className="bg-white dark:bg-chatgpt-gray-800 border-b border-chatgpt-gray-200 dark:border-chatgpt-gray-700 px-6 py-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold">Browser-Use Agent</h1>
+            {isLoading && (
+              <p className="text-sm text-chatgpt-gray-200">
+                Executando step {currentStep} de {maxSteps}...
+              </p>
+            )}
+          </div>
+          
+          <div className="flex items-center gap-2">
+            {/* Controles do agente */}
+            {isLoading && (
+              <>
+                {isPaused ? (
+                  <button
+                    onClick={() => handleControlAgent('resume')}
+                    className="p-2 rounded-lg hover:bg-chatgpt-gray-100 dark:hover:bg-chatgpt-gray-700"
+                    title="Resumir"
+                  >
+                    <Play size={20} />
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => handleControlAgent('pause')}
+                    className="p-2 rounded-lg hover:bg-chatgpt-gray-100 dark:hover:bg-chatgpt-gray-700"
+                    title="Pausar"
+                  >
+                    <Pause size={20} />
+                  </button>
+                )}
+                <button
+                  onClick={() => handleControlAgent('stop')}
+                  className="p-2 rounded-lg hover:bg-chatgpt-gray-100 dark:hover:bg-chatgpt-gray-700 text-red-500"
+                  title="Parar"
+                >
+                  <Square size={20} />
+                </button>
+              </>
+            )}
+            
+            <button
+              onClick={onToggleBrowserPreview}
+              className="p-2 rounded-lg hover:bg-chatgpt-gray-100 dark:hover:bg-chatgpt-gray-700"
+              title="Toggle Browser Preview"
+            >
+              <Monitor size={20} />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Messages Area */}
+      <div className="flex-1 overflow-y-auto px-6 py-4">
+        {messages.length === 0 ? (
+          <div className="h-full flex items-center justify-center">
+            <div className="text-center max-w-md">
+              <h2 className="text-2xl font-semibold mb-4">
+                Como posso ajudar você hoje?
+              </h2>
+              <p className="text-chatgpt-gray-200 mb-6">
+                Digite uma tarefa de automação web ou use o microfone para falar
+              </p>
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div className="p-4 rounded-lg bg-chatgpt-gray-100 dark:bg-chatgpt-gray-800 cursor-pointer hover:bg-chatgpt-gray-200 dark:hover:bg-chatgpt-gray-700">
+                  Buscar informações no Google
+                </div>
+                <div className="p-4 rounded-lg bg-chatgpt-gray-100 dark:bg-chatgpt-gray-800 cursor-pointer hover:bg-chatgpt-gray-200 dark:hover:bg-chatgpt-gray-700">
+                  Preencher formulário
+                </div>
+                <div className="p-4 rounded-lg bg-chatgpt-gray-100 dark:bg-chatgpt-gray-800 cursor-pointer hover:bg-chatgpt-gray-200 dark:hover:bg-chatgpt-gray-700">
+                  Extrair dados de site
+                </div>
+                <div className="p-4 rounded-lg bg-chatgpt-gray-100 dark:bg-chatgpt-gray-800 cursor-pointer hover:bg-chatgpt-gray-200 dark:hover:bg-chatgpt-gray-700">
+                  Adicionar item ao carrinho
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="max-w-4xl mx-auto">
+            {messages.map((message) => (
+              <MessageBubble key={message.id} message={message} />
+            ))}
+            <div ref={messagesEndRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Input Area */}
+      <div className="bg-white dark:bg-chatgpt-gray-800 border-t border-chatgpt-gray-200 dark:border-chatgpt-gray-700 px-6 py-4">
+        <div className="max-w-4xl mx-auto">
+          <div className="relative flex items-end gap-2">
+            <div className="flex-1 relative">
+              <textarea
+                value={input}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyPress={handleKeyPress}
+                placeholder="Digite sua mensagem..."
+                rows={1}
+                className="w-full px-4 py-3 pr-12 rounded-xl border border-chatgpt-gray-200 dark:border-chatgpt-gray-700 bg-white dark:bg-chatgpt-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                style={{ minHeight: '52px', maxHeight: '200px' }}
+              />
+              
+              {/* Mic Button */}
+              {isSupported && (
+                <button
+                  onClick={handleToggleMic}
+                  className={`absolute right-3 top-1/2 -translate-y-1/2 p-2 rounded-lg transition-colors ${
+                    isListening 
+                      ? 'text-red-500 bg-red-50 dark:bg-red-900/20' 
+                      : 'text-chatgpt-gray-200 hover:bg-chatgpt-gray-100 dark:hover:bg-chatgpt-gray-700'
+                  }`}
+                  title={isListening ? 'Parar gravação' : 'Gravar áudio'}
+                >
+                  {isListening ? <MicOff size={20} /> : <Mic size={20} />}
+                </button>
+              )}
+            </div>
+
+            <button
+              onClick={handleSendMessage}
+              disabled={!input.trim() || isLoading}
+              className="p-3 rounded-xl bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <Send size={20} />
+            </button>
+          </div>
+          
+          {isListening && (
+            <div className="mt-2 text-sm text-red-500 flex items-center gap-2">
+              <span className="animate-pulse-subtle">🔴</span>
+              Gravando...
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/examples/ui/chatgpt-frontend/components/MessageBubble.tsx
+++ b/examples/ui/chatgpt-frontend/components/MessageBubble.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { User, Bot, Info } from 'lucide-react'
+
+interface Message {
+  id: string
+  type: 'user' | 'assistant' | 'system'
+  content: string
+  timestamp: string
+  screenshot?: string
+  action?: string
+  thought?: string
+  stepNumber?: number
+}
+
+interface MessageBubbleProps {
+  message: Message
+}
+
+export default function MessageBubble({ message }: MessageBubbleProps) {
+  const isUser = message.type === 'user'
+  const isSystem = message.type === 'system'
+
+  if (isSystem) {
+    return (
+      <div className="flex justify-center my-4">
+        <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400 text-sm">
+          <Info size={16} />
+          <span>{message.content}</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`flex gap-4 mb-6 ${isUser ? 'flex-row-reverse' : ''}`}>
+      {/* Avatar */}
+      <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${
+        isUser 
+          ? 'bg-blue-500 text-white' 
+          : 'bg-green-500 text-white'
+      }`}>
+        {isUser ? <User size={18} /> : <Bot size={18} />}
+      </div>
+
+      {/* Content */}
+      <div className={`flex-1 ${isUser ? 'flex justify-end' : ''}`}>
+        <div className={`max-w-3xl ${isUser ? 'text-right' : ''}`}>
+          {/* Message Content */}
+          <div className={`rounded-2xl px-4 py-3 ${
+            isUser 
+              ? 'bg-blue-500 text-white' 
+              : 'bg-chatgpt-gray-100 dark:bg-chatgpt-gray-800'
+          }`}>
+            <ReactMarkdown 
+              remarkPlugins={[remarkGfm]}
+              className="markdown-content"
+            >
+              {message.content}
+            </ReactMarkdown>
+          </div>
+
+          {/* Step Info (apenas para assistant) */}
+          {!isUser && message.stepNumber && (
+            <div className="mt-2 text-xs text-chatgpt-gray-200 space-y-1">
+              <div>Step {message.stepNumber}</div>
+              {message.action && (
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">Ação:</span>
+                  <span className="px-2 py-0.5 rounded bg-chatgpt-gray-200 dark:bg-chatgpt-gray-700">
+                    {message.action}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Screenshot (apenas para assistant) */}
+          {!isUser && message.screenshot && (
+            <div className="mt-3">
+              <img 
+                src={`data:image/png;base64,${message.screenshot}`}
+                alt={`Screenshot - Step ${message.stepNumber}`}
+                className="rounded-lg border border-chatgpt-gray-200 dark:border-chatgpt-gray-700 max-w-full h-auto cursor-pointer hover:opacity-90 transition-opacity"
+                onClick={() => {
+                  // Abrir screenshot em nova aba
+                  const win = window.open()
+                  if (win) {
+                    win.document.write(`<img src="data:image/png;base64,${message.screenshot}" />`)
+                  }
+                }}
+              />
+            </div>
+          )}
+
+          {/* Timestamp */}
+          <div className="mt-1 text-xs text-chatgpt-gray-200 opacity-70">
+            {new Date(message.timestamp).toLocaleTimeString('pt-BR', {
+              hour: '2-digit',
+              minute: '2-digit'
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/examples/ui/chatgpt-frontend/components/Sidebar.tsx
+++ b/examples/ui/chatgpt-frontend/components/Sidebar.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { MessageSquare, Plus, Trash2 } from 'lucide-react'
+
+interface Session {
+  id: string
+  title: string
+  createdAt: string
+}
+
+interface SidebarProps {
+  currentSessionId: string | null
+  onSessionSelect: (sessionId: string) => void
+}
+
+export default function Sidebar({ currentSessionId, onSessionSelect }: SidebarProps) {
+  const [sessions, setSessions] = useState<Session[]>([])
+
+  const createNewChat = () => {
+    // Criar nova sessão (será criada de fato quando enviar primeira mensagem)
+    const newSessionId = `new-${Date.now()}`
+    onSessionSelect(newSessionId)
+  }
+
+  const deleteSession = (sessionId: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setSessions(sessions.filter(s => s.id !== sessionId))
+    if (currentSessionId === sessionId) {
+      onSessionSelect('')
+    }
+  }
+
+  return (
+    <div className="w-64 bg-chatgpt-gray-900 text-white flex flex-col h-full">
+      {/* Header */}
+      <div className="p-3 border-b border-chatgpt-gray-700">
+        <button
+          onClick={createNewChat}
+          className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg border border-chatgpt-gray-700 hover:bg-chatgpt-gray-800 transition-colors"
+        >
+          <Plus size={18} />
+          <span className="text-sm font-medium">Novo Chat</span>
+        </button>
+      </div>
+
+      {/* Sessions List */}
+      <div className="flex-1 overflow-y-auto p-2">
+        {sessions.length === 0 ? (
+          <div className="text-center text-chatgpt-gray-200 text-sm mt-8">
+            <MessageSquare size={32} className="mx-auto mb-2 opacity-50" />
+            <p className="opacity-70">Nenhuma conversa ainda</p>
+            <p className="opacity-50 text-xs mt-1">Inicie um novo chat</p>
+          </div>
+        ) : (
+          sessions.map((session) => (
+            <div
+              key={session.id}
+              onClick={() => onSessionSelect(session.id)}
+              className={`
+                group flex items-center justify-between gap-2 px-3 py-2.5 rounded-lg mb-1 cursor-pointer
+                ${currentSessionId === session.id 
+                  ? 'bg-chatgpt-gray-800' 
+                  : 'hover:bg-chatgpt-gray-800'
+                }
+              `}
+            >
+              <div className="flex items-center gap-3 flex-1 min-w-0">
+                <MessageSquare size={16} className="flex-shrink-0 opacity-70" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm truncate">{session.title}</p>
+                  <p className="text-xs opacity-50 truncate">{session.createdAt}</p>
+                </div>
+              </div>
+              <button
+                onClick={(e) => deleteSession(session.id, e)}
+                className="opacity-0 group-hover:opacity-100 p-1 hover:text-red-400 transition-opacity"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="p-3 border-t border-chatgpt-gray-700">
+        <div className="text-xs text-chatgpt-gray-200 opacity-70 text-center">
+          Browser-Use Chat v1.0
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/examples/ui/chatgpt-frontend/hooks/useSpeechRecognition.ts
+++ b/examples/ui/chatgpt-frontend/hooks/useSpeechRecognition.ts
@@ -1,0 +1,94 @@
+import { useState, useEffect, useCallback } from 'react'
+
+interface UseSpeechRecognitionReturn {
+  isListening: boolean
+  transcript: string
+  startListening: () => void
+  stopListening: () => void
+  isSupported: boolean
+}
+
+export function useSpeechRecognition(): UseSpeechRecognitionReturn {
+  const [isListening, setIsListening] = useState(false)
+  const [transcript, setTranscript] = useState('')
+  const [recognition, setRecognition] = useState<any>(null)
+
+  // Verificar se Speech Recognition API está disponível
+  const isSupported = typeof window !== 'undefined' && 
+    ('SpeechRecognition' in window || 'webkitSpeechRecognition' in window)
+
+  useEffect(() => {
+    if (!isSupported) return
+
+    // Criar instância do Speech Recognition
+    const SpeechRecognition = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    const recognitionInstance = new SpeechRecognition()
+
+    recognitionInstance.continuous = true
+    recognitionInstance.interimResults = true
+    recognitionInstance.lang = 'pt-BR'
+
+    recognitionInstance.onresult = (event: any) => {
+      let finalTranscript = ''
+      
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const transcript = event.results[i][0].transcript
+        if (event.results[i].isFinal) {
+          finalTranscript += transcript + ' '
+        }
+      }
+
+      if (finalTranscript) {
+        setTranscript(finalTranscript.trim())
+      }
+    }
+
+    recognitionInstance.onerror = (event: any) => {
+      console.error('Erro no reconhecimento de voz:', event.error)
+      setIsListening(false)
+    }
+
+    recognitionInstance.onend = () => {
+      setIsListening(false)
+    }
+
+    setRecognition(recognitionInstance)
+
+    return () => {
+      if (recognitionInstance) {
+        recognitionInstance.stop()
+      }
+    }
+  }, [isSupported])
+
+  const startListening = useCallback(() => {
+    if (!recognition) return
+
+    try {
+      setTranscript('')
+      recognition.start()
+      setIsListening(true)
+    } catch (error) {
+      console.error('Erro ao iniciar reconhecimento de voz:', error)
+    }
+  }, [recognition])
+
+  const stopListening = useCallback(() => {
+    if (!recognition) return
+
+    try {
+      recognition.stop()
+      setIsListening(false)
+    } catch (error) {
+      console.error('Erro ao parar reconhecimento de voz:', error)
+    }
+  }, [recognition])
+
+  return {
+    isListening,
+    transcript,
+    startListening,
+    stopListening,
+    isSupported,
+  }
+}

--- a/examples/ui/chatgpt-frontend/hooks/useWebSocket.ts
+++ b/examples/ui/chatgpt-frontend/hooks/useWebSocket.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react'
+
+interface UseWebSocketReturn {
+  sendMessage: (message: any) => void
+  agentStatus: 'idle' | 'running' | 'paused' | 'stopped'
+}
+
+export function useWebSocket(
+  sessionId: string | null,
+  onMessage: (data: any) => void
+): UseWebSocketReturn {
+  const wsRef = useRef<WebSocket | null>(null)
+  const [agentStatus, setAgentStatus] = useState<'idle' | 'running' | 'paused' | 'stopped'>('idle')
+
+  useEffect(() => {
+    if (!sessionId || sessionId.startsWith('new-')) {
+      return
+    }
+
+    // Conectar ao WebSocket
+    const ws = new WebSocket(`ws://localhost:8000/ws/${sessionId}`)
+
+    ws.onopen = () => {
+      console.log('WebSocket conectado')
+      setAgentStatus('idle')
+    }
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data)
+        console.log('WebSocket message:', data)
+
+        // Atualizar status baseado no tipo de evento
+        if (data.type === 'agent_started') {
+          setAgentStatus('running')
+        } else if (data.type === 'control') {
+          if (data.action === 'paused') setAgentStatus('paused')
+          if (data.action === 'resumed') setAgentStatus('running')
+          if (data.action === 'stopped') setAgentStatus('stopped')
+        } else if (data.type === 'done') {
+          setAgentStatus('idle')
+        }
+
+        onMessage(data)
+      } catch (error) {
+        console.error('Erro ao processar mensagem WebSocket:', error)
+      }
+    }
+
+    ws.onerror = (error) => {
+      console.error('Erro no WebSocket:', error)
+    }
+
+    ws.onclose = () => {
+      console.log('WebSocket desconectado')
+      setAgentStatus('idle')
+    }
+
+    wsRef.current = ws
+
+    return () => {
+      ws.close()
+    }
+  }, [sessionId, onMessage])
+
+  const sendMessage = (message: any) => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify(message))
+    }
+  }
+
+  return {
+    sendMessage,
+    agentStatus,
+  }
+}

--- a/examples/ui/chatgpt-frontend/next.config.js
+++ b/examples/ui/chatgpt-frontend/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    domains: ['localhost'],
+  },
+}
+
+module.exports = nextConfig

--- a/examples/ui/chatgpt-frontend/package.json
+++ b/examples/ui/chatgpt-frontend/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "browser-use-chatgpt-frontend",
+  "version": "1.0.0",
+  "description": "ChatGPT-style frontend for browser-use",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "^14.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.6.0",
+    "lucide-react": "^0.300.0",
+    "react-markdown": "^9.0.0",
+    "remark-gfm": "^4.0.0",
+    "zustand": "^4.4.7"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.0.0",
+    "eslint-config-next": "^14.0.0",
+    "postcss": "^8.4.32",
+    "tailwindcss": "^3.3.6",
+    "typescript": "^5.3.0"
+  }
+}

--- a/examples/ui/chatgpt-frontend/postcss.config.js
+++ b/examples/ui/chatgpt-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/examples/ui/chatgpt-frontend/tailwind.config.js
+++ b/examples/ui/chatgpt-frontend/tailwind.config.js
@@ -1,0 +1,23 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx,mdx}',
+    './components/**/*.{js,ts,jsx,tsx,mdx}',
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        'chatgpt-gray': {
+          50: '#f7f7f8',
+          100: '#ececf1',
+          200: '#d9d9e3',
+          700: '#40414f',
+          800: '#343541',
+          900: '#202123',
+        },
+      },
+    },
+  },
+  plugins: [],
+}

--- a/examples/ui/chatgpt-frontend/tsconfig.json
+++ b/examples/ui/chatgpt-frontend/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/ui/chatgpt_backend.py
+++ b/examples/ui/chatgpt_backend.py
@@ -1,0 +1,386 @@
+"""
+FastAPI backend para interface ChatGPT-style do browser-use.
+
+Fornece endpoints REST e WebSocket para:
+- Criar e gerenciar sessões de agente
+- Streaming de eventos em tempo real
+- Controle de execução (pause/resume/stop)
+- Upload de áudio para transcrição
+"""
+
+import asyncio
+import base64
+import logging
+import os
+import uuid
+from pathlib import Path
+from typing import Dict, Optional
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, UploadFile, File
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
+
+from browser_use import Agent
+from browser_use.browser.browser import Browser
+from browser_use.browser.context import BrowserContext
+
+from session_manager import SessionManager
+from voice_services import VoiceServices
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Inicializar FastAPI
+app = FastAPI(title="Browser-Use ChatGPT API", version="1.0.0")
+
+# CORS para permitir frontend React
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:3000", "http://localhost:3001"],  # Next.js default ports
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Gerenciador de sessões global
+session_manager = SessionManager()
+
+# Serviços de voz
+voice_services = VoiceServices()
+
+
+# ==================== Models ====================
+
+class ChatRequest(BaseModel):
+    """Requisição para criar nova tarefa de chat"""
+    message: str
+    session_id: Optional[str] = None
+    llm_provider: str = "openai"
+    llm_model: str = "gpt-4o-mini"
+    max_steps: int = 10
+
+
+class ChatResponse(BaseModel):
+    """Resposta ao criar chat"""
+    session_id: str
+    message: str
+    status: str
+
+
+class ControlRequest(BaseModel):
+    """Requisição para controlar execução do agente"""
+    action: str  # 'pause', 'resume', 'stop'
+
+
+class SessionStatus(BaseModel):
+    """Status da sessão"""
+    session_id: str
+    active: bool
+    paused: bool
+    stopped: bool
+    current_step: int
+    max_steps: int
+    task: str
+
+
+# ==================== Endpoints REST ====================
+
+@app.get("/")
+async def root():
+    """Health check endpoint"""
+    return {
+        "status": "ok",
+        "service": "Browser-Use ChatGPT API",
+        "active_sessions": len(session_manager.sessions)
+    }
+
+
+@app.post("/api/chat", response_model=ChatResponse)
+async def create_chat(request: ChatRequest):
+    """
+    Cria uma nova sessão de chat ou adiciona mensagem a sessão existente.
+    
+    Args:
+        request: ChatRequest com mensagem e configurações
+        
+    Returns:
+        ChatResponse com session_id e status
+    """
+    try:
+        # Criar ou recuperar sessão
+        if request.session_id and request.session_id in session_manager.sessions:
+            session_id = request.session_id
+            logger.info(f"Adicionando tarefa à sessão existente: {session_id}")
+        else:
+            session_id = str(uuid.uuid4())
+            logger.info(f"Criando nova sessão: {session_id}")
+        
+        # Criar agente em background
+        asyncio.create_task(
+            session_manager.create_agent_session(
+                session_id=session_id,
+                task=request.message,
+                llm_provider=request.llm_provider,
+                llm_model=request.llm_model,
+                max_steps=request.max_steps
+            )
+        )
+        
+        return ChatResponse(
+            session_id=session_id,
+            message="Agente iniciado com sucesso",
+            status="running"
+        )
+        
+    except Exception as e:
+        logger.error(f"Erro ao criar chat: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/api/session/{session_id}/status", response_model=SessionStatus)
+async def get_session_status(session_id: str):
+    """
+    Obtém status atual da sessão.
+    
+    Args:
+        session_id: ID da sessão
+        
+    Returns:
+        SessionStatus com informações da sessão
+    """
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Sessão não encontrada")
+    
+    agent = session.get("agent")
+    
+    return SessionStatus(
+        session_id=session_id,
+        active=session.get("active", False),
+        paused=agent.state.paused if agent else False,
+        stopped=agent.state.stopped if agent else False,
+        current_step=agent.state.n_steps if agent else 0,
+        max_steps=session.get("max_steps", 10),
+        task=session.get("task", "")
+    )
+
+
+@app.post("/api/session/{session_id}/control")
+async def control_session(session_id: str, request: ControlRequest):
+    """
+    Controla execução do agente (pause/resume/stop).
+    
+    Args:
+        session_id: ID da sessão
+        request: ControlRequest com ação desejada
+        
+    Returns:
+        Status da operação
+    """
+    try:
+        result = await session_manager.control_agent(session_id, request.action)
+        return {"status": "success", "action": request.action, "result": result}
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logger.error(f"Erro ao controlar sessão: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/api/session/{session_id}/history")
+async def get_session_history(session_id: str):
+    """
+    Obtém histórico completo da sessão.
+    
+    Args:
+        session_id: ID da sessão
+        
+    Returns:
+        Lista de eventos/mensagens da sessão
+    """
+    history = session_manager.get_history(session_id)
+    if history is None:
+        raise HTTPException(status_code=404, detail="Sessão não encontrada")
+    
+    return {"session_id": session_id, "history": history}
+
+
+@app.get("/api/session/{session_id}/screenshot/{step}")
+async def get_screenshot(session_id: str, step: int):
+    """
+    Obtém screenshot de um step específico.
+    
+    Args:
+        session_id: ID da sessão
+        step: Número do step
+        
+    Returns:
+        Imagem PNG do screenshot
+    """
+    session = session_manager.get_session(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Sessão não encontrada")
+    
+    # Buscar screenshot no diretório da sessão
+    screenshot_dir = session.get("screenshot_dir")
+    if not screenshot_dir:
+        raise HTTPException(status_code=404, detail="Diretório de screenshots não encontrado")
+    
+    screenshot_path = Path(screenshot_dir) / f"step_{step}.png"
+    if not screenshot_path.exists():
+        raise HTTPException(status_code=404, detail="Screenshot não encontrado")
+    
+    return FileResponse(screenshot_path, media_type="image/png")
+
+
+@app.post("/api/voice/transcribe")
+async def transcribe_audio(file: UploadFile = File(...)):
+    """
+    Transcreve áudio para texto usando Whisper API.
+    
+    Args:
+        file: Arquivo de áudio (mp3, wav, webm, etc)
+        
+    Returns:
+        Texto transcrito
+    """
+    try:
+        # Ler conteúdo do arquivo
+        audio_bytes = await file.read()
+        
+        # Transcrever usando Whisper
+        text = await voice_services.transcribe_audio(audio_bytes, filename=file.filename)
+        
+        return {"text": text, "status": "success"}
+        
+    except Exception as e:
+        logger.error(f"Erro ao transcrever áudio: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/api/voice/synthesize")
+async def synthesize_speech(request: dict):
+    """
+    Converte texto em fala usando TTS API.
+    
+    Args:
+        request: Dict com 'text' a ser sintetizado
+        
+    Returns:
+        Áudio base64 encoded
+    """
+    try:
+        text = request.get("text")
+        if not text:
+            raise HTTPException(status_code=400, detail="Texto não fornecido")
+        
+        # Sintetizar usando TTS
+        audio_bytes = await voice_services.synthesize_speech(text)
+        
+        # Converter para base64
+        audio_b64 = base64.b64encode(audio_bytes).decode('utf-8')
+        
+        return {"audio": audio_b64, "format": "mp3", "status": "success"}
+        
+    except Exception as e:
+        logger.error(f"Erro ao sintetizar fala: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ==================== WebSocket ====================
+
+@app.websocket("/ws/{session_id}")
+async def websocket_endpoint(websocket: WebSocket, session_id: str):
+    """
+    WebSocket para streaming de eventos em tempo real.
+    
+    Envia eventos:
+    - step_start: Início de um novo step
+    - step_end: Fim de um step com screenshot
+    - action: Ação executada pelo agente
+    - thought: Pensamento do modelo
+    - error: Erro ocorrido
+    - done: Tarefa concluída
+    
+    Args:
+        websocket: Conexão WebSocket
+        session_id: ID da sessão para conectar
+    """
+    await websocket.accept()
+    logger.info(f"WebSocket conectado para sessão: {session_id}")
+    
+    try:
+        # Registrar WebSocket na sessão
+        await session_manager.register_websocket(session_id, websocket)
+        
+        # Enviar mensagem de confirmação
+        await websocket.send_json({
+            "type": "connected",
+            "session_id": session_id,
+            "message": "WebSocket conectado com sucesso"
+        })
+        
+        # Manter conexão aberta e processar mensagens do cliente
+        while True:
+            try:
+                # Receber mensagens do cliente (ex: comandos de controle)
+                data = await websocket.receive_json()
+                
+                # Processar comandos
+                if data.get("type") == "control":
+                    action = data.get("action")
+                    await session_manager.control_agent(session_id, action)
+                    await websocket.send_json({
+                        "type": "control_response",
+                        "action": action,
+                        "status": "success"
+                    })
+                    
+            except WebSocketDisconnect:
+                logger.info(f"WebSocket desconectado: {session_id}")
+                break
+            except Exception as e:
+                logger.error(f"Erro no WebSocket: {e}")
+                await websocket.send_json({
+                    "type": "error",
+                    "message": str(e)
+                })
+                
+    except Exception as e:
+        logger.error(f"Erro fatal no WebSocket: {e}")
+    finally:
+        # Remover WebSocket da sessão
+        await session_manager.unregister_websocket(session_id, websocket)
+
+
+# ==================== Startup/Shutdown ====================
+
+@app.on_event("startup")
+async def startup_event():
+    """Inicialização da aplicação"""
+    logger.info("🚀 Browser-Use ChatGPT API iniciada")
+    logger.info("📡 WebSocket endpoint: ws://localhost:8000/ws/{session_id}")
+    logger.info("🌐 REST API: http://localhost:8000/docs")
+
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    """Limpeza ao encerrar aplicação"""
+    logger.info("🛑 Encerrando Browser-Use ChatGPT API...")
+    await session_manager.cleanup_all_sessions()
+
+
+# ==================== Main ====================
+
+if __name__ == "__main__":
+    import uvicorn
+    
+    uvicorn.run(
+        "chatgpt_backend:app",
+        host="0.0.0.0",
+        port=8000,
+        reload=True,
+        log_level="info"
+    )

--- a/examples/ui/session_manager.py
+++ b/examples/ui/session_manager.py
@@ -1,0 +1,433 @@
+"""
+Gerenciador de sessões para múltiplos agentes browser-use.
+
+Responsabilidades:
+- Criar e gerenciar agentes ativos
+- Conectar callbacks aos WebSockets
+- Controlar execução (pause/resume/stop)
+- Manter histórico de eventos
+"""
+
+import asyncio
+import base64
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Any
+
+from fastapi import WebSocket
+
+from browser_use import Agent
+from browser_use.browser.browser import Browser
+from browser_use.browser.context import BrowserContext
+
+logger = logging.getLogger(__name__)
+
+
+class SessionManager:
+    """Gerencia múltiplas sessões de agentes browser-use"""
+    
+    def __init__(self):
+        self.sessions: Dict[str, Dict[str, Any]] = {}
+        self.websockets: Dict[str, List[WebSocket]] = {}
+        
+    async def create_agent_session(
+        self,
+        session_id: str,
+        task: str,
+        llm_provider: str = "openai",
+        llm_model: str = "gpt-4o-mini",
+        max_steps: int = 10
+    ):
+        """
+        Cria uma nova sessão de agente e inicia execução.
+        
+        Args:
+            session_id: ID único da sessão
+            task: Tarefa a ser executada
+            llm_provider: Provedor do LLM (openai, anthropic, google, etc)
+            llm_model: Modelo específico
+            max_steps: Número máximo de steps
+        """
+        try:
+            logger.info(f"Criando sessão {session_id} com tarefa: {task}")
+            
+            # Criar diretório para screenshots
+            screenshot_dir = Path(f"/tmp/browser-use-sessions/{session_id}/screenshots")
+            screenshot_dir.mkdir(parents=True, exist_ok=True)
+            
+            # Inicializar sessão
+            self.sessions[session_id] = {
+                "task": task,
+                "active": True,
+                "max_steps": max_steps,
+                "screenshot_dir": str(screenshot_dir),
+                "history": [],
+                "agent": None,
+                "created_at": datetime.now().isoformat()
+            }
+            
+            # Criar LLM baseado no provider
+            llm = self._create_llm(llm_provider, llm_model)
+            
+            # Criar browser context
+            browser = Browser()
+            context = await browser.new_context()
+            
+            # Callbacks para streaming
+            async def on_step_callback(browser_state, model_output, step_number):
+                """Callback chamado a cada step do agente"""
+                await self._handle_step(session_id, browser_state, model_output, step_number)
+            
+            async def on_done_callback(history):
+                """Callback chamado quando agente termina"""
+                await self._handle_done(session_id, history)
+            
+            # Criar agente
+            agent = Agent(
+                task=task,
+                llm=llm,
+                browser_context=context,
+                register_new_step_callback=on_step_callback,
+                register_done_callback=on_done_callback
+            )
+            
+            self.sessions[session_id]["agent"] = agent
+            self.sessions[session_id]["browser"] = browser
+            self.sessions[session_id]["context"] = context
+            
+            # Enviar evento de início
+            await self._broadcast_to_session(session_id, {
+                "type": "agent_started",
+                "session_id": session_id,
+                "task": task,
+                "max_steps": max_steps,
+                "timestamp": datetime.now().isoformat()
+            })
+            
+            # Executar agente
+            logger.info(f"Iniciando execução do agente {session_id}")
+            history = await agent.run(max_steps=max_steps)
+            
+            logger.info(f"Agente {session_id} concluído")
+            
+        except Exception as e:
+            logger.error(f"Erro ao criar sessão {session_id}: {e}")
+            await self._broadcast_to_session(session_id, {
+                "type": "error",
+                "error": str(e),
+                "timestamp": datetime.now().isoformat()
+            })
+            self.sessions[session_id]["active"] = False
+    
+    def _create_llm(self, provider: str, model: str):
+        """Cria instância do LLM baseado no provider"""
+        
+        if provider == "openai":
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(model=model)
+        
+        elif provider == "anthropic":
+            from langchain_anthropic import ChatAnthropic
+            return ChatAnthropic(model=model)
+        
+        elif provider == "google":
+            from langchain_google_genai import ChatGoogleGenerativeAI
+            return ChatGoogleGenerativeAI(model=model)
+        
+        elif provider == "groq":
+            from langchain_groq import ChatGroq
+            return ChatGroq(model=model)
+        
+        else:
+            # Default para OpenAI
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(model="gpt-4o-mini")
+    
+    async def _handle_step(self, session_id: str, browser_state, model_output, step_number: int):
+        """
+        Processa e transmite dados de cada step do agente.
+        
+        Args:
+            session_id: ID da sessão
+            browser_state: Estado atual do browser
+            model_output: Output do modelo LLM
+            step_number: Número do step atual
+        """
+        try:
+            session = self.sessions.get(session_id)
+            if not session:
+                return
+            
+            # Capturar screenshot
+            screenshot_b64 = None
+            if browser_state and hasattr(browser_state, 'screenshot'):
+                screenshot = browser_state.screenshot
+                if screenshot:
+                    # Salvar screenshot em arquivo
+                    screenshot_path = Path(session["screenshot_dir"]) / f"step_{step_number}.png"
+                    screenshot_path.write_bytes(screenshot)
+                    
+                    # Converter para base64 para enviar via WebSocket
+                    screenshot_b64 = base64.b64encode(screenshot).decode('utf-8')
+            
+            # Extrair informações do model_output
+            action_name = None
+            thought = None
+            extracted_content = None
+            
+            if model_output:
+                if hasattr(model_output, 'action'):
+                    action = model_output.action
+                    if action:
+                        action_name = action.__class__.__name__ if hasattr(action, '__class__') else str(action)
+                
+                if hasattr(model_output, 'current_state') and model_output.current_state:
+                    thought = model_output.current_state.get('evaluation_previous_goal')
+                
+                if hasattr(model_output, 'extracted_content'):
+                    extracted_content = model_output.extracted_content
+            
+            # Dados do step
+            step_data = {
+                "type": "step",
+                "step_number": step_number,
+                "url": browser_state.url if browser_state and hasattr(browser_state, 'url') else None,
+                "title": browser_state.title if browser_state and hasattr(browser_state, 'title') else None,
+                "screenshot": screenshot_b64,
+                "action": action_name,
+                "thought": thought,
+                "extracted_content": extracted_content,
+                "timestamp": datetime.now().isoformat()
+            }
+            
+            # Adicionar ao histórico
+            session["history"].append(step_data)
+            
+            # Broadcast para todos os WebSockets conectados
+            await self._broadcast_to_session(session_id, step_data)
+            
+            logger.info(f"Step {step_number} processado para sessão {session_id}")
+            
+        except Exception as e:
+            logger.error(f"Erro ao processar step {step_number} da sessão {session_id}: {e}")
+    
+    async def _handle_done(self, session_id: str, history):
+        """
+        Processa finalização do agente.
+        
+        Args:
+            session_id: ID da sessão
+            history: Histórico completo da execução
+        """
+        try:
+            session = self.sessions.get(session_id)
+            if not session:
+                return
+            
+            # Marcar sessão como inativa
+            session["active"] = False
+            
+            # Extrair resultado final
+            final_result = None
+            if history and hasattr(history, 'final_result'):
+                final_result = history.final_result()
+            
+            # Enviar evento de conclusão
+            done_data = {
+                "type": "done",
+                "session_id": session_id,
+                "final_result": final_result,
+                "total_steps": len(session["history"]),
+                "timestamp": datetime.now().isoformat()
+            }
+            
+            await self._broadcast_to_session(session_id, done_data)
+            
+            logger.info(f"Sessão {session_id} finalizada com sucesso")
+            
+        except Exception as e:
+            logger.error(f"Erro ao finalizar sessão {session_id}: {e}")
+    
+    async def _broadcast_to_session(self, session_id: str, data: dict):
+        """
+        Envia dados para todos os WebSockets conectados a uma sessão.
+        
+        Args:
+            session_id: ID da sessão
+            data: Dados a serem enviados
+        """
+        if session_id not in self.websockets:
+            return
+        
+        # Lista de WebSockets a remover (desconectados)
+        to_remove = []
+        
+        for ws in self.websockets[session_id]:
+            try:
+                await ws.send_json(data)
+            except Exception as e:
+                logger.warning(f"Erro ao enviar para WebSocket: {e}")
+                to_remove.append(ws)
+        
+        # Remover WebSockets desconectados
+        for ws in to_remove:
+            self.websockets[session_id].remove(ws)
+    
+    async def register_websocket(self, session_id: str, websocket: WebSocket):
+        """
+        Registra um WebSocket para receber eventos de uma sessão.
+        
+        Args:
+            session_id: ID da sessão
+            websocket: Conexão WebSocket
+        """
+        if session_id not in self.websockets:
+            self.websockets[session_id] = []
+        
+        self.websockets[session_id].append(websocket)
+        logger.info(f"WebSocket registrado para sessão {session_id}")
+        
+        # Enviar histórico existente para novo cliente
+        session = self.sessions.get(session_id)
+        if session and session.get("history"):
+            for event in session["history"]:
+                try:
+                    await websocket.send_json(event)
+                except Exception as e:
+                    logger.warning(f"Erro ao enviar histórico: {e}")
+    
+    async def unregister_websocket(self, session_id: str, websocket: WebSocket):
+        """
+        Remove um WebSocket de uma sessão.
+        
+        Args:
+            session_id: ID da sessão
+            websocket: Conexão WebSocket
+        """
+        if session_id in self.websockets and websocket in self.websockets[session_id]:
+            self.websockets[session_id].remove(websocket)
+            logger.info(f"WebSocket removido da sessão {session_id}")
+    
+    async def control_agent(self, session_id: str, action: str):
+        """
+        Controla execução do agente (pause/resume/stop).
+        
+        Args:
+            session_id: ID da sessão
+            action: Ação a executar ('pause', 'resume', 'stop')
+            
+        Returns:
+            Resultado da operação
+        """
+        session = self.sessions.get(session_id)
+        if not session:
+            raise ValueError(f"Sessão {session_id} não encontrada")
+        
+        agent = session.get("agent")
+        if not agent:
+            raise ValueError(f"Agente não encontrado para sessão {session_id}")
+        
+        if action == "pause":
+            agent.pause()
+            logger.info(f"Agente {session_id} pausado")
+            await self._broadcast_to_session(session_id, {
+                "type": "control",
+                "action": "paused",
+                "timestamp": datetime.now().isoformat()
+            })
+            return "paused"
+        
+        elif action == "resume":
+            agent.resume()
+            logger.info(f"Agente {session_id} resumido")
+            await self._broadcast_to_session(session_id, {
+                "type": "control",
+                "action": "resumed",
+                "timestamp": datetime.now().isoformat()
+            })
+            return "resumed"
+        
+        elif action == "stop":
+            agent.stop()
+            session["active"] = False
+            logger.info(f"Agente {session_id} parado")
+            await self._broadcast_to_session(session_id, {
+                "type": "control",
+                "action": "stopped",
+                "timestamp": datetime.now().isoformat()
+            })
+            return "stopped"
+        
+        else:
+            raise ValueError(f"Ação inválida: {action}")
+    
+    def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Obtém dados de uma sessão.
+        
+        Args:
+            session_id: ID da sessão
+            
+        Returns:
+            Dicionário com dados da sessão ou None
+        """
+        return self.sessions.get(session_id)
+    
+    def get_history(self, session_id: str) -> Optional[List[dict]]:
+        """
+        Obtém histórico de eventos de uma sessão.
+        
+        Args:
+            session_id: ID da sessão
+            
+        Returns:
+            Lista de eventos ou None
+        """
+        session = self.sessions.get(session_id)
+        if session:
+            return session.get("history", [])
+        return None
+    
+    async def cleanup_session(self, session_id: str):
+        """
+        Remove uma sessão e libera recursos.
+        
+        Args:
+            session_id: ID da sessão
+        """
+        session = self.sessions.get(session_id)
+        if not session:
+            return
+        
+        try:
+            # Fechar browser context
+            context = session.get("context")
+            if context:
+                await context.close()
+            
+            # Fechar browser
+            browser = session.get("browser")
+            if browser:
+                await browser.close()
+            
+            # Remover sessão
+            del self.sessions[session_id]
+            
+            # Remover WebSockets
+            if session_id in self.websockets:
+                del self.websockets[session_id]
+            
+            logger.info(f"Sessão {session_id} removida e recursos liberados")
+            
+        except Exception as e:
+            logger.error(f"Erro ao limpar sessão {session_id}: {e}")
+    
+    async def cleanup_all_sessions(self):
+        """Remove todas as sessões e libera recursos"""
+        session_ids = list(self.sessions.keys())
+        for session_id in session_ids:
+            await self.cleanup_session(session_id)
+        
+        logger.info("Todas as sessões foram limpas")

--- a/examples/ui/voice_services.py
+++ b/examples/ui/voice_services.py
@@ -1,0 +1,180 @@
+"""
+Serviços de voz para transcrição (STT) e síntese (TTS).
+
+Integra com:
+- OpenAI Whisper API para Speech-to-Text
+- OpenAI TTS API para Text-to-Speech
+"""
+
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import openai
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceServices:
+    """Fornece serviços de transcrição e síntese de voz"""
+    
+    def __init__(self):
+        """Inicializa serviços de voz"""
+        self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        if not self.openai_api_key:
+            logger.warning("OPENAI_API_KEY não configurada - serviços de voz não disponíveis")
+        
+        self.client = openai.AsyncOpenAI(api_key=self.openai_api_key) if self.openai_api_key else None
+    
+    async def transcribe_audio(self, audio_bytes: bytes, filename: str = "audio.webm") -> str:
+        """
+        Transcreve áudio para texto usando Whisper API.
+        
+        Args:
+            audio_bytes: Bytes do arquivo de áudio
+            filename: Nome do arquivo (para determinar formato)
+            
+        Returns:
+            Texto transcrito
+            
+        Raises:
+            ValueError: Se API key não configurada
+            Exception: Erros da API
+        """
+        if not self.client:
+            raise ValueError("OpenAI API key não configurada")
+        
+        try:
+            # Salvar temporariamente o áudio
+            with tempfile.NamedTemporaryFile(suffix=Path(filename).suffix, delete=False) as temp_file:
+                temp_file.write(audio_bytes)
+                temp_path = temp_file.name
+            
+            try:
+                # Transcrever usando Whisper
+                with open(temp_path, "rb") as audio_file:
+                    transcript = await self.client.audio.transcriptions.create(
+                        model="whisper-1",
+                        file=audio_file,
+                        language="pt"  # Português como padrão, pode ser configurável
+                    )
+                
+                logger.info(f"Áudio transcrito com sucesso: {transcript.text[:100]}...")
+                return transcript.text
+                
+            finally:
+                # Remover arquivo temporário
+                Path(temp_path).unlink(missing_ok=True)
+                
+        except Exception as e:
+            logger.error(f"Erro ao transcrever áudio: {e}")
+            raise
+    
+    async def synthesize_speech(
+        self,
+        text: str,
+        voice: str = "alloy",
+        model: str = "tts-1",
+        speed: float = 1.0
+    ) -> bytes:
+        """
+        Converte texto em fala usando TTS API.
+        
+        Args:
+            text: Texto a ser sintetizado
+            voice: Voz a usar (alloy, echo, fable, onyx, nova, shimmer)
+            model: Modelo TTS (tts-1 ou tts-1-hd)
+            speed: Velocidade da fala (0.25 a 4.0)
+            
+        Returns:
+            Bytes do áudio MP3
+            
+        Raises:
+            ValueError: Se API key não configurada
+            Exception: Erros da API
+        """
+        if not self.client:
+            raise ValueError("OpenAI API key não configurada")
+        
+        try:
+            # Sintetizar fala
+            response = await self.client.audio.speech.create(
+                model=model,
+                voice=voice,
+                input=text,
+                speed=speed
+            )
+            
+            # Ler bytes do áudio
+            audio_bytes = response.content
+            
+            logger.info(f"Fala sintetizada com sucesso: {len(audio_bytes)} bytes")
+            return audio_bytes
+            
+        except Exception as e:
+            logger.error(f"Erro ao sintetizar fala: {e}")
+            raise
+    
+    async def transcribe_audio_with_timestamps(
+        self,
+        audio_bytes: bytes,
+        filename: str = "audio.webm"
+    ) -> dict:
+        """
+        Transcreve áudio com timestamps detalhados.
+        
+        Args:
+            audio_bytes: Bytes do arquivo de áudio
+            filename: Nome do arquivo
+            
+        Returns:
+            Dict com texto e timestamps
+        """
+        if not self.client:
+            raise ValueError("OpenAI API key não configurada")
+        
+        try:
+            # Salvar temporariamente o áudio
+            with tempfile.NamedTemporaryFile(suffix=Path(filename).suffix, delete=False) as temp_file:
+                temp_file.write(audio_bytes)
+                temp_path = temp_file.name
+            
+            try:
+                # Transcrever com timestamps
+                with open(temp_path, "rb") as audio_file:
+                    transcript = await self.client.audio.transcriptions.create(
+                        model="whisper-1",
+                        file=audio_file,
+                        language="pt",
+                        response_format="verbose_json",
+                        timestamp_granularities=["word", "segment"]
+                    )
+                
+                return {
+                    "text": transcript.text,
+                    "language": transcript.language,
+                    "duration": transcript.duration,
+                    "words": transcript.words if hasattr(transcript, 'words') else [],
+                    "segments": transcript.segments if hasattr(transcript, 'segments') else []
+                }
+                
+            finally:
+                # Remover arquivo temporário
+                Path(temp_path).unlink(missing_ok=True)
+                
+        except Exception as e:
+            logger.error(f"Erro ao transcrever áudio com timestamps: {e}")
+            raise
+
+
+# Vozes disponíveis na OpenAI TTS
+AVAILABLE_VOICES = {
+    "alloy": "Voz neutra e equilibrada",
+    "echo": "Voz masculina clara",
+    "fable": "Voz britânica expressiva",
+    "onyx": "Voz masculina profunda",
+    "nova": "Voz feminina energética",
+    "shimmer": "Voz feminina suave"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,13 @@ eval = [
     "hyperbrowser==0.47.0",
     "browserbase==1.4.0",
 ]
+chatgpt-ui = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.34.0",
+    "websockets>=14.0",
+]
 all = [
-    "browser-use[cli,examples,aws]",
+    "browser-use[cli,examples,aws,chatgpt-ui]",
 ]
 
 # will prefer to use local source code checked out in ../../browser-use (if present) instead of pypi browser-use package


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduced a ChatGPT-style UI with a Next.js frontend and FastAPI backend to control browser-use agents via text and voice, with real-time WebSocket streaming and browser screenshots.

- **New Features**
  - Next.js chat interface with dark mode and markdown messages.
  - Voice commands via Web Speech API, plus Whisper STT and TTS endpoints.
  - WebSocket streaming of agent steps with screenshots and an action timeline.
  - Pause/resume/stop controls and per-session history.
  - Browser preview panel showing current URL, title, and screenshots.
  - Docs added in examples/ui and chatgpt-frontend.

- **Migration**
  - Install: pip install "browser-use[chatgpt-ui]".
  - Set env: export OPENAI_API_KEY=your_key_here.
  - Run backend: cd examples/ui && python chatgpt_backend.py (http://localhost:8000).
  - Run frontend: cd examples/ui/chatgpt-frontend && npm install && npm run dev (http://localhost:3000).

<!-- End of auto-generated description by cubic. -->

