### PR TITLE
change browser-use install to uvx browser-use install

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -50,7 +50,7 @@ source .venv/bin/activate
 ```
 ```bash install browser-use & chromium
 uv pip install browser-use
-browser-use install
+uvx browser-use install
 ```
 </Tab>
 <Tab title="pip">
@@ -85,7 +85,7 @@ browser-use install
   <Tab title="uv">
     ```bash install browser-use & chromium theme={null}
     uv pip install browser-use
-    browser-use install
+    uvx browser-use install
     ```
   </Tab>
 
@@ -223,7 +223,7 @@ source .venv/bin/activate
 ```
 ```bash install browser-use & chromium
 uv pip install browser-use
-browser-use install
+uvx browser-use install
 ```
 </Tab>
 <Tab title="pip">

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ BROWSER_USE_API_KEY=your-key
 
 **4. Install Chromium browser:**
 ```bash
-browser-use install
+uvx uvx uvx browser-use install
 ```
 
 **5. Run your first agent:**

--- a/docs/examples/apps/vibetest-use.mdx
+++ b/docs/examples/apps/vibetest-use.mdx
@@ -38,7 +38,7 @@ source .venv/bin/activate
 uv pip install -e .
 
 # 4.  Install browser runtime once
-browser-use install
+uvx browser-use install
 ```
 
 ### 1) Claude Code

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -22,7 +22,7 @@ source .venv/bin/activate
 ```
 ```bash install browser-use & chromium
 uv pip install browser-use
-browser-use install
+uvx browser-use install
 ```
 </Tab>
 <Tab title="pip">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch docs from "browser-use install" to "uvx browser-use install" to run the installer via uvx and keep setup consistent. Updated README, Quickstart, Agents guide, and Vibetest example to fix the CLI command.

<!-- End of auto-generated description by cubic. -->

