### PR TITLE
small fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ BROWSER_USE_API_KEY=your-key
 
 **4. Install Chromium browser:**
 ```bash
-uvx uvx uvx browser-use install
+uvx browser-use install
 ```
 
 **5. Run your first agent:**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrects the Chromium install command in the README to prevent failed installs. Removes duplicated "uvx" so the command is: uvx browser-use install.

<!-- End of auto-generated description by cubic. -->

