### PR TITLE
Update Onkernel references to Kernel in docs

### DIFF
--- a/docs/customize/browser/remote.mdx
+++ b/docs/customize/browser/remote.mdx
@@ -16,7 +16,7 @@ from browser_use import Agent, Browser, ChatOpenAI
 # Use Browser-Use cloud browser service
 browser = Browser(
     use_cloud=True,  # Automatically provisions a cloud browser
-    # cdp_url="http://remote-server:9222" # CDP URL from your favorite browser provider like Onkernel, AnchorBrowser, HyperBrowser, BrowserBase, Steel.dev, etc.
+    # cdp_url="http://remote-server:9222" # CDP URL from your favorite browser provider like Kernel, AnchorBrowser, HyperBrowser, BrowserBase, Steel.dev, etc.
 )
 
 agent = Agent(
@@ -38,7 +38,7 @@ agent = Agent(
 - ✅ Optimized for browser automation
 
 ### Third-Party Cloud Browsers
-Get a CDP URL from your favorite browser provider like Onkernel, AnchorBrowser, HyperBrowser, BrowserBase, Steel.dev, etc.
+Get a CDP URL from your favorite browser provider like <a href="https://www.onkernel.com/docs/introduction#connect-over-cdp">Kernel</a>, AnchorBrowser, HyperBrowser, BrowserBase, Steel.dev, etc.
 
 
 ### Proxy Connection


### PR DESCRIPTION
## Summary
- Updated "Onkernel" to "Kernel" in remote browser documentation
- Added hyperlink to Kernel's CDP documentation

## Changes
- Line 19: Updated code comment to reference "Kernel" instead of "Onkernel"
- Line 41: Changed "Onkernel" to "Kernel" and linked to https://www.onkernel.com/docs/introduction#connect-over-cdp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated remote browser docs to rename Onkernel to Kernel and add a link to Kernel’s CDP docs. Clarifies the provider name and helps users connect over CDP.

<!-- End of auto-generated description by cubic. -->

