### PR TITLE
docs: added pricing for bu llm

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ https://github.com/user-attachments/assets/ac34f75c-057a-43ef-ad06-5b2c9d42bf06
 
 We optimized **ChatBrowserUse()** specifically for browser automation tasks. On avg it completes tasks 3-5x faster than other models with SOTA accuracy.
 
+**Pricing (per 1M tokens):**
+- Input tokens: $0.50
+- Output tokens: $3.00  
+- Cached tokens: $0.10
+
 For other LLM providers, see our [supported models documentation](https://docs.browser-use.com/supported-models).
 </details>
 

--- a/browser_use/tokens/custom_pricing.py
+++ b/browser_use/tokens/custom_pricing.py
@@ -9,16 +9,7 @@ from typing import Any
 # Custom model pricing data
 # Format matches LiteLLM's model_prices_and_context_window.json structure
 CUSTOM_MODEL_PRICING: dict[str, dict[str, Any]] = {
-	'browser-use/fast': {
-		'input_cost_per_token': 0.50 / 1_000_000,  # $0.50 per 1M tokens
-		'output_cost_per_token': 3.00 / 1_000_000,  # $3.00 per 1M tokens
-		'cache_read_input_token_cost': 0.10 / 1_000_000,  # $0.10 per 1M tokens
-		'cache_creation_input_token_cost': None,  # Not specified
-		'max_tokens': None,  # Not specified
-		'max_input_tokens': None,  # Not specified
-		'max_output_tokens': None,  # Not specified
-	},
-	'browser-use/smart': {
+	'bu-1-0': {
 		'input_cost_per_token': 0.50 / 1_000_000,  # $0.50 per 1M tokens
 		'output_cost_per_token': 3.00 / 1_000_000,  # $3.00 per 1M tokens
 		'cache_read_input_token_cost': 0.10 / 1_000_000,  # $0.10 per 1M tokens

--- a/docs/supported-models.mdx
+++ b/docs/supported-models.mdx
@@ -30,6 +30,20 @@ BROWSER_USE_API_KEY=
 
 Get your API key from the [Browser Use Cloud](https://cloud.browser-use.com/new-api-key). New signups get \$10 free credit via OAuth or \$1 via email.
 
+#### Pricing
+
+ChatBrowserUse offers competitive pricing per 1 million tokens:
+
+| Token Type | Price per 1M tokens |
+|------------|---------------------|
+| Input tokens | $0.50 |
+| Output tokens | $3.00 |
+| Cached tokens | $0.10 |
+
+<Note>
+  Cached tokens provide significant cost savings on repeated context, reducing input costs by 80%.
+</Note>
+
 ### Google Gemini [example](https://github.com/browser-use/browser-use/blob/main/examples/models/gemini.py)
 
 <Warning>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added clear pricing for the Browser Use LLM and aligned the custom pricing map to the new model id bu-1-0 for consistency.

- **New Features**
  - Documented per-1M token pricing in README and Supported Models:
    - Input: $0.50, Output: $3.00, Cached: $0.10.
  - Noted 80% savings with cached tokens on repeated context.

- **Refactors**
  - Replaced 'browser-use/fast' and 'browser-use/smart' pricing keys with 'bu-1-0' to match current model naming.

<!-- End of auto-generated description by cubic. -->

