### PR TITLE
msg-for-file-path-not-there

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -383,7 +383,7 @@ class Tools(Generic[Context]):
 							if not browser_session.is_local:
 								pass
 							else:
-								msg = f'File path {params.path} is not available. Upload files must be in available_file_paths, downloaded_files, or a file managed by file_system.'
+								msg = f'File path {params.path} is not available. To fix: The user must add this file path to the available_file_paths parameter when creating the Agent. Example: Agent(task="...", llm=llm, browser=browser, available_file_paths=["{params.path}"])'
 								logger.error(f'❌ {msg}')
 								return ActionResult(error=msg)
 					else:
@@ -391,7 +391,7 @@ class Tools(Generic[Context]):
 						if not browser_session.is_local:
 							pass
 						else:
-							msg = f'File path {params.path} is not available. Upload files must be in available_file_paths, downloaded_files, or a file managed by file_system.'
+							msg = f'File path {params.path} is not available. To fix: The user must add this file path to the available_file_paths parameter when creating the Agent. Example: Agent(task="...", llm=llm, browser=browser, available_file_paths=["{params.path}"])'
 							raise BrowserError(message=msg, long_term_memory=msg)
 
 			# For local browsers, ensure the file exists on the local filesystem
@@ -1504,7 +1504,7 @@ class CodeAgentTools(Tools[Context]):
 								if not browser_session.is_local:
 									pass
 								else:
-									msg = f'File path {params.path} is not available. Upload files must be in available_file_paths, downloaded_files, or a file managed by file_system.'
+									msg = f'File path {params.path} is not available. To fix: add this file path to the available_file_paths parameter when creating the Agent. Example: Agent(task="...", llm=llm, browser=browser, available_file_paths=["{params.path}"])'
 									logger.error(f'❌ {msg}')
 									return ActionResult(error=msg)
 						else:
@@ -1512,7 +1512,7 @@ class CodeAgentTools(Tools[Context]):
 							if not browser_session.is_local:
 								pass
 							else:
-								msg = f'File path {params.path} is not available. Upload files must be in available_file_paths or downloaded_files.'
+								msg = f'File path {params.path} is not available. To fix: add this file path to the available_file_paths parameter when creating the Agent. Example: Agent(task="...", llm=llm, browser=browser, available_file_paths=["{params.path}"])'
 								logger.error(f'❌ {msg}')
 								return ActionResult(error=msg)
 


### PR DESCRIPTION
Auto-generated PR for branch: msg-for-file-path-not-there

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines `upload_file` path validation errors to include clear instructions and an example for adding paths to `available_file_paths`.
> 
> - **Tools**:
>   - **`browser_use/tools/service.py`**:
>     - Update `upload_file` error messages to provide actionable guidance when `params.path` is not in `available_file_paths` (with example `Agent(..., available_file_paths=["{params.path}"])`).
>     - Applies to both standard `Tools.upload_file` and `CodeAgentTools.upload_file` (whitelist path checks and non-FileSystem paths).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ba26ae9fb0a161e0d6544893677bf0e6dc5a37e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->