### PR TITLE
better descripiton for extract

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -38,6 +38,7 @@ from browser_use.tools.views import (
 	ClickElementAction,
 	CloseTabAction,
 	DoneAction,
+	ExtractAction,
 	GetDropdownOptionsAction,
 	InputTextAction,
 	NavigateAction,
@@ -577,15 +578,16 @@ class Tools(Generic[Context]):
 			"""LLM extracts structured data from page markdown. Use when: on right page, know what to extract, haven't called before on same page+query. Can't get interactive elements. Set extract_links=True for URLs. Use start_from_char if truncated. If fails, use find_text instead.""",
 		)
 		async def extract(
-			query: str,
+			params: ExtractAction,
 			browser_session: BrowserSession,
 			page_extraction_llm: BaseChatModel,
 			file_system: FileSystem,
-			extract_links: bool = False,
-			start_from_char: int = 0,
 		):
 			# Constants
 			MAX_CHAR_LIMIT = 30000
+			query = params.query
+			extract_links = params.extract_links
+			start_from_char = params.start_from_char
 
 			# Extract clean markdown using the unified method
 			try:
@@ -603,7 +605,7 @@ class Tools(Generic[Context]):
 			if start_from_char > 0:
 				if start_from_char >= len(content):
 					return ActionResult(
-						error=f'start_from_char ({start_from_char}) exceeds content length ({len(content)}). Content has {final_filtered_length} characters after filtering.'
+						error=f'start_from_char ({start_from_char}) exceeds content length {final_filtered_length} characters.'
 					)
 				content = content[start_from_char:]
 				content_stats['started_from_char'] = start_from_char

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -4,6 +4,16 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 # Action Input Models
+class ExtractAction(BaseModel):
+	query: str
+	extract_links: bool = Field(
+		default=False, description='Set True to true if the query requires links, else false to safe tokens'
+	)
+	start_from_char: int = Field(
+		default=0, description='Use this for long markdowns to start from a specific character (not index in browser_state)'
+	)
+
+
 class SearchAction(BaseModel):
 	query: str
 	engine: str = Field(


### PR DESCRIPTION
Auto-generated PR for: better descripiton for extract

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace extract’s loose params with a new ExtractAction model and adjust handling/error text accordingly.
> 
> - **Tools**:
>   - **Extract action** (`browser_use/tools/service.py`):
>     - Switch to structured params: `params: ExtractAction`; read `query`, `extract_links`, `start_from_char` from `params`.
>     - Minor error message tweak for `start_from_char` bounds.
>   - **Action models** (`browser_use/tools/views.py`):
>     - Add `ExtractAction` with `query`, `extract_links`, `start_from_char`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13836049618d11b4a1a020df53a8a20566873cb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->