### PR TITLE
fix-enter

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1810,6 +1810,16 @@ class DefaultActionWatchdog(BaseWatchdog):
 				# If it's a special key, use original logic
 				if normalized_keys in special_keys:
 					await self._dispatch_key_event(cdp_session, 'keyDown', normalized_keys)
+					# For Enter key, also dispatch a char event to trigger keypress listeners
+					if normalized_keys == 'Enter':
+						await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
+							params={
+								'type': 'char',
+								'text': '\r',
+								'key': 'Enter',
+							},
+							session_id=cdp_session.session_id,
+						)
 					await self._dispatch_key_event(cdp_session, 'keyUp', normalized_keys)
 				else:
 					# It's text (single character or string) - send each character as text input

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -845,7 +845,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 				)
 
 		@self.registry.action(
-			'Request screenshot of current viewport. Use when: visual inspection needed, layout unclear, element positions uncertain, debugging UI issues, or verifying page state. Screenshot included in next observation.',
+			'Request screenshot of current viewport. Use when: visual inspection needed, layout unclear, element positions uncertain, debugging UI issues, or verifying page state. Screenshot is included in the next browser_state.',
 		)
 		async def screenshot():
 			"""Request that a screenshot be included in the next observation"""


### PR DESCRIPTION
Auto-generated PR for: fix-enter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure Enter key triggers keypress listeners by sending a char event and update the screenshot action description to reference next browser_state.
> 
> - **Browser actions (CDP)**:
>   - `on_SendKeysEvent`: For special `Enter`, also dispatch a `char` event (`'\r'`) between `keyDown` and `keyUp` to trigger keypress listeners.
> - **Tools**:
>   - `screenshot` action description: clarified that the screenshot is included in the next `browser_state` (not “observation”).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e33393afcf8f1848507078c5d613af2ff76ebf8e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->