### PR TITLE
Support unicode characters in filenames and improve path handling, and fixed path validation failures in Windows OS environments.

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -1,5 +1,6 @@
 import asyncio
 import re
+import os
 import shutil
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
@@ -227,8 +228,9 @@ class FileSystem:
 		"""Check if filename matches the required pattern: name.extension"""
 		# Build extensions pattern from _file_types
 		extensions = '|'.join(self._file_types.keys())
-		pattern = rf'^[a-zA-Z0-9_\-]+\.({extensions})$'
-		return bool(re.match(pattern, file_name))
+		pattern = rf'^[a-zA-Z0-9_\-\u4e00-\u9fff]+\.({extensions})$'
+		file_basename = os.path.basename(file_name)
+		return bool(re.match(pattern, file_basename))
 
 	def _parse_filename(self, filename: str) -> tuple[str, str]:
 		"""Parse filename into name and extension. Always check _is_valid_filename first."""


### PR DESCRIPTION
Support unicode characters in filenames and improve path handling, and fixed path validation failures in Windows OS environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Unicode (CJK) characters in filenames and validate only the basename to handle OS path separators. Fixes filename validation failures on Windows.

<sup>Written for commit 23ade5e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

