### PR TITLE
Support unicode characters in filenames and improve path handling, and fixed path validation failures in Windows OS environments.

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -229,8 +229,8 @@ class FileSystem:
 		# Build extensions pattern from _file_types
 		extensions = '|'.join(self._file_types.keys())
 		pattern = rf'^[a-zA-Z0-9_\-\u4e00-\u9fff]+\.({extensions})$'
-		file_basename = os.path.basename(file_name)
-		return bool(re.match(pattern, file_basename))
+		file_name_base = os.path.basename(file_name)
+		return bool(re.match(pattern, file_name_base))
 
 	def _parse_filename(self, filename: str) -> tuple[str, str]:
 		"""Parse filename into name and extension. Always check _is_valid_filename first."""


### PR DESCRIPTION
Support unicode characters in filenames and improve path handling, and fixed path validation failures in Windows OS environments.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow unicode filenames and fix Windows path validation by validating only the base name. This prevents false “invalid filename” errors and supports Chinese characters.

- **New Features**
  - Allow CJK unicode characters in filenames via an updated validation pattern.

- **Bug Fixes**
  - Validate only the file’s basename (os.path.basename) to avoid path separator issues on Windows.

<sup>Written for commit 44d9c96. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



