### PR TITLE
Support unicode characters in filenames and improve path handling, and fixed path validation failures in Windows OS environments.

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -229,8 +229,8 @@ class FileSystem:
 		# Build extensions pattern from _file_types
 		extensions = '|'.join(self._file_types.keys())
 		pattern = rf'^[a-zA-Z0-9_\-\u4e00-\u9fff]+\.({extensions})$'
-		file_basename = os.path.basename(file_name)
-		return bool(re.match(pattern, file_basename))
+		file_name_base = os.path.basename(file_name)
+		return bool(re.match(pattern, file_name_base))
 
 	def _parse_filename(self, filename: str) -> tuple[str, str]:
 		"""Parse filename into name and extension. Always check _is_valid_filename first."""


### PR DESCRIPTION
Support unicode characters in filenames and improve path handling, and fixed path validation failures in Windows OS environments.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for CJK characters in filenames and makes filename validation path-safe, fixing validation errors on Windows. Validation now checks only the basename, not the full path.

- **New Features**
  - Allow filenames with common CJK Unicode characters.

- **Bug Fixes**
  - Use os.path.basename before regex validation to prevent Windows path validation failures.

<sup>Written for commit 44d9c96. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

