### PR TITLE
enh: add base_url parameter to ChatOpenAI in mcp

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -557,7 +557,7 @@ class BrowserUseServer:
 			self.llm = ChatOpenAI(
 				model=llm_config.get('model', 'gpt-4o-mini'),
 				api_key=api_key,
-			base_url=llm_config.get('base_url') or os.getenv('OPENAI_BASE_URL'),
+				base_url=llm_config.get('base_url') or os.getenv('OPENAI_BASE_URL'),
 				temperature=llm_config.get('temperature', 0.7),
 				# max_tokens=llm_config.get('max_tokens'),
 			)


### PR DESCRIPTION
Add support for custom OpenAI-compatible base URLs

This PR enables using OpenAI-compatible API providers (like OpenRouter, LocalAI, LM Studio, etc.) by adding support for custom `base_url` configuration. Currently, browser-use only works with OpenAI's official API endpoint, limiting flexibility for users who want to use alternative providers or self-hosted models.

Done:

- [x] Added `base_url` parameter support to `ChatOpenAI` initialization in both LLM configuration (`__init__`) and agent retry method (`_retry_with_browser_use_agent`)
- [x] Falls back to `OPENAI_BASE_URL` environment variable if not specified in config





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add base_url support to ChatOpenAI so browser-use can work with OpenAI-compatible endpoints and self-hosted models. The base_url is read from llm_config and falls back to the OPENAI_BASE_URL environment variable.

<sup>Written for commit 49c257fdb6f892d8db517c8e01fe779ad215d17e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





