### PR TITLE
fix: improved sandbox example removing bugged output_model_schema

### DIFF
--- a/examples/sandbox/example.py
+++ b/examples/sandbox/example.py
@@ -12,15 +12,8 @@ To run this example:
 import asyncio
 import os
 
-from pydantic import BaseModel
-
 from browser_use import Browser, ChatBrowserUse, sandbox
 from browser_use.agent.service import Agent
-
-
-class IPAddress(BaseModel):
-	ip_address: str
-	location: str
 
 
 # Example with event callbacks to monitor execution
@@ -40,16 +33,15 @@ def on_browser_ready(data):
 	# cloud_proxy_country_code='us',
 	# cloud_timeout=60,
 )
-async def pydantic_example(browser: Browser) -> IPAddress | None:
+async def pydantic_example(browser: Browser):
 	agent = Agent(
 		"""go and check my ip address and the location. return the result in json format""",
 		browser=browser,
-		output_model_schema=IPAddress,
 		llm=ChatBrowserUse(),
 	)
 	res = await agent.run()
 
-	return res.structured_output
+	return res.final_result()
 
 
 async def main():


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the sandbox example by removing the bugged output_model_schema and Pydantic model, and returning agent.final_result() for reliable output. This prevents runtime errors and simplifies the example.

- **Bug Fixes**
  - Removed IPAddress BaseModel and output_model_schema usage.
  - Switched from structured_output to final_result().

<sup>Written for commit 8977a536966a95f8dcb13049f941369b18989185. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

