### PR TITLE
fix(llm/google): fix image handling in first user message with system text

### DIFF
--- a/browser_use/llm/google/serializer.py
+++ b/browser_use/llm/google/serializer.py
@@ -5,6 +5,7 @@ from google.genai.types import Content, ContentListUnion, Part
 from browser_use.llm.messages import (
 	AssistantMessage,
 	BaseMessage,
+	ContentPartImageParam,
 	SystemMessage,
 	UserMessage,
 )
@@ -14,26 +15,33 @@ class GoogleMessageSerializer:
 	"""Serializer for converting messages to Google Gemini format."""
 
 	@staticmethod
+	def _serialize_image(part: ContentPartImageParam) -> Part:
+		"""Convert a ContentPartImageParam to google format image part."""
+		url = part.image_url.url
+		header, data = url.split(',', 1)
+		image_bytes = base64.b64decode(data)
+		return Part.from_bytes(data=image_bytes, mime_type='image/jpeg')
+
+	@staticmethod
 	def serialize_messages(
 		messages: list[BaseMessage], include_system_in_user: bool = False
 	) -> tuple[ContentListUnion, str | None]:
 		"""
-		Convert a list of BaseMessages to Google format, extracting system message.
+		Convert a list of BaseMessages to Google format, extracting system messages.
 
-		Google handles system instructions separately from the conversation, so we need to:
-		1. Extract any system messages and return them separately as a string (or include in first user message if flag is set)
-		2. Convert the remaining messages to Content objects
+		Google handles system instructions separately, so we need to:
+		1. Extract system messages and return them separately as a string.
+		2. Optionally include them in the first user message if requested.
 
 		Args:
-		    messages: List of messages to convert
-		    include_system_in_user: If True, system/developer messages are prepended to the first user message
+		    messages: List of messages to convert.
+		    include_system_in_user: If True, system messages are prepended to the first user message.
 
 		Returns:
 		    A tuple of (formatted_messages, system_message) where:
-		    - formatted_messages: List of Content objects for the conversation
-		    - system_message: System instruction string or None
+		      - formatted_messages: List of Content objects for the conversation.
+		      - system_message: System instruction string or None.
 		"""
-
 		messages = [m.model_copy(deep=True) for m in messages]
 
 		formatted_messages: ContentListUnion = []
@@ -41,20 +49,18 @@ class GoogleMessageSerializer:
 		system_parts: list[str] = []
 
 		for i, message in enumerate(messages):
-			role = message.role if hasattr(message, 'role') else None
+			role = getattr(message, 'role', None)
 
 			# Handle system/developer messages
 			if isinstance(message, SystemMessage) or role in ['system', 'developer']:
-				# Extract system message content as string
 				if isinstance(message.content, str):
 					if include_system_in_user:
 						system_parts.append(message.content)
 					else:
 						system_message = message.content
 				elif message.content is not None:
-					# Handle Iterable of content parts
 					parts = []
-					for part in message.content:
+					for part in message.content or []:
 						if part.type == 'text':
 							parts.append(part.text)
 					combined_text = '\n'.join(parts)
@@ -70,10 +76,8 @@ class GoogleMessageSerializer:
 			elif isinstance(message, AssistantMessage):
 				role = 'model'
 			else:
-				# Default to user for any unknown message types
 				role = 'user'
 
-			# Initialize message parts
 			message_parts: list[Part] = []
 
 			# If this is the first user message and we have system parts, prepend them
@@ -82,39 +86,31 @@ class GoogleMessageSerializer:
 				if isinstance(message.content, str):
 					message_parts.append(Part.from_text(text=f'{system_text}\n\n{message.content}'))
 				else:
-					# Add system text as the first part
-					message_parts.append(Part.from_text(text=system_text))
-				system_parts = []  # Clear after using
+					message_parts.append(Part.from_text(text=f'{system_text}\n\n{getattr(message, "text", "")}'))
+					for part in message.content or []:
+						if part.type == 'image_url':
+							image_part = GoogleMessageSerializer._serialize_image(part)
+							message_parts.append(image_part)
+
+				system_parts = []
+
 			else:
 				# Extract content and create parts normally
 				if isinstance(message.content, str):
-					# Regular text content
 					message_parts = [Part.from_text(text=message.content)]
 				elif message.content is not None:
-					# Handle Iterable of content parts
-					for part in message.content:
+					for part in message.content or []:
 						if part.type == 'text':
 							message_parts.append(Part.from_text(text=part.text))
 						elif part.type == 'refusal':
 							message_parts.append(Part.from_text(text=f'[Refusal] {part.refusal}'))
 						elif part.type == 'image_url':
-							# Handle images
-							url = part.image_url.url
-
-							# Format: data:image/jpeg;base64,<data>
-							header, data = url.split(',', 1)
-							# Decode base64 to bytes
-							image_bytes = base64.b64decode(data)
-
-							# Add image part
-							image_part = Part.from_bytes(data=image_bytes, mime_type='image/jpeg')
-
+							image_part = GoogleMessageSerializer._serialize_image(part)
 							message_parts.append(image_part)
 
 			# Create the Content object
 			if message_parts:
 				final_message = Content(role=role, parts=message_parts)
-				# for some reason, the type checker is not able to infer the type of formatted_messages
 				formatted_messages.append(final_message)  # type: ignore
 
 		return formatted_messages, system_message


### PR DESCRIPTION
When include_system_in_user=True, non-text content (images) in the first
user message was not being serialized. Now properly handles mixed content
by extracting image serialization logic into a helper method.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image serialization in the first user message when include_system_in_user is true for Google Gemini, so mixed text + image content is preserved. Adds a small helper for consistent image handling.

- **Bug Fixes**
  - Serialize image_url parts in the first user message when system text is prepended.
  - Preserve mixed content (text and images) in the Google format.

- **Refactors**
  - Extract image serialization into _serialize_image().
  - Simplify role/content handling with getattr and safe iteration.

<sup>Written for commit d8061b692231c6b232302703b082afcdf3517e54. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

