### PR TITLE
Fix download monitoring issues with fetch requests and blob downloads

### DIFF
--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -869,7 +869,6 @@ class DownloadsWatchdog(BaseWatchdog):
 			# We just need to wait for it to appear in the downloads directory
 			expected_path = downloads_dir / suggested_filename
 
- 
 			# For remote browsers, don't poll local filesystem; downloadProgress handler will emit the event
 			if not self.browser_session.is_local:
 				return


### PR DESCRIPTION
Fixes three issues in download monitoring:

1. **Prevent false PDF downloads from fetch/XHR**: Skip programmatic requests (fetch() and XHR) since real browsers don't download PDFs loaded this way
2. **Fix case-sensitive header lookup**: Normalize HTTP headers to lowercase for case-insensitive Content-Disposition detection
3. **Fix race condition with blob downloads**: Capture initial file list before any processing to detect fast blob: downloads

Fixes #3515

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves download monitoring accuracy by preventing false PDF events, capturing fast blob downloads, and avoiding stale cache skips. Fixes #3515.

- **Bug Fixes**
  - Skip Fetch/XHR responses so programmatic PDF loads aren’t treated as downloads
  - Normalize headers to lowercase and ignore stale session cache entries; allow retries if background download fails
  - Capture initial downloads snapshot and detect new files when filePath is missing to handle fast blob downloads

<sup>Written for commit 6db6678a8397ce7934883225777eb3cce6a2aa96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

