### PR TITLE
improve judge logging to laminar and separate code

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -912,6 +912,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			self._message_manager._add_context_message(UserMessage(content=msg))
 			self.AgentOutput = self.DoneAgentOutput
 
+	@observe(ignore_input=True, ignore_output=False)
 	async def _judge_trace(self) -> JudgementResult | None:
 		"""Judge the trace of the agent"""
 		task = self.task
@@ -943,6 +944,24 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			self.logger.error(f'Judge trace failed: {e}')
 			# Return a default judgement on failure
 			return None
+
+	async def _judge_and_log(self) -> None:
+		"""Run judge evaluation and log the verdict"""
+		judgement = await self._judge_trace()
+
+		# Attach judgement to last action result
+		if self.history.history[-1].result[-1].is_done:
+			self.history.history[-1].result[-1].judgement = judgement
+
+			# Log the verdict
+			if judgement:
+				verdict_color = '\033[32m' if judgement.verdict else '\033[31m'
+				verdict_text = '✅ PASS' if judgement.verdict else '❌ FAIL'
+				judge_log = f'\n⚖️  {verdict_color}Judge Verdict: {verdict_text}\033[0m\n'
+				if judgement.failure_reason:
+					judge_log += f'   Failure: {judgement.failure_reason}\n'
+				judge_log += f'   {judgement.reasoning}\n'
+				self.logger.info(judge_log)
 
 	async def _get_model_output_with_retry(self, input_messages: list[BaseMessage]) -> AgentOutput:
 		"""Get model output with retry logic for empty actions"""
@@ -1739,20 +1758,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				if is_done:
 					# Agent has marked the task as done
 					if self.settings.use_judge:
-						judgement = await self._judge_trace()
-						# Modify the last action result (that should have is_done=True) to include the judgement
-						if self.history.history[-1].result[-1].is_done:
-							self.history.history[-1].result[-1].judgement = judgement
-							# Log the judgement verdict
-							if judgement:
-								verdict_color = '\033[32m' if judgement.verdict else '\033[31m'
-								verdict_text = '✅ PASS' if judgement.verdict else '❌ FAIL'
-								judge_log = f'\n⚖️  {verdict_color}Judge Verdict: {verdict_text}\033[0m\n'
-								if judgement.failure_reason:
-									judge_log += f'   Failure: {judgement.failure_reason}\n'
-								judge_log += f'   {judgement.reasoning}\n'
-								self.logger.info(judge_log)
-
+						await self._judge_and_log()
 					break
 			else:
 				agent_run_error = 'Failed to complete task in maximum steps'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extracts judgement logic into `_judge_and_log()` and adds `@observe` to `_judge_trace`, replacing inline judge code in `run()`.
> 
> - **Agent judgement flow**:
>   - Add `@observe` to `_judge_trace` for observability.
>   - Introduce `_judge_and_log()` to run judge, attach `judgement` to final action, and log colored verdict with optional failure details.
>   - Replace inline judge logic in `run()` with a call to `_judge_and_log()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29ec2cacb6bc4639d3dcff1bca337926714435a7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Laminar instrumentation to judge evaluation and centralized verdict logging in a new _judge_and_log method for cleaner code and clearer logs.

- **Refactors**
  - Added @observe(ignore_input=True, ignore_output=False) to _judge_trace for Laminar logging.
  - Extracted verdict logging into _judge_and_log; attaches judgement to the last is_done action and logs pass/fail with reason.
  - Replaced inline judgement handling in the run loop with a call to _judge_and_log.

<sup>Written for commit 29ec2cacb6bc4639d3dcff1bca337926714435a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

