### PR TITLE
Add download statistics badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
     </picture>
 </div>
 
-</br>
+<div align="center">
+<img src="https://media.browser-use.tools/badges/package" height="48" alt="Browser-Use Package Download Statistics">
+</div>
 
 ---
 


### PR DESCRIPTION
Added a badge for Browser-Use package download statistics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The README now shows a centered download statistics badge for the Browser-Use package. This helps users quickly see usage at a glance.

<sup>Written for commit dd6d09f14dedfb1ae067d938d5f4b4ff9453eaaf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

