### PR TITLE
default to PNG everywhere

### DIFF
--- a/browser_use/actor/README.md
+++ b/browser_use/actor/README.md
@@ -75,7 +75,7 @@ await element.drag_to(target_element)  # Drag and drop
 value = await element.get_attribute("value")
 box = await element.get_bounding_box()  # Returns BoundingBox or None
 info = await element.get_basic_info()  # Comprehensive element info
-screenshot_b64 = await element.screenshot(format='jpeg')
+screenshot_b64 = await element.screenshot(format='png')
 
 # Execute JavaScript on element (this context is the element)
 text = await element.evaluate("() => this.textContent")
@@ -108,7 +108,7 @@ await page.press("Escape")     # Single keys
 
 # Page controls
 await page.set_viewport_size(width=1920, height=1080)
-page_screenshot = await page.screenshot()  # JPEG by default
+page_screenshot = await page.screenshot()  # PNG by default
 page_png = await page.screenshot(format="png", quality=90)
 
 # Page information
@@ -166,7 +166,7 @@ products = await page.extract_content(
 - `evaluate(page_function: str, *args)` → `str` - Execute JavaScript (MUST use (...args) => format)
 - `press(key: str)` - Press key on page (supports "Control+A" format)
 - `set_viewport_size(width: int, height: int)` - Set viewport dimensions
-- `screenshot(format='jpeg', quality=None)` → `str` - Take page screenshot, return base64
+- `screenshot(format='png', quality=None)` → `str` - Take page screenshot, return base64
 - `get_url()` → `str`, `get_title()` → `str` - Get page information
 - `mouse` → `Mouse` - Get mouse interface for this page
 
@@ -181,7 +181,7 @@ products = await page.extract_content(
 - `evaluate(page_function: str, *args)` → `str` - Execute JavaScript on element (this = element)
 - `get_attribute(name: str)` → `str | None` - Get attribute value
 - `get_bounding_box()` → `BoundingBox | None` - Get element position/size
-- `screenshot(format='jpeg', quality=None)` → `str` - Take element screenshot, return base64
+- `screenshot(format='png', quality=None)` → `str` - Take element screenshot, return base64
 - `get_basic_info()` → `ElementInfo` - Get comprehensive element information
 
 

--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -679,7 +679,7 @@ class Element:
 		except Exception:
 			return None
 
-	async def screenshot(self, format: str = 'jpeg', quality: int | None = None) -> str:
+	async def screenshot(self, format: str = 'png', quality: int | None = None) -> str:
 		"""Take a screenshot of this element and return base64 encoded image.
 
 		Args:

--- a/browser_use/actor/page.py
+++ b/browser_use/actor/page.py
@@ -188,7 +188,7 @@ class Page:
 
 		return js_code
 
-	async def screenshot(self, format: str = 'jpeg', quality: int | None = None) -> str:
+	async def screenshot(self, format: str = 'png', quality: int | None = None) -> str:
 		"""Take a screenshot and return base64 encoded image.
 
 		Args:

--- a/browser_use/agent/cloud_events.py
+++ b/browser_use/agent/cloud_events.py
@@ -155,7 +155,7 @@ class CreateAgentStepEvent(BaseEvent):
 		# Capture screenshot as base64 data URL if available
 		screenshot_url = None
 		if browser_state_summary.screenshot:
-			screenshot_url = f'data:image/jpeg;base64,{browser_state_summary.screenshot}'
+			screenshot_url = f'data:image/png;base64,{browser_state_summary.screenshot}'
 			import logging
 
 			logger = logging.getLogger(__name__)

--- a/browser_use/agent/judge.py
+++ b/browser_use/agent/judge.py
@@ -158,9 +158,9 @@ Set `reached_captcha` to true if:
 Respond with EXACTLY this JSON structure (no additional text before or after):
 
 {{
-	"reasoning": "Breakdown of user task into key points. Detailed analysis covering: what went well, what didn't work, trajectory quality assessment, tool usage evaluation, output quality review, and overall user satisfaction prediction",
+	"reasoning": "Breakdown of user task into key points. Detailed analysis covering: what went well, what didn't work, trajectory quality assessment, tool usage evaluation, output quality review, and overall user satisfaction prediction.",
 	"verdict": true or false,
-	"failure_reason": "If verdict is false, provide the key reason why the task was not completed successfully. If verdict is true, use an empty string.",
+	"failure_reason": "A brief explanation of key reasons why the task was not completed successfully in case of failure. If verdict is true, use an empty string. Keep it concise and easy to read.",
 	"impossible_task": true or false,
 	"reached_captcha": true or false
 }}

--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -373,8 +373,8 @@ Available tabs:
 				content_parts.append(
 					ContentPartImageParam(
 						image_url=ImageURL(
-							url=f'data:image/jpeg;base64,{screenshot}',
-							media_type='image/jpeg',
+							url=f'data:image/png;base64,{screenshot}',
+							media_type='image/png',
 							detail=self.vision_detail_level,
 						),
 					)

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -973,7 +973,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				verdict_text = '✅ PASS' if judgement.verdict else '❌ FAIL'
 				judge_log += f'⚖️  {verdict_color}Judge Verdict: {verdict_text}\033[0m\n'
 				if judgement.failure_reason:
-					judge_log += f'   Failure: {judgement.failure_reason}\n'
+					judge_log += f'   Failure Reason: {judgement.failure_reason}\n'
 				if judgement.reached_captcha:
 					judge_log += '   🤖 Captcha Detected: Agent encountered captcha challenges\n'
 					judge_log += '   👉 🥷 Use Browser Use Cloud for the most stealth browser infra: https://docs.browser-use.com/customize/browser/remote\n'

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -94,7 +94,8 @@ class JudgementResult(BaseModel):
 	reasoning: str | None = Field(default=None, description='Explanation of the judgement')
 	verdict: bool = Field(description='Whether the trace was successful or not')
 	failure_reason: str | None = Field(
-		default=None, description='If the trace was not successful, the reason why. Otherwise empty.'
+		default=None,
+		description='A brief explanation of key reasons why the task was not completed successfully in case of failure. If verdict is true, use an empty string. Keep it concise and easy to read.',
 	)
 	impossible_task: bool = Field(
 		default=False,

--- a/browser_use/browser/watchdogs/screenshot_watchdog.py
+++ b/browser_use/browser/watchdogs/screenshot_watchdog.py
@@ -39,7 +39,7 @@ class ScreenshotWatchdog(BaseWatchdog):
 			cdp_session = await self.browser_session.get_or_create_cdp_session()
 
 			# Prepare screenshot parameters
-			params = CaptureScreenshotParameters(format='jpeg', quality=60, captureBeyondViewport=False)
+			params = CaptureScreenshotParameters(format='png', captureBeyondViewport=False)
 
 			# Take screenshot using CDP
 			self.logger.debug(f'[ScreenshotWatchdog] Taking screenshot with params: {params}')

--- a/browser_use/code_use/service.py
+++ b/browser_use/code_use/service.py
@@ -614,8 +614,8 @@ class CodeAgent:
 				content_parts.append(
 					ContentPartImageParam(
 						image_url=ImageURL(
-							url=f'data:image/jpeg;base64,{self._last_screenshot}',
-							media_type='image/jpeg',
+							url=f'data:image/png;base64,{self._last_screenshot}',
+							media_type='image/png',
 							detail='auto',
 						),
 					)

--- a/browser_use/llm/messages.py
+++ b/browser_use/llm/messages.py
@@ -61,7 +61,7 @@ class ImageURL(BaseModel):
     [Vision guide](https://platform.openai.com/docs/guides/vision#low-or-high-fidelity-image-understanding).
     """
 	# needed for Anthropic
-	media_type: SupportedImageMediaType = 'image/jpeg'
+	media_type: SupportedImageMediaType = 'image/png'
 
 	def __str__(self) -> str:
 		url_display = _format_image_url(self.url)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Changes default screenshot/media format from JPEG to PNG across actor APIs, agents, cloud/events, and LLM messaging; updates docs and minor judge/log text.
> 
> - **Screenshots & Images (PNG default)**:
>   - Actor APIs: `Page.screenshot()` and `Element.screenshot()` default to `format='png'` in `browser_use/actor/page.py` and `browser_use/actor/element.py`.
>   - Watchdog: `ScreenshotWatchdog` uses `CaptureScreenshotParameters(format='png')`.
>   - LLM Messaging: `ImageURL.media_type` default set to `image/png` in `browser_use/llm/messages.py`.
>   - Data URLs: All screenshot embeddings switched to `data:image/png;base64,...` in `agent/cloud_events.py`, `agent/prompts.py`, `agent/judge.py`, and `code_use/service.py`.
> - **Docs**:
>   - Update README examples to reflect PNG defaults for page/element screenshots.
> - **Agent/Judge text tweaks**:
>   - Refine `JudgementResult.failure_reason` description and system prompt punctuation.
>   - Log label changed to `Failure Reason:` in `agent/service.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67d2f126652b27c3d0ad16c0d5834964243e9a52. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default screenshot format is now PNG across the app to improve image clarity and standardize media types. This updates code, prompts, events, and docs to use image/png consistently.

- **Refactors**
  - Page and element screenshot defaults changed from 'jpeg' to 'png'.
  - CDP screenshots now use PNG (quality param removed).
  - Data URLs and media_type switched to image/png in prompts, cloud events, code-use, and LLM messages.
  - README examples updated to reflect PNG defaults.
  - Minor wording improvements for judge failure reasons and logs.

- **Migration**
  - If you rely on JPEG, pass format='jpeg' explicitly when calling screenshot().
  - Update any code that expects data:image/jpeg to handle data:image/png.

<sup>Written for commit 67d2f126652b27c3d0ad16c0d5834964243e9a52. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

