### PR TITLE
vision defaults to True

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ Complete reference for all agent configuration options
 
 ### Vision & Processing
 
-* `use_vision` (default: `"auto"`): Vision mode - `"auto"` includes screenshot tool but only uses vision when requested, `True` always includes screenshots, `False` never includes screenshots and excludes screenshot tool
+* `use_vision` (default: `"True"`): Vision mode - `"auto"` includes screenshot tool but only uses vision when requested, `True` always includes screenshots, `False` never includes screenshots and excludes screenshot tool
 * `vision_detail_level` (default: `'auto'`): Screenshot detail level - `'low'`, `'high'`, or `'auto'`
 * `page_extraction_llm`: Separate LLM model for page content extraction. You can choose a small & fast model because it only needs to extract text from the page (default: same as `llm`)
 

--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -292,7 +292,7 @@ class MessageManager:
 		model_output: AgentOutput | None = None,
 		result: list[ActionResult] | None = None,
 		step_info: AgentStepInfo | None = None,
-		use_vision: bool | Literal['auto'] = 'auto',
+		use_vision: bool | Literal['auto'] = True,
 		page_filtered_actions: str | None = None,
 		sensitive_data=None,
 		available_file_paths: list[str] | None = None,  # Always pass current available_file_paths

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -150,7 +150,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		register_should_stop_callback: Callable[[], Awaitable[bool]] | None = None,
 		# Agent settings
 		output_model_schema: type[AgentStructuredOutput] | None = None,
-		use_vision: bool | Literal['auto'] = 'auto',
+		use_vision: bool | Literal['auto'] = True,
 		save_conversation_path: str | Path | None = None,
 		save_conversation_path_encoding: str | None = 'utf-8',
 		max_failures: int = 3,

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class AgentSettings(BaseModel):
 	"""Configuration options for the Agent"""
 
-	use_vision: bool | Literal['auto'] = 'auto'
+	use_vision: bool | Literal['auto'] = True
 	vision_detail_level: Literal['auto', 'low', 'high'] = 'auto'
 	save_conversation_path: str | Path | None = None
 	save_conversation_path_encoding: str | None = 'utf-8'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set use_vision default from "auto" to True across the agent settings and services, enabling screenshots/vision by default. Updated AGENTS.md to reflect the new default.

- **Migration**
  - To keep previous behavior, set use_vision='auto'.
  - To disable vision, set use_vision=False.

<sup>Written for commit d3a88ce3514aefac30c0c1a5700dd73b24a147da. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

