### PR TITLE
Remove deprecated agent.context documentation

### DIFF
--- a/docs/customize/hooks.mdx
+++ b/docs/customize/hooks.mdx
@@ -92,7 +92,6 @@ When working with agent hooks, you have access to the entire `Agent` instance. H
 - `agent.task` lets you see what the main task is, `agent.add_new_task(...)` lets you queue up a new one
 - `agent.tools` give access to the `Tools()` object and `Registry()` containing the available actions
   - `agent.tools.registry.execute_action('click', {'index': 123}, browser_session=agent.browser_session)`
-- `agent.context` lets you access any user-provided context object passed in to `Agent(context=...)`
 - `agent.sensitive_data` contains the sensitive data dict, which can be updated in-place to add/remove/modify items
 - `agent.settings` contains all the configuration options passed to the `Agent(...)` at init time
 - `agent.llm` gives direct access to the main LLM object (e.g. `ChatOpenAI`)


### PR DESCRIPTION
Remove `agent.context` reference from documentation because it is deprecated.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1762903033523869?thread_ts=1762903033.523869&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-73851c35-0197-4994-aad9-bcc2bcceb977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-73851c35-0197-4994-aad9-bcc2bcceb977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the deprecated agent.context reference from the hooks documentation to match the current Agent API and prevent confusion. This is a docs-only update reflecting that context is no longer supported.

<sup>Written for commit a92a1190c207d9e597047d269c57123205eef5a3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

