### PR TITLE
Add polynomial to url endings

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1604,6 +1604,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			'deb',
 			'rpm',
 			'iso',
+			# GitHub/Project paths
+			'polynomial',
 		}
 
 		excluded_words = {


### PR DESCRIPTION
Add 'polynomial' to the `excluded_extensions` set to prevent the agent from automatically opening URLs containing it.

Previously, the agent would automatically navigate to URLs like `numpy.polynomial` when encountering them in tasks, even when they represented project paths or labels rather than web pages to be opened. This change ensures such URLs are treated as excluded extensions, allowing the agent to decide navigation based on context.

---
[Slack Thread](https://browser-use.slack.com/archives/C091NM0S79T/p1762931711238959?thread_ts=1762931711.238959&cid=C091NM0S79T)

<a href="https://cursor.com/background-agent?bcId=bc-1410a12d-a2e8-4447-8166-5e6939e45ee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1410a12d-a2e8-4447-8166-5e6939e45ee6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops auto-navigation to URLs containing “polynomial” (e.g., numpy.polynomial) by adding it to excluded_extensions. This prevents false opens of project paths/labels and lets the agent decide navigation based on context.

<sup>Written for commit 8f1b73335c87501437a4aff13d831608294451c8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treats `.polynomial` as an excluded extension during task URL extraction to prevent automatic navigation to such paths.
> 
> - **Agent URL extraction (`browser_use/agent/service.py`)**:
>   - Add `"polynomial"` to `excluded_extensions` in `_extract_start_url`, preventing auto-navigation to URLs containing `.polynomial` (e.g., project/module paths).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f1b73335c87501437a4aff13d831608294451c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->