### PR TITLE
Add http_client to Anthropic Chat

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -50,6 +50,7 @@ class ChatAnthropic(BaseChatModel):
 	max_retries: int = 10
 	default_headers: Mapping[str, str] | None = None
 	default_query: Mapping[str, object] | None = None
+	http_client: httpx.AsyncClient | None = None
 
 	# Static
 	@property
@@ -67,6 +68,7 @@ class ChatAnthropic(BaseChatModel):
 			'max_retries': self.max_retries,
 			'default_headers': self.default_headers,
 			'default_query': self.default_query,
+			'http_client': self.http_client,
 		}
 
 		# Create client_params dict with non-None values and non-NotGiven values


### PR DESCRIPTION
We need the http_client to be able to properly handle client lifecycles 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added an optional http_client to ChatAnthropic so you can inject a shared httpx.AsyncClient. This enables custom timeouts/proxies and connection reuse for lower overhead.

- **New Features**
  - Accepts http_client and forwards it in client params when provided.

<sup>Written for commit d251105e646901d682bd4496f92c0dfefd94fc38. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

