### PR TITLE
more logging

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1453,9 +1453,10 @@ class BrowserSession(BaseModel):
 			async with httpx.AsyncClient() as client:
 				headers = self.browser_profile.headers or {}
 				version_info = await client.get(url, headers=headers)
+				self.logger.debug(f'Raw version info: {str(version_info)}')
 				self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
 
-		assert self.cdp_url is not None
+		assert self.cdp_url is not None, 'CDP URL is None.'
 
 		browser_location = 'local browser' if self.is_local else 'remote browser'
 		self.logger.debug(f'🌎 Connecting to existing chromium-based browser via CDP: {self.cdp_url} -> ({browser_location})')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add debug logging of the raw version info response in session.connect and a clearer assert message when the CDP URL is missing. This helps diagnose failures when connecting to existing Chromium browsers via CDP.

<sup>Written for commit a2e81f17d7048a5c2c0d11c3c951f852875d22b2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

