### PR TITLE
add the system prompt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ include = [
     "browser_use/agent/system_prompt.md",
     "browser_use/agent/system_prompt_no_thinking.md",
     "browser_use/agent/system_prompt_flash.md",
+    "browser_use/agent/system_prompt_flash_anthropic.md",
     "browser_use/code_use/system_prompt.md",
     "browser_use/cli_templates/*.py",
     "browser_use/py.typed",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add system_prompt_flash_anthropic.md to the package includes so it ships with releases. Prevents missing-file errors when loading the Anthropic flash system prompt in production.

<sup>Written for commit 3ec547135b034191bc8df2a9614833d2e6f6327e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

