### PR TITLE
Handle None session_manager in DownloadsWatchdog network handler

### DIFF
--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -333,6 +333,11 @@ class DownloadsWatchdog(BaseWatchdog):
 					This callback is registered globally and uses session_id to determine the correct target.
 					"""
 					try:
+						# Check if session_manager exists (may be None during browser shutdown)
+						if not self.browser_session.session_manager:
+							self.logger.warning('[DownloadsWatchdog] Session manager not found, skipping network monitoring')
+							return
+
 						# Look up target_id from session_id
 						event_target_id = self.browser_session.session_manager.get_target_id_from_session_id(session_id)
 						if not event_target_id:


### PR DESCRIPTION
### Problem:
AttributeError: 'NoneType' object has no attribute 'get_target_id_from_session_id' occurred when the network response handler ran after browser shutdown or before connection, when session_manager was None.

### Root Cause:
The global Network.responseReceived callback can fire after session_manager is cleared during _disconnect_from_browser(), causing a race condition.

### Solution:
Added a None check before accessing session_manager.get_target_id_from_session_id() in on_response_received, returning early if session_manager is None. Added a warning log for visibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handled None session_manager in DownloadsWatchdog to avoid crashes when Network.responseReceived fires during browser shutdown or before connection. We now skip network monitoring and log a warning if session_manager is missing.

<sup>Written for commit a3e1ed7274010a5bebcd34f489747d9204ef3818. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

