### PR TITLE
Sanitize api key from logs

### DIFF
--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -14,6 +14,7 @@ from browser_use.llm.messages import (
 	SystemMessage,
 	UserMessage,
 )
+from browser_use.llm.sanitization import sanitize_api_key, sanitize_dict, sanitize_string
 from browser_use.llm.messages import (
 	ContentPartImageParam as ContentImage,
 )
@@ -137,6 +138,10 @@ __all__ = [
 	'ContentText',
 	'ContentRefusal',
 	'ContentImage',
+	# Sanitization utilities
+	'sanitize_api_key',
+	'sanitize_dict',
+	'sanitize_string',
 	# Chat models
 	'BaseChatModel',
 	'ChatOpenAI',

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -112,6 +112,16 @@ class ChatAnthropic(BaseChatModel):
 	def name(self) -> str:
 		return str(self.model)
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatAnthropic(model={self.model!r}, api_key={sanitize_api_key(self.api_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatAnthropic(model={self.model}, api_key={sanitize_api_key(self.api_key)})'
+
 	def _get_usage(self, response: Message) -> ChatInvokeUsage | None:
 		usage = ChatInvokeUsage(
 			prompt_tokens=response.usage.input_tokens

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -63,6 +63,16 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 	def provider(self) -> str:
 		return 'anthropic_bedrock'
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose AWS credentials"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatAnthropicBedrock(model={self.model!r}, aws_access_key={sanitize_api_key(self.aws_access_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose AWS credentials"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatAnthropicBedrock(model={self.model}, aws_access_key={sanitize_api_key(self.aws_access_key)})'
+
 	def _get_client_params(self) -> dict[str, Any]:
 		"""Prepare client parameters dictionary for Bedrock."""
 		client_params: dict[str, Any] = {}

--- a/browser_use/llm/aws/chat_bedrock.py
+++ b/browser_use/llm/aws/chat_bedrock.py
@@ -99,6 +99,16 @@ class ChatAWSBedrock(BaseChatModel):
 	def name(self) -> str:
 		return str(self.model)
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose AWS credentials"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatAWSBedrock(model={self.model!r}, aws_access_key_id={sanitize_api_key(self.aws_access_key_id)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose AWS credentials"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatAWSBedrock(model={self.model}, aws_access_key_id={sanitize_api_key(self.aws_access_key_id)})'
+
 	def _get_inference_config(self) -> dict[str, Any]:
 		"""Get the inference configuration for the request."""
 		config = {}

--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -40,6 +40,16 @@ class ChatAzureOpenAI(ChatOpenAILike):
 	def provider(self) -> str:
 		return 'azure'
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatAzureOpenAI(model={self.model!r}, api_key={sanitize_api_key(self.api_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatAzureOpenAI(model={self.model}, api_key={sanitize_api_key(self.api_key)})'
+
 	def _get_client_params(self) -> dict[str, Any]:
 		_client_params: dict[str, Any] = {}
 

--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -78,6 +78,16 @@ class ChatBrowserUse(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatBrowserUse(model={self.model!r}, api_key={sanitize_api_key(self.api_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatBrowserUse(model={self.model}, api_key={sanitize_api_key(self.api_key)})'
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, request_type: str = 'browser_agent'

--- a/browser_use/llm/cerebras/chat.py
+++ b/browser_use/llm/cerebras/chat.py
@@ -58,6 +58,16 @@ class ChatCerebras(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatCerebras(model={self.model!r}, api_key={sanitize_api_key(self.api_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatCerebras(model={self.model}, api_key={sanitize_api_key(self.api_key)})'
+
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
 		if response.usage is not None:
 			usage = ChatInvokeUsage(

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -59,6 +59,16 @@ class ChatDeepSeek(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatDeepSeek(model={self.model!r}, api_key={sanitize_api_key(self.api_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatDeepSeek(model={self.model}, api_key={sanitize_api_key(self.api_key)})'
+
 	@overload
 	async def ainvoke(
 		self,

--- a/browser_use/llm/exceptions.py
+++ b/browser_use/llm/exceptions.py
@@ -11,8 +11,12 @@ class ModelProviderError(ModelError):
 		status_code: int = 502,
 		model: str | None = None,
 	):
-		super().__init__(message)
-		self.message = message
+		from browser_use.llm.sanitization import sanitize_string
+		
+		# Sanitize the message to remove any API keys
+		sanitized_message = sanitize_string(message)
+		super().__init__(sanitized_message)
+		self.message = sanitized_message
 		self.status_code = status_code
 		self.model = model
 
@@ -26,4 +30,5 @@ class ModelRateLimitError(ModelProviderError):
 		status_code: int = 429,
 		model: str | None = None,
 	):
+		# ModelProviderError will sanitize the message
 		super().__init__(message, status_code, model)

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -148,6 +148,16 @@ class ChatGoogle(BaseChatModel):
 	def name(self) -> str:
 		return str(self.model)
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatGoogle(model={self.model!r}, api_key={sanitize_api_key(self.api_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatGoogle(model={self.model}, api_key={sanitize_api_key(self.api_key)})'
+
 	def _get_stop_reason(self, response: types.GenerateContentResponse) -> str | None:
 		"""Extract stop_reason from Google response."""
 		if hasattr(response, 'candidates') and response.candidates:

--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -84,6 +84,16 @@ class ChatGroq(BaseChatModel):
 	def name(self) -> str:
 		return str(self.model)
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatGroq(model={self.model!r}, api_key={sanitize_api_key(self.api_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatGroq(model={self.model}, api_key={sanitize_api_key(self.api_key)})'
+
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
 		usage = (
 			ChatInvokeUsage(

--- a/browser_use/llm/oci_raw/chat.py
+++ b/browser_use/llm/oci_raw/chat.py
@@ -98,6 +98,14 @@ class ChatOCIRaw(BaseChatModel):
 	def model(self) -> str:
 		return self.model_id
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose sensitive data"""
+		return f'ChatOCIRaw(model_id={self.model_id!r}, provider={self.provider!r}, compartment_id=***)'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose sensitive data"""
+		return f'ChatOCIRaw(model_id={self.model_id}, provider={self.provider}, compartment_id=***)'
+
 	@property
 	def model_name(self) -> str:
 		# Override for telemetry - return shorter name (max 100 chars)

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -57,6 +57,14 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose sensitive data"""
+		return f'ChatOllama(model={self.model!r}, host={self.host!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose sensitive data"""
+		return f'ChatOllama(model={self.model}, host={self.host})'
+
 	@overload
 	async def ainvoke(self, messages: list[BaseMessage], output_format: None = None) -> ChatInvokeCompletion[str]: ...
 

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -120,6 +120,16 @@ class ChatOpenAI(BaseChatModel):
 	def name(self) -> str:
 		return str(self.model)
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatOpenAI(model={self.model!r}, api_key={sanitize_api_key(self.api_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatOpenAI(model={self.model}, api_key={sanitize_api_key(self.api_key)})'
+
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
 		if response.usage is not None:
 			completion_tokens = response.usage.completion_tokens

--- a/browser_use/llm/openrouter/chat.py
+++ b/browser_use/llm/openrouter/chat.py
@@ -95,6 +95,16 @@ class ChatOpenRouter(BaseChatModel):
 	def name(self) -> str:
 		return str(self.model)
 
+	def __repr__(self) -> str:
+		"""Safe repr that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatOpenRouter(model={self.model!r}, api_key={sanitize_api_key(self.api_key)!r})'
+
+	def __str__(self) -> str:
+		"""Safe str that doesn't expose API keys"""
+		from browser_use.llm.sanitization import sanitize_api_key
+		return f'ChatOpenRouter(model={self.model}, api_key={sanitize_api_key(self.api_key)})'
+
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
 		"""Extract usage information from the OpenRouter response."""
 		if response.usage is None:

--- a/browser_use/llm/sanitization.py
+++ b/browser_use/llm/sanitization.py
@@ -1,0 +1,122 @@
+"""Utilities for sanitizing sensitive data from logs and error messages."""
+
+import re
+from typing import Any
+
+
+def sanitize_api_key(value: str | None, show_chars: int = 3) -> str:
+	"""
+	Sanitize an API key by showing only the first few characters.
+	
+	Args:
+		value: The API key to sanitize
+		show_chars: Number of characters to show from the start (default: 3)
+	
+	Returns:
+		Sanitized string like 'csk-c9m…' or '<not set>' if None
+	"""
+	if value is None:
+		return '<not set>'
+	if not isinstance(value, str):
+		return '<invalid>'
+	if len(value) <= show_chars:
+		return '***'
+	return f'{value[:show_chars]}…'
+
+
+def sanitize_dict(data: dict[str, Any], sensitive_keys: set[str] | None = None) -> dict[str, Any]:
+	"""
+	Recursively sanitize a dictionary by masking sensitive keys.
+	
+	Args:
+		data: Dictionary to sanitize
+		sensitive_keys: Set of key names to sanitize (default: api_key, auth_token, password, secret)
+	
+	Returns:
+		New dictionary with sensitive values masked
+	"""
+	if sensitive_keys is None:
+		sensitive_keys = {'api_key', 'auth_token', 'password', 'secret', 'token', 'authorization'}
+	
+	result = {}
+	for key, value in data.items():
+		key_lower = key.lower()
+		
+		# Check if key matches any sensitive pattern
+		is_sensitive = any(sensitive in key_lower for sensitive in sensitive_keys)
+		
+		if is_sensitive:
+			result[key] = sanitize_api_key(value) if isinstance(value, str) else '<redacted>'
+		elif isinstance(value, dict):
+			result[key] = sanitize_dict(value, sensitive_keys)
+		elif isinstance(value, list):
+			result[key] = [sanitize_dict(item, sensitive_keys) if isinstance(item, dict) else item for item in value]
+		else:
+			result[key] = value
+	
+	return result
+
+
+def sanitize_string(text: str, patterns: list[str] | None = None) -> str:
+	"""
+	Sanitize a string by replacing API key patterns with masked versions.
+	
+	Args:
+		text: Text to sanitize
+		patterns: List of regex patterns to match API keys (default: common API key formats)
+	
+	Returns:
+		Sanitized text with API keys masked
+	"""
+	if patterns is None:
+		# Common API key patterns
+		patterns = [
+			# OpenAI style: sk-... or sk-proj-...
+			r'sk-[a-zA-Z0-9_-]{20,}',
+			# Anthropic style: sk-ant-...
+			r'sk-ant-[a-zA-Z0-9_-]{20,}',
+			# Google API keys (alphanumeric, 39+ chars)
+			r'AIza[a-zA-Z0-9_-]{35,}',
+			# Generic API keys (key=value patterns)
+			r'(?i)(api[_-]?key|apikey|auth[_-]?token|token)["\']?\s*[:=]\s*["\']?([a-zA-Z0-9_-]{20,})',
+			# Cerebras/OpenRouter style: csk-..., or-...
+			r'csk-[a-zA-Z0-9_-]{20,}',
+			r'or-[a-zA-Z0-9_-]{20,}',
+			# AWS style
+			r'AKIA[a-zA-Z0-9]{16,}',
+			# Browser Use API keys
+			r'bu-[a-zA-Z0-9_-]{20,}',
+		]
+	
+	sanitized = text
+	for pattern in patterns:
+		# Find all matches
+		matches = re.finditer(pattern, sanitized)
+		for match in matches:
+			matched_text = match.group(0)
+			# If this is a key=value match, only mask the value part
+			if match.lastindex and match.lastindex >= 2:
+				key_part = match.group(1)
+				value_part = match.group(2)
+				masked_value = sanitize_api_key(value_part)
+				replacement = f'{key_part}={masked_value}'
+			else:
+				replacement = sanitize_api_key(matched_text)
+			
+			sanitized = sanitized.replace(matched_text, replacement)
+	
+	return sanitized
+
+
+def sanitize_exception_message(exc: Exception) -> str:
+	"""
+	Sanitize an exception message by removing sensitive data.
+	
+	Args:
+		exc: Exception to sanitize
+	
+	Returns:
+		Sanitized exception message
+	"""
+	message = str(exc)
+	return sanitize_string(message)

--- a/tests/ci/test_api_key_sanitization.py
+++ b/tests/ci/test_api_key_sanitization.py
@@ -1,0 +1,158 @@
+"""Tests for API key sanitization in logs and errors."""
+
+import pytest
+
+from browser_use.llm.anthropic.chat import ChatAnthropic
+from browser_use.llm.browser_use.chat import ChatBrowserUse
+from browser_use.llm.cerebras.chat import ChatCerebras
+from browser_use.llm.deepseek.chat import ChatDeepSeek
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.google.chat import ChatGoogle
+from browser_use.llm.groq.chat import ChatGroq
+from browser_use.llm.openai.chat import ChatOpenAI
+from browser_use.llm.openrouter.chat import ChatOpenRouter
+from browser_use.llm.sanitization import sanitize_api_key, sanitize_dict, sanitize_string
+
+
+class TestSanitization:
+	"""Test API key sanitization utilities."""
+
+	def test_sanitize_api_key_basic(self):
+		"""Test basic API key sanitization."""
+		# Test with a typical API key
+		api_key = 'sk-1234567890abcdefghijklmnopqrstuvwxyz'
+		sanitized = sanitize_api_key(api_key)
+		assert sanitized == 'sk-…'
+		assert 'abcdefghijklmnopqrstuvwxyz' not in sanitized
+
+	def test_sanitize_api_key_short(self):
+		"""Test sanitization of short keys."""
+		short_key = 'sk'
+		sanitized = sanitize_api_key(short_key)
+		assert sanitized == '***'
+
+	def test_sanitize_api_key_none(self):
+		"""Test sanitization of None."""
+		sanitized = sanitize_api_key(None)
+		assert sanitized == '<not set>'
+
+	def test_sanitize_dict(self):
+		"""Test dictionary sanitization."""
+		data = {
+			'model': 'gpt-4o',
+			'api_key': 'sk-1234567890abcdefghijklmnopqrstuvwxyz',
+			'temperature': 0.5,
+			'nested': {'auth_token': 'secret-token-here', 'value': 42},
+		}
+		sanitized = sanitize_dict(data)
+		assert sanitized['model'] == 'gpt-4o'
+		assert sanitized['temperature'] == 0.5
+		assert 'abcdefghijklmnopqrstuvwxyz' not in sanitized['api_key']
+		assert 'secret-token-here' not in sanitized['nested']['auth_token']
+		assert sanitized['nested']['value'] == 42
+
+	def test_sanitize_string_openai(self):
+		"""Test string sanitization with OpenAI-style keys."""
+		text = "Error: Invalid API key 'sk-1234567890abcdefghijklmnopqrstuvwxyz' provided"
+		sanitized = sanitize_string(text)
+		assert 'abcdefghijklmnopqrstuvwxyz' not in sanitized
+		assert 'sk-…' in sanitized
+
+	def test_sanitize_string_cerebras(self):
+		"""Test string sanitization with Cerebras-style keys."""
+		text = "Error with key csk-c9m9rpdkjpjfxcr1234567890abcdefghijklmnopqrstuvwxyz"
+		sanitized = sanitize_string(text)
+		assert 'c9m9rpdkjpjfxcr1234567890abcdefghijklmnopqrstuvwxyz' not in sanitized
+		assert 'csk-…' in sanitized
+
+	def test_sanitize_string_google(self):
+		"""Test string sanitization with Google API keys."""
+		text = "Google API key AIzaSyC1234567890abcdefghijklmnopqrstuvwxyz failed"
+		sanitized = sanitize_string(text)
+		assert 'AIzaSyC1234567890abcdefghijklmnopqrstuvwxyz' not in sanitized
+
+	def test_model_provider_error_sanitization(self):
+		"""Test that ModelProviderError sanitizes API keys in messages."""
+		error_msg = "API request failed with key 'sk-1234567890abcdefghijklmnopqrstuvwxyz'"
+		error = ModelProviderError(error_msg, status_code=401)
+		assert 'abcdefghijklmnopqrstuvwxyz' not in str(error)
+		assert 'abcdefghijklmnopqrstuvwxyz' not in error.message
+
+
+class TestChatModelRepr:
+	"""Test that chat model __repr__ and __str__ don't expose API keys."""
+
+	def test_openai_repr(self):
+		"""Test ChatOpenAI repr doesn't expose API key."""
+		model = ChatOpenAI(model='gpt-4o', api_key='sk-1234567890abcdefghijklmnopqrstuvwxyz')
+		repr_str = repr(model)
+		str_str = str(model)
+		assert 'abcdefghijklmnopqrstuvwxyz' not in repr_str
+		assert 'abcdefghijklmnopqrstuvwxyz' not in str_str
+		assert 'sk-…' in repr_str or '<not set>' in repr_str or '***' in repr_str
+
+	def test_anthropic_repr(self):
+		"""Test ChatAnthropic repr doesn't expose API key."""
+		model = ChatAnthropic(model='claude-sonnet-4-0', api_key='sk-ant-1234567890abcdefghijklmnopqrstuvwxyz')
+		repr_str = repr(model)
+		str_str = str(model)
+		assert 'abcdefghijklmnopqrstuvwxyz' not in repr_str
+		assert 'abcdefghijklmnopqrstuvwxyz' not in str_str
+
+	def test_google_repr(self):
+		"""Test ChatGoogle repr doesn't expose API key."""
+		model = ChatGoogle(model='gemini-2.5-flash', api_key='AIzaSyC1234567890abcdefghijklmnopqrstuvwxyz')
+		repr_str = repr(model)
+		str_str = str(model)
+		assert 'AIzaSyC1234567890abcdefghijklmnopqrstuvwxyz' not in repr_str
+		assert 'AIzaSyC1234567890abcdefghijklmnopqrstuvwxyz' not in str_str
+
+	def test_cerebras_repr(self):
+		"""Test ChatCerebras repr doesn't expose API key."""
+		model = ChatCerebras(model='llama3.1-8b', api_key='csk-c9m9rpdkjpjfxcr1234567890abcdefghijklmnopqrstuvwxyz')
+		repr_str = repr(model)
+		str_str = str(model)
+		assert 'c9m9rpdkjpjfxcr1234567890abcdefghijklmnopqrstuvwxyz' not in repr_str
+		assert 'c9m9rpdkjpjfxcr1234567890abcdefghijklmnopqrstuvwxyz' not in str_str
+
+	def test_groq_repr(self):
+		"""Test ChatGroq repr doesn't expose API key."""
+		model = ChatGroq(model='qwen/qwen3-32b', api_key='gsk-1234567890abcdefghijklmnopqrstuvwxyz')
+		repr_str = repr(model)
+		str_str = str(model)
+		assert 'abcdefghijklmnopqrstuvwxyz' not in repr_str
+		assert 'abcdefghijklmnopqrstuvwxyz' not in str_str
+
+	def test_deepseek_repr(self):
+		"""Test ChatDeepSeek repr doesn't expose API key."""
+		model = ChatDeepSeek(model='deepseek-chat', api_key='sk-1234567890abcdefghijklmnopqrstuvwxyz')
+		repr_str = repr(model)
+		str_str = str(model)
+		assert 'abcdefghijklmnopqrstuvwxyz' not in repr_str
+		assert 'abcdefghijklmnopqrstuvwxyz' not in str_str
+
+	def test_openrouter_repr(self):
+		"""Test ChatOpenRouter repr doesn't expose API key."""
+		model = ChatOpenRouter(model='openai/gpt-4o', api_key='sk-or-1234567890abcdefghijklmnopqrstuvwxyz')
+		repr_str = repr(model)
+		str_str = str(model)
+		assert 'abcdefghijklmnopqrstuvwxyz' not in repr_str
+		assert 'abcdefghijklmnopqrstuvwxyz' not in str_str
+
+	def test_browser_use_repr(self):
+		"""Test ChatBrowserUse repr doesn't expose API key."""
+		# This will fail to initialize without a valid key, but we can test the repr after catching the error
+		try:
+			model = ChatBrowserUse(model='bu-latest', api_key='bu-1234567890abcdefghijklmnopqrstuvwxyz')
+			# If it doesn't fail, test the repr
+			repr_str = repr(model)
+			str_str = str(model)
+			assert 'abcdefghijklmnopqrstuvwxyz' not in repr_str
+			assert 'abcdefghijklmnopqrstuvwxyz' not in str_str
+		except ValueError:
+			# Expected if API key validation fails
+			pass
+
+
+if __name__ == '__main__':
+	pytest.main([__file__, '-v'])


### PR DESCRIPTION
Implement API key sanitization to prevent sensitive credentials from being exposed in logs and error messages.

User LLM model API keys were being exposed in error tracebacks (e.g., `UnprocessableEntityError` details) and logs, creating a security vulnerability. This PR introduces a sanitization layer by:
- Creating `browser_use/llm/sanitization.py` with utilities to mask API keys in strings and dictionaries.
- Overriding `__repr__` and `__str__` methods for all LLM chat classes to ensure API keys are masked when model instances are logged or printed.
- Modifying `ModelProviderError` to automatically sanitize its message, preventing direct exposure of keys in exception messages.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1763052889563969?thread_ts=1763052889.563969&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-7ab362e0-46b6-48b0-b166-5b676b02b433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ab362e0-46b6-48b0-b166-5b676b02b433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes API keys in logs and exception messages to prevent credential leaks across all LLM providers. Ensures model repr/str and errors never expose raw keys.

- **Bug Fixes**
  - Added sanitization utilities (sanitize_api_key, sanitize_string, sanitize_dict).
  - Masked keys in __repr__ and __str__ for all chat classes (OpenAI, Anthropic, Google, Groq, Azure, AWS Bedrock, OpenRouter, Cerebras, BrowserUse, etc.).
  - Auto-sanitized ModelProviderError messages.
  - Added tests covering key formats and repr/str behavior.
  - No breaking changes.

<sup>Written for commit 22d8103a6ce4faa83a8b20494ac2962350cbeb46. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

