### PR TITLE
InterruptedError is due to user interrupting, so should be warning

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -849,7 +849,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Handle InterruptedError specially
 		if isinstance(error, InterruptedError):
 			error_msg = 'The agent was interrupted mid-step' + (f' - {str(error)}' if str(error) else '')
-			self.logger.error(f'{error_msg}')
+			# NOTE: This is not an error, it's a normal part of the execution when the user interrupts the agent
+			self.logger.warning(f'{error_msg}')
 			return
 
 		# Handle all other exceptions


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Treat user-initiated agent interruptions as warnings instead of errors to reduce noisy logs and avoid false alerts.

- **Bug Fixes**
  - In _handle_step_error, log InterruptedError with warning and return early since this is expected user behavior.

<sup>Written for commit deea28b4bb2f01b70669ff52554f7b5c8cfeee11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

