### PR TITLE
pr-3564

### DIFF
--- a/browser_use/dom/serializer/clickable_elements.py
+++ b/browser_use/dom/serializer/clickable_elements.py
@@ -18,17 +18,9 @@ class ClickableElementDetector:
 		if node.tag_name in {'html', 'body'}:
 			return False
 
-		# Skip elements explicitly marked as inert or aria-hidden
-		if node.attributes:
-			if 'inert' in node.attributes:
-				return False
-
-			aria_hidden = node.attributes.get('aria-hidden')
-			if isinstance(aria_hidden, str):
-				if aria_hidden.strip().lower() in {'true', '1'}:
-					return False
-			elif aria_hidden:
-				return False
+		# Skip elements marked as inert (computed during tree construction for O(1) lookup)
+		if node.is_inert:
+			return False
 
 		# IFRAME elements should be interactive if they're large enough to potentially need scrolling
 		# Small iframes (< 100px width or height) are unlikely to have scrollable content

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -569,6 +569,22 @@ class DomService:
 					node['parentId']
 				]  # parents should always be in the lookup
 
+			# Propagate is_inert from parent or check current node
+			if dom_tree_node.parent_node and dom_tree_node.parent_node.is_inert:
+				# Parent is inert, so this node is too
+				dom_tree_node.is_inert = True
+			elif attributes:
+				# Check if current node has inert or aria-hidden='true'
+				if 'inert' in attributes:
+					dom_tree_node.is_inert = True
+				else:
+					aria_hidden = attributes.get('aria-hidden')
+					if isinstance(aria_hidden, str):
+						if aria_hidden.strip().lower() in {'true', '1'}:
+							dom_tree_node.is_inert = True
+					elif aria_hidden:
+						dom_tree_node.is_inert = True
+
 			# Check if this is an HTML frame node and add it to the list
 			updated_html_frames = html_frames.copy()
 			if node['nodeType'] == NodeType.ELEMENT_NODE.value and node['nodeName'] == 'HTML' and node.get('frameId') is not None:

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -391,6 +391,12 @@ class EnhancedDOMTreeNode:
 
 	uuid: str = field(default_factory=uuid7str)
 
+	is_inert: bool = False
+	"""
+	Whether this node or any ancestor has inert or aria-hidden='true'.
+	Computed during tree construction for O(1) lookup.
+	"""
+
 	@property
 	def parent(self) -> 'EnhancedDOMTreeNode | None':
 		return self.parent_node


### PR DESCRIPTION
Auto-generated PR for branch: pr-3564

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `is_inert` propagation (via `inert` and `aria-hidden`) during DOM tree construction and skip inert elements in clickable detection.
> 
> - **DOM Model**:
>   - Add `is_inert` boolean to `EnhancedDOMTreeNode` in `browser_use/dom/views.py` for O(1) inert lookup.
> - **Tree Construction** (`browser_use/dom/service.py`):
>   - Compute and propagate `is_inert` from ancestors; set when element has `inert` or `aria-hidden` truthy.
>   - Preserve existing iframe/scroll handling; add debug logging around HTML frame scroll.
> - **Clickable Detection** (`browser_use/dom/serializer/clickable_elements.py`):
>   - Skip nodes with `is_inert` before other interactivity checks.
>   - Keep large iframe handling unchanged (interactive if >100x100).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a7b099502aef716cd9d6afcac140ae291059502. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip inert and aria-hidden elements when detecting interactive DOM nodes. This prevents clicks on hidden or disabled UI and makes checks O(1) via a precomputed flag.

- Bug Fixes
  - Compute and propagate is_inert during tree build (from inert or aria-hidden='true/1', inherited from parent).
  - is_interactive now ignores nodes with is_inert.

<sup>Written for commit 7a7b099502aef716cd9d6afcac140ae291059502. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

