### PR TITLE
sanitize everything now

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Literal, Optional
 from browser_use.dom.views import NodeType, SimplifiedNode
 from browser_use.llm.messages import ContentPartImageParam, ContentPartTextParam, ImageURL, SystemMessage, UserMessage
 from browser_use.observability import observe_debug
-from browser_use.utils import is_new_tab_page
+from browser_use.utils import is_new_tab_page, sanitize_surrogates
 
 if TYPE_CHECKING:
 	from browser_use.agent.views import AgentStepInfo
@@ -352,15 +352,6 @@ Available tabs:
 			logging.getLogger(__name__).warning(f'Failed to resize screenshot: {e}, using original')
 			return screenshot_b64
 
-	@staticmethod
-	def _sanitize_surrogates(text: str) -> str:
-		"""Remove surrogate characters that can't be encoded in UTF-8.
-
-		Surrogate pairs (U+D800 to U+DFFF) are invalid in UTF-8 when unpaired.
-		These often appear in DOM content from mathematical symbols or emojis.
-		"""
-		return text.encode('utf-8', errors='ignore').decode('utf-8')
-
 	@observe_debug(ignore_input=True, ignore_output=True, name='get_user_message')
 	def get_user_message(self, use_vision: bool = True) -> UserMessage:
 		"""Get complete state as a single cached message"""
@@ -392,7 +383,7 @@ Available tabs:
 			state_description += '</page_specific_actions>\n'
 
 		# Sanitize surrogates from all text content
-		state_description = self._sanitize_surrogates(state_description)
+		state_description = sanitize_surrogates(state_description)
 
 		# Check if we have images to include (from read_file action)
 		has_images = bool(self.read_state_images)

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -51,7 +51,7 @@ from browser_use.tools.views import (
 	SwitchTabAction,
 	UploadFileAction,
 )
-from browser_use.utils import create_task_with_error_handling, time_execution_sync
+from browser_use.utils import create_task_with_error_handling, sanitize_surrogates, time_execution_sync
 
 logger = logging.getLogger(__name__)
 
@@ -741,6 +741,10 @@ You will be given a query and the markdown of a webpage that has been filtered t
 - Do not answer in conversational format - directly output the relevant information or that the information is unavailable.
 </output>
 """.strip()
+
+			# Sanitize surrogates from content to prevent UTF-8 encoding errors
+			content = sanitize_surrogates(content)
+			query = sanitize_surrogates(query)
 
 			prompt = f'<query>\n{query}\n</query>\n\n<content_stats>\n{stats_summary}\n</content_stats>\n\n<webpage_content>\n{content}\n</webpage_content>'
 

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -733,3 +733,18 @@ def create_task_with_error_handling(
 
 	task.add_done_callback(_handle_task_exception)
 	return task
+
+
+def sanitize_surrogates(text: str) -> str:
+	"""Remove surrogate characters that can't be encoded in UTF-8.
+
+	Surrogate pairs (U+D800 to U+DFFF) are invalid in UTF-8 when unpaired.
+	These often appear in DOM content from mathematical symbols or emojis.
+
+	Args:
+		text: The text to sanitize
+
+	Returns:
+		Text with surrogate characters removed
+	"""
+	return text.encode('utf-8', errors='ignore').decode('utf-8')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent UTF-8 encoding errors by sanitizing surrogate characters across the agent and tools. Centralizes sanitization and applies it to DOM-derived text and extraction inputs.

- **Bug Fixes**
  - Sanitize state_description in get_user_message to avoid encoding crashes.
  - Sanitize content and query in extract() to prevent UTF-8 errors.

- **Refactors**
  - Moved sanitize_surrogates to utils and reused it across modules.
  - Removed the local _sanitize_surrogates method from prompts.py.

<sup>Written for commit a64c82ef2c6328fafdb5604418131b9d1a5f6c99. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

