### PR TITLE
fix: improve CDPClient cleanup

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -410,6 +410,7 @@ class BrowserSession(BaseModel):
 
 	# Mutable private state shared between watchdogs
 	_cdp_client_root: CDPClient | None = PrivateAttr(default=None)
+	_connection_lock: Any = PrivateAttr(default=None)  # asyncio.Lock for preventing concurrent connections
 
 	# PUBLIC: SessionManager instance (OWNS all targets and sessions)
 	session_manager: Any = Field(default=None, exclude=True)  # SessionManager
@@ -471,14 +472,25 @@ class BrowserSession(BaseModel):
 	async def reset(self) -> None:
 		"""Clear all cached CDP sessions with proper cleanup."""
 
-		# TODO: clear the event bus queue here, implement this helper
-		# await self.event_bus.wait_for_idle(timeout=5.0)
-		# await self.event_bus.clear()
+		cdp_status = 'connected' if self._cdp_client_root else 'not connected'
+		session_mgr_status = 'exists' if self.session_manager else 'None'
+		self.logger.info(
+			f'🔄 Resetting browser session (CDP: {cdp_status}, SessionManager: {session_mgr_status}, '
+			f'focus: {self.agent_focus_target_id[-4:] if self.agent_focus_target_id else "None"})'
+		)
 
 		# Clear session manager (which owns _targets, _sessions, _target_sessions)
 		if self.session_manager:
 			await self.session_manager.clear()
 			self.session_manager = None
+
+		# Close CDP WebSocket before clearing to prevent stale event handlers
+		if self._cdp_client_root:
+			try:
+				await self._cdp_client_root.stop()
+				self.logger.debug('Closed CDP client WebSocket during reset')
+			except Exception as e:
+				self.logger.debug(f'Error closing CDP client during reset: {e}')
 
 		self._cdp_client_root = None  # type: ignore
 		self._cached_browser_state_summary = None
@@ -504,10 +516,13 @@ class BrowserSession(BaseModel):
 			self._demo_mode.reset()
 			self._demo_mode = None
 
+		self.logger.info('✅ Browser session reset complete')
+
 	def model_post_init(self, __context) -> None:
 		"""Register event handlers after model initialization."""
-		# Check if handlers are already registered to prevent duplicates
+		self._connection_lock = asyncio.Lock()
 
+		# Check if handlers are already registered to prevent duplicates
 		from browser_use.browser.watchdog_base import BaseWatchdog
 
 		start_handlers = self.event_bus.handlers.get('BrowserStartEvent', [])
@@ -540,6 +555,8 @@ class BrowserSession(BaseModel):
 
 	async def kill(self) -> None:
 		"""Kill the browser session and reset all state."""
+		self.logger.info('🛑 kill() called - stopping browser with force=True and resetting state')
+
 		# First save storage state while CDP is still connected
 		from browser_use.browser.events import SaveStorageStateEvent
 
@@ -561,6 +578,8 @@ class BrowserSession(BaseModel):
 		This clears event buses and cached state but keeps the browser alive.
 		Useful when you want to clean up resources but plan to reconnect later.
 		"""
+		self.logger.info('⏸️  stop() called - stopping browser gracefully (force=False) and resetting state')
+
 		# First save storage state while CDP is still connected
 		from browser_use.browser.events import SaveStorageStateEvent
 
@@ -583,9 +602,11 @@ class BrowserSession(BaseModel):
 
 		Returns:
 			Dict with 'cdp_url' key containing the CDP URL
-		"""
 
-		# await self.reset()
+		Note: This method is idempotent - calling start() multiple times is safe.
+		- If already connected, it skips reconnection
+		- If you need to reset state, call stop() or kill() first
+		"""
 
 		# Initialize and attach all watchdogs FIRST so LocalBrowserWatchdog can handle BrowserLaunchEvent
 		await self.attach_all_watchdogs()
@@ -623,31 +644,33 @@ class BrowserSession(BaseModel):
 
 			assert self.cdp_url and '://' in self.cdp_url
 
-			# Only connect if not already connected
-			if self._cdp_client_root is None:
-				# Setup browser via CDP (for both local and remote cases)
-				await self.connect(cdp_url=self.cdp_url)
-				assert self.cdp_client is not None
+			# Use lock to prevent concurrent connection attempts (race condition protection)
+			async with self._connection_lock:
+				# Only connect if not already connected
+				if self._cdp_client_root is None:
+					# Setup browser via CDP (for both local and remote cases)
+					await self.connect(cdp_url=self.cdp_url)
+					assert self.cdp_client is not None
 
-				# Notify that browser is connected (single place)
-				self.event_bus.dispatch(BrowserConnectedEvent(cdp_url=self.cdp_url))
+					# Notify that browser is connected (single place)
+					self.event_bus.dispatch(BrowserConnectedEvent(cdp_url=self.cdp_url))
 
-				if self.browser_profile.demo_mode:
-					try:
-						demo = self.demo_mode
-						if demo:
-							await demo.ensure_ready()
-					except Exception as exc:
-						self.logger.warning(f'[DemoMode] Failed to inject demo overlay: {exc}')
-			else:
-				self.logger.debug('Already connected to CDP, skipping reconnection')
-				if self.browser_profile.demo_mode:
-					try:
-						demo = self.demo_mode
-						if demo:
-							await demo.ensure_ready()
-					except Exception as exc:
-						self.logger.warning(f'[DemoMode] Failed to inject demo overlay: {exc}')
+					if self.browser_profile.demo_mode:
+						try:
+							demo = self.demo_mode
+							if demo:
+								await demo.ensure_ready()
+						except Exception as exc:
+							self.logger.warning(f'[DemoMode] Failed to inject demo overlay: {exc}')
+				else:
+					self.logger.debug('Already connected to CDP, skipping reconnection')
+					if self.browser_profile.demo_mode:
+						try:
+							demo = self.demo_mode
+							if demo:
+								await demo.ensure_ready()
+						except Exception as exc:
+							self.logger.warning(f'[DemoMode] Failed to inject demo overlay: {exc}')
 
 			# Return the CDP URL for other components
 			return {'cdp_url': self.cdp_url}
@@ -1011,6 +1034,9 @@ class BrowserSession(BaseModel):
 					self.logger.debug(f'Failed to cleanup cloud browser session: {e}')
 
 			# Clear CDP session cache before stopping
+			self.logger.info(
+				f'📢 on_BrowserStopEvent - Calling reset() (force={event.force}, keep_alive={self.browser_profile.keep_alive})'
+			)
 			await self.reset()
 
 			# Reset state
@@ -1440,6 +1466,17 @@ class BrowserSession(BaseModel):
 		if not self.cdp_url:
 			raise RuntimeError('Cannot setup CDP connection without CDP URL')
 
+		# Prevent duplicate connections - clean up existing connection first
+		if self._cdp_client_root is not None:
+			self.logger.warning(
+				'⚠️ connect() called but CDP client already exists! Cleaning up old connection before creating new one.'
+			)
+			try:
+				await self._cdp_client_root.stop()
+			except Exception as e:
+				self.logger.debug(f'Error stopping old CDP client: {e}')
+			self._cdp_client_root = None
+
 		if not self.cdp_url.startswith('ws'):
 			# If it's an HTTP URL, fetch the WebSocket URL from /json/version endpoint
 			url = self.cdp_url.rstrip('/')
@@ -1552,7 +1589,24 @@ class BrowserSession(BaseModel):
 			# Fatal error - browser is not usable without CDP connection
 			self.logger.error(f'❌ FATAL: Failed to setup CDP connection: {e}')
 			self.logger.error('❌ Browser cannot continue without CDP connection')
-			# Clean up any partial state
+
+			# Clear SessionManager state
+			if self.session_manager:
+				try:
+					await self.session_manager.clear()
+					self.logger.debug('Cleared SessionManager state after initialization failure')
+				except Exception as cleanup_error:
+					self.logger.debug(f'Error clearing SessionManager: {cleanup_error}')
+
+			# Close CDP client WebSocket and unregister handlers
+			if self._cdp_client_root:
+				try:
+					await self._cdp_client_root.stop()  # Close WebSocket and unregister handlers
+					self.logger.debug('Closed CDP client WebSocket after initialization failure')
+				except Exception as cleanup_error:
+					self.logger.debug(f'Error closing CDP client: {cleanup_error}')
+
+			self.session_manager = None
 			self._cdp_client_root = None
 			self.agent_focus_target_id = None
 			# Re-raise as a fatal error


### PR DESCRIPTION
Enhance SessionManager and BrowserSession with defensive checks and connection management

- Added defensive checks in SessionManager to skip target attachment and focus recovery if the browser is shutting down (i.e., _cdp_client_root is None).
- Introduced a connection lock in BrowserSession to prevent concurrent connection attempts, ensuring safe CDP client management.
- Improved logging for session reset and connection handling, providing clearer insights into the browser session state during operations.
- Enhanced error handling when stopping the CDP client and clearing session manager state on initialization failures.

These changes improve the robustness and reliability of session management in the browser environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved CDP client cleanup and connection handling to prevent race conditions and stale sessions, making browser start/stop more reliable.

- **Bug Fixes**
  - Added a connection lock to block concurrent connect attempts.
  - Closed CDP WebSocket during reset/stop/kill before clearing state, with clearer logs.
  - Skipped target attach and focus recovery when the CDP client is absent (browser shutting down).
  - On connect failure or duplicate connect, stopped the existing client, cleared SessionManager, and reset state.

<sup>Written for commit 6c1f772a2d0d7b8070c42bf91336471ccf6cf309. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

