### PR TITLE
refactor: change stop/reset logs from info to debug

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -474,7 +474,7 @@ class BrowserSession(BaseModel):
 
 		cdp_status = 'connected' if self._cdp_client_root else 'not connected'
 		session_mgr_status = 'exists' if self.session_manager else 'None'
-		self.logger.info(
+		self.logger.debug(
 			f'🔄 Resetting browser session (CDP: {cdp_status}, SessionManager: {session_mgr_status}, '
 			f'focus: {self.agent_focus_target_id[-4:] if self.agent_focus_target_id else "None"})'
 		)
@@ -555,7 +555,7 @@ class BrowserSession(BaseModel):
 
 	async def kill(self) -> None:
 		"""Kill the browser session and reset all state."""
-		self.logger.info('🛑 kill() called - stopping browser with force=True and resetting state')
+		self.logger.debug('🛑 kill() called - stopping browser with force=True and resetting state')
 
 		# First save storage state while CDP is still connected
 		from browser_use.browser.events import SaveStorageStateEvent
@@ -578,7 +578,7 @@ class BrowserSession(BaseModel):
 		This clears event buses and cached state but keeps the browser alive.
 		Useful when you want to clean up resources but plan to reconnect later.
 		"""
-		self.logger.info('⏸️  stop() called - stopping browser gracefully (force=False) and resetting state')
+		self.logger.debug('⏸️  stop() called - stopping browser gracefully (force=False) and resetting state')
 
 		# First save storage state while CDP is still connected
 		from browser_use.browser.events import SaveStorageStateEvent


### PR DESCRIPTION
change logging level from info to debug in BrowserSession methods

Updated the logging level for session management methods in BrowserSession to debug for more granular logging. This change applies to the reset, kill, and stop methods, enhancing the clarity of log outputs during browser session operations without cluttering the info logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the log level for BrowserSession reset(), kill(), and stop() messages from info to debug. This reduces noise in info logs while keeping detailed session lifecycle events available for troubleshooting.

- **Refactors**
  - Replaced logger.info with logger.debug in reset(), kill(), and stop().
  - No runtime behavior changes; logging only.

<sup>Written for commit 2d433dca4b995aa9600259954bb7006ef1766a09. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

