### PR TITLE
we call the judge before done callback to enable in the cloud

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1575,6 +1575,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		if self.history.is_done():
 			await self.log_completion()
+
+			# Run judge before done callback if enabled
+			if self.settings.use_judge:
+				await self._judge_and_log()
+
 			if self.register_done_callback:
 				if inspect.iscoroutinefunction(self.register_done_callback):
 					await self.register_done_callback(self.history)
@@ -1772,6 +1777,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if self.history.is_done():
 			await self.log_completion()
 
+			# Run judge before done callback if enabled
+			if self.settings.use_judge:
+				await self._judge_and_log()
+
 			if self.register_done_callback:
 				if inspect.iscoroutinefunction(self.register_done_callback):
 					await self.register_done_callback(self.history)
@@ -1887,9 +1896,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 				if is_done:
 					# Agent has marked the task as done
-					if self.settings.use_judge:
-						await self._judge_and_log()
-
 					if self._demo_mode_enabled and self.history.history:
 						final_result_text = self.history.final_result() or 'Task completed'
 						await self._demo_mode_log(f'Final Result: {final_result_text}', 'success', {'tag': 'task'})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run the judge before the done callback when a task completes. This ensures judged results and logs are available to cloud deployments that use the done callback.

- **Bug Fixes**
  - Invoke _judge_and_log before register_done_callback in take_step and _execute_step when use_judge is enabled.
  - Remove the old judge call in on_force_exit_log_telemetry to prevent double execution and keep ordering consistent.

<sup>Written for commit 7dc5f5bf24944f1463968079a9632bda5370f0a5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

