### PR TITLE
update readme2

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ We optimized **ChatBrowserUse()** specifically for browser automation tasks. On 
 
 **Pricing (per 1M tokens):**
 - Input tokens: $0.20
+- Cached input tokens: $0.02
 - Output tokens: $2.00
-- Cached tokens: $0.02
 
 For other LLM providers, see our [supported models documentation](https://docs.browser-use.com/supported-models).
 </details>


### PR DESCRIPTION
Auto-generated PR for: update readme2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update README pricing to include cached input token rate and clean up the FAQ list.
> 
> - **Docs**:
>   - Update `README.md` FAQ pricing:
>     - Add bullet for `Cached input tokens: $0.02`.
>     - Remove/adjust redundant cached tokens line and tidy list formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bed21c45f167b7e0e9c5b04aa9e6f2e7fd3250c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the README pricing by renaming “Cached tokens” to “Cached input tokens” at $0.02 per 1M tokens. This removes ambiguity between input and output token costs.

<sup>Written for commit 2bed21c45f167b7e0e9c5b04aa9e6f2e7fd3250c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

