### PR TITLE
Set default max actions per step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,7 +300,7 @@ Check out all customizable parameters <a href="/customize/agent/all-parameters">
 ### Actions & Behavior
 
 * `initial_actions`: List of actions to run before the main task without LLM. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/initial_actions.py)
-* `max_actions_per_step` (default: `10`): Maximum actions per step, e.g. for form filling the agent can output 10 fields at once. We execute the actions until the page changes.
+* `max_actions_per_step` (default: `4`): Maximum actions per step, e.g. for form filling the agent can output 4 fields at once. We execute the actions until the page changes.
 * `max_failures` (default: `3`): Maximum retries for steps with errors
 * `final_response_after_failure` (default: `True`): If True, attempt to force one final model call with intermediate output after max\_failures is reached
 * `use_thinking` (default: `True`): Controls whether the agent uses its internal "thinking" field for explicit reasoning steps.

--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 class SystemPrompt:
 	def __init__(
 		self,
-		max_actions_per_step: int = 10,
+		max_actions_per_step: int = 4,
 		override_system_message: str | None = None,
 		extend_system_message: str | None = None,
 		use_thinking: bool = True,

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -159,7 +159,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		generate_gif: bool | str = False,
 		available_file_paths: list[str] | None = None,
 		include_attributes: list[str] | None = None,
-		max_actions_per_step: int = 10,
+		max_actions_per_step: int = 4,
 		use_thinking: bool = True,
 		flash_mode: bool = False,
 		demo_mode: bool | None = None,

--- a/docs/customize/agent/all-parameters.mdx
+++ b/docs/customize/agent/all-parameters.mdx
@@ -19,7 +19,7 @@ mode: "wide"
 
 ### Actions & Behavior
 - `initial_actions`: List of actions to run before the main task without LLM. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/initial_actions.py)
-- `max_actions_per_step` (default: `10`): Maximum actions per step, e.g. for form filling the agent can output 10 fields at once. We execute the actions until the page changes.
+- `max_actions_per_step` (default: `4`): Maximum actions per step, e.g. for form filling the agent can output 4 fields at once. We execute the actions until the page changes.
 - `max_failures` (default: `3`): Maximum retries for steps with errors
 - `final_response_after_failure` (default: `True`): If True, attempt to force one final model call with intermediate output after max_failures is reached
 - `use_thinking` (default: `True`): Controls whether the agent uses its internal "thinking" field for explicit reasoning steps.


### PR DESCRIPTION
Update `max_actions_per_step` default from 10 to 4 across the codebase and documentation.

This change aligns with the cloud service behavior and improves form-filling efficiency while reducing instability from multiple simultaneous browser actions.

---
[Slack Thread](https://browser-use.slack.com/archives/C09SGG1L8RK/p1763187387977299?thread_ts=1763187387.977299&cid=C09SGG1L8RK)

<a href="https://cursor.com/background-agent?bcId=bc-c9bff35a-7764-4427-a45e-3c7df9c0d868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9bff35a-7764-4427-a45e-3c7df9c0d868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default max_actions_per_step to 4 (was 10) to match the cloud service. This makes form filling more stable and avoids issues when too many actions run at once.

<sup>Written for commit 487bd19e80d1e30209767402ce6483ea58ac5b7d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

