### PR TITLE
disable telemetry logs for chatbrowseruse

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -105,6 +105,7 @@ class ChatBrowserUse(BaseChatModel):
 		"""
 		# Get ANONYMIZED_TELEMETRY setting from config
 		from browser_use.config import CONFIG
+
 		anonymized_telemetry = CONFIG.ANONYMIZED_TELEMETRY
 
 		# Prepare request payload


### PR DESCRIPTION
Auto-generated PR for: disable telemetry logs for chatbrowseruse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Passes `anonymized_telemetry` from `CONFIG.ANONYMIZED_TELEMETRY` in `ChatBrowserUse.ainvoke` request payload to control telemetry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f6d606fac50c0e871badaad01036139f16182f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables telemetry logging for ChatBrowserUse by sending the anonymized_telemetry flag from CONFIG in the ainvoke request payload. Telemetry now respects the global ANONYMIZED_TELEMETRY setting, allowing logs to be suppressed when disabled.

<sup>Written for commit 1f6d606fac50c0e871badaad01036139f16182f8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



