### PR TITLE
Configure screenshot size for browser-use models

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -215,7 +215,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Auto-configure llm_screenshot_size for Claude Sonnet models
 		if llm_screenshot_size is None:
 			model_name = getattr(llm, 'model', '')
-			if isinstance(model_name, str) and model_name.startswith('claude-sonnet'):
+			if isinstance(model_name, str) and (model_name.startswith('claude-sonnet') or 'browser-use' in model_name):
 				llm_screenshot_size = (1400, 850)
 				logger.info('🖼️  Auto-configured LLM screenshot size for Claude Sonnet: 1400x850')
 


### PR DESCRIPTION
Auto-configure `llm_screenshot_size` for models containing 'browser-use' in their name to match Claude Sonnet models.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1763343108086029?thread_ts=1763343108.086029&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-f89be972-8372-40ba-a6e2-40167ffaa94c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f89be972-8372-40ba-a6e2-40167ffaa94c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-configure the LLM screenshot size to 1400x850 for models whose name includes “browser-use,” matching the Claude Sonnet default when llm_screenshot_size is not provided. This ensures consistent screenshot dimensions across browser-use and Claude Sonnet models.

<sup>Written for commit efc0f83063e6427e8776ba60e6d5323f5c74b261. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

