### PR TITLE
Add log redaction option to agent init

### DIFF
--- a/docs/customize/agent/all-parameters.mdx
+++ b/docs/customize/agent/all-parameters.mdx
@@ -34,6 +34,7 @@ mode: "wide"
 - `save_conversation_path_encoding` (default: `'utf-8'`): Encoding for saved conversations
 - `available_file_paths`: List of file paths the agent can access
 - `sensitive_data`: Dictionary of sensitive data to handle carefully. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/sensitive_data.py)
+- `redact_logs` (default: `False`): Redact sensitive information from all logger outputs including task, URLs, LLM responses, action parameters, and CDP URLs. Useful for protecting sensitive data in production logs
 
 ### Visual Output
 - `generate_gif` (default: `False`): Generate GIF of agent actions. Set to `True` or string path

--- a/examples/features/redact_logs.py
+++ b/examples/features/redact_logs.py
@@ -1,0 +1,52 @@
+"""
+Example demonstrating log redaction for protecting sensitive data.
+
+This example shows how to use the redact_logs parameter to automatically
+redact sensitive information from all logger outputs.
+"""
+
+import asyncio
+
+from browser_use import Agent, Browser, ChatBrowserUse
+
+
+async def main():
+	# Example 1: Agent with log redaction enabled
+	# All sensitive data will be redacted from logs
+	agent = Agent(
+		task='Go to https://example.com and search for confidential information',
+		llm=ChatBrowserUse(),
+		browser=Browser(headless=True),
+		redact_logs=True,  # Enable log redaction
+	)
+
+	# When logs are written, sensitive information will be replaced with:
+	# - Task content: [REDACTED_TASK]
+	# - URLs: [REDACTED_URL]
+	# - CDP URLs: [REDACTED_CDP_URL]
+	# - Action parameters (text, query, value, content): [REDACTED]
+
+	# Run the agent
+	history = await agent.run(max_steps=3)
+
+	print('\n' + '=' * 80)
+	print('With redact_logs=True, all sensitive data in logs is automatically redacted')
+	print('=' * 80 + '\n')
+
+	# Example 2: Normal logging (default behavior)
+	agent_normal = Agent(
+		task='Go to https://example.com and search for information',
+		llm=ChatBrowserUse(),
+		browser=Browser(headless=True),
+		redact_logs=False,  # Default: no redaction
+	)
+
+	history_normal = await agent_normal.run(max_steps=3)
+
+	print('\n' + '=' * 80)
+	print('With redact_logs=False (default), logs show full details')
+	print('=' * 80 + '\n')
+
+
+if __name__ == '__main__':
+	asyncio.run(main())

--- a/tests/ci/test_log_redaction.py
+++ b/tests/ci/test_log_redaction.py
@@ -1,0 +1,150 @@
+"""Test log redaction functionality"""
+
+import asyncio
+import logging
+
+import pytest
+
+from browser_use import Agent, Browser
+from browser_use.logging_config import LogRedactionFilter
+
+
+class TestLogRedactionFilter:
+	"""Test the LogRedactionFilter class"""
+
+	def test_redact_task(self):
+		"""Test that task content is redacted"""
+		task = 'Go to https://example.com and search for my secret password'
+		filter_obj = LogRedactionFilter(task=task)
+
+		text = f'Agent task: {task}'
+		redacted = filter_obj._redact_string(text)
+
+		assert '[REDACTED_TASK]' in redacted
+		assert task not in redacted
+
+	def test_redact_urls(self):
+		"""Test that URLs are redacted"""
+		filter_obj = LogRedactionFilter()
+
+		text = 'Testing URL: https://example.com/sensitive-path and http://test.com'
+		redacted = filter_obj._redact_string(text)
+
+		assert 'https://example.com' not in redacted
+		assert 'http://test.com' not in redacted
+		assert '[REDACTED_URL]' in redacted
+
+	def test_redact_cdp_url(self):
+		"""Test that CDP URL is redacted"""
+		cdp_url = 'http://localhost:9222'
+		filter_obj = LogRedactionFilter(cdp_url=cdp_url)
+
+		text = f'Connecting to {cdp_url}/devtools/browser'
+		redacted = filter_obj._redact_string(text)
+
+		assert cdp_url not in redacted
+		assert '[REDACTED_CDP_URL]' in redacted
+
+	def test_redact_json_text_fields(self):
+		"""Test that JSON text fields are redacted"""
+		filter_obj = LogRedactionFilter()
+
+		text = '{"text": "sensitive data", "query": "secret query", "content": "private content"}'
+		redacted = filter_obj._redact_string(text)
+
+		assert 'sensitive data' not in redacted
+		assert 'secret query' not in redacted
+		assert 'private content' not in redacted
+		assert '[REDACTED]' in redacted
+
+	def test_redact_json_value_fields(self):
+		"""Test that JSON value fields are redacted"""
+		filter_obj = LogRedactionFilter()
+
+		text = '{"value": "my password"}'
+		redacted = filter_obj._redact_string(text)
+
+		assert 'my password' not in redacted
+		assert '[REDACTED]' in redacted
+
+	def test_filter_applies_to_log_record(self):
+		"""Test that filter applies redaction to log records"""
+		task = 'My secret task'
+		filter_obj = LogRedactionFilter(task=task)
+
+		# Create a mock log record
+		record = logging.LogRecord(
+			name='test',
+			level=logging.INFO,
+			pathname='',
+			lineno=0,
+			msg=f'Processing task: {task}',
+			args=(),
+			exc_info=None,
+		)
+
+		# Apply filter
+		result = filter_obj.filter(record)
+
+		assert result is True  # Filter should return True
+		assert '[REDACTED_TASK]' in record.msg
+		assert task not in record.msg
+
+
+class TestAgentLogRedaction:
+	"""Test Agent integration with log redaction"""
+
+	async def test_agent_with_redact_logs_enabled(self, mock_llm):
+		"""Test that agent applies redaction filter when redact_logs=True"""
+		task = 'Go to https://example.com'
+
+		agent = Agent(
+			task=task,
+			llm=mock_llm,
+			browser=Browser(headless=True, keep_alive=False),
+			redact_logs=True,
+		)
+
+		# Check that redaction filter is stored
+		assert agent.redact_logs is True
+		assert agent._redaction_filter is not None
+		assert isinstance(agent._redaction_filter, LogRedactionFilter)
+
+		# Check that logger has the filter applied
+		logger = agent.logger
+		assert any(isinstance(f, LogRedactionFilter) for f in logger.filters)
+
+		await agent.close()
+
+	async def test_agent_without_redact_logs(self, mock_llm):
+		"""Test that agent doesn't apply redaction filter when redact_logs=False"""
+		task = 'Go to https://example.com'
+
+		agent = Agent(
+			task=task,
+			llm=mock_llm,
+			browser=Browser(headless=True, keep_alive=False),
+			redact_logs=False,
+		)
+
+		# Check that redaction filter is not stored
+		assert agent.redact_logs is False
+		assert agent._redaction_filter is None
+
+		# Check that logger doesn't have the filter applied
+		logger = agent.logger
+		assert not any(isinstance(f, LogRedactionFilter) for f in logger.filters)
+
+		await agent.close()
+
+	async def test_agent_default_redact_logs_false(self, mock_llm):
+		"""Test that redact_logs defaults to False"""
+		agent = Agent(
+			task='test task',
+			llm=mock_llm,
+			browser=Browser(headless=True, keep_alive=False),
+		)
+
+		assert agent.redact_logs is False
+
+		await agent.close()


### PR DESCRIPTION
Add `redact_logs` option to Agent to redact sensitive information from all logger outputs for enhanced privacy and security.

This is implemented via a logging filter, ensuring a clean, centralized approach to redacting task strings, URLs, LLM outputs, and action parameters without modifying individual log calls.

---
[Slack Thread](https://browser-use.slack.com/archives/C091NM0S79T/p1763434160210069?thread_ts=1763434160.210069&cid=C091NM0S79T)

<a href="https://cursor.com/background-agent?bcId=bc-bb92605c-4c70-43ed-98a9-f1a794747db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bb92605c-4c70-43ed-98a9-f1a794747db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a redact_logs option to Agent to automatically hide sensitive data in logs and telemetry. Improves privacy with a centralized filter, so we don’t touch individual log calls.

- **New Features**
  - New Agent parameter redact_logs (default: false) to enable log redaction.
  - Central LogRedactionFilter applied to the agent logger; redacts task text, URLs, CDP URL, and common JSON fields (text, query, content, value).
  - Telemetry fields are sanitized when enabled (task, URLs, final result, CDP hostname).
  - Updated docs, added an example, and tests covering filter behavior and Agent integration.

<sup>Written for commit 1498549b276a6cbc09e7fd70e1d74e3ec3297338. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

