### PR TITLE
more timeout for gemini 3 pro

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -233,6 +233,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				"""Determine timeout based on model name"""
 				model_name = getattr(llm_model, 'model', '').lower()
 				if 'gemini' in model_name:
+					if '3-pro' in model_name:
+						return 90
 					return 45
 				elif 'groq' in model_name:
 					return 30


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Special-case Gemini 3 Pro to use a 90s default LLM timeout (other Gemini models remain at 45s).
> 
> - **Agent timeout configuration** (`browser_use/agent/service.py`):
>   - Adjust `_get_model_timeout` to return `90` seconds for `gemini 3-pro` models; keep other `gemini` models at `45` seconds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67e2d779d857125e7efd0e9048b59d3912a79255. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase timeout to 90 seconds for Gemini 3 Pro to reduce request failures and handle longer responses.
Other Gemini models remain at 45 seconds; Groq stays at 30 seconds.

<sup>Written for commit 67e2d779d857125e7efd0e9048b59d3912a79255. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

