### PR TITLE
add the captcha and impossible flag in AgentEvent

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1523,6 +1523,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		judge_verdict = judgement_data.get('verdict') if judgement_data else None
 		judge_reasoning = judgement_data.get('reasoning') if judgement_data else None
 		judge_failure_reason = judgement_data.get('failure_reason') if judgement_data else None
+		judge_reached_captcha = judgement_data.get('reached_captcha') if judgement_data else None
+		judge_impossible_task = judgement_data.get('impossible_task') if judgement_data else None
 
 		self.telemetry.capture(
 			AgentTelemetryEvent(
@@ -1553,6 +1555,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				judge_verdict=judge_verdict,
 				judge_reasoning=judge_reasoning,
 				judge_failure_reason=judge_failure_reason,
+				judge_reached_captcha=judge_reached_captcha,
+				judge_impossible_task=judge_impossible_task,
 			)
 		)
 

--- a/browser_use/telemetry/views.py
+++ b/browser_use/telemetry/views.py
@@ -52,6 +52,8 @@ class AgentTelemetryEvent(BaseTelemetryEvent):
 	judge_verdict: bool | None = None
 	judge_reasoning: str | None = None
 	judge_failure_reason: str | None = None
+	judge_reached_captcha: bool | None = None
+	judge_impossible_task: bool | None = None
 
 	name: str = 'agent_event'
 

--- a/examples/features/judge_trace.py
+++ b/examples/features/judge_trace.py
@@ -16,7 +16,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from browser_use import Agent
-from browser_use.llm.google.chat import ChatGoogle
+from browser_use.llm.browser_use.chat import ChatBrowserUse
 
 # task from GAIA
 task = """
@@ -27,7 +27,7 @@ Round your result to the nearest 1000 hours and do not use any comma separators 
 
 
 async def main():
-	llm = ChatGoogle(model='gemini-2.5-flash', temperature=1.0)
+	llm = ChatBrowserUse(base_url='http://localhost:8080')
 	agent = Agent(
 		task=task,
 		llm=llm,
@@ -36,6 +36,11 @@ async def main():
 		ground_truth='16',  # The TRUE answer is 17 but we put 16 to demonstrate judge can detect when the answer is wrong.
 	)
 	history = await agent.run()
+
+	# Get the judgement result
+	if history.is_judged():
+		judgement = history.judgement()
+		print(f'Agent history judgement: {judgement}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds two telemetry flags to AgentEvent to record when a CAPTCHA is reached and when a task is judged impossible. Updates the judge_trace example to use ChatBrowserUse and print the judgement when available.

- **New Features**
  - Telemetry: Added judge_reached_captcha and judge_impossible_task to AgentTelemetryEvent and populate them during agent event logging.
  - Example: Switched judge_trace to ChatBrowserUse (local base_url) and print judgement if present.

<sup>Written for commit e62129ba93a304a71b9a258a0c48961e33925fd1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

