### PR TITLE
BU model fix

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -216,7 +216,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Auto-configure llm_screenshot_size for Claude Sonnet models
 		if llm_screenshot_size is None:
 			model_name = getattr(llm, 'model', '')
-			if isinstance(model_name, str) and (model_name.startswith('claude-sonnet') or 'browser-use' in model_name):
+			if isinstance(model_name, str) and model_name.startswith('claude-sonnet'):
 				llm_screenshot_size = (1400, 850)
 				logger.info('🖼️  Auto-configured LLM screenshot size for Claude Sonnet: 1400x850')
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Restricts auto-configured LLM screenshot size to only `claude-sonnet` models, removing the `browser-use` model check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d525b7e60e863d297a6aef614bb81fa3b38cced. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts auto-configuration of llm_screenshot_size to Claude Sonnet models only. Prevents incorrect screenshot sizing for other models that include "browser-use" in their name.

- **Bug Fixes**
  - Removed the "browser-use" substring check; auto-config now triggers only when model_name.startswith('claude-sonnet').

<sup>Written for commit 5d525b7e60e863d297a6aef614bb81fa3b38cced. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

