### PR TITLE
deepcogito/cogito-v2.1-671b

### DIFF
--- a/examples/models/openrouter.py
+++ b/examples/models/openrouter.py
@@ -15,19 +15,20 @@ load_dotenv()
 
 # All the models are type safe from OpenAI in case you need a list of supported models
 llm = ChatOpenAI(
-	model='x-ai/grok-4',
+	# model='x-ai/grok-4',
+	model='deepcogito/cogito-v2.1-671b',
 	base_url='https://openrouter.ai/api/v1',
 	api_key=os.getenv('OPENROUTER_API_KEY'),
 )
 agent = Agent(
-	task='Go to example.com, click on the first link, and give me the title of the page',
+	task='Find the number of stars of the browser-use repo',
 	llm=llm,
+	use_vision=False,
 )
 
 
 async def main():
 	await agent.run(max_steps=10)
-	input('Press Enter to continue...')
 
 
 asyncio.run(main())


### PR DESCRIPTION
Auto-generated PR for: deepcogito/cogito-v2.1-671b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the OpenRouter example to use deepcogito/cogito-v2.1-671b, change the task to fetch repo stars, disable vision, and remove the post-run input pause.
> 
> - **Examples**:
>   - **`examples/models/openrouter.py`**:
>     - Switch `llm` model to `deepcogito/cogito-v2.1-671b` (comment out `x-ai/grok-4`).
>     - Update `Agent` task to "Find the number of stars of the browser-use repo".
>     - Add `use_vision=False` to `Agent` config.
>     - Remove blocking `input(...)` after `agent.run()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5f307f5c100c3f448aa9f86be184368ce356516. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the OpenRouter example to use deepcogito/cogito-v2.1-671b. Disabled vision, changed the default task to fetch browser-use repo stars, and removed the blocking input prompt.

<sup>Written for commit f5f307f5c100c3f448aa9f86be184368ce356516. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

