### PR TITLE
Fixing the identified issue

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1776,12 +1776,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		try:
 			await asyncio.wait_for(
 				self.step(step_info),
-				timeout=180,  # 3 minute timeout
+				timeout=self.settings.step_timeout,
 			)
 			self.logger.debug(f'✅ Completed step {step + 1}/{max_steps}')
 		except TimeoutError:
 			# Handle step timeout gracefully
-			error_msg = f'Step {step + 1} timed out after 180 seconds'
+			error_msg = f'Step {step + 1} timed out after {self.settings.step_timeout} seconds'
 			self.logger.error(f'⏰ {error_msg}')
 			await self._demo_mode_log(error_msg, 'error', {'step': step + 1})
 			self.state.consecutive_failures += 1


### PR DESCRIPTION
Fix hardcoded step timeout to use `self.settings.step_timeout`.

---
[Slack Thread](https://browser-use.slack.com/archives/C08SZRT860M/p1763774697131229?thread_ts=1763774697.131229&cid=C08SZRT860M)

<a href="https://cursor.com/background-agent?bcId=bc-8f8b15a8-fc0b-42e7-a719-9c25ca0dc84e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f8b15a8-fc0b-42e7-a719-9c25ca0dc84e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the hardcoded 180s step timeout with self.settings.step_timeout to make timeouts configurable. Update the timeout error message to show the configured value.

<sup>Written for commit 15e7fd6eec5df806ed9dfa3140bf3a7c3c691dc8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the hardcoded 180s step timeout with `self.settings.step_timeout` and updates the timeout error message accordingly.
> 
> - **Agent step execution (`browser_use/agent/service.py`)**:
>   - Replace hardcoded `timeout=180` with `self.settings.step_timeout` in `asyncio.wait_for(self.step(...))`.
>   - Update timeout error message to reflect the configured `step_timeout` value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15e7fd6eec5df806ed9dfa3140bf3a7c3c691dc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->