### PR TITLE
Update default step timeout to 180

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -178,7 +178,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		include_tool_call_examples: bool = False,
 		vision_detail_level: Literal['auto', 'low', 'high'] = 'auto',
 		llm_timeout: int | None = None,
-		step_timeout: int = 120,
+		step_timeout: int = 180,
 		directly_open_url: bool = True,
 		include_recent_events: bool = False,
 		sample_images: list[ContentPartTextParam | ContentPartImageParam] | None = None,

--- a/docs/customize/agent/all-parameters.mdx
+++ b/docs/customize/agent/all-parameters.mdx
@@ -42,7 +42,7 @@ mode: "wide"
 ### Performance & Limits
 - `max_history_items`: Maximum number of last steps to keep in the LLM memory. If `None`, we keep all steps. 
 - `llm_timeout` (default: `90`): Timeout in seconds for LLM calls
-- `step_timeout` (default: `120`): Timeout in seconds for each step
+- `step_timeout` (default: `180`): Timeout in seconds for each step
 - `directly_open_url` (default: `True`): If we detect a url in the task, we directly open it.
 
 ### Advanced Options


### PR DESCRIPTION
Set the default `step_timeout` to 180 seconds in the agent service and documentation.

This change ensures consistency across the codebase, aligning the default value in `browser_use/agent/service.py` and `docs/customize/agent/all-parameters.mdx` with the existing value in `browser_use/agent/views.py`.

---
[Slack Thread](https://browser-use.slack.com/archives/C08SZRT860M/p1763775050054049?thread_ts=1763775050.054049&cid=C08SZRT860M)

<a href="https://cursor.com/background-agent?bcId=bc-a5adc71a-9451-4c3f-92cc-bc07698ca1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a5adc71a-9451-4c3f-92cc-bc07698ca1f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default step timeout to 180 seconds in the agent service and docs. This matches the value already used in views and keeps behavior consistent across the codebase.

<sup>Written for commit 79ba4572ddcd4dcd0b822bb774a651908853e74c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

