### PR TITLE
Optimize javascript result memory handling

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1185,7 +1185,12 @@ Validated Code (after quote fixing):
 					include_extracted_content_only_once = True
 
 				# Return only the result, not the code (code is already in user's cell)
-				return ActionResult(extracted_content=result_text, long_term_memory=memory, include_extracted_content_only_once=include_extracted_content_only_once, metadata=metadata)
+				return ActionResult(
+					extracted_content=result_text,
+					long_term_memory=memory,
+					include_extracted_content_only_once=include_extracted_content_only_once,
+					metadata=metadata,
+				)
 
 			except Exception as e:
 				# CDP communication or other system errors


### PR DESCRIPTION
Implement memory handling for JavaScript execution results to align with the `extract` function's logic for large content.

---
[Slack Thread](https://browser-use.slack.com/archives/C08SZRT860M/p1763798103571769?thread_ts=1763798103.571769&cid=C08SZRT860M)

<a href="https://cursor.com/background-agent?bcId=bc-9ce30962-138e-4447-863e-7e756c88d217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9ce30962-138e-4447-863e-7e756c88d217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>









<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized JavaScript evaluate memory handling: full results stay in extracted_content; long_term_memory holds the full text for small outputs and a summary for large ones.

- **New Features**
  - Added long_term_memory and include_extracted_content_only_once to ActionResult.
  - For results >1000 chars, store a summary in long_term_memory and set include_extracted_content_only_once; for small results, store the full text.

- **Refactors**
  - Removed file_system dependency; evaluate does not require a FileSystem parameter.

<sup>Written for commit 688ff43f265adeab910e8c9c27205aabc5b2d6d4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds size-aware long_term_memory and include_extracted_content_only_once to `evaluate()` results, keeping full output in `extracted_content` and summarizing when large.
> 
> - **Tools (`browser_use/tools/service.py`)**
>   - **JavaScript `evaluate()`**:
>     - Introduces size-aware memory handling with `MAX_MEMORY_LENGTH=1000`.
>     - For small results: store full text in `long_term_memory`; for large results: store a brief summary and set `include_extracted_content_only_once=True`.
>     - Return now includes `long_term_memory`, `include_extracted_content_only_once`, and preserves `metadata` (e.g., extracted images).
>     - Keeps full result in `extracted_content` with existing truncation at 20,000 chars.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5833f885a7cc04c85121c82f798f69d4e87e362e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->