### PR TITLE
Reorder prompt for last action context

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -364,6 +364,8 @@ class MessageManager:
 			sample_images=self.sample_images,
 			read_state_images=self.state.read_state_images,
 			llm_screenshot_size=self.llm_screenshot_size,
+			model_output=model_output,
+			result=result,
 		).get_user_message(effective_use_vision)
 
 		# Store state message text for history


### PR DESCRIPTION
Moves the last action and its result to the bottom of the prompt to improve agent performance by making recent feedback more prominent.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1763802802703529?thread_ts=1763802802.703529&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-05e556bd-22fd-4adc-a4ca-a47e379e44da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05e556bd-22fd-4adc-a4ca-a47e379e44da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered the prompt to put the last executed actions and their result at the bottom in a dedicated <last_actions> block to make recent feedback clearer and reduce repetition.

- **New Features**
  - Pass model_output and result into the prompt builder from MessageManager.
  - Build a compact <last_actions> section with up to the last 3 action names, the full last action payload, and its outcome (extracted content, memory, errors).
  - Append this section to the end of the user message after page-specific actions.

<sup>Written for commit 0abd29de554f80b8e88eb9a4d4bcc6cd8fe5b6dc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

