### PR TITLE
Fix scroll action for pdf viewers

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1625,7 +1625,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 	async def _scroll_with_cdp_gesture(self, pixels: int) -> bool:
 		"""
-		Scroll using CDP Input.dispatchMouseEvent to simulate mouse wheel.
+		Scroll using CDP Input.synthesizeScrollGesture to simulate realistic scroll gesture.
 
 		Args:
 			pixels: Number of pixels to scroll (positive = down, negative = up)
@@ -1639,35 +1639,41 @@ class DefaultActionWatchdog(BaseWatchdog):
 			cdp_client = cdp_session.cdp_client
 			session_id = cdp_session.session_id
 
-			# Get viewport dimensions
-			layout_metrics = await cdp_client.send.Page.getLayoutMetrics(session_id=session_id)
-			viewport_width = layout_metrics['layoutViewport']['clientWidth']
-			viewport_height = layout_metrics['layoutViewport']['clientHeight']
+			# Get viewport dimensions from cached value if available
+			if self.browser_session._original_viewport_size:
+				viewport_width, viewport_height = self.browser_session._original_viewport_size
+			else:
+				# Fallback: query layout metrics
+				layout_metrics = await cdp_client.send.Page.getLayoutMetrics(session_id=session_id)
+				viewport_width = layout_metrics['layoutViewport']['clientWidth']
+				viewport_height = layout_metrics['layoutViewport']['clientHeight']
 
 			# Calculate center of viewport
 			center_x = viewport_width / 2
 			center_y = viewport_height / 2
 
-			# For mouse wheel, positive deltaY scrolls down, negative scrolls up
-			delta_y = pixels
+			# For scroll gesture, positive yDistance scrolls up, negative scrolls down
+			# (opposite of mouseWheel deltaY convention)
+			y_distance = -pixels
 
-			# Dispatch mouse wheel event
-			await cdp_client.send.Input.dispatchMouseEvent(
+			# Synthesize scroll gesture with faster speed
+			await cdp_client.send.Input.synthesizeScrollGesture(
 				params={
-					'type': 'mouseWheel',
 					'x': center_x,
 					'y': center_y,
-					'deltaX': 0,
-					'deltaY': delta_y,
+					'xDistance': 0,
+					'yDistance': y_distance,
+					'speed': 1200,  # pixels per second (faster than default 800)
 				},
 				session_id=session_id,
 			)
 
-			self.logger.debug(f'📄 Scrolled via CDP mouse wheel: {pixels}px')
+			self.logger.debug(f'📄 Scrolled via CDP gesture: {pixels}px')
 			return True
 
 		except Exception as e:
-			self.logger.warning(f'❌ Scrolling via CDP failed: {type(e).__name__}: {e}')
+			# Not critical - JavaScript fallback will handle scrolling
+			self.logger.debug(f'CDP gesture scroll failed ({type(e).__name__}: {e}), falling back to JS')
 			return False
 
 	async def _scroll_element_container(self, element_node, pixels: int) -> bool:

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -491,7 +491,7 @@ class DOMWatchdog(BaseWatchdog):
 			self.browser_session._cached_browser_state_summary = browser_state
 
 			# Cache viewport size for coordinate conversion (if llm_screenshot_size is enabled)
-			if self.browser_session.llm_screenshot_size and page_info:
+			if page_info:
 				self.browser_session._original_viewport_size = (page_info.viewport_width, page_info.viewport_height)
 
 			self.logger.debug('🔍 DOMWatchdog.on_BrowserStateRequestEvent: ✅ COMPLETED - Returning browser state')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces mouse wheel scrolling with CDP synthesizeScrollGesture (using cached viewport when available) and always caches viewport size during browser state build.
> 
> - **Scrolling behavior**:
>   - Replace `Input.dispatchMouseEvent` mouse wheel with `Input.synthesizeScrollGesture` in `browser_use/browser/watchdogs/default_action_watchdog.py` for realistic scrolling, inverted `yDistance` handling, and faster speed.
>   - Use cached `browser_session._original_viewport_size` when available; improved logging and soft-fail fallback.
> - **Viewport caching**:
>   - In `browser_use/browser/watchdogs/dom_watchdog.py`, always cache `page_info.viewport_width/height` to `browser_session._original_viewport_size` (removes dependency on `llm_screenshot_size`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a396927435f24244f6842ec5bc8b4410ab4d6066. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken scrolling in PDF viewers by switching to a realistic CDP scroll gesture. Also improves coordinate reliability by caching viewport size and adds a safe JS fallback.

- **Bug Fixes**
  - Use Input.synthesizeScrollGesture instead of mouse wheel events.
  - Cache viewport size from page info for accurate gesture coordinates.
  - Correct scroll direction using yDistance and set faster gesture speed.
  - Fall back to JS scrolling if CDP gesture fails (logged at debug).

<sup>Written for commit a396927435f24244f6842ec5bc8b4410ab4d6066. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

