### PR TITLE
Remove pages from browser state

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -232,12 +232,7 @@ class AgentMessagePrompt:
 					elements_text = f'... {pages_above:.1f} pages above ...\n{elements_text}'
 			else:
 				elements_text = f'[Start of page]\n{elements_text}'
-			if has_content_below:
-				if self.browser_state.page_info:
-					pi = self.browser_state.page_info
-					pages_below = pi.pixels_below / pi.viewport_height if pi.viewport_height > 0 else 0
-					elements_text = f'{elements_text}\n... {pages_below:.1f} pages below ...'
-			else:
+			if not has_content_below:
 				elements_text = f'{elements_text}\n[End of page]'
 		else:
 			elements_text = 'empty page'

--- a/browser_use/code_use/formatting.py
+++ b/browser_use/code_use/formatting.py
@@ -173,9 +173,7 @@ async def format_browser_state_for_llm(
 		else:
 			dom_html = '[Start of page]\n' + dom_html
 
-		if pages_below > 0:
-			dom_html += f'\n... {pages_below:.1f} pages below '
-		else:
+		if pages_below <= 0:
 			dom_html += '\n[End of page]'
 
 	# Truncate DOM if too long and notify LLM


### PR DESCRIPTION
Remove the "pages below" indicator from the browser state.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1764022099576379?thread_ts=1764022099.576379&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-6e04fe47-3528-4df6-a583-5c9b95961407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e04fe47-3528-4df6-a583-5c9b95961407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "pages below" indicator from the browser state and now show a simple [End of page] marker when there’s no content below. This makes page boundaries consistent and reduces noise across prompts and formatting.

<sup>Written for commit e9cd88e6a502bf8e206368323cff2db98cc4ccbf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the "pages below" footer and now only appends "[End of page]" when there’s no content below, keeping the "pages above" hint intact across prompts and code-use formatting.
> 
> - **Agent prompts (`browser_use/agent/prompts.py`)**:
>   - Stop appending `... X.X pages below ...`; append `[End of page]` only when `has_content_below` is false.
> - **Code-use formatting (`browser_use/code_use/formatting.py`)**:
>   - Remove `... X.X pages below` hint; append `[End of page]` only when `pages_below <= 0`.
>   - Retain `... X.X pages above ...` and `[Start of page]` markers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9cd88e6a502bf8e206368323cff2db98cc4ccbf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->