### PR TITLE
fix: use default_factory for event_timeout to allow runtime env var c…

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -119,7 +119,7 @@ class NavigateToUrlEvent(BaseEvent[None]):
 	# existing_tab: PageHandle | None = None  # TODO
 
 	# time limits enforced by bubus, not exposed to LLM:
-	event_timeout: float | None = _get_timeout('TIMEOUT_NavigateToUrlEvent', 15.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_NavigateToUrlEvent', 15.0))  # seconds
 
 
 class ClickElementEvent(ElementSelectedEvent[dict[str, Any] | None]):
@@ -130,7 +130,7 @@ class ClickElementEvent(ElementSelectedEvent[dict[str, Any] | None]):
 	# click_count: int = 1           # TODO
 	# expect_download: bool = False  # moved to downloads_watchdog.py
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_ClickElementEvent', 15.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ClickElementEvent', 15.0))  # seconds
 
 
 class ClickCoordinateEvent(BaseEvent[dict]):
@@ -141,7 +141,7 @@ class ClickCoordinateEvent(BaseEvent[dict]):
 	button: Literal['left', 'right', 'middle'] = 'left'
 	force: bool = False  # If True, skip safety checks (file input, print, select)
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_ClickCoordinateEvent', 15.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ClickCoordinateEvent', 15.0))  # seconds
 
 
 class TypeTextEvent(ElementSelectedEvent[dict | None]):
@@ -153,7 +153,7 @@ class TypeTextEvent(ElementSelectedEvent[dict | None]):
 	is_sensitive: bool = False  # Flag to indicate if text contains sensitive data
 	sensitive_key_name: str | None = None  # Name of the sensitive key being typed (e.g., 'username', 'password')
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_TypeTextEvent', 15.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_TypeTextEvent', 15.0))  # seconds
 
 
 class ScrollEvent(ElementSelectedEvent[None]):
@@ -163,7 +163,7 @@ class ScrollEvent(ElementSelectedEvent[None]):
 	amount: int  # pixels
 	node: 'EnhancedDOMTreeNode | None' = None  # None means scroll page
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_ScrollEvent', 8.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ScrollEvent', 8.0))  # seconds
 
 
 class SwitchTabEvent(BaseEvent[TargetID]):
@@ -171,7 +171,7 @@ class SwitchTabEvent(BaseEvent[TargetID]):
 
 	target_id: TargetID | None = Field(default=None, description='None means switch to the most recently opened tab')
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_SwitchTabEvent', 10.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_SwitchTabEvent', 10.0))  # seconds
 
 
 class CloseTabEvent(BaseEvent[None]):
@@ -179,7 +179,7 @@ class CloseTabEvent(BaseEvent[None]):
 
 	target_id: TargetID
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_CloseTabEvent', 10.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_CloseTabEvent', 10.0))  # seconds
 
 
 class ScreenshotEvent(BaseEvent[str]):
@@ -188,7 +188,7 @@ class ScreenshotEvent(BaseEvent[str]):
 	full_page: bool = False
 	clip: dict[str, float] | None = None  # {x, y, width, height}
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_ScreenshotEvent', 8.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ScreenshotEvent', 8.0))  # seconds
 
 
 class BrowserStateRequestEvent(BaseEvent[BrowserStateSummary]):
@@ -198,7 +198,7 @@ class BrowserStateRequestEvent(BaseEvent[BrowserStateSummary]):
 	include_screenshot: bool = True
 	include_recent_events: bool = False
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_BrowserStateRequestEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStateRequestEvent', 30.0))  # seconds
 
 
 # class WaitForConditionEvent(BaseEvent):
@@ -213,19 +213,19 @@ class BrowserStateRequestEvent(BaseEvent[BrowserStateSummary]):
 class GoBackEvent(BaseEvent[None]):
 	"""Navigate back in browser history."""
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_GoBackEvent', 15.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_GoBackEvent', 15.0))  # seconds
 
 
 class GoForwardEvent(BaseEvent[None]):
 	"""Navigate forward in browser history."""
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_GoForwardEvent', 15.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_GoForwardEvent', 15.0))  # seconds
 
 
 class RefreshEvent(BaseEvent[None]):
 	"""Refresh/reload the current page."""
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_RefreshEvent', 15.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_RefreshEvent', 15.0))  # seconds
 
 
 class WaitEvent(BaseEvent[None]):
@@ -234,7 +234,7 @@ class WaitEvent(BaseEvent[None]):
 	seconds: float = 3.0
 	max_seconds: float = 10.0  # Safety cap
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_WaitEvent', 60.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_WaitEvent', 60.0))  # seconds
 
 
 class SendKeysEvent(BaseEvent[None]):
@@ -242,7 +242,7 @@ class SendKeysEvent(BaseEvent[None]):
 
 	keys: str  # e.g., "ctrl+a", "cmd+c", "Enter"
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_SendKeysEvent', 15.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_SendKeysEvent', 15.0))  # seconds
 
 
 class UploadFileEvent(ElementSelectedEvent[None]):
@@ -251,7 +251,7 @@ class UploadFileEvent(ElementSelectedEvent[None]):
 	node: 'EnhancedDOMTreeNode'
 	file_path: str
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_UploadFileEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_UploadFileEvent', 30.0))  # seconds
 
 
 class GetDropdownOptionsEvent(ElementSelectedEvent[dict[str, str]]):
@@ -261,9 +261,8 @@ class GetDropdownOptionsEvent(ElementSelectedEvent[dict[str, str]]):
 
 	node: 'EnhancedDOMTreeNode'
 
-	event_timeout: float | None = _get_timeout(
-		'TIMEOUT_GetDropdownOptionsEvent',
-		15.0,
+	event_timeout: float | None = Field(
+		default_factory=lambda: _get_timeout('TIMEOUT_GetDropdownOptionsEvent', 15.0)
 	)  # some dropdowns lazy-load the list of options on first interaction, so we need to wait for them to load (e.g. table filter lists can have thousands of options)
 
 
@@ -275,7 +274,7 @@ class SelectDropdownOptionEvent(ElementSelectedEvent[dict[str, str]]):
 	node: 'EnhancedDOMTreeNode'
 	text: str  # The option text to select
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_SelectDropdownOptionEvent', 8.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_SelectDropdownOptionEvent', 8.0))  # seconds
 
 
 class ScrollToTextEvent(BaseEvent[None]):
@@ -284,7 +283,7 @@ class ScrollToTextEvent(BaseEvent[None]):
 	text: str
 	direction: Literal['up', 'down'] = 'down'
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_ScrollToTextEvent', 15.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ScrollToTextEvent', 15.0))  # seconds
 
 
 # ============================================================================
@@ -296,7 +295,7 @@ class BrowserStartEvent(BaseEvent):
 	cdp_url: str | None = None
 	launch_options: dict[str, Any] = Field(default_factory=dict)
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_BrowserStartEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStartEvent', 30.0))  # seconds
 
 
 class BrowserStopEvent(BaseEvent):
@@ -304,7 +303,7 @@ class BrowserStopEvent(BaseEvent):
 
 	force: bool = False
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_BrowserStopEvent', 45.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStopEvent', 45.0))  # seconds
 
 
 class BrowserLaunchResult(BaseModel):
@@ -319,13 +318,13 @@ class BrowserLaunchEvent(BaseEvent[BrowserLaunchResult]):
 
 	# TODO: add executable_path, proxy settings, preferences, extra launch args, etc.
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_BrowserLaunchEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserLaunchEvent', 30.0))  # seconds
 
 
 class BrowserKillEvent(BaseEvent):
 	"""Kill local browser subprocess."""
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_BrowserKillEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserKillEvent', 30.0))  # seconds
 
 
 # TODO: replace all Runtime.evaluate() calls with this event
@@ -378,7 +377,7 @@ class BrowserConnectedEvent(BaseEvent):
 
 	cdp_url: str
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_BrowserConnectedEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserConnectedEvent', 30.0))  # seconds
 
 
 class BrowserStoppedEvent(BaseEvent):
@@ -386,7 +385,7 @@ class BrowserStoppedEvent(BaseEvent):
 
 	reason: str | None = None
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_BrowserStoppedEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStoppedEvent', 30.0))  # seconds
 
 
 class TabCreatedEvent(BaseEvent):
@@ -395,7 +394,7 @@ class TabCreatedEvent(BaseEvent):
 	target_id: TargetID
 	url: str
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_TabCreatedEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_TabCreatedEvent', 30.0))  # seconds
 
 
 class TabClosedEvent(BaseEvent):
@@ -407,7 +406,7 @@ class TabClosedEvent(BaseEvent):
 	# new_focus_target_id: int | None = None
 	# new_focus_url: str | None = None
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_TabClosedEvent', 10.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_TabClosedEvent', 10.0))  # seconds
 
 
 # TODO: emit this when DOM changes significantly, inner frame navigates, form submits, history.pushState(), etc.
@@ -424,7 +423,7 @@ class AgentFocusChangedEvent(BaseEvent):
 	target_id: TargetID
 	url: str
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_AgentFocusChangedEvent', 10.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_AgentFocusChangedEvent', 10.0))  # seconds
 
 
 class TargetCrashedEvent(BaseEvent):
@@ -433,7 +432,7 @@ class TargetCrashedEvent(BaseEvent):
 	target_id: TargetID
 	error: str
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_TargetCrashedEvent', 10.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_TargetCrashedEvent', 10.0))  # seconds
 
 
 class NavigationStartedEvent(BaseEvent):
@@ -442,7 +441,7 @@ class NavigationStartedEvent(BaseEvent):
 	target_id: TargetID
 	url: str
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_NavigationStartedEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_NavigationStartedEvent', 30.0))  # seconds
 
 
 class NavigationCompleteEvent(BaseEvent):
@@ -454,7 +453,7 @@ class NavigationCompleteEvent(BaseEvent):
 	error_message: str | None = None  # Error/timeout message if navigation had issues
 	loading_status: str | None = None  # Detailed loading status (e.g., network timeout info)
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_NavigationCompleteEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_NavigationCompleteEvent', 30.0))  # seconds
 
 
 # ============================================================================
@@ -469,7 +468,7 @@ class BrowserErrorEvent(BaseEvent):
 	message: str
 	details: dict[str, Any] = Field(default_factory=dict)
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_BrowserErrorEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserErrorEvent', 30.0))  # seconds
 
 
 # ============================================================================
@@ -482,7 +481,7 @@ class SaveStorageStateEvent(BaseEvent):
 
 	path: str | None = None  # Optional path, uses profile default if not provided
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_SaveStorageStateEvent', 45.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_SaveStorageStateEvent', 45.0))  # seconds
 
 
 class StorageStateSavedEvent(BaseEvent):
@@ -492,7 +491,7 @@ class StorageStateSavedEvent(BaseEvent):
 	cookies_count: int
 	origins_count: int
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_StorageStateSavedEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_StorageStateSavedEvent', 30.0))  # seconds
 
 
 class LoadStorageStateEvent(BaseEvent):
@@ -500,7 +499,7 @@ class LoadStorageStateEvent(BaseEvent):
 
 	path: str | None = None  # Optional path, uses profile default if not provided
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_LoadStorageStateEvent', 45.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_LoadStorageStateEvent', 45.0))  # seconds
 
 
 # TODO: refactor this to:
@@ -514,7 +513,7 @@ class StorageStateLoadedEvent(BaseEvent):
 	cookies_count: int
 	origins_count: int
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_StorageStateLoadedEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_StorageStateLoadedEvent', 30.0))  # seconds
 
 
 # ============================================================================
@@ -534,7 +533,7 @@ class FileDownloadedEvent(BaseEvent):
 	from_cache: bool = False
 	auto_download: bool = False  # Whether this was an automatic download (e.g., PDF auto-download)
 
-	event_timeout: float | None = _get_timeout('TIMEOUT_FileDownloadedEvent', 30.0)  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_FileDownloadedEvent', 30.0))  # seconds
 
 
 class AboutBlankDVDScreensaverShownEvent(BaseEvent):


### PR DESCRIPTION
### Problem

The `event_timeout` fields on all event classes were evaluated at **module import time**, not at instance creation time. This meant that environment variables like `TIMEOUT_TypeTextEvent` had to be set **before** importing `browser_use`, making dynamic runtime configuration impossible.

```python
# This didn't work:
import os
from browser_use.browser.events import TypeTextEvent

os.environ["TIMEOUT_TypeTextEvent"] = "60"  # Too late - already evaluated to 15.0
event = TypeTextEvent(...)
print(event.event_timeout)  # 15.0 ❌
```

### Solution

Changed all `event_timeout` field defaults from:
```python
event_timeout: float | None = _get_timeout('TIMEOUT_X', 15.0)
```

To:
```python
event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_X', 15.0))
```

Using `default_factory` defers the [_get_timeout()](cci:1://file:///Users/tomergal/CascadeProjects/browser-use/browser_use/browser/events.py:15:0-42:15) call until each event instance is created, allowing users to set timeout environment variables at any point before creating events.

### After this fix

```python
import os
from browser_use.browser.events import TypeTextEvent

os.environ["TIMEOUT_TypeTextEvent"] = "60"
event = TypeTextEvent(...)
print(event.event_timeout)  # 60.0 ✅
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make event timeouts read environment variables at runtime by deferring evaluation to event instantiation. This enables dynamic configuration (e.g., setting TIMEOUT_* after import) to take effect when creating events.

- **Bug Fixes**
  - Switched all event_timeout fields to use Field(default_factory=...) so _get_timeout runs per instance.
  - TIMEOUT_* env vars are now read when an event is created, not at module import time.
  - Defaults remain unchanged if no env vars are set.

<sup>Written for commit 00462f9282c8d768111269493edaf71a638aa717. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

