### PR TITLE
Increase screenshot event timeout to 15 seconds

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -188,7 +188,7 @@ class ScreenshotEvent(BaseEvent[str]):
 	full_page: bool = False
 	clip: dict[str, float] | None = None  # {x, y, width, height}
 
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ScreenshotEvent', 8.0))  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ScreenshotEvent', 15.0))  # seconds
 
 
 class BrowserStateRequestEvent(BaseEvent[BrowserStateSummary]):


### PR DESCRIPTION
Increase the default timeout for `TIMEOUT_ScreenshotEvent` to 15 seconds.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1764178131486469?thread_ts=1764178131.486469&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-00392000-bb99-47f3-8645-18b5decb2dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-00392000-bb99-47f3-8645-18b5decb2dfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased the default timeout for TIMEOUT_ScreenshotEvent from 8s to 15s to reduce timeouts on slow pages and large captures. Improves reliability for full-page screenshots and in variable network conditions.

<sup>Written for commit 717845c4a72e3144cde3c46c4ce4953199895eb6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

