### PR TITLE
Quick Hack allow passing Base URL to MCP Server

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -553,12 +553,16 @@ class BrowserUseServer:
 
 		# Initialize LLM from config
 		llm_config = get_default_llm(self.config)
+		base_url = llm_config.get('base_url', None)
+		kwargs = {}
+		if base_url:
+			kwargs['base_url'] = base_url
 		if api_key := llm_config.get('api_key'):
 			self.llm = ChatOpenAI(
-				model=llm_config.get('model', 'gpt-4o-mini'),
+				model=llm_config.get('model', 'gpt-o4-mini'),
 				api_key=api_key,
 				temperature=llm_config.get('temperature', 0.7),
-				# max_tokens=llm_config.get('max_tokens'),
+				**kwargs,
 			)
 
 		# Initialize FileSystem for extraction actions
@@ -606,10 +610,15 @@ class BrowserUseServer:
 			else:
 				llm_model = llm_config.get('model', 'gpt-4o')
 
+			base_url = llm_config.get('base_url', None)
+			kwargs = {}
+			if base_url:
+				kwargs['base_url'] = base_url
 			llm = ChatOpenAI(
 				model=llm_model,
 				api_key=api_key,
 				temperature=llm_config.get('temperature', 0.7),
+				**kwargs,
 			)
 
 		# Get profile config and merge with tool parameters


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for passing a custom LLM base_url from config to ChatOpenAI in the MCP server, enabling self-hosted or proxied endpoints. Also updates the default model used during initial session setup.

- **New Features**
  - Read base_url from llm_config and forward it to ChatOpenAI in both init and retry paths.

- **Refactors**
  - Change default initial model from gpt-4o-mini to gpt-o4-mini.

<sup>Written for commit 839ef52d3e613826c0a00a25592ed6aa0420c8f0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

