### PR TITLE
now newlines are executed well with send keys

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -153,7 +153,7 @@ class TypeTextEvent(ElementSelectedEvent[dict | None]):
 	is_sensitive: bool = False  # Flag to indicate if text contains sensitive data
 	sensitive_key_name: str | None = None  # Name of the sensitive key being typed (e.g., 'username', 'password')
 
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_TypeTextEvent', 15.0))  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_TypeTextEvent', 60.0))  # seconds
 
 
 class ScrollEvent(ElementSelectedEvent[None]):
@@ -242,7 +242,7 @@ class SendKeysEvent(BaseEvent[None]):
 
 	keys: str  # e.g., "ctrl+a", "cmd+c", "Enter"
 
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_SendKeysEvent', 15.0))  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_SendKeysEvent', 60.0))  # seconds
 
 
 class UploadFileEvent(ElementSelectedEvent[None]):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes newline handling in SendKeys so Enter works reliably in forms and text areas. Also increases typing timeouts and removes artificial delays for faster, more reliable input.

- **Bug Fixes**
  - Map '\n' and '\r' to Enter by dispatching rawKeyDown, char, and keyUp (VK 13), ensuring correct submissions and line breaks.

- **Refactors**
  - Increase default timeouts for TypeTextEvent and SendKeysEvent from 15s to 60s.
  - Remove 18ms per-character delay in typing and send-keys loops.

<sup>Written for commit c4bb681058655a3bf22c5778e8fbaef3212851a6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

