### PR TITLE
docs(sandbox): fix async sandbox example by adding asyncio.run and import asyncio

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -143,15 +143,21 @@ Sandboxes are the **easiest way to run Browser-Use in production**. We handle ag
 To run in production with authentication, just add `@sandbox` to your function:
 
 ```python
+import asyncio
 from browser_use import Browser, sandbox, ChatBrowserUse
 from browser_use.agent.service import Agent
 
 @sandbox(cloud_profile_id='your-profile-id')
 async def production_task(browser: Browser):
-    agent = Agent(task="Your authenticated task", browser=browser, llm=ChatBrowserUse())
+    agent = Agent(
+        task="Your authenticated task",
+        browser=browser,
+        llm=ChatBrowserUse(),
+    )
     await agent.run()
 
-await production_task()
+if __name__ == "__main__":
+    asyncio.run(production_task())
 ```
 
 See [Going to Production](/production) for how to sync your cookies to the cloud.


### PR DESCRIPTION
**Description:**
This PR updates the Sandbox Quickstart example to make it fully runnable when
copied into a standalone script.

**Changes:**
- Added `import asyncio`
- Wrapped the async sandbox entrypoint in:
  ```python
  if __name__ == "__main__":
      asyncio.run(production_task())
  ```
- Prevents the “coroutine was never awaited” runtime error.

**Issue:**
No related issue (minor documentation fix).

**Dependencies:**
None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the async Sandbox Quickstart example so it runs as a standalone script without errors. Added import asyncio and a __main__ guard that calls asyncio.run(production_task()), preventing the “coroutine was never awaited” runtime error.

<sup>Written for commit 7fd4a38a2b7cfe72dc3d6a15e009c96cebeee490. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

