### PR TITLE
Add provider options to ChatVercel for enhanced model routing

### DIFF
--- a/browser_use/llm/vercel/chat.py
+++ b/browser_use/llm/vercel/chat.py
@@ -189,6 +189,8 @@ class ChatVercel(BaseChatModel):
 	        prompt-based JSON extraction. Auto-detects common reasoning models by default.
 	    timeout: Request timeout in seconds
 	    max_retries: Maximum number of retries for failed requests
+	    provider_options: Provider routing options for the gateway. Use this to control which
+	        providers are used and in what order. Example: {'gateway': {'order': ['vertex', 'anthropic']}}
 	"""
 
 	# Model configuration
@@ -218,6 +220,7 @@ class ChatVercel(BaseChatModel):
 	default_query: Mapping[str, object] | None = None
 	http_client: httpx.AsyncClient | None = None
 	_strict_response_validation: bool = False
+	provider_options: dict[str, Any] | None = None
 
 	# Static
 	@property
@@ -382,6 +385,8 @@ class ChatVercel(BaseChatModel):
 				model_params['max_tokens'] = self.max_tokens
 			if self.top_p is not None:
 				model_params['top_p'] = self.top_p
+			if self.provider_options:
+				model_params['extra_body'] = {'providerOptions': self.provider_options}
 
 			if output_format is None:
 				# Return string response
@@ -400,11 +405,12 @@ class ChatVercel(BaseChatModel):
 
 			else:
 				is_google_model = self.model.startswith('google/')
+				is_anthropic_model = self.model.startswith('anthropic/')
 				is_reasoning_model = self.reasoning_models and any(
 					str(pattern).lower() in str(self.model).lower() for pattern in self.reasoning_models
 				)
 
-				if is_google_model or is_reasoning_model:
+				if is_google_model or is_anthropic_model or is_reasoning_model:
 					modified_messages = [m.model_copy(deep=True) for m in messages]
 
 					schema = SchemaOptimizer.create_gemini_optimized_schema(output_format)
@@ -431,10 +437,14 @@ class ChatVercel(BaseChatModel):
 
 					vercel_messages = VercelMessageSerializer.serialize_messages(modified_messages)
 
+					request_params = model_params.copy()
+					if self.provider_options:
+						request_params['extra_body'] = {'providerOptions': self.provider_options}
+
 					response = await self.get_client().chat.completions.create(
 						model=self.model,
 						messages=vercel_messages,
-						**model_params,
+						**request_params,
 					)
 
 					content = response.choices[0].message.content if response.choices else None
@@ -479,6 +489,10 @@ class ChatVercel(BaseChatModel):
 						'schema': schema,
 					}
 
+					request_params = model_params.copy()
+					if self.provider_options:
+						request_params['extra_body'] = {'providerOptions': self.provider_options}
+
 					response = await self.get_client().chat.completions.create(
 						model=self.model,
 						messages=vercel_messages,
@@ -486,7 +500,7 @@ class ChatVercel(BaseChatModel):
 							json_schema=response_format_schema,
 							type='json_schema',
 						),
-						**model_params,
+						**request_params,
 					)
 
 					content = response.choices[0].message.content if response.choices else None

--- a/docs/supported-models.mdx
+++ b/docs/supported-models.mdx
@@ -358,10 +358,22 @@ api_key = os.getenv('VERCEL_API_KEY')
 if not api_key:
     raise ValueError('VERCEL_API_KEY is not set')
 
-# Use Vercel AI Gateway
+# Basic usage
 llm = ChatVercel(
     model='openai/gpt-4o',
     api_key=api_key,
+)
+
+# With provider options - control which providers are used and in what order
+# This will try Vertex AI first, then fall back to Anthropic if Vertex fails
+llm_with_provider_options = ChatVercel(
+    model='anthropic/claude-sonnet-4',
+    api_key=api_key,
+    provider_options={
+        'gateway': {
+            'order': ['vertex', 'anthropic']  # Try Vertex AI first, then Anthropic
+        }
+    },
 )
 
 agent = Agent(

--- a/examples/models/vercel_ai_gateway.py
+++ b/examples/models/vercel_ai_gateway.py
@@ -24,9 +24,22 @@ api_key = os.getenv('VERCEL_API_KEY')
 if not api_key:
 	raise ValueError('VERCEL_API_KEY is not set')
 
+# Basic usage
 llm = ChatVercel(
 	model='openai/gpt-4o',
 	api_key=api_key,
+)
+
+# Example with provider options - control which providers are used and in what order
+# This will try Vertex AI first, then fall back to Anthropic if Vertex fails
+llm_with_provider_options = ChatVercel(
+	model='anthropic/claude-sonnet-4',
+	api_key=api_key,
+	provider_options={
+		'gateway': {
+			'order': ['vertex', 'anthropic']  # Try Vertex AI first, then Anthropic
+		}
+	},
 )
 
 agent = Agent(
@@ -34,9 +47,15 @@ agent = Agent(
 	llm=llm,
 )
 
+agent_with_provider_options = Agent(
+	task='Go to example.com and summarize the main content',
+	llm=llm_with_provider_options,
+)
+
 
 async def main():
 	await agent.run(max_steps=10)
+	await agent_with_provider_options.run(max_steps=10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added provider options to ChatVercel to control Vercel AI Gateway routing and fallback order. Also improved handling for Anthropic models and updated docs and examples.

- **New Features**
  - Added provider_options to ChatVercel; passed as extra_body.providerOptions.
  - Supports gateway routing order (e.g., ['vertex', 'anthropic']).
  - Anthropic models now follow the optimized structured-output path.
  - Updated docs and example to show basic and provider-order usage.

<sup>Written for commit 5c581c642ea32ed7085ccdacddcdc72683196988. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

