### PR TITLE
get rid of force

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -267,9 +267,8 @@ class Tools(Generic[Context]):
 				asyncio.create_task(browser_session.highlight_coordinate_click(actual_x, actual_y))
 
 				# Dispatch ClickCoordinateEvent - handler will check for safety and click
-				# Pass force parameter from params (defaults to False for safety)
 				event = browser_session.event_bus.dispatch(
-					ClickCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y, force=params.force)
+					ClickCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y, force=True)
 				)
 				await event
 				# Wait for handler to complete and get any exception or metadata

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -38,7 +38,6 @@ class ClickElementAction(BaseModel):
 	index: int | None = Field(default=None, ge=1, description='Element index from browser_state')
 	coordinate_x: int | None = Field(default=None, description='Horizontal coordinate relative to viewport left edge')
 	coordinate_y: int | None = Field(default=None, description='Vertical coordinate relative to viewport top edge')
-	force: bool = Field(default=False, description='If True, skip safety checks (file input, print, select)')
 	# expect_download: bool = Field(default=False, description='set True if expecting a download, False otherwise')  # moved to downloads_watchdog.py
 	# click_count: int = 1  # TODO
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Drops the `force` parameter from `ClickElementAction` and always dispatches coordinate clicks with `force=True`.
> 
> - **Click actions**:
>   - Remove `force` field from `ClickElementAction` in `browser_use/tools/views.py`.
>   - In `browser_use/tools/service.py`, `_click_by_coordinate` now always dispatches `ClickCoordinateEvent` with `force=True` and no longer reads from params.
> - **Types/API**:
>   - Updates action input model and event dispatch to align with the removal of `force`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa0d1fb00fa6216f8fd844b741d1534a58ac7830. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the force flag from ClickElementAction and made coordinate clicks always forced. This simplifies the API and makes click behavior consistent.

- **Migration**
  - Remove the force field from ClickElementAction payloads; it is no longer supported.
  - Adjust any logic that relied on optional safety gating for coordinate clicks.

<sup>Written for commit aa0d1fb00fa6216f8fd844b741d1534a58ac7830. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

