### PR TITLE
fix example

### DIFF
--- a/examples/features/judge_trace.py
+++ b/examples/features/judge_trace.py
@@ -27,7 +27,7 @@ Round your result to the nearest 1000 hours and do not use any comma separators 
 
 
 async def main():
-	llm = ChatBrowserUse(base_url='http://localhost:8080')
+	llm = ChatBrowserUse()
 	agent = Agent(
 		task=task,
 		llm=llm,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update `examples/features/judge_trace.py` to instantiate `ChatBrowserUse()` without an explicit `base_url`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ffd26fbe030cd55b800726cf1227972e59fe507. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update judge_trace example to initialize ChatBrowserUse() without a hardcoded localhost base_url. This makes the example work out of the box with default settings and avoids connection errors when no local server is running.

<sup>Written for commit 3ffd26fbe030cd55b800726cf1227972e59fe507. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

