### PR TITLE
Revert "fix:#3620/Quote fixer for javascript evaluate action"

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1219,7 +1219,7 @@ Validated Code (after quote fixing):
 		fixed_code = re.sub(r'\\\\([.*+?^${}()|[\]])', r'\\\1', fixed_code)
 
 		# Pattern 3: Fix XPath expressions with mixed quotes
-		xpath_pattern = r'document\.evaluate\s*\(\s*"([^"]*)"\s*,'
+		xpath_pattern = r'document\.evaluate\s*\(\s*"([^"]*\'[^"]*)"'
 
 		def fix_xpath_quotes(match):
 			xpath_with_quotes = match.group(1)
@@ -1228,7 +1228,7 @@ Validated Code (after quote fixing):
 		fixed_code = re.sub(xpath_pattern, fix_xpath_quotes, fixed_code)
 
 		# Pattern 4: Fix querySelector/querySelectorAll with mixed quotes
-		selector_pattern = r'(querySelector(?:All)?)\s*\(\s*"([^"]*)"\s*\)'
+		selector_pattern = r'(querySelector(?:All)?)\s*\(\s*"([^"]*\'[^"]*)"'
 
 		def fix_selector_quotes(match):
 			method_name = match.group(1)
@@ -1238,7 +1238,7 @@ Validated Code (after quote fixing):
 		fixed_code = re.sub(selector_pattern, fix_selector_quotes, fixed_code)
 
 		# Pattern 5: Fix closest() calls with mixed quotes
-		closest_pattern = r'\.closest\s*\(\s*"([^"]*)"\s*\)'
+		closest_pattern = r'\.closest\s*\(\s*"([^"]*\'[^"]*)"'
 
 		def fix_closest_quotes(match):
 			selector_with_quotes = match.group(1)
@@ -1247,7 +1247,7 @@ Validated Code (after quote fixing):
 		fixed_code = re.sub(closest_pattern, fix_closest_quotes, fixed_code)
 
 		# Pattern 6: Fix .matches() calls with mixed quotes (similar to closest)
-		matches_pattern = r'\.matches\s*\(\s*"([^"]*)"\s*\)'
+		matches_pattern = r'\.matches\s*\(\s*"([^"]*\'[^"]*)"'
 
 		def fix_matches_quotes(match):
 			selector_with_quotes = match.group(1)


### PR DESCRIPTION
Reverts browser-use/browser-use#3623

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens regex in `_validate_and_fix_javascript` to only convert selectors/XPath with mixed quotes for `document.evaluate`, `querySelector(All)`, `.closest`, and `.matches`.
> 
> - **Quote fixer adjustments in `browser_use/tools/service.py`**:
>   - Refines regex for mixed-quote detection:
>     - `document.evaluate` XPath strings now matched only when containing both single and double quotes.
>     - `querySelector(All)`, `.closest`, and `.matches` selectors likewise restricted to mixed-quote cases.
>   - Continues converting matched strings to template literals without affecting non-mixed quote inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c5b2945f37b458e6faa48695f65e9855ee53d74. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the JavaScript quote fixer to its previous behavior, only targeting mixed-quote strings. Prevents over-matching and unintended rewrites in document.evaluate, querySelector(All), closest, and matches.

<sup>Written for commit 1c5b2945f37b458e6faa48695f65e9855ee53d74. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

