### PR TITLE
Bugfix to #3702

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -524,14 +524,15 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 	@property
 	def logger(self) -> logging.Logger:
 		"""Get instance-specific logger with task ID in the name"""
-
-		_browser_session_id = self.browser_session.id if self.browser_session else '----'
+		# logger may be called in __init__ so we don't assume self.* attributes have been initialized
+		_task_id = task_id[-4:] if (task_id := getattr(self, 'task_id', None)) else '----'
+		_browser_session_id = browser_session.id[-4:] if (browser_session := getattr(self, 'browser_session', None)) else '----'
 		_current_target_id = (
-			self.browser_session.agent_focus_target_id[-2:]
-			if self.browser_session and self.browser_session.agent_focus_target_id
+			browser_session.agent_focus_target_id[-2:]
+			if (browser_session := getattr(self, 'browser_session', None)) and browser_session.agent_focus_target_id
 			else '--'
 		)
-		return logging.getLogger(f'browser_use.Agent🅰 {self.task_id[-4:]} ⇢ 🅑 {_browser_session_id[-4:]} 🅣 {_current_target_id}')
+		return logging.getLogger(f'browser_use.Agent🅰 {_task_id} ⇢ 🅑 {_browser_session_id} 🅣 {_current_target_id}')
 
 	@property
 	def browser_profile(self) -> BrowserProfile:


### PR DESCRIPTION
Closes #3702

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Agent.logger to be safe during initialization and when IDs are missing, preventing crashes and malformed log names. Closes #3702.

- **Bug Fixes**
  - Use getattr to safely read task_id and browser_session; slice IDs only when present.
  - Fallback to '----' for missing task/session IDs and '--' for missing target ID.
  - Precompute ID fragments to avoid repeated attribute access and slicing errors.

<sup>Written for commit ef03559d5183bb3320a731d9d4479aa677827775. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

