### PR TITLE
fix the supported model broken link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ Then add your API key to the file.
   ```
 </CodeGroup>
 
-See [Supported Models](/supported-models) for more.
+See [Supported Models](https://docs.browser-use.com/supported-models#supported-models) for more.
 
 ## 3. Run your first agent
 


### PR DESCRIPTION
ref: #3710 


cc: @mertunsall @MagMueller 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the broken “Supported Models” link in AGENTS.md by pointing to the correct docs URL. This ensures readers can access the models list without 404s.

<sup>Written for commit a26832d7307267e09a2eba32d214fa8745a923c0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

