### PR TITLE
faster scroll

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1793,14 +1793,14 @@ class DefaultActionWatchdog(BaseWatchdog):
 			# (opposite of mouseWheel deltaY convention)
 			y_distance = -pixels
 
-			# Synthesize scroll gesture with faster speed
+			# Synthesize scroll gesture - use very high speed for near-instant scrolling
 			await cdp_client.send.Input.synthesizeScrollGesture(
 				params={
 					'x': center_x,
 					'y': center_y,
 					'xDistance': 0,
 					'yDistance': y_distance,
-					'speed': 1200,  # pixels per second (faster than default 800)
+					'speed': 50000,  # pixels per second (high = near-instant scroll)
 				},
 				session_id=session_id,
 			)

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -846,7 +846,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 							completed_scrolls += 1
 
 							# Small delay to ensure scroll completes before next one
-							await asyncio.sleep(0.3)
+							await asyncio.sleep(0.15)
 
 						except Exception as e:
 							logger.warning(f'Scroll {i + 1}/{num_full_pages} failed: {e}')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speed up automated scrolling with near-instant CDP scroll gestures (50000 px/s). Also cuts the wait between consecutive scrolls from 300ms to 150ms to reduce action time.

<sup>Written for commit 2e3aed30456c5b8c730fbfd4a235643add431ad1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

