### PR TITLE
Revert "faster scroll"

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1793,14 +1793,14 @@ class DefaultActionWatchdog(BaseWatchdog):
 			# (opposite of mouseWheel deltaY convention)
 			y_distance = -pixels
 
-			# Synthesize scroll gesture - use very high speed for near-instant scrolling
+			# Synthesize scroll gesture with faster speed
 			await cdp_client.send.Input.synthesizeScrollGesture(
 				params={
 					'x': center_x,
 					'y': center_y,
 					'xDistance': 0,
 					'yDistance': y_distance,
-					'speed': 50000,  # pixels per second (high = near-instant scroll)
+					'speed': 1200,  # pixels per second (faster than default 800)
 				},
 				session_id=session_id,
 			)

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -846,7 +846,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 							completed_scrolls += 1
 
 							# Small delay to ensure scroll completes before next one
-							await asyncio.sleep(0.15)
+							await asyncio.sleep(0.3)
 
 						except Exception as e:
 							logger.warning(f'Scroll {i + 1}/{num_full_pages} failed: {e}')


### PR DESCRIPTION
Reverts browser-use/browser-use#3732

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the previous “faster scroll” change to restore smoother, more reliable scrolling. Lowers gesture speed and adds a longer pause between scrolls to avoid overshoot and flaky behavior.

- **Bug Fixes**
  - Lowered CDP scroll speed from 50000 to 1200 px/s.
  - Increased inter-scroll delay from 150ms to 300ms.

<sup>Written for commit 7b3b4ce13d4cc3cd2c0fd28e368438f8a9d197f8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

