### PR TITLE
Disable automatic ts download

### DIFF
--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -396,6 +396,7 @@ class DownloadsWatchdog(BaseWatchdog):
 							'.ico',
 							'.css',
 							'.js',
+							'.ts',
 							'.woff',
 							'.woff2',
 							'.ttf',


### PR DESCRIPTION
Add `.ts` to the `unwanted_extensions` list to prevent automatic downloading of `.ts` files.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQD6KA/p1765259596911009?thread_ts=1765259596.911009&cid=D092QUQD6KA)

<a href="https://cursor.com/background-agent?bcId=bc-5ee1d510-d1d2-4b25-85bf-f9166a0e50a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ee1d510-d1d2-4b25-85bf-f9166a0e50a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent automatic downloading of .ts files by adding ".ts" to the downloads watchdog's unwanted_extensions list. This avoids saving TypeScript assets and reduces unnecessary downloads.

<sup>Written for commit 9986c52dfd7538f6a44f48ebb91b4e34f80419c9. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

