### PR TITLE
add support for gemini

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -31,6 +31,9 @@ VerifiedGeminiModels = Literal[
 	'gemini-flash-latest',
 	'gemini-flash-lite-latest',
 	'gemini-2.5-pro',
+	'gemini-3.0-flash',
+	'gemini-3.0-flash-lite',
+	'gemini-3.0-pro',
 	'gemma-3-27b-it',
 	'gemma-3-4b',
 	'gemma-3-12b',
@@ -223,7 +226,9 @@ class ChatGoogle(BaseChatModel):
 			config['seed'] = self.seed
 
 		# set default for flash, flash-lite, gemini-flash-lite-latest, and gemini-flash-latest models
-		if self.thinking_budget is None and ('gemini-2.5-flash' in self.model or 'gemini-flash' in self.model):
+		if self.thinking_budget is None and (
+			'gemini-2.5-flash' in self.model or 'gemini-3.0-flash' in self.model or 'gemini-flash' in self.model
+		):
 			self.thinking_budget = 0
 
 		if self.thinking_budget is not None:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for Gemini 3.0 models and sets a default thinking_budget of 0 for flash variants to prevent unintended reasoning costs.

- **New Features**
  - Added models: gemini-3.0-flash, gemini-3.0-flash-lite, gemini-3.0-pro.
  - Default thinking_budget=0 for gemini-3.0-flash (and existing flash variants).

<sup>Written for commit 47ad81b5905aec34f2be5c71f5e0f8d069368331. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

