### PR TITLE
Fix #3726: prevent screenshots from being sent to judge when vision is disabled

### DIFF
--- a/browser_use/agent/judge.py
+++ b/browser_use/agent/judge.py
@@ -46,6 +46,7 @@ def construct_judge_messages(
 	screenshot_paths: list[str],
 	max_images: int = 10,
 	ground_truth: str | None = None,
+	use_vision: bool = True,
 ) -> list[BaseMessage]:
 	"""
 	Construct messages for judge evaluation of agent trace.
@@ -57,6 +58,7 @@ def construct_judge_messages(
 		screenshot_paths: List of screenshot file paths
 		max_images: Maximum number of screenshots to include
 		ground_truth: Optional ground truth answer or criteria that must be satisfied for success
+		use_vision: Whether vision is enabled. If False, screenshots are not encoded (defensive guard).
 
 	Returns:
 		List of messages for LLM judge evaluation
@@ -66,22 +68,25 @@ def construct_judge_messages(
 	steps_text = '\n'.join(agent_steps)
 	steps_text_truncated = _truncate_text(steps_text, 40000)
 
-	# Select last N screenshots
-	selected_screenshots = screenshot_paths[-max_images:] if len(screenshot_paths) > max_images else screenshot_paths
+	# Select last N screenshots - only if vision is enabled (defensive guard)
+	selected_screenshots = []
+	if use_vision:
+		selected_screenshots = screenshot_paths[-max_images:] if len(screenshot_paths) > max_images else screenshot_paths
 
-	# Encode screenshots
+	# Encode screenshots - only if vision is enabled
 	encoded_images: list[ContentPartImageParam] = []
-	for img_path in selected_screenshots:
-		encoded = _encode_image(img_path)
-		if encoded:
-			encoded_images.append(
-				ContentPartImageParam(
-					image_url=ImageURL(
-						url=f'data:image/png;base64,{encoded}',
-						media_type='image/png',
+	if use_vision:
+		for img_path in selected_screenshots:
+			encoded = _encode_image(img_path)
+			if encoded:
+				encoded_images.append(
+					ContentPartImageParam(
+						image_url=ImageURL(
+							url=f'data:image/png;base64,{encoded}',
+							media_type='image/png',
+						)
 					)
 				)
-			)
 
 	# System prompt for judge - conditionally add ground truth section
 	ground_truth_section = ''


### PR DESCRIPTION
### Bug
Screenshots were still being sent to the LLM judge even when `use_vision=False`, causing unnecessary token usage and violating expected behavior.

### Fix
Added a proper guard to ensure screenshots are only attached when vision is enabled.

### Related Issue
Closes #3726




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents screenshots from being sent to the LLM judge when vision is disabled, reducing token usage and aligning behavior with expectations. Fixes #3726.

- **Bug Fixes**
  - Added a use_vision guard in judge message construction to skip screenshot selection and encoding when disabled.
  - In judge_trace, compute effective_use_vision (true, false, or auto only when screenshots exist) and pass it to the judge; only include screenshots when effective_use_vision is true.

<sup>Written for commit 2c49f41dd394a5b71209a7609130eef99c542403. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



