### PR TITLE
docs fix ChatOpenAI import path

### DIFF
--- a/docs/customize/actor/basics.mdx
+++ b/docs/customize/actor/basics.mdx
@@ -29,7 +29,7 @@ graph TD
 
 ```python
 from browser_use import Browser, Agent
-from browser_use.llm.openai import ChatOpenAI
+from browser_use.llm.openai.chat import ChatOpenAI
 
 async def main():
     llm = ChatOpenAI(api_key="your-api-key")

--- a/docs/customize/actor/examples.mdx
+++ b/docs/customize/actor/examples.mdx
@@ -48,7 +48,7 @@ screenshot = await page.screenshot()
 ## LLM-Powered Features
 
 ```python
-from browser_use.llm.openai import ChatOpenAI
+from browser_use.llm.openai.chat import ChatOpenAI
 from pydantic import BaseModel
 
 llm = ChatOpenAI(api_key="your-api-key")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed ChatOpenAI import path in actor docs to browser_use.llm.openai.chat so code examples import correctly.

<sup>Written for commit ab48cc51dfe895547c8244b9449f3dbca3ca66ec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

