### PR TITLE
Browser logging constant documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_element_detection_bug.yml
+++ b/.github/ISSUE_TEMPLATE/1_element_detection_bug.yml
@@ -106,7 +106,7 @@ body:
     id: logs
     attributes:
       label: Full DEBUG Log Output
-      description: Please copy and paste the *full* log output *from the start of the run*. Make sure to set `BROWSER_USE_LOG_LEVEL=DEBUG` in your `.env` or shell environment.
+      description: Please copy and paste the *full* log output *from the start of the run*. Make sure to set `BROWSER_USE_LOGGING_LEVEL=DEBUG` in your `.env` or shell environment.
       render: shell
       placeholder: |
         $ python /app/browser-use/examples/browser/real_browser.py

--- a/.github/ISSUE_TEMPLATE/2_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.yml
@@ -70,7 +70,7 @@ body:
     id: logs
     attributes:
       label: Full DEBUG Log Output
-      description: Please copy and paste the log output. Make sure to set `BROWSER_USE_LOG_LEVEL=DEBUG` in your `.env` or shell environment.
+      description: Please copy and paste the log output. Make sure to set `BROWSER_USE_LOGGING_LEVEL=DEBUG` in your `.env` or shell environment.
       render: shell
       placeholder: |
         $ python /app/browser-use/examples/browser/real_browser.py

--- a/docs/customize/integrations/mcp-server.mdx
+++ b/docs/customize/integrations/mcp-server.mdx
@@ -357,7 +357,7 @@ Claude Desktop can't find `uvx` in its PATH. Use the full path in your config:
 
 Enable debug logging by setting:
 ```bash
-export BROWSER_USE_LOG_LEVEL=DEBUG
+export BROWSER_USE_LOGGING_LEVEL=DEBUG
 uvx --from 'browser-use[cli]' browser-use --mcp
 ```
 


### PR DESCRIPTION
Update `BROWSER_USE_LOG_LEVEL` to `BROWSER_USE_LOGGING_LEVEL` in docs and issue templates to reflect the correct environment variable.

---
[Slack Thread](https://browser-use.slack.com/archives/D092QUQDC56/p1765568387594429?thread_ts=1765568387.594429&cid=D092QUQDC56)

<a href="https://cursor.com/background-agent?bcId=bc-1026a73d-001f-4cf3-9b58-fdc4d76051c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1026a73d-001f-4cf3-9b58-fdc4d76051c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the correct env var name for debug logging across docs and issue templates: BROWSER_USE_LOGGING_LEVEL. This fixes confusion when enabling DEBUG logs.

- **Bug Fixes**
  - Updated element detection and general bug report templates to use BROWSER_USE_LOGGING_LEVEL.
  - Corrected MCP server docs example to export BROWSER_USE_LOGGING_LEVEL=DEBUG.

<sup>Written for commit db36243b5f32d264ef16b85a904a8e2ec742c5b2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

