### PR TITLE
Dont skip failrues by default

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2701,7 +2701,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self,
 		history: AgentHistoryList,
 		max_retries: int = 3,
-		skip_failures: bool = True,
+		skip_failures: bool = False,
 		delay_between_actions: float = 2.0,
 		max_step_interval: float = 5.0,
 		summary_llm: BaseChatModel | None = None,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Changed rerun_history to not skip failures by default. Failed actions are now retried and surfaced during history replays.

- **Migration**
  - If you want to keep the previous behavior, call rerun_history with skip_failures=True.

<sup>Written for commit 05b41f64a9f5b7e8141a5a5f45a3c220c7af7992. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

