### PR TITLE
added gemini 3 flash preview model

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -33,6 +33,7 @@ VerifiedGeminiModels = Literal[
 	'gemini-flash-lite-latest',
 	'gemini-2.5-pro',
 	'gemini-3-pro-preview',
+	'gemini-3-flash-preview',
 	'gemma-3-27b-it',
 	'gemma-3-4b',
 	'gemma-3-12b',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the gemini-3-flash-preview model to the supported Google models list, enabling clients to use the new Gemini 3 Flash preview. No changes to existing behavior.

<sup>Written for commit eb2382c7c4d77f83785cfaca52807b0b9ea24d25. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

