### PR TITLE
fix: change max_step_interval to 45s

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2703,7 +2703,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_retries: int = 3,
 		skip_failures: bool = False,
 		delay_between_actions: float = 2.0,
-		max_step_interval: float = 5.0,
+		max_step_interval: float = 45.0,
 		summary_llm: BaseChatModel | None = None,
 		ai_step_llm: BaseChatModel | None = None,
 	) -> list[ActionResult]:
@@ -2713,7 +2713,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		Args:
 		                history: The history to replay
 		                max_retries: Maximum number of retries per action
-		                skip_failures: Whether to skip failed actions or stop execution
+		                skip_failures: Whether to skip failed actions or stop execution. When True, also skips
+		                               steps that had errors in the original run (e.g., modal close buttons that
+		                               auto-dismissed, or elements that became non-interactable)
 		                delay_between_actions: Delay between actions in seconds (used when no saved interval)
 		                max_step_interval: Maximum delay from saved step_interval (caps LLM time from original run)
 		                summary_llm: Optional LLM to use for generating the final summary. If not provided, uses the agent's LLM
@@ -2730,69 +2732,88 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		results = []
 
-		for i, history_item in enumerate(history.history):
-			goal = history_item.model_output.current_state.next_goal if history_item.model_output else ''
-			step_num = history_item.metadata.step_number if history_item.metadata else i
-			step_name = 'Initial actions' if step_num == 0 else f'Step {step_num}'
+		try:
+			for i, history_item in enumerate(history.history):
+				goal = history_item.model_output.current_state.next_goal if history_item.model_output else ''
+				step_num = history_item.metadata.step_number if history_item.metadata else i
+				step_name = 'Initial actions' if step_num == 0 else f'Step {step_num}'
 
-			# Determine step delay
-			if history_item.metadata and history_item.metadata.step_interval is not None:
-				# Cap the saved interval to max_step_interval (saved interval includes LLM time)
-				step_delay = min(history_item.metadata.step_interval, max_step_interval)
-				# Format delay nicely - show ms for values < 1s, otherwise show seconds
-				if step_delay < 1.0:
-					delay_str = f'{step_delay * 1000:.0f}ms'
-				else:
-					delay_str = f'{step_delay:.1f}s'
-				if history_item.metadata.step_interval > max_step_interval:
-					delay_source = f'capped to {delay_str} (saved was {history_item.metadata.step_interval:.1f}s)'
-				else:
-					delay_source = f'using saved step_interval={delay_str}'
-			else:
-				step_delay = delay_between_actions
-				if step_delay < 1.0:
-					delay_str = f'{step_delay * 1000:.0f}ms'
-				else:
-					delay_str = f'{step_delay:.1f}s'
-				delay_source = f'using default delay={delay_str}'
-
-			self.logger.info(f'Replaying {step_name} ({i + 1}/{len(history.history)}) [{delay_source}]: {goal}')
-
-			if (
-				not history_item.model_output
-				or not history_item.model_output.action
-				or history_item.model_output.action == [None]
-			):
-				self.logger.warning(f'{step_name}: No action to replay, skipping')
-				results.append(ActionResult(error='No action to replay'))
-				continue
-
-			retry_count = 0
-			while retry_count < max_retries:
-				try:
-					result = await self._execute_history_step(history_item, step_delay, ai_step_llm)
-					results.extend(result)
-					break
-
-				except Exception as e:
-					retry_count += 1
-					if retry_count == max_retries:
-						error_msg = f'{step_name} failed after {max_retries} attempts: {str(e)}'
-						self.logger.error(error_msg)
-						if not skip_failures:
-							results.append(ActionResult(error=error_msg))
-							raise RuntimeError(error_msg)
+				# Determine step delay
+				if history_item.metadata and history_item.metadata.step_interval is not None:
+					# Cap the saved interval to max_step_interval (saved interval includes LLM time)
+					step_delay = min(history_item.metadata.step_interval, max_step_interval)
+					# Format delay nicely - show ms for values < 1s, otherwise show seconds
+					if step_delay < 1.0:
+						delay_str = f'{step_delay * 1000:.0f}ms'
 					else:
-						self.logger.warning(f'{step_name} failed (attempt {retry_count}/{max_retries}), retrying...')
-						await asyncio.sleep(delay_between_actions)
+						delay_str = f'{step_delay:.1f}s'
+					if history_item.metadata.step_interval > max_step_interval:
+						delay_source = f'capped to {delay_str} (saved was {history_item.metadata.step_interval:.1f}s)'
+					else:
+						delay_source = f'using saved step_interval={delay_str}'
+				else:
+					step_delay = delay_between_actions
+					if step_delay < 1.0:
+						delay_str = f'{step_delay * 1000:.0f}ms'
+					else:
+						delay_str = f'{step_delay:.1f}s'
+					delay_source = f'using default delay={delay_str}'
 
-		# Generate AI summary of rerun completion
-		self.logger.info('🤖 Generating AI summary of rerun completion...')
-		summary_result = await self._generate_rerun_summary(self.task, results, summary_llm)
-		results.append(summary_result)
+				self.logger.info(f'Replaying {step_name} ({i + 1}/{len(history.history)}) [{delay_source}]: {goal}')
 
-		await self.close()
-		return results
+				if (
+					not history_item.model_output
+					or not history_item.model_output.action
+					or history_item.model_output.action == [None]
+				):
+					self.logger.warning(f'{step_name}: No action to replay, skipping')
+					results.append(ActionResult(error='No action to replay'))
+					continue
+
+				# Check if the original step had errors - skip if skip_failures is enabled
+				original_had_error = any(r.error for r in history_item.result if r.error)
+				if original_had_error and skip_failures:
+					error_msgs = [r.error for r in history_item.result if r.error]
+					self.logger.warning(
+						f'{step_name}: Original step had error(s), skipping (skip_failures=True): {error_msgs[0][:100] if error_msgs else "unknown"}'
+					)
+					results.append(
+						ActionResult(
+							error=f'Skipped - original step had error: {error_msgs[0][:100] if error_msgs else "unknown"}'
+						)
+					)
+					continue
+
+				retry_count = 0
+				while retry_count < max_retries:
+					try:
+						result = await self._execute_history_step(history_item, step_delay, ai_step_llm)
+						results.extend(result)
+						break
+
+					except Exception as e:
+						retry_count += 1
+						if retry_count == max_retries:
+							error_msg = f'{step_name} failed after {max_retries} attempts: {str(e)}'
+							self.logger.error(error_msg)
+							# Always record the error in results so AI summary counts it correctly
+							results.append(ActionResult(error=error_msg))
+							if not skip_failures:
+								raise RuntimeError(error_msg)
+							# With skip_failures=True, continue to next step
+						else:
+							self.logger.warning(f'{step_name} failed (attempt {retry_count}/{max_retries}), retrying...')
+							await asyncio.sleep(delay_between_actions)
+
+			# Generate AI summary of rerun completion
+			self.logger.info('🤖 Generating AI summary of rerun completion...')
+			summary_result = await self._generate_rerun_summary(self.task, results, summary_llm)
+			results.append(summary_result)
+
+			return results
+		finally:
+			# Always close resources, even on failure
+			await self.close()
 
 	async def _execute_initial_actions(self) -> None:
 		# Execute initial actions if provided
@@ -2895,13 +2916,37 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					state,
 				)
 				if updated_action is None:
-					# Build informative error message
+					# Build informative error message with diagnostic info
 					elem_info = self._format_element_for_error(historical_elem)
-					selector_count = len(state.dom_state.selector_map) if state.dom_state.selector_map else 0
+					selector_map = state.dom_state.selector_map or {}
+					selector_count = len(selector_map)
+
+					# Find elements with same node_name for diagnostics
+					hist_node = historical_elem.node_name.lower() if historical_elem else ''
+					similar_elements = []
+					if historical_elem and historical_elem.attributes:
+						hist_aria = historical_elem.attributes.get('aria-label', '')
+						for idx, elem in selector_map.items():
+							if elem.node_name.lower() == hist_node and elem.attributes:
+								elem_aria = elem.attributes.get('aria-label', '')
+								if elem_aria:
+									similar_elements.append(f'{idx}:{elem_aria[:30]}')
+									if len(similar_elements) >= 5:
+										break
+
+					diagnostic = ''
+					if similar_elements:
+						diagnostic = f'\n  Available <{hist_node.upper()}> with aria-label: {similar_elements}'
+					elif hist_node:
+						same_node_count = sum(1 for e in selector_map.values() if e.node_name.lower() == hist_node)
+						diagnostic = (
+							f'\n  Found {same_node_count} <{hist_node.upper()}> elements (none with matching identifiers)'
+						)
+
 					raise ValueError(
 						f'Could not find matching element for action {i} in current page.\n'
 						f'  Looking for: {elem_info}\n'
-						f'  Page has {selector_count} interactive elements.\n'
+						f'  Page has {selector_count} interactive elements.{diagnostic}\n'
 						f'  Tried: EXACT hash → STABLE hash → XPATH → ATTRIBUTE matching'
 					)
 				pending_actions.append(updated_action)
@@ -3000,7 +3045,18 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if highlight_index is None:
 				tried_attrs = [k for k in ['name', 'id', 'aria-label'] if k in hist_attrs and hist_attrs[k]]
-				self.logger.debug(f'ATTRIBUTE match failed (tried: {tried_attrs})')
+				# Log what was tried and what's available on the page for debugging
+				same_node_elements = [
+					(idx, elem.attributes.get('aria-label') or elem.attributes.get('id') or elem.attributes.get('name'))
+					for idx, elem in selector_map.items()
+					if elem.node_name.lower() == hist_name and elem.attributes
+				]
+				self.logger.debug(
+					f'ATTRIBUTE match failed for <{hist_name.upper()}> '
+					f'(tried: {tried_attrs}, looking for: {[hist_attrs.get(k) for k in tried_attrs]}). '
+					f'Page has {len(same_node_elements)} <{hist_name.upper()}> elements with identifiers: '
+					f'{same_node_elements[:5]}{"..." if len(same_node_elements) > 5 else ""}'
+				)
 
 		if highlight_index is None:
 			return None
@@ -3054,7 +3110,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				- max_retries: Maximum retries per action (default: 3)
 				- skip_failures: Continue on failure (default: True)
 				- delay_between_actions: Delay when no saved interval (default: 2.0s)
-				- max_step_interval: Cap on saved step_interval (default: 5.0s)
+				- max_step_interval: Cap on saved step_interval (default: 45.0s)
 				- summary_llm: Custom LLM for final summary
 				- ai_step_llm: Custom LLM for extract re-evaluation
 		"""

--- a/tests/ci/test_rerun_ai_summary.py
+++ b/tests/ci/test_rerun_ai_summary.py
@@ -3,7 +3,9 @@
 from unittest.mock import AsyncMock
 
 from browser_use.agent.service import Agent
-from browser_use.agent.views import ActionResult, RerunSummaryAction
+from browser_use.agent.views import ActionResult, AgentHistory, AgentHistoryList, RerunSummaryAction, StepMetadata
+from browser_use.browser.views import BrowserStateHistory
+from browser_use.dom.views import DOMRect, NodeType
 from tests.ci.conftest import create_mock_llm
 
 
@@ -164,6 +166,411 @@ async def test_generate_rerun_summary_statistics():
 		assert summary.is_done is True
 		assert summary.success is False  # partial completion
 		assert '3 of 5' in (summary.extracted_content or '')
+
+	finally:
+		await agent.close()
+
+
+async def test_rerun_skips_steps_with_original_errors():
+	"""Test that rerun_history skips steps that had errors in the original run when skip_failures=True"""
+
+	# Create a mock LLM for summary
+	summary_action = RerunSummaryAction(
+		summary='Rerun completed with skipped steps',
+		success=True,
+		completion_status='complete',
+	)
+
+	async def custom_ainvoke(*args, **kwargs):
+		output_format = args[1] if len(args) > 1 else kwargs.get('output_format')
+		if output_format is RerunSummaryAction:
+			from browser_use.llm.views import ChatInvokeCompletion
+
+			return ChatInvokeCompletion(completion=summary_action, usage=None)
+		raise ValueError('Unexpected output_format')
+
+	mock_summary_llm = AsyncMock()
+	mock_summary_llm.ainvoke.side_effect = custom_ainvoke
+
+	llm = create_mock_llm(actions=None)
+	agent = Agent(task='Test task', llm=llm)
+
+	# Create mock history with a step that has an error
+	mock_state = BrowserStateHistory(
+		url='https://example.com',
+		title='Test Page',
+		tabs=[],
+		interacted_element=[None],
+	)
+
+	# Get the dynamically created AgentOutput type from the agent
+	AgentOutput = agent.AgentOutput
+
+	# Create a step that originally had an error (using navigate action which doesn't require element matching)
+	failed_step = AgentHistory(
+		model_output=AgentOutput(
+			evaluation_previous_goal=None,
+			memory='Trying to navigate',
+			next_goal=None,
+			action=[{'navigate': {'url': 'https://example.com/page'}}],  # type: ignore[arg-type]
+		),
+		result=[ActionResult(error='Navigation failed - network error')],
+		state=mock_state,
+		metadata=StepMetadata(
+			step_start_time=0,
+			step_end_time=1,
+			step_number=1,
+			step_interval=1.0,
+		),
+	)
+
+	# Create history with the failed step
+	history = AgentHistoryList(history=[failed_step])
+
+	try:
+		# Run rerun with skip_failures=True - should skip the step with original error
+		results = await agent.rerun_history(
+			history,
+			skip_failures=True,
+			summary_llm=mock_summary_llm,
+		)
+
+		# The step should have been skipped (not retried) because it originally had an error
+		# We should have 2 results: the skipped step result and the AI summary
+		assert len(results) == 2
+
+		# First result should indicate the step was skipped
+		skipped_result = results[0]
+		assert skipped_result.error is not None
+		assert 'Skipped - original step had error' in skipped_result.error
+
+		# Second result should be the AI summary
+		summary_result = results[1]
+		assert summary_result.is_done is True
+
+	finally:
+		await agent.close()
+
+
+async def test_rerun_does_not_skip_originally_failed_when_skip_failures_false():
+	"""Test that rerun_history does NOT skip steps with original errors when skip_failures=False.
+	When skip_failures=False, the step should be attempted (and will succeed since navigate doesn't need element matching)."""
+
+	# Create a mock LLM for summary (will be reached after the step succeeds)
+	summary_action = RerunSummaryAction(
+		summary='Rerun completed',
+		success=True,
+		completion_status='complete',
+	)
+
+	async def custom_ainvoke(*args, **kwargs):
+		output_format = args[1] if len(args) > 1 else kwargs.get('output_format')
+		if output_format is RerunSummaryAction:
+			from browser_use.llm.views import ChatInvokeCompletion
+
+			return ChatInvokeCompletion(completion=summary_action, usage=None)
+		raise ValueError('Unexpected output_format')
+
+	mock_summary_llm = AsyncMock()
+	mock_summary_llm.ainvoke.side_effect = custom_ainvoke
+
+	llm = create_mock_llm(actions=None)
+	agent = Agent(task='Test task', llm=llm)
+
+	# Create mock history with a step that has an error
+	mock_state = BrowserStateHistory(
+		url='https://example.com',
+		title='Test Page',
+		tabs=[],
+		interacted_element=[None],
+	)
+
+	# Get the dynamically created AgentOutput type from the agent
+	AgentOutput = agent.AgentOutput
+
+	# Create a step that originally had an error but uses navigate (which will work on rerun)
+	failed_step = AgentHistory(
+		model_output=AgentOutput(
+			evaluation_previous_goal=None,
+			memory='Trying to navigate',
+			next_goal=None,
+			action=[{'navigate': {'url': 'https://example.com/page'}}],  # type: ignore[arg-type]
+		),
+		result=[ActionResult(error='Navigation failed - network error')],
+		state=mock_state,
+		metadata=StepMetadata(
+			step_start_time=0,
+			step_end_time=1,
+			step_number=1,
+			step_interval=1.0,
+		),
+	)
+
+	# Create history with the failed step
+	history = AgentHistoryList(history=[failed_step])
+
+	try:
+		# Run rerun with skip_failures=False - should attempt to replay (and succeed since navigate works)
+		results = await agent.rerun_history(
+			history,
+			skip_failures=False,
+			max_retries=1,
+			summary_llm=mock_summary_llm,
+		)
+
+		# With skip_failures=False, the step should NOT be skipped even if original had error
+		# The navigate action should succeed
+		assert len(results) == 2
+
+		# First result should be the successful navigation (not skipped)
+		nav_result = results[0]
+		# It should NOT contain "Skipped" since skip_failures=False
+		if nav_result.error:
+			assert 'Skipped' not in nav_result.error
+
+	finally:
+		await agent.close()
+
+
+async def test_rerun_cleanup_on_failure(httpserver):
+	"""Test that rerun_history properly cleans up resources (closes browser/connections) even when it fails.
+
+	This test verifies the try/finally cleanup logic by creating a step that will fail
+	(element matching fails) and checking that the browser session is properly closed afterward.
+	"""
+	from browser_use.dom.views import DOMInteractedElement
+
+	# Set up a test page with a button that has DIFFERENT attributes than our historical element
+	test_html = """<!DOCTYPE html>
+	<html>
+	<body>
+		<button id="real-button" aria-label="real-button">Click me</button>
+	</body>
+	</html>"""
+	httpserver.expect_request('/test').respond_with_data(test_html, content_type='text/html')
+	test_url = httpserver.url_for('/test')
+
+	llm = create_mock_llm(actions=None)
+	agent = Agent(task='Test task', llm=llm)
+	AgentOutput = agent.AgentOutput
+
+	# Step 1: Navigate to test page
+	navigate_step = AgentHistory(
+		model_output=AgentOutput(
+			evaluation_previous_goal=None,
+			memory='Navigate to test page',
+			next_goal=None,
+			action=[{'navigate': {'url': test_url}}],  # type: ignore[arg-type]
+		),
+		result=[ActionResult(long_term_memory='Navigated')],
+		state=BrowserStateHistory(
+			url=test_url,
+			title='Test Page',
+			tabs=[],
+			interacted_element=[None],
+		),
+		metadata=StepMetadata(
+			step_start_time=0,
+			step_end_time=1,
+			step_number=1,
+			step_interval=0.1,
+		),
+	)
+
+	# Step 2: Click on element that won't be found (different identifiers)
+	failing_step = AgentHistory(
+		model_output=AgentOutput(
+			evaluation_previous_goal=None,
+			memory='Trying to click non-existent button',
+			next_goal=None,
+			action=[{'click': {'index': 100}}],  # type: ignore[arg-type]
+		),
+		result=[ActionResult(long_term_memory='Clicked button')],  # Original succeeded
+		state=BrowserStateHistory(
+			url=test_url,
+			title='Test Page',
+			tabs=[],
+			interacted_element=[
+				DOMInteractedElement(
+					node_id=1,
+					backend_node_id=9999,
+					frame_id=None,
+					node_type=NodeType.ELEMENT_NODE,
+					node_value='',
+					node_name='BUTTON',
+					attributes={'aria-label': 'non-existent-button', 'id': 'fake-id'},
+					x_path='html/body/button[999]',
+					element_hash=123456789,
+					stable_hash=987654321,
+					bounds=DOMRect(x=0, y=0, width=100, height=50),
+					ax_name='non-existent',
+				)
+			],
+		),
+		metadata=StepMetadata(
+			step_start_time=0,
+			step_end_time=1,
+			step_number=2,
+			step_interval=0.1,
+		),
+	)
+
+	history = AgentHistoryList(history=[navigate_step, failing_step])
+
+	# Run rerun with skip_failures=False - should fail and raise RuntimeError
+	# but the try/finally should ensure cleanup happens
+	try:
+		await agent.rerun_history(
+			history,
+			skip_failures=False,
+			max_retries=1,  # Fail quickly
+		)
+		assert False, 'Expected RuntimeError to be raised'
+	except RuntimeError as e:
+		# Expected - the step should fail on element matching
+		assert 'failed after 1 attempts' in str(e)
+
+	# If we get here without hanging, the cleanup worked
+	# The browser session should be closed by the finally block in rerun_history
+	# We can verify by checking that calling close again doesn't cause issues
+	# (close() is idempotent - calling it multiple times should be safe)
+	await agent.close()  # Should not hang or error since already closed
+
+
+async def test_rerun_records_errors_when_skip_failures_true(httpserver):
+	"""Test that rerun_history records errors in results even when skip_failures=True.
+
+	This ensures the AI summary correctly counts failures. Previously, when skip_failures=True
+	and a step failed after all retries, no error result was appended, causing the AI summary
+	to incorrectly report success=True even with multiple failures.
+	"""
+	from browser_use.dom.views import DOMInteractedElement
+
+	# Set up a test page with a button that has DIFFERENT attributes than our historical element
+	# This ensures element matching will fail (the historical element won't be found)
+	test_html = """<!DOCTYPE html>
+	<html>
+	<body>
+		<button id="real-button" aria-label="real-button">Click me</button>
+	</body>
+	</html>"""
+	httpserver.expect_request('/test').respond_with_data(test_html, content_type='text/html')
+	test_url = httpserver.url_for('/test')
+
+	# Create a mock LLM for summary that returns partial success
+	summary_action = RerunSummaryAction(
+		summary='Some steps failed',
+		success=False,
+		completion_status='partial',
+	)
+
+	async def custom_ainvoke(*args, **kwargs):
+		output_format = args[1] if len(args) > 1 else kwargs.get('output_format')
+		if output_format is RerunSummaryAction:
+			from browser_use.llm.views import ChatInvokeCompletion
+
+			return ChatInvokeCompletion(completion=summary_action, usage=None)
+		raise ValueError('Unexpected output_format')
+
+	mock_summary_llm = AsyncMock()
+	mock_summary_llm.ainvoke.side_effect = custom_ainvoke
+
+	llm = create_mock_llm(actions=None)
+	agent = Agent(task='Test task', llm=llm)
+
+	# Create history with:
+	# 1. First step navigates to test page (will succeed)
+	# 2. Second step tries to click a non-existent element (will fail on element matching)
+	AgentOutput = agent.AgentOutput
+
+	# Step 1: Navigate to test page
+	navigate_step = AgentHistory(
+		model_output=AgentOutput(
+			evaluation_previous_goal=None,
+			memory='Navigate to test page',
+			next_goal=None,
+			action=[{'navigate': {'url': test_url}}],  # type: ignore[arg-type]
+		),
+		result=[ActionResult(long_term_memory='Navigated')],
+		state=BrowserStateHistory(
+			url=test_url,
+			title='Test Page',
+			tabs=[],
+			interacted_element=[None],
+		),
+		metadata=StepMetadata(
+			step_start_time=0,
+			step_end_time=1,
+			step_number=1,
+			step_interval=0.1,
+		),
+	)
+
+	# Step 2: Click on element that won't exist on current page (different hash/attributes)
+	failing_step = AgentHistory(
+		model_output=AgentOutput(
+			evaluation_previous_goal=None,
+			memory='Trying to click non-existent button',
+			next_goal=None,
+			action=[{'click': {'index': 100}}],  # type: ignore[arg-type]  # Original index doesn't matter, matching will fail
+		),
+		result=[ActionResult(long_term_memory='Clicked button')],  # Original succeeded
+		state=BrowserStateHistory(
+			url=test_url,
+			title='Test Page',
+			tabs=[],
+			interacted_element=[
+				DOMInteractedElement(
+					node_id=1,
+					backend_node_id=9999,
+					frame_id=None,
+					node_type=NodeType.ELEMENT_NODE,
+					node_value='',
+					node_name='BUTTON',
+					# This element has completely different identifiers than the real button
+					attributes={'aria-label': 'non-existent-button', 'id': 'fake-id'},
+					x_path='html/body/button[999]',  # XPath that doesn't exist
+					element_hash=123456789,  # Hash that won't match
+					stable_hash=987654321,  # Stable hash that won't match
+					bounds=DOMRect(x=0, y=0, width=100, height=50),
+					ax_name='non-existent',
+				)
+			],
+		),
+		metadata=StepMetadata(
+			step_start_time=0,
+			step_end_time=1,
+			step_number=2,
+			step_interval=0.1,
+		),
+	)
+
+	history = AgentHistoryList(history=[navigate_step, failing_step])
+
+	try:
+		# Run rerun with skip_failures=True - should NOT raise but should record the error
+		results = await agent.rerun_history(
+			history,
+			skip_failures=True,
+			max_retries=1,  # Fail quickly
+			summary_llm=mock_summary_llm,
+		)
+
+		# Should have 3 results: navigation success + error from failed step + AI summary
+		assert len(results) == 3
+
+		# First result should be successful navigation
+		nav_result = results[0]
+		assert nav_result.error is None
+
+		# Second result should be the error (element matching failed)
+		error_result = results[1]
+		assert error_result.error is not None
+		assert 'failed after 1 attempts' in error_result.error
+
+		# Third result should be the AI summary
+		summary_result = results[2]
+		assert summary_result.is_done is True
 
 	finally:
 		await agent.close()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the default max_step_interval from 5s to 45s to prevent rerun timeouts when original steps had long LLM delays. Also make reruns more reliable with better skipping, error recording, and cleanup.

- **Bug Fixes**
  - Cap saved step_interval at 45s and update docs.
  - When skip_failures=True, skip steps that errored in the original run; when False, attempt them.
  - Always record a final error result after max retries so the summary counts failures; only raise when skip_failures=False.
  - Ensure resources are closed with try/finally; add clearer element-matching diagnostics and focused tests for skipping, cleanup, and error accounting.

<sup>Written for commit b9c8346499cd5bec346294c7fac530c7e1ec3b09. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

