### PR TITLE
add support for external skillservice

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -140,6 +140,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Skills integration
 		skill_ids: list[str | Literal['*']] | None = None,
 		skills: list[str | Literal['*']] | None = None,  # Alias for skill_ids
+		skill_service: Any | None = None,
 		# Initial agent run parameters
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		initial_actions: list[dict[str, dict[str, Any]]] | None = None,
@@ -314,10 +315,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			raise ValueError('Cannot specify both "skills" and "skill_ids" parameters. Use "skills" for the cleaner API.')
 		skill_ids = skills or skill_ids
 
-		# Skills integration
+		# Skills integration - use injected service or create from skill_ids
 		self.skill_service = None
 		self._skills_registered = False
-		if skill_ids:
+		if skill_service is not None:
+			self.skill_service = skill_service
+		elif skill_ids:
 			from browser_use.skills import SkillService
 
 			self.skill_service = SkillService(skill_ids=skill_ids)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an optional skill_service parameter to the agent so you can inject an external SkillService. If provided, the agent uses it; otherwise it builds one from skill_ids.

- **New Features**
  - New optional parameter: skill_service.
  - Precedence: use injected skill_service; fallback to SkillService(skill_ids) when skill_ids are set.

<sup>Written for commit cf0894ff8d95fee23d822dbccbd27d2539af2901. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

