### PR TITLE
fix: include shadow DOM form elements in selector_map even without sn…

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2984,11 +2984,23 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		highlight_index: int | None = None
 		match_level: MatchLevel | None = None
 
-		# Debug: log what we're looking for
-		self.logger.debug(
-			f'Searching for element: <{historical_element.node_name}> '
+		# Debug: log what we're looking for and what's available
+		self.logger.info(
+			f'🔍 Searching for element: <{historical_element.node_name}> '
 			f'hash={historical_element.element_hash} stable_hash={historical_element.stable_hash}'
 		)
+		# Log what elements are in selector_map for debugging
+		if historical_element.node_name:
+			hist_name = historical_element.node_name.lower()
+			matching_nodes = [
+				(idx, elem.node_name, elem.attributes.get('name') if elem.attributes else None)
+				for idx, elem in selector_map.items()
+				if elem.node_name.lower() == hist_name
+			]
+			self.logger.info(
+				f'🔍 Selector map has {len(selector_map)} elements, '
+				f'{len(matching_nodes)} are <{hist_name.upper()}>: {matching_nodes}'
+			)
 
 		# Level 1: EXACT hash match
 		for idx, elem in selector_map.items():
@@ -3054,8 +3066,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					for idx, elem in selector_map.items()
 					if elem.node_name.lower() == hist_name and elem.attributes
 				]
-				self.logger.debug(
-					f'ATTRIBUTE match failed for <{hist_name.upper()}> '
+				self.logger.info(
+					f'🔍 ATTRIBUTE match failed for <{hist_name.upper()}> '
 					f'(tried: {tried_attrs}, looking for: {[hist_attrs.get(k) for k in tried_attrs]}). '
 					f'Page has {len(same_node_elements)} <{hist_name.upper()}> elements with identifiers: '
 					f'{same_node_elements[:5]}{"..." if len(same_node_elements) > 5 else ""}'

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -525,6 +525,25 @@ class DomService:
 
 			# Get snapshot data and calculate absolute position
 			snapshot_data = snapshot_lookup.get(node['backendNodeId'], None)
+
+			# DIAGNOSTIC: Log when interactive elements don't have snapshot data
+			if not snapshot_data and node['nodeName'].upper() in ['INPUT', 'BUTTON', 'SELECT', 'TEXTAREA', 'A']:
+				parent_has_shadow = False
+				parent_info = ''
+				if 'parentId' in node and node['parentId'] in enhanced_dom_tree_node_lookup:
+					parent = enhanced_dom_tree_node_lookup[node['parentId']]
+					if parent.shadow_root_type:
+						parent_has_shadow = True
+						parent_info = f'parent={parent.tag_name}(shadow={parent.shadow_root_type})'
+				attr_str = ''
+				if 'attributes' in node and node['attributes']:
+					attrs_dict = {node['attributes'][i]: node['attributes'][i + 1] for i in range(0, len(node['attributes']), 2)}
+					attr_str = f'name={attrs_dict.get("name", "N/A")} id={attrs_dict.get("id", "N/A")}'
+				self.logger.debug(
+					f'🔍 NO SNAPSHOT DATA for <{node["nodeName"]}> backendNodeId={node["backendNodeId"]} '
+					f'{attr_str} {parent_info} (snapshot_lookup has {len(snapshot_lookup)} entries)'
+				)
+
 			absolute_position = None
 			if snapshot_data and snapshot_data.bounds:
 				absolute_position = DOMRect(


### PR DESCRIPTION
…apshot data

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include shadow DOM form elements in selector_map and assign action indices even when DOMSnapshot lacks layout data. Fixes missed interactions in web components and login forms, with added targeted logging for easier debugging.

- **Bug Fixes**
  - Detect shadow DOM by walking parent chain to find a document-fragment shadow root.
  - Mark inputs, buttons, selects, textareas, and links inside shadow DOM as interactive even without snapshot_node; include them in selector_map.
  - Preserve existing behavior for file inputs and scrollable containers.
  - Add focused logs in agent, snapshot builder, serializer, and DOM service to trace element search/matches and missing snapshot data.

<sup>Written for commit 07b7a6d8c0ba3a0efe7da08c03aa188e579f7b3f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

