### PR TITLE
fix: use correct MIME type for images in Google serializer

### DIFF
--- a/browser_use/llm/google/serializer.py
+++ b/browser_use/llm/google/serializer.py
@@ -106,8 +106,11 @@ class GoogleMessageSerializer:
 							# Decode base64 to bytes
 							image_bytes = base64.b64decode(data)
 
+							# Use the media_type from ImageURL, which correctly identifies the image format
+							mime_type = part.image_url.media_type
+
 							# Add image part
-							image_part = Part.from_bytes(data=image_bytes, mime_type='image/jpeg')
+							image_part = Part.from_bytes(data=image_bytes, mime_type=mime_type)
 
 							message_parts.append(image_part)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the correct image MIME type from ImageURL when building image parts in the Google serializer instead of hardcoding JPEG. This fixes Linear 3740 where ActionResult images broke after the Google Gen AI bump.

- **Bug Fixes**
  - Set mime_type from part.image_url.media_type in Part.from_bytes so non-JPEG images (e.g., PNG, WEBP, GIF) render correctly.

<sup>Written for commit 221d85744e1e0881c8485fd007e21e07a1996f8a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

