### PR TITLE
fix: respect use_vision=False in judge to prevent screenshot leakage

### DIFF
--- a/browser_use/agent/judge.py
+++ b/browser_use/agent/judge.py
@@ -4,6 +4,8 @@ import base64
 import logging
 from pathlib import Path
 
+from typing import Literal
+
 from browser_use.llm.messages import (
 	BaseMessage,
 	ContentPartImageParam,
@@ -46,6 +48,7 @@ def construct_judge_messages(
 	screenshot_paths: list[str],
 	max_images: int = 10,
 	ground_truth: str | None = None,
+	use_vision: bool | Literal['auto'] = True,
 ) -> list[BaseMessage]:
 	"""
 	Construct messages for judge evaluation of agent trace.
@@ -66,22 +69,24 @@ def construct_judge_messages(
 	steps_text = '\n'.join(agent_steps)
 	steps_text_truncated = _truncate_text(steps_text, 40000)
 
-	# Select last N screenshots
-	selected_screenshots = screenshot_paths[-max_images:] if len(screenshot_paths) > max_images else screenshot_paths
-
-	# Encode screenshots
+	# Only include screenshots if use_vision is not False
 	encoded_images: list[ContentPartImageParam] = []
-	for img_path in selected_screenshots:
-		encoded = _encode_image(img_path)
-		if encoded:
-			encoded_images.append(
-				ContentPartImageParam(
-					image_url=ImageURL(
-						url=f'data:image/png;base64,{encoded}',
-						media_type='image/png',
+	if use_vision is not False:
+		# Select last N screenshots
+		selected_screenshots = screenshot_paths[-max_images:] if len(screenshot_paths) > max_images else screenshot_paths
+
+		# Encode screenshots
+		for img_path in selected_screenshots:
+			encoded = _encode_image(img_path)
+			if encoded:
+				encoded_images.append(
+					ContentPartImageParam(
+						image_url=ImageURL(
+							url=f'data:image/png;base64,{encoded}',
+							media_type='image/png',
+						)
 					)
 				)
-			)
 
 	# System prompt for judge - conditionally add ground truth section
 	ground_truth_section = ''

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1267,6 +1267,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			screenshot_paths=screenshot_paths,
 			max_images=10,
 			ground_truth=self.settings.ground_truth,
+			use_vision=self.settings.use_vision,
 		)
 
 		# Call LLM with JudgementResult as output format

--- a/tests/ci/test_judge_use_vision.py
+++ b/tests/ci/test_judge_use_vision.py
@@ -1,0 +1,142 @@
+"""Tests for judge respecting use_vision setting."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from browser_use.agent.judge import construct_judge_messages
+from browser_use.llm.messages import ContentPartImageParam
+
+
+class TestJudgeUseVision:
+    """Test that construct_judge_messages respects use_vision parameter."""
+
+    @pytest.fixture
+    def sample_screenshot_paths(self):
+        """Create temporary screenshot files for testing."""
+        temp_files = []
+        for i in range(3):
+            with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as f:
+                # Write a minimal valid PNG header
+                f.write(b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR')
+                f.write(b'\x00' * 20)  # Minimal image data
+                temp_files.append(f.name)
+        yield temp_files
+        # Cleanup
+        for f in temp_files:
+            Path(f).unlink(missing_ok=True)
+
+    def test_use_vision_true_includes_screenshots(self, sample_screenshot_paths):
+        """When use_vision=True, screenshots should be included."""
+        messages = construct_judge_messages(
+            task="Test task",
+            final_result="Test result",
+            agent_steps=["Step 1", "Step 2"],
+            screenshot_paths=sample_screenshot_paths,
+            use_vision=True,
+        )
+        
+        # Check that the user message contains image parts
+        user_message = messages[1]
+        image_parts = [
+            part for part in user_message.content 
+            if isinstance(part, ContentPartImageParam)
+        ]
+        assert len(image_parts) > 0, "Screenshots should be included when use_vision=True"
+
+    def test_use_vision_false_excludes_screenshots(self, sample_screenshot_paths):
+        """When use_vision=False, screenshots should NOT be included."""
+        messages = construct_judge_messages(
+            task="Test task",
+            final_result="Test result",
+            agent_steps=["Step 1", "Step 2"],
+            screenshot_paths=sample_screenshot_paths,
+            use_vision=False,
+        )
+        
+        # Check that the user message contains NO image parts
+        user_message = messages[1]
+        image_parts = [
+            part for part in user_message.content 
+            if isinstance(part, ContentPartImageParam)
+        ]
+        assert len(image_parts) == 0, "Screenshots should NOT be included when use_vision=False"
+
+    def test_use_vision_auto_includes_screenshots(self, sample_screenshot_paths):
+        """When use_vision='auto', screenshots should be included (same as True for judge)."""
+        messages = construct_judge_messages(
+            task="Test task",
+            final_result="Test result",
+            agent_steps=["Step 1", "Step 2"],
+            screenshot_paths=sample_screenshot_paths,
+            use_vision='auto',
+        )
+        
+        # Check that the user message contains image parts
+        user_message = messages[1]
+        image_parts = [
+            part for part in user_message.content 
+            if isinstance(part, ContentPartImageParam)
+        ]
+        assert len(image_parts) > 0, "Screenshots should be included when use_vision='auto'"
+
+    def test_use_vision_default_includes_screenshots(self, sample_screenshot_paths):
+        """Default behavior (use_vision not specified) should include screenshots."""
+        messages = construct_judge_messages(
+            task="Test task",
+            final_result="Test result",
+            agent_steps=["Step 1", "Step 2"],
+            screenshot_paths=sample_screenshot_paths,
+            # use_vision not specified, defaults to True
+        )
+        
+        # Check that the user message contains image parts
+        user_message = messages[1]
+        image_parts = [
+            part for part in user_message.content 
+            if isinstance(part, ContentPartImageParam)
+        ]
+        assert len(image_parts) > 0, "Screenshots should be included by default"
+
+    def test_use_vision_false_message_shows_zero_screenshots(self, sample_screenshot_paths):
+        """When use_vision=False, message should indicate 0 screenshots attached."""
+        messages = construct_judge_messages(
+            task="Test task",
+            final_result="Test result",
+            agent_steps=["Step 1", "Step 2"],
+            screenshot_paths=sample_screenshot_paths,
+            use_vision=False,
+        )
+        
+        # Check that the user message text indicates 0 screenshots
+        user_message = messages[1]
+        text_parts = [
+            part for part in user_message.content 
+            if hasattr(part, 'text')
+        ]
+        assert len(text_parts) > 0
+        text_content = text_parts[0].text
+        assert "0 screenshots from execution are attached" in text_content
+
+    def test_empty_screenshot_paths_no_error(self):
+        """Empty screenshot_paths should not cause errors regardless of use_vision."""
+        # Should not raise any errors
+        messages_true = construct_judge_messages(
+            task="Test task",
+            final_result="Test result",
+            agent_steps=["Step 1"],
+            screenshot_paths=[],
+            use_vision=True,
+        )
+        messages_false = construct_judge_messages(
+            task="Test task",
+            final_result="Test result",
+            agent_steps=["Step 1"],
+            screenshot_paths=[],
+            use_vision=False,
+        )
+        
+        assert len(messages_true) == 2
+        assert len(messages_false) == 2
+


### PR DESCRIPTION
### Bug
When `use_vision=False`, screenshots are still sent to the judge LLM. This is a **privacy concern** as websites may contain sensitive data that users explicitly do not want shared with LLMs.

As noted by @leandertolksdorf in #3726:
> *The point was, if for whatever reason I've set use_vision = false, browser-use still wanted to send screenshots to the LLM. In my opinion, this is a privacy flaw. Websites could contain sensitive data, and if the user does not want to use vision, it should also not use vision in the judging step.*

### Root Cause
`construct_judge_messages()` always encodes and includes screenshots regardless of the `use_vision` setting.

### Fix
1. Added `use_vision` parameter to `construct_judge_messages()`
2. Only encode and include screenshots when `use_vision` is not `False`
3. Pass `self.settings.use_vision` from `_judge_trace()` to `construct_judge_messages()`

This approach ensures user privacy preferences are respected while still allowing:
- `use_vision=True`: Screenshots sent to both agent and judge
- `use_vision='auto'`: Screenshots sent to judge (current behavior preserved)
- `use_vision=False`: No screenshots sent anywhere (privacy respected)

### Tests
Added 6 comprehensive tests covering all `use_vision` modes.

### Related Issue
Fixes #3726

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents screenshot leakage in judge when use_vision=False. Screenshots are no longer sent to the judge LLM, honoring user privacy preferences.

- **Bug Fixes**
  - Added use_vision parameter to construct_judge_messages and passed self.settings.use_vision from _judge_trace.
  - Only include screenshots when use_vision is not False; True and 'auto' continue to attach screenshots.
  - Added tests covering True, False, 'auto', default behavior, and empty screenshot lists.

<sup>Written for commit d73bca47e8eccf8c956914bb8c1b434ac441aaae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

