### PR TITLE
fix: resolve Gemini API error on empty action schemas

### DIFF
--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -95,7 +95,7 @@ class NoParamsAction(BaseModel):
 	model_config = ConfigDict(extra='ignore')
 
 	# Optional field required by Gemini API which errors on empty objects in response_schema
-	description: str | None = Field(None, description="Optional description for the action")
+	description: str | None = Field(None, description='Optional description for the action')
 
 
 class GetDropdownOptionsAction(BaseModel):


### PR DESCRIPTION
Fixes #3786.

When using the Gemini API (via LiteLLM or directly), the request fails with a `BadRequestError`. This is because Gemini's API strictly enforces that any parameter defined as `type: OBJECT` in the `response_schema` must have a non-empty `properties` map.

The `go_back` action (and others using `NoParamsAction`) previously generated an empty object schema (`{"type": "object", "properties": {}}`), causing this validation failure.

**Error Message:**
> `GeminiException BadRequestError - * GenerateContentRequest.generation_config.response_schema.properties["action"].items.any_of[3].properties["go_back"].properties: should be non-empty for OBJECT type`

## Changes
- Modified `NoParamsAction` in `browser_use/tools/service.py` to include an optional `description` field.
- This ensures Pydantic generates a valid schema (e.g., `{"properties": {"description": {"type": "string"}}}`) instead of an empty one.
- The new field is optional (`None` by default) and is explicitly ignored by the action logic (`_`), ensuring no side effects on existing functionality.

- Verified that `NoParamsAction.model_json_schema()` now produces a schema with properties, satisfying the Gemini API requirement.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Gemini BadRequestError by ensuring actions with no params produce a non-empty object schema. Adds an optional description field to NoParamsAction so Pydantic includes properties in the response_schema.

- **Bug Fixes**
  - Added description: str | None = Field(None, ...) to NoParamsAction in browser_use/tools/views.py to satisfy Gemini’s OBJECT-type schema requirement.
  - Field is optional and ignored by action logic, so behavior remains unchanged.

<sup>Written for commit bd6c1d76e208415f5e1e751bd9fcc45f70538e1f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





