### PR TITLE
feat: remove redundant retry step from history

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2735,6 +2735,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		results = []
 
+		# Track previous step for redundant retry detection
+		previous_item: AgentHistory | None = None
+		previous_step_succeeded: bool = False
+
 		try:
 			for i, history_item in enumerate(history.history):
 				goal = history_item.model_output.current_state.next_goal if history_item.model_output else ''
@@ -2787,11 +2791,27 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					)
 					continue
 
+				# Check if this step is a redundant retry of the previous step
+				# This handles cases where original run needed to click same element multiple times
+				# due to slow page response, but during replay the first click already worked
+				if self._is_redundant_retry_step(history_item, previous_item, previous_step_succeeded):
+					self.logger.info(f'{step_name}: Skipping redundant retry (previous step already succeeded with same element)')
+					results.append(
+						ActionResult(
+							extracted_content='Skipped - redundant retry of previous step',
+							include_in_memory=False,
+						)
+					)
+					# Don't update previous_item/previous_step_succeeded - keep tracking the original step
+					continue
+
 				retry_count = 0
+				step_succeeded = False
 				while retry_count < max_retries:
 					try:
 						result = await self._execute_history_step(history_item, step_delay, ai_step_llm)
 						results.extend(result)
+						step_succeeded = True
 						break
 
 					except Exception as e:
@@ -2807,6 +2827,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 						else:
 							self.logger.warning(f'{step_name} failed (attempt {retry_count}/{max_retries}), retrying...')
 							await asyncio.sleep(delay_between_actions)
+
+				# Update tracking for redundant retry detection
+				previous_item = history_item
+				previous_step_succeeded = step_succeeded
 
 			# Generate AI summary of rerun completion
 			self.logger.info('🤖 Generating AI summary of rerun completion...')
@@ -3108,6 +3132,77 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			parts.append(f'xpath="{xpath_short}"')
 
 		return ' '.join(parts)
+
+	def _is_redundant_retry_step(
+		self,
+		current_item: AgentHistory,
+		previous_item: AgentHistory | None,
+		previous_step_succeeded: bool,
+	) -> bool:
+		"""
+		Detect if current step is a redundant retry of the previous step.
+
+		This handles cases where the original run needed to click the same element multiple
+		times due to slow page response, but during replay the first click already succeeded.
+		When the page has already navigated, subsequent retry clicks on the same element
+		would fail because that element no longer exists.
+
+		Returns True if:
+		- Previous step succeeded
+		- Both steps target the same element (by element_hash, stable_hash, or xpath)
+		- Both steps perform the same action type (e.g., both are clicks)
+		"""
+		if not previous_item or not previous_step_succeeded:
+			return False
+
+		# Get interacted elements from both steps (first action in each)
+		curr_elements = current_item.state.interacted_element
+		prev_elements = previous_item.state.interacted_element
+
+		if not curr_elements or not prev_elements:
+			return False
+
+		curr_elem = curr_elements[0] if curr_elements else None
+		prev_elem = prev_elements[0] if prev_elements else None
+
+		if not curr_elem or not prev_elem:
+			return False
+
+		# Check if same element by various matching strategies
+		same_by_hash = curr_elem.element_hash == prev_elem.element_hash
+		same_by_stable_hash = (
+			curr_elem.stable_hash is not None
+			and prev_elem.stable_hash is not None
+			and curr_elem.stable_hash == prev_elem.stable_hash
+		)
+		same_by_xpath = curr_elem.x_path == prev_elem.x_path
+
+		if not (same_by_hash or same_by_stable_hash or same_by_xpath):
+			return False
+
+		# Check if same action type
+		curr_actions = current_item.model_output.action if current_item.model_output else []
+		prev_actions = previous_item.model_output.action if previous_item.model_output else []
+
+		if not curr_actions or not prev_actions:
+			return False
+
+		# Get the action type (first key in the action dict)
+		curr_action_data = curr_actions[0].model_dump(exclude_unset=True)
+		prev_action_data = prev_actions[0].model_dump(exclude_unset=True)
+
+		curr_action_type = next(iter(curr_action_data.keys()), None)
+		prev_action_type = next(iter(prev_action_data.keys()), None)
+
+		if curr_action_type != prev_action_type:
+			return False
+
+		self.logger.debug(
+			f'🔄 Detected redundant retry: both steps target same element '
+			f'<{curr_elem.node_name}> with action "{curr_action_type}"'
+		)
+
+		return True
 
 	async def load_and_rerun(
 		self,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skips redundant retry steps during history reruns when the previous step already succeeded on the same element and action. This avoids replay failures after navigation and speeds up reruns.

- **New Features**
  - Detect redundant retries by matching element (hash/stable_hash/xpath) and action type.
  - Track previous step success and skip the duplicate, adding a “Skipped - redundant retry of previous step” result.
  - Added tests for rerun behavior and the detection helper.

<sup>Written for commit bb13679f85f0eed26d43e4d54bdff08dbb2dd381. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

