### PR TITLE
fix: proper newline handling in text input

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -864,33 +864,14 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# Type the text character by character to the focused element
 			for char in text:
-				# Handle newline characters as Enter key
+				# Handle newline characters - send as text character, not as Enter key
 				if char == '\n':
-					# Send proper Enter key sequence
-					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
-						params={
-							'type': 'keyDown',
-							'key': 'Enter',
-							'code': 'Enter',
-							'windowsVirtualKeyCode': 13,
-						},
-						session_id=cdp_session.session_id,
-					)
-					# Send char event with carriage return
+					self.logger.debug('Sending newline as text character')
+					# Just send the newline character as text input
 					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
 						params={
 							'type': 'char',
-							'text': '\r',
-						},
-						session_id=cdp_session.session_id,
-					)
-					# Send keyup
-					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
-						params={
-							'type': 'keyUp',
-							'key': 'Enter',
-							'code': 'Enter',
-							'windowsVirtualKeyCode': 13,
+							'text': '\n',
 						},
 						session_id=cdp_session.session_id,
 					)
@@ -1549,16 +1530,22 @@ class DefaultActionWatchdog(BaseWatchdog):
 			else:
 				self.logger.debug(f'🎯 Typing text character by character: "{text}"')
 
+			# Replace literal \n (two characters: backslash + n) with actual newline
+			text = text.replace('\\n', '\n')
+
 			for i, char in enumerate(text):
 				# Handle newline characters as Enter key
 				if char == '\n':
 					# Send proper Enter key sequence
+					# Use Shift+Enter for ALL platforms to ensure proper newline behavior
+					self.logger.debug('Using Shift+Enter for newline on all platforms')
 					await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
 						params={
-							'type': 'keyDown',
+							'type': 'rawKeyDown',
 							'key': 'Enter',
 							'code': 'Enter',
 							'windowsVirtualKeyCode': 13,
+							'modifiers': 8,  # Shift modifier for all platforms
 						},
 						session_id=cdp_session.session_id,
 					)


### PR DESCRIPTION
Summary

Fix improper newline handling in text input that causes form submission instead of line breaks.

Problem

When typing text with newlines (`\n`) into text fields:
1. `_type_to_page` sends Enter key (keyDown/keyUp) instead of newline character - this submits forms instead of creating line breaks
2. `_input_text_element_node_impl` doesn't convert literal `\n` strings to actual newlines
3. Plain Enter key without Shift modifier triggers form submission in many web apps
4. Single `\n` character can produce multiple line breaks due to redundant key events

Solution

`_type_to_page` method
- Send newline as text character (`type: 'char', text: '\n'`) instead of Enter key sequence

`_input_text_element_node_impl` method
- Add `text = text.replace('\\n', '\n')` to convert literal backslash-n to actual newlines
- Use Shift+Enter (`modifiers: 8`) for proper line break behavior across all platforms

Testing

Tested on Windows with various web forms and textarea elements. Line breaks now work correctly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix newline handling in text inputs to prevent accidental form submissions and ensure consistent line breaks across platforms.

- **Bug Fixes**
  - Send '\n' as a text character in _type_to_page instead of Enter key events.
  - Convert literal "\\n" to actual newline and use Shift+Enter (modifiers: 8) in _input_text_element_node_impl for reliable line breaks.
  - Removed redundant keyDown/keyUp sequences that caused multiple line breaks.

<sup>Written for commit 000f7fe075d06fd9668b7f57994d05294cd18978. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

