### PR TITLE
refactor: Replace print with logger.debug in actor/page.py

### DIFF
--- a/browser_use/actor/page.py
+++ b/browser_use/actor/page.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 from pydantic import BaseModel
 
+from browser_use import logger
 from browser_use.actor.utils import get_key_info
 from browser_use.dom.serializer.serializer import DOMTreeSerializer
 from browser_use.dom.service import DomService
@@ -129,8 +130,8 @@ class Page:
 		else:
 			expression = f'({page_function})()'
 
-		# Debug: print the actual expression being evaluated
-		print(f'DEBUG: Evaluating JavaScript: {repr(expression)}')
+		# Debug: log the actual expression being evaluated
+		logger.debug(f'Evaluating JavaScript: {repr(expression)}')
 
 		params: 'EvaluateParameters' = {'expression': expression, 'returnByValue': True, 'awaitPromise': True}
 		result = await self._client.send.Runtime.evaluate(


### PR DESCRIPTION
## Background
The page.py file in the browser_use/actor directory was using a print statement for debugging purposes, which is inconsistent with the project's logging strategy. The project already has a centralized logging system using Python's logging module, configured through browser_use/logging_config.py .

## Changes
1. File Modified : browser_use/actor/page.py
2. Change : Replaced the debug print statement on line 134 with a logger.debug call
3. Logger Used : The existing logger imported from browser_use
4. Log Level : debug (matching the original debug print intent)
## Benefits
- Unified Logging : Aligns with the project's existing logging system
- Flexible Configuration : Debug logs can be easily enabled/disabled via environment variables or code configuration
- Better Context : Logs include component name and timestamp when configured
- Structured Output : Consistent log format across the project
- Reduced Console Clutter : Users can control log verbosity based on their needs
- Improved Debugging : Better integration with logging tools and services
## Impact
- No Breaking Changes : This is a refactoring change that preserves functionality
- Minimal Scope : Only affects one debug statement in a single file
- Backward Compatible : Existing functionality remains unchanged
## Testing
- ✅ Python syntax check passed ( python -m py_compile browser_use/actor/page.py )
- ✅ No other print statements left in the file (verified via grep )
- ✅ Uses existing project logger (no new dependencies)
- ✅ Log level appropriately set to debug for debugging purposes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the debug print in browser_use/actor/page.py to logger.debug to align with the project’s logging system. This keeps behavior the same while providing structured logs and configurable verbosity.

<sup>Written for commit 6b77410683bd2d5d116a70b99b31a31572beaf15. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

