### PR TITLE
fix: propagate API status codes to enable proper handling of 429 Rate Limits

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -418,7 +418,7 @@ class ChatGoogle(BaseChatModel):
 				elapsed = time.time() - start_time
 				self.logger.error(f'💥 API call failed after {elapsed:.2f}s: {type(e).__name__}: {e}')
 				if isinstance(e, ClientError):
-                    raise ModelProviderError(e.message, status_code=e.code, model=self.model
+                    raise ModelProviderError(e.message, status_code=e.code, model=self.model)
 				# Re-raise the exception
 				raise
 


### PR DESCRIPTION
Handle ClientError specifically and raise ModelProviderError.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagate Google API status codes by catching ClientError and raising ModelProviderError with status_code. This lets callers properly handle 429 rate limits and similar errors.

- **Bug Fixes**
  - Catch ClientError in Google chat API calls.
  - Raise ModelProviderError with status_code and model to surface 429 to callers.

<sup>Written for commit 527db7f58745307915476ddd301216f06391c67f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



