### PR TITLE
feat: add save_page_as_pdf action

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -286,6 +286,15 @@ class ScrollToTextEvent(BaseEvent[None]):
 	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ScrollToTextEvent', 15.0))  # seconds
 
 
+class SavePageAsPdfEvent(BaseEvent[dict[str, Any]]):
+	"""Save the current page as PDF using CDP Page.printToPDF."""
+
+	filename: str | None = None  
+	print_background: bool = True  
+
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_SavePageAsPdfEvent', 30.0))  # seconds
+
+
 # ============================================================================
 
 

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -105,3 +105,9 @@ class GetDropdownOptionsAction(BaseModel):
 class SelectDropdownOptionAction(BaseModel):
 	index: int
 	text: str = Field(description='exact text/value')
+
+
+class SavePageAsPdfAction(BaseModel):
+	filename: str | None = Field(
+		default=None, description='Custom filename (without .pdf extension). Uses page title if not provided'
+	)


### PR DESCRIPTION
## Why do we need this PR?

When a user wants to save/print a webpage, calling `window.print()` opens an OS-level print dialog that the browser automation agent **cannot interact with**. This PR adds a [save_page_as_pdf](cci:1:/browser-use/browser_use/tools/service.py:946:2-977:40) action that allows agents to directly save any page as PDF using CDP `Page.printToPDF`, bypassing the print dialog entirely.

### Use Cases:
- User asks: "Download this page as PDF"
- User asks: "Save this article for offline reading"  
- User asks: "Archive this webpage"

## Demo

<img width="803" height="497" alt="Screenshot 2025-12-25 at 11 38 50 PM" src="https://github.com/user-attachments/assets/e85b0649-6237-456a-bd79-202d2680e574" />

The agent:
1. Navigates to the page
2. Calls [save_page_as_pdf](cci:1:/browser-use/browser_use/tools/service.py:946:2-977:40) action
3. PDF is saved to downloads folder (no dialog popup!)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a save_page_as_pdf action that uses CDP Page.printToPDF to download the current page as a PDF, bypassing the OS print dialog. Saves to the browser downloads folder and returns file metadata.

- **New Features**
  - New SavePageAsPdfAction with optional filename (defaults to page title).
  - SavePageAsPdfEvent and handler generate the PDF via CDP, include backgrounds, and ensure unique filenames.
  - Emits FileDownloadedEvent with path, size, and mime type.
  - Tools action returns ActionResult with metadata and clear errors on failure.
  - CI tests cover PDF creation and custom filenames.

<sup>Written for commit 33536abaa11a7aed25d60c2f006284bef6ffbf8f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

