### PR TITLE
fix: Add clear error message for unsupported Qwen 3 VL MoE in Ollama

### DIFF
--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
@@ -15,6 +16,35 @@ from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
 
+# Pattern to detect Qwen 3 VL MoE models (unsupported by llama.cpp/Ollama)
+# Matches: qwen3-vl-moe, qwen3vlmoe, qwen-3-vl-moe, qwen3_vl_moe, etc.
+QWEN3_VL_MOE_PATTERN = re.compile(r'qwen[-_]?3[-_]?vl[-_]?moe', re.IGNORECASE)
+
+
+def is_unsupported_qwen_model(model_name: str) -> bool:
+	"""
+	Check if the model is a known unsupported Qwen architecture.
+
+	Qwen 3 VL MoE models use 'qwen3vlmoe' architecture which is not
+	supported by llama.cpp/Ollama at the time of writing.
+
+	See: https://github.com/browser-use/browser-use/issues/3813
+	"""
+	if not model_name:
+		return False
+	return bool(QWEN3_VL_MOE_PATTERN.search(model_name))
+
+
+def get_unsupported_model_message(model_name: str) -> str:
+	"""Generate a helpful error message for unsupported models."""
+	return (
+		f"Model '{model_name}' uses the 'qwen3vlmoe' architecture which is not supported by Ollama/llama.cpp. "
+		f'Supported alternatives:\n'
+		f"  • Ollama vision models: 'qwen2.5-vl', 'qwen2-vl', 'llava', 'llava-llama3'\n"
+		f'  • Cloud providers: Use OpenRouter or ChatBrowserUse for Qwen 3 VL MoE\n'
+		f'See: https://github.com/browser-use/browser-use/issues/3813'
+	)
+
 
 @dataclass
 class ChatOllama(BaseChatModel):
@@ -24,17 +54,12 @@ class ChatOllama(BaseChatModel):
 
 	model: str
 
-	# # Model params
-	# TODO (matic): Why is this commented out?
-	# temperature: float | None = None
-
 	# Client initialization parameters
 	host: str | None = None
 	timeout: float | httpx.Timeout | None = None
 	client_params: dict[str, Any] | None = None
 	ollama_options: Mapping[str, Any] | Options | None = None
 
-	# Static
 	@property
 	def provider(self) -> str:
 		return 'ollama'
@@ -57,6 +82,16 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def _validate_model(self) -> None:
+		"""
+		Validate the model is supported by Ollama.
+
+		Raises:
+			ModelProviderError: If the model architecture is not supported.
+		"""
+		if is_unsupported_qwen_model(self.model):
+			raise ModelProviderError(message=get_unsupported_model_message(self.model), model=self.name)
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -68,6 +103,9 @@ class ChatOllama(BaseChatModel):
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		# Pre-validate model architecture
+		self._validate_model()
+
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
 
 		try:
@@ -95,5 +133,18 @@ class ChatOllama(BaseChatModel):
 
 				return ChatInvokeCompletion(completion=completion, usage=None)
 
+		except ModelProviderError:
+			# Re-raise our own errors without wrapping
+			raise
 		except Exception as e:
-			raise ModelProviderError(message=str(e), model=self.name) from e
+			error_msg = str(e)
+
+			# Enhance error message for unknown architecture errors
+			if 'unknown model architecture' in error_msg.lower():
+				error_msg = (
+					f'{error_msg}\n\n'
+					f'This model architecture is not supported by your local Ollama installation. '
+					f'Try using a supported model or a cloud provider.'
+				)
+
+			raise ModelProviderError(message=error_msg, model=self.name) from e

--- a/browser_use/llm/tests/test_ollama_chat.py
+++ b/browser_use/llm/tests/test_ollama_chat.py
@@ -1,0 +1,109 @@
+"""
+Tests for ChatOllama model validation.
+
+Tests the fix for: https://github.com/browser-use/browser-use/issues/3813
+"""
+
+import pytest
+
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.ollama.chat import (
+	ChatOllama,
+	get_unsupported_model_message,
+	is_unsupported_qwen_model,
+)
+
+
+class TestQwenModelDetection:
+	"""Test detection of unsupported Qwen 3 VL MoE models."""
+
+	@pytest.mark.parametrize(
+		'model_name',
+		[
+			'qwen3-vl-moe',
+			'qwen3vlmoe',
+			'qwen-3-vl-moe',
+			'qwen3_vl_moe',
+			'Qwen3-VL-MoE',  # Case insensitive
+			'QWEN3VLMOE',
+			'qwen-3-vl-moe-7b',
+			'some-prefix-qwen3vlmoe-suffix',
+		],
+	)
+	def test_detects_unsupported_qwen3_vl_moe(self, model_name: str):
+		"""Should detect Qwen 3 VL MoE variants as unsupported."""
+		assert is_unsupported_qwen_model(model_name) is True
+
+	@pytest.mark.parametrize(
+		'model_name',
+		[
+			'qwen2-vl',
+			'qwen2.5-vl',
+			'qwen-vl',  # No "3" and no "moe"
+			'qwen3',  # No "vl" or "moe"
+			'qwen-moe',  # No "3" or "vl"
+			'llama3',
+			'llava',
+			'phi-3-vision',
+			'gpt-4',
+			'',
+		],
+	)
+	def test_allows_supported_models(self, model_name: str):
+		"""Should allow supported models through."""
+		assert is_unsupported_qwen_model(model_name) is False
+
+	def test_handles_none_gracefully(self):
+		"""Should handle None input gracefully."""
+		assert is_unsupported_qwen_model('') is False
+
+
+class TestChatOllamaValidation:
+	"""Test ChatOllama model validation."""
+
+	def test_validate_model_raises_for_unsupported(self):
+		"""Should raise ModelProviderError for unsupported models."""
+		chat = ChatOllama(model='qwen3-vl-moe')
+
+		with pytest.raises(ModelProviderError) as exc_info:
+			chat._validate_model()
+
+		assert 'qwen3vlmoe' in exc_info.value.message.lower()
+		assert 'not supported' in exc_info.value.message.lower()
+		assert exc_info.value.model == 'qwen3-vl-moe'
+
+	def test_validate_model_passes_for_supported(self):
+		"""Should not raise for supported models."""
+		chat = ChatOllama(model='qwen2.5-vl')
+
+		# Should not raise
+		chat._validate_model()
+
+	@pytest.mark.asyncio
+	async def test_ainvoke_raises_early_for_unsupported_model(self):
+		"""Should raise before attempting API call for unsupported models."""
+		chat = ChatOllama(model='qwen3vlmoe')
+
+		with pytest.raises(ModelProviderError) as exc_info:
+			await chat.ainvoke(messages=[])
+
+		assert 'qwen3vlmoe' in exc_info.value.message.lower()
+
+
+class TestErrorMessages:
+	"""Test error message quality."""
+
+	def test_error_message_includes_alternatives(self):
+		"""Error message should include helpful alternatives."""
+		message = get_unsupported_model_message('qwen3-vl-moe')
+
+		assert 'qwen2.5-vl' in message
+		assert 'qwen2-vl' in message
+		assert 'llava' in message
+		assert 'OpenRouter' in message or 'cloud' in message.lower()
+
+	def test_error_message_includes_issue_link(self):
+		"""Error message should reference the GitHub issue."""
+		message = get_unsupported_model_message('qwen3-vl-moe')
+
+		assert '3813' in message


### PR DESCRIPTION
- Add QWEN3_VL_MOE_PATTERN regex for robust model detection
- Create is_unsupported_qwen_model() helper (case-insensitive)
- Create get_unsupported_model_message() for consistent errors
- Add _validate_model() for early model validation
- Add comprehensive test suite (24 tests, all passing)
- Suggest alternatives: qwen2.5-vl, qwen2-vl, llava
- Recommend cloud providers for qwen-3-vl-moe access

Fixes #3813





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds early validation and a clear error for Qwen 3 VL MoE models, which Ollama/llama.cpp do not support. Prevents confusing failures and points users to supported options (fixes #3813).

- **Bug Fixes**
  - Detect unsupported models with a case-insensitive regex (qwen[-_]3[-_]vl[-_]moe).
  - Validate in ChatOllama before requests and raise ModelProviderError with a helpful message.
  - Error message lists alternatives (qwen2.5-vl, qwen2-vl, llava, llava-llama3) and suggests cloud providers; includes issue link.
  - Improve exception handling to clarify “unknown model architecture” errors.
  - Add tests for detection, validation, and messaging.

<sup>Written for commit bce8c97ff29e0196b03a71da0fa75aa2d50c442b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





