### PR TITLE
fix: remove synthetic events leaking isTrusted:false

### DIFF
--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -972,13 +972,11 @@ class Element:
 							}
 							// Use the native setter to clear the value
 							// This allows React to detect the change via its value tracking
-							const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-								window.HTMLInputElement.prototype,
-								'value'
-							)?.set || Object.getOwnPropertyDescriptor(
-								window.HTMLTextAreaElement.prototype,
-								'value'
-							)?.set;
+							// Check element type first to use correct prototype (textarea vs input)
+							const proto = this.tagName.toLowerCase() === 'textarea'
+								? window.HTMLTextAreaElement.prototype
+								: window.HTMLInputElement.prototype;
+							const nativeInputValueSetter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
 							
 							if (nativeInputValueSetter) {
 								nativeInputValueSetter.call(this, '');


### PR DESCRIPTION
### Problem

Events created using JavaScript constructors like `new Event()` or `new InputEvent()` always have `isTrusted: false`. This is expected browser behavior and is used to distinguish real user interactions from programmatic ones.

Previously, the code dispatched synthetic `input`, `change`, and `click` events after text or UI interactions. These events were detectable because `isTrusted` was always `false`, which allowed websites to identify automation.

Many sites rely on `isTrusted` checks for bot detection, making this a real issue.

### Solution

Removed unnecessary synthetic event dispatching from the following areas:

* `_trigger_framework_events`
  Removed synthetic events and replaced them with a `focus()` / `blur()` cycle.

* `_set_value_directly`
  Removed synthetic `input` and `change` events.

* `_clear_text_field`
  Removed synthetic events and now uses the native value setter with `focus()` / `blur()`.

* Native `<select>` handler
  Removed redundant synthetic `input` event.

* ARIA dropdown handler
  Removed redundant synthetic `click` event.

* Custom dropdown handler
  Removed redundant synthetic `click` event.

### Why This Works

Text input already relies on CDP’s `Input.dispatchKeyEvent`, which generates events with `isTrusted: true`. Frameworks receive these trusted events naturally.

The removed synthetic events were redundant and only introduced detectable automation signals.

### Known Limitations

* Native `<select>` elements still require a synthetic `change` event because there is no CDP alternative.
* Date and time inputs use direct value setting, which may not trigger all framework hooks but avoids leaking `isTrusted: false`.

### Testing

Verified that:

* No synthetic `input` or `change` events are dispatched from the updated methods.
* No redundant synthetic `click` events are dispatched from dropdown handlers.
* CDP character-by-character typing continues to work correctly.
* The code now clearly documents the `isTrusted` limitation.

Closes #3829

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed synthetic input/change/click events that exposed isTrusted:false and switched to native value setters, focus/blur cycles, and trusted CDP events. This reduces automation detection while keeping frameworks in sync.

- **Bug Fixes**
  - Replaced synthetic events in text clearing and direct value setting with native setters (using correct input/textarea prototypes) plus focus/blur.
  - Updated framework event trigger to only use focus/blur (no synthetic input/change).
  - Dropdowns: use item.click() for ARIA/custom menus; keep synthetic change for native <select> and custom dropdown containers where needed.
  - Verified CDP typing still emits isTrusted:true and no redundant synthetic events are dispatched.

<sup>Written for commit e28182131a20db4757adbd6db28e9054f9866501. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

