### PR TITLE
feat: Add remote_debugging_port option to BrowserProfile

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -550,6 +550,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	# Session/connection configuration
 	cdp_url: str | None = Field(default=None, description='CDP URL for connecting to existing browser instance')
 	is_local: bool = Field(default=False, description='Whether this is a local browser instance')
+	remote_debugging_port: int | None = Field(
+		default=None,
+		description='Fixed port for Chrome remote debugging. If not set, a random free port is used. Useful for connecting to the browser from external tools.',
+	)
 	use_cloud: bool = Field(
 		default=False,
 		description='Use browser-use cloud browser service instead of local browser',

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -106,8 +106,8 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				# Get launch args from profile
 				launch_args = profile.get_args()
 
-				# Add debugging port
-				debug_port = self._find_free_port()
+				# Add debugging port (use configured port or find a free one)
+				debug_port = profile.remote_debugging_port or self._find_free_port()
 				launch_args.extend(
 					[
 						f'--remote-debugging-port={debug_port}',


### PR DESCRIPTION
Add ability to set a fixed Chrome remote debugging port instead of always using a random free port. This is useful for:
- Connecting to the browser from external tools
- Predictable CDP URLs for testing/automation scripts
- Scenarios where port discovery is difficult

Usage:
  BrowserProfile(remote_debugging_port=9222)

If not set, falls back to finding a random free port (existing behavior)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add remote_debugging_port to BrowserProfile to allow a fixed Chrome debugging port for predictable CDP URLs and easier external tool connections. If unset, behavior remains the same with a random free port.

- **New Features**
  - Set BrowserProfile(remote_debugging_port=9222) to force the port.
  - local_browser_watchdog honors the configured port when launching Chrome.

<sup>Written for commit 1e18fd84ccccdd5ad3a662336876b5ccee2bf4b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

