### PR TITLE
fixed broken links in docs

### DIFF
--- a/docs/customize/agent/basics.mdx
+++ b/docs/customize/agent/basics.mdx
@@ -19,7 +19,7 @@ async def main():
 ```
 
 - `task`: The task you want to automate.
-- `llm`: Your favorite LLM. See <a href="/customize/supported-models">Supported Models</a>.
+- `llm`: Your favorite LLM. See <a href="/supported-models">Supported Models</a>.
 
 
 The agent is executed using the async `run()` method:

--- a/docs/customize/code-agent/basics.mdx
+++ b/docs/customize/code-agent/basics.mdx
@@ -34,8 +34,8 @@ BROWSER_USE_API_KEY=your-api-key
 ```
 
 <Note>
-CodeAgent currently only works with [ChatBrowserUse](https://chat.browser-use.com) which is optimized for this use case.
-Don't have one? We give you $10 to try it out [here](https://cloud.browser-use.com/dashboard/api).
+CodeAgent currently only works with [ChatBrowserUse](/supported-models) which is optimized for this use case.
+Don't have one? We give you $10 to try it out [here](https://cloud.browser-use.com/new-api-key).
 </Note>
 
 ## When to Use

--- a/docs/customize/integrations/mcp-server.mdx
+++ b/docs/customize/integrations/mcp-server.mdx
@@ -169,7 +169,7 @@ When you monitor tasks, the AI automatically interprets step data into natural l
 - Use clearer, more specific instructions
 
 **Need help?**
-Check the [v2 API Reference](/api-reference/v2) for detailed specifications.
+Check our [Cloud Documentation](https://docs.cloud.browser-use.com) for detailed specifications.
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed broken links in the docs to restore navigation and remove 404s. Addresses Linear 3836.

- **Bug Fixes**
  - Agent basics: updated Supported Models link to /supported-models.
  - CodeAgent basics: linked ChatBrowserUse to /supported-models and updated API key URL to https://cloud.browser-use.com/new-api-key.
  - MCP server: replaced v2 API Reference link with https://docs.cloud.browser-use.com.

<sup>Written for commit 75b5a0dffd993b29aa67013cafc78a7f446df3af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

