### PR TITLE
  docs: add missing video recording dependency notice

### DIFF
--- a/docs/customize/browser/all-parameters.mdx
+++ b/docs/customize/browser/all-parameters.mdx
@@ -91,6 +91,19 @@ The `Browser` instance also provides all [Actor](/customize/actor/all-parameters
 
 ## Recording & Debugging
 
+<Warning>
+Video recording requires additional optional dependencies. If these are not installed, no video will be saved and no error will be raised.
+
+Install with:
+```bash
+pip install "browser-use[video]"
+```
+or:
+```bash
+pip install imageio[ffmpeg] numpy
+```
+</Warning>
+
 - `record_video_dir`: Directory to save video recordings as `.mp4` files
 - `record_video_size` (default: `ViewportSize`): The frame size (width, height) of the video recording.
 - `record_video_framerate` (default: `30`): The framerate to use for the video recording.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a warning to the Browser recording docs that video capture requires optional dependencies, with install commands: pip install "browser-use[video]" or pip install imageio[ffmpeg] numpy. Addresses Linear 3803 by adding the missing dependency install alert to the recording section.

<sup>Written for commit 4c151c214c6cb0237b2f6344c99991fdf80ce421. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

