### PR TITLE
fix: include jarvis attributes in DOM serialization for custom action…

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -77,6 +77,10 @@ DEFAULT_INCLUDE_ATTRIBUTES = [
 	'live',
 	# Accessibility name (contains text content for StaticText elements)
 	'ax_name',
+	# Custom attributes for action prioritization (e.g. Jarvis)
+	'jarvis-type',
+	'jarvis-label',
+	'jarvis-model-id',
 ]
 
 STATIC_ATTRIBUTES = {
@@ -129,6 +133,10 @@ STATIC_ATTRIBUTES = {
 	'aria-valuemax',
 	'aria-valuenow',
 	'aria-placeholder',
+	# Custom attributes for action prioritization
+	'jarvis-type',
+	'jarvis-label',
+	'jarvis-model-id',
 }
 
 # Class patterns that indicate dynamic/transient UI state - excluded from stable hash


### PR DESCRIPTION
**Problem: Custom Attribute Stripping**
Fixes: #3828
I ran into an issue where the LLM couldn’t recognize that certain elements supported custom actions like search_select.
The problem wasn’t with the elements themselves, but with how the DOM was being simplified and serialized before being sent to the model. The HTML elements had custom attributes such as jarvis-type="SearchSelect", but those attributes were getting stripped out during serialization. Since the LLM never saw them in the prompt, it treated the element as a normal text input and defaulted to input_text instead of using the specialized action.
So even though the metadata existed in the DOM, it never reached the LLM.

**Fix: Preserving Action Metadata**

After digging into the DOM serialization layer, I found that only a hard-coded list of attributes was allowed through. The Jarvis-specific attributes weren’t included in that list.
I fixed this in browser_use/dom/views.py by making sure these attributes are always preserved.

**1. Updated DEFAULT_INCLUDE_ATTRIBUTES**

I added the Jarvis attributes to the default whitelist so they appear in the serialized DOM that gets sent to the LLM:
`DEFAULT_INCLUDE_ATTRIBUTES = [
    # ... existing attributes
    'ax_name',
    'jarvis-type',
    'jarvis-label',
    'jarvis-model-id',
]
`
This allows the LLM to clearly see that an element supports a custom interaction.

**2. Updated STATIC_ATTRIBUTES**

I also added the same attributes to STATIC_ATTRIBUTES:
`STATIC_ATTRIBUTES = {
    # ... existing attributes
    'itemprop',
    'jarvis-type',
    'jarvis-label',
    'jarvis-model-id',
}
`

This makes sure these attributes are treated as meaningful identifiers, helping the agent keep a stable reference to the element even if other parts of the page change.

**Verification**
To make sure everything worked correctly, I verified it step by step:
Created a reproduction page
I built a local HTML file with an <input> containing jarvis-type="SearchSelect".
Mocked the serializer
I ran DOMTreeSerializer on the page to see exactly what the LLM would receive.
Before vs After
**Before**
`[7]<input type=text id=target placeholder=---请选择--- />
`

**After**

`[7]<input type=text id=target placeholder=---请选择--- 
    jarvis-model-id=22 
    jarvis-label=项目 
    jarvis-type=SearchSelect />
`
This confirmed that the custom attributes are now preserved and visible to the model.
Regression testing
I ran the existing tests/ci/browser/test_dom_serializer.py test suite to ensure nothing broke around shadow DOM or iframe handling.


**Final Result**
The changes are committed on my fork under the branch
fix/3828-jarvis-attributes.
Once this is merged, the LLM will correctly recognize these attributes and—guided by the custom tool descriptions—prioritize the correct specialized actions instead of falling back to generic input behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Jarvis DOM attributes in serialization so the model detects custom actions (e.g., SearchSelect) instead of defaulting to plain text input. Addresses Linear 3828.

- **Bug Fixes**
  - Added jarvis-type, jarvis-label, jarvis-model-id to DEFAULT_INCLUDE_ATTRIBUTES and STATIC_ATTRIBUTES in browser_use/dom/views.py.
  - Exposes action metadata to the model and improves stable element identification.

<sup>Written for commit 192bc212f90d8e54f9073e063904e57bdc5b7edf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

