### PR TITLE
Fix `DOMInteractedElement` had limitations when dealing with special …

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -528,8 +528,8 @@ class EnhancedDOMTreeNode:
 			# Control characters or first char is digit
 			elif (0x1 <= code <= 0x1F) or code == 0x7F or (i == 0 and 0x30 <= code <= 0x39):
 				result.append(f'\\{code:x} ')
-			# First char is hyphen and only char
-			elif i == 0 and char == '-' and len(value) == 1:
+			# First char is hyphen and (only char OR followed by digit)
+			elif i == 0 and char == '-' and (len(value) == 1 or (len(value) > 1 and 0x30 <= ord(value[1]) <= 0x39)):
 				result.append(f'\\{char}')
 			# Safe characters: letters, digits, hyphen, underscore, non-ASCII
 			elif (code >= 0x80 or char == '-' or char == '_' or 


### PR DESCRIPTION
Fixes #3820

Problem

`DOMInteractedElement` had limitations when dealing with special DOM cases:

1. XPath doesn't work with Shadow DOM - XPath fundamentally cannot traverse shadow DOM boundaries (the XPath specification predates Shadow DOM)
2. Limited iframe context - Only `frame_id` was provided, without full frame hierarchy
3. No shadow DOM context - No information about which shadow hosts contain an element
4. No alternative selector - Only XPath was available, which fails for shadow DOM elements

This made it difficult to reliably identify and interact with elements in:
- Shadow DOM components
- Iframes
- Shadow DOM inside iframes
- Iframes inside shadow DOM

Solution

Enhanced `DOMInteractedElement` with new fields that properly capture shadow DOM and iframe hierarchy:

### New Fields Added

1. `css_selector` - CSS selector that works with shadow DOM (unlike XPath)
2. `shadow_path` - List of shadow host tag names from root to element
3. iframe_chain` - Full frame hierarchy (list of frame IDs)
4. is_in_shadow_dom - Boolean flag for quick detection
5. `is_in_iframe - Boolean flag for quick detection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add shadow DOM and iframe support to DOMInteractedElement for reliable element identification beyond XPath. Generates robust CSS selectors and captures shadow and frame hierarchy to improve interactions, including nested cases.

- **New Features**
  - Added css_selector that works in shadow DOM and uses ID/class and nth-of-type for specificity, with proper CSS escaping.
  - Added shadow_path listing shadow hosts from root to element.
  - Added iframe_chain with full frame ID hierarchy.
  - Added is_in_shadow_dom and is_in_iframe flags.
  - Updated serialization and loader to include and populate these fields.

<sup>Written for commit 66a1f4a126da843477e729d5f84bb18262b170ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

