### PR TITLE
fix: allow screenshot action in registry regardless of vision settings

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -294,7 +294,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		elif controller is not None:
 			self.tools = controller
 		else:
-			# Exclude screenshot tool when use_vision is not auto
 			exclude_actions = ['screenshot'] if use_vision != 'auto' else []
 			self.tools = Tools(exclude_actions=exclude_actions, display_files_in_done_text=display_files_in_done_text)
 


### PR DESCRIPTION
fixes:#3719
I fixed a crash that happened when the LLM used the screenshot action while use_vision=True.
Previously, screenshot was removed from the tool registry in this mode, so if the LLM still called it, AgentOutput validation failed with a Pydantic error and the agent crashed.

I removed the exclusion logic so screenshot is always a valid action. Now, even with vision enabled, calling screenshot works normally and the output validates correctly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the tool registry logic by removing an outdated comment; screenshot is still excluded when use_vision is not 'auto'.

<sup>Written for commit 95985364eee6eac8109a2fa5c9f9ec8125458845. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



