### PR TITLE
fix: add bu-30b-a3b-preview to valid models list

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -68,7 +68,7 @@ class ChatBrowserUse(BaseChatModel):
 			retry_max_delay: Maximum delay in seconds between retries (default: 60.0).
 		"""
 		# Validate model name - allow bu-* and browser-use/* patterns
-		valid_models = ['bu-latest', 'bu-1-0']
+		valid_models = ['bu-latest', 'bu-1-0', 'bu-30b-a3b-preview']
 		is_valid = model in valid_models or model.startswith('browser-use/')
 		if not is_valid:
 			raise ValueError(f"Invalid model: '{model}'. Must be one of {valid_models} or start with 'browser-use/'")


### PR DESCRIPTION
fixes:#3850
I ran into an issue with the ChatBrowserUse class in browser_use/llm/browser_use/chat.py where the model name validation was too strict. The code only allowed bu-latest, bu-1-0, or model names starting with browser-use/. Because of this, a valid model called bu-30b-a3b-preview was being rejected during initialization, throwing a ValueError: Invalid model, even though the model itself is supported and usable.

To fix this, I updated the valid_models list in the __init__ method to explicitly include bu-30b-a3b-preview. I also created a small reproduction script (reproduce_issue.py) to verify the behavior. Before the fix, the script failed immediately with the validation error. After the fix, the model passed validation and the initialization continued normally (moving on to API key validation or succeeding if the key was present). This confirms that the issue was purely due to overly restrictive validation and that the update correctly resolves it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bu-30b-a3b-preview to the valid model list in ChatBrowserUse so the model passes validation.
Prevents the “Invalid model” ValueError when initializing with this supported model.

<sup>Written for commit 40181e22d760a5ecb0b04a868653d56dbb57ff6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

