### PR TITLE
fix(browser): add explicit fallback for CDP session attachment 

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1258,54 +1258,63 @@ class BrowserSession(BaseModel):
 					self.logger.debug(f'[SessionManager] Target appeared after {attempt * 100}ms')
 					break
 
-			if not session:
 				# 2) If still no session, explicit attach fallback
 				self.logger.warning(
 					f'[SessionManager] Target {target_id[:8]}... has no session after auto-attach wait; '
 					f'trying explicit Target.attachToTarget fallback'
 				)
 
-				try:
-					assert self._cdp_client_root is not None
-					attach_result = await self._cdp_client_root.send.Target.attachToTarget(
-						params={'targetId': target_id, 'flatten': True}
-					)
-					session_id = attach_result.get('sessionId')
-					if not session_id:
-						raise RuntimeError('attachToTarget did not return a sessionId')
+				# Use per-target lock to prevent concurrent attachment requests for the SAME target
+				# This ensures only one thread actually calls Target.attachToTarget
+				async with self.session_manager._get_attachment_lock(target_id):
+					# Check again inside the lock - another thread might have finished the attachment
+					session = self.session_manager._get_session_for_target(target_id)
+					if session:
+						self.logger.debug(f'[SessionManager] Target {target_id[:8]}... attached by another thread while waiting for lock')
+						return session
 
-					# Fetch targetInfo to mimic AttachedToTargetEvent
 					try:
-						target_info_result = await self._cdp_client_root.send.Target.getTargetInfo(params={'targetId': target_id})
-						target_info = target_info_result.get('targetInfo', {})
-					except Exception as info_err:
-						self.logger.debug(
-							f'[SessionManager] getTargetInfo failed for {target_id[:8]}... after explicit attach: {info_err}'
+						assert self._cdp_client_root is not None
+						attach_result = await self._cdp_client_root.send.Target.attachToTarget(
+							params={'targetId': target_id, 'flatten': True}
 						)
-						target_info = {
-							'targetId': target_id,
-							'type': 'page',
-							'url': 'about:blank',
-							'title': '',
+						session_id = attach_result.get('sessionId')
+						if not session_id:
+							raise RuntimeError('attachToTarget did not return a sessionId')
+
+						# Fetch targetInfo to mimic AttachedToTargetEvent
+						try:
+							target_info_result = await self._cdp_client_root.send.Target.getTargetInfo(params={'targetId': target_id})
+							target_info = target_info_result.get('targetInfo', {})
+						except Exception as info_err:
+							self.logger.debug(
+								f'[SessionManager] getTargetInfo failed for {target_id[:8]}... after explicit attach: {info_err}'
+							)
+							target_info = {
+								'targetId': target_id,
+								'type': 'page',
+								'url': 'about:blank',
+								'title': '',
+							}
+
+						manual_event = {
+							'sessionId': session_id,
+							'targetInfo': target_info,
+							'waitingForDebugger': False,
 						}
+						# Reuse SessionManager's single source of truth
+						await self.session_manager._handle_target_attached(manual_event)
+					except Exception as attach_err:
+						# Log at error level since this is a hard failure after multiple attempts
+						self.logger.error(
+							f'[SessionManager] Explicit Target.attachToTarget failed for {target_id[:8]}...: {attach_err}'
+						)
 
-					manual_event = {
-						'sessionId': session_id,
-						'targetInfo': target_info,
-						'waitingForDebugger': False,
-					}
-					# Reuse SessionManager's single source of truth
-					await self.session_manager._handle_target_attached(manual_event)
-				except Exception as attach_err:
-					self.logger.error(
-						f'[SessionManager] Explicit Target.attachToTarget failed for {target_id[:8]}...: {attach_err}'
-					)
-
-				# Try getting session again
+				# Try getting session again (outside lock to verify final state)
 				session = self.session_manager._get_session_for_target(target_id)
 
 			if not session:
-				# Timeout - target doesn't exist
+				# Timeout - target doesn't exist or attachment failed completely
 				raise ValueError(f'Target {target_id} not found - may have detached or never existed')
 
 		# Validate session is still active


### PR DESCRIPTION
### Fixes: #3735
The problem
In some setups especially when using an external Chrome instance with extensions calling
navigate(new_tab=True) would open a new tab, but Chrome DevTools Protocol (CDP) wouldn’t attach to that tab in time.
CDP normally auto-attaches within a 2-second window, but in these environments the attach event sometimes never arrives. When that happens, the code throws an error like:
`ValueError: Target ... not found – may have detached or never existed`

So the tab exists, but the session is never registered, and everything crashes.

**What I fixed**
I updated browser_use/browser/session.py to make tab attachment more robust instead of relying only on CDP’s auto-attach behavior.

**How the fix works** 
Normal behavior stays the same
The code still waits up to 2 seconds for Chrome’s automatic AttachedToTarget event.
Fallback if auto-attach fails
If no session appears within that time, the code manually attaches to the tab by calling:
`Target.attachToTarget
`

Manual session registration
After forcing the attach, the code manually informs the SessionManager that:
“This target is now attached—register this session ID.”
This effectively simulates the missing auto-attach event.

**The result**
Even if Chrome fails to auto-attach (which happens with extensions or slower environments), the session is still created and registered correctly.
The navigation succeeds, and the crash is fully avoided.
**In short**: no more failures just because Chrome didn’t auto-attach in time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit, idempotent fallback to attach a CDP session when Chrome doesn’t auto-attach to a new tab. Prevents “Target not found” crashes and makes new-tab navigation reliable with external Chrome or extensions (addresses #3735; hardens attachment races #3857).

- **Bug Fixes**
  - Waits up to 2s for auto-attach, then does a final session check.
  - Falls back to Target.attachToTarget (flatten: true) under a per-target lock to avoid races.
  - Manually registers the session with safe targetInfo defaults via SessionManager.
  - Idempotent handling: ignores duplicate attaches and only updates target info if a session already exists; logs hard failures.

<sup>Written for commit 3f8a96e060f7f2dd84fe3744907cad782e2b16df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

