### PR TITLE
fix(llm): set explicit default host for Ollama to prevent connection …

### DIFF
--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -29,7 +29,7 @@ class ChatOllama(BaseChatModel):
 	# temperature: float | None = None
 
 	# Client initialization parameters
-	host: str | None = None
+	host: str | None = 'http://127.0.0.1:11434'
 	timeout: float | httpx.Timeout | None = None
 	client_params: dict[str, Any] | None = None
 	ollama_options: Mapping[str, Any] | Options | None = None


### PR DESCRIPTION
…issues (#3093)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a default Ollama host to http://127.0.0.1:11434 in ChatOllama to prevent connection failures when no host is provided. Addresses Linear #3093 by defaulting clients to the local Ollama server.

<sup>Written for commit ed19195b85a521730d701db534f0ea7f7d90aabb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

