### PR TITLE
initial sentienceapi experiment

### DIFF
--- a/browser_use/integrations/sentience/__init__.py
+++ b/browser_use/integrations/sentience/__init__.py
@@ -1,0 +1,5 @@
+"""Sentience integration for browser-use Agent."""
+
+from .state_injector import build_sentience_state, format_snapshot_for_llm
+
+__all__ = ["build_sentience_state", "format_snapshot_for_llm"]

--- a/browser_use/integrations/sentience/state_injector.py
+++ b/browser_use/integrations/sentience/state_injector.py
@@ -1,0 +1,136 @@
+"""Inject Sentience semantic geometry into Agent context."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from browser_use.browser.session import BrowserSession
+    from sentience.models import Snapshot
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SentienceState:
+    """Sentience state with snapshot and formatted prompt block."""
+
+    url: str
+    snapshot: "Snapshot"
+    prompt_block: str
+
+
+def format_snapshot_for_llm(snapshot: "Snapshot", limit: int = 100) -> str:
+    """
+    Format Sentience snapshot for LLM consumption.
+
+    Creates a compact inventory of elements with IDs, roles, names, and bbox centers.
+    This gives the LLM a reduced action space to pick from.
+
+    Args:
+        snapshot: Sentience Snapshot object
+        limit: Maximum number of elements to include (default: 100)
+
+    Returns:
+        Formatted string for LLM prompt
+    """
+    lines = []
+    for el in snapshot.elements[:limit]:
+        # Calculate bbox center
+        cx = int(el.bbox.x + el.bbox.width / 2)
+        cy = int(el.bbox.y + el.bbox.height / 2)
+
+        # Get role (prefer role, fallback to tag)
+        role = getattr(el, "role", None) or getattr(el, "tag", None) or "el"
+
+        # Get name/text (truncate if too long)
+        name = (getattr(el, "name", None) or getattr(el, "text", None) or "").strip()
+        if len(name) > 80:
+            name = name[:77] + "..."
+
+        # Format: [ID] <role> "name" @ (cx,cy)
+        lines.append(f"[{el.id}] <{role}> \"{name}\" @ ({cx},{cy})")
+
+    return "\n".join(lines)
+
+
+async def build_sentience_state(
+    browser_session: "BrowserSession",
+) -> Optional[SentienceState]:
+    """
+    Build Sentience state from browser session.
+
+    Takes a snapshot using the Sentience extension and formats it for LLM consumption.
+    If snapshot fails (extension not loaded, timeout, etc.), returns None.
+
+    Args:
+        browser_session: Browser-use BrowserSession instance
+
+    Returns:
+        SentienceState with snapshot and formatted prompt, or None if snapshot failed
+    """
+    try:
+        # Import here to avoid requiring sentience as a hard dependency
+        from sentience.backends import BrowserUseAdapter
+        from sentience.backends.snapshot import snapshot
+        from sentience.models import SnapshotOptions
+
+        # Create adapter and backend
+        adapter = BrowserUseAdapter(browser_session)
+        backend = await adapter.create_backend()
+
+        # Give extension a moment to inject (especially after navigation)
+        # The snapshot() call has its own timeout, but a small delay helps
+        import asyncio
+        await asyncio.sleep(0.5)
+
+        # Get API key from environment if available
+        api_key = os.getenv("SENTIENCE_API_KEY")
+        # Limit to 100 elements to keep prompt size manageable
+        if api_key:
+            options = SnapshotOptions(sentience_api_key=api_key, limit=100)
+        else:
+            options = SnapshotOptions(limit=100)  # Use default options if no API key
+
+        # Take snapshot with retry logic (extension may need time to inject after navigation)
+        max_retries = 2
+        last_error = None
+        for attempt in range(max_retries):
+            try:
+                snap = await snapshot(backend, options=options)
+                break  # Success
+            except Exception as e:
+                last_error = e
+                if attempt < max_retries - 1:
+                    # Wait a bit longer before retry
+                    logger.debug(f"Sentience snapshot attempt {attempt + 1} failed, retrying...")
+                    await asyncio.sleep(1.0)
+                else:
+                    raise  # Re-raise on final attempt
+
+        # Get URL from snapshot or browser state
+        url = getattr(snap, "url", "") or ""
+
+        # Format for LLM (limit to 100 elements to keep prompt size manageable)
+        formatted = format_snapshot_for_llm(snap, limit=100)
+
+        prompt = (
+            "## Sentience Element Inventory (semantic geometry)\n"
+            "Use these numeric IDs with tools like click(index=ID) / input_text(index=ID,...).\n"
+            "Prefer these IDs over guessing coordinates.\n\n"
+            f"{formatted}"
+        )
+
+        logger.info(f"✅ Sentience snapshot: {len(snap.elements)} elements, URL: {url}")
+        return SentienceState(url=url, snapshot=snap, prompt_block=prompt)
+
+    except ImportError:
+        logger.warning("⚠️  Sentience SDK not available, skipping snapshot")
+        return None
+    except Exception as e:
+        # Log warning if extension not loaded or snapshot fails
+        logger.warning(f"⚠️  Sentience snapshot skipped: {e}")
+        return None

--- a/playground/example.py
+++ b/playground/example.py
@@ -1,0 +1,81 @@
+from browser_use import Agent, BrowserProfile, ChatBrowserUse
+from dotenv import load_dotenv
+import asyncio
+import glob
+from pathlib import Path
+
+# Sentience SDK imports
+from sentience import get_extension_dir
+
+load_dotenv()
+
+async def main():
+    # Find Playwright browser to avoid password prompt
+    playwright_path = Path.home() / "Library/Caches/ms-playwright"
+    chromium_patterns = [
+        playwright_path / "chromium-*/chrome-mac*/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+        playwright_path / "chromium-*/chrome-mac*/Chromium.app/Contents/MacOS/Chromium",
+    ]
+    
+    executable_path = None
+    for pattern in chromium_patterns:
+        matches = glob.glob(str(pattern))
+        if matches:
+            matches.sort()
+            executable_path = matches[-1]  # Use latest version
+            if Path(executable_path).exists():
+                print(f"✅ Found Playwright browser: {executable_path}")
+                break
+    
+    if not executable_path:
+        print("⚠️  Playwright browser not found, browser-use will try to install it")
+    
+    # Get Sentience extension path
+    sentience_ext_path = get_extension_dir()
+    print(f"Loading Sentience extension from: {sentience_ext_path}")
+    
+    # Get default extension paths and combine with Sentience extension
+    # Chrome only uses the LAST --load-extension arg, so we must combine all extensions
+    all_extension_paths = [sentience_ext_path]
+    
+    # Create a temporary profile to ensure default extensions are downloaded
+    temp_profile = BrowserProfile(enable_default_extensions=True)
+    default_ext_paths = temp_profile._ensure_default_extensions_downloaded()
+    
+    if default_ext_paths:
+        all_extension_paths.extend(default_ext_paths)
+        print(f"Found {len(default_ext_paths)} default extensions")
+    
+    # Combine all extensions into a single --load-extension arg
+    combined_extensions = ",".join(all_extension_paths)
+    print(f"Loading {len(all_extension_paths)} extensions total (including Sentience)")
+    
+    # Create browser profile with ALL extensions combined
+    browser_profile = BrowserProfile(
+        executable_path=executable_path,  # Use Playwright browser if found
+        enable_default_extensions=False,  # Disable auto-loading, we'll load manually
+        args=[
+            "--enable-extensions",
+            "--disable-extensions-file-access-check",
+            "--disable-extensions-http-throttling",
+            "--extensions-on-chrome-urls",
+            f"--load-extension={combined_extensions}",  # Load ALL extensions together
+        ],
+    )
+    
+    # Create agent with Sentience-enabled browser
+    llm = ChatBrowserUse()
+    task = "Find the number 1 post on Show HN"
+    agent = Agent(
+        task=task,
+        llm=llm,
+        browser_profile=browser_profile,
+        calculate_cost=True
+    )
+    history = await agent.run()
+    print(f"Token usage: {history.usage}")
+    usage_summary = await agent.token_cost_service.get_usage_summary()
+    print(f"Usage summary: {usage_summary}")
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/playground/sentience_basic.py
+++ b/playground/sentience_basic.py
@@ -1,0 +1,270 @@
+"""
+Basic example: Sentience extension with browser-use.
+
+This example demonstrates:
+1. Loading the Sentience Chrome extension in browser-use
+2. Taking a snapshot to detect page elements
+3. Using semantic queries to find elements
+4. Clicking on elements using grounded coordinates
+
+Requirements:
+    pip install browser-use sentienceapi
+
+Usage:
+    python playground/sentience_basic.py
+"""
+
+import asyncio
+import glob
+import logging
+import os
+import sys
+from pathlib import Path
+
+# Enable debug logging for sentience
+logging.basicConfig(level=logging.DEBUG, format='%(name)s - %(levelname)s - %(message)s')
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use.browser import BrowserProfile, BrowserSession
+
+# Sentience SDK imports
+from sentience import find, get_extension_dir, query
+from sentience.backends import (
+	BrowserUseAdapter,
+	ExtensionNotLoadedError,
+	click,
+	snapshot,
+	type_text,
+)
+
+
+def log(msg: str) -> None:
+	"""Print with flush for immediate output."""
+	print(msg, flush=True)
+
+
+async def main():
+	"""Demo: Use Sentience grounding with browser-use to search Google."""
+
+	# Get path to Sentience extension
+	sentience_ext_path = get_extension_dir()
+	log(f"Loading Sentience extension from: {sentience_ext_path}")
+	
+	# Verify extension exists
+	if not os.path.exists(sentience_ext_path):
+		raise FileNotFoundError(f"Sentience extension not found at: {sentience_ext_path}")
+	if not os.path.exists(os.path.join(sentience_ext_path, "manifest.json")):
+		raise FileNotFoundError(f"Sentience extension manifest not found at: {sentience_ext_path}/manifest.json")
+	log(f"✅ Sentience extension verified at: {sentience_ext_path}")
+
+	# Find Playwright browser to avoid password prompt
+	playwright_path = Path.home() / "Library/Caches/ms-playwright"
+	chromium_patterns = [
+		playwright_path / "chromium-*/chrome-mac*/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+		playwright_path / "chromium-*/chrome-mac*/Chromium.app/Contents/MacOS/Chromium",
+	]
+	
+	executable_path = None
+	for pattern in chromium_patterns:
+		matches = glob.glob(str(pattern))
+		if matches:
+			matches.sort()
+			executable_path = matches[-1]  # Use latest version
+			if Path(executable_path).exists():
+				log(f"✅ Found Playwright browser: {executable_path}")
+				break
+	
+	if not executable_path:
+		log("⚠️  Playwright browser not found, browser-use will try to install it")
+
+	# Get default extension paths and combine with Sentience extension
+	# Chrome only uses the LAST --load-extension arg, so we must combine all extensions
+	log("Collecting all extension paths...")
+	all_extension_paths = [sentience_ext_path]
+	
+	# Create a temporary profile to ensure default extensions are downloaded
+	# This ensures extensions exist before we try to load them
+	temp_profile = BrowserProfile(enable_default_extensions=True)
+	default_ext_paths = temp_profile._ensure_default_extensions_downloaded()
+	
+	if default_ext_paths:
+		all_extension_paths.extend(default_ext_paths)
+		log(f"  ✅ Found {len(default_ext_paths)} default extensions")
+	else:
+		log("  ⚠️  No default extensions found (this is OK, Sentience will still work)")
+	
+	log(f"Total extensions to load: {len(all_extension_paths)} (including Sentience)")
+	
+	# Combine all extensions into a single --load-extension arg
+	combined_extensions = ",".join(all_extension_paths)
+	log(f"Combined extension paths (first 100 chars): {combined_extensions[:100]}...")
+
+	# Create browser profile with ALL extensions combined
+	# Strategy: Disable default extensions, manually load all together
+	profile = BrowserProfile(
+		headless=False,  # Run with visible browser for demo
+		executable_path=executable_path,  # Use Playwright browser if found
+		enable_default_extensions=False,  # Disable auto-loading, we'll load manually
+		ignore_default_args=[
+			"--enable-automation",
+			"--disable-extensions",  # Important: don't disable extensions
+			"--hide-scrollbars",
+			# Don't disable component extensions - we need background pages for Sentience
+		],
+		args=[
+			"--enable-extensions",
+			"--disable-extensions-file-access-check",  # Allow extension file access
+			"--disable-extensions-http-throttling",  # Don't throttle extension HTTP
+			"--extensions-on-chrome-urls",  # Allow extensions on chrome:// URLs
+			f"--load-extension={combined_extensions}",  # Load ALL extensions together
+		],
+	)
+	
+	log("Browser profile configured with Sentience extension")
+
+	# Start browser session
+	log("Creating BrowserSession...")
+	session = BrowserSession(browser_profile=profile)
+	log("Starting browser session (this may take a moment)...")
+	try:
+		await session.start()
+		log("✅ Browser session started successfully")
+	except Exception as e:
+		log(f"❌ Error starting browser session: {e}")
+		import traceback
+		log(traceback.format_exc())
+		return
+
+	try:
+		# Navigate to Google
+		log("Getting current page...")
+		try:
+			page = await session.get_current_page()
+			log(f"✅ Got page: {page}")
+		except Exception as e:
+			log(f"❌ Error getting page: {e}")
+			import traceback
+			log(traceback.format_exc())
+			return
+		
+		log("Navigating to Google...")
+		try:
+			await page.goto("https://www.google.com")
+			log("✅ Navigated to Google")
+		except Exception as e:
+			log(f"❌ Error navigating to Google: {e}")
+			import traceback
+			log(traceback.format_exc())
+			return
+
+		# Wait for page to settle
+		log("Waiting 2 seconds for page to settle...")
+		await asyncio.sleep(2)
+		log("Done waiting")
+
+		# Create Sentience adapter and backend
+		log("Creating Sentience adapter...")
+		adapter = BrowserUseAdapter(session)
+		log("Creating backend...")
+		backend = await adapter.create_backend()
+		log("Created Sentience backend")
+		
+		# Give extension more time to initialize after page load
+		log("Waiting for extension to initialize...")
+		await asyncio.sleep(1)
+
+		# Take a snapshot using Sentience extension
+		try:
+			log("Taking snapshot (this waits for extension to inject)...")
+			
+			# Enhanced diagnostics before snapshot
+			log("Checking extension injection status...")
+			diag = await backend.eval("""
+				(() => {
+					const hasSentience = typeof window.sentience !== 'undefined';
+					const hasSnapshot = hasSentience && typeof window.sentience.snapshot === 'function';
+					const extId = document.documentElement.dataset.sentienceExtensionId || null;
+					return {
+						window_sentience: hasSentience,
+						window_sentience_snapshot: hasSnapshot,
+						extension_id_attr: extId,
+						url: window.location.href,
+						ready_state: document.readyState
+					};
+				})()
+			""")
+			log(f"Extension diagnostics: {diag}")
+			
+			if not diag.get("window_sentience"):
+				log("⚠️  window.sentience not found - extension may not have injected yet")
+				log("   This can happen if:")
+				log("   1. Extension wasn't loaded in browser args")
+				log("   2. Page loaded before extension could inject")
+				log("   3. Content Security Policy is blocking the extension")
+				log("   Waiting for extension injection (up to 10 seconds)...")
+			else:
+				log("✅ window.sentience found!")
+
+			snap = await snapshot(backend)
+			log(f"✅ Snapshot taken: {len(snap.elements)} elements found")
+		except ExtensionNotLoadedError as e:
+			log(f"❌ Extension not loaded error:")
+			log(f"   {e}")
+			if hasattr(e, 'diagnostics') and e.diagnostics:
+				log(f"   Diagnostics: {e.diagnostics.to_dict()}")
+			log("\nTroubleshooting steps:")
+			log("1. Verify extension path exists and contains manifest.json")
+			log(f"2. Check browser console for extension errors")
+			log("3. Try increasing timeout in snapshot() call")
+			log("4. Ensure --enable-extensions is in browser args")
+			return
+
+		# Find the search input using semantic query
+		# Google's search box has role=combobox or role=textbox
+		search_input = find(snap, 'role=combobox[name*="Search"]')
+		if not search_input:
+			search_input = find(snap, 'role=textbox[name*="Search"]')
+
+		if search_input:
+			print(f"Found search input: {search_input.role} at {search_input.bbox}")
+
+			# Click on the search input using grounded coordinates
+			await click(backend, search_input.bbox)
+			print("Clicked on search input")
+
+			# Type a search query
+			await type_text(backend, "Sentience AI browser automation")
+			print("Typed search query")
+
+			# Take another snapshot after typing
+			await asyncio.sleep(1)
+			snap2 = await snapshot(backend)
+			print(f"After typing: {len(snap2.elements)} elements")
+
+			# Find and click the search button
+			search_btn = find(snap2, 'role=button[name*="Search"]')
+			if search_btn:
+				await click(backend, search_btn.bbox)
+				print("Clicked search button")
+		else:
+			print("Could not find search input")
+			# List all textbox/combobox elements for debugging
+			textboxes = query(snap, "role=textbox")
+			comboboxes = query(snap, "role=combobox")
+			print(f"Found {len(textboxes)} textboxes, {len(comboboxes)} comboboxes")
+
+		# Keep browser open for inspection
+		print("\nPress Enter to close browser...")
+		input()
+
+	finally:
+		await session.close()
+
+
+if __name__ == "__main__":
+	asyncio.run(main())

--- a/playground/sentience_cached_snapshot.py
+++ b/playground/sentience_cached_snapshot.py
@@ -1,0 +1,147 @@
+"""
+Advanced example: Sentience CachedSnapshot for efficient action loops.
+
+This example demonstrates:
+1. Using CachedSnapshot to reduce redundant snapshot calls
+2. The invalidate() pattern after DOM-modifying actions
+3. Scrolling and finding elements across multiple snapshots
+4. Element grounding with BBox coordinates
+
+Requirements:
+    pip install browser-use sentienceapi
+
+Usage:
+    python playground/sentience_cached_snapshot.py
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use.browser import BrowserProfile, BrowserSession
+
+# Sentience SDK imports
+from sentience import find, get_extension_dir, query
+from sentience.backends import (
+	BrowserUseAdapter,
+	CachedSnapshot,
+	ExtensionNotLoadedError,
+	click,
+	scroll,
+	snapshot,
+	type_text,
+)
+
+
+async def main():
+	"""Demo: CachedSnapshot for efficient element grounding."""
+
+	extension_path = get_extension_dir()
+	print(f"Sentience extension: {extension_path}")
+
+	profile = BrowserProfile(
+		headless=False,
+		args=[
+			f"--load-extension={extension_path}",
+			f"--disable-extensions-except={extension_path}",
+		],
+	)
+
+	session = BrowserSession(browser_profile=profile)
+	await session.start()
+
+	try:
+		# Navigate to a page with many elements
+		page = await session.get_current_page()
+		await page.goto("https://news.ycombinator.com")
+		print("Navigated to Hacker News")
+		await asyncio.sleep(2)
+
+		# Create Sentience backend
+		adapter = BrowserUseAdapter(session)
+		backend = await adapter.create_backend()
+
+		# Create cached snapshot with 2-second freshness
+		cache = CachedSnapshot(backend, max_age_ms=2000)
+
+		# Take initial snapshot (cached)
+		snap1 = await cache.get()
+		print(f"Initial snapshot: {len(snap1.elements)} elements")
+		print(f"Cache age: {cache.age_ms:.0f}ms")
+
+		# Second call uses cached version (no extension call)
+		snap2 = await cache.get()
+		print(f"Cached snapshot: {len(snap2.elements)} elements")
+		print(f"Cache age: {cache.age_ms:.0f}ms")
+		assert snap1 is snap2, "Should be same cached instance"
+
+		# Find all links on the page
+		links = query(snap1, "role=link")
+		print(f"Found {len(links)} links on page")
+
+		# Find the first story link (links with numeric index have class 'storylink' historically)
+		story_links = [el for el in links if el.name and len(el.name) > 10]
+		if story_links:
+			print(f"\nFirst few story titles:")
+			for link in story_links[:3]:
+				print(f"  - {link.name[:50]}...")
+
+		# Scroll down the page
+		print("\nScrolling down...")
+		await scroll(backend, delta_y=500)
+
+		# After scroll, cache should still be valid (scroll doesn't change DOM)
+		# But if we want fresh element positions, we force refresh
+		cache.invalidate()  # Manual invalidation
+		print("Cache invalidated after scroll")
+
+		# Take fresh snapshot to get updated element positions
+		snap3 = await cache.get()
+		print(f"Fresh snapshot after scroll: {len(snap3.elements)} elements")
+		print(f"Cache age: {cache.age_ms:.0f}ms")
+
+		# Demonstrate force_refresh parameter
+		snap4 = await cache.get(force_refresh=True)
+		print(f"Force refresh: {len(snap4.elements)} elements")
+
+		# Find the "More" link at bottom
+		more_link = find(snap4, 'role=link[name="More"]')
+		if more_link:
+			print(f"\nFound 'More' link at: {more_link.bbox}")
+
+			# Click to load next page
+			await click(backend, more_link.bbox)
+			print("Clicked 'More' link")
+
+			# Invalidate cache after navigation
+			cache.invalidate()
+
+			# Wait for new content
+			await asyncio.sleep(2)
+
+			# Take snapshot of new page
+			snap5 = await cache.get()
+			print(f"New page snapshot: {len(snap5.elements)} elements")
+
+		# Demo: Print cache statistics
+		print("\n--- Cache Usage Pattern ---")
+		print("1. Take initial snapshot: cache.get()")
+		print("2. Reuse for multiple queries: find(snap, ...), query(snap, ...)")
+		print("3. After DOM changes: cache.invalidate()")
+		print("4. Get fresh data: cache.get()")
+
+		print("\nPress Enter to close browser...")
+		input()
+
+	finally:
+		await session.close()
+
+
+if __name__ == "__main__":
+	asyncio.run(main())


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds experimental Sentience integration that injects a compact inventory of page elements (IDs, roles, names, bbox centers) into the agent’s LLM context to improve action grounding. Includes playground examples and a state injector; safely skips when the SDK or extension isn’t available.

- **New Features**
  - Injects a Sentience prompt block during context prep with up to 100 elements.
  - Builds snapshots with retries and formats them for tools like click(index=ID) and input_text(index=ID,...).
  - Logs element count, prompt size, and sample lines for debugging.
  - Adds playground scripts showing extension loading, semantic queries, clicks, typing, scroll, and CachedSnapshot usage.

- **Dependencies**
  - Optional: sentienceapi SDK and the Sentience Chrome extension. Injection is skipped if not present.
  - Optional SENTIENCE_API_KEY for API-backed snapshots.

<sup>Written for commit a949fde1cc95283538a385e3af9ee8e2e33f4195. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

