### PR TITLE
fix: resolve UnboundLocalError in ScrollToTextEvent by initializing 

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2291,6 +2291,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 		]
 
 		found = False
+		js_result = None  # Initialize to prevent UnboundLocalError
+
 		for query in search_queries:
 			try:
 				# Perform search
@@ -2355,10 +2357,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 				raise BrowserError(f'Text not found: "{event.text}"', details={'text': event.text})
 
 		# If we got here and found is True, return None (success)
-		if found:
-			return None
-		else:
-			raise BrowserError(f'Text not found: "{event.text}"', details={'text': event.text})
+		return None
 
 	async def on_GetDropdownOptionsEvent(self, event: GetDropdownOptionsEvent) -> dict[str, str]:
 		"""Handle get dropdown options request with CDP."""


### PR DESCRIPTION
Fixes:#3212

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented UnboundLocalError in ScrollToTextEvent by initializing js_result and simplifying the not-found logic. This stops crashes during scroll-to-text and ensures clean completion on success.

- **Bug Fixes**
  - Initialize js_result = None before running search to avoid “referenced before assignment”.
  - Remove redundant final check; raise when text isn’t found earlier, and return None on success.

<sup>Written for commit d9ed3107034d35f5999ace9dbbfe91997c6a6f62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

