### PR TITLE
fix(serializer): include state-indicating classes in serialized DOM (…

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -1052,13 +1052,39 @@ class DOMTreeSerializer:
 
 		# Include HTML attributes
 		if node.attributes:
-			attributes_to_include.update(
-				{
-					key: str(value).strip()
-					for key, value in node.attributes.items()
-					if key in include_attributes and str(value).strip() != ''
-				}
-			)
+			for key, value in node.attributes.items():
+				# Always include attributes in the list
+				if key in include_attributes and str(value).strip() != '':
+					attributes_to_include[key] = str(value).strip()
+
+				# Special handling for CSS classes that indicate state
+				# Even if 'class' is not in include_attributes, we want to know about state
+				elif key == 'class' and value:
+					state_classes = []
+					for cls in str(value).split():
+						if cls.lower() in [
+							'active',
+							'checked',
+							'selected',
+							'disabled',
+							'enabled',
+							'open',
+							'closed',
+							'expanded',
+							'collapsed',
+							'valid',
+							'invalid',
+							'focused',
+							'hidden',
+							'visible',
+						]:
+							state_classes.append(cls)
+
+					if state_classes:
+						# If we found state classes, add them
+						# If class is already included (unexpectedly), join them?
+						# But we are in the 'elif' so it wasn't included.
+						attributes_to_include['class'] = ' '.join(state_classes)
 
 		# Add format hints for date/time inputs to help LLMs use the correct format
 		# NOTE: These formats are standardized by HTML5 specification (ISO 8601), NOT locale-dependent


### PR DESCRIPTION
Fixes : #3437
**Checkbox Double-Clicking Issue & Fix** 

**The Issue:**
The agent was sometimes clicking checkboxes twice, which caused them to turn on and then immediately turn off. This happened mainly on modern websites that use custom checkboxes. Instead of the normal HTML checked attribute, these sites show the checkbox state using CSS classes like checked or active. However, in browser-use, the DOM serializer was set up to remove the class attribute to save tokens. Because of this, the agent always saw the checkbox as <div class=>, whether it was checked or not. Since the agent couldn’t “see” that the checkbox was already selected, it assumed the click failed and clicked again.

**The Fix:**
I fixed this by adding Smart Class Extraction in browser_use/dom/serializer/serializer.py, inside the DOMTreeSerializer._build_attributes_string method. Instead of completely removing the class attribute, the serializer now checks the class names. If it finds important state-related keywords like checked, active, selected, disabled, open, expanded, focused, or hidden, it keeps only those classes. This way, the agent can clearly see states like <div class="checked"> and understands that the action worked, so it doesn’t click again.

**Verification:**
To confirm the fix works reliably, I wrote a clean and focused unit test called test_serializer_fix.py. I used mocked DOM nodes that behave like the real internal structures used by browser-use. The tests covered single checked states, multiple state classes together, case-insensitive matches (like Checked vs checked), and different output formats. All tests passed successfully, proving the fix works as intended and prevents the double-clicking problem.