### PR TITLE
fix: resolve MCP server startup issues on Windows and missing optiona…

### DIFF
--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -369,7 +369,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		return port
 
 	@staticmethod
-	async def _wait_for_cdp_url(port: int, timeout: float = 30) -> str:
+	async def _wait_for_cdp_url(port: int, timeout: float = 60) -> str:
 		"""Wait for the browser to start and return the CDP URL."""
 		import aiohttp
 

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -11,6 +11,22 @@ if '--mcp' in sys.argv:
 	os.environ['BROWSER_USE_SETUP_LOGGING'] = 'false'
 	logging.disable(logging.CRITICAL)
 
+	# Run as MCP server immediately to avoid loading TUI dependencies
+	import asyncio
+
+	try:
+		from browser_use.mcp.server import main as mcp_main
+
+		asyncio.run(mcp_main())
+		sys.exit(0)
+	except ImportError as e:
+		# MCP server import failed - likely missing mcp dependencies
+		print(f'Failed to start MCP server: {e}', file=sys.stderr)
+		sys.exit(1)
+	except Exception as e:
+		print(f'Failed to start MCP server: {e}', file=sys.stderr)
+		sys.exit(1)
+
 # Special case: install command doesn't need CLI dependencies
 if len(sys.argv) > 1 and sys.argv[1] == 'install':
 	import platform

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -26,8 +26,6 @@ Or as an MCP server in Claude Desktop or other MCP clients:
 import os
 import sys
 
-from browser_use.llm import ChatAWSBedrock
-
 # Set environment variables BEFORE any browser_use imports to prevent early logging
 os.environ['BROWSER_USE_LOGGING_LEVEL'] = 'critical'
 os.environ['BROWSER_USE_SETUP_LOGGING'] = 'false'
@@ -594,6 +592,8 @@ class BrowserUseServer:
 			aws_region = llm_config.get('region') or os.getenv('REGION')
 			if not aws_region:
 				aws_region = 'us-east-1'
+			from browser_use.llm import ChatAWSBedrock
+
 			llm = ChatAWSBedrock(
 				model=llm_model,  # or any Bedrock model
 				aws_region=aws_region,

--- a/docs/customize/integrations/mcp-server.mdx
+++ b/docs/customize/integrations/mcp-server.mdx
@@ -184,7 +184,7 @@ The local MCP server runs as a stdio-based process on your machine. This is the 
 #### Start MCP Server Manually
 
 ```bash
-uvx --from 'browser-use[cli]' browser-use --mcp
+uvx browser-use --mcp
 ```
 
 The server will start in stdio mode, ready to accept MCP connections.
@@ -200,7 +200,7 @@ The most common use case is integrating with Claude Desktop. Add this configurat
   "mcpServers": {
     "browser-use": {
       "command": "/Users/your-username/.local/bin/uvx",
-      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+      "args": ["browser-use", "--mcp"],
       "env": {
         "OPENAI_API_KEY": "your-openai-api-key-here"
       }
@@ -216,7 +216,7 @@ The most common use case is integrating with Claude Desktop. Add this configurat
   "mcpServers": {
     "browser-use": {
       "command": "uvx",
-      "args": ["--from", "browser-use[cli]", "browser-use", "--mcp"],
+      "args": ["browser-use", "--mcp"],
       "env": {
         "OPENAI_API_KEY": "your-openai-api-key-here"
       }
@@ -231,7 +231,7 @@ The most common use case is integrating with Claude Desktop. Add this configurat
 - Replace `"command": "uvx"` with the full path, e.g., `"command": "/Users/your-username/.local/bin/uvx"`
 - Replace `your-username` with your actual username
 
-**CLI Extras Required:** The `--from browser-use[cli]` flag installs the CLI extras needed for MCP server support.
+**CLI Extras:** The `browser-use[cli]` extra is no longer required for MCP mode, but useful if you want the TUI.
 </Note>
 
 #### Environment Variables
@@ -298,7 +298,7 @@ async def use_browser_mcp():
     # Connect to browser-use MCP server
     server_params = StdioServerParameters(
         command="uvx",
-        args=["--from", "browser-use[cli]", "browser-use", "--mcp"]
+        args=["browser-use", "--mcp"]
     )
 
     async with stdio_client(server_params) as (read, write):
@@ -327,9 +327,9 @@ asyncio.run(use_browser_mcp())
 #### Common Issues
 
 **"CLI addon is not installed" Error**
-Make sure you're using `--from 'browser-use[cli]'` in your uvx command:
+This error should no longer occur with recent versions. If it does, try updating: `uvx --refresh browser-use --mcp`.
 ```bash
-uvx --from 'browser-use[cli]' browser-use --mcp
+uvx browser-use --mcp
 ```
 
 **"spawn uvx ENOENT" Error (macOS/Linux)**
@@ -358,7 +358,7 @@ Claude Desktop can't find `uvx` in its PATH. Use the full path in your config:
 Enable debug logging by setting:
 ```bash
 export BROWSER_USE_LOGGING_LEVEL=DEBUG
-uvx --from 'browser-use[cli]' browser-use --mcp
+uvx browser-use --mcp
 ```
 
 ### Security Considerations


### PR DESCRIPTION
Fixes:#3447
**The Problem:**
Some users were unable to start the MCP server using the command uvx browser-use mcp, especially on Windows or minimal environments. The main reason was that browser_use/cli.py imported textual and click at the top level. These libraries are part of the optional [cli] extras and are often not installed if a user only wants to run the MCP server. Because of this, the program crashed immediately with an ImportError, even before it could detect that the user only wanted the MCP server and not the TUI.

At the same time, users were also seeing “Internal Server Error” during server startup. This turned out to be caused by browser_use/mcp/server.py importing ChatAWSBedrock at the top level. That import indirectly requires boto3. Since boto3 is optional and many users rely on OpenAI or Anthropic instead of AWS Bedrock, the server was crashing on startup even when Bedrock was not being used.

**The Solution:**
First, I made the CLI entry point more robust. In browser_use/cli.py, the script now checks for the mcp flag right at the beginning. If mcp is present, it immediately imports only the minimal server-related code and runs the MCP server. This completely skips importing textual, click, and other heavy TUI dependencies. As a result, uvx browser-use mcp now works smoothly without requiring browser-use[cli].

Second, I fixed the AWS Bedrock issue by switching to lazy imports. In browser_use/mcp/server.py, the ChatAWSBedrock import was moved from the top of the file into the exact place where it is needed. Now, boto3 is only required if the user explicitly selects the Bedrock model provider. This prevents unnecessary crashes and allows the server to start correctly for users who don’t use AWS at all.

**Documentation Update:**
Finally, I updated the MCP server documentation to match these improvements. I removed the instruction to run the server using from 'browser-use[cli]' and simplified it to just uvx browser-use mcp. I also cleaned up the troubleshooting section by removing errors related to missing CLI addons, since the underlying problem has now been fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3447. MCP server now starts reliably on Windows and minimal installs by skipping TUI imports and lazy-loading AWS Bedrock to avoid boto3 crashes.

- **Bug Fixes**
  - CLI: start MCP server with minimal imports; do not load textual/click for mcp mode.
  - Server: lazy-load ChatAWSBedrock only when Bedrock is selected to prevent ImportError.
  - Browser: increase CDP wait timeout to 60s to reduce startup flakiness.

- **Migration**
  - Use: uvx browser-use --mcp
  - browser-use[cli] is optional and only needed for the TUI.

<sup>Written for commit e32c85dee784a68cadeec3da696be38459360742. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

