### PR TITLE
feat: add close_on_finish parameter to Agent.run for session control

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2150,6 +2150,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_steps: int = 100,
 		on_step_start: AgentHookFunc | None = None,
 		on_step_end: AgentHookFunc | None = None,
+		close_on_finish: bool = True,
 	) -> AgentHistoryList[AgentStructuredOutput]:
 		"""Execute the task with maximum number of steps"""
 
@@ -2353,7 +2354,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			# Use longer timeout to avoid deadlocks in tests with multiple agents
 			await self.eventbus.stop(timeout=3.0)
 
-			await self.close()
+			if close_on_finish:
+				await self.close()
 
 	@observe_debug(ignore_input=True, ignore_output=True)
 	@time_execution_async('--multi_act')
@@ -3520,11 +3522,19 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_steps: int = 100,
 		on_step_start: AgentHookFunc | None = None,
 		on_step_end: AgentHookFunc | None = None,
+		close_on_finish: bool = True,
 	) -> AgentHistoryList[AgentStructuredOutput]:
 		"""Synchronous wrapper around the async run method for easier usage without asyncio."""
 		import asyncio
 
-		return asyncio.run(self.run(max_steps=max_steps, on_step_start=on_step_start, on_step_end=on_step_end))
+		return asyncio.run(
+			self.run(
+				max_steps=max_steps,
+				on_step_start=on_step_start,
+				on_step_end=on_step_end,
+				close_on_finish=close_on_finish,
+			)
+		)
 
 	def detect_variables(self) -> dict[str, DetectedVariable]:
 		"""Detect reusable variables in agent history"""


### PR DESCRIPTION
This pull request introduces a new close_on_finish control to support persistent browser sessions when running an agent. It addresses Issue #3213 by extending both Agent.run() and Agent.run_sync() with a close_on_finish parameter, allowing users to decide whether the browser session should automatically close once the agent has finished its task. This is particularly useful for inspecting the final browser state or reusing the same session for follow-up tasks.

As part of the change, the Agent.run method signature was updated to include close_on_finish: bool = True. The cleanup logic in the finally block was then modified so that await self.close() is only executed when close_on_finish is set to True, preserving existing behavior by default. In addition, Agent.run_sync was updated to accept this new parameter and correctly forward it to the asynchronous run method.

The implementation was verified through a manual validation script (verify_close_control.py), which confirmed that setting close_on_finish=False keeps the browser session open after execution, while leaving it as True maintains the previous automatic-close behavior. To ensure there were no unintended side effects, existing regression tests, including tests/ci/browser/test_dom_serializer.py, were executed and all passed successfully. This change cleanly resolves Issue #3213 without impacting current users who rely on the default behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a close_on_finish parameter to Agent.run and run_sync to control whether the browser session closes after execution. Defaults to True to preserve current behavior and enables persistent sessions for inspection or follow-ups. Addresses #3213.

- New Features
  - Added close_on_finish: bool (default True) to gate self.close() at the end of run.
  - run_sync now forwards close_on_finish to the async run method.

<sup>Written for commit ee339d6d6b4463bba44408930325921a4ad98922. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

