### PR TITLE
Fix: iframe visibility checks and prevent AX tree retrieval hangs

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -210,9 +210,14 @@ class DomService:
 
 	async def _get_ax_tree_for_all_frames(self, target_id: TargetID) -> GetFullAXTreeReturns:
 		"""Recursively collect all frames and merge their accessibility trees into a single array."""
-
 		cdp_session = await self.browser_session.get_or_create_cdp_session(target_id=target_id, focus=False)
-		frame_tree = await cdp_session.cdp_client.send.Page.getFrameTree(session_id=cdp_session.session_id)
+		try:
+			frame_tree = await asyncio.wait_for(
+				cdp_session.cdp_client.send.Page.getFrameTree(session_id=cdp_session.session_id), timeout=2.0
+			)
+		except Exception as e:
+			self.logger.warning(f'Failed to get frame tree for target {target_id}: {e}')
+			return {'nodes': []}
 
 		def collect_all_frame_ids(frame_tree_node) -> list[str]:
 			"""Recursively collect all frame IDs from the frame tree."""
@@ -227,21 +232,33 @@ class DomService:
 		# Collect all frame IDs recursively
 		all_frame_ids = collect_all_frame_ids(frame_tree['frameTree'])
 
-		# Get accessibility tree for each frame
-		ax_tree_requests = []
-		for frame_id in all_frame_ids:
-			ax_tree_request = cdp_session.cdp_client.send.Accessibility.getFullAXTree(
-				params={'frameId': frame_id}, session_id=cdp_session.session_id
-			)
-			ax_tree_requests.append(ax_tree_request)
+		# Function to safely get AX tree for a single frame
+		async def _safe_get_ax_tree(frame_id: str):
+			try:
+				# Use a short timeout for each frame to prevent hanging
+				result = await asyncio.wait_for(
+					cdp_session.cdp_client.send.Accessibility.getFullAXTree(
+						params={'frameId': frame_id}, session_id=cdp_session.session_id
+					),
+					timeout=1.0,  # 1 second timeout per frame
+				)
+				return result
+			except Exception as e:
+				# Log but don't fail if one frame (e.g. cross-origin) fails
+				self.logger.debug(f'Failed to get AX tree for frame {frame_id}: {e}')
+				return None
+
+		# Get accessibility tree for each frame concurrently
+		ax_tree_requests = [_safe_get_ax_tree(frame_id) for frame_id in all_frame_ids]
 
 		# Wait for all requests to complete
-		ax_trees = await asyncio.gather(*ax_tree_requests)
+		ax_trees_results = await asyncio.gather(*ax_tree_requests)
 
-		# Merge all AX nodes into a single array
+		# Merge all valid AX nodes into a single array
 		merged_nodes: list[AXNode] = []
-		for ax_tree in ax_trees:
-			merged_nodes.extend(ax_tree['nodes'])
+		for result in ax_trees_results:
+			if result and 'nodes' in result:
+				merged_nodes.extend(result['nodes'])
 
 		return {'nodes': merged_nodes}
 

--- a/tests/ci/browser/test_iframe_interactions.py
+++ b/tests/ci/browser/test_iframe_interactions.py
@@ -1,0 +1,119 @@
+"""Unit tests for iframe interaction fixes."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from browser_use.browser.watchdogs.default_action_watchdog import DefaultActionWatchdog
+from browser_use.dom.service import DomService
+from browser_use.dom.views import EnhancedDOMTreeNode
+
+
+@pytest.mark.asyncio
+async def test_get_ax_tree_for_all_frames_handles_timeout():
+	# Mock BrowserSession and CDPClient
+	mock_browser_session = AsyncMock()
+	mock_cdp_session = AsyncMock()
+	mock_browser_session.get_or_create_cdp_session.return_value = mock_cdp_session
+	mock_cdp_session.session_id = 'session-123'
+
+	# Mock frame tree
+	mock_cdp_session.cdp_client.send.Page.getFrameTree.return_value = {
+		'frameTree': {'frame': {'id': 'frame-1'}, 'childFrames': [{'frame': {'id': 'frame-2'}}]}
+	}
+
+	# Mock getFullAXTree to hang for frame-2
+	async def side_effect_ax_tree(params, session_id):
+		if params['frameId'] == 'frame-2':
+			# Simulate hang (wait longer than timeout)
+			import asyncio
+
+			await asyncio.sleep(2.0)
+			return {'nodes': []}
+		return {'nodes': [{'nodeId': '1'}]}
+
+	mock_cdp_session.cdp_client.send.Accessibility.getFullAXTree.side_effect = side_effect_ax_tree
+
+	service = DomService(mock_browser_session)
+
+	# Run the method - it should not hang indefinitely
+	# The timeout in code is 1.0s, so it should finish quickly
+	result = await service._get_ax_tree_for_all_frames('target-1')
+
+	assert result is not None
+	# process only frame-1, frame-2 should fail/timeout
+	# We expect nodes from frame-1 only
+	assert len(result['nodes']) == 1
+	assert result['nodes'][0]['nodeId'] == '1'
+
+
+@pytest.mark.asyncio
+async def test_scroll_parent_iframes_into_view():
+	mock_browser_session = AsyncMock()
+
+	# Use model_construct to bypass Pydantic validation for mocks
+	# Supply event_bus as it is a required field
+	watchdog = DefaultActionWatchdog.model_construct(browser_session=mock_browser_session, event_bus=MagicMock())
+	# logger is a property, do not try to set it.
+
+	# Element inside Iframe2
+	element_node = MagicMock(spec=EnhancedDOMTreeNode)
+	element_node.parent = MagicMock(spec=EnhancedDOMTreeNode)
+
+	# Iframe2 element (in Iframe1 doc)
+	iframe2_node = element_node.parent
+	iframe2_node.tag_name = 'IFRAME'
+	iframe2_node.backend_node_id = 102
+	iframe2_node.parent = MagicMock(spec=EnhancedDOMTreeNode)
+
+	# Iframe1 element (in Main doc)
+	iframe1_node = iframe2_node.parent
+	iframe1_node.tag_name = 'IFRAME'
+	iframe1_node.backend_node_id = 101
+	iframe1_node.parent = MagicMock(spec=EnhancedDOMTreeNode)
+
+	# Main document root (not iframe)
+	root_node = iframe1_node.parent
+	root_node.tag_name = 'HTML'
+	root_node.parent = None
+
+	# Mock cdp_client_for_node to return different sessions
+	session1 = AsyncMock()
+	session1.session_id = 'session-1'
+	session2 = AsyncMock()
+	session2.session_id = 'session-2'
+
+	async def side_effect_cdp_client(node):
+		if node == iframe1_node:
+			return session1  # Main session
+		if node == iframe2_node:
+			return session2  # Iframe1 session
+		return session1
+
+	mock_browser_session.cdp_client_for_node.side_effect = side_effect_cdp_client
+
+	# Execute
+	await watchdog._scroll_parent_iframes_into_view(element_node)
+
+	# Verify calls
+	# Should scroll Iframe2 first (closest parent iframe)
+	# Then Iframe1
+
+	# Check Iframe2 scroll (using session2 - Iframe1 session)
+	# Wait, loop order:
+	# current = element.parent (iframe2_node) -> IS IFRAME -> scroll it
+	# current = iframe2_node.parent (iframe1_node) -> IS IFRAME -> scroll it
+
+	# Verify scrollIntoViewIfNeeded called for iframe2_node
+	# args: params={'backendNodeId': 102}, session_id='session-2'
+	# Actually my mock logic for session might be simplified, but let's check call args
+
+	assert session2.cdp_client.send.DOM.scrollIntoViewIfNeeded.called
+	call_args2 = session2.cdp_client.send.DOM.scrollIntoViewIfNeeded.call_args.kwargs
+	assert call_args2['params']['backendNodeId'] == 102
+
+	# Verify scrollIntoViewIfNeeded called for iframe1_node
+	# args: params={'backendNodeId': 101}, session_id='session-1'
+	assert session1.cdp_client.send.DOM.scrollIntoViewIfNeeded.called
+	call_args1 = session1.cdp_client.send.DOM.scrollIntoViewIfNeeded.call_args.kwargs
+	assert call_args1['params']['backendNodeId'] == 101


### PR DESCRIPTION
Issue #3109 (Inside Iframe Interaction): The root cause was that elements inside iframes were "technically" visible in the DOM but hidden from the user because parent iframes weren't scrolled into view. My fix _scroll_parent_iframes_into_view ensures they are visible.
Issue #3382 (Context Restoration): This issue is actually resolved by the design of cdp_client_for_node, which I verified in browser/session.py. It dynamically resolves the session for every action based on the target node's session_id. The "inability to restore" previously experienced was due to get_state() hanging on unresponsive frames, preventing the agent from "seeing" the main frame again. My timeout fix in DomService prevents this hang, ensuring the agent always gets a fresh state with valid main frame elements, allowing it to "switch back" seamlessly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix iframe interactions by scrolling parent iframes into view before actions, and prevent hangs when fetching accessibility trees with targeted timeouts. Addresses #3109 (inside iframe interaction) and #3382 (context restoration) by ensuring elements are truly visible and state retrieval stays responsive.

- **Bug Fixes**
  - Recursively scroll parent iframes into view before clicking elements, using the correct CDP session per parent frame.
  - Add short timeouts to Page.getFrameTree and per-frame Accessibility.getFullAXTree, and safely merge results to avoid hangs on unresponsive/cross-origin frames.
  - Add CI tests for AX tree timeout handling and parent iframe scrolling.

<sup>Written for commit dfbb691995eafc6b02cb938804713e4aae66c623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

