### PR TITLE
fix: Parse LLM string output in get_model_output to prevent crash (#3…

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1608,6 +1608,16 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			response = await self.llm.ainvoke(input_messages, **kwargs)
 			parsed: AgentOutput = response.completion  # type: ignore[assignment]
 
+			# If the result is a string, we need to parse it (e.g. from custom LLM implementation/DeepSeek R1)
+			if isinstance(parsed, str):
+				try:
+					parsed = self.AgentOutput.model_validate_json(parsed)
+				except ValidationError:
+					# If we can't parse it, we remove the think tags and try again
+					# This is common for DeepSeek R1 to put the thought in <think> tags
+					cleaned_parsed = self._remove_think_tags(parsed)
+					parsed = self.AgentOutput.model_validate_json(cleaned_parsed)
+
 			# Replace any shortened URLs in the LLM response back to original URLs
 			if urls_replaced:
 				self._recursive_process_all_strings_inside_pydantic_model(parsed, urls_replaced)


### PR DESCRIPTION
Fixes: #3876
I fixed the crash by making the 
Agent
 robust to string outputs from LLMs.

Identified the Root Cause: The 
Agent
 expected run_llm (or llm.ainvoke) to return an object with an .action attribute. When you returned a plain JSON string, it crashed with 'str' object has no attribute 'action'.
Implemented the Fix: I updated 
get_model_output
 in 
browser_use/agent/service.py
 to check if the result is a string.
Added Parsing Logic: If it is a string, the agent now automatically:
Parses it as JSON into the expected AgentOutput format.
Handles Reasoning Models: It strips `
` tags (common in DeepSeek R1) before parsing, ensuring compatibility with reasoning models that output thought chains.

This ensures your custom run_llm override works seamlessly even if it returns a raw JSON string.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the agent from crashing when an LLM returns a raw JSON string by parsing string outputs in get_model_output and stripping <think> tags when needed. Fixes #3876.

- **Bug Fixes**
  - Parse string responses from run_llm/llm.ainvoke into AgentOutput via model_validate_json.
  - On parse failure, strip <think>…</think> (e.g., DeepSeek R1) and retry parsing.
  - Scoped to get_model_output in browser_use/agent/service.py; no change for non-string responses.

<sup>Written for commit e798a6240e8c2982e544004ec1a3c9baf76ac8fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

