### PR TITLE
fix(browser): make event bus timeout configurable

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -363,7 +363,7 @@ class BrowserSession(BaseModel):
 		super().__init__(
 			id=id or str(uuid7str()),
 			browser_profile=resolved_browser_profile,
-			event_bus_timeout=event_bus_timeout or 5.0,
+			event_bus_timeout=event_bus_timeout if event_bus_timeout is not None else 5.0,
 		)
 
 	# Session configuration (session identity only)


### PR DESCRIPTION
fixes:#3076

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the event bus shutdown timeout configurable to improve reliability across environments. Adds event_bus_timeout (default 5s) to Session and uses it when stopping the event bus in stop() and kill().

<sup>Written for commit d30463790e29b74abee41ad04b3a0c5babd48928. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

