### PR TITLE
fix(browser): improve local browser connection reliability 

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1705,6 +1705,15 @@ class DefaultActionWatchdog(BaseWatchdog):
 					}
 				});
 
+				// GeneXus / Enterprise Framework Specifics:
+				// Some frameworks bind strictly to 'onchange' or 'onblur' attributes
+				if (typeof element.onchange === 'function') {
+					try { element.onchange(); } catch (e) {}
+				}
+				if (typeof element.onblur === 'function') {
+					try { element.onblur(); } catch (e) {}
+				}
+
 				// Special React synthetic event handling
 				// React uses internal fiber properties for event system
 				if (element._reactInternalFiber || element._reactInternalInstance || element.__reactInternalInstance) {


### PR DESCRIPTION
Fixes:#3068
Summary of Changes: This PR addresses connection reliability issues when using a local browser instance (executable_path) and fixes a Windows-specific crash.

Fix Connection Timeout (
LocalBrowserWatchdog
):
Problem: If the browser process crashed upon startup (e.g., invalid path, permission errors), the watchdog would blindly wait for the full 30-second timeout before raising a generic TimeoutError.
Fix: Updated 
_wait_for_cdp_url
 to actively check if the subprocess has exited. If the process crashes, it now fails immediately and raises a RuntimeError containing the process exit code and stderr output, providing significantly better debugging feedback.
Fix Windows Unicode Crash (
BrowserSession
):
Problem: The BrowserSession.reset() method logged a message containing a Green Check Mark emoji (✅). On Windows systems with default legacy encodings (cp1252), this caused a UnicodeEncodeError and crashed the entire agent execution.
Fix: Removed the emoji from the log message to ensuring cross-platform compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves local browser connection reliability by failing fast on startup crashes and fixes a Windows log encoding crash (Linear #3068). Adds a configurable event bus timeout for cleaner shutdowns.

- **Bug Fixes**
  - Local startup: _wait_for_cdp_url now detects a crashed subprocess and fails immediately with exit code and stderr, instead of waiting 30s.
  - Windows logging: removed the emoji from BrowserSession.reset() to avoid UnicodeEncodeError on cp1252.
  - Form events: trigger onchange/onblur handlers after input to support GeneXus/Enterprise frameworks.

<sup>Written for commit a7ab0e3645454f87839554cde3c8d47ab34330f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

