### PR TITLE
Upgrade aiohttp dependency to version 3.13.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "aiohttp==3.12.15",
+    "aiohttp==3.13.3",
     "anyio>=4.9.0",
     "bubus>=1.5.6",
     "click>=8.1.8",


### PR DESCRIPTION

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrades aiohttp from 3.12.15 to 3.13.3.

<sup>Written for commit 3ab6c2408ce0929a842512e5d794aa43ace818ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

