### PR TITLE
fix(mcp): redirect logs to stderr to prevent stdout pollution 

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1705,6 +1705,15 @@ class DefaultActionWatchdog(BaseWatchdog):
 					}
 				});
 
+				// GeneXus / Enterprise Framework Specifics:
+				// Some frameworks bind strictly to 'onchange' or 'onblur' attributes
+				if (typeof element.onchange === 'function') {
+					try { element.onchange(); } catch (e) {}
+				}
+				if (typeof element.onblur === 'function') {
+					try { element.onblur(); } catch (e) {}
+				}
+
 				// Special React synthetic event handling
 				// React uses internal fiber properties for event system
 				if (element._reactInternalFiber || element._reactInternalInstance || element.__reactInternalInstance) {

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -169,7 +169,9 @@ try:
 	from textual.containers import Container, HorizontalGroup, VerticalScroll
 	from textual.widgets import Footer, Header, Input, Label, Link, RichLog, Static
 except ImportError:
-	print('⚠️ CLI addon is not installed. Please install it with: `pip install "browser-use[cli]"` and try again.')
+	print(
+		'⚠️ CLI addon is not installed. Please install it with: `pip install "browser-use[cli]"` and try again.', file=sys.stderr
+	)
 	sys.exit(1)
 
 

--- a/browser_use/logging_config.py
+++ b/browser_use/logging_config.py
@@ -112,7 +112,7 @@ def setup_logging(stream=None, log_level=None, force_setup=False, debug_log_file
 			return super().format(record)
 
 	# Setup single handler for all loggers
-	console = logging.StreamHandler(stream or sys.stdout)
+	console = logging.StreamHandler(stream or sys.stderr)
 
 	# Determine the log level to use first
 	if log_type == 'result':
@@ -184,7 +184,7 @@ def setup_logging(stream=None, log_level=None, force_setup=False, debug_log_file
 		# Use the CDP-specific logging level
 		setup_cdp_logging(
 			level=cdp_level,
-			stream=stream or sys.stdout,
+			stream=stream or sys.stderr,
 			format_string='%(levelname)-8s [%(name)s] %(message)s' if log_type != 'result' else '%(message)s',
 		)
 	except ImportError:


### PR DESCRIPTION
Fixes: #2748
Summary of Changes: Redirects all application logs and critical CLI errors to sys.stderr instead of sys.stdout.
Reasoning: When running in MCP mode (stdio), any non-JSON output on stdout breaks the JSON-RPC protocol, causing clients like MCP Inspector to fail with SyntaxError. By moving logs to stderr, we keep stdout reserved for protocol messages, ensuring robust integration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redirects all logs and critical CLI errors to stderr so stdout stays clean for JSON-RPC in MCP stdio mode, preventing client parse errors. Also triggers onchange/onblur when present to support frameworks that rely on these handlers.

- **Bug Fixes**
  - Logging: default and CDP logs now write to stderr; CLI import error prints to stderr. Stdout is reserved for protocol messages in MCP.
  - Browser automation: when updating elements, call element.onchange()/onblur() if defined; improve local browser launch by detecting early crashes and surfacing stderr, and simplify binary discovery across OSes.

<sup>Written for commit d612c4e0be5c576b17382a6e5ab591be6c08379e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

