### PR TITLE
make event bus timeout configurable using env

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -59,6 +59,7 @@ from browser_use.agent.views import (
 	JudgementResult,
 	StepMetadata,
 )
+from browser_use.browser.events import _get_timeout
 from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
 from browser_use.browser.views import BrowserStateSummary
 from browser_use.config import CONFIG
@@ -2350,8 +2351,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			self._log_final_outcome_messages()
 
 			# Stop the event bus gracefully, waiting for all events to be processed
-			# Use longer timeout to avoid deadlocks in tests with multiple agents
-			await self.eventbus.stop(timeout=3.0)
+			# Configurable via TIMEOUT_AgentEventBusStop env var (default: 3.0s)
+			await self.eventbus.stop(timeout=_get_timeout('TIMEOUT_AgentEventBusStop', 3.0))
 
 			await self.close()
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Made the Agent event bus stop timeout configurable via the TIMEOUT_AgentEventBusStop env var (default 3s) to let tests and deployments tune shutdown wait time. This connects to Linear 3076 by allowing environments to adjust the idle wait instead of using a fixed value.

<sup>Written for commit 9c042d7d9869b478a66fc5c311bff6de207b6906. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

