### PR TITLE
fix(#3889): Draft.js editors lose first character when typing

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1568,7 +1568,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 			)
 
 			if _is_draftjs and len(text) > 0 and clear:
-				# Prepend a space as "sacrifice character" - it will be dropped by Draft.js 
+				# Prepend a space as "sacrifice character" - it will be dropped by Draft.js
 				# Only when clear=True (cursor at leaf start), otherwise Draft.js won't drop it
 				text = ' ' + text
 				self.logger.debug('🎯 Draft.js detected, prepending sacrifice space')


### PR DESCRIPTION
Fixes #3889

## Problem
First letter is missed when typing in Draft.js editors (e.g., x.com posts/comments).

## Cause  
CDP's `dispatchKeyEvent` doesn't trigger `beforeinput` events that Draft.js relies on. When selection is at `isSelectionAtLeafStart`, Draft.js expects character data from `beforeinput.data`, which CDP never provides.

## Approaches Explored

### 1. Synthetic `beforeinput` event for first character
Dispatched a JavaScript `beforeinput` event before typing the first character.
- **Result**: Fixed 'A', but then 'B' started missing
- **Why it failed**: The first character sent via CDP is always dropped, regardless of prior events

### 2. CDP `Input.insertText`
Considered using `Input.insertText` to trigger `beforeinput`.
- **Why it failed**: CDP commands bypass DOM event dispatch entirely; `beforeinput` is never fired

### 3. Empty `beforeinput` to "wake up" Draft.js
Send empty `beforeinput` first, then type normally.
- **Why it failed**: Doesn't address the root cause - Draft.js still drops the first CDP character at leaf start

## Solution
Detect Draft.js editors via DOM attributes (`DraftEditor` class, `data-contents`, `data-block`, `data-offset-key`) and prepend a sacrifice space character that Draft.js will drop, preserving the actual intended text.

## Testing
- x.com post/comment: Full text typed correctly
- Non-Draft.js inputs (Google search): No side effects

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes first character being dropped when typing into Draft.js editors (e.g., x.com posts/comments). Detects Draft.js and prepends a sacrificial space so the intended text is preserved. Fixes #3889.

- **Bug Fixes**
  - Detect Draft.js via class/data attributes (DraftEditor, data-contents, data-block, data-offset-key).
  - Prepend a single space only for Draft.js when clear=True (cursor at leaf start); Draft.js drops it, keeping user text intact.
  - Scope limited to Draft.js; verified on x.com, with no side effects on standard inputs.

<sup>Written for commit b1fad345d613aea16c5c0727b4dc64f79f06b77c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes missing first character when typing into Draft.js editors by scoping a targeted workaround to Draft.js-only nodes.
> 
> - Detects Draft.js via attributes/classes (`DraftEditor`, `data-contents`, `data-block`, `data-offset-key`) in `default_action_watchdog.py`
> - Prepends a single leading space to `text` only for Draft.js inputs, ensuring the framework drops the space and keeps the actual text
> - Leaves non-Draft.js inputs unchanged; logs detection for observability
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9dec964bef7b949677e41120084e8567662f5af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->