### PR TITLE
Improve placeholder handling for 2FA secrets in registry service

### DIFF
--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -455,8 +455,8 @@ class Registry(Generic[Context]):
 				# check if the placeholder key, like x_password is in the output parameters of the LLM and replace it with the sensitive data
 				for placeholder in matches:
 					if placeholder in applicable_secrets:
-						# generate a totp code if secret is a 2fa secret
-						if 'bu_2fa_code' in placeholder:
+						# generate a totp code if secret is suffixed with bu_2fa_code
+						if placeholder.endswith('bu_2fa_code'):
 							totp = pyotp.TOTP(applicable_secrets[placeholder], digits=6)
 							replacement_value = totp.now()
 						else:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Generate TOTP codes only when the placeholder key ends with "bu_2fa_code". This supports multiple 2FA secrets and avoids false matches in secret replacement.

<sup>Written for commit dd8a63ce41b631293e111cc35d6001f9924f503c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

