### PR TITLE
Custom tool registry documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -776,14 +776,14 @@ Tools are the functions that the agent has to interact with the world.
 ## Quick Example
 
 ```python  theme={null}
-from browser_use import Tools, ActionResult, Browser
+from browser_use import Tools, ActionResult, BrowserSession
 
 tools = Tools()
 
 @tools.action('Ask human for help with a question')
-def ask_human(question: str, browser: Browser) -> ActionResult:
+async def ask_human(question: str, browser_session: BrowserSession) -> ActionResult:
     answer = input(f'{question} > ')
-    return f'The human responded with: {answer}'
+    return ActionResult(extracted_content=f'The human responded with: {answer}')
 
 agent = Agent(
     task='Ask human for help',
@@ -792,8 +792,13 @@ agent = Agent(
 )
 ```
 
+<Warning>
+**Important**: The parameter must be named exactly `browser_session` with type `BrowserSession` (not `browser: Browser`). 
+The agent injects parameters by name matching, so using the wrong name will cause your tool to fail silently.
+</Warning>
+
 <Note>
-  Use `browser` parameter in tools for deterministic [Actor](https://docs.browser-use.com/customize/actor/basics) actions.
+  Use `browser_session` parameter in tools for deterministic [Actor](https://docs.browser-use.com/customize/actor/basics) actions.
 </Note>
 
 
@@ -821,9 +826,9 @@ from browser_use import Tools, Agent, ActionResult
 tools = Tools()
 
 @tools.action(description='Ask human for help with a question')
-def ask_human(question: str) -> ActionResult:
+async def ask_human(question: str) -> ActionResult:
     answer = input(f'{question} > ')
-    return f'The human responded with: {answer}'
+    return ActionResult(extracted_content=f'The human responded with: {answer}')
 ```
 
 ```python  theme={null}
@@ -834,6 +839,11 @@ agent = Agent(task='...', llm=llm, tools=tools)
 * `allowed_domains` - List of domains where tool can run (e.g. `['*.example.com']`), defaults to all domains
 
 The Agent fills your function parameters based on their names, type hints, & defaults.
+
+<Warning>
+**Common Pitfall**: Parameter names must match exactly! Use `browser_session: BrowserSession` (not `browser: Browser`). 
+The agent injects special parameters by **name matching**, so using incorrect names will cause your tool to fail silently.
+</Warning>
 
 
 # Tools: Available Tools

--- a/docs/customize/tools/add.mdx
+++ b/docs/customize/tools/add.mdx
@@ -21,14 +21,14 @@ Examples:
 Simply add `@tools.action(...)` to your function.
 
 ```python
-from browser_use import Tools, Agent
+from browser_use import Tools, Agent, ActionResult
 
 tools = Tools()
 
 @tools.action(description='Ask human for help with a question')
-def ask_human(question: str) -> ActionResult:
+async def ask_human(question: str) -> ActionResult:
     answer = input(f'{question} > ')
-    return f'The human responded with: {answer}'
+    return ActionResult(extracted_content=f'The human responded with: {answer}')
 ```
 
 ```python
@@ -39,6 +39,12 @@ agent = Agent(task='...', llm=llm, tools=tools)
 - **`allowed_domains`** - List of domains where tool can run (e.g. `['*.example.com']`), defaults to all domains
 
 The Agent fills your function parameters based on their names, type hints, & defaults.
+
+<Warning>
+**Common Pitfall**: Parameter names must match exactly! Use `browser_session: BrowserSession` (not `browser: Browser`). 
+The agent injects special parameters by **name matching**, so using incorrect names will cause your tool to fail silently.
+See [Available Objects](#available-objects) below for the correct parameter names.
+</Warning>
 
 
 ## Available Objects
@@ -130,3 +136,39 @@ For a comprehensive example of custom tools with Playwright integration, see:
 **[Playwright Integration Example](https://github.com/browser-use/browser-use/blob/main/examples/browser/playwright_integration.py)**
 
 This shows how to create custom actions that use Playwright's precise browser automation alongside Browser-Use.
+
+## Common Pitfalls
+
+<Warning>
+The agent injects special parameters **by name**, not by type. Using incorrect parameter names is the most common cause of tools failing silently.
+</Warning>
+
+### ❌ Wrong: Using `browser: Browser`
+
+```python
+from browser_use import Tools, ActionResult, Browser
+
+@tools.action('My action')
+def my_action(browser: Browser) -> ActionResult:  # WRONG!
+    # This will NOT receive the browser session
+    pass
+```
+
+### ✅ Correct: Using `browser_session: BrowserSession`
+
+```python
+from browser_use import Tools, ActionResult, BrowserSession
+
+@tools.action('My action')
+async def my_action(browser_session: BrowserSession) -> ActionResult:  # CORRECT!
+    page = await browser_session.must_get_current_page()
+    # Now you have access to the browser
+    return ActionResult(extracted_content='Done')
+```
+
+### Key Points
+
+1. **Use `browser_session: BrowserSession`** - not `browser: Browser`
+2. **Use `async` functions** - recommended for consistency with browser operations
+3. **Return `ActionResult`** - not plain strings (though strings work, `ActionResult` provides more control)
+4. **Parameter names must match exactly** - see [Available Objects](#available-objects) for the full list of injectable parameters

--- a/docs/customize/tools/basics.mdx
+++ b/docs/customize/tools/basics.mdx
@@ -10,14 +10,14 @@ mode: "wide"
 
 
 ```python
-from browser_use import Tools, ActionResult, Browser
+from browser_use import Tools, ActionResult, BrowserSession
 
 tools = Tools()
 
 @tools.action('Ask human for help with a question')
-def ask_human(question: str, browser: Browser) -> ActionResult:
+async def ask_human(question: str, browser_session: BrowserSession) -> ActionResult:
     answer = input(f'{question} > ')
-    return f'The human responded with: {answer}'
+    return ActionResult(extracted_content=f'The human responded with: {answer}')
 
 agent = Agent(
     task='Ask human for help',
@@ -26,6 +26,11 @@ agent = Agent(
 )
 ```
 
+<Warning>
+**Important**: The parameter must be named exactly `browser_session` with type `BrowserSession` (not `browser: Browser`). 
+The agent injects parameters by name matching, so using the wrong name will cause your tool to fail silently.
+</Warning>
+
 <Note>
-Use `browser` parameter in tools for deterministic [Actor](/customize/actor/basics) actions.
+Use `browser_session` parameter in tools for deterministic [Actor](/customize/actor/basics) actions.
 </Note>


### PR DESCRIPTION
Update custom tool registry documentation to clarify correct parameter naming and function signatures.

The previous documentation incorrectly showed `browser: Browser` as an injectable parameter for custom tools. The agent injects parameters by name matching, so the correct parameter name is `browser_session: BrowserSession`. This PR fixes this, recommends async functions, and adds a "Common Pitfalls" section to guide users.

---
[Slack Thread](https://browser-use.slack.com/archives/C08TZGLPLER/p1768767006926899?thread_ts=1768767006.926899&cid=C08TZGLPLER)

<a href="https://cursor.com/background-agent?bcId=bc-a9112a17-72ed-4ef2-acba-8d9873477a89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9112a17-72ed-4ef2-acba-8d9873477a89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified custom tool docs to use the correct `browser_session: BrowserSession` injection and recommend async functions with `ActionResult`, preventing silent tool failures. Added warnings and a Common Pitfalls section to make name-based parameter injection clear.

- **Bug Fixes**
  - Fixed examples to use `browser_session: BrowserSession` (not `browser: Browser`), return `ActionResult`, and be `async`.
  - Added warnings about name-based injection and a Common Pitfalls section with wrong/correct examples.
  - Updated AGENTS.md and tools docs (add.mdx, basics.mdx) for consistency.

<sup>Written for commit 1c70a9dbc561c9f077f8fe0f592c8b4f41cb1876. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies custom tool docs and examples to correctly use `browser_session: BrowserSession`, `async` functions, and `ActionResult`, reducing silent failures from name-based injection mismatches.
> 
> - Update examples in `AGENTS.md`, `docs/customize/tools/basics.mdx`, and `docs/customize/tools/add.mdx` to replace `browser: Browser` with `browser_session: BrowserSession`, switch to `async`, and return `ActionResult`
> - Add prominent warnings about name-based parameter injection and a new **Common Pitfalls** section with wrong/correct examples
> - Minor note updates to reference deterministic Actor actions via `browser_session`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c70a9dbc561c9f077f8fe0f592c8b4f41cb1876. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->