### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       IS_SANDBOX: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
@@ -40,7 +40,7 @@ jobs:
         run: echo "PLAYWRIGHT_VERSION=$(uv pip list --format json | jq -r '.[] | select(.name == "playwright") | .version')" >> $GITHUB_ENV
 
       # - name: Cache chrome binaries
-      #   uses: actions/cache@v4
+      #   uses: actions/cache@v5
       #   with:
       #     path: |
       #       /tmp/google-chrome-stable_current_amd64.deb
@@ -55,7 +55,7 @@ jobs:
       # - run: playwright install chrome --with-deps
 
       - name: Cache chromium binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright

--- a/.github/workflows/cloud_evals.yml
+++ b/.github/workflows/cloud_evals.yml
@@ -20,7 +20,7 @@ jobs:
   trigger_cloud_eval_image_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.TRIGGER_CLOUD_BUILD_GH_KEY }}
           script: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     name: syntax-errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -31,7 +31,7 @@ jobs:
     name: code-style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -42,7 +42,7 @@ jobs:
     name: type-checker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -20,10 +20,10 @@ jobs:
     name: pip-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
       - run: uv build --python 3.12
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: dist-artifact
           path: |
@@ -42,9 +42,9 @@ jobs:
       ANONYMIZED_TELEMETRY: 'false'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist-artifact
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create pre-release tag
         run: |
           git fetch --tags
@@ -74,7 +74,7 @@ jobs:
       IN_DOCKER: 'True'
       ANONYMIZED_TELEMETRY: 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # General settings
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
 
       - name: Get week number for cache key
@@ -37,7 +37,7 @@ jobs:
 
       - name: Cache chromium binaries
         id: cache-chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright
@@ -56,7 +56,7 @@ jobs:
       TEST_FILENAMES: ${{ steps.lsgrep.outputs.TEST_FILENAMES }}
       # ["test_browser", "test_tools", "test_browser_session", "test_tab_management", ...]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Force fresh checkout to avoid any caching issues
           fetch-depth: 1
@@ -113,14 +113,14 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           activate-environment: true
 
       - name: Cache uv packages and venv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/uv
@@ -137,7 +137,7 @@ jobs:
 
       - name: Cache chromium binaries
         id: cache-chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright
@@ -150,7 +150,7 @@ jobs:
         run: uvx playwright install chromium --with-deps --no-shell
 
       - name: Cache browser-use extensions
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.config/browseruse/extensions
@@ -197,14 +197,14 @@ jobs:
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       BROWSER_USE_API_KEY: ${{ secrets.BROWSER_USE_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           activate-environment: true
 
       - name: Cache uv packages and venv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/uv
@@ -221,7 +221,7 @@ jobs:
 
       - name: Cache chromium binaries
         id: cache-chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright
@@ -234,7 +234,7 @@ jobs:
         run: uvx playwright install chromium --with-deps --no-shell
 
       - name: Cache browser-use extensions
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.config/browseruse/extensions
@@ -271,7 +271,7 @@ jobs:
 
       - name: Comment PR with agent evaluation results
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         continue-on-error: true
         with:
           script: |


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/lint.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/test.yaml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/docker.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/package.yaml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/claude.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/package.yaml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/package.yaml`
- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/claude.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/publish.yml`
- Updated `actions/stale` from `v9` to `v10` in `.github/workflows/stale-bot.yml`
- Updated `actions/cache` from `v4` to `v5` in `.github/workflows/test.yaml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/test.yaml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/cloud_evals.yml`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates CI workflows to the latest major versions of core GitHub Actions to improve security, reliability, and remove deprecation warnings. Changes cover lint, test, docker, package, publish, stale-bot, claude, and cloud_evals workflows with no behavior changes expected.

- **Dependencies**
  - actions/checkout → v6
  - actions/cache → v5
  - actions/upload-artifact → v6
  - actions/download-artifact → v7
  - actions/stale → v10
  - actions/github-script → v8

<sup>Written for commit d8a5d68604835e6cafb231ff661449bb8112fc80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

