### PR TITLE
fix(cli): enable chaining multiple run commands on same session

### DIFF
--- a/browser_use/skill_cli/sessions.py
+++ b/browser_use/skill_cli/sessions.py
@@ -20,6 +20,7 @@ class SessionInfo:
 	profile: str | None
 	browser_session: BrowserSession
 	python_session: PythonSession = field(default_factory=PythonSession)
+	agent: Any = None  # Persistent agent for chaining run commands
 
 
 class SessionRegistry:


### PR DESCRIPTION
## Summary

- Persist agent across `run` commands in the same session
- Use `agent.add_new_task()` for subsequent runs instead of creating new agents
- Aligns CLI behavior with documented Python API pattern for task chaining

## Problem

Currently, each `browser-use run` command creates a **new Agent instance**, which loses the context and browser state from previous runs. This causes subsequent runs on the same session to fail:

```bash
browser-use --session test run "go to wikipedia.org"     # ✅ done: true, steps: 2
browser-use --session test run "search for France"       # ❌ done: false, steps: 0
browser-use --session test run "get first paragraph"     # ❌ done: false, steps: 0
```

The second and third runs return `steps: 0` because the new agent doesn't have the context from the previous agent's work.

## Solution

This fix aligns the CLI with the [documented Python API pattern for task chaining](https://docs.browser-use.com/examples/templates/follow-up-tasks):

```python
# Documented pattern - reuse agent with add_new_task()
agent = Agent(task='first task', browser_session=browser)
await agent.run()

agent.add_new_task('follow up task')  # Preserves context!
await agent.run()
```

**Changes:**
1. Add `agent` field to `SessionInfo` to persist the agent across runs
2. On first run: create agent and store in session
3. On subsequent runs: call `session.agent.add_new_task(task)` then run

## After this fix

```bash
browser-use --session test run "go to wikipedia.org"     # ✅ done: true, steps: 2
browser-use --session test run "search for France"       # ✅ done: true, steps: 2
browser-use --session test run "get first paragraph"     # ✅ done: true, steps: 2
```

## Testing

Tested locally with multiple chained runs - all complete successfully with `done: true`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables chaining multiple CLI run commands in the same session by reusing the agent. Preserves context and browser state so follow-up tasks complete instead of returning steps: 0.

- **Bug Fixes**
  - Persist agent in SessionInfo and reuse it across runs.
  - First run creates and stores the agent; subsequent runs use agent.add_new_task(task) before run, aligning the CLI with the documented Python API pattern.

<sup>Written for commit 900a027acf94d45614cc676c3467c26973d6ba77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

