### PR TITLE
Added support for new browser use model

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -68,7 +68,7 @@ class ChatBrowserUse(BaseChatModel):
 			retry_max_delay: Maximum delay in seconds between retries (default: 60.0).
 		"""
 		# Validate model name - allow bu-* and browser-use/* patterns
-		valid_models = ['bu-latest', 'bu-1-0']
+		valid_models = ['bu-latest', 'bu-1-0', 'bu-1-5']
 		is_valid = model in valid_models or model.startswith('browser-use/')
 		if not is_valid:
 			raise ValueError(f"Invalid model: '{model}'. Must be one of {valid_models} or start with 'browser-use/'")

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -12,6 +12,6 @@ load_dotenv()
 
 agent = Agent(
 	task='Find the number of stars of the following repos: browser-use, playwright, stagehand, react, nextjs',
-	llm=ChatBrowserUse(),
+	llm=ChatBrowserUse(model='bu-1-5'),
 )
 agent.run_sync()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for the new bu-1-5 model in ChatBrowserUse and updates the simple example to use it. Existing models (bu-latest, bu-1-0) and the browser-use/* pattern remain supported.

<sup>Written for commit 37586c9e9f61fbe72b47a9f37ee9000780c4c699. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

