### PR TITLE
Added browser use 2-0 support

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -68,7 +68,7 @@ class ChatBrowserUse(BaseChatModel):
 			retry_max_delay: Maximum delay in seconds between retries (default: 60.0).
 		"""
 		# Validate model name - allow bu-* and browser-use/* patterns
-		valid_models = ['bu-latest', 'bu-1-0', 'bu-1-5']
+		valid_models = ['bu-latest', 'bu-1-0', 'bu-2-0']
 		is_valid = model in valid_models or model.startswith('browser-use/')
 		if not is_valid:
 			raise ValueError(f"Invalid model: '{model}'. Must be one of {valid_models} or start with 'browser-use/'")

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -12,6 +12,6 @@ load_dotenv()
 
 agent = Agent(
 	task='Find the number of stars of the following repos: browser-use, playwright, stagehand, react, nextjs',
-	llm=ChatBrowserUse(model='bu-1-5'),
+	llm=ChatBrowserUse(model='bu-2-0'),
 )
 agent.run_sync()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for the bu-2-0 Browser Use model so agents can use the latest LLM.

- **New Features**
  - Allow bu-2-0 in ChatBrowserUse model validation (replaces bu-1-5).
  - Update examples/simple.py to use bu-2-0.

- **Migration**
  - If you used bu-1-5, switch to bu-2-0.

<sup>Written for commit f3aad3c1457c8ed64af65203bdc3bb5360311b61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

