### PR TITLE
fix: preserve CDP connection for chrome-extension:// pages

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1522,9 +1522,7 @@ class BrowserSession(BaseModel):
 					'⚠️ connect() called but CDP client already exists! Preserving connection for extension pages.'
 				)
 			else:
-				self.logger.warning(
-					'⚠️ connect() called but CDP client already exists! Cleaning up old connection.'
-				)
+				self.logger.warning('⚠️ connect() called but CDP client already exists! Cleaning up old connection.')
 				try:
 					await self._cdp_client_root.stop()
 				except Exception as e:


### PR DESCRIPTION
fixes #3601

### Problem
added `await self._cdp_client_root.stop()` in `reset()` and `connect()`, which closes ALL CDP sessions including extension contexts. This breaks chrome-extension:// page interactions.

### Solution
Conditionally preserve CDP connections when extension targets are present:
- Added `_has_extension_targets()` to detect chrome-extension:// URLs
- Modified `reset()` and `connect()` to only call `.stop()` when no extensions detected
- Non-extension workflows unchanged (proper cleanup still occurs)

### Changes
**`browser_use/browser/session.py`**:
- Line 476: Added `_has_extension_targets()` method
- Lines 498-521: Modified `reset()` with conditional CDP cleanup
- Lines 1519-1537: Modified `connect()` with conditional CDP cleanup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the CDP connection when chrome-extension:// targets are present to keep extension pages working. Prevents broken interactions caused by closing all CDP sessions during reset/connect (fixes #3601).

- **Bug Fixes**
  - Added _has_extension_targets() to detect extension URLs.
  - Updated reset() and connect() to skip stopping the CDP client when extensions exist; non-extension flows still clean up.

<sup>Written for commit 49706b79eed6a59c40601d890e0a96e259fbc1d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

