### PR TITLE
Remove '--headed' argument from 'open' command

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -204,7 +204,6 @@ Examples:
 	# open <url>
 	p = subparsers.add_parser('open', help='Navigate to URL')
 	p.add_argument('url', help='URL to navigate to')
-	p.add_argument('--headed', action='store_true', help='Show browser window')
 
 	# click <index>
 	p = subparsers.add_parser('click', help='Click element by index')


### PR DESCRIPTION
Removed the duplicate -headed argument from the open subparser (line 207 in the original code). The global -headed flag defined on line 193 is sufficient for all commands, including the open command.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant --headed flag from the open command to rely on the global --headed option instead. This avoids conflicting flags and keeps CLI help consistent.

<sup>Written for commit ec0199e1e7bdcb15fdc5a8b644c50fe1b7af137b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

