### PR TITLE
detect JS event listeners for clickable elements (resolves #958)

### DIFF
--- a/browser_use/dom/serializer/clickable_elements.py
+++ b/browser_use/dom/serializer/clickable_elements.py
@@ -18,9 +18,9 @@ class ClickableElementDetector:
 		if node.tag_name in {'html', 'body'}:
 			return False
 
-		# Check for JavaScript click event listeners detected via CDP
+		# Check for JavaScript click event listeners detected via CDP (without DOM mutation)
 		# this handles vue.js @click, react onClick, angular (click), etc.
-		if node.attributes and node.attributes.get('data-browser-use-js-click') == 'true':
+		if node.has_js_click_listener:
 			return True
 
 		# IFRAME elements should be interactive if they're large enough to potentially need scrolling

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -298,19 +298,21 @@ class DomService:
 			self.logger.debug(f'Failed to get iframe scroll positions: {e}')
 		iframe_scroll_ms = (time.time() - start_iframe_scroll) * 1000
 
-		# Detect and mark elements with JavaScript click event listeners
+		# Detect elements with JavaScript click event listeners (without mutating DOM)
 		start_js_listener_detection = time.time()
+		js_click_listener_backend_ids: set[int] = set()
 		try:
+			# Step 1: Run JS to find elements with click listeners and return them by reference
 			js_listener_result = await cdp_session.cdp_client.send.Runtime.evaluate(
 				params={
 					'expression': """
 					(() => {
 						// getEventListeners is only available in DevTools context via includeCommandLineAPI
 						if (typeof getEventListeners !== 'function') {
-							return { success: false, error: 'getEventListeners not available', count: 0 };
+							return null;
 						}
 
-						let count = 0;
+						const elementsWithListeners = [];
 						const allElements = document.querySelectorAll('*');
 
 						for (const el of allElements) {
@@ -318,27 +320,73 @@ class DomService:
 								const listeners = getEventListeners(el);
 								// Check for click-related event listeners
 								if (listeners.click || listeners.mousedown || listeners.mouseup || listeners.pointerdown || listeners.pointerup) {
-									el.setAttribute('data-browser-use-js-click', 'true');
-									count++;
+									elementsWithListeners.push(el);
 								}
 							} catch (e) {
 								// Ignore errors for individual elements (e.g., cross-origin)
 							}
 						}
 
-						return { success: true, count };
+						return elementsWithListeners;
 					})()
 					""",
 					'includeCommandLineAPI': True,  # enables getEventListeners()
-					'returnByValue': True,
+					'returnByValue': False,  # Return object references, not values
 				},
 				session_id=cdp_session.session_id,
 			)
-			js_listener_value = js_listener_result.get('result', {}).get('value', {})
-			if js_listener_value.get('success'):
-				self.logger.debug(f'Marked {js_listener_value.get("count", 0)} elements with JS click listeners')
+
+			result_object_id = js_listener_result.get('result', {}).get('objectId')
+			if result_object_id:
+				# Step 2: Get array properties to access each element
+				array_props = await cdp_session.cdp_client.send.Runtime.getProperties(
+					params={
+						'objectId': result_object_id,
+						'ownProperties': True,
+					},
+					session_id=cdp_session.session_id,
+				)
+
+				# Step 3: For each element, get its backend node ID via DOM.describeNode
+				element_object_ids: list[str] = []
+				for prop in array_props.get('result', []):
+					# Array indices are numeric property names
+					prop_name = prop.get('name', '') if isinstance(prop, dict) else ''
+					if isinstance(prop_name, str) and prop_name.isdigit():
+						prop_value = prop.get('value', {}) if isinstance(prop, dict) else {}
+						if isinstance(prop_value, dict):
+							object_id = prop_value.get('objectId')
+							if object_id and isinstance(object_id, str):
+								element_object_ids.append(object_id)
+
+				# Batch resolve backend node IDs (run in parallel)
+				async def get_backend_node_id(object_id: str) -> int | None:
+					try:
+						node_info = await cdp_session.cdp_client.send.DOM.describeNode(
+							params={'objectId': object_id},
+							session_id=cdp_session.session_id,
+						)
+						return node_info.get('node', {}).get('backendNodeId')
+					except Exception:
+						return None
+
+				# Resolve all element object IDs to backend node IDs in parallel
+				backend_ids = await asyncio.gather(*[get_backend_node_id(oid) for oid in element_object_ids])
+				js_click_listener_backend_ids = {bid for bid in backend_ids if bid is not None}
+
+				# Release the array object to avoid memory leaks
+				try:
+					await cdp_session.cdp_client.send.Runtime.releaseObject(
+						params={'objectId': result_object_id},
+						session_id=cdp_session.session_id,
+					)
+				except Exception:
+					pass  # Best effort cleanup
+
+				self.logger.debug(f'Detected {len(js_click_listener_backend_ids)} elements with JS click listeners')
 		except Exception as e:
 			self.logger.debug(f'Failed to detect JS event listeners: {e}')
+		js_listener_detection_ms = (time.time() - start_js_listener_detection) * 1000
 
 		# Define CDP request factories to avoid duplication
 		def create_snapshot_request():
@@ -457,9 +505,11 @@ class DomService:
 			device_pixel_ratio=device_pixel_ratio,
 			cdp_timing={
 				'iframe_scroll_detection_ms': iframe_scroll_ms,
+				'js_listener_detection_ms': js_listener_detection_ms,
 				'cdp_parallel_calls_ms': cdp_calls_ms,
 				'snapshot_processing_ms': snapshot_processing_ms,
 			},
+			js_click_listener_backend_ids=js_click_listener_backend_ids if js_click_listener_backend_ids else None,
 		)
 
 	@observe_debug(ignore_input=True, ignore_output=True, name='get_dom_tree')
@@ -497,6 +547,7 @@ class DomService:
 		ax_tree = trees.ax_tree
 		snapshot = trees.snapshot
 		device_pixel_ratio = trees.device_pixel_ratio
+		js_click_listener_backend_ids = trees.js_click_listener_backend_ids or set()
 
 		# Build AX tree lookup
 		start_ax = time.time()
@@ -621,6 +672,7 @@ class DomService:
 				ax_node=enhanced_ax_node,
 				snapshot_node=snapshot_data,
 				is_visible=None,
+				has_js_click_listener=node['backendNodeId'] in js_click_listener_backend_ids,
 				absolute_position=absolute_position,
 			)
 

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -196,6 +196,8 @@ class TargetAllTrees:
 	ax_tree: GetFullAXTreeReturns
 	device_pixel_ratio: float
 	cdp_timing: dict[str, float]
+	js_click_listener_backend_ids: set[int] | None = None
+	"""Backend node IDs of elements with JS click/mouse event listeners (detected via CDP getEventListeners)."""
 
 
 @dataclass(slots=True)
@@ -436,6 +438,12 @@ class EnhancedDOMTreeNode:
 
 	# Compound control child components information
 	_compound_children: list[dict[str, Any]] = field(default_factory=list)
+
+	has_js_click_listener: bool = False
+	"""
+	Whether this element has JS click/mouse event listeners attached (detected via CDP getEventListeners)
+	Used to identify clicks that don't use native interactive HTML tags
+	"""
 
 	uuid: str = field(default_factory=uuid7str)
 


### PR DESCRIPTION
Uses CDP Runtime.evaluate with includeCommandLineAPI to access getEventListeners() and mark elements with click/mousedown/pointerdown listeners before DOM snapshot capture. Fixes #958.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects JavaScript click/mouse listeners via CDP and treats those elements as clickable during the DOM snapshot. Resolves #958 and captures React/Vue/Angular click handlers without mutating the page.

- **New Features**
  - Use Runtime.evaluate (includeCommandLineAPI) with getEventListeners() to collect element refs, resolve to backend node IDs, and flag nodes as has_js_click_listener.
  - Update clickable element serializer to treat flagged nodes as interactive.

<sup>Written for commit 1794849886787c1cc66403107e3fbec4621540ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

