### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       IS_SANDBOX: '1'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
@@ -40,7 +40,7 @@ jobs:
         run: echo "PLAYWRIGHT_VERSION=$(uv pip list --format json | jq -r '.[] | select(.name == "playwright") | .version')" >> $GITHUB_ENV
 
       # - name: Cache chrome binaries
-      #   uses: actions/cache@v4
+      #   uses: actions/cache@v5
       #   with:
       #     path: |
       #       /tmp/google-chrome-stable_current_amd64.deb
@@ -55,7 +55,7 @@ jobs:
       # - run: playwright install chrome --with-deps
 
       - name: Cache chromium binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright

--- a/.github/workflows/cloud_evals.yml
+++ b/.github/workflows/cloud_evals.yml
@@ -20,7 +20,7 @@ jobs:
   trigger_cloud_eval_image_build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.TRIGGER_CLOUD_BUILD_GH_KEY }}
           script: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
     name: syntax-errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -31,7 +31,7 @@ jobs:
     name: code-style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -42,7 +42,7 @@ jobs:
     name: type-checker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -20,10 +20,10 @@ jobs:
     name: pip-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
       - run: uv build --python 3.12
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: dist-artifact
           path: |
@@ -42,9 +42,9 @@ jobs:
       ANONYMIZED_TELEMETRY: 'false'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v5
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: dist-artifact
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Create pre-release tag
         run: |
           git fetch --tags
@@ -74,7 +74,7 @@ jobs:
       IN_DOCKER: 'True'
       ANONYMIZED_TELEMETRY: 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
@@ -88,7 +88,7 @@ jobs:
       #   run: echo "PLAYWRIGHT_VERSION=$(uv pip list --format json | jq -r '.[] | select(.name == "playwright") | .version')" >> $GITHUB_ENV
 
       # - name: Cache playwright binaries
-      #   uses: actions/cache@v3
+      #   uses: actions/cache@v5
       #   with:
       #     path: |
       #       ~/.cache/ms-playwright

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           # General settings
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
 
       - name: Get week number for cache key
@@ -37,7 +37,7 @@ jobs:
 
       - name: Cache chromium binaries
         id: cache-chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright
@@ -56,7 +56,7 @@ jobs:
       TEST_FILENAMES: ${{ steps.lsgrep.outputs.TEST_FILENAMES }}
       # ["test_browser", "test_tools", "test_browser_session", "test_tab_management", ...]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Force fresh checkout to avoid any caching issues
           fetch-depth: 1
@@ -113,14 +113,14 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           activate-environment: true
 
       - name: Cache uv packages and venv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/uv
@@ -137,7 +137,7 @@ jobs:
 
       - name: Cache chromium binaries
         id: cache-chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright
@@ -150,7 +150,7 @@ jobs:
         run: uvx playwright install chromium --with-deps --no-shell
 
       - name: Cache browser-use extensions
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.config/browseruse/extensions
@@ -197,14 +197,14 @@ jobs:
       GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
       BROWSER_USE_API_KEY: ${{ secrets.BROWSER_USE_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           activate-environment: true
 
       - name: Cache uv packages and venv
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/uv
@@ -221,7 +221,7 @@ jobs:
 
       - name: Cache chromium binaries
         id: cache-chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright
@@ -234,7 +234,7 @@ jobs:
         run: uvx playwright install chromium --with-deps --no-shell
 
       - name: Cache browser-use extensions
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.config/browseruse/extensions
@@ -271,7 +271,7 @@ jobs:
 
       - name: Comment PR with agent evaluation results
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         continue-on-error: true
         with:
           script: |


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v3`](https://github.com/actions/cache/releases/tag/v3), [`v4`](https://github.com/actions/cache/releases/tag/v4) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | claude.yml, publish.yml, test.yaml |
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | claude.yml, docker.yml, lint.yml, package.yaml, publish.yml, test.yaml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | package.yaml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | cloud_evals.yml, test.yaml |
| `actions/stale` | [`v9`](https://github.com/actions/stale/releases/tag/v9) | [`v10`](https://github.com/actions/stale/releases/tag/v10) | [Release](https://github.com/actions/stale/releases/tag/v10) | stale-bot.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | package.yaml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/cache** (v3 → v5):
  - ⚠️ v4 uses a new caching backend - existing caches may not be reused on first run

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded GitHub Actions to Node 24–compatible versions to prevent CI failures when GitHub runners switch from Node 20. Keeps workflows working and retains SHA pinning for security.

- **Dependencies**
  - actions/checkout: v6
  - actions/cache: v5 (new backend; first run may not reuse existing caches)
  - actions/upload-artifact: v6
  - actions/download-artifact: v7
  - actions/github-script: v8
  - actions/stale: v10
  - Updated in: claude.yml, cloud_evals.yml, docker.yml, lint.yml, package.yaml, publish.yml, stale-bot.yml, test.yaml

- **Migration**
  - Expect a cache miss on the first run after merge.
  - Run the updated workflows on a branch to verify before merging.

<sup>Written for commit 82977f6be2c26b3291d84761e2885b29a53d44b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

