### PR TITLE
fix(#2867): verify dropdown selection and retry on framework revert

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2857,7 +2857,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 				# Check if selection was reverted by framework - try clicking as fallback
 				if selection_result.get('selectionReverted'):
-					self.logger.info(f'⚠️ Selection was reverted by page framework, trying click fallback...')
+					self.logger.info('⚠️ Selection was reverted by page framework, trying click fallback...')
 					target_option = selection_result.get('targetOption', {})
 					option_index = target_option.get('index', 0)
 


### PR DESCRIPTION
Resolves #2867.

The select_dropdown action was claiming success even when frameworks like Wix intercepted and reverted the programmatic selection. The agent would report task completion, but the dropdown value remained unchanged.

- Added verification after setting selection - checks if `element.value === expectedValue`
- If framework reverted the value, try click-based fallback (mousedown -> selectedIndex -> click option -> mouseup -> change)
- If both methods fail, properly report the error instead of claiming success
- Agent can then recover by clicking visible option elements directly

Only affects native `<select>` elements in `on_SelectDropdownOptionEvent`. ARIA/custom dropdowns already use click-based selection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropdown selection reliability by verifying the final value and retrying with a click-based fallback when frameworks revert programmatic changes. Aligns with #2867 so the agent no longer claims success when the value doesn’t stick.

- **Bug Fixes**
  - Verify selection after setting (element.value === expectedValue).
  - If reverted, use click-based fallback (focus, mousedown, set selectedIndex, click option, mouseup, change, blur).
  - If both methods fail, return a clear error so the agent can recover.
  - Provide target option and available options when a revert is detected to aid recovery.
  - Scope: affects native <select> in on_SelectDropdownOptionEvent; ARIA/custom dropdowns unchanged.

<sup>Written for commit 6f8c07793222c1ecde1fc7e4ba65d4bd8de8ec94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

