### PR TITLE
fix(cli): handle WinError 87 in is_server_running on Windows

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -44,7 +44,11 @@ def is_server_running(session: str) -> bool:
 		pid = int(pid_path.read_text().strip())
 		os.kill(pid, 0)
 		return True
-	except (OSError, ValueError):
+	except OSError as e:
+		if getattr(e, 'winerror', None) == 87:
+			return False
+		return False
+	except ValueError:
 		return False
 
 


### PR DESCRIPTION
Fixes:#3918 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent CLI crashes on Windows by handling WinError 87 in is_server_running; addresses #3918. If os.kill(pid, 0) raises WinError 87, we now return False and treat the server as not running.

<sup>Written for commit 6f49759d7d034dc133465a2bfcf602ef256f0b02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

