### PR TITLE
Fix #3912: Windows compatibility issues

### DIFF
--- a/browser_use/actor/page.py
+++ b/browser_use/actor/page.py
@@ -317,17 +317,16 @@ class Page:
 
 	async def set_content(self, html: str, timeout: float | None = None) -> None:
 		"""Set the content of the page.
-		
+
 		Args:
 			html: HTML content to set
 			timeout: Timeout in seconds (not used currently, kept for compatibility)
 		"""
-		import json
-		
+
 		# Use arrow function format required by evaluate()
 		# Pass HTML as argument to avoid escaping issues
 		js_code = '(html) => { document.open(); document.write(html); document.close(); }'
-		
+
 		await self.evaluate(js_code, html)
 
 	async def navigate(self, url: str) -> None:

--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -40,6 +40,7 @@ def is_server_running(session: str) -> bool:
 	try:
 		pid = int(pid_path.read_text().strip())
 		import psutil
+
 		return psutil.pid_exists(pid)
 	except (OSError, ValueError):
 		# OSError: PID file unreadable/locked, ValueError: invalid PID format


### PR DESCRIPTION
This PR fixes two Windows-specific issues that were preventing browser-use from working properly on Windows systems.

Problems Addressed

1. CLI server check fails on Windows
The is_server_running() function in skill_cli/utils.py was using os.kill(pid, 0) to check whether a process is alive. This works on Unix-based systems but fails on Windows, where signal 0 isn’t supported, resulting in a SystemError.

2. Missing set_content() method on Page
The Page class did not implement a set_content() method, which is part of the standard Playwright API. As a result, calls like page.set_content(html) raised an AttributeError, breaking scripts that rely on this functionality.

Solution

Fix 1: Cross-platform process check
Replaced os.kill(pid, 0) with psutil.pid_exists(pid), which works reliably across all platforms. Since psutil is already a dependency, this change introduces no additional requirements.

Fix 2: Implement set_content()
Added a set_content() method to the Page class. The method uses JavaScript evaluation with document.open(), document.write(), and document.close() to set the page HTML. This approach is robust and works consistently across different contexts.

Testing

Verified that psutil.pid_exists() correctly detects running processes on Windows
Confirmed that page.set_content() sets HTML content without errors
Ensured backward compatibility with existing functionality

Changes
browser_use/skill_cli/utils.py: replaced os.kill with psutil.pid_exists
browser_use/actor/page.py: added set_content() method
These updates make browser-use fully functional on Windows while keeping behavior unchanged on other platforms.

Fixes:#3912 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3912 by restoring Windows compatibility: switches the CLI process check to psutil.pid_exists and adds a Playwright-compatible Page.set_content(). This prevents server detection failures, avoids crashes on unreadable PID files, and stops AttributeError when setting page HTML.

- **Bug Fixes**
  - CLI: replace os.kill(pid, 0) with psutil.pid_exists(pid) and gracefully handle unreadable/locked PID files.
  - Page API: add set_content(html) using document.open/write/close via evaluate, matching Playwright behavior.

<sup>Written for commit 1761dddae0c020d7f2674c7094ed44740e422819. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

