### PR TITLE
feat: add bu-2-0 pricing

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -59,6 +59,7 @@ class ChatBrowserUse(BaseChatModel):
 		Args:
 			model: Model name to use. Options:
 				- 'bu-latest' or 'bu-1-0': Default model
+				- 'bu-2-0': Latest premium model
 				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
 			api_key: API key for browser-use cloud. Defaults to BROWSER_USE_API_KEY env var.
 			base_url: Base URL for the API. Defaults to BROWSER_USE_LLM_URL env var or production URL.

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -8,7 +8,7 @@ Usage:
     model = llm.azure_gpt_4_1_mini
     model = llm.openai_gpt_4o
     model = llm.google_gemini_2_5_pro
-    model = llm.bu_latest
+    model = llm.bu_latest  # or bu_1_0, bu_2_0
 """
 
 import os
@@ -83,6 +83,7 @@ cerebras_qwen_3_coder_480b: 'BaseChatModel'
 
 bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
+bu_2_0: 'BaseChatModel'
 
 
 def get_llm_by_name(model_name: str):
@@ -311,6 +312,7 @@ __all__ += [
 	# Browser Use instances - created on demand
 	'bu_latest',
 	'bu_1_0',
+	'bu_2_0',
 ]
 
 # NOTE: OCI backend is optional. The try/except ImportError and conditional __all__ are required

--- a/browser_use/tokens/custom_pricing.py
+++ b/browser_use/tokens/custom_pricing.py
@@ -10,14 +10,23 @@ from typing import Any
 # Format matches LiteLLM's model_prices_and_context_window.json structure
 CUSTOM_MODEL_PRICING: dict[str, dict[str, Any]] = {
 	'bu-1-0': {
-		'input_cost_per_token': 0.2 / 1_000_000,  # $0.50 per 1M tokens
-		'output_cost_per_token': 2.00 / 1_000_000,  # $3.00 per 1M tokens
-		'cache_read_input_token_cost': 0.02 / 1_000_000,  # $0.10 per 1M tokens
+		'input_cost_per_token': 0.2 / 1_000_000,  # $0.20 per 1M tokens
+		'output_cost_per_token': 2.00 / 1_000_000,  # $2.00 per 1M tokens
+		'cache_read_input_token_cost': 0.02 / 1_000_000,  # $0.02 per 1M tokens
 		'cache_creation_input_token_cost': None,  # Not specified
 		'max_tokens': None,  # Not specified
 		'max_input_tokens': None,  # Not specified
 		'max_output_tokens': None,  # Not specified
-	}
+	},
+	'bu-2-0': {
+		'input_cost_per_token': 0.60 / 1_000_000,  # $0.60 per 1M tokens
+		'output_cost_per_token': 3.50 / 1_000_000,  # $3.50 per 1M tokens
+		'cache_read_input_token_cost': 0.06 / 1_000_000,  # $0.06 per 1M tokens
+		'cache_creation_input_token_cost': None,  # Not specified
+		'max_tokens': None,  # Not specified
+		'max_input_tokens': None,  # Not specified
+		'max_output_tokens': None,  # Not specified
+	},
 }
 CUSTOM_MODEL_PRICING['bu-latest'] = CUSTOM_MODEL_PRICING['bu-1-0']
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -12,6 +12,6 @@ load_dotenv()
 
 agent = Agent(
 	task='Find the number of stars of the following repos: browser-use, playwright, stagehand, react, nextjs',
-	llm=ChatBrowserUse(),
+	llm=ChatBrowserUse(model='bu-2-0'),
 )
 agent.run_sync()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the bu-2-0 premium model with explicit pricing and SDK support. You can now select it via llm.bu_2_0 or ChatBrowserUse(model='bu-2-0').

- New Features
  - Added bu-2-0 pricing (input/output/cache) to CUSTOM_MODEL_PRICING.
  - Exposed bu_2_0 in browser_use.llm.models and listed it in ChatBrowserUse options.
  - Updated example to use bu-2-0; corrected bu-1-0 pricing comments.

<sup>Written for commit c011c529fcc846547bd51db4793b2369ba1bf0c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

