### PR TITLE
Increase BrowserStateRequestEvent timeout from 30s to 60s

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -198,7 +198,7 @@ class BrowserStateRequestEvent(BaseEvent[BrowserStateSummary]):
 	include_screenshot: bool = True
 	include_recent_events: bool = False
 
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStateRequestEvent', 30.0))  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStateRequestEvent', 60.0))  # seconds
 
 
 # class WaitForConditionEvent(BaseEvent):


### PR DESCRIPTION
## Summary
- Increased `BrowserStateRequestEvent` timeout from 30s to 60s

## Root Cause
Production data analysis (BU2, last 24h) revealed:
- **36.5% of consecutive failures** are `AsyncIO CancelledError` in `get_browser_state_summary`
- The `BrowserStateRequestEvent` has a **30 second timeout** which is too short
- Complex pages can take 30-60s for DOM extraction alone

## Why This Matters
The browser state request includes:
1. DOM tree extraction (can be 30-60s on complex pages)
2. Screenshot capture (~1-3s)
3. Various metadata collection

30s was cutting it too close. 60s provides 2x buffer.

## Configuration
Can be overridden via environment variable:
```bash
export TIMEOUT_BrowserStateRequestEvent=90
```

## Related PRs
- #3966 - LLM timeout increase (45s → 75s)
- #3967 - Step timeout increase (120s → 180s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration change that only increases the default timeout for `BrowserStateRequestEvent`; primary impact is potentially longer waits and resource usage before failing.
> 
> **Overview**
> Increases the default `event_timeout` for `BrowserStateRequestEvent` in `browser_use/browser/events.py` from 30s to 60s (still overridable via `TIMEOUT_BrowserStateRequestEvent`). This reduces premature cancellations when collecting browser state on complex pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5520053560978701adf36a1130ab7178680543b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased BrowserStateRequestEvent timeout from 30s to 60s to reduce AsyncIO CancelledError on complex pages and improve stability. The timeout remains configurable via the TIMEOUT_BrowserStateRequestEvent env var.

<sup>Written for commit b5520053560978701adf36a1130ab7178680543b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

