### PR TITLE
gemini thinking with in context params

### DIFF
--- a/browser_use/llm/google/serializer.py
+++ b/browser_use/llm/google/serializer.py
@@ -5,6 +5,7 @@ from google.genai.types import Content, ContentListUnion, Part
 from browser_use.llm.messages import (
 	AssistantMessage,
 	BaseMessage,
+	ContentPartTextParam,
 	SystemMessage,
 	UserMessage,
 )
@@ -94,7 +95,16 @@ class GoogleMessageSerializer:
 					# Handle Iterable of content parts
 					for part in message.content:
 						if part.type == 'text':
-							message_parts.append(Part.from_text(text=part.text))
+							# Use Part() directly to include thought_signature if present (Gemini 3)
+							if isinstance(part, ContentPartTextParam) and part.thought_signature is not None:
+								message_parts.append(
+									Part(
+										text=part.text,
+										thought_signature=part.thought_signature,
+									)
+								)
+							else:
+								message_parts.append(Part.from_text(text=part.text))
 						elif part.type == 'refusal':
 							message_parts.append(Part.from_text(text=f'[Refusal] {part.refusal}'))
 						elif part.type == 'image_url':

--- a/browser_use/llm/messages.py
+++ b/browser_use/llm/messages.py
@@ -29,6 +29,12 @@ def _format_image_url(url: str, max_length: int = 50) -> str:
 class ContentPartTextParam(BaseModel):
 	text: str
 	type: Literal['text'] = 'text'
+	thought_signature: bytes | None = None
+	"""Google Gemini 3 thought signature for this text part.
+
+	Required by Gemini 3 to maintain conversation coherence when sending
+	text parts back in the history. Other providers ignore this field.
+	"""
 
 	def __str__(self) -> str:
 		return f'Text: {_truncate(self.text)}'

--- a/browser_use/llm/views.py
+++ b/browser_use/llm/views.py
@@ -1,4 +1,6 @@
-from typing import Generic, TypeVar, Union
+from __future__ import annotations
+
+from typing import Any, Generic, TypeVar, Union
 
 from pydantic import BaseModel
 
@@ -36,6 +38,15 @@ class ChatInvokeCompletion(BaseModel, Generic[T]):
 
 	completion: T
 	"""The completion of the response."""
+
+	text_parts: list[Any] | None = None
+	"""Structured text parts with metadata (e.g., Gemini thought_signature).
+
+	Type: list[ContentPartTextParam] | None
+
+	When present, these parts should be used instead of raw completion string
+	to preserve thought signatures for Gemini 3 models in conversation history.
+	"""
 
 	# Thinking stuff
 	thinking: str | None = None


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Gemini 3 thinking support and in-context parameters. We now extract internal reasoning and preserve thought_signature on non-thinking text parts so conversations stay coherent across turns.

- **New Features**
  - Extracts Gemini 3 thinking and exposes it via completion.thinking.
  - Returns structured text_parts (non-thinking) with optional thought_signature.
  - Serializer sends thought_signature when present on text parts.
  - String completion still returned for compatibility.

- **Migration**
  - For Gemini 3, prefer using completion.text_parts to build the next message so thought_signature is preserved.
  - Do not send thinking content back; only pass non-thinking text parts with their signatures.
  - No changes needed for other providers.

<sup>Written for commit 4d19a343e82789333ff280de4c281ea9ba5aaaab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

