### PR TITLE
switched to bu-2-0 in all the examples

### DIFF
--- a/examples/browser/cloud_browser.py
+++ b/examples/browser/cloud_browser.py
@@ -21,7 +21,7 @@ async def basic():
 
 	agent = Agent(
 		task='Go to github.com/browser-use/browser-use and tell me the star count',
-		llm=ChatBrowserUse(),
+		llm=ChatBrowserUse(model='bu-2-0'),
 		browser=browser,
 	)
 
@@ -39,7 +39,7 @@ async def full_config():
 
 	agent = Agent(
 		task='go and check my ip address and the location',
-		llm=ChatBrowserUse(),
+		llm=ChatBrowserUse(model='bu-2-0'),
 		browser=browser,
 	)
 

--- a/examples/demo_mode_example.py
+++ b/examples/demo_mode_example.py
@@ -6,7 +6,7 @@ from browser_use import Agent, ChatBrowserUse
 async def main() -> None:
 	agent = Agent(
 		task='Please find the latest commit on browser-use/browser-use repo and tell me the commit message. Please summarize what it is about.',
-		llm=ChatBrowserUse(),
+		llm=ChatBrowserUse(model='bu-2-0'),
 		demo_mode=True,
 	)
 	await agent.run(max_steps=5)

--- a/examples/features/judge_trace.py
+++ b/examples/features/judge_trace.py
@@ -27,7 +27,7 @@ Round your result to the nearest 1000 hours and do not use any comma separators 
 
 
 async def main():
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 	agent = Agent(
 		task=task,
 		llm=llm,

--- a/examples/features/rerun_history.py
+++ b/examples/features/rerun_history.py
@@ -59,7 +59,7 @@ async def main():
 	# Example task to demonstrate history saving and rerunning
 	history_file = Path('agent_history.json')
 	task = 'Go to https://browser-use.github.io/stress-tests/challenges/reference-number-form.html and fill the form with example data and submit and extract the refernence number.'
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 
 	# Optional: Use custom LLMs for AI features during rerun
 	# Uncomment to use a custom LLM:

--- a/examples/getting_started/01_basic_search.py
+++ b/examples/getting_started/01_basic_search.py
@@ -19,7 +19,7 @@ from browser_use import Agent, ChatBrowserUse
 
 
 async def main():
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 	task = "Search Google for 'what is browser automation' and tell me the top 3 results"
 	agent = Agent(task=task, llm=llm)
 	await agent.run()

--- a/examples/getting_started/02_form_filling.py
+++ b/examples/getting_started/02_form_filling.py
@@ -30,7 +30,7 @@ from browser_use import Agent, ChatBrowserUse
 
 async def main():
 	# Initialize the model
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 
 	# Define a form filling task
 	task = """

--- a/examples/getting_started/03_data_extraction.py
+++ b/examples/getting_started/03_data_extraction.py
@@ -30,7 +30,7 @@ from browser_use import Agent, ChatBrowserUse
 
 async def main():
 	# Initialize the model
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 
 	# Define a data extraction task
 	task = """

--- a/examples/getting_started/04_multi_step_task.py
+++ b/examples/getting_started/04_multi_step_task.py
@@ -30,7 +30,7 @@ from browser_use import Agent, ChatBrowserUse
 
 async def main():
 	# Initialize the model
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 
 	# Define a multi-step task
 	task = """

--- a/examples/integrations/agentmail/2fa.py
+++ b/examples/integrations/agentmail/2fa.py
@@ -28,7 +28,7 @@ async def main():
 	tools = EmailTools(email_client=email_client, inbox=inbox)
 
 	# Initialize the LLM for browser-use agent
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 
 	# Set your local browser path
 	browser = Browser(executable_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome')

--- a/examples/models/browser_use_llm.py
+++ b/examples/models/browser_use_llm.py
@@ -22,7 +22,7 @@ if not os.getenv('BROWSER_USE_API_KEY'):
 async def main():
 	agent = Agent(
 		task='Find the number of stars of the browser-use repo',
-		llm=ChatBrowserUse(),
+		llm=ChatBrowserUse(model='bu-2-0'),
 	)
 
 	# Run the agent

--- a/examples/sandbox/example.py
+++ b/examples/sandbox/example.py
@@ -37,7 +37,7 @@ async def pydantic_example(browser: Browser):
 	agent = Agent(
 		"""go and check my ip address and the location. return the result in json format""",
 		browser=browser,
-		llm=ChatBrowserUse(),
+		llm=ChatBrowserUse(model='bu-2-0'),
 	)
 	res = await agent.run()
 

--- a/examples/sandbox/structured_output.py
+++ b/examples/sandbox/structured_output.py
@@ -29,7 +29,7 @@ async def get_ip_location(browser: Browser) -> AgentHistoryList:
 	agent = Agent(
 		task='Go to ipinfo.io and extract my IP address and location details (country, city, region)',
 		browser=browser,
-		llm=ChatBrowserUse(),
+		llm=ChatBrowserUse(model='bu-2-0'),
 		output_model_schema=IPLocation,
 	)
 	return await agent.run(max_steps=10)

--- a/examples/use-cases/buy_groceries.py
+++ b/examples/use-cases/buy_groceries.py
@@ -24,7 +24,7 @@ class GroceryCart(BaseModel):
 async def add_to_cart(items: list[str] = ['milk', 'eggs', 'bread']):
 	browser = Browser(cdp_url='http://localhost:9222')
 
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 
 	# Task prompt
 	task = f"""

--- a/examples/use-cases/pcpartpicker.py
+++ b/examples/use-cases/pcpartpicker.py
@@ -6,7 +6,7 @@ from browser_use import Agent, Browser, ChatBrowserUse, Tools
 async def main():
 	browser = Browser(cdp_url='http://localhost:9222')
 
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 
 	tools = Tools()
 

--- a/examples/use-cases/phone_comparison.py
+++ b/examples/use-cases/phone_comparison.py
@@ -34,7 +34,7 @@ async def find(item: str = 'Used iPhone 12'):
 	"""
 	browser = Browser(cdp_url='http://localhost:9222')
 
-	llm = ChatBrowserUse()
+	llm = ChatBrowserUse(model='bu-2-0')
 
 	# Task prompt
 	task = f"""


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated all examples to use ChatBrowserUse(model='bu-2-0') so they run against the current recommended model and produce consistent results. No library code changes.

- **Refactors**
  - Replaced ChatBrowserUse() with ChatBrowserUse(model='bu-2-0') across example folders (browser, getting_started, features, integrations, sandbox, use-cases).
  - No API changes; examples remain runnable as before.

<sup>Written for commit 20f4f2a98452577f342e22109b729da6981c3053. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

