### PR TITLE
fix: validate file size on upload and dynamic text extension list

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import os
 
 from cdp_use.cdp.input.commands import DispatchKeyEventParameters
 
@@ -2268,6 +2269,14 @@ class DefaultActionWatchdog(BaseWatchdog):
 			# Get CDP client and session
 			cdp_client = self.browser_session.cdp_client
 			session_id = await self._get_session_id_for_element(element_node)
+
+			# Validate file before upload
+			if os.path.exists(event.file_path):
+				file_size = os.path.getsize(event.file_path)
+				if file_size == 0:
+					msg = f'Upload failed - file {event.file_path} is empty (0 bytes).'
+					raise BrowserError(message=msg, long_term_memory=msg)
+				self.logger.debug(f'📎 File {event.file_path} validated ({file_size} bytes)')
 
 			# Set file(s) to upload
 			backend_node_id = element_node.backend_node_id

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -328,7 +328,11 @@ class FileSystem:
 					)
 					return result
 
-				if extension in ['md', 'txt', 'json', 'jsonl', 'csv']:
+				# Text-based extensions: derive from _file_types, excluding those with special readers
+				_special_extensions = {'docx', 'pdf', 'jpg', 'jpeg', 'png'}
+				text_extensions = [ext for ext in self._file_types if ext not in _special_extensions]
+
+				if extension in text_extensions:
 					import anyio
 
 					async with await anyio.open_file(full_filename, 'r') as f:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -469,10 +469,14 @@ class Tools(Generic[Context]):
 							msg = f'File path {params.path} is not available. To fix: The user must add this file path to the available_file_paths parameter when creating the Agent. Example: Agent(task="...", llm=llm, browser=browser, available_file_paths=["{params.path}"])'
 							raise BrowserError(message=msg, long_term_memory=msg)
 
-			# For local browsers, ensure the file exists on the local filesystem
+			# For local browsers, ensure the file exists and has content
 			if browser_session.is_local:
 				if not os.path.exists(params.path):
 					msg = f'File {params.path} does not exist'
+					return ActionResult(error=msg)
+				file_size = os.path.getsize(params.path)
+				if file_size == 0:
+					msg = f'File {params.path} is empty (0 bytes). The file may not have been saved correctly.'
 					return ActionResult(error=msg)
 
 			# Get the selector map to find the node


### PR DESCRIPTION
## Summary
- **Upload file 0-byte check** (service.py): Catches empty files early with a clear error message before they reach CDP, preventing the silent 0-byte upload failures seen across multiple platforms (23+ upload failures in last 2 weeks)
- **Upload watchdog 0-byte check** (default_action_watchdog.py): Validates file has content before `DOM.setFileInputFiles` CDP call — prevents empty files from being silently passed to websites
- **Dynamic text extension list** (file_system.py): Replaces hardcoded `['md', 'txt', 'json', 'jsonl', 'csv']` in `read_file_structured()` with dynamic derivation from `_file_types`, so new text-based file types automatically work for external file reading

## Context
From analysis of 60,968 Laminar judgements (Jan 15-29), file upload failures account for 23+ cases where the `upload_file` tool passes 0-byte files to websites, causing cascading failures. The "HERO.mp4 saga" — where one user tried 15+ websites and every upload was reported as 0 bytes — highlights this is a real issue. These checks catch the problem at the earliest point with a clear error message.

## Test plan
- [x] All 44 filesystem tests pass
- [x] Pre-commit hooks pass (ruff format, ruff check, pyright)
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit e072135590c0e5297b05b05dc15ff66f299a2c04. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents silent 0-byte uploads and makes text file reading auto-extensible. We now validate file size before any upload and derive supported text extensions from the central type list.

- **Bug Fixes**
  - Validate local files exist and are non-empty in the upload service; return a clear error.
  - Block 0-byte files in the CDP upload watchdog before DOM.setFileInputFiles; log file size.

- **New Features**
  - Derive text extensions in read_file_structured from _file_types (excluding special formats) so new text-based types work without code changes.

<sup>Written for commit e072135590c0e5297b05b05dc15ff66f299a2c04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

