### PR TITLE
feat: add extract_data action for efficient structured data extraction

### DIFF
--- a/browser_use/agent/system_prompts/system_prompt.md
+++ b/browser_use/agent/system_prompts/system_prompt.md
@@ -67,7 +67,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - By default, only elements in the visible viewport are listed.
 - If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack).
 - If the page is not fully loaded, use the wait action.
-- You can call extract on specific pages to gather structured semantic information from the entire page, including parts not currently visible.
+- For extracting **structured/tabular data** (product lists, search results, table rows), prefer `extract_data` with CSS selectors — it is much faster and cheaper than `extract`. Use `extract` only when you need semantic understanding or the data is unstructured.
 - Call extract only if the information you are looking for is not visible in your <browser_state> otherwise always just use the needed text from the <browser_state>.
 - Calling the extract tool is expensive! DO NOT query the same page with the same extract query multiple times. Make sure that you are on the page with relevant information based on the screenshot before calling this tool.
 - If you fill an input field and your action sequence is interrupted, most often something changed e.g. suggestions popped up under the field.
@@ -92,6 +92,27 @@ Strictly follow these rules while using the browser and navigating the web:
 - If the task is really long, initialize a `results.md` file to accumulate your results.
 - DO NOT use the file system if the task is less than 10 steps!
 </file_system>
+<data_extraction>
+When the task involves extracting data from web pages (scraping, collecting lists, gathering tabular data):
+
+**Choose the right tool:**
+- `extract_data` (CSS selectors) — Use for **structured, repeating elements**: product cards, table rows, list items, search results. Fast, cheap, no LLM cost. Example: `extract_data(selector="table tbody tr", attributes=["text"], save_to_file="data.csv")`
+- `extract` (LLM-powered) — Use for **unstructured or complex content** that needs interpretation: summarizing articles, answering questions about page content, extracting data that requires reasoning.
+- `evaluate` (JavaScript) — Use for **complex DOM operations**: shadow DOM, computed styles, dynamic content, or when you need to run custom logic.
+
+**Multi-page extraction pattern:**
+When you need data from multiple pages (pagination, sub-pages):
+1. Use `save_to_file` parameter on extract or extract_data to **accumulate results to a file** across pages — this keeps data out of your context window.
+2. Initialize a todo.md checklist to track pages processed.
+3. For paginated lists: extract current page data → click "Next" → extract again → repeat. Each call appends to the same file.
+4. For sub-page crawling: collect links first with `extract_data(selector="a.item-link", attributes=["href", "text"])`, then visit each.
+
+**Efficient patterns:**
+- When extracting 10+ items, ALWAYS use `save_to_file` to avoid filling your context window.
+- Use `.csv` for tabular data, `.jsonl` for JSON records with varied schemas.
+- Use `extract_data` first with a broad selector, then refine if needed.
+- Inspect the page DOM structure via browser_state before choosing selectors.
+</data_extraction>
 <task_completion_rules>
 You must call the `done` action in one of two cases:
 - When you have fully completed the USER REQUEST.

--- a/browser_use/agent/system_prompts/system_prompt_anthropic.md
+++ b/browser_use/agent/system_prompts/system_prompt_anthropic.md
@@ -67,7 +67,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - By default, only elements in the visible viewport are listed.
 - If a captcha appears, attempt solving it if possible. If not, use fallback strategies (e.g., alternative site, backtrack). Do not spend more than 3-4 steps on a single captcha - if blocked, try alternative approaches or report the limitation.
 - If the page is not fully loaded, use the wait action.
-- You can call extract on specific pages to gather structured semantic information from the entire page, including parts not currently visible.
+- For extracting **structured/tabular data** (product lists, search results, table rows), prefer `extract_data` with CSS selectors — it is much faster and cheaper than `extract`. Use `extract` only when you need semantic understanding or the data is unstructured.
 - Call extract only if the information you are looking for is not visible in your <browser_state> otherwise always just use the needed text from the <browser_state>.
 - Calling the extract tool is expensive! DO NOT query the same page with the same extract query multiple times. Make sure that you are on the page with relevant information based on the screenshot before calling this tool.
 - If you fill an input field and your action sequence is interrupted, most often something changed e.g. suggestions popped up under the field.
@@ -95,6 +95,27 @@ Strictly follow these rules while using the browser and navigating the web:
 - If the task is really long, initialize a `results.md` file to accumulate your results.
 - DO NOT use the file system if the task is less than 10 steps!
 </file_system>
+<data_extraction>
+When the task involves extracting data from web pages (scraping, collecting lists, gathering tabular data):
+
+**Choose the right tool:**
+- `extract_data` (CSS selectors) — Use for **structured, repeating elements**: product cards, table rows, list items, search results. Fast, cheap, no LLM cost. Example: `extract_data(selector="table tbody tr", attributes=["text"], save_to_file="data.csv")`
+- `extract` (LLM-powered) — Use for **unstructured or complex content** that needs interpretation: summarizing articles, answering questions about page content, extracting data that requires reasoning.
+- `evaluate` (JavaScript) — Use for **complex DOM operations**: shadow DOM, computed styles, dynamic content, or when you need to run custom logic.
+
+**Multi-page extraction pattern:**
+When you need data from multiple pages (pagination, sub-pages):
+1. Use `save_to_file` parameter on extract or extract_data to **accumulate results to a file** across pages — this keeps data out of your context window.
+2. Initialize a todo.md checklist to track pages processed.
+3. For paginated lists: extract current page data → click "Next" → extract again → repeat. Each call appends to the same file.
+4. For sub-page crawling: collect links first with `extract_data(selector="a.item-link", attributes=["href", "text"])`, then visit each.
+
+**Efficient patterns:**
+- When extracting 10+ items, ALWAYS use `save_to_file` to avoid filling your context window.
+- Use `.csv` for tabular data, `.jsonl` for JSON records with varied schemas.
+- Use `extract_data` first with a broad selector, then refine if needed.
+- Inspect the page DOM structure via browser_state before choosing selectors.
+</data_extraction>
 <task_completion_rules>
 You must call the `done` action in one of two cases:
 - When you have fully completed the USER REQUEST.

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -40,6 +40,7 @@ from browser_use.tools.views import (
 	CloseTabAction,
 	DoneAction,
 	ExtractAction,
+	ExtractDataAction,
 	GetDropdownOptionsAction,
 	InputTextAction,
 	NavigateAction,
@@ -671,6 +672,7 @@ class Tools(Generic[Context]):
 			query = params['query'] if isinstance(params, dict) else params.query
 			extract_links = params['extract_links'] if isinstance(params, dict) else params.extract_links
 			start_from_char = params['start_from_char'] if isinstance(params, dict) else params.start_from_char
+			save_to_file = params['save_to_file'] if isinstance(params, dict) else params.save_to_file
 
 			# Extract clean markdown using the unified method
 			try:
@@ -766,6 +768,22 @@ You will be given a query and the markdown of a webpage that has been filtered t
 					f'<url>\n{current_url}\n</url>\n<query>\n{query}\n</query>\n<result>\n{response.completion}\n</result>'
 				)
 
+				# If save_to_file is set, append to file and return short confirmation
+				if save_to_file:
+					file_obj = file_system.get_file(save_to_file)
+					if file_obj:
+						await file_system.append_file(save_to_file, f'\n{response.completion}\n')
+					else:
+						await file_system.write_file(save_to_file, response.completion + '\n')
+					line_count = len(response.completion.splitlines())
+					memory = f'Extracted {line_count} lines from {current_url} and saved to {save_to_file}. Query: {query}'
+					logger.info(f'📄 {memory}')
+					return ActionResult(
+						extracted_content=memory,
+						include_extracted_content_only_once=False,
+						long_term_memory=memory,
+					)
+
 				# Simple memory handling
 				MAX_MEMORY_LENGTH = 10000
 				if len(extracted_content) < MAX_MEMORY_LENGTH:
@@ -785,6 +803,149 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			except Exception as e:
 				logger.debug(f'Error extracting content: {e}')
 				raise RuntimeError(str(e))
+
+		@self.registry.action(
+			"""Extract structured data from page using CSS selectors. Much faster and cheaper than extract for structured/tabular data. Uses querySelectorAll to find elements, then extracts specified attributes. Use "text" for innerText, "href" for links, or any HTML attribute. Set save_to_file to accumulate data across pages without consuming context. Returns JSON array of objects.""",
+			param_model=ExtractDataAction,
+		)
+		async def extract_data(
+			params: ExtractDataAction,
+			browser_session: BrowserSession,
+			file_system: FileSystem,
+		):
+			selector = params['selector'] if isinstance(params, dict) else params.selector
+			attributes = params['attributes'] if isinstance(params, dict) else params.attributes
+			save_to_file = params['save_to_file'] if isinstance(params, dict) else params.save_to_file
+			max_results = params['max_results'] if isinstance(params, dict) else params.max_results
+
+			# Build JavaScript to extract data using CSS selectors
+			# The JS runs querySelectorAll and extracts requested attributes for each element
+			attrs_js = json.dumps(attributes)
+			js_code = f"""
+(function() {{
+	try {{
+		const elements = document.querySelectorAll({json.dumps(selector)});
+		const maxResults = {max_results};
+		const attrs = {attrs_js};
+		const results = [];
+		const limit = Math.min(elements.length, maxResults);
+		for (let i = 0; i < limit; i++) {{
+			const el = elements[i];
+			const row = {{}};
+			for (const attr of attrs) {{
+				if (attr === 'text') {{
+					row['text'] = el.innerText ? el.innerText.trim() : '';
+				}} else if (attr === 'html') {{
+					row['html'] = el.innerHTML ? el.innerHTML.trim() : '';
+				}} else {{
+					row[attr] = el.getAttribute(attr) || '';
+				}}
+			}}
+			results.push(row);
+		}}
+		return JSON.stringify({{
+			total_on_page: elements.length,
+			extracted: results.length,
+			data: results
+		}});
+	}} catch(e) {{
+		return JSON.stringify({{error: e.message}});
+	}}
+}})()
+""".strip()
+
+			try:
+				cdp_session = await browser_session.get_or_create_cdp_session()
+				result = await cdp_session.cdp_client.send.Runtime.evaluate(
+					params={'expression': js_code, 'returnByValue': True, 'awaitPromise': True},
+					session_id=cdp_session.session_id,
+				)
+
+				if result.get('exceptionDetails'):
+					error_msg = f'extract_data JavaScript error: {result["exceptionDetails"].get("text", "Unknown")}'
+					return ActionResult(error=error_msg)
+
+				result_value = result.get('result', {}).get('value', '{}')
+				if isinstance(result_value, str):
+					parsed = json.loads(result_value)
+				else:
+					parsed = result_value
+
+				if 'error' in parsed:
+					return ActionResult(error=f'extract_data error: {parsed["error"]}')
+
+				total_on_page = parsed.get('total_on_page', 0)
+				extracted_count = parsed.get('extracted', 0)
+				data = parsed.get('data', [])
+
+				current_url = await browser_session.get_current_page_url()
+
+				# If save_to_file is set, write data to file and return short confirmation
+				if save_to_file and data:
+					is_csv = save_to_file.endswith('.csv')
+					is_jsonl = save_to_file.endswith('.jsonl')
+
+					if is_csv:
+						import csv
+						import io
+
+						output = io.StringIO()
+						file_obj = file_system.get_file(save_to_file)
+						# Write header only if file is new/empty
+						write_header = file_obj is None or not file_obj.content.strip()
+						writer = csv.DictWriter(output, fieldnames=data[0].keys())
+						if write_header:
+							writer.writeheader()
+						writer.writerows(data)
+						file_content = output.getvalue()
+					elif is_jsonl:
+						file_content = '\n'.join(json.dumps(row, ensure_ascii=False) for row in data) + '\n'
+					else:
+						file_content = json.dumps(data, ensure_ascii=False, indent=2) + '\n'
+
+					file_obj = file_system.get_file(save_to_file)
+					if file_obj:
+						await file_system.append_file(save_to_file, file_content)
+					else:
+						await file_system.write_file(save_to_file, file_content)
+
+					memory = f'Extracted {extracted_count} items (of {total_on_page} on page) from {current_url} using selector "{selector}" → saved to {save_to_file}'
+					logger.info(f'📊 {memory}')
+					return ActionResult(
+						extracted_content=memory,
+						include_extracted_content_only_once=False,
+						long_term_memory=memory,
+					)
+
+				# No save_to_file: return data in context
+				if not data:
+					memory = f'No elements found matching selector "{selector}" on {current_url}'
+					logger.info(f'📊 {memory}')
+					return ActionResult(extracted_content=memory, long_term_memory=memory)
+
+				# Format for context
+				result_json = json.dumps(data, ensure_ascii=False, indent=2)
+				extracted_content = f'Extracted {extracted_count} items (of {total_on_page} on page) from {current_url} using "{selector}":\n{result_json}'
+
+				MAX_MEMORY_LENGTH = 10000
+				if len(extracted_content) < MAX_MEMORY_LENGTH:
+					memory = extracted_content
+					include_once = False
+				else:
+					file_name = await file_system.save_extracted_content(extracted_content)
+					memory = f'Extracted {extracted_count} items using "{selector}" → saved to {file_name} and in <read_state>'
+					include_once = True
+
+				logger.info(f'📊 {memory}')
+				return ActionResult(
+					extracted_content=extracted_content,
+					include_extracted_content_only_once=include_once,
+					long_term_memory=memory,
+				)
+
+			except Exception as e:
+				logger.debug(f'Error in extract_data: {e}')
+				raise RuntimeError(f'extract_data failed: {str(e)}')
 
 		@self.registry.action(
 			"""Scroll by pages. REQUIRED: down=True/False (True=scroll down, False=scroll up, default=True). Optional: pages=0.5-10.0 (default 1.0). Use index for scroll elements (dropdowns/custom UI). High pages (10) reaches bottom. Multi-page scrolls sequentially. Viewport-based height, fallback 1000px/page.""",

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -12,6 +12,26 @@ class ExtractAction(BaseModel):
 	start_from_char: int = Field(
 		default=0, description='Use this for long markdowns to start from a specific character (not index in browser_state)'
 	)
+	save_to_file: str | None = Field(
+		default=None,
+		description='If set, append extracted content to this file (e.g. "results.csv") instead of returning all tokens. Use for multi-page extraction to accumulate data across pages.',
+	)
+
+
+class ExtractDataAction(BaseModel):
+	selector: str = Field(description='CSS selector to match elements, e.g. "table tr", ".product-card", "ul.results > li"')
+	attributes: list[str] = Field(
+		default=['text'],
+		description='List of attributes to extract per element. Use "text" for innerText, "href" for links, or any HTML attribute name like "src", "data-id", etc.',
+	)
+	save_to_file: str | None = Field(
+		default=None,
+		description='If set, append extracted rows to this file as JSON lines (e.g. "data.jsonl") or CSV (e.g. "data.csv"). Keeps data out of context window.',
+	)
+	max_results: int = Field(
+		default=10000,
+		description='Maximum number of elements to extract. Prevents accidental extraction of huge DOMs.',
+	)
 
 
 class SearchAction(BaseModel):


### PR DESCRIPTION
## Summary

- **New `extract_data` action** — Uses CSS selectors (`querySelectorAll`) to extract structured data directly from the page without any LLM cost. Supports extracting `text`, `href`, `src`, or any HTML attribute. Returns structured JSON and optionally saves directly to CSV/JSONL/JSON files.
- **New `save_to_file` parameter on `extract`** — LLM-extracted content can now be written directly to a file instead of consuming context window tokens. Enables accumulating data across multiple pages without blowing up the agent's memory.
- **New `<data_extraction>` section in system prompts** — Guides the agent on when to use `extract_data` vs `extract` vs `evaluate`, and documents the multi-page extraction pattern (extract → click Next → extract → repeat with `save_to_file` appending to same file).

## Problem

Data extraction tasks are the #1 use case for power users (20 of 72 users with 100+ tasks). But the agent is bad at:
1. **Extracting 100+ items from a page** — forces all tokens through LLM output, expensive and slow
2. **Looping through 10+ pages** — no guidance on pagination patterns, fills context window
3. **Saving to files** — can't accumulate data across pages without re-outputting everything
4. **Structured data** — uses expensive LLM extraction even for simple table/list data that CSS selectors handle trivially

## Solution

### `extract_data` action (zero LLM cost)
```python
# Extract all product cards with names, prices, and links
extract_data(
    selector=".product-card",
    attributes=["text", "href", "data-price"],
    save_to_file="products.csv"
)
```
- Runs `querySelectorAll` via CDP JavaScript evaluation
- Extracts specified attributes from each matching element
- Optionally saves directly to CSV (with auto-headers), JSONL, or JSON
- Returns count summary instead of all data → keeps context clean

### `save_to_file` on `extract`
```python
# LLM extraction that saves directly to file
extract(
    query="Extract all company names and their revenue",
    save_to_file="companies.jsonl"
)
```
- Appends LLM-extracted content to file instead of returning in context
- Enables multi-page accumulation: extract page 1 → click Next → extract page 2 → same file

### System prompt guidance
New `<data_extraction>` section teaches the agent:
- When to use `extract_data` (structured) vs `extract` (semantic) vs `evaluate` (complex JS)
- Multi-page pagination pattern with `save_to_file`
- Best practices: always use `save_to_file` for 10+ items, use CSV for tables, JSONL for varied schemas

## Test plan
- [ ] Verify `extract_data` with simple CSS selector on a page with a table
- [ ] Verify `extract_data` with `save_to_file` writes correct CSV with headers
- [ ] Verify `extract_data` with `save_to_file` appends on second call (no duplicate headers)
- [ ] Verify `extract` with `save_to_file` writes to file and returns short memory
- [ ] Verify agent uses `extract_data` when given a data extraction task
- [ ] Verify multi-page extraction pattern works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds extract_data for fast, zero-LLM structured scraping via CSS selectors, plus save_to_file on extract to accumulate results across pages without filling context. Updates system prompts to guide when to use extract_data vs extract vs evaluate.

- **New Features**
  - add extract_data: uses querySelectorAll with CSS selectors; extracts text/href/html/any attribute; supports max_results; returns JSON or saves to CSV/JSONL/JSON; when saving, returns a short count summary
  - add save_to_file to extract: appends LLM-extracted content to a file instead of returning all tokens; ideal for multi-page runs
  - update system prompts: new <data_extraction> section with tool selection rules and a pagination pattern (extract → click Next → repeat, appending to the same file)

<sup>Written for commit 6c53f20d114b7478750bfc5875cc86b5f050dab4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

