### PR TITLE
fix: wrong command to install browser-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ BROWSER_USE_API_KEY=your-key
 
 **4. Install Chromium browser:**
 ```bash
-uvx browser-use install
+uv pip install browser-use
 ```
 
 **5. Run your first agent:**


### PR DESCRIPTION
install using pip instead

error message: 
```
➜  browseruse git:(master) ✗ uvx browser-use install                    
usage: browser-use [-h] [--session SESSION] [--browser {chromium,real,remote}] [--headed] [--profile PROFILE] [--json]
                   [--api-key API_KEY]
                   {open,click,type,input,scroll,back,screenshot,state,switch,close-tab,keys,select,eval,extract,python,run,sessions,close,server}
                   ...
browser-use: error: argument command: invalid choice: 'install' (choose from 'open', 'click', 'type', 'input', 'scroll', 'back', 'screenshot', 'state', 'switch', 'close-tab', 'keys', 'select', 'eval', 'extract', 'python', 'run', 'sessions', 'close', 'server')
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the README install command to use "uv pip install browser-use" instead of "uvx browser-use install". This prevents the "invalid choice: install" CLI error and clarifies the installation step.

<sup>Written for commit 9a058753b23cb5570ea591d17b6a5401b3ecbb66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

