### PR TITLE
added optional file_name param to ss action

### DIFF
--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -98,6 +98,15 @@ class NoParamsAction(BaseModel):
 	description: str | None = Field(None, description='Optional description for the action')
 
 
+class ScreenshotAction(BaseModel):
+	model_config = ConfigDict(extra='ignore')
+
+	file_name: str | None = Field(
+		default=None,
+		description='If provided, saves screenshot to this file and returns path. Otherwise screenshot is included in next observation.',
+	)
+
+
 class GetDropdownOptionsAction(BaseModel):
 	index: int
 


### PR DESCRIPTION
so it can return path if it needs; resolves 833 failures where agents tried write_file with .png and got rejected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an optional file_name to the screenshot action so you can save a PNG and get the path back. Keeps the old “include in next observation” behavior and avoids failures where agents tried write_file with .png.

- **New Features**
  - Added ScreenshotAction with file_name; sanitizes name and appends .png if missing.
  - When provided, saves viewport screenshot to the workspace directory and returns the path in attachments; when omitted, sets include_screenshot for the next observation.

<sup>Written for commit a81a4937941f8005dd6a1d85dd2a948b42915b99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

