### PR TITLE
Revert "feat(cli): add --cdp-url flag to connect to existing browser …

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -68,9 +68,7 @@ def connect_to_server(session: str, timeout: float = 60.0) -> socket.socket:
 	return sock
 
 
-def ensure_server(
-	session: str, browser: str, headed: bool, profile: str | None, api_key: str | None, cdp_url: str | None = None
-) -> bool:
+def ensure_server(session: str, browser: str, headed: bool, profile: str | None, api_key: str | None) -> bool:
 	"""Start server if not running. Returns True if started."""
 	# Check if server is already running and responsive
 	if is_server_running(session):
@@ -95,8 +93,6 @@ def ensure_server(
 		cmd.append('--headed')
 	if profile:
 		cmd.extend(['--profile', profile])
-	if cdp_url:
-		cmd.extend(['--cdp-url', cdp_url])
 
 	# Set up environment
 	env = os.environ.copy()
@@ -198,7 +194,6 @@ Examples:
 	parser.add_argument('--profile', help='Chrome profile (real browser mode)')
 	parser.add_argument('--json', action='store_true', help='Output as JSON')
 	parser.add_argument('--api-key', help='Browser-Use API key')
-	parser.add_argument('--cdp-url', help='CDP URL to connect to existing browser (e.g., http://localhost:9222)')
 
 	subparsers = parser.add_subparsers(dest='command', help='Command to execute')
 
@@ -344,17 +339,6 @@ def main() -> int:
 	parser = build_parser()
 	args = parser.parse_args()
 
-	# Use different default session for CDP URL to avoid conflicts with other browser modes.
-	# This prevents issues where an existing 'default' session (e.g., using chromium mode)
-	# would be reused when the user specifies --cdp-url, since session parameters are
-	# set at creation time. The same issue would occur switching between any browser modes
-	# (e.g., --browser chromium to --browser real), but CDP is the most common case where
-	# users expect to connect to a specific existing browser.
-	# NOTE: This must happen before any command handling (server, sessions, close --all)
-	# so that those commands also target the correct session.
-	if getattr(args, 'cdp_url', None) and args.session == 'default':
-		args.session = 'cdp-default'
-
 	if not args.command:
 		parser.print_help()
 		return 0
@@ -420,11 +404,11 @@ def main() -> int:
 			return 1
 
 	# Ensure server is running
-	ensure_server(args.session, args.browser, args.headed, args.profile, args.api_key, getattr(args, 'cdp_url', None))
+	ensure_server(args.session, args.browser, args.headed, args.profile, args.api_key)
 
 	# Build params from args
 	params = {}
-	skip_keys = {'command', 'session', 'browser', 'headed', 'profile', 'json', 'api_key', 'server_command', 'cdp_url'}
+	skip_keys = {'command', 'session', 'browser', 'headed', 'profile', 'json', 'api_key', 'server_command'}
 
 	for key, value in vars(args).items():
 		if key not in skip_keys and value is not None:

--- a/browser_use/skill_cli/server.py
+++ b/browser_use/skill_cli/server.py
@@ -32,13 +32,11 @@ class SessionServer:
 		browser_mode: str,
 		headed: bool,
 		profile: str | None,
-		cdp_url: str | None = None,
 	) -> None:
 		self.session_name = session_name
 		self.browser_mode = browser_mode
 		self.headed = headed
 		self.profile = profile
-		self.cdp_url = cdp_url
 		self.running = True
 		self._server: asyncio.Server | None = None
 		self._shutdown_event: asyncio.Event | None = None
@@ -125,7 +123,6 @@ class SessionServer:
 				self.browser_mode,
 				self.headed,
 				self.profile,
-				self.cdp_url,
 			)
 
 			# Dispatch to handler
@@ -241,7 +238,6 @@ def main() -> None:
 	parser.add_argument('--browser', default='chromium', choices=['chromium', 'real', 'remote'])
 	parser.add_argument('--headed', action='store_true', help='Show browser window')
 	parser.add_argument('--profile', help='Chrome profile (real browser mode)')
-	parser.add_argument('--cdp-url', help='CDP URL to connect to existing browser')
 	args = parser.parse_args()
 
 	logger.info(f'Starting server for session: {args.session}')
@@ -252,7 +248,6 @@ def main() -> None:
 		browser_mode=args.browser,
 		headed=args.headed,
 		profile=args.profile,
-		cdp_url=getattr(args, 'cdp_url', None),
 	)
 
 	try:


### PR DESCRIPTION
…via CDP (#3927)"

This reverts commit e0504b1c7dd4f0fbec091354f4e2a5ba9776e1bd, reversing changes made to f798633548f2da90019aaf0516672272039a8921.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts external CDP support in the CLI by removing the --cdp-url flag and related session/server logic. The CLI now supports only chromium, real, and remote modes.

- **Refactors**
  - Removed --cdp-url CLI option and parsing.
  - Simplified ensure_server and session creation APIs (no cdp_url parameter).
  - Dropped cdp-specific session naming and logging.
  - Removed CDP precedence from create_browser_session; only standard modes remain.

- **Migration**
  - Remove any use of --cdp-url in scripts or docs.
  - Use chromium, real (with --profile), or remote modes instead.

<sup>Written for commit a7250241b2a33c473ef1bb792cca60e42c0bc882. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

