### PR TITLE
docs: add quotes around browser-use[cli] for shell compatibility

### DIFF
--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -12,10 +12,10 @@ The `browser-use` command provides fast, persistent browser automation. It maint
 
 ```bash
 # Run without installing (recommended for one-off use)
-uvx browser-use[cli] open https://example.com
+uvx "browser-use[cli]" open https://example.com
 
 # Or install permanently
-uv pip install browser-use[cli]
+uv pip install "browser-use[cli]"
 
 # Install browser dependencies (Chromium)
 browser-use install


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add quotes around browser-use[cli] in CLI examples to prevent bracket expansion and ensure cross-shell compatibility. Updates uvx and pip install commands in SKILL.md.

<sup>Written for commit 00ec02ea21c0eab31757a6f76730c710f5f4ddf3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

