### PR TITLE
feat(download): support agent-local downloads for remote browsers

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -410,6 +410,10 @@ class BrowserLaunchArgs(BaseModel):
 		description='Directory to save downloads to.',
 		validation_alias=AliasChoices('downloads_dir', 'save_downloads_path'),
 	)
+	download_from_remote_browser: bool = Field(
+		default=False,
+		description='When True and using a remote browser (CDP/cloud/Docker), download files to the agent local filesystem via HTTP fetch instead of the browser container. Files become accessible to the agent.',
+	)
 	traces_dir: str | Path | None = Field(
 		default=None,
 		description='Directory for saving playwright trace.zip files (playwright actions, screenshots, DOM snapshots, HAR traces).',

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -170,6 +170,7 @@ class BrowserSession(BaseModel):
 		user_data_dir: str | Path | None = None,
 		args: list[str] | None = None,
 		downloads_path: str | Path | None = None,
+		download_from_remote_browser: bool | None = None,
 		# Common params
 		headers: dict[str, str] | None = None,
 		allowed_domains: list[str] | None = None,
@@ -245,6 +246,7 @@ class BrowserSession(BaseModel):
 		chromium_sandbox: bool | None = None,
 		devtools: bool | None = None,
 		downloads_path: str | Path | None = None,
+		download_from_remote_browser: bool | None = None,
 		traces_dir: str | Path | None = None,
 		# From BrowserContextArgs
 		accept_downloads: bool | None = None,

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -877,8 +877,7 @@ class DownloadsWatchdog(BaseWatchdog):
 
 			# For remote browsers with download_from_remote_browser: fetch file in-browser and save to agent local fs
 			use_fetch_for_remote = (
-				not self.browser_session.is_local
-				and self.browser_session.browser_profile.download_from_remote_browser
+				not self.browser_session.is_local and self.browser_session.browser_profile.download_from_remote_browser
 			)
 			# Try manual JavaScript fetch as a fallback for local browsers (disabled for regular local downloads)
 			if use_fetch_for_remote or (self.browser_session.is_local and self._use_js_fetch_for_local):

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -67,6 +67,7 @@ class DownloadsWatchdog(BaseWatchdog):
 	_network_monitored_targets: set[str] = PrivateAttr(default_factory=set)  # Track targets with network monitoring enabled
 	_detected_downloads: set[str] = PrivateAttr(default_factory=set)  # Track detected download URLs to avoid duplicates
 	_network_callback_registered: bool = PrivateAttr(default=False)  # Track if global network callback is registered
+	_use_js_fetch_for_local: bool = PrivateAttr(default=False)  # Guard for JS fetch fallback path (local browsers only)
 
 	# Direct callback support for download waiting (bypasses event bus for synchronization)
 	_download_start_callbacks: list[Any] = PrivateAttr(default_factory=list)  # Callbacks for download start
@@ -924,9 +925,7 @@ class DownloadsWatchdog(BaseWatchdog):
 						except ValueError:
 							pass
 					if cdp_session is None:
-						cdp_session = await self.browser_session.get_or_create_cdp_session(
-							target_id=target_id, focus=False
-						)
+						cdp_session = await self.browser_session.get_or_create_cdp_session(target_id=target_id, focus=False)
 					assert cdp_session
 
 					result = await cdp_session.cdp_client.send.Runtime.evaluate(

--- a/browser_use/skill_cli/__init__.py
+++ b/browser_use/skill_cli/__init__.py
@@ -12,8 +12,6 @@ Usage:
     browser-use close
 """
 
-__all__ = ['main']
-
 
 def __getattr__(name: str):
 	"""Lazy import to avoid runpy warnings when running as module."""

--- a/tests/ci/browser/test_remote_download.py
+++ b/tests/ci/browser/test_remote_download.py
@@ -4,7 +4,6 @@ When download_from_remote_browser is True and using a remote browser (is_local=F
 downloads are fetched in-browser and saved to the agent's local filesystem.
 """
 
-
 from browser_use.browser.profile import BrowserProfile
 
 

--- a/tests/ci/browser/test_remote_download.py
+++ b/tests/ci/browser/test_remote_download.py
@@ -1,0 +1,34 @@
+"""Test remote browser download support.
+
+When download_from_remote_browser is True and using a remote browser (is_local=False),
+downloads are fetched in-browser and saved to the agent's local filesystem.
+"""
+
+
+from browser_use.browser.profile import BrowserProfile
+
+
+def test_browser_profile_accepts_download_from_remote_browser():
+	"""BrowserProfile accepts download_from_remote_browser flag."""
+	profile = BrowserProfile(download_from_remote_browser=True)
+	assert profile.download_from_remote_browser is True
+
+	profile_default = BrowserProfile()
+	assert profile_default.download_from_remote_browser is False
+
+
+async def test_download_from_remote_browser_flag_flows_to_session(browser_session, mock_llm):
+	"""When creating Browser with download_from_remote_browser=True, the profile has the flag set."""
+	from browser_use import Agent
+	from browser_use.browser import BrowserSession
+	from browser_use.browser.profile import BrowserProfile
+
+	profile = BrowserProfile(headless=True, user_data_dir=None, download_from_remote_browser=True)
+	session = BrowserSession(browser_profile=profile)
+	await session.start()
+	try:
+		assert session.browser_profile.download_from_remote_browser is True
+		agent = Agent(task='test', llm=mock_llm, browser_session=session)
+		assert agent.browser_session.browser_profile.download_from_remote_browser is True
+	finally:
+		await session.kill()

--- a/tests/ci/security/test_safe_code_execution.py
+++ b/tests/ci/security/test_safe_code_execution.py
@@ -1,0 +1,57 @@
+"""Test opt-in safe code execution for REPL path."""
+
+import os
+
+import pytest
+
+from browser_use.skill_cli.python_session import SAFE_CODE_EXECUTION, _safe_exec
+
+
+class TestSafeCodeExecution:
+	"""Test _safe_exec blocks dangerous operations."""
+
+	def test_safe_exec_blocks_import_builtin(self):
+		"""Block __import__ and similar dangerous builtins."""
+		with pytest.raises(ValueError, match='Disallowed function'):
+			_safe_exec("__import__('os').system('echo hacked')", {})
+
+	def test_safe_exec_blocks_import_statement(self):
+		"""Block import statements via explicit AST check."""
+		with pytest.raises(ValueError, match='Import statements are not allowed'):
+			_safe_exec('import os', {})
+
+	def test_safe_exec_blocks_import_from(self):
+		"""Block from x import y statements."""
+		with pytest.raises(ValueError, match='Import statements are not allowed'):
+			_safe_exec('from os import system', {})
+
+	def test_safe_exec_allows_simple_expressions(self):
+		"""Allow simple expressions and assignments."""
+		ns: dict = {}
+		_safe_exec('x = 1 + 2', ns)
+		assert ns['x'] == 3
+
+	def test_safe_exec_allows_print(self):
+		"""Allow print (in safe_builtins)."""
+		ns: dict = {}
+		_safe_exec('print("hello")', ns)
+		# No exception, print executed
+
+	def test_safe_exec_copies_back_variables(self):
+		"""Safe variables are copied back to parent namespace."""
+		ns: dict = {}
+		_safe_exec('r = {"a": 1}', ns)
+		assert ns['r'] == {'a': 1}
+
+	def test_safe_exec_isolates_namespace_no_escape(self):
+		"""Dangerous objects in parent namespace are NOT visible (no os.system escape)."""
+		ns: dict = {'os': __import__('os')}
+		with pytest.raises((NameError, ValueError)):
+			_safe_exec('os.system("echo pwned")', ns)
+
+
+def test_safe_code_execution_flag_default_off():
+	"""SAFE_CODE_EXECUTION defaults to False when env not set."""
+	# Avoid pollution from other tests - check default
+	if 'BROWSER_USE_SAFE_CODE_EXECUTION' not in os.environ:
+		assert SAFE_CODE_EXECUTION is False


### PR DESCRIPTION
### Summary
Minimal support for remote browser downloads by allowing files to be saved to the agent’s local filesystem when using remote or containerized browsers.

### Changes
- Add `BrowserProfile` flag `download_from_remote_browser`
- On download events, fetch file in-browser and save to agent local fs (existing JS fetch path)
- Existing behavior unchanged when the flag is off
- Add tests for the flag and its flow into the session

### Motivation
Remote browser setups (Docker, cloud, etc.) currently download into the browser container, making files inaccessible to the agent. This flag enables agent-local downloads without changing agent prompts or progress tracking.

### Related
- Inspired by #3875
- Addresses #3879

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds agent‑local downloads for remote/CDP/cloud/Docker browsers by fetching files in‑page and saving to the agent’s filesystem. Also tightens optional safe REPL mode and keeps structured output JSON clean when the simple judge runs.

- **New Features**
  - Added BrowserProfile flag download_from_remote_browser (flows into BrowserSession and Agent).
  - For remote sessions, fetch in the initiating frame (CDP session fallback) and save to downloads_dir with unique filenames; uses _track_download for unified completion; local behavior unchanged.
  - Opt‑in safe REPL (BROWSER_USE_SAFE_CODE_EXECUTION) that blocks imports and dangerous builtins/attributes while preserving browser and user vars.

- **Bug Fixes**
  - Remote progress path manually fires download‑complete callbacks and dispatches FileDownloadedEvent when no local file exists; handled guard prevents double‑fire; restored use_fetch_for_remote and frameId fallback to avoid click handler timeouts.
  - Simple judge: store override note in ActionResult.judge_note, keeping extracted_content untouched so structured_output JSON parses reliably.

<sup>Written for commit b2279aff78f8fcc1dfc95fb405f8920807b628c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

