### PR TITLE
fix(docker): update chromium path to support playwright 1.57.0+

### DIFF
--- a/docker/base-images/chromium/Dockerfile
+++ b/docker/base-images/chromium/Dockerfile
@@ -9,7 +9,7 @@ RUN --mount=type=cache,target=/root/.cache,sharing=locked \
     echo "Installing chromium browser via temporary playwright..." && \
     pip install --no-cache-dir playwright && \
     PLAYWRIGHT_BROWSERS_PATH=/opt/playwright playwright install chromium --with-deps --no-shell && \
-    ln -s /opt/playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium-browser && \
+    ln -s /opt/playwright/chromium-*/chrome-linux*/chrome /usr/bin/chromium-browser && \
     chmod -R 755 /opt/playwright && \
     pip uninstall playwright -y && \
     rm -f pyproject.toml


### PR DESCRIPTION
### Summary
Updates the Chromium symlink creation in `docker/base-images/chromium/Dockerfile` to correctly handle the directory structure changes introduced in Playwright 1.57.0+.

### Problem
As reported in #3779, Playwright 1.57.0+ changed the default installation directory for Chromium on Linux:
- **Old path:** `chromium-<version>/chrome-linux/chrome`
- **New path:** `chromium-<version>/chrome-linux64/chrome`

While the Python `LocalBrowserWatchdog` was previously updated to handle this via glob patterns (in commit `97ce4a85`), the base image Dockerfile was missed and still relied on the hardcoded `chrome-linux` path. This causes the Docker build/runtime to fail when the image attempts to locate the browser binary.

### Solution
Updated the symlink command to use a wildcard pattern that matches both directory structures:
```diff
- RUN ln -s /opt/playwright/chromium-*/chrome-linux/chrome /usr/bin/chromium-browser
+ RUN ln -s /opt/playwright/chromium-*/chrome-linux*/chrome /usr/bin/chromium-browser

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Chromium symlink in the Docker base image to support Playwright 1.57.0+ by matching both chrome-linux and chrome-linux64 directories. This restores successful builds and ensures the browser binary is found at runtime.

<sup>Written for commit 81a5ca9d2831977fa1f42b7d48a2a1797d6a9f20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

