### PR TITLE
feat(agent): add final_actions parameter for post-completion actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,6 +300,7 @@ Check out all customizable parameters <a href="https://docs.browser-use.com/cust
 ### Actions & Behavior
 
 * `initial_actions`: List of actions to run before the main task without LLM. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/initial_actions.py)
+* `final_actions`: List of actions to run after task completion without LLM. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/final_actions.py)
 * `max_actions_per_step` (default: `3`): Maximum actions per step, e.g. for form filling the agent can output 3 fields at once. We execute the actions until the page changes.
 * `max_failures` (default: `3`): Maximum retries for steps with errors
 * `final_response_after_failure` (default: `True`): If True, attempt to force one final model call with intermediate output after max\_failures is reached

--- a/docs/customize/agent/all-parameters.mdx
+++ b/docs/customize/agent/all-parameters.mdx
@@ -23,6 +23,7 @@ mode: "wide"
 
 ### Actions & Behavior
 - `initial_actions`: List of actions to run before the main task without LLM. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/initial_actions.py)
+- `final_actions`: List of actions to run after task completion without LLM. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/final_actions.py)
 - `max_actions_per_step` (default: `4`): Maximum actions per step, e.g. for form filling the agent can output 4 fields at once. We execute the actions until the page changes.
 - `max_failures` (default: `3`): Maximum retries for steps with errors
 - `final_response_after_failure` (default: `True`): If True, attempt to force one final model call with intermediate output after max_failures is reached

--- a/examples/features/final_actions.py
+++ b/examples/features/final_actions.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use import Agent, ChatOpenAI
+
+llm = ChatOpenAI(model='gpt-4.1-mini')
+
+# Actions to run BEFORE the main task (without LLM)
+initial_actions = [
+	{'navigate': {'url': 'https://en.wikipedia.org/wiki/Randomness', 'new_tab': False}},
+]
+
+# Actions to run AFTER the task completes successfully (without LLM)
+final_actions = [
+	{'go_to_url': {'url': 'about:blank'}},  # Navigate to blank page after completion
+]
+
+agent = Agent(
+	task='What theories are displayed on the page? Give me a short summary.',
+	initial_actions=initial_actions,
+	final_actions=final_actions,
+	llm=llm,
+)
+
+
+async def main():
+	history = await agent.run(max_steps=10)
+	print(f'Task completed: {history.is_done()}')
+	print(f'Final result: {history.final_result()}')
+
+
+if __name__ == '__main__':
+	asyncio.run(main())


### PR DESCRIPTION
This PR implements the `final_actions` feature requested in #2451.

## What's this about?
Currently we have `initial_actions` that run before the task starts, but users have been asking for the opposite - a way to run cleanup/finalizing actions after the task completes. Think: taking a final screenshot, navigating to a blank page, saving state, etc.

## What I did
I followed the existing `initial_actions` pattern closely to keep things consistent:

1. **Added the parameter** (right after `initial_actions` in `__init__`):
   ```python
   initial_actions: list[dict[str, dict[str, Any]]] | None = None,
   final_actions: list[dict[str, dict[str, Any]]] | None = None,

2. **Created** `_execute_final_actions()`
* Mirrors `_execute_initial_actions()` logic.
* Saves to history.
* Handles both flash_mode and standard mode.


3. **Integrated the call**
* Executes after `history.is_done()` returns `True`, right before the `run()` method returns.


4. **Added docs and example**
* Updated `AGENTS.md` and `all-parameters.mdx`.
* Created `examples/features/final_actions.py`.



## Usage

```python
agent = Agent(
    task="Search for something",
    llm=llm,
    final_actions=[
        {'go_to_url': {'url': 'about:blank'}},
    ]
)




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a final_actions parameter to run cleanup steps after a task completes, mirroring initial_actions but at the end. This lets users perform post-completion actions (e.g., navigate to a blank page) without an LLM call.

- **New Features**
  - Added final_actions to Agent and _execute_final_actions(); runs after history.is_done() and before returning.
  - Supports flash_mode and standard mode; saves results and metadata to history.
  - Updated docs (AGENTS.md, all-parameters) and added examples/features/final_actions.py.

<sup>Written for commit 85997f4a3a3d5ab68660bdf60bbf31d8ddeb72ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

