### PR TITLE
 CDP Session Loss Fix

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1324,10 +1324,7 @@ class BrowserSession(BaseModel):
 			Other exceptions from command_fn if not session-related
 
 		Example:
-			>>> result = await self._send_cdp_with_retry(
-			...     cdp_session,
-			...     lambda s: s.cdp_client.send.Target.activateTarget(params={'targetId': target_id})
-			... )
+			>>> result = await self._send_cdp_with_retry(cdp_session, lambda s: s.cdp_client.send.Target.activateTarget(params={'targetId': target_id}))
 		"""
 		for attempt in range(max_retries):
 			try:
@@ -1340,7 +1337,7 @@ class BrowserSession(BaseModel):
 						# Session detached, wait and refresh
 						wait_time = 0.1 * (2**attempt)  # Exponential backoff
 						self.logger.debug(
-							f'CDP session detached during command, retrying in {wait_time*1000:.0f}ms '
+							f'CDP session detached during command, retrying in {wait_time * 1000:.0f}ms '
 							f'(attempt {attempt + 1}/{max_retries})'
 						)
 						await asyncio.sleep(wait_time)
@@ -1358,9 +1355,7 @@ class BrowserSession(BaseModel):
 						continue
 					else:
 						# All retries exhausted
-						raise RuntimeError(
-							f'CDP session detached and all {max_retries} retries failed'
-						) from e
+						raise RuntimeError(f'CDP session detached and all {max_retries} retries failed') from e
 				# Different error, propagate immediately
 				raise
 

--- a/tests/ci/conftest.py
+++ b/tests/ci/conftest.py
@@ -7,14 +7,15 @@ Sets up environment variables to ensure tests never connect to production servic
 import os
 import socketserver
 import tempfile
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
 from dotenv import load_dotenv
-from typing import Any
 
 try:
 	from pytest_httpserver import HTTPServer  # type: ignore
+
 	HAS_HTTPSERVER = True
 except ImportError:
 	HTTPServer = Any  # type: ignore
@@ -181,6 +182,7 @@ async def browser_session():
 
 
 if HAS_HTTPSERVER:
+
 	@pytest.fixture(scope='function')
 	def cloud_sync(httpserver: HTTPServer):  # type: ignore[valid-type]
 		"""
@@ -203,9 +205,10 @@ if HAS_HTTPSERVER:
 
 		return cloud_sync
 else:
+
 	@pytest.fixture(scope='function')
 	def cloud_sync():
-		pytest.skip("pytest-httpserver not installed")
+		pytest.skip('pytest-httpserver not installed')
 
 
 @pytest.fixture(scope='function')

--- a/tests/ci/test_cdp_session_retry.py
+++ b/tests/ci/test_cdp_session_retry.py
@@ -5,7 +5,7 @@ during tab switches and other operations.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,21 +21,21 @@ class TestCDPSessionRetry:
 		# Create minimal browser session mock
 		session = MagicMock(spec=BrowserSession)
 		session.logger = MagicMock()
-		
+
 		# Bind the method to the mock instance
 		retry_method = BrowserSession._send_cdp_with_retry.__get__(session, BrowserSession)
-		
+
 		# Create mock CDP session
 		cdp_session = MagicMock(spec=CDPSession)
 		cdp_session.target_id = 'test-target-id-12345678'
-		
+
 		# Mock successful command
 		async def successful_command(s):
 			return {'success': True}
-		
+
 		# Execute
 		result = await retry_method(cdp_session, successful_command)
-		
+
 		# Verify
 		assert result == {'success': True}
 		assert session.logger.debug.call_count == 0  # No retry logs
@@ -46,36 +46,36 @@ class TestCDPSessionRetry:
 		# Create minimal browser session mock
 		session = MagicMock(spec=BrowserSession)
 		session.logger = MagicMock()
-		
+
 		# Mock get_or_create_cdp_session for refresh
 		new_cdp_session = MagicMock(spec=CDPSession)
 		new_cdp_session.target_id = 'test-target-id-12345678'
-		
+
 		async def mock_get_session(target_id, focus):
 			return new_cdp_session
-		
+
 		session.get_or_create_cdp_session = mock_get_session
-		
+
 		# Bind the method
 		retry_method = BrowserSession._send_cdp_with_retry.__get__(session, BrowserSession)
-		
+
 		# Create mock CDP session
 		cdp_session = MagicMock(spec=CDPSession)
 		cdp_session.target_id = 'test-target-id-12345678'
-		
+
 		# Mock command that fails first time, succeeds second time
 		call_count = 0
-		
+
 		async def flaky_command(s):
 			nonlocal call_count
 			call_count += 1
 			if call_count == 1:
 				raise Exception("{'code': -32001, 'message': 'Session with given id not found.'}")
 			return {'success': True}
-		
+
 		# Execute
 		result = await retry_method(cdp_session, flaky_command, max_retries=3)
-		
+
 		# Verify
 		assert result == {'success': True}
 		assert call_count == 2  # Failed once, succeeded on retry
@@ -87,27 +87,27 @@ class TestCDPSessionRetry:
 		# Create minimal browser session mock
 		session = MagicMock(spec=BrowserSession)
 		session.logger = MagicMock()
-		
+
 		# Mock get_or_create_cdp_session for refresh
 		new_cdp_session = MagicMock(spec=CDPSession)
 		new_cdp_session.target_id = 'test-target-id-12345678'
-		
+
 		async def mock_get_session(target_id, focus):
 			return new_cdp_session
-		
+
 		session.get_or_create_cdp_session = mock_get_session
-		
+
 		# Bind the method
 		retry_method = BrowserSession._send_cdp_with_retry.__get__(session, BrowserSession)
-		
+
 		# Create mock CDP session
 		cdp_session = MagicMock(spec=CDPSession)
 		cdp_session.target_id = 'test-target-id-12345678'
-		
+
 		# Mock command that always fails
 		async def always_fails(s):
 			raise Exception("{'code': -32001, 'message': 'Session with given id not found.'}")
-		
+
 		# Execute and verify exception
 		with pytest.raises(RuntimeError, match='all 3 retries failed'):
 			await retry_method(cdp_session, always_fails, max_retries=3)
@@ -118,22 +118,22 @@ class TestCDPSessionRetry:
 		# Create minimal browser session mock
 		session = MagicMock(spec=BrowserSession)
 		session.logger = MagicMock()
-		
+
 		# Bind the method
 		retry_method = BrowserSession._send_cdp_with_retry.__get__(session, BrowserSession)
-		
+
 		# Create mock CDP session
 		cdp_session = MagicMock(spec=CDPSession)
 		cdp_session.target_id = 'test-target-id-12345678'
-		
+
 		# Mock command that fails with different error
 		async def different_error(s):
 			raise ValueError('Some other error')
-		
+
 		# Execute and verify exception propagates immediately
 		with pytest.raises(ValueError, match='Some other error'):
 			await retry_method(cdp_session, different_error)
-		
+
 		# Verify no retry logs
 		assert session.logger.debug.call_count == 0
 
@@ -143,55 +143,55 @@ class TestCDPSessionRetry:
 		# Create minimal browser session mock
 		session = MagicMock(spec=BrowserSession)
 		session.logger = MagicMock()
-		
+
 		# Mock get_or_create_cdp_session for refresh
 		new_cdp_session = MagicMock(spec=CDPSession)
 		new_cdp_session.target_id = 'test-target-id-12345678'
-		
+
 		async def mock_get_session(target_id, focus):
 			return new_cdp_session
-		
+
 		session.get_or_create_cdp_session = mock_get_session
-		
+
 		# Bind the method
 		retry_method = BrowserSession._send_cdp_with_retry.__get__(session, BrowserSession)
-		
+
 		# Create mock CDP session
 		cdp_session = MagicMock(spec=CDPSession)
 		cdp_session.target_id = 'test-target-id-12345678'
-		
+
 		# Track sleep times
 		sleep_times = []
 		original_sleep = asyncio.sleep
-		
+
 		async def mock_sleep(duration):
 			sleep_times.append(duration)
 			await original_sleep(0)  # Don't actually sleep in test
-		
+
 		# Patch asyncio.sleep
 		# Note: We use the global asyncio module which is already imported
 		asyncio.sleep = mock_sleep
-		
+
 		try:
 			# Mock command that fails 3 times, succeeds 4th time
 			call_count = 0
-			
+
 			async def flaky_command(s):
 				nonlocal call_count
 				call_count += 1
 				if call_count < 4:
 					raise Exception("{'code': -32001, 'message': 'Session with given id not found.'}")
 				return {'success': True}
-			
+
 			# Execute
 			await retry_method(cdp_session, flaky_command, max_retries=4)
-			
+
 			# Verify exponential backoff: 0.1, 0.2, 0.4
 			assert len(sleep_times) == 3
 			assert sleep_times[0] == 0.1  # 0.1 * 2^0
 			assert sleep_times[1] == 0.2  # 0.1 * 2^1
 			assert sleep_times[2] == 0.4  # 0.1 * 2^2
-		
+
 		finally:
 			# Restore original sleep
 			asyncio.sleep = original_sleep
@@ -202,24 +202,24 @@ class TestCDPSessionRetry:
 		# Create minimal browser session mock
 		session = MagicMock(spec=BrowserSession)
 		session.logger = MagicMock()
-		
+
 		# Mock get_or_create_cdp_session that raises ValueError (target gone)
 		async def mock_get_session(target_id, focus):
 			raise ValueError('Target test-target-id-12345678 not found - may have detached or never existed')
-		
+
 		session.get_or_create_cdp_session = mock_get_session
-		
+
 		# Bind the method
 		retry_method = BrowserSession._send_cdp_with_retry.__get__(session, BrowserSession)
-		
+
 		# Create mock CDP session
 		cdp_session = MagicMock(spec=CDPSession)
 		cdp_session.target_id = 'test-target-id-12345678'
-		
+
 		# Mock command that fails with session error
 		async def fails_command(s):
 			raise Exception("{'code': -32001, 'message': 'Session with given id not found.'}")
-		
+
 		# Execute and verify error message
 		with pytest.raises(RuntimeError, match='target no longer exists'):
 			await retry_method(cdp_session, fails_command)


### PR DESCRIPTION
Fix: CDP Session Loss on Tab Switch (#3134)
Description
Fixes issue #3134 where switching tabs causes Session with given id not found (-32001) errors.

The Bug
A race condition exists between Chrome's asynchronous session detachment and Browser-Use's session usage. When a tab switch occurs:

get_or_create_cdp_session
 retrieves a valid session.
Chrome asynchronously fires DetachedFromTarget in the background.
The code attempts to use the session immediately, but it's now invalid.
Error -32001 is raised, crashing the agent.
The Fix
Implemented a robust retry mechanism with exponential backoff in 
BrowserSession
:

Added 
_send_cdp_with_retry()
 helper method:

Automatically catches session detachment errors
Retries up to 3 times
Uses exponential backoff (100ms, 200ms, 400ms)
Refreshes the session from the pool before retrying
Updated 
on_SwitchTabEvent
:

Wraps the critical activateTarget call with the retry logic
Ensures tab switching is resilient to temporary session instability
Verification
Automated Tests
Added 
tests/ci/test_cdp_session_retry.py
 covering:

Successful commands (pass-through)
Retry on session detachment (recovery)
Exhausted retries (proper error raising)
 Exponential backoff timing
Non-session error propagation
Run the tests:

bash
pytest tests/ci/test_cdp_session_retry.py -v
