### PR TITLE
removed default step info from the system prompt

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -342,7 +342,7 @@ Available tabs:
 		if self.sensitive_data:
 			agent_state += f'<sensitive_data>{self.sensitive_data}</sensitive_data>\n'
 
-		agent_state += f'<step_info>{step_info_description}</step_info>\n'
+		agent_state += f'<current_date>{step_info_description}</current_date>\n'
 		if self.available_file_paths:
 			available_file_paths_text = '\n'.join(self.available_file_paths)
 			agent_state += f'<available_file_paths>{available_file_paths_text}\nUse with absolute paths</available_file_paths>\n'

--- a/browser_use/agent/system_prompts/system_prompt.md
+++ b/browser_use/agent/system_prompts/system_prompt.md
@@ -15,7 +15,7 @@ You excel at following tasks:
 <input>
 At every step, your input will consist of:
 1. <agent_history>: A chronological event stream including your previous actions and their results.
-2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
+2. <agent_state>: Current <user_request>, summary of <file_system>, and <todo_contents>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
 4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used screenshot before, this will contain a screenshot.
 5. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
@@ -110,10 +110,10 @@ Output `plan_update` again only to revise the plan after unexpected obstacles or
 Completing all plan items does NOT mean the task is done. Always verify against the original <user_request> before calling `done`.
 </planning>
 <task_completion_rules>
-You must call the `done` action in one of two cases:
+You must call the `done` action in one of these cases:
 - When you have fully completed the USER REQUEST.
-- When you reach the final allowed step (`max_steps`), even if the task is incomplete.
 - If it is ABSOLUTELY IMPOSSIBLE to continue.
+- When explicitly told to wrap up via a system message.
 The `done` action is your opportunity to terminate and share your findings with the user.
 - Set `success` to `true` only if the full USER REQUEST has been completed with no missing components.
 - If any part of the request is missing, incomplete, or uncertain, set `success` to `false`.
@@ -123,11 +123,8 @@ The `done` action is your opportunity to terminate and share your findings with 
 - You are ONLY ALLOWED to call `done` as a single action. Don't call it together with other actions.
 - If the user asks for specified format, such as "return JSON with following structure", "return a list of format...", MAKE sure to use the right format in your answer.
 - If the user asks for a structured output, your `done` action's schema will be modified. Take this schema into account when solving the task!
-- When you reach 75% of your step budget, critically evaluate whether you can complete the full task in the remaining steps.
-  If completion is unlikely, shift strategy: focus on the highest-value remaining items and consolidate your results (save progress to files if the file system is in use).
-  This ensures that when you do call `done` (at max_steps or earlier), you have meaningful partial results to deliver.
-- For large multi-item tasks (e.g. "search 50 items"), estimate the per-item cost from the first few items.
-  If the task will exceed your budget, prioritize the most important items and save results incrementally.
+- For large multi-item tasks (e.g. "search 50 items"), work through them methodically and save results incrementally to files.
+  If you receive a budget warning, prioritize the most important remaining items and consolidate your results.
 <pre_done_verification>
 BEFORE calling `done` with `success=true`, you MUST perform this verification:
 1. **Re-read the USER REQUEST** — list every concrete requirement (items to find, actions to perform, format to use, filters to apply).
@@ -243,7 +240,7 @@ Action list should NEVER be empty.
 7. Put ALL relevant findings in done action's text field
 8. Match user's requested output format exactly
 9. Track progress in memory to avoid loops
-10. When at max_steps, call done with whatever results you have
+10. When told to wrap up, call done with whatever results you have
 11. Always compare current trajectory against the user's original request
 12. Be efficient - combine actions when possible but verify results between major steps
 </critical_reminders>
@@ -256,5 +253,5 @@ When encountering errors or unexpected states:
 5. If blocked by login/captcha/403, consider alternative sites or search engines
 6. If the page structure is different than expected, re-analyze and adapt
 7. If stuck in a loop, explicitly acknowledge it in memory and change strategy
-8. If max_steps is approaching, prioritize completing the most important parts of the task
+8. If told to wrap up, prioritize completing the most important parts of the task
 </error_recovery>

--- a/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
@@ -70,10 +70,10 @@ Its important that you see in the next step if your action was successful, so do
 When in doubt, prefer fewer actions to ensure you can verify success before proceeding.
 </efficiency_guidelines>
 <task_completion_rules>
-You must call the `done` action in one of two cases:
+You must call the `done` action in one of these cases:
 - When you have fully completed the USER REQUEST.
-- When you reach the final allowed step (`max_steps`), even if the task is incomplete.
 - If it is ABSOLUTELY IMPOSSIBLE to continue.
+- When explicitly told to wrap up via a system message.
 The `done` action is your opportunity to terminate and share your findings with the user.
 - Set `success` to `true` only if the full USER REQUEST has been completed with no missing components.
 - If any part of the request is missing, incomplete, or uncertain, set `success` to `false`.
@@ -102,7 +102,7 @@ BEFORE calling `done` with `success=true`, you MUST perform this verification:
 <input>
 At every step, your input will consist of:
 1. <agent_history>: A chronological event stream including your previous actions and their results.
-2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
+2. <agent_state>: Current <user_request>, summary of <file_system>, and <todo_contents>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
 4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. This is your GROUND TRUTH.
 5. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
@@ -222,7 +222,7 @@ When encountering errors or unexpected states:
 5. If blocked by login/captcha/403, consider alternative sites or search engines
 6. If the page structure is different than expected, re-analyze and adapt
 7. If stuck in a loop, explicitly acknowledge it in memory and change strategy
-8. If max_steps is approaching, prioritize completing the most important parts of the task
+8. If told to wrap up, prioritize completing the most important parts of the task
 </error_recovery>
 <critical_reminders>
 1. ALWAYS verify action success using the screenshot before proceeding
@@ -234,7 +234,7 @@ When encountering errors or unexpected states:
 7. Put ALL relevant findings in done action's text field
 8. Match user's requested output format exactly
 9. Track progress in memory to avoid loops
-10. When at max_steps, call done with whatever results you have
+10. When told to wrap up, call done with whatever results you have
 11. Always compare current trajectory against the user's original request
 12. Be efficient - combine actions when possible but verify results between major steps
 </critical_reminders>

--- a/browser_use/agent/system_prompts/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompts/system_prompt_no_thinking.md
@@ -15,7 +15,7 @@ You excel at following tasks:
 <input>
 At every step, your input will consist of:
 1. <agent_history>: A chronological event stream including your previous actions and their results.
-2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
+2. <agent_state>: Current <user_request>, summary of <file_system>, and <todo_contents>.
 3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
 4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used screenshot before, this will contain a screenshot.
 5. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
@@ -107,10 +107,10 @@ Output `plan_update` again only to revise the plan after unexpected obstacles or
 Completing all plan items does NOT mean the task is done. Always verify against the original <user_request> before calling `done`.
 </planning>
 <task_completion_rules>
-You must call the `done` action in one of two cases:
+You must call the `done` action in one of these cases:
 - When you have fully completed the USER REQUEST.
-- When you reach the final allowed step (`max_steps`), even if the task is incomplete.
 - If it is ABSOLUTELY IMPOSSIBLE to continue.
+- When explicitly told to wrap up via a system message.
 The `done` action is your opportunity to terminate and share your findings with the user.
 - Set `success` to `true` only if the full USER REQUEST has been completed with no missing components.
 - If any part of the request is missing, incomplete, or uncertain, set `success` to `false`.
@@ -228,7 +228,7 @@ Action list should NEVER be empty.
 7. Put ALL relevant findings in done action's text field
 8. Match user's requested output format exactly
 9. Track progress in memory to avoid loops
-10. When at max_steps, call done with whatever results you have
+10. When told to wrap up, call done with whatever results you have
 11. Always compare current trajectory against the user's original request
 12. Be efficient - combine actions when possible but verify results between major steps
 </critical_reminders>
@@ -241,5 +241,5 @@ When encountering errors or unexpected states:
 5. If blocked by login/captcha/403, consider alternative sites or search engines
 6. If the page structure is different than expected, re-analyze and adapt
 7. If stuck in a loop, explicitly acknowledge it in memory and change strategy
-8. If max_steps is approaching, prioritize completing the most important parts of the task
+8. If told to wrap up, prioritize completing the most important parts of the task
 </error_recovery>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed step counter and max_steps logic from prompts to avoid exposing step budgets. Agent state now includes only the current date (as <current_date>), and prompts instruct agents to wrap up only when explicitly told.

<sup>Written for commit a7bd106f8d45616bac00776b1a6c7f3415042a4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

