### PR TITLE
fix: clean up async tasks on close when keep_alive=True (#3791)

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -285,6 +285,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if browser and browser_session:
 			raise ValueError('Cannot specify both "browser" and "browser_session" parameters. Use "browser" for the cleaner API.')
 		browser_session = browser or browser_session
+		# Track whether the Agent owns the BrowserSession lifecycle.
+		self._owns_browser_session: bool = browser_session is None
 
 		if browser_session is not None and demo_mode is not None and browser_session.browser_profile.demo_mode != demo_mode:
 			browser_session.browser_profile = browser_session.browser_profile.model_copy(update={'demo_mode': demo_mode})
@@ -3912,19 +3914,20 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					await self.browser_session.kill()
 				else:
 					# keep_alive=True sessions should not keep the event loop alive after agent.run().
-					# Stop the session EventBus runloop, then reset its async primitives so it can
-					# restart on the next dispatch (e.g. reuse or teardown).
-					await self.browser_session.event_bus.stop(
-						clear=False,
-						timeout=_get_timeout('TIMEOUT_BrowserSessionEventBusStopOnAgentClose', 1.0),
-					)
-					# bubus.EventBus.stop() shuts down its queue, which prevents future dispatch()
-					# from restarting the runloop. Reset internal async primitives so it can restart.
-					try:
-						self.browser_session.event_bus.event_queue = None  # type: ignore[attr-defined]
-						self.browser_session.event_bus._on_idle = None  # type: ignore[attr-defined]
-					except Exception:
-						pass
+					# Only stop the session EventBus if this Agent created the session. For injected
+					# sessions, stopping the EventBus can break reuse/teardown flows.
+					if self._owns_browser_session:
+						await self.browser_session.event_bus.stop(
+							clear=False,
+							timeout=_get_timeout('TIMEOUT_BrowserSessionEventBusStopOnAgentClose', 1.0),
+						)
+						# bubus.EventBus.stop() shuts down its queue, which prevents future dispatch()
+						# from restarting the runloop. Reset internal async primitives so it can restart.
+						try:
+							self.browser_session.event_bus.event_queue = None  # type: ignore[attr-defined]
+							self.browser_session.event_bus._on_idle = None  # type: ignore[attr-defined]
+						except Exception:
+							pass
 
 			# Close skill service if configured
 			if self.skill_service is not None:


### PR DESCRIPTION
Clean up async tasks (EventBus, CDP, watchdogs) when keep_alive=True so asyncio.run() doesn't hang on exit. Resolves #3791.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop the keep_alive session EventBus on agent.close() only when the Agent owns the session, and reset it so asyncio.run() exits cleanly while the browser/session remain reusable. No browser kill or BrowserStopEvent.

- **Bug Fixes**
  - keep_alive=True: stop the session EventBus only if the Agent created the session (clear=False, 1s timeout); reset event_queue and _on_idle so the run loop can restart; never kill the browser. Injected sessions: do not stop the EventBus.
  - keep_alive=False: unchanged — browser_session.kill() tears down the session and stops the EventBus with clear=True.

<sup>Written for commit 6cd4b4e5618a608d658bc14107242444657522f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

