### PR TITLE
Fixed structured output issue with simple judge

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1514,7 +1514,13 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				self.logger.info(f'⚠️  Simple judge overriding success to failure: {reason}')
 				last_result.success = False
 				note = f'[Simple judge: {reason}]'
-				if last_result.extracted_content:
+				# When structured output is expected, don't append judge text to extracted_content
+				# as it would corrupt the JSON and break end-user parsers
+				if self.output_model_schema is not None:
+					if last_result.metadata is None:
+						last_result.metadata = {}
+					last_result.metadata['simple_judge'] = note
+				elif last_result.extracted_content:
 					last_result.extracted_content += f'\n\n{note}'
 				else:
 					last_result.extracted_content = note


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed JSON corruption in structured outputs by changing how the simple judge records its note. When a schema is expected, the note is stored in metadata instead of appended to extracted_content.

- **Bug Fixes**
  - When output_model_schema is set, write the simple judge note to result.metadata['simple_judge'] (initializing metadata if needed).
  - Preserve previous behavior (append to extracted_content) when no structured output is expected.

<sup>Written for commit 07817c2c5b1445ab650e0c2edc516d3d5bcc2b6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

