### PR TITLE
fix(llm): remove reasoning token double-count in OpenAI usage calcula…

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -123,11 +123,6 @@ class ChatOpenAI(BaseChatModel):
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
 		if response.usage is not None:
 			completion_tokens = response.usage.completion_tokens
-			completion_token_details = response.usage.completion_tokens_details
-			if completion_token_details is not None:
-				reasoning_tokens = completion_token_details.reasoning_tokens
-				if reasoning_tokens is not None:
-					completion_tokens += reasoning_tokens
 
 			usage = ChatInvokeUsage(
 				prompt_tokens=response.usage.prompt_tokens,

--- a/tests/ci/test_openai_usage.py
+++ b/tests/ci/test_openai_usage.py
@@ -1,0 +1,24 @@
+"""Test OpenAI usage token counting."""
+
+from unittest.mock import MagicMock
+
+
+def test_get_usage_does_not_double_count_reasoning_tokens():
+	from openai.types.chat.chat_completion import ChatCompletion
+
+	from browser_use.llm.openai.chat import ChatOpenAI
+
+	mock_response = MagicMock(spec=ChatCompletion)
+	mock_response.usage.prompt_tokens = 100
+	mock_response.usage.completion_tokens = 500
+	mock_response.usage.total_tokens = 600
+	mock_response.usage.completion_tokens_details.reasoning_tokens = 400
+	mock_response.usage.prompt_tokens_details = None
+
+	client = ChatOpenAI(model='o4-mini')
+	usage = client._get_usage(mock_response)
+
+	assert usage is not None
+	assert usage.completion_tokens == 500
+	assert usage.prompt_tokens == 100
+	assert usage.total_tokens == 600


### PR DESCRIPTION
## Summary
Removes reasoning token double-counting in `ChatOpenAI._get_usage()`. The OpenAI API already includes `reasoning_tokens` as a subset of `completion_tokens` — adding them again inflates reported token counts ~2x for all reasoning models.

Fixes #4065

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stopped counting reasoning tokens twice in ChatOpenAI._get_usage so usage numbers for reasoning models are accurate. Completion and total tokens now align with OpenAI’s reported usage.

- **Bug Fixes**
  - Use completion_tokens from the API without adding reasoning_tokens.
  - Added a test to confirm prompt, completion, and total tokens match the API response.

<sup>Written for commit 3a0a83a3ad241675a33e92eb40f52394af18ed3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

