### PR TITLE
fix: remove double-counting of reasoning_tokens in OpenAI usage

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -122,13 +122,9 @@ class ChatOpenAI(BaseChatModel):
 
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
 		if response.usage is not None:
-			completion_tokens = response.usage.completion_tokens
-			completion_token_details = response.usage.completion_tokens_details
-			if completion_token_details is not None:
-				reasoning_tokens = completion_token_details.reasoning_tokens
-				if reasoning_tokens is not None:
-					completion_tokens += reasoning_tokens
-
+			# Note: completion_tokens already includes reasoning_tokens per OpenAI API docs.
+			# Unlike Google Gemini where thinking_tokens are reported separately,
+			# OpenAI's reasoning_tokens are a subset of completion_tokens.
 			usage = ChatInvokeUsage(
 				prompt_tokens=response.usage.prompt_tokens,
 				prompt_cached_tokens=response.usage.prompt_tokens_details.cached_tokens
@@ -137,7 +133,7 @@ class ChatOpenAI(BaseChatModel):
 				prompt_cache_creation_tokens=None,
 				prompt_image_tokens=None,
 				# Completion
-				completion_tokens=completion_tokens,
+				completion_tokens=response.usage.completion_tokens,
 				total_tokens=response.usage.total_tokens,
 			)
 		else:


### PR DESCRIPTION
## Summary
Fixes #4065 - OpenAI reasoning tokens were being double-counted in `_get_usage()`, inflating reported token counts by ~2x for all reasoning models (o1, o3, o4-mini, etc.).

## Problem
The `_get_usage()` method was incorrectly adding `reasoning_tokens` to `completion_tokens`:

```python
completion_tokens = response.usage.completion_tokens
if completion_token_details is not None:
    reasoning_tokens = completion_token_details.reasoning_tokens
    if reasoning_tokens is not None:
        completion_tokens += reasoning_tokens  # ← Double counting!
```

## Root Cause
According to OpenAI's API documentation, `completion_tokens` already **includes** `reasoning_tokens` as a subset. This is explicitly stated in the `CompletionTokensDetails` field description:

> reasoning tokens are "counted in the total completion tokens for purposes of billing, output, and context window limits"

This differs from Google Gemini where `thinking_tokens` are reported separately and need to be added.

## Solution
Removed the `reasoning_tokens` addition and used `completion_tokens` directly, with a clarifying comment explaining the difference from Gemini.

## Impact
- ✅ Fixes inflated cost calculations for users of o1, o1-pro, o3, o3-mini, o3-pro, o4-mini
- ✅ Fixes inflated usage logging and telemetry  
- ✅ Aligns with other OpenAI-compatible providers in the codebase (OpenRouter, Vercel, Cerebras, Groq)
- ✅ No behavioral impact (token counts aren't used for budget limits or context window management)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-counting of OpenAI reasoning_tokens in _get_usage(), which inflated completion token and cost numbers for reasoning models. Aligns token reporting with OpenAI docs and fixes #4065.

- **Bug Fixes**
  - Use response.usage.completion_tokens directly; remove added reasoning_tokens.
  - Corrects usage and cost logs for o1, o1-pro, o3, o3-mini, o3-pro, o4-mini.

<sup>Written for commit 993a4c1f5b36e5ce6ed28e6c9e74439954f6c413. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

