### PR TITLE
feat: Action-first mode improvements

### DIFF
--- a/browser_use/agent/system_prompt_flash.md
+++ b/browser_use/agent/system_prompt_flash.md
@@ -107,7 +107,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - If the file is too large, you are only given a preview of your file. Use `read_file` to see the full content if necessary.
 - If exists, <available_file_paths> includes files you have downloaded or uploaded by the user. You can only read or upload these files but you don't have write access.
 - If the task is really long, initialize a `results.md` file to accumulate your results.
-- DO NOT use the file system if the task is less than 10 steps!
+- If you need to remember something from the current state, write it to a file.
 </file_system>
 
 <task_completion_rules>
@@ -151,29 +151,10 @@ Its important that you see in the next step if your action was successful, so do
 - do not use input_text and then scroll, because you would not see if the input text was successful or not. 
 </efficiency_guidelines>
 
-<reasoning_rules>
-Be clear and concise in your decision-making. Exhibit the following reasoning patterns to successfully achieve the <user_request>:
-- Reason about <agent_history> to track progress and context toward <user_request>.
-- Analyze the most recent "Next Goal" and "Action Result" in <agent_history> and clearly state what you previously tried to achieve.
-- Analyze all relevant items in <agent_history>, <browser_state>, <read_state>, <file_system>, <read_state> and the screenshot to understand your state.
-- Explicitly judge success/failure/uncertainty of the last action. Never assume an action succeeded just because it appears to be executed in your last step in <agent_history>. For example, you might have "Action 1/1: Input '2025-05-05' into element 3." in your history even though inputting text failed. Always verify using <browser_vision> (screenshot) as the primary ground truth. If a screenshot is unavailable, fall back to <browser_state>. If the expected change is missing, mark the last action as failed (or uncertain) and plan a recovery.
-- If todo.md is empty and the task is multi-step, generate a stepwise plan in todo.md using file tools.
-- Analyze `todo.md` to guide and track your progress. 
-- If any todo.md items are finished, mark them as complete in the file.
-- Analyze whether you are stuck, e.g. when you repeat the same actions multiple times without any progress. Then consider alternative approaches e.g. scrolling for more context or send_keys to interact with keys directly or different pages.
-- Analyze the <read_state> where one-time information are displayed due to your previous action. Reason about whether you want to keep this information in memory and plan writing them into a file if applicable using the file tools.
-- If you see information relevant to <user_request>, plan saving the information into a file.
-- Before writing data into a file, analyze the <file_system> and check if the file already has some content to avoid overwriting.
-- Decide what concise, actionable context should be stored in memory to inform future reasoning.
-- When ready to finish, state you are preparing to call done and communicate completion/results to the user.
-- Before done, use read_file to verify file contents intended for user output.
-- Always reason about the <user_request>. Make sure to carefully analyze the specific steps and information required. E.g. specific filters, specific form fields, specific information to search. Make sure to always compare the current trajactory with the user request and think carefully if thats how the user requested it.
-</reasoning_rules>
 
 <output>
 You must respond with a valid JSON in this exact format:
 {{
-  "memory": "Up to 5 sentences of specific reasoning about: Was the previous step successful / failed? What do we need to remember from the current state for the task? Plan ahead what are the best next actions. What's the next immediate goal? Depending on the complexity think longer. For example if its opvious to click the start button just say: click start. But if you need to remember more about the step it could be: Step successful, need to remember A, B, C to visit later. Next click on A.",
   "action":[{{"go_to_url": {{ "url": "url_value"}}}}]
 }}
 

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -228,8 +228,9 @@ class AgentOutput(BaseModel):
 				del schema['properties']['thinking']
 				del schema['properties']['evaluation_previous_goal']
 				del schema['properties']['next_goal']
+				del schema['properties']['memory']
 				# Update required fields to only include remaining properties
-				schema['required'] = ['action', 'memory']
+				schema['required'] = ['action']
 				return schema
 
 		model = create_model(

--- a/examples/models/gemini.py
+++ b/examples/models/gemini.py
@@ -20,6 +20,7 @@ async def run_search():
 	agent = Agent(
 		llm=llm,
 		task='How many stars does the browser-use repo have?',
+		flash_mode=True,
 	)
 
 	await agent.run()


### PR DESCRIPTION
## Summary

This PR includes improvements for action-first mode.

## Changes

Enhancements to action-first functionality in browser-use.

🤖 Generated with auto-updater script

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streamlined action-first (flash) mode to be truly action-only. The JSON output now requires only actions, and the prompt encourages saving state to files when needed.

- **Refactors**
  - Removed reasoning_rules and the memory field from the flash system prompt; added simple guidance to write important state to files.
  - Updated AgentOutput schema in action-first mode to drop memory/thinking/evaluation_previous_goal/next_goal; required field is now only action.
  - Enabled flash_mode in the Gemini example to show intended usage.

<sup>Written for commit 3557ee30d7a5b287ed03aac7ef56bca43b0da3f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

