### PR TITLE
feat(install): always install from GitHub main branch

### DIFF
--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -485,18 +485,15 @@ install_browser_use() {
 	# Activate venv and install
 	activate_venv
 
-	# Install from GitHub branch (for testing) or PyPI (production)
-	if [ -n "$BROWSER_USE_BRANCH" ]; then
-		BROWSER_USE_REPO="${BROWSER_USE_REPO:-browser-use/browser-use}"
-		log_info "Installing from GitHub: $BROWSER_USE_REPO@$BROWSER_USE_BRANCH"
-		# Clone and install locally to ensure all dependencies are resolved
-		local tmp_dir=$(mktemp -d)
-		git clone --depth 1 --branch "$BROWSER_USE_BRANCH" "https://github.com/$BROWSER_USE_REPO.git" "$tmp_dir"
-		uv pip install "$tmp_dir"
-		rm -rf "$tmp_dir"
-	else
-		uv pip install browser-use
-	fi
+	# Install from GitHub (main branch by default, or custom branch for testing)
+	BROWSER_USE_BRANCH="${BROWSER_USE_BRANCH:-main}"
+	BROWSER_USE_REPO="${BROWSER_USE_REPO:-browser-use/browser-use}"
+	log_info "Installing from GitHub: $BROWSER_USE_REPO@$BROWSER_USE_BRANCH"
+	# Clone and install locally to ensure all dependencies are resolved
+	local tmp_dir=$(mktemp -d)
+	git clone --depth 1 --branch "$BROWSER_USE_BRANCH" "https://github.com/$BROWSER_USE_REPO.git" "$tmp_dir"
+	uv pip install "$tmp_dir"
+	rm -rf "$tmp_dir"
 
 	log_success "browser-use installed"
 }


### PR DESCRIPTION
Changes install.sh to clone from github.com/browser-use/browser-use@main by default instead of installing from PyPI. Custom branches and repos can still be specified via BROWSER_USE_BRANCH and BROWSER_USE_REPO environment variables.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update install.sh to install browser-use from github.com/browser-use/browser-use@main by default instead of PyPI. You can still install a specific branch or fork by setting BROWSER_USE_BRANCH and BROWSER_USE_REPO.

<sup>Written for commit 8af57fa19ad8d2dd40f6b158922067828dea3d80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

