### PR TITLE
fix: stop cloud sessions when reconnecting via cdp_url

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import re
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, Union, cast, overload
@@ -1028,6 +1029,14 @@ class BrowserSession(BaseModel):
 			else:
 				self.logger.debug(f'File already tracked: {event.path}')
 
+	def _cloud_session_id_from_cdp_url(self) -> str | None:
+		"""Derive cloud browser session ID from a Browser Use CDP URL."""
+		if not self.cdp_url:
+			return None
+		host = urlparse(self.cdp_url).hostname or ''
+		match = re.match(r'^([0-9a-fA-F-]{36})\.cdp\d+\.browser-use\.com$', host)
+		return match.group(1) if match else None
+
 	async def on_BrowserStopEvent(self, event: BrowserStopEvent) -> None:
 		"""Handle browser stop request."""
 
@@ -1037,13 +1046,16 @@ class BrowserSession(BaseModel):
 				self.event_bus.dispatch(BrowserStoppedEvent(reason='Kept alive due to keep_alive=True'))
 				return
 
-			# Clean up cloud browser session if using cloud browser
-			if self.browser_profile.use_cloud:
+			# Clean up cloud browser session for both:
+			# 1) native use_cloud sessions (current_session_id set by create_browser)
+			# 2) reconnected cdp_url sessions (derive UUID from host)
+			cloud_session_id = self._cloud_browser_client.current_session_id or self._cloud_session_id_from_cdp_url()
+			if cloud_session_id:
 				try:
-					await self._cloud_browser_client.stop_browser()
-					self.logger.info('🌤️ Cloud browser session cleaned up')
+					await self._cloud_browser_client.stop_browser(cloud_session_id)
+					self.logger.info(f'🌤️ Cloud browser session cleaned up: {cloud_session_id}')
 				except Exception as e:
-					self.logger.debug(f'Failed to cleanup cloud browser session: {e}')
+					self.logger.debug(f'Failed to cleanup cloud browser session {cloud_session_id}: {e}')
 
 			# Clear CDP session cache before stopping
 			self.logger.info(


### PR DESCRIPTION
## Summary
- derive cloud browser session UUID from Browser Use CDP host (e.g. `<uuid>.cdp0.browser-use.com`)
- use that UUID as a fallback in `BrowserSession.on_BrowserStopEvent` when `_cloud_browser_client.current_session_id` is empty
- ensure reconnected sessions created via `BrowserSession(cdp_url=...)` are properly stopped in cloud, not just reset locally

## Why
Reconnected cloud sessions (common MFA resume pattern) can leak browser instances because stop logic only used `current_session_id`, which is populated when the same process created the cloud browser. In reconnect flows, that field is often unset.

## Change
- add `_cloud_session_id_from_cdp_url()` helper in `browser_use/browser/session.py`
- update stop handler to use:
  - `current_session_id` when present
  - else derived session id from `cdp_url` host

## Validation
- `python3 -m py_compile browser_use/browser/session.py`
- manual validation in downstream Bear integration where Passport reconnects to cdp_url and closes session after OTP


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Properly stop cloud browser sessions when reconnecting via cdp_url, preventing orphaned instances in common MFA resume flows.

- **Bug Fixes**
  - Derive the cloud session UUID from the cdp_url host and use it when current_session_id is empty.
  - Pass the explicit session ID to stop_browser and log the cleaned-up ID.
  - Works for both native use_cloud sessions and cdp_url reconnects.

<sup>Written for commit cd7aa0b21f2c0f967781ed7374e76f799ca5386c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

