### PR TITLE
docs: remove stale TODO about persistent websocket connection

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -38,7 +38,6 @@ class DomService:
 
 	Either browser or page must be provided.
 
-	TODO: currently we start a new websocket connection PER STEP, we should definitely keep this persistent
 	"""
 
 	logger: logging.Logger


### PR DESCRIPTION
The TODO comment in `browser_use/dom/service.py` regarding persistent websocket connections is outdated and misleading. Detailed analysis of `SessionManager` and `BrowserSession` confirms that session persistence and reuse are already implemented efficiently via event-driven CDP session management.

I have verified this behavior with a reproduction script and confirmed that existing tests pass. This PR removes the stale TODO to avoid confusion.

Confirmed by:
- Code analysis of `browser_use/browser/session_manager.py`
- Reproduction script verifying single session creation across multiple steps
- Running `tests/ci/browser/test_dom_serializer.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stale TODO about persistent websocket connections from DomService to reflect current session persistence. No functional changes.

<sup>Written for commit b5ec06c451087338b8b83e219af537ad8a892120. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

