### PR TITLE
Fix RFC 6266 filename parsing in Content-Disposition header

### DIFF
--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -528,15 +528,28 @@ class DownloadsWatchdog(BaseWatchdog):
 
 						# Extract filename from Content-Disposition if available
 						suggested_filename = None
-						if 'filename=' in content_disposition:
-							# Parse filename from Content-Disposition header
+						if content_disposition:
+							# Try RFC 6266 filename* parameter first (supports UTF-8)
 							import re
-
-							filename_match = re.search(r'filename[^;=\n]*=(([\'"]).*?\2|[^;\n]*)', content_disposition)
-							if filename_match:
-								suggested_filename = filename_match.group(1).strip('\'"')
-
-						self.logger.info(f'[DownloadsWatchdog] 🔍 Detected downloadable content via network: {url[:80]}...')
+							from urllib.parse import unquote
+							
+							filename_star_match = re.search(
+								r"filename\*=([^']+)'([^']*)'(.+)",
+								content_disposition
+							)
+							if filename_star_match:
+								encoding = filename_star_match.group(1) or 'utf-8'
+								filename_encoded = filename_star_match.group(3)
+								suggested_filename = unquote(filename_encoded, encoding=encoding)
+							
+							# Fallback to standard filename parameter
+							elif 'filename=' in content_disposition:
+								filename_match = re.search(
+									r'filename[^;=\n]*=(([\'"]).*?\2|[^;\n]*)',
+									content_disposition
+								)
+								if filename_match:
+									suggested_filename = filename_match.group(1).strip('\'"\')
 						self.logger.debug(
 							f'[DownloadsWatchdog]   Content-Type: {content_type}, Is PDF: {is_pdf}, Is Attachment: {is_download_attachment}'
 						)

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -531,22 +531,16 @@ class DownloadsWatchdog(BaseWatchdog):
 						suggested_filename = None
 						if content_disposition:
 							# Try RFC 6266 filename* parameter first (supports UTF-8)
-							
-							filename_star_match = re.search(
-								r"filename\*=([^']+)'([^']*)'(.+)",
-								content_disposition
-							)
+
+							filename_star_match = re.search(r"filename\*=([^']+)'([^']*)'([^;]+)", content_disposition)
 							if filename_star_match:
 								encoding = filename_star_match.group(1) or 'utf-8'
 								filename_encoded = filename_star_match.group(3)
 								suggested_filename = unquote(filename_encoded, encoding=encoding)
-							
+
 							# Fallback to standard filename parameter
 							elif 'filename=' in content_disposition:
-								filename_match = re.search(
-									r'filename[^;=\n]*=(([\'"]).*?\2|[^;\n]*)',
-									content_disposition
-								)
+								filename_match = re.search(r'filename[^;=\n]*=(([\'"]).*?\2|[^;\n]*)', content_disposition)
 								if filename_match:
 									suggested_filename = filename_match.group(1).strip('\'"')
 						self.logger.debug(

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -3,10 +3,11 @@
 import asyncio
 import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import anyio
 from bubus import BaseEvent
@@ -530,8 +531,6 @@ class DownloadsWatchdog(BaseWatchdog):
 						suggested_filename = None
 						if content_disposition:
 							# Try RFC 6266 filename* parameter first (supports UTF-8)
-							import re
-							from urllib.parse import unquote
 							
 							filename_star_match = re.search(
 								r"filename\*=([^']+)'([^']*)'(.+)",
@@ -549,7 +548,7 @@ class DownloadsWatchdog(BaseWatchdog):
 									content_disposition
 								)
 								if filename_match:
-									suggested_filename = filename_match.group(1).strip('\'"\')
+									suggested_filename = filename_match.group(1).strip('\'"')
 						self.logger.debug(
 							f'[DownloadsWatchdog]   Content-Type: {content_type}, Is PDF: {is_pdf}, Is Attachment: {is_download_attachment}'
 						)


### PR DESCRIPTION
## Description
This PR fixes the Content-Disposition header parsing to fully comply with RFC 6266, addressing issues with non-ASCII filenames and multiple file downloads.

## Changes
- Added support for `filename*=UTF-8''` parameter parsing
- Implemented proper URL decoding for encoded filenames
- Maintained backward compatibility with standard `filename=` parameter

## Problem Solved
The current implementation only handles the basic `filename=` parameter and fails when:
1. Filenames contain non-ASCII characters (common in international contexts)
2. Servers use the RFC 6266 compliant `filename*=` parameter
3. Multiple files are downloaded, causing them to overwrite each other as 'download'

## Testing
All test cases passed successfully including:
- Standard ASCII filenames
- UTF-8 encoded Japanese, Korean, and Chinese characters
- ISO-8859-1 encoded filenames
- Filenames with spaces and special characters

Fixes #4094

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Content-Disposition filename parsing to comply with RFC 6266, correctly handling non-ASCII and encoded filenames. Prevents “download” overwrites and tightens regex to avoid capturing trailing parameters; also addresses linting with imports at the file header and ruff-compliant formatting.

- **Bug Fixes**
  - Parse filename* (UTF-8) per RFC 6266 and URL-decode; fallback to filename=.
  - Preserve international characters and spaces in suggested filenames.
  - Update regex to stop at semicolons so only the filename is captured.

<sup>Written for commit 540cf34c68110bcf6fe62e71d49c89331f3a827a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

