### PR TITLE
support web bot auth (RFC 9421)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,7 @@ repos:
       - id: end-of-file-fixer
       # best practices enforcement
       - id: detect-private-key
+        exclude: tests/scripts/test_web_bot_auth_e2e\.py
       # - id: check-docstring-first
       - id: debug-statements
       - id: forbid-submodules

--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 	from browser_use.agent.views import ActionModel, ActionResult, AgentHistoryList
 	from browser_use.browser import BrowserProfile, BrowserSession
 	from browser_use.browser import BrowserSession as Browser
+	from browser_use.browser.web_bot_auth import WebBotAuthConfig
 	from browser_use.code_use.service import CodeAgent
 	from browser_use.dom.service import DomService
 	from browser_use.llm import models
@@ -84,6 +85,7 @@ _LAZY_IMPORTS = {
 	'BrowserSession': ('browser_use.browser', 'BrowserSession'),
 	'Browser': ('browser_use.browser', 'BrowserSession'),  # Alias for BrowserSession
 	'BrowserProfile': ('browser_use.browser', 'BrowserProfile'),
+	'WebBotAuthConfig': ('browser_use.browser.web_bot_auth', 'WebBotAuthConfig'),
 	# Tools (moderate weight)
 	'Tools': ('browser_use.tools.service', 'Tools'),
 	'Controller': ('browser_use.tools.service', 'Controller'),  # alias
@@ -136,6 +138,7 @@ __all__ = [
 	'BrowserSession',
 	'Browser',  # Alias for BrowserSession
 	'BrowserProfile',
+	'WebBotAuthConfig',
 	'Controller',
 	'DomService',
 	'SystemPrompt',

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 from pydantic import AfterValidator, AliasChoices, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from browser_use.browser.cloud.views import CloudBrowserParams
+from browser_use.browser.web_bot_auth import WebBotAuthConfig
 from browser_use.config import CONFIG
 from browser_use.utils import _log_pretty_path, logger
 
@@ -601,6 +602,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	enable_default_extensions: bool = Field(
 		default_factory=_get_enable_default_extensions_default,
 		description="Enable automation-optimized extensions: ad blocking (uBlock Origin), cookie handling (I still don't care about cookies), and URL cleaning (ClearURLs). All extensions work automatically without manual intervention. Extensions are automatically downloaded and loaded when enabled. Can be disabled via BROWSER_USE_DISABLE_EXTENSIONS=1 environment variable.",
+	)
+	web_bot_auth: WebBotAuthConfig | None = Field(
+		default=None,
+		description='Web Bot Auth config for cryptographic bot identity signing on outgoing requests (RFC 9421). Disabled by default.',
 	)
 	demo_mode: bool = Field(
 		default=False,

--- a/browser_use/browser/web_bot_auth.py
+++ b/browser_use/browser/web_bot_auth.py
@@ -1,0 +1,247 @@
+"""Web Bot Auth — RFC 9421 HTTP Message Signatures for bot identity verification.
+Signs outgoing browser requests with Ed25519 so that sites can verify the bot's identity.
+
+Spec: https://www.kernel.sh/docs/browsers/bot-detection/web-bot-auth
+"""
+
+import base64
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+from typing import Self
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+def _b64url_encode(data: bytes) -> str:
+	"""Base64url encode without padding (RFC 4648 §5)."""
+	return base64.urlsafe_b64encode(data).rstrip(b'=').decode()
+
+
+def _load_ed25519_private_key(config: 'WebBotAuthConfig'):
+	"""Load an Ed25519 private key from whichever source the config provides.
+
+	Returns a cryptography Ed25519PrivateKey instance.
+	"""
+	from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+	from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+	if config.private_key_pem:
+		key = load_pem_private_key(config.private_key_pem.encode(), password=None)
+	elif config.private_key_path:
+		key = load_pem_private_key(config.private_key_path.read_bytes(), password=None)
+	elif config.private_key_jwk:
+		jwk = config.private_key_jwk
+		assert jwk.get('kty') == 'OKP' and jwk.get('crv') == 'Ed25519', 'JWK must be Ed25519 (kty=OKP, crv=Ed25519)'
+		d_bytes = base64.urlsafe_b64decode(jwk['d'] + '==')
+		key = Ed25519PrivateKey.from_private_bytes(d_bytes)
+	else:
+		raise ValueError('No key source provided')
+
+	assert isinstance(key, Ed25519PrivateKey), f'Key must be Ed25519, got {type(key).__name__}'
+	return key
+
+
+def _derive_public_jwk_and_keyid(config: 'WebBotAuthConfig') -> tuple[dict, str]:
+	"""Derive (public_jwk, keyid) from a config's private key.
+
+	Returns (jwk_dict, keyid_string) where keyid is the JWK Thumbprint (RFC 7638).
+	"""
+	from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+	key = _load_ed25519_private_key(config)
+	pub_bytes = key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+	x_b64url = _b64url_encode(pub_bytes)
+
+	jwk = {'kty': 'OKP', 'crv': 'Ed25519', 'x': x_b64url}
+	canonical = json.dumps(jwk, separators=(',', ':'), sort_keys=True)
+	keyid = _b64url_encode(hashlib.sha256(canonical.encode()).digest())
+
+	return jwk, keyid
+
+
+class WebBotAuthConfig(BaseModel):
+	"""Configuration for Web Bot Auth (RFC 9421 HTTP Message Signatures).
+
+	Enables cryptographic bot identity verification on outgoing browser requests.
+
+	Quick start:
+	    from browser_use import BrowserSession, WebBotAuthConfig
+
+	    # Generate a fresh identity
+	    config = WebBotAuthConfig.generate()
+
+	    # Use it — all requests are signed automatically
+	    session = BrowserSession(headless=True, web_bot_auth=config)
+
+	    # Host this at /.well-known/http-message-signatures-directory
+	    print(config.public_jwk)  # {'kty': 'OKP', 'crv': 'Ed25519', 'x': '...'}
+	    print(config.keyid)       # JWK Thumbprint string
+	"""
+
+	model_config = ConfigDict(extra='forbid')
+
+	private_key_pem: str | None = Field(
+		default=None,
+		description='PEM-encoded Ed25519 private key string.',
+	)
+	private_key_path: Path | None = Field(
+		default=None,
+		description='Path to a PEM-encoded Ed25519 private key file.',
+	)
+	private_key_jwk: dict | None = Field(
+		default=None,
+		description='Ed25519 private key in JWK format (dict with kty, crv, d, x fields).',
+	)
+	signature_agent_url: str | None = Field(
+		default=None,
+		description='URL to the public key directory (Signature-Agent header).',
+	)
+	ttl_seconds: int = Field(
+		default=3600,
+		ge=1,
+		description='Signature TTL in seconds (default: 1 hour).',
+	)
+
+	@model_validator(mode='after')
+	def validate_exactly_one_key_source(self) -> Self:
+		sources = sum(
+			[
+				self.private_key_pem is not None,
+				self.private_key_path is not None,
+				self.private_key_jwk is not None,
+			]
+		)
+		assert sources == 1, 'Exactly one of private_key_pem, private_key_path, or private_key_jwk must be provided'
+		return self
+
+	# ── Factory methods ───────────────────────────────────────────────
+
+	@classmethod
+	def generate(
+		cls,
+		signature_agent_url: str | None = None,
+		ttl_seconds: int = 3600,
+	) -> 'WebBotAuthConfig':
+		"""Generate a fresh Ed25519 identity and return a ready-to-use config.
+
+		Usage:
+		    config = WebBotAuthConfig.generate()
+		    session = BrowserSession(headless=True, web_bot_auth=config)
+		"""
+		from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+		from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
+
+		key = Ed25519PrivateKey.generate()
+		pem = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode()
+		return cls(
+			private_key_pem=pem,
+			signature_agent_url=signature_agent_url,
+			ttl_seconds=ttl_seconds,
+		)
+
+	# ── Derived properties ────────────────────────────────────────────
+
+	@property
+	def public_jwk(self) -> dict:
+		"""Public JWK dict for hosting in a key directory.
+
+		Host this at /.well-known/http-message-signatures-directory:
+		    {"keys": [config.public_jwk]}
+		"""
+		jwk, _ = _derive_public_jwk_and_keyid(self)
+		return jwk
+
+	@property
+	def keyid(self) -> str:
+		"""JWK Thumbprint (RFC 7638) used as keyid in signatures."""
+		_, keyid = _derive_public_jwk_and_keyid(self)
+		return keyid
+
+	# ── Utility methods ───────────────────────────────────────────────
+
+	def save_private_key(self, path: str | Path) -> None:
+		"""Save the private key as a PEM file for reuse across sessions."""
+		from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
+
+		key = _load_ed25519_private_key(self)
+		pem_bytes = key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+		Path(path).write_bytes(pem_bytes)
+
+
+class WebBotAuthSigner:
+	"""Signs HTTP requests per the Web Bot Auth / RFC 9421 HTTP Message Signatures spec.
+
+	Produces Signature, Signature-Input, and optionally Signature-Agent headers
+	using Ed25519 over a deterministic signature base string.
+	"""
+
+	def __init__(self, config: WebBotAuthConfig) -> None:
+		self._private_key = _load_ed25519_private_key(config)
+
+		jwk, keyid = _derive_public_jwk_and_keyid(config)
+		self._pub_b64url = jwk['x']
+		self._keyid = keyid
+
+		self._signature_agent_url = config.signature_agent_url
+		self._ttl_seconds = config.ttl_seconds
+
+	@property
+	def keyid(self) -> str:
+		"""The JWK Thumbprint used as keyid in signatures."""
+		return self._keyid
+
+	def sign_request_headers(self, url: str) -> dict[str, str]:
+		"""Generate Web Bot Auth headers for a request URL.
+
+		Returns a dict with 'Signature', 'Signature-Input', and optionally
+		'Signature-Agent' headers ready to be added to the request.
+		"""
+		parsed = urlparse(url)
+		authority = parsed.hostname or ''
+		if parsed.port and parsed.port not in (80, 443):
+			authority += f':{parsed.port}'
+
+		now = int(time.time())
+		expires = now + self._ttl_seconds
+		nonce = _b64url_encode(os.urandom(64))
+
+		# Determine signed components
+		components = ['@authority']
+		if self._signature_agent_url:
+			components.append('signature-agent')
+
+		# Build the signature-input string (inner list of RFC 8941 dictionary)
+		component_list = ' '.join(f'"{c}"' for c in components)
+		sig_input = (
+			f'({component_list})'
+			f';created={now}'
+			f';expires={expires}'
+			f';nonce="{nonce}"'
+			f';keyid="{self._keyid}"'
+			f';alg="ed25519"'
+			f';tag="web-bot-auth"'
+		)
+
+		# Build the signature base (the exact bytes that get signed)
+		lines = [f'"@authority": {authority}']
+		if self._signature_agent_url:
+			lines.append(f'"signature-agent": {self._signature_agent_url}')
+		lines.append(f'"@signature-params": {sig_input}')
+		sig_base = '\n'.join(lines)
+
+		# Ed25519 sign
+		signature_bytes = self._private_key.sign(sig_base.encode('utf-8'))
+		sig_b64 = base64.b64encode(signature_bytes).decode()
+
+		headers: dict[str, str] = {
+			'Signature': f'sig1=:{sig_b64}:',
+			'Signature-Input': f'sig1={sig_input}',
+		}
+		if self._signature_agent_url:
+			headers['Signature-Agent'] = self._signature_agent_url
+
+		return headers

--- a/tests/ci/test_web_bot_auth.py
+++ b/tests/ci/test_web_bot_auth.py
@@ -1,0 +1,254 @@
+"""Tests for Web Bot Auth (RFC 9421 HTTP Message Signatures) integration."""
+
+import base64
+import hashlib
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from browser_use.browser.web_bot_auth import WebBotAuthConfig, WebBotAuthSigner, _b64url_encode
+
+# ---------------------------------------------------------------------------
+# Helper — only needed for JWK-specific tests
+# ---------------------------------------------------------------------------
+
+
+def _pem_to_jwk(pem: str) -> dict:
+	"""Convert PEM private key to JWK dict."""
+	from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+	from cryptography.hazmat.primitives.serialization import (
+		Encoding,
+		NoEncryption,
+		PrivateFormat,
+		PublicFormat,
+		load_pem_private_key,
+	)
+
+	key = load_pem_private_key(pem.encode(), password=None)
+	assert isinstance(key, Ed25519PrivateKey)
+	d_bytes = key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+	x_bytes = key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+	return {
+		'kty': 'OKP',
+		'crv': 'Ed25519',
+		'd': _b64url_encode(d_bytes),
+		'x': _b64url_encode(x_bytes),
+	}
+
+
+# ---------------------------------------------------------------------------
+# WebBotAuthConfig — validation
+# ---------------------------------------------------------------------------
+
+
+class TestWebBotAuthConfig:
+	def test_no_key_rejects(self):
+		with pytest.raises(Exception, match='Exactly one'):
+			WebBotAuthConfig()
+
+	def test_multiple_keys_rejects(self):
+		config = WebBotAuthConfig.generate()
+		assert config.private_key_pem is not None
+		jwk = _pem_to_jwk(config.private_key_pem)
+		with pytest.raises(Exception, match='Exactly one'):
+			WebBotAuthConfig(private_key_pem=config.private_key_pem, private_key_jwk=jwk)
+
+	def test_extra_fields_forbidden(self):
+		with pytest.raises(Exception):
+			WebBotAuthConfig(private_key_pem='dummy', bogus_field='nope')  # type: ignore[call-arg]
+
+	def test_jwk_key_accepted_and_matches_pem_keyid(self):
+		config = WebBotAuthConfig.generate()
+		assert config.private_key_pem is not None
+		jwk = _pem_to_jwk(config.private_key_pem)
+		loaded = WebBotAuthConfig(private_key_jwk=jwk)
+		assert loaded.keyid == config.keyid
+
+
+# ---------------------------------------------------------------------------
+# WebBotAuthConfig.generate() and derived properties
+# ---------------------------------------------------------------------------
+
+
+class TestWebBotAuthConfigGenerate:
+	def test_generate_creates_valid_config(self):
+		config = WebBotAuthConfig.generate()
+		assert config.private_key_pem is not None
+		assert config.private_key_pem.startswith('-----BEGIN PRIVATE KEY-----')
+		assert config.private_key_jwk is None
+		assert config.private_key_path is None
+
+	def test_generate_with_options(self):
+		url = 'https://bot.example.com/.well-known/http-message-signatures-directory'
+		config = WebBotAuthConfig.generate(signature_agent_url=url, ttl_seconds=300)
+		assert config.signature_agent_url == url
+		assert config.ttl_seconds == 300
+
+	def test_generate_unique_keys(self):
+		assert WebBotAuthConfig.generate().keyid != WebBotAuthConfig.generate().keyid
+
+	def test_public_jwk_format(self):
+		jwk = WebBotAuthConfig.generate().public_jwk
+		assert jwk['kty'] == 'OKP'
+		assert jwk['crv'] == 'Ed25519'
+		assert 'x' in jwk
+		assert 'd' not in jwk  # must NOT contain private key
+
+	def test_keyid_is_jwk_thumbprint(self):
+		"""keyid = SHA-256 of canonical JWK JSON, base64url-encoded (RFC 7638)."""
+		config = WebBotAuthConfig.generate()
+		canonical = json.dumps(config.public_jwk, separators=(',', ':'), sort_keys=True)
+		expected = _b64url_encode(hashlib.sha256(canonical.encode()).digest())
+		assert config.keyid == expected
+
+	def test_keyid_matches_signer(self):
+		config = WebBotAuthConfig.generate()
+		assert config.keyid == WebBotAuthSigner(config).keyid
+
+	def test_save_and_load_private_key(self, tmp_path: Path):
+		config = WebBotAuthConfig.generate()
+		key_path = tmp_path / 'test-key.pem'
+		config.save_private_key(key_path)
+
+		loaded = WebBotAuthConfig(private_key_path=key_path)
+		assert loaded.keyid == config.keyid
+
+
+# ---------------------------------------------------------------------------
+# WebBotAuthSigner — header generation and signature verification
+# ---------------------------------------------------------------------------
+
+
+class TestWebBotAuthSigner:
+	def test_headers_present(self):
+		signer = WebBotAuthSigner(WebBotAuthConfig.generate())
+		headers = signer.sign_request_headers('https://example.com/page')
+		assert 'Signature' in headers
+		assert 'Signature-Input' in headers
+		assert 'Signature-Agent' not in headers
+
+	def test_signature_agent_header_included(self):
+		url = 'https://bot.example.com/.well-known/http-message-signatures-directory'
+		config = WebBotAuthConfig.generate(signature_agent_url=url)
+		headers = WebBotAuthSigner(config).sign_request_headers('https://example.com/page')
+		assert headers['Signature-Agent'] == url
+
+	def test_signature_input_format(self):
+		config = WebBotAuthConfig.generate()
+		signer = WebBotAuthSigner(config)
+		headers = signer.sign_request_headers('https://example.com/page')
+
+		inner = headers['Signature-Input'][len('sig1=') :]
+		assert '("@authority")' in inner
+		assert ';created=' in inner
+		assert ';expires=' in inner
+		assert ';nonce="' in inner
+		assert f';keyid="{config.keyid}"' in inner
+		assert ';alg="ed25519"' in inner
+		assert ';tag="web-bot-auth"' in inner
+
+	def test_signature_input_with_agent_url(self):
+		url = 'https://bot.example.com/.well-known/http-message-signatures-directory'
+		config = WebBotAuthConfig.generate(signature_agent_url=url)
+		inner = WebBotAuthSigner(config).sign_request_headers('https://example.com/')['Signature-Input']
+		assert '("@authority" "signature-agent")' in inner
+
+	def test_signature_is_64_byte_ed25519(self):
+		headers = WebBotAuthSigner(WebBotAuthConfig.generate()).sign_request_headers('https://example.com/')
+		sig = headers['Signature']
+		assert sig.startswith('sig1=:') and sig.endswith(':')
+		assert len(base64.b64decode(sig[len('sig1=:') : -1])) == 64
+
+	def test_unique_nonce_per_request(self):
+		signer = WebBotAuthSigner(WebBotAuthConfig.generate())
+		h1 = signer.sign_request_headers('https://example.com/')
+		h2 = signer.sign_request_headers('https://example.com/')
+
+		nonce_re = re.compile(r';nonce="([^"]+)"')
+		m1 = nonce_re.search(h1['Signature-Input'])
+		m2 = nonce_re.search(h2['Signature-Input'])
+		assert m1 and m2
+		assert m1.group(1) != m2.group(1)
+
+	def test_signature_verifies(self):
+		"""Reconstruct signature base and verify Ed25519 signature."""
+		from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+		from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+		config = WebBotAuthConfig.generate()
+		assert config.private_key_pem is not None
+		headers = WebBotAuthSigner(config).sign_request_headers('https://example.com/page?foo=bar')
+
+		sig_bytes = base64.b64decode(headers['Signature'][len('sig1=:') : -1])
+		sig_input_str = headers['Signature-Input'][len('sig1=') :]
+		sig_base = f'"@authority": example.com\n"@signature-params": {sig_input_str}'
+
+		key = load_pem_private_key(config.private_key_pem.encode(), password=None)
+		assert isinstance(key, Ed25519PrivateKey)
+		key.public_key().verify(sig_bytes, sig_base.encode('utf-8'))
+
+	def test_signature_with_agent_url_verifies(self):
+		from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+		from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+		agent_url = 'https://bot.example.com/.well-known/http-message-signatures-directory'
+		config = WebBotAuthConfig.generate(signature_agent_url=agent_url)
+		assert config.private_key_pem is not None
+		headers = WebBotAuthSigner(config).sign_request_headers('https://target.example.com/api')
+
+		sig_bytes = base64.b64decode(headers['Signature'][len('sig1=:') : -1])
+		sig_input_str = headers['Signature-Input'][len('sig1=') :]
+		sig_base = f'"@authority": target.example.com\n"signature-agent": {agent_url}\n"@signature-params": {sig_input_str}'
+
+		key = load_pem_private_key(config.private_key_pem.encode(), password=None)
+		assert isinstance(key, Ed25519PrivateKey)
+		key.public_key().verify(sig_bytes, sig_base.encode('utf-8'))
+
+	def test_non_standard_port_in_authority(self):
+		from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+		from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+		config = WebBotAuthConfig.generate()
+		assert config.private_key_pem is not None
+		headers = WebBotAuthSigner(config).sign_request_headers('https://example.com:8443/path')
+
+		sig_bytes = base64.b64decode(headers['Signature'][len('sig1=:') : -1])
+		sig_input_str = headers['Signature-Input'][len('sig1=') :]
+		sig_base = f'"@authority": example.com:8443\n"@signature-params": {sig_input_str}'
+
+		key = load_pem_private_key(config.private_key_pem.encode(), password=None)
+		assert isinstance(key, Ed25519PrivateKey)
+		key.public_key().verify(sig_bytes, sig_base.encode('utf-8'))
+
+
+# ---------------------------------------------------------------------------
+# BrowserSession integration
+# ---------------------------------------------------------------------------
+
+
+class TestWebBotAuthBrowserSession:
+	def test_disabled_by_default(self):
+		from browser_use.browser.profile import BrowserProfile
+		from browser_use.browser.session import BrowserSession
+
+		assert BrowserProfile().web_bot_auth is None
+		assert BrowserSession(headless=True)._web_bot_auth_signer is None
+
+	def test_browser_profile_accepts_config(self):
+		from browser_use.browser.profile import BrowserProfile
+
+		config = WebBotAuthConfig.generate()
+		profile = BrowserProfile(web_bot_auth=config)
+		assert profile.web_bot_auth is not None
+		assert profile.web_bot_auth.keyid == config.keyid
+
+	def test_direct_kwarg_on_browser_session(self):
+		"""web_bot_auth can be passed directly to BrowserSession without BrowserProfile wrapper."""
+		from browser_use.browser.session import BrowserSession
+
+		config = WebBotAuthConfig.generate()
+		session = BrowserSession(headless=True, web_bot_auth=config)
+		assert session.browser_profile.web_bot_auth is not None
+		assert session.browser_profile.web_bot_auth.keyid == config.keyid

--- a/tests/scripts/test_web_bot_auth_e2e.py
+++ b/tests/scripts/test_web_bot_auth_e2e.py
@@ -1,0 +1,111 @@
+"""
+Web Bot Auth — End-to-end test of the full developer experience.
+
+  Part A: Without auth → no signature headers on the wire
+  Part B: With WebBotAuthConfig.generate() → signatures verified locally
+  Part C: With RFC 9421 test key → Cloudflare validates signature server-side
+
+Run:  uv run python tests/scripts/test_web_bot_auth_e2e.py
+"""
+
+import asyncio
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from browser_use import BrowserSession, WebBotAuthConfig
+
+# ── Local header capture server ───────────────────────────────────────
+
+
+class CaptureHandler(BaseHTTPRequestHandler):
+	captured: dict[str, str] = {}
+
+	def do_GET(self):
+		CaptureHandler.captured = dict(self.headers)
+		self.send_response(200)
+		self.end_headers()
+		self.wfile.write(b'<h1>ok</h1>')
+
+	def log_message(self, *a):
+		pass
+
+
+def start_server() -> tuple[HTTPServer, str]:
+	srv = HTTPServer(('127.0.0.1', 0), CaptureHandler)
+	threading.Thread(target=srv.serve_forever, daemon=True).start()
+	port = srv.server_address[1]
+	return srv, f'http://127.0.0.1:{port}/test'
+
+
+# RFC 9421 test key — matches Cloudflare's verification endpoint.
+# From https://github.com/cloudflare/web-bot-auth (examples/rfc9421-keys/ed25519.pem)
+RFC9421_TEST_KEY_PEM = """\
+-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
+-----END PRIVATE KEY-----"""
+
+
+async def main():
+	server, url = start_server()
+
+	# ── Part A: Without auth ──────────────────────────────────────────
+	print('\n── Part A: Without Web Bot Auth ──')
+	session = BrowserSession(headless=True)
+	try:
+		await session.start()
+		CaptureHandler.captured = {}
+		await session.navigate_to(url)
+		await asyncio.sleep(1)
+		assert not (CaptureHandler.captured.get('Signature') or CaptureHandler.captured.get('signature'))
+		print('  No Signature headers (correct)')
+	finally:
+		await session.stop()
+
+	# ── Part B: With generated identity ───────────────────────────────
+	print('\n── Part B: With WebBotAuthConfig.generate() ──')
+	config = WebBotAuthConfig.generate()
+	print(f'  keyid:      {config.keyid}')
+	print(f'  public_jwk: {config.public_jwk}')
+
+	session = BrowserSession(headless=True, web_bot_auth=config)
+	try:
+		await session.start()
+		CaptureHandler.captured = {}
+		await session.navigate_to(url)
+		await asyncio.sleep(1)
+
+		sig = CaptureHandler.captured.get('Signature') or CaptureHandler.captured.get('signature')
+		sig_input = CaptureHandler.captured.get('Signature-Input') or CaptureHandler.captured.get('signature-input')
+		assert sig, f'No Signature header! Headers: {list(CaptureHandler.captured.keys())}'
+		assert sig_input, 'No Signature-Input header!'
+		assert 'web-bot-auth' in sig_input
+		assert config.keyid in sig_input
+		print('  Signature headers present and contain correct keyid')
+	finally:
+		await session.stop()
+
+	# ── Part C: Cloudflare verification with RFC 9421 test key ────────
+	print('\n── Part C: Cloudflare server-side verification ──')
+	cf_config = WebBotAuthConfig(private_key_pem=RFC9421_TEST_KEY_PEM)
+	assert cf_config.keyid == 'poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U'
+	print(f'  keyid matches Cloudflare directory: {cf_config.keyid}')
+
+	session = BrowserSession(headless=True, web_bot_auth=cf_config)
+	try:
+		await session.start()
+		await session.navigate_to('https://http-message-signatures-example.research.cloudflare.com/')
+		await asyncio.sleep(3)
+
+		page = await session.get_current_page()
+		text = await page.evaluate('() => document.body.innerText')
+		print(f'  Cloudflare says: {(text or "").split(chr(10))[1].strip()}')
+		assert 'successfully authenticated' in (text or '').lower(), f'Cloudflare did not validate! Response: {text[:200]}'
+	finally:
+		await session.stop()
+		server.shutdown()
+
+	print('\n  ALL CHECKS PASSED\n')
+
+
+if __name__ == '__main__':
+	asyncio.run(main())


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Web Bot Auth (RFC 9421) to sign outgoing HTTP requests with Ed25519 so sites can verify a bot’s identity. Automatically signs http(s) requests via CDP Fetch and plays well with proxy auth.

- **New Features**
  - WebBotAuthConfig: generate(), accept PEM/path/JWK, expose public_jwk and keyid, ttl, optional signature_agent_url; save_private_key writes 0600; raises ValueError on invalid key config; available as from browser_use import WebBotAuthConfig.
  - BrowserProfile/BrowserSession: new web_bot_auth option; adds Signature, Signature-Input, and optional Signature-Agent; signs @authority (and signature-agent if set); default TTL 1h; non-http requests pass through; integration avoids duplicate Fetch handlers with proxy auth.
  - Tests: unit + e2e coverage; local verification via pytest-httpserver; Cloudflare verification using the RFC 9421 test key (pre-commit exclude for the test key file).

- **Migration**
  - Disabled by default. To enable: session = BrowserSession(web_bot_auth=WebBotAuthConfig.generate()).
  - Optional: host {"keys":[config.public_jwk]} at /.well-known/http-message-signatures-directory when using signature_agent_url.

<sup>Written for commit 4dffd32a9bef62cdb1db7533041e2a6462e92558. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



See:
- https://www.kernel.sh/docs/browsers/bot-detection/web-bot-auth
- https://www.kernel.sh/blog/webbotauth