### PR TITLE
Agent max clickable parameter

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -114,6 +114,7 @@ class MessageManager:
 		include_recent_events: bool = False,
 		sample_images: list[ContentPartTextParam | ContentPartImageParam] | None = None,
 		llm_screenshot_size: tuple[int, int] | None = None,
+		max_clickable_elements_length: int = 40000,
 	):
 		self.task = task
 		self.state = state
@@ -127,6 +128,7 @@ class MessageManager:
 		self.include_recent_events = include_recent_events
 		self.sample_images = sample_images
 		self.llm_screenshot_size = llm_screenshot_size
+		self.max_clickable_elements_length = max_clickable_elements_length
 
 		assert max_history_items is None or max_history_items > 5, 'max_history_items must be None or greater than 5'
 
@@ -470,6 +472,7 @@ class MessageManager:
 			include_attributes=self.include_attributes,
 			step_info=step_info,
 			page_filtered_actions=page_filtered_actions,
+			max_clickable_elements_length=self.max_clickable_elements_length,
 			sensitive_data=self.sensitive_data_description,
 			available_file_paths=available_file_paths,
 			screenshots=screenshots,

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -204,6 +204,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		loop_detection_enabled: bool = True,
 		llm_screenshot_size: tuple[int, int] | None = None,
 		message_compaction: MessageCompactionSettings | bool | None = True,
+		max_clickable_elements_length: int = 40000,
 		_url_shortening_limit: int = 25,
 		**kwargs,
 	):
@@ -409,6 +410,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			loop_detection_window=loop_detection_window,
 			loop_detection_enabled=loop_detection_enabled,
 			message_compaction=message_compaction,
+			max_clickable_elements_length=max_clickable_elements_length,
 		)
 
 		# Token cost service
@@ -514,6 +516,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			include_recent_events=self.include_recent_events,
 			sample_images=self.sample_images,
 			llm_screenshot_size=llm_screenshot_size,
+			max_clickable_elements_length=self.settings.max_clickable_elements_length,
 		)
 
 		if self.sensitive_data:

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -88,6 +88,7 @@ class AgentSettings(BaseModel):
 	# Loop detection settings
 	loop_detection_window: int = 20  # Rolling window size for action similarity tracking
 	loop_detection_enabled: bool = True  # Whether to enable loop detection nudges
+	max_clickable_elements_length: int = 40000  # Max characters for clickable elements in prompt
 
 
 class PageFingerprint(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.11.10a1"
+version = "0.11.10a2"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [


### PR DESCRIPTION
Expose `max_clickable_elements_length` as a configurable parameter in the `Agent` and bump the version.

This parameter controls the maximum length of clickable elements text included in the agent's prompt, allowing users to adjust the level of detail or manage prompt token usage.

---
[Slack Thread](https://browser-use.slack.com/archives/C09TE8XR38R/p1770833444811299?thread_ts=1770833444.811299&cid=C09TE8XR38R)

<p><a href="https://cursor.com/background-agent?bcId=bc-d0047393-d2d4-5c6e-a2ed-131d59dadb73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0047393-d2d4-5c6e-a2ed-131d59dadb73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Agent setting, max_clickable_elements_length, to cap clickable element text in prompts and control token usage. Defaults to 40000; behavior is unchanged unless you override it.

- **New Features**
  - AgentSettings now includes max_clickable_elements_length (default 40000).
  - Agent accepts the parameter and passes it through MessageManager to prompt creation.
  - Bumped package version to 0.11.10a2.

<sup>Written for commit 270e418cead0c5a87420faccd393cb4be4d5d5c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

