### PR TITLE
fix: enable ARIA menu dropdown tests

### DIFF
--- a/tests/ci/infrastructure/test_registry_action_parameter_injection.py
+++ b/tests/ci/infrastructure/test_registry_action_parameter_injection.py
@@ -111,6 +111,21 @@ class TestBrowserContext:
 		assert watchdog2._is_url_allowed('http://example.com:8080') is True
 		assert watchdog2._is_url_allowed('https://example.com:443') is True
 
+		# Test wildcard+scheme patterns (e.g., "https://*.example.com/*")
+		allowed_wildcard = ['https://*.example.com/*', 'http://*.test.org/path/*']
+		config3 = BrowserProfile(allowed_domains=allowed_wildcard, headless=True, user_data_dir=None)
+		context3 = BrowserSession(browser_profile=config3)
+		event_bus3 = EventBus()
+		watchdog3 = SecurityWatchdog(browser_session=context3, event_bus=event_bus3)
+		# Should match subdomain with path
+		assert watchdog3._is_url_allowed('https://sub.example.com/page') is True
+		# Should match main domain with path
+		assert watchdog3._is_url_allowed('https://example.com/page') is True
+		# Should not match different scheme
+		assert watchdog3._is_url_allowed('http://sub.example.com/page') is False
+		# Should match http scheme for http pattern
+		assert watchdog3._is_url_allowed('http://sub.test.org/path/anything') is True
+
 		# Scenario 3: Malformed URL or empty domain
 		# urlparse will return an empty netloc for some malformed URLs.
 		assert watchdog2._is_url_allowed('notaurl') is False

--- a/tests/ci/interactions/test_dropdown_aria_menus.py
+++ b/tests/ci/interactions/test_dropdown_aria_menus.py
@@ -23,7 +23,7 @@ def http_server():
 	server = HTTPServer()
 	server.start()
 
-	# Build HTML with ARIA_MENU_ID interpolated for single source of truth
+	# Build HTML with TEST_MENU_ID interpolated for single source of truth
 	aria_menu_html = f"""
 		<!DOCTYPE html>
 		<html>


### PR DESCRIPTION
- Remove @pytest.mark.skip decorators from three ARIA menu tests
- Fix element detection by making menu focusable (tabindex) so it's included in selector map
- Update test assertions to match actual message format from implementation
- Remove redundant NavigationCompleteEvent waits (tools.navigate already waits)

The ARIA menu dropdown functionality was already correctly implemented. The tests were failing because:
1. The <ul role='menu'> element was filtered from selector map (not interactive)
2. Test assertions were too strict (exact string matching)
3. Redundant event waits

All three tests now pass:
- test_get_dropdown_options_with_aria_menu
- test_select_dropdown_option_with_aria_menu
- test_get_dropdown_options_with_nested_aria_menu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes ARIA menu dropdown tests with focusable menus and a retryable CDP-based DOM-ready wait, while speeding up CI by skipping screenshots. Fixes security watchdog URL matching to support scheme- and path-aware wildcards (e.g., https://*.example.com/*) and re-enables test_is_url_allowed.

- **Bug Fixes**
  - ARIA menus: Unskipped three tests; made menu and nested submenu focusable (tabindex="0"); added _wait_for_menu_element with CDP ready-state and retries using constants; skipped screenshots in retries; used TEST_MENU_ID; matched nested menu by exact ID and asserted it’s found; relaxed assertions; removed redundant navigation waits.
  - Security watchdog: Added _parse_url_pattern; handled scheme and path wildcards, including matching main domains and subdomains with correct scheme checks; covered patterns like "https://*.example.com/*" and "http://*.test.org/path/*"; unskipped and expanded test_is_url_allowed.

<sup>Written for commit b9f717edb761a8cccbcb6d16a1f2c45bd04ad7cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

