### PR TITLE
Attempt fix: #3919 Cannot launch Chromium / CDP handshake fails on network-restricted Azu

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -921,15 +921,20 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		"""Get Chrome args for enabling default extensions (ad blocker and cookie handler)."""
 		extension_paths = self._ensure_default_extensions_downloaded()
 
+		if not extension_paths:
+			logger.warning(
+				'[BrowserProfile] ⚠️ Default extensions are enabled but none are available locally; '
+				'skipping extension launch args.'
+			)
+			return []
+
 		args = [
 			'--enable-extensions',
 			'--disable-extensions-file-access-check',
 			'--disable-extensions-http-throttling',
 			'--enable-extension-activity-logging',
+			f'--load-extension={",".join(extension_paths)}',
 		]
-
-		if extension_paths:
-			args.append(f'--load-extension={",".join(extension_paths)}')
 
 		return args
 


### PR DESCRIPTION
Automated first-pass attempt for issue #3919.

Issue: https://github.com/browser-use/browser-use/issues/3919
Estimated LOC target: 15-45

This is a draft PR for maintainer review and iteration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip all extension launch args when default extensions aren’t available to prevent Chromium launch failures/CDP handshake issues in network-restricted environments (e.g., Azure). Adds tests to enforce the behavior.

- **Bug Fixes**
  - Return [] from _get_extension_args when no extensions are downloaded; otherwise include --enable-extensions and --load-extension with resolved paths.
  - Added tests for both paths (no extensions vs. available extensions).

<sup>Written for commit 8e549e7d46109d4372d56467bf2b218def58ae20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

