### PR TITLE
fix: skip planning sections in system prompt when planning is disabled

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -503,6 +503,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				is_anthropic=is_anthropic,
 				is_browser_use_model=is_browser_use_model,
 				model_name=self.llm.model,
+				enable_planning=self.settings.enable_planning,
 			).get_system_message(),
 			file_system=self.file_system,
 			state=self.state.message_manager_state,


### PR DESCRIPTION
## Summary

When `enable_planning=False` (set automatically for flash/browser-use fine-tuned models), the `<planning>` instructions and `current_plan_item`/`plan_update` output schema fields were still included in the system prompt. This wastes ~257 tokens per call and tells the model to produce output fields that are structurally stripped from its schema.

**Changes:**
- Add `enable_planning: bool = True` param to `SystemPrompt` (no behaviour change when `True`)
- Add `_strip_planning_sections()` which removes `<planning>` block + planning output fields via regex when `enable_planning=False`
- Pass `enable_planning=self.settings.enable_planning` from `Agent.__init__` → `SystemPrompt`

## What gets stripped (~257 tokens saved per call)

```
<planning>
Decide whether to plan based on task complexity:
...
</planning>
```
```json
"current_plan_item": 0,
"plan_update": ["Todo item 1", "Todo item 2", "Todo item 3"],
```
```
`current_plan_item` and `plan_update` are optional. See <planning> for details.
```

## Test plan

- [ ] `enable_planning=True` (default): system prompt unchanged, all existing tests pass
- [ ] `enable_planning=False` (flash mode / browser-use models): `<planning>` block absent, output schema fields absent
- [ ] No regression for `override_system_message` path (stripping is skipped entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 2899dc5ba654037bcee315fb0cd4d3faff97664a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip planning instructions and plan-related fields from the system prompt when planning is disabled, saving ~257 tokens per call and avoiding unused output fields.

- **Bug Fixes**
  - Added enable_planning flag to SystemPrompt (default true).
  - When false, strip the <planning> block and current_plan_item/plan_update via regex.
  - Passed settings.enable_planning from Agent to SystemPrompt.

<sup>Written for commit 2899dc5ba654037bcee315fb0cd4d3faff97664a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

