### PR TITLE
fix: prevent judge from corrupting structured output

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -337,6 +337,9 @@ class ActionResult(BaseModel):
 	extracted_content: str | None = None
 	include_extracted_content_only_once: bool = False  # Whether the extracted content should be used to update the read_state
 
+	# Simple judge override note — stored separately so extracted_content stays pure (e.g. JSON for structured output)
+	judge_note: str | None = None
+
 	# Metadata for observability (e.g., click coordinates)
 	metadata: dict | None = None
 

--- a/tests/ci/test_simple_judge_structured_output.py
+++ b/tests/ci/test_simple_judge_structured_output.py
@@ -1,0 +1,169 @@
+"""Tests that _run_simple_judge does not corrupt structured output JSON.
+
+Regression test for https://github.com/browser-use/browser-use/issues/4103
+When output_model_schema is set, _run_simple_judge must not append text
+to extracted_content because that would break model_validate_json().
+"""
+
+import json
+from unittest.mock import AsyncMock
+
+from pydantic import BaseModel, Field
+
+from browser_use.agent.service import Agent
+from browser_use.agent.views import (
+	ActionResult,
+	AgentHistory,
+	AgentHistoryList,
+	BrowserStateHistory,
+	SimpleJudgeResult,
+)
+from browser_use.llm.views import ChatInvokeCompletion
+from tests.ci.conftest import create_mock_llm
+
+
+class ContactList(BaseModel):
+	"""Example structured output schema for testing."""
+
+	contacts: list[str] = Field(default_factory=list, description='List of contact names')
+
+
+def _make_done_result(extracted_content: str) -> ActionResult:
+	"""Create a done ActionResult with given extracted_content."""
+	return ActionResult(
+		is_done=True,
+		success=True,
+		extracted_content=extracted_content,
+	)
+
+
+def _make_history(result: ActionResult) -> AgentHistoryList:
+	"""Wrap a single ActionResult into a minimal AgentHistoryList."""
+	return AgentHistoryList(
+		history=[
+			AgentHistory(
+				model_output=None,
+				result=[result],
+				state=BrowserStateHistory(url='about:blank', title='', tabs=[], interacted_element=[]),
+			)
+		]
+	)
+
+
+async def test_judge_rejection_preserves_structured_json():
+	"""When output_model_schema is set and judge rejects, extracted_content must remain valid JSON."""
+	structured_json = json.dumps({'contacts': ['Alice', 'Bob']})
+
+	# Set up agent with output_model_schema
+	llm = create_mock_llm()
+	agent = Agent(task='Extract contacts', llm=llm, output_model_schema=ContactList)
+
+	# Manually build history as if the agent had completed with structured output
+	done_result = _make_done_result(structured_json)
+	agent.history = _make_history(done_result)
+
+	# Mock the LLM to return a judge rejection on the next call
+	async def judge_ainvoke(*args, **kwargs):
+		judge = SimpleJudgeResult(is_correct=False, reason='Task requirements not fully met')
+		return ChatInvokeCompletion(completion=judge, usage=None)
+
+	agent.llm.ainvoke = AsyncMock(side_effect=judge_ainvoke)
+
+	# Run the simple judge
+	await agent._run_simple_judge()
+
+	# extracted_content must still be valid JSON parseable by the output model
+	last = agent.history.history[-1].result[-1]
+	parsed = ContactList.model_validate_json(last.extracted_content)
+	assert parsed.contacts == ['Alice', 'Bob'], 'Structured output should remain intact'
+
+	# Judge note should be stored separately in judge_note field
+	assert last.judge_note is not None
+	assert 'not fully met' in last.judge_note
+
+	# Success should be overridden to False
+	assert last.success is False
+
+
+async def test_judge_rejection_appends_to_plain_text():
+	"""Without output_model_schema, the judge should append its note to extracted_content."""
+	llm = create_mock_llm()
+	agent = Agent(task='Extract contacts', llm=llm)
+
+	done_result = _make_done_result('Here are the contacts: Alice, Bob')
+	agent.history = _make_history(done_result)
+
+	async def judge_ainvoke(*args, **kwargs):
+		judge = SimpleJudgeResult(is_correct=False, reason='Incomplete result')
+		return ChatInvokeCompletion(completion=judge, usage=None)
+
+	agent.llm.ainvoke = AsyncMock(side_effect=judge_ainvoke)
+
+	await agent._run_simple_judge()
+
+	last = agent.history.history[-1].result[-1]
+	# In plain-text mode, the note should be appended to extracted_content
+	assert '[Simple judge: Incomplete result]' in last.extracted_content
+	assert 'Here are the contacts' in last.extracted_content
+	# judge_note should also be populated
+	assert last.judge_note is not None
+	assert 'Incomplete result' in last.judge_note
+	assert last.success is False
+
+
+async def test_judge_approval_leaves_content_untouched():
+	"""When the judge approves (is_correct=True), nothing should be modified."""
+	structured_json = json.dumps({'contacts': ['Alice']})
+
+	llm = create_mock_llm()
+	agent = Agent(task='Extract contacts', llm=llm, output_model_schema=ContactList)
+
+	done_result = _make_done_result(structured_json)
+	agent.history = _make_history(done_result)
+
+	async def judge_ainvoke(*args, **kwargs):
+		judge = SimpleJudgeResult(is_correct=True, reason='')
+		return ChatInvokeCompletion(completion=judge, usage=None)
+
+	agent.llm.ainvoke = AsyncMock(side_effect=judge_ainvoke)
+
+	await agent._run_simple_judge()
+
+	last = agent.history.history[-1].result[-1]
+	assert last.extracted_content == structured_json
+	assert last.success is True
+	# No judge note should be set when approved
+	assert last.judge_note is None
+
+
+async def test_judge_skips_when_not_done():
+	"""_run_simple_judge should be a no-op when is_done is False."""
+	llm = create_mock_llm()
+	agent = Agent(task='Test', llm=llm)
+
+	result = ActionResult(is_done=False, success=None, extracted_content='some content')
+	agent.history = _make_history(result)
+
+	agent.llm.ainvoke = AsyncMock()
+
+	await agent._run_simple_judge()
+
+	# LLM should never have been called
+	agent.llm.ainvoke.assert_not_called()
+	assert result.extracted_content == 'some content'
+
+
+async def test_judge_skips_when_agent_reports_failure():
+	"""_run_simple_judge should be a no-op when the agent already reports failure."""
+	llm = create_mock_llm()
+	agent = Agent(task='Test', llm=llm)
+
+	result = ActionResult(is_done=True, success=False, extracted_content='failed')
+	agent.history = _make_history(result)
+
+	agent.llm.ainvoke = AsyncMock()
+
+	await agent._run_simple_judge()
+
+	agent.llm.ainvoke.assert_not_called()
+	assert result.extracted_content == 'failed'


### PR DESCRIPTION
## Summary
Fixes #4103

When using `output_model_schema` for structured output, `_run_simple_judge()` could corrupt the JSON stored in `extracted_content`, causing `model_validate_json()` to fail with "trailing characters".

The existing fix stored the judge note in the `metadata` dict, but this PR improves on that by:

- Adding a dedicated `judge_note` field to `ActionResult` for clearer semantics and discoverability
- Always storing the judge note in `judge_note` regardless of output mode
- Only appending to `extracted_content` in plain-text mode (no `output_model_schema`), preserving backward compatibility
- Keeping `metadata` for its intended purpose (observability data like click coordinates)

## Changes
- `browser_use/agent/views.py`: Add `judge_note: str | None` field to `ActionResult`
- `browser_use/agent/service.py`: Refactor `_run_simple_judge()` to use `judge_note` and only append to `extracted_content` for plain-text mode
- `tests/ci/test_simple_judge_structured_output.py`: New regression tests covering judge rejection with structured output, plain-text append, approval pass-through, and early-exit paths
- `tests/ci/test_sandbox_structured_output.py`: Add test verifying `structured_output` parses correctly after judge override

## Test plan
- [x] Judge rejection with `output_model_schema` keeps `extracted_content` as valid JSON
- [x] Judge rejection without `output_model_schema` still appends note to `extracted_content`
- [x] Judge approval leaves content untouched
- [x] Judge skips when `is_done=False` or `success=False`
- [x] `history.structured_output` parses correctly after judge override
- [x] All 14 related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the simple judge from corrupting structured output by storing its note separately. Keeps extracted_content valid JSON when output_model_schema is set, while preserving plain-text behavior.

- **Bug Fixes**
  - Added judge_note to ActionResult; judge notes are always stored there.
  - Structured output: do not append judge text to extracted_content; JSON remains parseable.
  - Plain-text mode: still append judge note to extracted_content for backward compatibility.
  - Refactored _run_simple_judge and added regression tests for reject/approve/skip and sandbox parsing.

<sup>Written for commit 582d644eacbf8adbdb410a0f8b33d025441f76c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

