### PR TITLE
feat: support directories in available_file_paths

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -93,6 +93,32 @@ def _detect_sensitive_key_name(text: str, sensitive_data: dict[str, str | dict[s
 	return None
 
 
+def _is_path_allowed(file_path: str, allowed_paths: list[str] | set[str]) -> bool:
+	"""Check if a file path is allowed by the available_file_paths list.
+
+	Entries in allowed_paths can be either:
+	  - Exact file paths: matched directly against file_path
+	  - Directory paths (ending with os.sep or '/'): any file under this directory is allowed
+
+	Directories that don't end with a separator are also detected via os.path.isdir().
+	"""
+	if not allowed_paths:
+		return False
+	resolved = os.path.abspath(file_path)
+	for entry in allowed_paths:
+		abs_entry = os.path.abspath(entry)
+		# Exact match
+		if resolved == abs_entry:
+			return True
+		# Directory match: entry is a directory and file_path is under it
+		if entry.endswith(('/', os.sep)) or os.path.isdir(entry):
+			# Ensure the directory path ends with separator for proper prefix matching
+			dir_prefix = abs_entry.rstrip(os.sep) + os.sep
+			if resolved.startswith(dir_prefix):
+				return True
+	return False
+
+
 def handle_browser_error(e: BrowserError) -> ActionResult:
 	if e.long_term_memory is not None:
 		if e.short_term_memory is not None:
@@ -726,8 +752,9 @@ class Tools(Generic[Context]):
 			params: UploadFileAction, browser_session: BrowserSession, available_file_paths: list[str], file_system: FileSystem
 		):
 			# Check if file is in available_file_paths (user-provided or downloaded files)
+			# available_file_paths entries can be exact file paths or directories
 			# For remote browsers (is_local=False), we allow absolute remote paths even if not tracked locally
-			if params.path not in available_file_paths:
+			if not _is_path_allowed(params.path, available_file_paths):
 				# Also check if it's a recently downloaded file that might not be in available_file_paths yet
 				downloaded_files = browser_session.downloaded_files
 				if params.path not in downloaded_files:
@@ -1537,7 +1564,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			'Read the complete content of a file. Use this to view file contents before editing or to retrieve data from files. Supports text files (txt, md, json, csv, jsonl), documents (pdf, docx), and images (jpg, png).'
 		)
 		async def read_file(file_name: str, available_file_paths: list[str], file_system: FileSystem):
-			if available_file_paths and file_name in available_file_paths:
+			if available_file_paths and _is_path_allowed(file_name, available_file_paths):
 				structured_result = await file_system.read_file_structured(file_name, external_file=True)
 			else:
 				structured_result = await file_system.read_file_structured(file_name)
@@ -1661,9 +1688,9 @@ Context: {context}"""
 					file_path = source
 
 					# Validate file path against whitelist (available_file_paths + downloaded files)
-					allowed_paths = set(available_file_paths or [])
-					allowed_paths.update(browser_session.downloaded_files)
-					if file_path not in allowed_paths:
+					# available_file_paths entries can be exact file paths or directories
+					allowed_paths = list(available_file_paths or []) + list(browser_session.downloaded_files)
+					if not _is_path_allowed(file_path, allowed_paths):
 						return ActionResult(
 							extracted_content=f'Error: File path not in available_file_paths: {file_path}. '
 							f'The user must add this path to available_file_paths when creating the Agent.',
@@ -2456,8 +2483,9 @@ class CodeAgentTools(Tools[Context]):
 			# 3. For remote browsers, allow any path (assume it exists remotely)
 
 			# If whitelist provided, validate path is in it
+			# available_file_paths entries can be exact file paths or directories
 			if available_file_paths:
-				if params.path not in available_file_paths:
+				if not _is_path_allowed(params.path, available_file_paths):
 					# Also check if it's a recently downloaded file
 					downloaded_files = browser_session.downloaded_files
 					if params.path not in downloaded_files:

--- a/tests/ci/infrastructure/test_path_allowed.py
+++ b/tests/ci/infrastructure/test_path_allowed.py
@@ -1,0 +1,124 @@
+"""
+Tests for _is_path_allowed utility function in tools/service.py.
+
+This function supports directory entries in available_file_paths, allowing
+users to whitelist entire directories instead of individual files.
+See: https://github.com/browser-use/browser-use/issues/4120
+"""
+
+from browser_use.tools.service import _is_path_allowed
+
+
+class TestIsPathAllowed:
+	"""Test _is_path_allowed with exact paths, directories, and edge cases."""
+
+	def test_exact_file_match(self):
+		"""Exact file path should match."""
+		assert _is_path_allowed('/tmp/test.txt', ['/tmp/test.txt']) is True
+
+	def test_exact_file_no_match(self):
+		"""Non-matching exact file path should not match."""
+		assert _is_path_allowed('/tmp/other.txt', ['/tmp/test.txt']) is False
+
+	def test_empty_allowed_paths(self):
+		"""Empty allowed_paths should never match."""
+		assert _is_path_allowed('/tmp/test.txt', []) is False
+
+	def test_directory_with_trailing_slash(self):
+		"""Directory entry with trailing slash should allow files under it."""
+		assert _is_path_allowed('/tmp/uploads/file.txt', ['/tmp/uploads/']) is True
+
+	def test_directory_with_trailing_slash_nested(self):
+		"""Directory entry with trailing slash should allow nested files."""
+		assert _is_path_allowed('/tmp/uploads/subdir/file.txt', ['/tmp/uploads/']) is True
+
+	def test_directory_with_trailing_slash_no_match(self):
+		"""File outside the directory should not match."""
+		assert _is_path_allowed('/tmp/other/file.txt', ['/tmp/uploads/']) is False
+
+	def test_real_directory_without_trailing_slash(self, tmp_path):
+		"""A real directory (detected via os.path.isdir) should allow files under it."""
+		subdir = tmp_path / 'mydir'
+		subdir.mkdir()
+		test_file = subdir / 'test.txt'
+		test_file.write_text('hello')
+
+		assert _is_path_allowed(str(test_file), [str(subdir)]) is True
+
+	def test_real_directory_nested_files(self, tmp_path):
+		"""A real directory should allow deeply nested files."""
+		subdir = tmp_path / 'mydir' / 'nested'
+		subdir.mkdir(parents=True)
+		test_file = subdir / 'deep.txt'
+		test_file.write_text('hello')
+
+		assert _is_path_allowed(str(test_file), [str(tmp_path / 'mydir')]) is True
+
+	def test_real_directory_rejects_outside_files(self, tmp_path):
+		"""A real directory should reject files outside it."""
+		subdir = tmp_path / 'mydir'
+		subdir.mkdir()
+		other_file = tmp_path / 'outside.txt'
+		other_file.write_text('hello')
+
+		assert _is_path_allowed(str(other_file), [str(subdir)]) is False
+
+	def test_mixed_files_and_directories(self, tmp_path):
+		"""Mix of exact file paths and directory entries should work."""
+		subdir = tmp_path / 'uploads'
+		subdir.mkdir()
+		file_in_dir = subdir / 'uploaded.txt'
+		file_in_dir.write_text('data')
+		exact_file = tmp_path / 'specific.txt'
+		exact_file.write_text('data')
+
+		allowed = [str(exact_file), str(subdir)]
+
+		assert _is_path_allowed(str(exact_file), allowed) is True
+		assert _is_path_allowed(str(file_in_dir), allowed) is True
+		assert _is_path_allowed(str(tmp_path / 'random.txt'), allowed) is False
+
+	def test_directory_prefix_attack(self):
+		"""Directory /tmp/up should NOT match /tmp/uploads/file.txt."""
+		# Using trailing slash explicitly
+		assert _is_path_allowed('/tmp/uploads/file.txt', ['/tmp/up/']) is False
+
+	def test_directory_name_prefix_attack_no_trailing_slash(self, tmp_path):
+		"""Ensure /foo/bar does not match /foo/bar_extra/file.txt via prefix."""
+		dir_a = tmp_path / 'bar'
+		dir_a.mkdir()
+		dir_b = tmp_path / 'bar_extra'
+		dir_b.mkdir()
+		test_file = dir_b / 'file.txt'
+		test_file.write_text('data')
+
+		assert _is_path_allowed(str(test_file), [str(dir_a)]) is False
+
+	def test_relative_path_resolved(self, tmp_path, monkeypatch):
+		"""Relative paths should be resolved to absolute for matching."""
+		monkeypatch.chdir(tmp_path)
+		test_file = tmp_path / 'test.txt'
+		test_file.write_text('hello')
+
+		assert _is_path_allowed('test.txt', [str(tmp_path) + '/']) is True
+
+	def test_set_input(self):
+		"""Should work with set input as well as list."""
+		assert _is_path_allowed('/tmp/test.txt', {'/tmp/test.txt'}) is True
+		assert _is_path_allowed('/tmp/other.txt', {'/tmp/test.txt'}) is False
+
+	def test_multiple_directories(self, tmp_path):
+		"""Multiple directory entries should all be checked."""
+		dir_a = tmp_path / 'a'
+		dir_b = tmp_path / 'b'
+		dir_a.mkdir()
+		dir_b.mkdir()
+		file_a = dir_a / 'file.txt'
+		file_a.write_text('a')
+		file_b = dir_b / 'file.txt'
+		file_b.write_text('b')
+
+		allowed = [str(dir_a), str(dir_b)]
+		assert _is_path_allowed(str(file_a), allowed) is True
+		assert _is_path_allowed(str(file_b), allowed) is True
+		assert _is_path_allowed(str(tmp_path / 'c' / 'file.txt'), allowed) is False


### PR DESCRIPTION
## Summary

Closes #4120

- Add `_is_path_allowed()` helper that checks whether a file path matches an entry in `available_file_paths`, supporting both **exact file paths** (existing behavior) and **directory paths** (new: any file under the directory is allowed)
- Update all four path validation sites in `tools/service.py`: `upload_file` (standard agent), `upload_file` (code-use agent), `read_file`, and `read_long_content`
- Directory entries are detected by trailing `/` or via `os.path.isdir()`, with proper prefix matching to prevent path traversal (e.g., `/tmp/up` won't match `/tmp/uploads/file.txt`)

### Usage

```python
agent = Agent(
    task="Upload the generated report",
    llm=llm,
    # Now you can whitelist a whole directory instead of listing every file
    available_file_paths=["/tmp/dynamic-uploads/"],
)
```

## Test plan

- [x] 15 unit tests for `_is_path_allowed` covering exact matches, directory matching (trailing slash and real directories), nested files, prefix attack prevention, relative path resolution, mixed entries, and edge cases
- [x] All existing infrastructure CI tests pass
- [x] `pyright` passes with 0 errors
- [x] `ruff check` shows no new warnings (only pre-existing ASYNC240)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add directory support to available_file_paths so you can whitelist a folder and allow uploads/reads for any file inside it. Keeps exact-file checks and adds safe, separator-aware matching.

- **New Features**
  - Added _is_path_allowed to support exact paths and directories (trailing slash or real directories).
  - Applied to all validations: upload_file (standard and code-use), read_file, and read_long_content.
  - Uses absolute paths and separator-safe prefixes to prevent prefix/path traversal; includes unit tests for exact matches, nested files, relative paths, and edge cases.

<sup>Written for commit d2c41faab645f3c07656ebf2daec8e9f0517cd20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

