### PR TITLE
#4143 Issue fix and test cases as well

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1423,10 +1423,78 @@ class DefaultActionWatchdog(BaseWatchdog):
 			self.logger.debug(f'All clearing strategies failed: {e}')
 			return False
 
+	@staticmethod
+	def _is_autocomplete_field(node: EnhancedDOMTreeNode) -> bool:
+		"""Detect if a node is an autocomplete/combobox field that needs mouse events to open its dropdown."""
+		attrs = node.attributes or {}
+		if attrs.get('role') == 'combobox':
+			return True
+		aria_ac = attrs.get('aria-autocomplete', '')
+		if aria_ac and aria_ac != 'none':
+			return True
+		haspopup = attrs.get('aria-haspopup', '')
+		if haspopup and haspopup != 'false' and (attrs.get('aria-controls') or attrs.get('aria-owns')):
+			return True
+		return False
+
+	async def _click_to_focus(self, cdp_session, input_coordinates: dict) -> bool:
+		"""Focus an element by dispatching mouse press/release events at its coordinates."""
+		try:
+			click_x = input_coordinates['input_x']
+			click_y = input_coordinates['input_y']
+
+			self.logger.debug(f'🎯 Attempting click-to-focus at ({click_x:.1f}, {click_y:.1f})')
+
+			await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
+				params={
+					'type': 'mousePressed',
+					'x': click_x,
+					'y': click_y,
+					'button': 'left',
+					'clickCount': 1,
+				},
+				session_id=cdp_session.session_id,
+			)
+			await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
+				params={
+					'type': 'mouseReleased',
+					'x': click_x,
+					'y': click_y,
+					'button': 'left',
+					'clickCount': 1,
+				},
+				session_id=cdp_session.session_id,
+			)
+
+			self.logger.debug('✅ Element focused using click method')
+			return True
+
+		except Exception as e:
+			self.logger.debug(f'Click focus failed: {e}')
+			return False
+
 	async def _focus_element_simple(
-		self, backend_node_id: int, object_id: str, cdp_session, input_coordinates: dict | None = None
+		self,
+		backend_node_id: int,
+		object_id: str,
+		cdp_session,
+		input_coordinates: dict | None = None,
+		element_node: EnhancedDOMTreeNode | None = None,
 	) -> bool:
-		"""Simple focus strategy: CDP first, then click if failed."""
+		"""Simple focus strategy: CDP first, then click if failed.
+
+		For autocomplete/combobox fields, prefer click-to-focus so that mouse events
+		fire and JS-driven dropdowns open properly. DOM.focus() only sets focus without
+		dispatching mousedown/mouseup/click events that many autocomplete widgets need.
+		"""
+
+		# For autocomplete fields, prefer click-to-focus to fire mouse events that open dropdowns
+		if element_node and self._is_autocomplete_field(element_node):
+			if input_coordinates and 'input_x' in input_coordinates:
+				self.logger.debug('🔍 Autocomplete field detected — using click-to-focus to fire mouse events')
+				if await self._click_to_focus(cdp_session, input_coordinates):
+					return True
+			# Fall through to DOM.focus if coordinates aren't available
 
 		# Strategy 1: Try CDP DOM.focus first
 		try:
@@ -1442,39 +1510,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 		# Strategy 2: Try click to focus if CDP failed
 		if input_coordinates and 'input_x' in input_coordinates and 'input_y' in input_coordinates:
-			try:
-				click_x = input_coordinates['input_x']
-				click_y = input_coordinates['input_y']
-
-				self.logger.debug(f'🎯 Attempting click-to-focus at ({click_x:.1f}, {click_y:.1f})')
-
-				# Click to focus
-				await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
-					params={
-						'type': 'mousePressed',
-						'x': click_x,
-						'y': click_y,
-						'button': 'left',
-						'clickCount': 1,
-					},
-					session_id=cdp_session.session_id,
-				)
-				await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
-					params={
-						'type': 'mouseReleased',
-						'x': click_x,
-						'y': click_y,
-						'button': 'left',
-						'clickCount': 1,
-					},
-					session_id=cdp_session.session_id,
-				)
-
-				self.logger.debug('✅ Element focused using click method')
+			if await self._click_to_focus(cdp_session, input_coordinates):
 				return True
-
-			except Exception as e:
-				self.logger.debug(f'Click focus failed: {e}')
 
 		# Both strategies failed
 		self.logger.debug('Focus strategies failed, will attempt typing anyway')
@@ -1696,7 +1733,11 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# Step 1: Focus the element using simple strategy
 			focused_successfully = await self._focus_element_simple(
-				backend_node_id=backend_node_id, object_id=object_id, cdp_session=cdp_session, input_coordinates=input_coordinates
+				backend_node_id=backend_node_id,
+				object_id=object_id,
+				cdp_session=cdp_session,
+				input_coordinates=input_coordinates,
+				element_node=element_node,
 			)
 
 			# Step 2: Check if this element requires direct value assignment (date/time inputs)


### PR DESCRIPTION
 The Bug

The input action focuses elements using DOM.focus() — a CDP API that programmatically moves focus without firing mouse events. This is fine for normal text inputs, but many real-world
autocomplete/combobox widgets (Select2, MUI Autocomplete, Ant Design, etc.) bind their dropdown-open logic to mousedown/click events, not the focus event.

  So when the agent does input(index=5, text="New York") on an autocomplete field:
  - DOM.focus() succeeds silently → text gets typed → but the dropdown never opens
  - The agent never sees suggestions to click on

  When you manually do click then type, it works because click dispatches real mouse events (mousePressed → mouseReleased) which the widget's JS listens for.

 What I changed

  1. browser_use/browser/watchdogs/default_action_watchdog.py

Modified _focus_element_simple() (the method that focuses an element before typing) to detect autocomplete fields and use click-to-focus instead of DOM.focus() for them:
  - Added _is_autocomplete_field() — detects combobox fields from ARIA attributes (role="combobox", aria-autocomplete, aria-haspopup + aria-controls/aria-owns)
  - Extracted _click_to_focus() — dispatches mousePressed/mouseReleased events at the element's coordinates
  - Changed the focus strategy order: for autocomplete fields, try click-to-focus first (so mouse events fire and the dropdown opens), then fall back to DOM.focus() only if coordinates aren't available

2. tests/ci/interactions/test_autocomplete_interaction.py
Added a test with an HTML page where the combobox dropdown only opens on mousedown/click  exactly the scenario that was broken. The test verifies that tools.input() triggers the dropdown to open.

What I didn't change

  - Normal (non-autocomplete) inputs still use DOM.focus() first — no behavior change for regular fields
  - The existing autocomplete detection in tools/service.py (the post-typing delay and hint message) is untouched — it still works as before
  - The _is_autocomplete_field logic intentionally excludes native <datalist> fields (which use the list attribute), since those are handled by the browser natively and don't need mouse events to work


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix input on autocomplete/combobox fields by preferring click-to-focus so mouse events fire and dropdowns open. This makes tools.input reliably show suggestions in common widgets.

- **Bug Fixes**
  - Detect combobox/autocomplete inputs via ARIA attributes (role="combobox", aria-autocomplete, aria-haspopup with controls/owns).
  - Use click-to-focus for these fields; fall back to DOM.focus() if coordinates aren’t available.
  - No change for regular inputs.
  - Added an integration test that only opens on mousedown/click to verify the fix.

<sup>Written for commit 2210203895b8b60915a4efd7a45674a526944cbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

