### PR TITLE
Fix hardcoded /tmp path creating unwanted folders on Windows

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -428,19 +428,8 @@ class BrowserLaunchArgs(BaseModel):
 	def set_default_downloads_path(self) -> Self:
 		"""Set a unique default downloads path if none is provided."""
 		if self.downloads_path is None:
-			import uuid
+			self.downloads_path = Path(tempfile.mkdtemp(prefix='browser-use-downloads-'))
 
-			# Create unique directory in /tmp for downloads
-			unique_id = str(uuid.uuid4())[:8]  # 8 characters
-			downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
-
-			# Ensure path doesn't already exist (extremely unlikely but possible)
-			while downloads_path.exists():
-				unique_id = str(uuid.uuid4())[:8]
-				downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
-
-			self.downloads_path = downloads_path
-			self.downloads_path.mkdir(parents=True, exist_ok=True)
 		return self
 
 	@staticmethod


### PR DESCRIPTION
## Summary

Fixes #4165

Replace hardcoded `Path('/tmp/browser-use-downloads-...')` with `tempfile.mkdtemp(prefix='browser-use-downloads-')` in `BrowserLaunchArgs.set_default_downloads_path()`.

On Windows, `Path('/tmp/...')` resolves to `C:\TMP\...`, creating visible folders on the C:\ drive at import time. `tempfile.mkdtemp()` uses the platform-appropriate temp directory (`%TEMP%` on Windows, `/tmp` on Linux/macOS) and also handles uniqueness and directory creation, simplifying the code from 12 lines to 1.

Note: `validate_user_data_dir()` in the same file already uses `tempfile.mkdtemp()` correctly (line 517), so this change makes the codebase consistent.

## Changes

- `browser_use/browser/profile.py`: Replace hardcoded `/tmp` path with `tempfile.mkdtemp()` (already imported at top of file)

## Test plan

- [x] Verify `tempfile` is already imported (line 3)
- [ ] On Windows: `from browser_use import Browser` should no longer create `C:\TMP` folder
- [ ] On Linux/macOS: behavior unchanged (downloads still go to `/tmp/browser-use-downloads-*`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace hardcoded /tmp downloads path with tempfile.mkdtemp to use the OS temp directory and stop creating C:\TMP folders on Windows. Behavior on Linux/macOS stays the same. Fixes #4165.

- **Bug Fixes**
  - Use Path(tempfile.mkdtemp(prefix='browser-use-downloads-')) in set_default_downloads_path.
  - Removes manual UUID logic and aligns with validate_user_data_dir.
  - Prevents import-time folder creation on Windows; path is unique and created by tempfile.

<sup>Written for commit 4f8016cfc4aaee1ab4e5134c23dcb8a6983f4693. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

