### PR TITLE
Fix run command failing in local mode

### DIFF
--- a/browser_use/skill_cli/commands/agent.py
+++ b/browser_use/skill_cli/commands/agent.py
@@ -199,7 +199,7 @@ async def _handle_local_task(session: SessionInfo, params: dict[str, Any]) -> An
 		from browser_use.agent.service import Agent
 
 		# Try to get LLM from environment (with optional model override)
-		llm = await get_llm(model=model)
+		llm = get_llm(model=model)
 		if llm is None:
 			if model:
 				return {


### PR DESCRIPTION
In the skill cli get_llm is incorrectly called using async, causing commands like run to fail in local mode. The get_llm method was originally async in c4ffaca6e79bb0128876bb0b358728e74ecd7a1b and it recently changed af9383a2c7f2264f1f40240a2129d100acd32cff. The change makes sense but it missed adjusting the the call in _handle_local_task. 

Reproduce in local mode using:

```bash
browser-use --headed open http://localhost:9257
browser-use run "Press the button"
```




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI run command in local mode by calling get_llm synchronously. Prevents runtime errors when starting local tasks.

<sup>Written for commit 9905a769d56131d57486be3eb92b021088e0ec13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

