### PR TITLE
Fix hardcoded /tmp path for Windows compatibility

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -430,14 +430,14 @@ class BrowserLaunchArgs(BaseModel):
 		if self.downloads_path is None:
 			import uuid
 
-			# Create unique directory in /tmp for downloads
+			# Create unique directory in system temp for downloads (cross-platform)
 			unique_id = str(uuid.uuid4())[:8]  # 8 characters
-			downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+			downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			# Ensure path doesn't already exist (extremely unlikely but possible)
 			while downloads_path.exists():
 				unique_id = str(uuid.uuid4())[:8]
-				downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+				downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			self.downloads_path = downloads_path
 			self.downloads_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Description

Fixes #4165 - Hardcoded /tmp creates unwanted C:\TMP folders on Windows

## Problem

When using browser-use on Windows, the library automatically creates a  folder at import time, even if a custom  is set.

Root cause: The path was hardcoded as  which on Windows resolves to the root of the current drive (C:\TMP).

## Solution

Replace hardcoded  with  which returns the appropriate temp directory for each platform:
- Linux/macOS: /tmp
- Windows: C:\Users\{user}\AppData\Local\Temp

## Changes

- : Use  instead of hardcoded 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the system temp directory for the default downloads path instead of hardcoded /tmp. This fixes Windows behavior and avoids creating C:\TMP folders.

- **Bug Fixes**
  - Replace /tmp with tempfile.gettempdir() when creating the default downloads directory.
  - Respects OS temp settings (TMP/TEMP) and ensures Linux/macOS use /tmp while Windows uses AppData\Local\Temp.

<sup>Written for commit 4676fdd84fb73330f501391f71e5bd68d1d29157. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

