### PR TITLE
Delete Exactly Duplicated Sections from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -381,45 +381,6 @@ See all helper methods in the [AgentHistoryList source code](https://github.com/
 
 For structured output, use the `output_model_schema` parameter with a Pydantic model. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/custom_output.py).
 
-## Agent History
-
-The `run()` method returns an `AgentHistoryList` object with the complete execution history:
-
-```python  theme={null}
-history = await agent.run()
-
-# Access useful information
-history.urls()                    # List of visited URLs
-history.screenshot_paths()        # List of screenshot paths
-history.screenshots()             # List of screenshots as base64 strings
-history.action_names()            # Names of executed actions
-history.extracted_content()       # List of extracted content from all actions
-history.errors()                  # List of errors (with None for steps without errors)
-history.model_actions()           # All actions with their parameters
-history.model_outputs()           # All model outputs from history
-history.last_action()             # Last action in history
-
-# Analysis methods
-history.final_result()            # Get the final extracted content (last step)
-history.is_done()                 # Check if agent completed successfully
-history.is_successful()           # Check if agent completed successfully (returns None if not done)
-history.has_errors()              # Check if any errors occurred
-history.model_thoughts()          # Get the agent's reasoning process (AgentBrain objects)
-history.action_results()          # Get all ActionResult objects from history
-history.action_history()          # Get truncated action history with essential fields
-history.number_of_steps()         # Get the number of steps in the history
-history.total_duration_seconds()  # Get total duration of all steps in seconds
-
-# Structured output (when using output_model_schema)
-history.structured_output         # Property that returns parsed structured output
-```
-
-See all helper methods in the [AgentHistoryList source code](https://github.com/browser-use/browser-use/blob/main/browser_use/agent/views.py#L301).
-
-## Structured Output
-
-For structured output, use the `output_model_schema` parameter with a Pydantic model. [Example](https://github.com/browser-use/browser-use/blob/main/examples/features/custom_output.py).
-
 
 # Agent Prompting Guide
 > Tips and tricks


### PR DESCRIPTION
these are exact duplicates repeated in the file. must be a mistake

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicated “Agent History” and “Structured Output” sections from AGENTS.md to eliminate redundancy and prevent confusion. Only repeated content was deleted; no changes to the original sections or wording elsewhere.

<sup>Written for commit 88fe3cbb28205d38b6961fe980d615dddde124e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

