### PR TITLE
fix(browser): exclude chrome-extension targets from page target selection

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3110,7 +3110,7 @@ class BrowserSession(BaseModel):
 		"""Close any extension options/welcome pages that have opened."""
 		try:
 			# Get all page targets from SessionManager
-			page_targets = self.session_manager.get_all_page_targets()
+			page_targets = self.session_manager.get_all_page_targets(include_chrome_extensions=True)
 
 			for target in page_targets:
 				target_url = target.url

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -147,16 +147,25 @@ class SessionManager:
 			return None
 		return self._sessions.get(next(iter(session_ids)))
 
-	def get_all_page_targets(self) -> list:
+	def get_all_page_targets(self, include_chrome_extensions: bool = False) -> list:
 		"""Get all page/tab targets using owned data.
+
+		Args:
+			include_chrome_extensions: Include chrome-extension:// page targets.
 
 		Returns:
 			List of Target objects for all page/tab targets
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
-				page_targets.append(target)
+			if target.target_type not in ('page', 'tab'):
+				continue
+
+			target_url = target.url or ''
+			if not include_chrome_extensions and target_url.startswith('chrome-extension://'):
+				continue
+
+			page_targets.append(target)
 		return page_targets
 
 	async def validate_session(self, target_id: TargetID) -> bool:

--- a/tests/ci/browser/test_session_manager_page_target_filter.py
+++ b/tests/ci/browser/test_session_manager_page_target_filter.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from browser_use.browser.session_manager import SessionManager
+
+
+def _build_session_manager_with_targets(targets: dict[str, SimpleNamespace]) -> SessionManager:
+	logger = SimpleNamespace(
+		info=lambda *args, **kwargs: None,
+		warning=lambda *args, **kwargs: None,
+		error=lambda *args, **kwargs: None,
+		debug=lambda *args, **kwargs: None,
+	)
+	browser_session = SimpleNamespace(logger=logger)
+	session_manager = SessionManager(browser_session)
+	session_manager._targets = targets
+	return session_manager
+
+
+def test_get_all_page_targets_excludes_chrome_extension_by_default():
+	session_manager = _build_session_manager_with_targets(
+		{
+			'normal': SimpleNamespace(
+				target_id='normal',
+				target_type='page',
+				url='https://example.com',
+				title='Example',
+			),
+			'extension': SimpleNamespace(
+				target_id='extension',
+				target_type='page',
+				url='chrome-extension://abcdef/panel.html',
+				title='Extension',
+			),
+			'tab': SimpleNamespace(
+				target_id='tab',
+				target_type='tab',
+				url='https://news.ycombinator.com',
+				title='HN',
+			),
+			'worker': SimpleNamespace(
+				target_id='worker',
+				target_type='worker',
+				url='https://example.com/worker.js',
+				title='Worker',
+			),
+		}
+	)
+
+	target_urls = [target.url for target in session_manager.get_all_page_targets()]
+
+	assert 'https://example.com' in target_urls
+	assert 'https://news.ycombinator.com' in target_urls
+	assert 'chrome-extension://abcdef/panel.html' not in target_urls
+	assert 'https://example.com/worker.js' not in target_urls
+
+
+def test_get_all_page_targets_can_include_chrome_extension_targets():
+	session_manager = _build_session_manager_with_targets(
+		{
+			'extension': SimpleNamespace(
+				target_id='extension',
+				target_type='page',
+				url='chrome-extension://abcdef/panel.html',
+				title='Extension',
+			),
+		}
+	)
+
+	target_urls = [
+		target.url for target in session_manager.get_all_page_targets(include_chrome_extensions=True)
+	]
+
+	assert target_urls == ['chrome-extension://abcdef/panel.html']

--- a/tests/ci/browser/test_session_manager_page_target_filter.py
+++ b/tests/ci/browser/test_session_manager_page_target_filter.py
@@ -1,16 +1,18 @@
 from types import SimpleNamespace
+from typing import cast
 
+from browser_use.browser.session import BrowserSession, Target
 from browser_use.browser.session_manager import SessionManager
 
 
-def _build_session_manager_with_targets(targets: dict[str, SimpleNamespace]) -> SessionManager:
+def _build_session_manager_with_targets(targets: dict[str, Target]) -> SessionManager:
 	logger = SimpleNamespace(
 		info=lambda *args, **kwargs: None,
 		warning=lambda *args, **kwargs: None,
 		error=lambda *args, **kwargs: None,
 		debug=lambda *args, **kwargs: None,
 	)
-	browser_session = SimpleNamespace(logger=logger)
+	browser_session = cast(BrowserSession, SimpleNamespace(logger=logger))
 	session_manager = SessionManager(browser_session)
 	session_manager._targets = targets
 	return session_manager
@@ -19,25 +21,25 @@ def _build_session_manager_with_targets(targets: dict[str, SimpleNamespace]) -> 
 def test_get_all_page_targets_excludes_chrome_extension_by_default():
 	session_manager = _build_session_manager_with_targets(
 		{
-			'normal': SimpleNamespace(
+			'normal': Target(
 				target_id='normal',
 				target_type='page',
 				url='https://example.com',
 				title='Example',
 			),
-			'extension': SimpleNamespace(
+			'extension': Target(
 				target_id='extension',
 				target_type='page',
 				url='chrome-extension://abcdef/panel.html',
 				title='Extension',
 			),
-			'tab': SimpleNamespace(
+			'tab': Target(
 				target_id='tab',
 				target_type='tab',
 				url='https://news.ycombinator.com',
 				title='HN',
 			),
-			'worker': SimpleNamespace(
+			'worker': Target(
 				target_id='worker',
 				target_type='worker',
 				url='https://example.com/worker.js',
@@ -57,7 +59,7 @@ def test_get_all_page_targets_excludes_chrome_extension_by_default():
 def test_get_all_page_targets_can_include_chrome_extension_targets():
 	session_manager = _build_session_manager_with_targets(
 		{
-			'extension': SimpleNamespace(
+			'extension': Target(
 				target_id='extension',
 				target_type='page',
 				url='chrome-extension://abcdef/panel.html',
@@ -66,8 +68,6 @@ def test_get_all_page_targets_can_include_chrome_extension_targets():
 		}
 	)
 
-	target_urls = [
-		target.url for target in session_manager.get_all_page_targets(include_chrome_extensions=True)
-	]
+	target_urls = [target.url for target in session_manager.get_all_page_targets(include_chrome_extensions=True)]
 
 	assert target_urls == ['chrome-extension://abcdef/panel.html']


### PR DESCRIPTION
# PR Title

fix(browser): exclude chrome-extension targets from page target selection

# PR Body

## Summary

Fixes #4133.

When Browser Use connects to Chrome via CDP, extension side panels (`chrome-extension://...`) can appear as `page` targets.
Previously, `SessionManager.get_all_page_targets()` returned those extension targets as regular page/tab targets, which could cause focus recovery and tab selection to switch to extension pages.

This PR updates page target selection to exclude extension targets by default.

## Changes

- Updated `SessionManager.get_all_page_targets()` to:
  - accept `include_chrome_extensions: bool = False`
  - filter out `chrome-extension://` targets by default
- Kept extension cleanup behavior intact by explicitly including extension targets in:
  - `BrowserSession._close_extension_options_pages()`

## Tests

Added:

- `tests/ci/browser/test_session_manager_page_target_filter.py`
  - `test_get_all_page_targets_excludes_chrome_extension_by_default`
  - `test_get_all_page_targets_can_include_chrome_extension_targets`

Validation run locally:

```bash
uv run --python 3.11 pytest tests/ci/browser/test_session_manager_page_target_filter.py -q
uv run --python 3.11 ruff check browser_use/browser/session_manager.py browser_use/browser/session.py tests/ci/browser/test_session_manager_page_target_filter.py
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Excluded chrome-extension:// targets from page target selection to prevent focus recovery and tab switching to extension panels. This keeps normal pages and tabs in focus by default.

- **Bug Fixes**
  - SessionManager.get_all_page_targets now takes include_chrome_extensions (default False) and filters extension URLs.
  - BrowserSession._close_extension_options_pages explicitly includes extension targets for cleanup.
  - Tests updated to be pyright-safe for default exclusion and optional inclusion.

<sup>Written for commit 246ab65222347e3520242bbe23a56712db760ab0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

