### PR TITLE
feat(#4142): add thinking block stripping for Minimax API support

### DIFF
--- a/tests/ci/test_llm_thinking_blocks.py
+++ b/tests/ci/test_llm_thinking_blocks.py
@@ -1,4 +1,5 @@
 """Tests for thinking block stripping in ChatOpenAI."""
+
 import pytest
 
 from browser_use.llm.openai.chat import ChatOpenAI
@@ -9,7 +10,7 @@ class TestChatOpenAIThinkingBlocks:
 
 	def test_strip_thinking_blocks_well_formed(self):
 		"""Test stripping well-formed thinking blocks."""
-		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=True)
+		llm = ChatOpenAI(model='test-model', strip_thinking_blocks=True)
 
 		# Test with well-formed thinking blocks
 		text = """
@@ -24,7 +25,7 @@ class TestChatOpenAIThinkingBlocks:
 
 	def test_strip_thinking_blocks_multiple(self):
 		"""Test stripping multiple thinking blocks."""
-		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=True)
+		llm = ChatOpenAI(model='test-model', strip_thinking_blocks=True)
 
 		text = """
 	<think>
@@ -39,11 +40,11 @@ class TestChatOpenAIThinkingBlocks:
 		result = llm._strip_thinking_blocks(text)
 		# Just verify the JSON is present and thinking blocks are removed
 		assert '{"name": "test", "value": 42}' in result
-		assert "<think>" not in result
+		assert '<think>' not in result
 
 	def test_strip_thinking_blocks_stray_close_tag(self):
 		"""Test stripping with stray closing tag."""
-		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=True)
+		llm = ChatOpenAI(model='test-model', strip_thinking_blocks=True)
 
 		# Test with stray closing tag (malformed)
 		text = """
@@ -56,7 +57,7 @@ class TestChatOpenAIThinkingBlocks:
 
 	def test_strip_thinking_blocks_no_thinking(self):
 		"""Test that text without thinking blocks is unchanged."""
-		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=True)
+		llm = ChatOpenAI(model='test-model', strip_thinking_blocks=True)
 
 		text = '{"name": "test", "value": 42}'
 		result = llm._strip_thinking_blocks(text)
@@ -64,7 +65,7 @@ class TestChatOpenAIThinkingBlocks:
 
 	def test_strip_thinking_blocks_method_always_strips(self):
 		"""Test that the _strip_thinking_blocks method always strips - flag is checked by caller."""
-		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=False)
+		llm = ChatOpenAI(model='test-model', strip_thinking_blocks=False)
 
 		# The _strip_thinking_blocks method always strips - the flag is checked by the caller
 		# This test verifies the method works correctly
@@ -75,9 +76,9 @@ class TestChatOpenAIThinkingBlocks:
 	{"name": "test", "value": 42}
 	"""
 		result = llm._strip_thinking_blocks(text)
-		assert "<think>" not in result
+		assert '<think>' not in result
 		assert '{"name": "test", "value": 42}' in result
 
 
-if __name__ == "__main__":
-	pytest.main([__file__, "-v"])
+if __name__ == '__main__':
+	pytest.main([__file__, '-v'])

--- a/tests/ci/test_llm_thinking_blocks.py
+++ b/tests/ci/test_llm_thinking_blocks.py
@@ -1,0 +1,83 @@
+"""Tests for thinking block stripping in ChatOpenAI."""
+import pytest
+
+from browser_use.llm.openai.chat import ChatOpenAI
+
+
+class TestChatOpenAIThinkingBlocks:
+	"""Tests for thinking block stripping functionality."""
+
+	def test_strip_thinking_blocks_well_formed(self):
+		"""Test stripping well-formed thinking blocks."""
+		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=True)
+
+		# Test with well-formed thinking blocks
+		text = """
+	<think>
+	This is some thinking about the problem.
+	The solution requires parsing JSON.
+	</think>
+	{"name": "test", "value": 42}
+	"""
+		result = llm._strip_thinking_blocks(text)
+		assert result == '{"name": "test", "value": 42}'
+
+	def test_strip_thinking_blocks_multiple(self):
+		"""Test stripping multiple thinking blocks."""
+		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=True)
+
+		text = """
+	<think>
+	First block of thinking
+	</think>
+	some text
+	<think>
+	Second block of thinking
+	</think>
+	{"name": "test", "value": 42}
+	"""
+		result = llm._strip_thinking_blocks(text)
+		# Just verify the JSON is present and thinking blocks are removed
+		assert '{"name": "test", "value": 42}' in result
+		assert "<think>" not in result
+
+	def test_strip_thinking_blocks_stray_close_tag(self):
+		"""Test stripping with stray closing tag."""
+		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=True)
+
+		# Test with stray closing tag (malformed)
+		text = """
+	This is some text without proper opening
+	</think>
+	{"name": "test", "value": 42}
+	"""
+		result = llm._strip_thinking_blocks(text)
+		assert result == '{"name": "test", "value": 42}'
+
+	def test_strip_thinking_blocks_no_thinking(self):
+		"""Test that text without thinking blocks is unchanged."""
+		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=True)
+
+		text = '{"name": "test", "value": 42}'
+		result = llm._strip_thinking_blocks(text)
+		assert result == '{"name": "test", "value": 42}'
+
+	def test_strip_thinking_blocks_method_always_strips(self):
+		"""Test that the _strip_thinking_blocks method always strips - flag is checked by caller."""
+		llm = ChatOpenAI(model="test-model", strip_thinking_blocks=False)
+
+		# The _strip_thinking_blocks method always strips - the flag is checked by the caller
+		# This test verifies the method works correctly
+		text = """
+	<think>
+	Thinking block
+	</think>
+	{"name": "test", "value": 42}
+	"""
+		result = llm._strip_thinking_blocks(text)
+		assert "<think>" not in result
+		assert '{"name": "test", "value": 42}' in result
+
+
+if __name__ == "__main__":
+	pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add strip_thinking_blocks option to ChatOpenAI to handle providers like Minimax that return <think>...</think> blocks in their responses. When enabled, strips thinking blocks before JSON parsing to prevent "Invalid JSON" errors.

Usage:
```python
ChatOpenAILike(
    model="MiniMax-M2.5",
    api_key="your-key",
    base_url="https://api.minimax.io/v1",
    strip_thinking_blocks=True,
)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in strip_thinking_blocks option to ChatOpenAI to remove <think> blocks from provider responses before JSON parsing, preventing “Invalid JSON” errors. Addresses Linear #4142 to improve compatibility with Minimax APIs.

- **New Features**
  - New strip_thinking_blocks flag (default False) on ChatOpenAI.
  - Strips well-formed <think>...</think> and stray </think> using compiled regex before model_validate_json.
  - Added _strip_thinking_blocks helper and tests (well-formed, multiple blocks, stray close tag, no-block); helper always strips, gating handled in ainvoke.

- **Migration**
  - For Minimax models (e.g., MiniMax-M2.5), set strip_thinking_blocks=True.

<sup>Written for commit 4e0b1aa15b03917d24655fdbca68fde7ca633d43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

