### PR TITLE
Address CDP issues in agent

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1030,9 +1030,9 @@ class BrowserSession(BaseModel):
 
 		duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
 		if not seen_events:
-			self.logger.error(
-				f'❌ No lifecycle events received for {url} after {duration_ms:.0f}ms! '
-				f'Monitoring may have failed. Target: {cdp_session.target_id[:8]}'
+			self.logger.warning(
+				f'⚠️ No lifecycle events received for {url} after {duration_ms:.0f}ms. '
+				f'Page may have loaded before monitoring started. Target: {cdp_session.target_id[:8]}'
 			)
 		else:
 			self.logger.warning(f'⚠️ Page readiness timeout ({timeout}s, {duration_ms:.0f}ms) for {url}')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make CDP handling more robust and reduce noisy errors during navigation. DOM build now requires only snapshot and dom_tree; ax_tree and device_pixel_ratio are optional with safe defaults.

- **Bug Fixes**
  - Raise TimeoutError only if snapshot or dom_tree fail; log optional failures as warnings and fall back to empty ax_tree and ratio 1.0.
  - When no lifecycle events are seen after navigation, log a warning with clearer context instead of an error.

<sup>Written for commit a4c7ea95589382c990d4fa05bc890f4821388c4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

