### PR TITLE
fix: use tempfile.gettempdir() for cross-platform downloads path

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -430,14 +430,14 @@ class BrowserLaunchArgs(BaseModel):
 		if self.downloads_path is None:
 			import uuid
 
-			# Create unique directory in /tmp for downloads
+			# Create unique directory in system temp folder for downloads
 			unique_id = str(uuid.uuid4())[:8]  # 8 characters
-			downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+			downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			# Ensure path doesn't already exist (extremely unlikely but possible)
 			while downloads_path.exists():
 				unique_id = str(uuid.uuid4())[:8]
-				downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+				downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			self.downloads_path = downloads_path
 			self.downloads_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Problem

`BrowserProfile.set_default_downloads_path()` hardcodes `/tmp/browser-use-downloads-{id}` as the default downloads directory. On Windows, Python resolves `/tmp` to the root of the current drive (e.g., `C:\TMP`), creating unwanted folders at `C:\TMP\browser-use-downloads-*` the moment the library is imported.

This happens because `DEFAULT_BROWSER_PROFILE = BrowserProfile()` in `session.py` triggers the Pydantic validator at module load time.

## Solution

Replace `Path(f'/tmp/browser-use-downloads-{unique_id}')` with `Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'`.

`tempfile.gettempdir()` returns the platform-appropriate temporary directory:
- **Linux**: `/tmp` (same as before)
- **macOS**: `/var/folders/.../T`
- **Windows**: `C:\Users\<user>\AppData\Local\Temp`

`tempfile` was already imported in the module.

## Changes

| File | Change |
|------|--------|
| `browser_use/browser/profile.py` | 2 lines: `Path(f'/tmp/...')` → `Path(tempfile.gettempdir()) / f'...'` |

Fixes #4165

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch BrowserProfile default downloads to the OS temp directory using tempfile.gettempdir() to avoid unwanted C:\TMP folders on Windows and keep paths consistent across platforms.

- **Bug Fixes**
  - Replaced hardcoded /tmp in both initial path and uniqueness check with tempfile.gettempdir().
  - Prevents folder creation at import on Windows; downloads now land in /tmp (Linux), /var/folders/.../T (macOS), or AppData\Local\Temp (Windows).

<sup>Written for commit 1dcec51625e3953cb457cf5c2ab19bf2c2f86767. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

