### PR TITLE
patched gemini version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "authlib==1.6.6",
-    "google-genai==1.60.0",
+    "google-genai==1.65.0",
     "openai==2.16.0",
     "anthropic==0.76.0",
     "groq==1.0.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded google-genai to 1.65.0 to resolve "'str' object has no attribute 'pop'" errors during Gemini calls. Addresses Linear 4224 and stabilizes response handling.

- **Dependencies**
  - google-genai: 1.60.0 → 1.65.0

<sup>Written for commit bab3e36c717f36c5f24151575e27cc68ecf76348. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

