### PR TITLE
fix: use tempfile.gettempdir() instead of hardcoded /tmp in BrowserProfile

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -430,14 +430,15 @@ class BrowserLaunchArgs(BaseModel):
 		if self.downloads_path is None:
 			import uuid
 
-			# Create unique directory in /tmp for downloads
+			# Create unique directory in system temp for downloads
 			unique_id = str(uuid.uuid4())[:8]  # 8 characters
-			downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+			tmp_dir = tempfile.gettempdir()
+			downloads_path = Path(tmp_dir) / f'browser-use-downloads-{unique_id}'
 
 			# Ensure path doesn't already exist (extremely unlikely but possible)
 			while downloads_path.exists():
 				unique_id = str(uuid.uuid4())[:8]
-				downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+				downloads_path = Path(tmp_dir) / f'browser-use-downloads-{unique_id}'
 
 			self.downloads_path = downloads_path
 			self.downloads_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Problem

`BrowserProfile` hardcodes `/tmp/` as the base directory for downloads:

```python
downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
```

On Windows, Python resolves `/tmp` to the root of the current drive (e.g., `C:\tmp` or `C:\TMP`), creating unwanted directories in `C:\` upon importing the library — even if a custom `downloads_path` is set later.

## Fix

Replace hardcoded `/tmp/` with `tempfile.gettempdir()`, which returns the platform-appropriate temporary directory:
- **Windows**: `%TEMP%` (usually `C:\Users\<user>\AppData\Local\Temp`)
- **macOS/Linux**: `/tmp`

The `tempfile` module was already imported in the file.

## Test

- `BrowserProfile()` now creates downloads directory under `tempfile.gettempdir()`
- Custom `downloads_path` still works as expected
- 42 CI tests pass, 2 consecutive clean runs

Fixes #4165

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the system temp directory (tempfile.gettempdir()) for BrowserProfile’s default downloads path instead of hardcoded /tmp. Prevents unwanted C:\tmp folders on Windows and keeps custom downloads_path behavior unchanged.

<sup>Written for commit 79c9a22b2a84bbd2f75a5174038de3d55be96623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

