### PR TITLE
fix: filter chrome-extension:// targets from get_all_page_targets

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -155,7 +155,7 @@ class SessionManager:
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
+			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
 				page_targets.append(target)
 		return page_targets
 


### PR DESCRIPTION
## Problem

When connecting to an existing Chrome browser via CDP that has extensions with side panels (e.g., Chrome's sidePanel API), the side panel page is reported as a target with `type: "page"` and a `chrome-extension://` URL.

`SessionManager.get_all_page_targets()` only filters by target type (`page`/`tab`) but not by URL scheme, so extension side panels pass through. This causes:

1. **Crash recovery** (`_recover_agent_focus`) picks `page_targets[-1]` — if the side panel was opened most recently, the agent switches focus to the extension
2. **Tab listing** (`get_tabs`) includes the side panel, which may cause the LLM to switch to it
3. **Initial connect** may select the side panel as the first page target

## Root Cause

`BrowserSession._is_valid_target()` already correctly filters `chrome-extension://` URLs (`include_chrome_extensions=False` by default), but this method is only used in `_cdp_get_all_pages()` and `get_all_frames()` — not in `get_all_page_targets()`.

## Fix

Add URL scheme check in `get_all_page_targets()` to exclude `chrome-extension://` URLs, consistent with the existing filtering in `_is_valid_target()`.

## Test

42 CI tests pass, 2 consecutive clean runs.

Fixes #4133

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out chrome-extension:// targets in get_all_page_targets so extension side panels aren’t treated as pages, preventing focus switches during crash recovery, tab listing, and initial connect. Fixes #4133.

<sup>Written for commit 98c82eca3f3a2de6632f36b860b48801fcfd1328. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

