### PR TITLE
fix: use tempfile.gettempdir() instead of hardcoded /tmp for downloads path

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -428,16 +428,17 @@ class BrowserLaunchArgs(BaseModel):
 	def set_default_downloads_path(self) -> Self:
 		"""Set a unique default downloads path if none is provided."""
 		if self.downloads_path is None:
+			import tempfile
 			import uuid
 
-			# Create unique directory in /tmp for downloads
+			# Create unique directory in system temp folder for downloads
 			unique_id = str(uuid.uuid4())[:8]  # 8 characters
-			downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+			downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			# Ensure path doesn't already exist (extremely unlikely but possible)
 			while downloads_path.exists():
 				unique_id = str(uuid.uuid4())[:8]
-				downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+				downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			self.downloads_path = downloads_path
 			self.downloads_path.mkdir(parents=True, exist_ok=True)

--- a/browser_use/code_use/service.py
+++ b/browser_use/code_use/service.py
@@ -6,6 +6,7 @@ import html
 import json
 import logging
 import re
+import tempfile
 import traceback
 from pathlib import Path
 from typing import Any
@@ -175,7 +176,7 @@ class CodeAgent:
 		# Initialize screenshot service for eval tracking
 		self.id = uuid7str()
 		timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
-		base_tmp = Path('/tmp')
+		base_tmp = Path(tempfile.gettempdir())
 		self.agent_directory = base_tmp / f'browser_use_code_agent_{self.id}_{timestamp}'
 		self.screenshot_service = ScreenshotService(agent_directory=self.agent_directory)
 


### PR DESCRIPTION
## Summary

Fixes #4165

On Windows, Python resolves the hardcoded `/tmp` path to `C:\TMP` (the root of the current drive), which:
1. Creates unwanted folders on the C:\ drive upon import
2. Is not the standard Windows temp location (`%TEMP%` / `%TMP%`)

## Changes

Replace hardcoded `'/tmp'` with `tempfile.gettempdir()` in two locations:
- **`browser_use/browser/profile.py`**: `BrowserProfile.set_default_downloads_path()` — the default downloads directory
- **`browser_use/code_use/service.py`**: `CodeUseAgentService.__init__()` — the agent working directory

`tempfile.gettempdir()` returns the platform-appropriate temp directory:
- Linux/macOS: `/tmp` (same as before)
- Windows: `C:\Users\<user>\AppData\Local\Temp` (correct location)

## Testing

- Verified `BrowserProfile()` creates downloads path under system temp dir
- Verified custom `downloads_path` is still respected
- Verified each profile gets a unique path
- All imports work correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use tempfile.gettempdir() for default downloads and agent working directories to respect the system temp folder on all platforms. Fixes Windows creating C:\TMP and aligns with %TEMP% (Fixes #4165).

- **Bug Fixes**
  - BrowserProfile.set_default_downloads_path uses system temp dir for unique downloads path.
  - CodeUseAgentService.__init__ sets agent_directory under the system temp dir.

<sup>Written for commit 15df021f604d3fb1e4863eab2e60ed31b9f30ce0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

