### PR TITLE
fix: use tempfile.gettempdir() instead of hardcoded /tmp

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -428,16 +428,17 @@ class BrowserLaunchArgs(BaseModel):
 	def set_default_downloads_path(self) -> Self:
 		"""Set a unique default downloads path if none is provided."""
 		if self.downloads_path is None:
+			import tempfile
 			import uuid
 
-			# Create unique directory in /tmp for downloads
+			# Create unique directory in the platform temp dir for downloads
 			unique_id = str(uuid.uuid4())[:8]  # 8 characters
-			downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+			downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			# Ensure path doesn't already exist (extremely unlikely but possible)
 			while downloads_path.exists():
 				unique_id = str(uuid.uuid4())[:8]
-				downloads_path = Path(f'/tmp/browser-use-downloads-{unique_id}')
+				downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			self.downloads_path = downloads_path
 			self.downloads_path.mkdir(parents=True, exist_ok=True)

--- a/browser_use/code_use/service.py
+++ b/browser_use/code_use/service.py
@@ -6,6 +6,7 @@ import html
 import json
 import logging
 import re
+import tempfile
 import traceback
 from pathlib import Path
 from typing import Any
@@ -175,7 +176,7 @@ class CodeAgent:
 		# Initialize screenshot service for eval tracking
 		self.id = uuid7str()
 		timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
-		base_tmp = Path('/tmp')
+		base_tmp = Path(tempfile.gettempdir())
 		self.agent_directory = base_tmp / f'browser_use_code_agent_{self.id}_{timestamp}'
 		self.screenshot_service = ScreenshotService(agent_directory=self.agent_directory)
 


### PR DESCRIPTION
## Summary

Fixes #4165

On Windows, `Path('/tmp')` resolves to the root of the current drive (e.g. `C:\TMP`), creating unwanted directories at import time when `DEFAULT_BROWSER_PROFILE = BrowserProfile()` is evaluated.

### Changes

1. **`browser_use/browser/profile.py`**: `BrowserProfile.set_default_downloads_path` now uses `tempfile.gettempdir()` instead of hardcoded `/tmp`
2. **`browser_use/code_use/service.py`**: `CodeUseService.__init__` now uses `tempfile.gettempdir()` instead of hardcoded `/tmp`

`tempfile.gettempdir()` returns the platform-appropriate temp directory:
- Linux: `/tmp`
- macOS: `/var/folders/.../T` (or `/tmp` symlink)
- Windows: `C:\Users\<user>\AppData\Local\Temp`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use tempfile.gettempdir() instead of hardcoded /tmp for temp directories in BrowserProfile and CodeUseService, fixing incorrect paths on Windows and working across OSes. Fixes #4165.

- **Bug Fixes**
  - BrowserProfile.set_default_downloads_path now creates a unique downloads dir under tempfile.gettempdir().
  - CodeUseService.__init__ builds agent_directory under tempfile.gettempdir().

<sup>Written for commit 8a253874336b6c35403ab9952577a34f3e53ace3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

