### PR TITLE
Docs primary colors

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,9 +3,9 @@
   "theme": "aspen",
   "name": "Browser Use",
   "colors": {
-    "primary": "#FE750E",
-    "light": "#FE750E",
-    "dark": "#FE750E"
+    "primary": "#2563EB",
+    "light": "#2563EB",
+    "dark": "#2563EB"
   },
   "background": {
     "color": {


### PR DESCRIPTION
Update primary theme colors to blue (`#2563EB`) in `docs.json` as requested.

---
[Slack Thread](https://browser-use.slack.com/archives/C08P3EMVDJ5/p1772330711315579?thread_ts=1772330711.315579&cid=C08P3EMVDJ5)

<p><a href="https://cursor.com/agents/bc-96520972-c404-5f8d-8e61-55f8da14b50a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96520972-c404-5f8d-8e61-55f8da14b50a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch docs site theme accents to blue (#2563EB) by updating the primary, light, and dark colors in docs/docs.json to match the new brand palette.

<sup>Written for commit c5dd82bca01b103382fcde0d6669deaa29314f05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

