### PR TITLE
fix: replace fragile PID 1 substring matching in Docker detection

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -20,19 +20,20 @@ logger = logging.getLogger(__name__)
 def is_running_in_docker() -> bool:
 	"""Detect if we are running in a docker container, for the purpose of optimizing chrome launch flags (dev shm usage, gpu settings, etc.)"""
 	try:
-		if Path('/.dockerenv').exists() or 'docker' in Path('/proc/1/cgroup').read_text().lower():
+		if Path('/.dockerenv').exists():
 			return True
 	except Exception:
 		pass
 
 	try:
-		# if init proc (PID 1) looks like uvicorn/python/uv/etc. then we're in Docker
-		# if init proc (PID 1) looks like bash/systemd/init/etc. then we're probably NOT in Docker
-		init_cmd = ' '.join(psutil.Process(1).cmdline())
-		if ('py' in init_cmd) or ('uv' in init_cmd) or ('app' in init_cmd):
+		cgroup_text = Path('/proc/1/cgroup').read_text().lower()
+		if 'docker' in cgroup_text or 'containerd' in cgroup_text:
 			return True
 	except Exception:
 		pass
+
+	if os.environ.get('container') or os.environ.get('DOCKER_CONTAINER'):
+		return True
 
 	try:
 		# if less than 10 total running procs, then we're almost certainly in a container


### PR DESCRIPTION
## Summary

Fixes #4149

The `is_running_in_docker()` function uses broad substring matching (`'py'`, `'uv'`, `'app'` in PID 1 command) that produces false positives on bare-metal Linux servers running Python-based services as PID 1.

## Changes

- `browser_use/config.py`: Replaced the fragile PID 1 command substring matching with:
  - Separate `/.dockerenv` file check
  - `/proc/1/cgroup` check for both `docker` and `containerd` patterns
  - Standard container environment variables (`container`, `DOCKER_CONTAINER`)
  - Kept the low-PID-count heuristic as a final fallback

## Impact

On non-Docker systems, `--no-sandbox` was being set unnecessarily, weakening Chrome's security. This fix eliminates the false positives while maintaining reliable detection inside actual containers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced fragile Docker detection with reliable checks to avoid false positives on bare-metal hosts. This prevents unnecessary --no-sandbox flags and keeps Chrome security intact outside containers.

- **Bug Fixes**
  - Removed PID 1 cmdline substring checks ('py', 'uv', 'app').
  - Added /.dockerenv check and /proc/1/cgroup scan for 'docker' or 'containerd'.
  - Recognize container environment vars: container, DOCKER_CONTAINER.
  - Kept low PID count heuristic as a final fallback.

<sup>Written for commit df6a9d0a741c7aeb94117bdeab94afcae6ff8021. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

