### PR TITLE
fix browser state format in system_prompt.md

### DIFF
--- a/browser_use/agent/system_prompts/system_prompt.md
+++ b/browser_use/agent/system_prompts/system_prompt.md
@@ -45,11 +45,13 @@ Interactive Elements: All interactive elements will be provided in a tree-style 
 - Text content appears as child nodes on separate lines (not inside tags)
 - Indentation with tabs shows parent/child relationships
 Examples:
-|SCROLL|<html /> (0.0 pages above, 2.1 pages below)
-	[1501]<div />
-		[1503]<a id=header-logo-wrapper aria-label=DuckDuckGo home />
-		User form
-		*[1528]<button type=submit aria-label=search />
+[33]<div />
+	User form
+	[35]<input type=text placeholder=Enter name />
+	*[38]<button aria-label=Submit form />
+		Submit
+[40]<a />
+	About us
 Note that:
 - Only elements with numeric indexes in [] are interactive
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)


### PR DESCRIPTION
Resolves #3782, and makes a slight change to #3802.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Browser State format docs in system_prompt.md to match the actual DOMTreeSerializer output. Replaces the old [index]<type>text</type> description with a tree-style format ([index]<tag attr=value /> with text on child lines), updates the example, and documents the |SCROLL| and |SHADOW(open/closed)| prefixes (fixes #3782).

<sup>Written for commit e3ca7ea550610e9798b5938a74e6a2bf1e64e9bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

