### PR TITLE
fix(#3099): use configured default model instead of hardcoding gpt-4o

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -399,8 +399,7 @@ class BrowserUseServer:
 							},
 							'model': {
 								'type': 'string',
-								'description': 'LLM model to use (e.g., gpt-4o, claude-3-opus-20240229)',
-								'default': 'gpt-4o',
+								'description': 'LLM model to use (e.g., gpt-4o, claude-3-opus-20240229). Defaults to the configured model.',
 							},
 							'allowed_domains': {
 								'type': 'array',
@@ -487,7 +486,7 @@ class BrowserUseServer:
 			return await self._retry_with_browser_use_agent(
 				task=arguments['task'],
 				max_steps=arguments.get('max_steps', 100),
-				model=arguments.get('model', 'gpt-4o'),
+				model=arguments.get('model'),
 				allowed_domains=arguments.get('allowed_domains', []),
 				use_vision=arguments.get('use_vision', True),
 			)
@@ -624,7 +623,7 @@ class BrowserUseServer:
 		self,
 		task: str,
 		max_steps: int = 100,
-		model: str = 'gpt-4o',
+		model: str | None = None,
 		allowed_domains: list[str] | None = None,
 		use_vision: bool = True,
 	) -> str:
@@ -653,11 +652,8 @@ class BrowserUseServer:
 			if not api_key:
 				return 'Error: OPENAI_API_KEY not set in config or environment'
 
-			# Override model if provided in tool call
-			if model != llm_config.get('model', 'gpt-4o'):
-				llm_model = model
-			else:
-				llm_model = llm_config.get('model', 'gpt-4o')
+			# Use explicit model from tool call, otherwise fall back to configured default
+			llm_model = model or llm_config.get('model', 'gpt-4o')
 
 			base_url = llm_config.get('base_url', None)
 			kwargs = {}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the configured default LLM model for MCP tool execution instead of hardcoding gpt-4o. Fixes #3099 and preserves explicit model overrides when provided.

- **Bug Fixes**
  - Tool schema now states the model defaults to the configured value.
  - Removed 'gpt-4o' defaults from argument handling and function signatures; model is optional.
  - Runtime falls back to llm_config['model'] when no model is passed.

<sup>Written for commit 50b22b2472fbe7ee7b7b3506455498f42d7ac395. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

