### PR TITLE
fix(#3124): wrong bedrock import paths in docs

### DIFF
--- a/docs/supported-models.mdx
+++ b/docs/supported-models.mdx
@@ -215,7 +215,8 @@ AWS Bedrock provides access to multiple model providers through a single API. We
 #### General AWS Bedrock (supports all providers)
 
 ```python
-from browser_use import Agent, ChatAWSBedrock
+from browser_use import Agent
+from browser_use.llm import ChatAWSBedrock
 
 # Works with any Bedrock model (Anthropic, Meta, AI21, etc.)
 llm = ChatAWSBedrock(
@@ -233,7 +234,8 @@ agent = Agent(
 #### Anthropic Claude via AWS Bedrock (convenience class)
 
 ```python
-from browser_use import Agent, ChatAnthropicBedrock
+from browser_use import Agent
+from browser_use.llm import ChatAnthropicBedrock
 
 # Anthropic-specific class with Claude defaults
 llm = ChatAnthropicBedrock(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed AWS Bedrock import paths in the docs so users import ChatAWSBedrock and ChatAnthropicBedrock from browser_use.llm, not browser_use. Prevents ImportError and aligns with the current package structure (Linear #3124).

<sup>Written for commit 94bc07b87dc76cf433fe96b29e6d0244466eacea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

