### PR TITLE
fix channel param to select correct browser binary

### DIFF
--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -1,5 +1,7 @@
 """Local browser watchdog for managing browser subprocess lifecycle."""
 
+from __future__ import annotations
+
 import asyncio
 import os
 import shutil
@@ -21,7 +23,7 @@ from browser_use.browser.watchdog_base import BaseWatchdog
 from browser_use.observability import observe_debug
 
 if TYPE_CHECKING:
-	pass
+	from browser_use.browser.profile import BrowserChannel
 
 
 class LocalBrowserWatchdog(BaseWatchdog):
@@ -215,7 +217,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		raise RuntimeError(f'Failed to launch browser after {max_retries} attempts')
 
 	@staticmethod
-	def _find_installed_browser_path(channel: 'BrowserChannel | None' = None) -> str | None:
+	def _find_installed_browser_path(channel: BrowserChannel | None = None) -> str | None:
 		"""Try to find browser executable from common fallback locations.
 
 		If a channel is specified, paths for that browser are searched first.


### PR DESCRIPTION
Resolves #3015 and mismatch with BrowserChannel in profile.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes browser selection by prioritizing the requested channel when finding the local binary. Prevents launching the wrong browser and aligns LocalBrowserWatchdog with profile.channel.

- **Bug Fixes**
  - Pass profile.channel to _find_installed_browser_path and prioritize channel-specific paths; skip prioritization when channel is default.
  - Map BrowserChannel values to path groups and expand OS coverage, including Edge paths on macOS and Linux.
  - Keep a clear fallback order (system Chrome → Playwright Chromium → other browsers incl. Canary/Dev/Brave/Edge → headless shell).

<sup>Written for commit f5df080b41ae2f16f1976c0fd3f3d4cb8445820f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

