### PR TITLE
fix: filter chrome-extension:// targets from get_all_page_targets (fixes #4133)

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -150,12 +150,16 @@ class SessionManager:
 	def get_all_page_targets(self) -> list:
 		"""Get all page/tab targets using owned data.
 
+		Filters out chrome-extension:// targets to prevent the agent from
+		accidentally switching focus to extension side panels or popups
+		(see issue #4133).
+
 		Returns:
 			List of Target objects for all page/tab targets
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
+			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
 				page_targets.append(target)
 		return page_targets
 


### PR DESCRIPTION
## Problem

Chrome extension side panels (`sidePanel` API) are reported by CDP as targets with `type: "page"` and `chrome-extension://` URLs. `SessionManager.get_all_page_targets()` only filters by target type (`page`/`tab`), so extension side panels pass through as regular page targets.

This causes three problems (as reported in #4133):

1. **`_recover_agent_focus`** picks `page_targets[-1]` — if the side panel was opened most recently, the agent switches focus to the extension
2. **`get_tabs`** includes extension panels in the tab list shown to the LLM, which may cause it to switch
3. **`connect`** may select an extension panel as `page_targets_from_manager[0]`

## Fix

Add `chrome-extension://` URL filtering to `get_all_page_targets()`, consistent with the existing `BrowserSession._is_valid_target()` which already filters these URLs (`include_chrome_extensions=False` by default) but is only used in `_cdp_get_all_pages()` and `get_all_frames()`.

```python
if target.target_type in ("page", "tab") and not target.url.startswith("chrome-extension://"):
```

Minimal, surgical change — one line of filtering logic added to the single method that feeds all affected code paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out chrome-extension:// targets from get_all_page_targets.
Prevents focus switching to extension side panels, keeps the tab list accurate, and avoids selecting extensions on connect (fixes #4133).

<sup>Written for commit 2b6a79c7fd343732fcf98aa406bbf261532dfd97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

