### PR TITLE
fix: handle dict input in _load_storage_state (fixes #4257)

### DIFF
--- a/browser_use/browser/watchdogs/storage_state_watchdog.py
+++ b/browser_use/browser/watchdogs/storage_state_watchdog.py
@@ -315,7 +315,7 @@ class StorageStateWatchdog(BaseWatchdog):
 
 			self.event_bus.dispatch(
 				StorageStateLoadedEvent(
-					path=str(load_source),
+					path='<dict>' if isinstance(load_source, dict) else str(load_source),
 					cookies_count=len(storage.get('cookies', [])),
 					origins_count=len(storage.get('origins', [])),
 				)


### PR DESCRIPTION
## Problem

When `storage_state` is passed as a dict (e.g., `storage_state={"cookies": [...]}`) to `BrowserSession`, the cookies and storage are never loaded.

### Root Cause

`_load_storage_state()` assumes the input is always a file path:

```python
load_path = path or self.browser_session.browser_profile.storage_state
if not load_path or not os.path.exists(str(load_path)):
    return  # <-- silently returns for dict input
```

When `storage_state` is a dict, `str(load_path)` produces something like `{"cookies": [...]}`, and `os.path.exists()` returns `False`, so the method returns without loading anything.

## Fix

Check if the input is a dict and use it directly, falling back to file-based loading for string/Path inputs.

This is consistent with:
- `_save_storage_state()` which already checks `isinstance(save_path, dict)` (line 183)
- `BrowserProfile.storage_state` type annotation: `str | Path | dict[str, Any] | None`

## Changes

- `browser_use/browser/watchdogs/storage_state_watchdog.py`: Handle dict input in `_load_storage_state()`

Fixes #4257

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loading of storage_state when passed as a dict by using the dict directly and falling back to file-based loading for strings/paths. Also sets StorageStateLoadedEvent.path to '<dict>' for dict sources so events report a clear source and cookies/origins load correctly.

<sup>Written for commit dc336c85eaddd734c6e7c726e4fe3bbce45d8c6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

