### PR TITLE
fix: Windows tunnel crash, storage_state dict ignored, Anthropic empty response

### DIFF
--- a/browser_use/browser/watchdogs/storage_state_watchdog.py
+++ b/browser_use/browser/watchdogs/storage_state_watchdog.py
@@ -231,21 +231,29 @@ class StorageStateWatchdog(BaseWatchdog):
 				self.logger.error(f'[StorageStateWatchdog] Failed to save storage state: {e}')
 
 	async def _load_storage_state(self, path: str | None = None) -> None:
-		"""Load browser storage state from file."""
+		"""Load browser storage state from file or dict."""
 		if not self.browser_session.cdp_client:
 			self.logger.warning('[StorageStateWatchdog] No CDP client available for loading')
 			return
 
-		load_path = path or self.browser_session.browser_profile.storage_state
-		if not load_path or not os.path.exists(str(load_path)):
+		load_source = path or self.browser_session.browser_profile.storage_state
+		if not load_source:
 			return
 
 		try:
-			# Read the storage state file asynchronously
-			import anyio
+			# If the source is already a dict, use it directly
+			if isinstance(load_source, dict):
+				storage = load_source
+				load_path = '<dict>'
+			else:
+				load_path = str(load_source)
+				if not os.path.exists(load_path):
+					return
+				# Read the storage state file asynchronously
+				import anyio
 
-			content = await anyio.Path(str(load_path)).read_text()
-			storage = json.loads(content)
+				content = await anyio.Path(load_path).read_text()
+				storage = json.loads(content)
 
 			# Apply cookies if present
 			if 'cookies' in storage and storage['cookies']:

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -160,6 +160,12 @@ class ChatAnthropic(BaseChatModel):
 				usage = self._get_usage(response)
 
 				# Extract text from the first content block
+				if not response.content:
+					raise ModelProviderError(
+						message='Anthropic API returned an empty response with no content blocks.',
+						status_code=502,
+						model=self.name,
+					)
 				first_content = response.content[0]
 				if isinstance(first_content, TextBlock):
 					response_text = first_content.text

--- a/browser_use/skill_cli/tunnel.py
+++ b/browser_use/skill_cli/tunnel.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import signal
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -145,28 +146,53 @@ def _delete_tunnel_info(port: int) -> None:
 
 
 def _is_process_alive(pid: int) -> bool:
-	"""Check if a process is still running."""
-	try:
-		os.kill(pid, 0)
-		return True
-	except (OSError, ProcessLookupError):
+	"""Check if a process is still running.
+
+	On Windows, uses ctypes to call OpenProcess (os.kill doesn't work reliably).
+	On Unix, uses os.kill(pid, 0) which is the standard approach.
+	"""
+	if sys.platform == 'win32':
+		import ctypes
+
+		PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+		handle = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+		if handle:
+			ctypes.windll.kernel32.CloseHandle(handle)
+			return True
 		return False
+	else:
+		try:
+			os.kill(pid, 0)
+			return True
+		except (OSError, ProcessLookupError):
+			return False
 
 
 def _kill_process(pid: int) -> bool:
 	"""Kill a process by PID. Returns True if killed, False if already dead."""
 	try:
-		os.kill(pid, signal.SIGTERM)
-		# Give it a moment to terminate gracefully
-		for _ in range(10):
-			if not _is_process_alive(pid):
-				return True
-			import time
+		if sys.platform == 'win32':
+			import ctypes
 
-			time.sleep(0.1)
-		# Force kill if still alive
-		os.kill(pid, signal.SIGKILL)
-		return True
+			PROCESS_TERMINATE = 0x0001
+			handle = ctypes.windll.kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
+			if handle:
+				ctypes.windll.kernel32.TerminateProcess(handle, 1)
+				ctypes.windll.kernel32.CloseHandle(handle)
+				return True
+			return False
+		else:
+			os.kill(pid, signal.SIGTERM)
+			# Give it a moment to terminate gracefully
+			for _ in range(10):
+				if not _is_process_alive(pid):
+					return True
+				import time
+
+				time.sleep(0.1)
+			# Force kill if still alive
+			os.kill(pid, signal.SIGKILL)
+			return True
 	except (OSError, ProcessLookupError):
 		return False
 

--- a/browser_use/skill_cli/tunnel.py
+++ b/browser_use/skill_cli/tunnel.py
@@ -155,10 +155,13 @@ def _is_process_alive(pid: int) -> bool:
 		import ctypes
 
 		PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+		STILL_ACTIVE = 259
 		handle = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
 		if handle:
+			exit_code = ctypes.c_ulong(0)
+			got_code = ctypes.windll.kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code))
 			ctypes.windll.kernel32.CloseHandle(handle)
-			return True
+			return bool(got_code and exit_code.value == STILL_ACTIVE)
 		return False
 	else:
 		try:
@@ -177,9 +180,9 @@ def _kill_process(pid: int) -> bool:
 			PROCESS_TERMINATE = 0x0001
 			handle = ctypes.windll.kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
 			if handle:
-				ctypes.windll.kernel32.TerminateProcess(handle, 1)
+				result = ctypes.windll.kernel32.TerminateProcess(handle, 1)
 				ctypes.windll.kernel32.CloseHandle(handle)
-				return True
+				return bool(result)
 			return False
 		else:
 			os.kill(pid, signal.SIGTERM)


### PR DESCRIPTION
## Summary
Fixes 3 bugs:

- **Windows tunnel crash (#3912):** `tunnel.py`'s `_is_process_alive()` uses `os.kill(pid, 0)` which raises `SystemError` on Windows (signal 0 is POSIX-only). `_kill_process()` uses `signal.SIGKILL` which doesn't exist on Windows. Fix: add Windows code path using `ctypes.windll.kernel32.OpenProcess/TerminateProcess`, matching the pattern already used in `utils.py` and `main.py`.

- **storage_state dict not applied (#4257):** When users pass `storage_state={"cookies": [...]}` (a dict), `_load_storage_state()` calls `os.path.exists(str(dict))` which is always `False`, silently ignoring the cookies. Fix: detect when `load_source` is a dict and use it directly instead of trying to read it as a file.

- **Anthropic empty response IndexError:** `response.content[0]` in `anthropic/chat.py` crashes with `IndexError` when the Anthropic API returns an empty content list (edge cases like content filtering or max_tokens=0). Fix: check `response.content` is non-empty before indexing, raise `ModelProviderError` with a clear message.

## Changes
- `browser_use/skill_cli/tunnel.py` — Cross-platform `_is_process_alive()` and `_kill_process()`
- `browser_use/browser/watchdogs/storage_state_watchdog.py` — Handle dict `storage_state` in `_load_storage_state()`
- `browser_use/llm/anthropic/chat.py` — Guard against empty `response.content`

## Test plan
- [x] All non-CI tests pass (CI tests require browser/API keys)
- [x] All modified modules import cleanly
- [x] tunnel.py: Windows path uses ctypes (no os.kill), Unix path unchanged
- [x] storage_state: dict detected via `isinstance` check, applied directly
- [x] Anthropic: empty content raises `ModelProviderError(502)` instead of `IndexError`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three stability issues: Windows tunnel liveness/termination checks, dict storage_state handling, and empty Anthropic responses. Improves reliability on Windows and prevents ignored cookies and IndexErrors.

- **Bug Fixes**
  - Windows tunnel: Make _is_process_alive and _kill_process cross-platform; on Windows use ctypes OpenProcess + GetExitCodeProcess (STILL_ACTIVE) for liveness and check TerminateProcess result; Unix keeps os.kill behavior.
  - storage_state dict: Detect dict input and apply it directly instead of treating it as a file path, so cookies load correctly.
  - Anthropic: Guard against empty response.content and raise a clear ModelProviderError (502) instead of crashing with IndexError.

<sup>Written for commit 37ea62a77a618675806e8cd480725eb5c212ad96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

