### PR TITLE
Fix CodeAgent initialization when passing an external Browser object

### DIFF
--- a/browser_use/code_use/service.py
+++ b/browser_use/code_use/service.py
@@ -219,6 +219,8 @@ class CodeAgent:
 			assert self._browser_profile_for_init is not None
 			self.browser_session = BrowserSession(browser_profile=self._browser_profile_for_init)
 			await self.browser_session.start()
+		elif not self.browser_session.is_cdp_connected:
+			await self.browser_session.start()
 
 		if self.browser_session:
 			self._demo_mode_enabled = bool(self.browser_session.browser_profile.demo_mode)


### PR DESCRIPTION
Fixes #4269

What is the issue?
When a user passes an existing 
Browser
 instance to 
CodeAgent
 (e.g., browser=Browser(...)), the agent fails to start the session. Because browser_session.start() is never called, the CDP client is never initialized (_cdp_client_root stays None) and critical event watchdogs (like 
DOMWatchdog
 and 
ScreenshotWatchdog
) are never attached.

This leads to a cascade of errors during the agent loop:

AssertionError: Root CDP client not initialized on every evaluate() call.
Failed to get browser state: Expected at least one handler to return a non-None result (because 
BrowserStateRequestEvent
 has no registered handlers).
Failed to capture screenshot for the same reason.
What is the fix?
Added a check in CodeAgent.run() (
browser_use/code_use/service.py
) to verify if an externally provided 
BrowserSession
 is actually connected. If it isn't (not self.browser_session.is_cdp_connected), we explicitly call await self.browser_session.start() before proceeding.

This ensures all watchdogs are attached and the CDP root client is initialized, regardless of whether 
CodeAgent
 created the session itself or received it from the user.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CodeAgent startup when an external Browser is provided by starting the session if CDP isn’t connected. This initializes the CDP root client and attaches DOM/Screenshot watchdogs, preventing evaluate(), browser state, and screenshot failures.

<sup>Written for commit 110fb40fa0585bc9e44f700fd33d1e6de8cad375. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

