### PR TITLE
don't explicitly pass newWindow: false to CDP createTarget

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -15,6 +15,7 @@ from cdp_use import CDPClient
 from cdp_use.cdp.fetch import AuthRequiredEvent, RequestPausedEvent
 from cdp_use.cdp.network import Cookie
 from cdp_use.cdp.target import SessionID, TargetID
+from cdp_use.cdp.target.commands import CreateTargetParameters
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from uuid_extensions import uuid7str
 
@@ -3206,7 +3207,7 @@ class BrowserSession(BaseModel):
 	async def _cdp_create_new_page(self, url: str = 'about:blank', background: bool = False, new_window: bool = False) -> str:
 		"""Create a new page/tab using CDP Target.createTarget. Returns target ID."""
 		# Only include newWindow when True, letting Chrome auto-create window as needed
-		params: dict[str, Any] = {'url': url, 'background': background}
+		params = CreateTargetParameters(url=url, background=background)
 		if new_window:
 			params['newWindow'] = True
 		# Use the root CDP client to create tabs at the browser level


### PR DESCRIPTION
Resolves #3908

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending newWindow: false to CDP Target.createTarget using CreateTargetParameters. Only include newWindow when true, relying on Chrome defaults for consistent tab creation; minor lint.

<sup>Written for commit b630ae596ef6ad52ce1fa8e52c13999465f9f8c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

