### PR TITLE
fix: split browser_click into two tools to remove oneOf from MCP schema

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -236,7 +236,10 @@ class BrowserUseServer:
 					inputSchema={
 						'type': 'object',
 						'properties': {
-							'index': {'type': 'integer', 'description': 'The index of the element to click (from browser_get_state).'},
+							'index': {
+								'type': 'integer',
+								'description': 'The index of the element to click (from browser_get_state).',
+							},
 							'new_tab': {'type': 'boolean', 'description': 'Open link in a new tab.', 'default': False},
 						},
 						'required': ['index'],
@@ -248,9 +251,14 @@ class BrowserUseServer:
 					inputSchema={
 						'type': 'object',
 						'properties': {
-							'coordinate_x': {'type': 'integer', 'description': 'X coordinate in pixels from left edge of viewport.'},
-							'coordinate_y': {'type': 'integer', 'description': 'Y coordinate in pixels from top edge of viewport.'},
-							'new_tab': {'type': 'boolean', 'description': 'Open link in a new tab.', 'default': False},
+							'coordinate_x': {
+								'type': 'integer',
+								'description': 'X coordinate in pixels from left edge of viewport.',
+							},
+							'coordinate_y': {
+								'type': 'integer',
+								'description': 'Y coordinate in pixels from top edge of viewport.',
+							},
 						},
 						'required': ['coordinate_x', 'coordinate_y'],
 					},
@@ -519,7 +527,6 @@ class BrowserUseServer:
 				return await self._click(
 					coordinate_x=arguments.get('coordinate_x'),
 					coordinate_y=arguments.get('coordinate_y'),
-					new_tab=arguments.get('new_tab', False),
 				)
 
 			elif tool_name == 'browser_type':
@@ -767,6 +774,9 @@ class BrowserUseServer:
 
 		# Coordinate-based clicking
 		if coordinate_x is not None and coordinate_y is not None:
+			if new_tab:
+				return 'Error: new_tab is only supported for index-based browser_click, not browser_click_at_coordinates'
+
 			from browser_use.browser.events import ClickCoordinateEvent
 
 			event = self.browser_session.event_bus.dispatch(

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -232,32 +232,27 @@ class BrowserUseServer:
 				),
 				types.Tool(
 					name='browser_click',
-					description='Click an element by index or at specific viewport coordinates. Use index for elements from browser_get_state, or coordinate_x/coordinate_y for pixel-precise clicking.',
+					description='Click on an element by its index from browser_get_state.',
 					inputSchema={
 						'type': 'object',
 						'properties': {
-							'index': {
-								'type': 'integer',
-								'description': 'The index of the element to click (from browser_get_state). Use this OR coordinates.',
-							},
-							'coordinate_x': {
-								'type': 'integer',
-								'description': 'X coordinate (pixels from left edge of viewport). Use with coordinate_y.',
-							},
-							'coordinate_y': {
-								'type': 'integer',
-								'description': 'Y coordinate (pixels from top edge of viewport). Use with coordinate_x.',
-							},
-							'new_tab': {
-								'type': 'boolean',
-								'description': 'Whether to open any resulting navigation in a new tab',
-								'default': False,
-							},
+							'index': {'type': 'integer', 'description': 'The index of the element to click (from browser_get_state).'},
+							'new_tab': {'type': 'boolean', 'description': 'Open link in a new tab.', 'default': False},
 						},
-						'oneOf': [
-							{'required': ['index']},
-							{'required': ['coordinate_x', 'coordinate_y']},
-						],
+						'required': ['index'],
+					},
+				),
+				types.Tool(
+					name='browser_click_at_coordinates',
+					description='Click at specific viewport pixel coordinates. Use when no element index is available.',
+					inputSchema={
+						'type': 'object',
+						'properties': {
+							'coordinate_x': {'type': 'integer', 'description': 'X coordinate in pixels from left edge of viewport.'},
+							'coordinate_y': {'type': 'integer', 'description': 'Y coordinate in pixels from top edge of viewport.'},
+							'new_tab': {'type': 'boolean', 'description': 'Open link in a new tab.', 'default': False},
+						},
+						'required': ['coordinate_x', 'coordinate_y'],
 					},
 				),
 				types.Tool(
@@ -517,6 +512,11 @@ class BrowserUseServer:
 			elif tool_name == 'browser_click':
 				return await self._click(
 					index=arguments.get('index'),
+					new_tab=arguments.get('new_tab', False),
+				)
+
+			elif tool_name == 'browser_click_at_coordinates':
+				return await self._click(
 					coordinate_x=arguments.get('coordinate_x'),
 					coordinate_y=arguments.get('coordinate_y'),
 					new_tab=arguments.get('new_tab', False),


### PR DESCRIPTION
## Problem

Fixes #4211.

`browser_click` in the MCP server used `oneOf` at the top level of its `inputSchema`:

```json
{
  "oneOf": [
    {"required": ["index"]},
    {"required": ["coordinate_x", "coordinate_y"]}
  ]
}
```

**Claude's API rejects `oneOf`/`allOf`/`anyOf` at the top level of tool input schemas** with HTTP 400. This error cascades to ALL registered MCP tools in the session — not just `browser_click` — because the entire MCP server fails to initialize.

## Fix

Split `browser_click` into two separate tools with flat, unambiguous schemas:

- **`browser_click`** — click by element index (from `browser_get_state`), requires `index`
- **`browser_click_at_coordinates`** — click at pixel coordinates, requires `coordinate_x` + `coordinate_y`

Both tools delegate to the existing `_click()` method. No behavior change — only the schema structure changes.

This is also more idiomatic MCP: tools with flat schemas are clearer to LLMs since the description precisely matches the accepted arguments.

## Changes

- Replaced single `browser_click` tool (with `oneOf`) with two tools
- Added `browser_click_at_coordinates` dispatch branch in the tool handler

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `browser_click` into two MCP tools to remove the top-level oneOf in the input schema. This fixes Claude API 400s and prevents MCP server init failures (addresses #4211).

- **Migration**
  - Use `browser_click` for index-based clicks. Supports `new_tab`.
  - Use `browser_click_at_coordinates` for pixel clicks (`coordinate_x`, `coordinate_y`). `new_tab` is not supported.

<sup>Written for commit a4d33e317cec8ed37197d23460acbfa268d2fdae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

