### PR TITLE
Fix docker detection false positives from broad substring matching

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -26,10 +26,8 @@ def is_running_in_docker() -> bool:
 		pass
 
 	try:
-		# if init proc (PID 1) looks like uvicorn/python/uv/etc. then we're in Docker
-		# if init proc (PID 1) looks like bash/systemd/init/etc. then we're probably NOT in Docker
-		init_cmd = ' '.join(psutil.Process(1).cmdline())
-		if ('py' in init_cmd) or ('uv' in init_cmd) or ('app' in init_cmd):
+		# Check for container environment variables
+		if os.environ.get('container') or os.environ.get('DOCKER_CONTAINER'):
 			return True
 	except Exception:
 		pass


### PR DESCRIPTION
Fixes #4149. The PID 1 command substring matching for 'py', 'uv', and 'app' was too broad and produced false positives on non-Docker systems. Removed the fragile heuristic and added standard container environment variable checks instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false Docker detection by removing the fragile PID 1 command substring heuristic in is_running_in_docker and switching to standard container env var checks (container, DOCKER_CONTAINER). Fixes #4149.

<sup>Written for commit 73964aeb71b0dbbfb47f6e52f8f164c46ed54240. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

