### PR TITLE
fix: extract structured output from tool_calls for tool-calling models

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -170,17 +170,28 @@ class ChatGroq(BaseChatModel):
 
 		if self.model in ToolCallingModels:
 			response = await self._invoke_with_tool_calling(groq_messages, output_format, schema)
+			# Tool-calling responses place the structured data in
+			# tool_calls[…].function.arguments, not in message.content.
+			tool_calls = response.choices[0].message.tool_calls
+			if not tool_calls:
+				raise ModelProviderError(
+					message='No tool calls in response',
+					status_code=500,
+					model=self.name,
+				)
+			raw_json = tool_calls[0].function.arguments
 		else:
 			response = await self._invoke_with_json_schema(groq_messages, output_format, schema)
+			raw_json = response.choices[0].message.content
 
-		if not response.choices[0].message.content:
+		if not raw_json:
 			raise ModelProviderError(
 				message='No content in response',
 				status_code=500,
 				model=self.name,
 			)
 
-		parsed_response = output_format.model_validate_json(response.choices[0].message.content)
+		parsed_response = output_format.model_validate_json(raw_json)
 		usage = self._get_usage(response)
 
 		return ChatInvokeCompletion(


### PR DESCRIPTION
## Problem

When using a model listed in `ToolCallingModels` (currently `kimi-k2-instruct`), `_invoke_structured_output` always fails with `"No content in response"`.

The root cause is that the Groq API returns structured data differently depending on the request format:

- **JSON schema mode** (`response_format`): result is in `message.content`
- **Tool-calling mode** (`tools` + `tool_choice`): result is in `message.tool_calls[0].function.arguments`, and `message.content` is `None`

The current code unconditionally reads from `message.content` after both paths, so the tool-calling path always hits the "No content" error.

## Fix

After the tool-calling path, extract the JSON string from `tool_calls[0].function.arguments` instead. The JSON schema path continues to read from `message.content` as before.

## How I tested

Ran structured output calls against `kimi-k2-instruct` via Groq — they now parse correctly instead of raising `ModelProviderError`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes structured output parsing for Groq tool-calling models by reading JSON from tool_calls[0].function.arguments instead of message.content, resolving the “No content in response” error for models like kimi-k2-instruct.

- **Bug Fixes**
  - Extract structured data from tool_calls[0].function.arguments for tool-calling responses; JSON schema path still reads message.content.
  - Raise a clear error when no tool calls are returned.

<sup>Written for commit c1a1a6991e5c2679bb18b09d49f0fd7c20070ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

