### PR TITLE
fix: include cache-read tokens in Anthropic total_tokens

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -119,7 +119,7 @@ class ChatAnthropic(BaseChatModel):
 				response.usage.cache_read_input_tokens or 0
 			),  # Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
 			completion_tokens=response.usage.output_tokens,
-			total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+			total_tokens=response.usage.input_tokens + (response.usage.cache_read_input_tokens or 0) + response.usage.output_tokens,
 			prompt_cached_tokens=response.usage.cache_read_input_tokens,
 			prompt_cache_creation_tokens=response.usage.cache_creation_input_tokens,
 			prompt_image_tokens=None,


### PR DESCRIPTION
## Problem

`_get_usage` computes `prompt_tokens` as `input_tokens + cache_read_input_tokens`, correctly accounting for cached prompt tokens. However, `total_tokens` is computed as `input_tokens + output_tokens`, which excludes the cached tokens.

This means `total_tokens < prompt_tokens + completion_tokens` whenever prompt caching is active, which breaks any downstream logic that relies on the invariant `total_tokens == prompt_tokens + completion_tokens` (e.g. cost tracking, rate-limit budgeting).

## Fix

Include `cache_read_input_tokens` in the `total_tokens` calculation, matching the existing `prompt_tokens` formula.

## Before / After




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Anthropic usage accounting by adding cache_read_input_tokens to total_tokens in _get_usage. This keeps total_tokens equal to prompt_tokens + completion_tokens when prompt caching is used, ensuring accurate cost and rate-limit tracking.

<sup>Written for commit bc659091c7d22a769a078828948fec37a38c65ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

