### PR TITLE
fix: filter chrome-extension:// targets from get_all_page_targets

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -150,12 +150,16 @@ class SessionManager:
 	def get_all_page_targets(self) -> list:
 		"""Get all page/tab targets using owned data.
 
+		Filters out chrome-extension:// targets (e.g. side panels) which are
+		reported by CDP as type "page" but should not be treated as navigable
+		browser tabs.
+
 		Returns:
 			List of Target objects for all page/tab targets
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
+			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
 				page_targets.append(target)
 		return page_targets
 


### PR DESCRIPTION
## Summary

Fixes #4133

- Filter out `chrome-extension://` URL targets in `SessionManager.get_all_page_targets()`, which is the source method used by all 15+ call sites (crash recovery, tab listing, initial connect, focus management, etc.)

## Problem

When connecting to a Chrome browser with extensions that use side panels (via Chrome's `sidePanel` API), CDP reports the side panel as a target with type `"page"` and a `chrome-extension://` URL. Since `get_all_page_targets()` only filtered by target type (`page`/`tab`) but not URL scheme, extension side panels passed through as regular page targets, causing:

1. **Crash/detach recovery** (`_recover_agent_focus`) picks the extension page as the recovery target
2. **Tab list** (`get_tabs`) includes the extension in "Available tabs" shown to the LLM
3. **Initial connect** may select the extension page as the first target

## Fix

Add URL scheme filtering to `get_all_page_targets()` to exclude `chrome-extension://` targets, consistent with the existing `_is_valid_target()` logic in `BrowserSession` which already handles this correctly (but is only used in `_cdp_get_all_pages()` and `get_all_frames()`).

## Test plan

- [ ] Connect to Chrome with extensions that have side panels (e.g. any extension using `chrome.sidePanel` API)
- [ ] Verify agent no longer switches focus to extension pages during recovery
- [ ] Verify extension side panels don't appear in tab list
- [ ] Verify existing CI tests pass (`uv run pytest -vxs tests/ci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter out chrome-extension:// targets in SessionManager.get_all_page_targets so extension side panels don’t appear as tabs. Prevents focus recovery and initial connect from selecting extension pages, and removes them from the tab list.

- **Bug Fixes**
  - Excludes chrome-extension:// URLs when target.type is page/tab.
  - Aligns with BrowserSession._is_valid_target so all call sites get consistent filtering.

<sup>Written for commit c93fe47d6d7e55e67405efefc518daf822777c98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

