### PR TITLE
fix: add runtime type check for CodeAgent in notebook export functions

### DIFF
--- a/browser_use/code_use/notebook_export.py
+++ b/browser_use/code_use/notebook_export.py
@@ -29,6 +29,11 @@ def export_to_ipynb(agent: CodeAgent, output_path: str | Path) -> Path:
 	        print(f'Notebook saved to {notebook_path}')
 		```
 	"""
+	assert isinstance(agent, CodeAgent), (
+		f'export_to_ipynb() requires a CodeAgent instance, got {type(agent).__name__}. '
+		'Use CodeAgent instead of Agent for notebook export functionality.'
+	)
+
 	output_path = Path(output_path)
 
 	# Create notebook structure
@@ -192,6 +197,11 @@ def session_to_python_script(agent: CodeAgent) -> str:
 	        print(script)
 		```
 	"""
+	assert isinstance(agent, CodeAgent), (
+		f'session_to_python_script() requires a CodeAgent instance, got {type(agent).__name__}. '
+		'Use CodeAgent instead of Agent for script export functionality.'
+	)
+
 	lines = []
 
 	lines.append('# Generated from browser-use code-use session\n')

--- a/browser_use/code_use/notebook_export.py
+++ b/browser_use/code_use/notebook_export.py
@@ -29,10 +29,11 @@ def export_to_ipynb(agent: CodeAgent, output_path: str | Path) -> Path:
 	        print(f'Notebook saved to {notebook_path}')
 		```
 	"""
-	assert isinstance(agent, CodeAgent), (
-		f'export_to_ipynb() requires a CodeAgent instance, got {type(agent).__name__}. '
-		'Use CodeAgent instead of Agent for notebook export functionality.'
-	)
+	if not isinstance(agent, CodeAgent):
+		raise TypeError(
+			f'export_to_ipynb() requires a CodeAgent instance, got {type(agent).__name__}. '
+			'Use CodeAgent instead of Agent for notebook export functionality.'
+		)
 
 	output_path = Path(output_path)
 
@@ -197,10 +198,11 @@ def session_to_python_script(agent: CodeAgent) -> str:
 	        print(script)
 		```
 	"""
-	assert isinstance(agent, CodeAgent), (
-		f'session_to_python_script() requires a CodeAgent instance, got {type(agent).__name__}. '
-		'Use CodeAgent instead of Agent for script export functionality.'
-	)
+	if not isinstance(agent, CodeAgent):
+		raise TypeError(
+			f'session_to_python_script() requires a CodeAgent instance, got {type(agent).__name__}. '
+			'Use CodeAgent instead of Agent for script export functionality.'
+		)
 
 	lines = []
 


### PR DESCRIPTION
## Summary

- `export_to_ipynb()` and `session_to_python_script()` accept a `CodeAgent` type hint but crash with a confusing `AttributeError: 'Agent' object has no attribute 'session'` when a regular `Agent` is passed
- Added runtime assertions at the start of both functions that raise a clear error message: `session_to_python_script() requires a CodeAgent instance, got Agent. Use CodeAgent instead of Agent for script export functionality.`

Fixes #4267

## Before

```
AttributeError: 'Agent' object has no attribute 'session'. Did you mean: 'version'?
```

## After

```
AssertionError: session_to_python_script() requires a CodeAgent instance, got Agent. Use CodeAgent instead of Agent for script export functionality.
```

## Test plan

- [x] Verified the assertion triggers when passing a regular `Agent` to either function
- [x] Verified `CodeAgent` instances still work as before (assertion passes)
- [x] No other code changes — existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add runtime type checks to `export_to_ipynb()` and `session_to_python_script()` to require a `CodeAgent`, preventing a confusing AttributeError when a regular `Agent` is passed. Uses explicit `isinstance` checks and raises `TypeError` (not assert) so the error is enforced under `python -O`.

<sup>Written for commit bda2ac9960e075a886db8b920bf3001d217e09a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

