### PR TITLE
lazy-load ChatAWSBedrock in MCP server to avoid boto3 requirement

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -37,8 +37,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-from browser_use.llm import ChatAWSBedrock
-
 # Configure logging for MCP mode - redirect to stderr but preserve critical diagnostics
 logging.basicConfig(
 	stream=sys.stderr, level=logging.WARNING, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', force=True
@@ -655,6 +653,8 @@ class BrowserUseServer:
 			if not aws_region:
 				aws_region = 'us-east-1'
 			aws_sso_auth = llm_config.get('aws_sso_auth', False)
+			from browser_use.llm import ChatAWSBedrock
+
 			llm = ChatAWSBedrock(
 				model=llm_model,  # or any Bedrock model
 				aws_region=aws_region,


### PR DESCRIPTION
Resolves #3447 (in part)

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lazy-loads `ChatAWSBedrock` in the MCP server so `boto3` is only needed when using Bedrock, preventing startup errors in environments without AWS deps.

- **Bug Fixes**
  - Moved `ChatAWSBedrock` import from module top to the Bedrock code path.
  - MCP server now imports Bedrock client only when configured, avoiding a global `boto3` requirement.

<sup>Written for commit 770e19e11253c93ba157107d9eaa3d9264c12ebb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

