### PR TITLE
fix: remove dead code from watchdogs and session

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -586,16 +586,6 @@ class AboutBlankDVDScreensaverShownEvent(BaseEvent):
 	error: str | None = None
 
 
-class DialogOpenedEvent(BaseEvent):
-	"""Event dispatched when a JavaScript dialog is opened and handled."""
-
-	dialog_type: str  # 'alert', 'confirm', 'prompt', or 'beforeunload'
-	message: str
-	url: str
-	frame_id: str | None = None  # Can be None when frameId is not provided by CDP
-	# target_id: TargetID   # TODO: add this to avoid needing target_id_from_frame() later
-
-
 # ============================================================================
 # Captcha Solver Events
 # ============================================================================

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -93,7 +93,6 @@ class CDPSession(BaseModel):
 
 	# Lifecycle monitoring (populated by SessionManager)
 	_lifecycle_events: Any = PrivateAttr(default=None)
-	_lifecycle_lock: Any = PrivateAttr(default=None)
 
 
 class BrowserSession(BaseModel):

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -867,7 +867,6 @@ class SessionManager:
 			from collections import deque
 
 			cdp_session._lifecycle_events = deque(maxlen=50)  # Keep last 50 events
-			cdp_session._lifecycle_lock = asyncio.Lock()
 
 			# Register ONE handler per session that stores events
 			def on_lifecycle_event(event, session_id=None):

--- a/browser_use/browser/watchdogs/crash_watchdog.py
+++ b/browser_use/browser/watchdogs/crash_watchdog.py
@@ -134,15 +134,6 @@ class CrashWatchdog(BaseWatchdog):
 		)
 		# logger.debug(f'[CrashWatchdog] Tracking request: {request.get("method", "")} {request.get("url", "")[:50]}...')
 
-	def _on_response_cdp(self, event: dict) -> None:
-		"""Remove request from tracking on response."""
-		request_id = event.get('requestId', '')
-		if request_id in self._active_requests:
-			elapsed = time.time() - self._active_requests[request_id].start_time
-			response = event.get('response', {})
-			self.logger.debug(f'[CrashWatchdog] Request completed in {elapsed:.2f}s: {response.get("url", "")[:50]}...')
-			# Don't remove yet - wait for loadingFinished
-
 	def _on_request_failed_cdp(self, event: dict) -> None:
 		"""Remove request from tracking on failure."""
 		request_id = event.get('requestId', '')

--- a/browser_use/browser/watchdogs/screenshot_watchdog.py
+++ b/browser_use/browser/watchdogs/screenshot_watchdog.py
@@ -31,7 +31,7 @@ class ScreenshotWatchdog(BaseWatchdog):
 			event: ScreenshotEvent with optional full_page and clip parameters
 
 		Returns:
-			Dict with 'screenshot' key containing base64-encoded screenshot or None
+			Base64-encoded screenshot string
 		"""
 		self.logger.debug('[ScreenshotWatchdog] Handler START - on_ScreenshotEvent called')
 		try:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed dead code in session and watchdogs and clarified screenshot return type to reduce maintenance overhead. No functional changes.

- **Refactors**
  - Removed unused `DialogOpenedEvent` from `browser_use/browser/events.py`.
  - Dropped `_lifecycle_lock` from `CDPSession` and its init in `SessionManager`.
  - Deleted unused `_on_response_cdp` in `CrashWatchdog`.
  - Updated `ScreenshotWatchdog.on_ScreenshotEvent` docstring to return a base64 string.

<sup>Written for commit f19fb8e61c1830106a9a42a53ed1b0dc528c969d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

