### PR TITLE
fix: remove dead parameters from tools and DOM modules

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -645,8 +645,6 @@ class DomService:
 		self,
 		target_id: TargetID,
 		all_frames: dict | None = None,
-		initial_html_frames: list[EnhancedDOMTreeNode] | None = None,
-		initial_total_frame_offset: DOMRect | None = None,
 		iframe_depth: int = 0,
 	) -> tuple[EnhancedDOMTreeNode, dict[str, float]]:
 		"""Get the DOM tree for a specific target.
@@ -654,8 +652,6 @@ class DomService:
 		Args:
 			target_id: Target ID of the page to get the DOM tree for.
 			all_frames: Pre-fetched frame hierarchy to avoid redundant CDP calls (optional, lazy fetch if None)
-			initial_html_frames: List of HTML frame nodes encountered so far
-			initial_total_frame_offset: Accumulated coordinate offset
 			iframe_depth: Current depth of iframe nesting to prevent infinite recursion
 
 		Returns:
@@ -959,10 +955,6 @@ class DomService:
 							content_document, _ = await self.get_dom_tree(
 								target_id=iframe_document_target['targetId'],
 								all_frames=all_frames,
-								# TODO: experiment with this values -> not sure whether the whole cross origin iframe should be ALWAYS included as soon as some part of it is visible or not.
-								# Current config: if the cross origin iframe is AT ALL visible, then just include everything inside of it!
-								# initial_html_frames=updated_html_frames,
-								initial_total_frame_offset=total_frame_offset,
 								iframe_depth=iframe_depth + 1,
 							)
 
@@ -975,9 +967,7 @@ class DomService:
 		# Note: all_frames stays None and will be lazily fetched inside _construct_enhanced_node
 		# only if/when a cross-origin iframe is encountered
 		start_construct = time.time()
-		enhanced_dom_tree_node = await _construct_enhanced_node(
-			dom_tree['root'], initial_html_frames, initial_total_frame_offset, all_frames
-		)
+		enhanced_dom_tree_node = await _construct_enhanced_node(dom_tree['root'], None, None, all_frames)
 		timing_info['construct_enhanced_tree_ms'] = (time.time() - start_construct) * 1000
 
 		# Count hidden elements per iframe for LLM hints

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -74,7 +74,6 @@ class Registry(Generic[Context]):
 	def _normalize_action_function_signature(
 		self,
 		func: Callable,
-		description: str,
 		param_model: type[BaseModel] | None = None,
 	) -> tuple[Callable, type[BaseModel]]:
 		"""
@@ -174,7 +173,6 @@ class Registry(Generic[Context]):
 
 			# Prepare arguments for original function
 			call_args = []
-			call_kwargs = {}
 
 			# Handle Type 1 pattern (first arg is the param model)
 			if param_model_provided and parameters and parameters[0].name not in special_param_names:
@@ -308,7 +306,7 @@ class Registry(Generic[Context]):
 				return func
 
 			# Normalize the function signature
-			normalized_func, actual_param_model = self._normalize_action_function_signature(func, description, param_model)
+			normalized_func, actual_param_model = self._normalize_action_function_signature(func, param_model)
 
 			action = RegisteredAction(
 				name=func.__name__,

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -7,9 +7,7 @@ from pydantic.json_schema import SkipJsonSchema
 # Action Input Models
 class ExtractAction(BaseModel):
 	query: str
-	extract_links: bool = Field(
-		default=False, description='Set True to true if the query requires links, else false to safe tokens'
-	)
+	extract_links: bool = Field(default=False, description='Set to true if the query requires links, else false to save tokens')
 	start_from_char: int = Field(
 		default=0, description='Use this for long markdowns to start from a specific character (not index in browser_state)'
 	)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed unused parameters in the DOM tree builder and tools registry to simplify APIs and reduce dead code. No behavior changes.

- **Refactors**
  - Removed `initial_html_frames` and `initial_total_frame_offset` from `get_dom_tree` and updated call sites.
  - Dropped the unused `description` arg in `_normalize_action_function_signature` and a dead `call_kwargs` variable.
  - Clarified `ExtractAction.extract_links` description to be concise and fix wording.

<sup>Written for commit 38086a64710e9e55937efbc3c1b0bb9eb9923cda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

