### PR TITLE
Update documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-Check out the [library docs](https://docs.browser-use.com) and the [cloud docs](https://docs.cloud.browser-use.com) for more!
+Check out the [library docs](https://docs.browser-use.com/open-source/introduction) and the [cloud docs](https://docs.cloud.browser-use.com) for more!
 
 <br/>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the README to point the “library docs” link to https://docs.browser-use.com/open-source/introduction so readers land on the correct introduction page.
The “cloud docs” link is unchanged.

<sup>Written for commit 34456c5a20e95c6f85c31e4e88f565a22dc44162. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

