### PR TITLE
docs: clarify Browser Use OSS model guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ curl -o ~/.claude/skills/browser-use/SKILL.md \
 
 We optimized **ChatBrowserUse()** specifically for browser automation tasks. On avg it completes tasks 3-5x faster than other models with SOTA accuracy.
 
+If you want the open-source fine-tuned preview, use `ChatBrowserUse(model='browser-use/bu-30b-a3b-preview')`. You still use it with the normal `Agent(...)` flow — Browser Use adds its system prompt automatically, so you do **not** need to prepend a separate Browser Use system message yourself. Use `bu-latest` / `bu-2-0` when you want the newest hosted Browser Use models, and the preview model when you specifically want the Browser Use-tuned open-source option.
+
 **Pricing (per 1M tokens):**
 - Input tokens: $0.20
 - Cached input tokens: $0.02

--- a/examples/models/bu_oss.py
+++ b/examples/models/bu_oss.py
@@ -17,9 +17,10 @@ try:
 except ImportError:
 	pass
 
-# Point to local llm-use server for testing
+# Use the Browser Use-tuned open-source preview like any other ChatBrowserUse model.
+# The Agent still supplies the Browser Use system prompt automatically.
 llm = ChatBrowserUse(
-	model='browser-use/bu-30b-a3b-preview',  # BU Open Source Model!!
+	model='browser-use/bu-30b-a3b-preview',
 )
 
 agent = Agent(


### PR DESCRIPTION
## Summary
- clarify when to use `ChatBrowserUse(model='browser-use/bu-30b-a3b-preview')`
- document that the normal `Agent(...)` flow already supplies the Browser Use system prompt
- mirror that guidance in the OSS model example comment

Closes #4225

## Validation
- `python3 -m py_compile examples/models/bu_oss.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how to use the Browser Use OSS preview model and when to prefer hosted variants. README now shows `ChatBrowserUse(model='browser-use/bu-30b-a3b-preview')` works with the normal `Agent` flow (no extra Browser Use system prompt), and the `bu_oss.py` comment mirrors this.

<sup>Written for commit b8a4e3740e0513d8427214c10df22fa8c3e18179. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

