### PR TITLE
fix: Add type check for session_to_python_script

### DIFF
--- a/browser_use/code_use/notebook_export.py
+++ b/browser_use/code_use/notebook_export.py
@@ -185,6 +185,9 @@ def session_to_python_script(agent: CodeAgent) -> str:
 	Returns:
 		Python script as a string
 
+	Raises:
+		TypeError: If agent is not a CodeAgent instance
+
 	Example:
 		```python
 	        await agent.run()
@@ -192,6 +195,13 @@ def session_to_python_script(agent: CodeAgent) -> str:
 	        print(script)
 		```
 	"""
+	# Type check to provide helpful error message
+	if not isinstance(agent, CodeAgent):
+		raise TypeError(
+			f"Expected a CodeAgent instance, got {type(agent).__name__}. "
+			"Use CodeAgent from browser_use.code_use instead of Agent."
+		)
+
 	lines = []
 
 	lines.append('# Generated from browser-use code-use session\n')


### PR DESCRIPTION
## Summary
Add a helpful error message when user passes wrong agent type to `session_to_python_script()`.

Currently the function fails with confusing `AttributeError: Agent object has no attribute session` when a regular `Agent` is passed instead of `CodeAgent`. This fix adds:

- Checks if the agent is a `CodeAgent` instance
- Raises a clear `TypeError` with instructions on how to fix the issue
- Points users to use `CodeAgent` instead of `Agent`

## Fixes
Fixes: #4267

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a type check to `session_to_python_script()` to require a `CodeAgent`, raising a helpful `TypeError` when a regular `Agent` is passed. Fixes #4267 and prevents a confusing `AttributeError` by guiding users to use `CodeAgent` from `browser_use.code_use`.

- **Bug Fixes**
  - Validate the agent is `CodeAgent`; otherwise raise a `TypeError` with instructions.
  - Avoids `AttributeError: Agent object has no attribute session` when `Agent` is used.

<sup>Written for commit e2dcc82831a5d21046a6e00df5ee2fc7cc4e85c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

