### PR TITLE
Fix token placeholder in message history logs

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -531,7 +531,8 @@ class MessageManager:
 		"""Get current message list, potentially trimmed to max tokens"""
 
 		# Log message history for debugging
-		logger.debug(self._log_history_lines())
+		if logger.isEnabledFor(logging.DEBUG):
+			logger.debug(self._log_history_lines())
 		self.last_input_messages = self.state.history.get_messages()
 		return self.last_input_messages
 

--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 from typing import Literal
 
 from browser_use.agent.message_manager.views import (
@@ -46,20 +47,28 @@ def _log_get_message_emoji(message: BaseMessage) -> str:
 	return emoji_map.get(message.__class__.__name__, '🎮')
 
 
-def _log_format_message_line(message: BaseMessage, content: str, is_last_message: bool, terminal_width: int) -> list[str]:
+def _log_estimate_token_count(message: BaseMessage) -> int | None:
+	"""Estimate token count for a message when provider usage metadata is unavailable."""
+	text = message.text.strip()
+	if not text:
+		return None
+	return max(1, len(text) // 4)
+
+
+def _log_format_message_line(
+	message: BaseMessage, content: str, token_count: int | None, is_last_message: bool, terminal_width: int
+) -> list[str]:
 	"""Format a single message for logging display"""
 	try:
 		lines = []
 
 		# Get emoji and token info
 		emoji = _log_get_message_emoji(message)
-		# token_str = str(message.metadata.tokens).rjust(4)
-		# TODO: fix the token count
-		token_str = '??? (TODO)'
+		token_str = str(token_count).rjust(4) if token_count is not None else '   ?'
 		prefix = f'{emoji}[{token_str}]: '
 
 		# Calculate available width (emoji=2 visual cols + [token]: =8 chars)
-		content_width = terminal_width - 10
+		content_width = max(10, terminal_width - 10)
 
 		# Handle last message wrapping
 		if is_last_message and len(content) > content_width:
@@ -492,40 +501,30 @@ class MessageManager:
 
 	def _log_history_lines(self) -> str:
 		"""Generate a formatted log string of message history for debugging / printing to terminal"""
-		# TODO: fix logging
+		try:
+			total_input_tokens = 0
+			message_lines: list[str] = []
+			messages = self.state.history.get_messages()
+			terminal_width = shutil.get_terminal_size((80, 20)).columns
 
-		# try:
-		# 	total_input_tokens = 0
-		# 	message_lines = []
-		# 	terminal_width = shutil.get_terminal_size((80, 20)).columns
+			for i, message in enumerate(messages):
+				try:
+					is_last_message = i == len(messages) - 1
+					token_count = _log_estimate_token_count(message)
+					if token_count is not None:
+						total_input_tokens += token_count
 
-		# 	for i, m in enumerate(self.state.history.messages):
-		# 		try:
-		# 			total_input_tokens += m.metadata.tokens
-		# 			is_last_message = i == len(self.state.history.messages) - 1
+					content = message.text
+					lines = _log_format_message_line(message, content, token_count, is_last_message, terminal_width)
+					message_lines.extend(lines)
+				except Exception as e:
+					logger.warning(f'Failed to format message {i} for logging: {e}')
+					message_lines.append('❓[   ?]: [Error formatting this message]')
 
-		# 			# Extract content for logging
-		# 			content = _log_extract_message_content(m.message, is_last_message, m.metadata)
-
-		# 			# Format the message line(s)
-		# 			lines = _log_format_message_line(m, content, is_last_message, terminal_width)
-		# 			message_lines.extend(lines)
-		# 		except Exception as e:
-		# 			logger.warning(f'Failed to format message {i} for logging: {e}')
-		# 			# Add a fallback line for this message
-		# 			message_lines.append('❓[   ?]: [Error formatting this message]')
-
-		# 	# Build final log message
-		# 	return (
-		# 		f'📜 LLM Message history ({len(self.state.history.messages)} messages, {total_input_tokens} tokens):\n'
-		# 		+ '\n'.join(message_lines)
-		# 	)
-		# except Exception as e:
-		# 	logger.warning(f'Failed to generate history log: {e}')
-		# 	# Return a minimal fallback message
-		# 	return f'📜 LLM Message history (error generating log: {e})'
-
-		return ''
+			return f'📜 LLM Message history ({len(messages)} messages, {total_input_tokens} tokens):\n' + '\n'.join(message_lines)
+		except Exception as e:
+			logger.warning(f'Failed to generate history log: {e}')
+			return f'📜 LLM Message history (error generating log: {e})'
 
 	@time_execution_sync('--get_messages')
 	def get_messages(self) -> list[BaseMessage]:

--- a/tests/ci/test_message_manager_logging.py
+++ b/tests/ci/test_message_manager_logging.py
@@ -1,0 +1,60 @@
+from browser_use.agent.message_manager.service import (
+	MessageManager,
+	_log_estimate_token_count,
+	_log_format_message_line,
+)
+from browser_use.agent.views import MessageManagerState
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.llm.messages import SystemMessage, UserMessage
+
+
+def test_log_format_message_line_with_numeric_token_count():
+	message = UserMessage(content='hello world')
+	lines = _log_format_message_line(
+		message=message,
+		content=message.text,
+		token_count=42,
+		is_last_message=True,
+		terminal_width=120,
+	)
+
+	assert lines
+	assert '[  42]:' in lines[0]
+	assert '??? (TODO)' not in lines[0]
+
+
+def test_log_format_message_line_with_missing_token_count():
+	message = UserMessage(content='hello world')
+	lines = _log_format_message_line(
+		message=message,
+		content=message.text,
+		token_count=None,
+		is_last_message=True,
+		terminal_width=120,
+	)
+
+	assert lines
+	assert '[   ?]:' in lines[0]
+	assert '??? (TODO)' not in lines[0]
+
+
+def test_log_estimate_token_count_empty_message_returns_none():
+	message = UserMessage(content='   ')
+	assert _log_estimate_token_count(message) is None
+
+
+def test_log_history_lines_does_not_include_todo_placeholder(tmp_path):
+	file_system = FileSystem(tmp_path)
+	message_manager = MessageManager(
+		task='Test task',
+		system_message=SystemMessage(content='System message'),
+		state=MessageManagerState(),
+		file_system=file_system,
+	)
+	message_manager._add_context_message(UserMessage(content='A short contextual message'))
+
+	history_log = message_manager._log_history_lines()
+
+	assert history_log
+	assert '??? (TODO)' not in history_log
+	assert '📜 LLM Message history' in history_log

--- a/tests/ci/test_message_manager_logging.py
+++ b/tests/ci/test_message_manager_logging.py
@@ -1,3 +1,5 @@
+import logging
+
 from browser_use.agent.message_manager.service import (
 	MessageManager,
 	_log_estimate_token_count,
@@ -58,3 +60,28 @@ def test_log_history_lines_does_not_include_todo_placeholder(tmp_path):
 	assert history_log
 	assert '??? (TODO)' not in history_log
 	assert '📜 LLM Message history' in history_log
+
+
+def test_get_messages_does_not_format_history_when_debug_disabled(tmp_path, monkeypatch):
+	file_system = FileSystem(tmp_path)
+	message_manager = MessageManager(
+		task='Test task',
+		system_message=SystemMessage(content='System message'),
+		state=MessageManagerState(),
+		file_system=file_system,
+	)
+	message_manager._add_context_message(UserMessage(content='A short contextual message'))
+
+	def _raise_if_called():
+		raise AssertionError('_log_history_lines should not be called when debug logging is disabled')
+
+	monkeypatch.setattr(message_manager, '_log_history_lines', _raise_if_called)
+
+	module_logger = logging.getLogger('browser_use.agent.message_manager.service')
+	previous_level = module_logger.level
+	try:
+		module_logger.setLevel(logging.INFO)
+		messages = message_manager.get_messages()
+		assert messages
+	finally:
+		module_logger.setLevel(previous_level)


### PR DESCRIPTION
This PR fixes a logging bug where message-history token output always showed `??? (TODO)` in debug logs, which made token visibility unusable during agent runs. The change removes that hardcoded placeholder and replaces it with explicit token formatting: numeric token counts when available and a stable `?` fallback when not. It also restores the message-history logging path and adds focused regression tests to ensure the placeholder cannot reappear. Runtime verification confirms logs now show token-prefixed lines (for example, `🧠[5729]`, `💬[ 602]`) instead of the TODO placeholder.

<img width="1005" height="809" alt="Screenshot 2026-03-11 at 7 42 02 PM" src="https://github.com/user-attachments/assets/a07f012b-592b-443c-bef6-bb73fa5ff2a7" />


[Issue Link](https://github.com/browser-use/browser-use/issues/4150)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes message-history debug logs to show real token counts instead of the "??? (TODO)" placeholder, and skips history formatting unless DEBUG is enabled. Shows numeric counts when known and "?" when unknown.

- **Bug Fixes**
  - Restores `MessageManager._log_history_lines()` to render history, sum tokens, and fit to terminal width via `shutil`.
  - Replaces the placeholder with right-justified token formatting in `_log_format_message_line()` and estimates tokens via `_log_estimate_token_count()` when metadata is missing.
  - Guards history formatting behind a DEBUG-level check in `get_messages()` to avoid overhead in normal runs; adds tests to cover placeholder removal, formatting, and the debug guard.

<sup>Written for commit 01502dfbc0fa44a895ff49a04d77a44ed2fd6726. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

