### PR TITLE
fix: parse RFC 6266 filename*= in Content-Disposition for non-ASCII downloads

### DIFF
--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -3,10 +3,11 @@
 import asyncio
 import json
 import os
+import re
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import anyio
 from bubus import BaseEvent
@@ -504,7 +505,8 @@ class DownloadsWatchdog(BaseWatchdog):
 						is_pdf = 'application/pdf' in content_type
 
 						# Check if it's marked as download via Content-Disposition header
-						content_disposition = str(headers.get('content-disposition', '')).lower()
+						content_disposition_raw = str(headers.get('content-disposition', ''))
+						content_disposition = content_disposition_raw.lower()
 						is_download_attachment = 'attachment' in content_disposition
 
 						# Filter out image/video/audio files even if marked as attachment
@@ -572,15 +574,27 @@ class DownloadsWatchdog(BaseWatchdog):
 						# Mark as detected to avoid duplicates
 						self._detected_downloads.add(url)
 
-						# Extract filename from Content-Disposition if available
+						# Extract filename from Content-Disposition if available (RFC 5987/6266)
 						suggested_filename = None
-						if 'filename=' in content_disposition:
-							# Parse filename from Content-Disposition header
-							import re
-
-							filename_match = re.search(r'filename[^;=\n]*=(([\'"]).*?\2|[^;\n]*)', content_disposition)
-							if filename_match:
-								suggested_filename = filename_match.group(1).strip('\'"')
+						if 'filename' in content_disposition:
+							# Try filename*= first (RFC 5987 extended parameter, handles non-ASCII)
+							# Use raw header to preserve percent-encoded values
+							filename_star_match = re.search(
+								r"filename\*\s*=\s*UTF-8''([^;\s]+)",
+								content_disposition_raw,
+								re.IGNORECASE,
+							)
+							if filename_star_match:
+								suggested_filename = unquote(filename_star_match.group(1))
+							else:
+								# Fall back to standard filename= parameter
+								filename_match = re.search(
+									r'filename\s*=\s*"([^"]+)"|filename\s*=\s*([^;\s]+)',
+									content_disposition_raw,
+									re.IGNORECASE,
+								)
+								if filename_match:
+									suggested_filename = (filename_match.group(1) or filename_match.group(2)).strip('\'"')
 
 						self.logger.info(f'[DownloadsWatchdog] 🔍 Detected downloadable content via network: {url[:80]}...')
 						self.logger.debug(

--- a/tests/ci/test_download_filename_parsing.py
+++ b/tests/ci/test_download_filename_parsing.py
@@ -1,0 +1,110 @@
+"""Tests for Content-Disposition filename parsing in downloads watchdog.
+
+Verifies RFC 5987/6266 filename*= parsing for non-ASCII filenames (Japanese, etc.)
+and backward compatibility with standard filename= parameter.
+"""
+
+import re
+from urllib.parse import unquote
+
+
+def parse_filename_from_content_disposition(content_disposition_raw: str) -> str | None:
+	"""Extract filename from Content-Disposition header, matching downloads_watchdog.py logic.
+
+	This replicates the parsing logic from DownloadsWatchdog._setup_network_monitoring
+	so we can unit test it without spinning up a full browser session.
+	"""
+	content_disposition = content_disposition_raw.lower()
+	suggested_filename = None
+
+	if 'filename' in content_disposition:
+		# Try filename*= first (RFC 5987, handles non-ASCII)
+		filename_star_match = re.search(
+			r"filename\*\s*=\s*UTF-8''([^;\s]+)",
+			content_disposition_raw,
+			re.IGNORECASE,
+		)
+		if filename_star_match:
+			suggested_filename = unquote(filename_star_match.group(1))
+		else:
+			# Fall back to standard filename= parameter
+			filename_match = re.search(
+				r'filename\s*=\s*"([^"]+)"|filename\s*=\s*([^;\s]+)',
+				content_disposition_raw,
+				re.IGNORECASE,
+			)
+			if filename_match:
+				suggested_filename = (filename_match.group(1) or filename_match.group(2)).strip('\'"')
+
+	return suggested_filename
+
+
+async def test_filename_star_utf8_japanese():
+	"""filename*=UTF-8'' with Japanese characters should decode correctly."""
+	header = "attachment; filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.pdf"
+	assert parse_filename_from_content_disposition(header) == '\u30c6\u30b9\u30c8.pdf'
+
+
+async def test_filename_star_utf8_chinese():
+	"""filename*=UTF-8'' with Chinese characters should decode correctly."""
+	header = "attachment; filename*=UTF-8''%E6%96%87%E4%BB%B6.pdf"
+	assert parse_filename_from_content_disposition(header) == '\u6587\u4ef6.pdf'
+
+
+async def test_filename_star_utf8_korean():
+	"""filename*=UTF-8'' with Korean characters should decode correctly."""
+	header = "attachment; filename*=UTF-8''%ED%8C%8C%EC%9D%BC.pdf"
+	assert parse_filename_from_content_disposition(header) == '\ud30c\uc77c.pdf'
+
+
+async def test_filename_star_takes_priority():
+	"""When both filename and filename* are present, filename* wins per RFC 6266."""
+	header = 'attachment; filename="fallback.pdf"; filename*=UTF-8\'\'%E3%83%86%E3%82%B9%E3%83%88.pdf'
+	assert parse_filename_from_content_disposition(header) == '\u30c6\u30b9\u30c8.pdf'
+
+
+async def test_filename_star_case_insensitive():
+	"""The UTF-8 charset label should be matched case-insensitively."""
+	header = "attachment; filename*=utf-8''%E3%83%86%E3%82%B9%E3%83%88.pdf"
+	assert parse_filename_from_content_disposition(header) == '\u30c6\u30b9\u30c8.pdf'
+
+
+async def test_plain_filename_quoted():
+	"""Standard quoted filename= should still work."""
+	header = 'attachment; filename="report.pdf"'
+	assert parse_filename_from_content_disposition(header) == 'report.pdf'
+
+
+async def test_plain_filename_unquoted():
+	"""Standard unquoted filename= should still work."""
+	header = 'attachment; filename=report.pdf'
+	assert parse_filename_from_content_disposition(header) == 'report.pdf'
+
+
+async def test_filename_with_spaces():
+	"""Filename with spaces in quotes should be preserved."""
+	header = 'attachment; filename="my report.pdf"'
+	assert parse_filename_from_content_disposition(header) == 'my report.pdf'
+
+
+async def test_filename_star_with_trailing_params():
+	"""filename*= should not capture trailing parameters after semicolon."""
+	header = "attachment; filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.pdf; size=12345"
+	assert parse_filename_from_content_disposition(header) == '\u30c6\u30b9\u30c8.pdf'
+
+
+async def test_no_filename():
+	"""Header without any filename should return None."""
+	header = 'attachment'
+	assert parse_filename_from_content_disposition(header) is None
+
+
+async def test_empty_header():
+	"""Empty header should return None."""
+	assert parse_filename_from_content_disposition('') is None
+
+
+async def test_filename_star_with_encoded_spaces():
+	"""Percent-encoded spaces in filename*= should decode properly."""
+	header = "attachment; filename*=UTF-8''my%20report%20%E3%83%86%E3%82%B9%E3%83%88.pdf"
+	assert parse_filename_from_content_disposition(header) == 'my report \u30c6\u30b9\u30c8.pdf'


### PR DESCRIPTION
## Problem

The Content-Disposition header parser in `downloads_watchdog.py` only handles the basic `filename=` parameter. When servers send non-ASCII filenames (Japanese, Chinese, Korean, etc.) using the RFC 5987/6266 `filename*=UTF-8''<percent-encoded>` form, the filename is not recognized and files get saved as `download`.

Additionally, the entire header was lowercased before filename extraction, which is unnecessary for the filename portion and could theoretically interfere with encoded values.

## Changes

- Parse `filename*=UTF-8''<encoded>` first, taking priority over plain `filename=` per RFC 6266
- URL-decode the percent-encoded filename via `urllib.parse.unquote`
- Fall back to standard `filename=` when `filename*=` is absent
- Preserve raw header casing for filename extraction (only use lowercase for the `attachment` check)
- Move `re` and `unquote` imports to file level instead of inline
- Added 12 unit tests covering Japanese/Chinese/Korean filenames, priority ordering, edge cases

## Test plan

- [x] `filename*=UTF-8''%E3%83%86%E3%82%B9%E3%83%88.pdf` decodes to `テスト.pdf`
- [x] `filename*=` takes priority over `filename=` when both present
- [x] Case-insensitive charset matching (`utf-8` and `UTF-8`)
- [x] Trailing parameters after semicolon are not captured
- [x] Plain `filename="report.pdf"` and `filename=report.pdf` still work
- [x] Filenames with spaces preserved
- [x] Empty/missing headers return None

Fixes #4094

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes download filename parsing to support RFC 6266 `filename*=` so non-ASCII filenames are preserved instead of defaulting to `download`.

- **Bug Fixes**
  - Parse `filename*=` (UTF-8, percent-decoded) and prefer it over `filename=`.
  - Fallback to `filename=`; keep quotes/spaces intact.
  - Use raw header for extraction; lowercase only for the `attachment` check.
  - Added unit tests covering i18n names, priority, and edge cases.

<sup>Written for commit c4469fb32bef0cdbb29629cd26ee636de5831d8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

