### PR TITLE
Add Lightpanda as alternative browser engine

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
 	# from browser_use.agent.service import Agent
 	from browser_use.agent.views import ActionModel, ActionResult, AgentHistoryList
-	from browser_use.browser import BrowserProfile, BrowserSession
+	from browser_use.browser import BrowserEngine, BrowserProfile, BrowserSession
 	from browser_use.browser import BrowserSession as Browser
 	from browser_use.code_use.service import CodeAgent
 	from browser_use.dom.service import DomService
@@ -85,6 +85,7 @@ _LAZY_IMPORTS = {
 	'BrowserSession': ('browser_use.browser', 'BrowserSession'),
 	'Browser': ('browser_use.browser', 'BrowserSession'),  # Alias for BrowserSession
 	'BrowserProfile': ('browser_use.browser', 'BrowserProfile'),
+	'BrowserEngine': ('browser_use.browser', 'BrowserEngine'),
 	# Tools (moderate weight)
 	'Tools': ('browser_use.tools.service', 'Tools'),
 	'Controller': ('browser_use.tools.service', 'Controller'),  # alias
@@ -138,6 +139,7 @@ __all__ = [
 	'BrowserSession',
 	'Browser',  # Alias for BrowserSession
 	'BrowserProfile',
+	'BrowserEngine',
 	'Controller',
 	'DomService',
 	'SystemPrompt',

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 from urllib.parse import urlparse
 
+import anyio
+
 if TYPE_CHECKING:
 	from browser_use.skills.views import Skill
 
@@ -2668,7 +2670,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				create_history_gif(task=self.task, history=self.history, output_path=output_path)
 
 				# Only emit output file event if GIF was actually created
-				if Path(output_path).exists():
+				if await anyio.Path(output_path).exists():
 					output_event = await CreateAgentOutputFileEvent.from_agent_and_file(self, output_path)
 					self.eventbus.dispatch(output_event)
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -465,6 +465,14 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			self.logger.warning('⚠️ DeepSeek models do not support use_vision=True yet. Setting use_vision=False for now...')
 			self.settings.use_vision = False
 
+		# Handle Lightpanda engine: screenshots are useless (no rendering), force vision off
+		from browser_use.browser.profile import BrowserEngine
+
+		if self.browser_session.browser_profile.browser_engine == BrowserEngine.LIGHTPANDA:
+			if self.settings.use_vision is True:
+				self.logger.warning('⚠️ Lightpanda has no graphical rendering. Setting use_vision=False.')
+			self.settings.use_vision = False
+
 		# Handle users trying to use use_vision=True with XAI models that don't support it
 		# grok-3 variants and grok-code don't support vision; grok-2 and grok-4 do
 		model_lower = self.llm.model.lower()

--- a/browser_use/browser/__init__.py
+++ b/browser_use/browser/__init__.py
@@ -2,13 +2,14 @@ from typing import TYPE_CHECKING
 
 # Type stubs for lazy imports
 if TYPE_CHECKING:
-	from .profile import BrowserProfile, ProxySettings
+	from .profile import BrowserEngine, BrowserProfile, ProxySettings
 	from .session import BrowserSession
 
 
 # Lazy imports mapping for heavy browser components
 _LAZY_IMPORTS = {
 	'ProxySettings': ('.profile', 'ProxySettings'),
+	'BrowserEngine': ('.profile', 'BrowserEngine'),
 	'BrowserProfile': ('.profile', 'BrowserProfile'),
 	'BrowserSession': ('.session', 'BrowserSession'),
 }
@@ -37,5 +38,6 @@ def __getattr__(name: str):
 __all__ = [
 	'BrowserSession',
 	'BrowserProfile',
+	'BrowserEngine',
 	'ProxySettings',
 ]

--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -295,7 +295,7 @@ class BrowserStartEvent(BaseEvent):
 	cdp_url: str | None = None
 	launch_options: dict[str, Any] = Field(default_factory=dict)
 
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStartEvent', 30.0))  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStartEvent', 60.0))  # seconds
 
 
 class BrowserStopEvent(BaseEvent):

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -275,6 +275,13 @@ class RecordHarMode(str, Enum):
 	MINIMAL = 'minimal'
 
 
+class BrowserEngine(str, Enum):
+	"""Browser engine to use for the session."""
+
+	CHROMIUM = 'chromium'
+	LIGHTPANDA = 'lightpanda'
+
+
 class BrowserChannel(str, Enum):
 	CHROMIUM = 'chromium'
 	CHROME = 'chrome'
@@ -558,6 +565,12 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	# ... extends options defined in:
 	# BrowserLaunchPersistentContextArgs, BrowserLaunchArgs, BrowserNewContextArgs, BrowserConnectArgs
 
+	# Browser engine selection
+	browser_engine: BrowserEngine = Field(
+		default=BrowserEngine.CHROMIUM,
+		description='Browser engine to use: chromium (default) or lightpanda (headless-only, no rendering).',
+	)
+
 	# Session/connection configuration
 	cdp_url: str | None = Field(default=None, description='CDP URL for connecting to existing browser instance')
 	is_local: bool = Field(default=False, description='Whether this is a local browser instance')
@@ -796,8 +809,27 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	def model_post_init(self, __context: Any) -> None:
 		"""Called after model initialization to set up display configuration."""
+		if self.browser_engine == BrowserEngine.LIGHTPANDA:
+			self._apply_lightpanda_constraints()
+			return
 		self.detect_display_configuration()
 		self._copy_profile()
+
+	def _apply_lightpanda_constraints(self) -> None:
+		"""Apply constraints for the Lightpanda browser engine (no rendering, no extensions, always headless)."""
+		if self.headless is False:
+			logger.warning('⚠️ Lightpanda has no graphical rendering. Forcing headless=True.')
+		self.headless = True
+
+		if self.enable_default_extensions:
+			self.enable_default_extensions = False
+
+		if self.demo_mode:
+			logger.warning('⚠️ Lightpanda has no graphical rendering. Forcing demo_mode=False.')
+			self.demo_mode = False
+
+		self.highlight_elements = False
+		self.deterministic_rendering = False
 
 	def _copy_profile(self) -> None:
 		"""Copy profile to temp directory if user_data_dir is not None and not already a temp dir."""
@@ -842,6 +874,19 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		self.user_data_dir = temp_dir
 
 	def get_args(self) -> list[str]:
+		"""Get the list of browser CLI launch args for this profile."""
+		if self.browser_engine == BrowserEngine.LIGHTPANDA:
+			return self._get_lightpanda_args()
+		return self._get_chrome_args()
+
+	def _get_lightpanda_args(self) -> list[str]:
+		"""Get Lightpanda CLI launch args. Lightpanda uses --host/--port instead of Chrome flags."""
+		args = []
+		# Extra user-provided args are passed through (Lightpanda may support some custom flags)
+		args.extend(self.args)
+		return args
+
+	def _get_chrome_args(self) -> list[str]:
 		"""Get the list of all Chrome CLI launch args for this profile (compiled from defaults, user-provided, and system-specific)."""
 
 		if isinstance(self.ignore_default_args, list):

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -170,6 +170,8 @@ class BrowserSession(BaseModel):
 		id: str | None = None,
 		cdp_url: str | None = None,
 		browser_profile: BrowserProfile | None = None,
+		# Browser engine selection
+		browser_engine: str | None = None,
 		# Local browser launch params
 		executable_path: str | Path | None = None,
 		headless: bool | None = None,
@@ -276,6 +278,8 @@ class BrowserSession(BaseModel):
 		use_cloud: bool | None = None,
 		cloud_browser: bool | None = None,  # Backward compatibility alias
 		cloud_browser_params: CloudBrowserParams | None = None,
+		## Browser engine
+		browser_engine: str | None = None,
 		## Other params
 		disable_security: bool | None = None,
 		deterministic_rendering: bool | None = None,

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Literal, Self, Union, cast, overload
 from urllib.parse import urlparse, urlunparse
 from uuid import UUID
 
+import anyio
 import httpx
 from bubus import EventBus
 from cdp_use import CDPClient
@@ -1339,7 +1340,6 @@ class BrowserSession(BaseModel):
 			Storage state dict with cookies in Playwright format.
 
 		"""
-		from pathlib import Path
 
 		# Get all cookies using Storage.getCookies (returns decrypted cookies from all domains)
 		cookies = await self._cdp_get_cookies()
@@ -1365,9 +1365,9 @@ class BrowserSession(BaseModel):
 		if output_path:
 			import json
 
-			output_file = Path(output_path).expanduser().resolve()
-			output_file.parent.mkdir(parents=True, exist_ok=True)
-			output_file.write_text(json.dumps(storage_state, indent=2, ensure_ascii=False), encoding='utf-8')
+			output_file = await anyio.Path(output_path).expanduser().resolve()
+			await output_file.parent.mkdir(parents=True, exist_ok=True)
+			await output_file.write_text(json.dumps(storage_state, indent=2, ensure_ascii=False), encoding='utf-8')
 			self.logger.info(f'💾 Exported {len(cookies)} cookies to {output_file}')
 
 		return storage_state
@@ -3834,7 +3834,7 @@ class BrowserSession(BaseModel):
 		screenshot_data = base64.b64decode(result['data'])
 
 		if path:
-			Path(path).write_bytes(screenshot_data)
+			await anyio.Path(path).write_bytes(screenshot_data)
 
 		return screenshot_data
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1365,7 +1365,7 @@ class BrowserSession(BaseModel):
 		if output_path:
 			import json
 
-			output_file = await anyio.Path(output_path).expanduser().resolve()
+			output_file = await (await anyio.Path(output_path).expanduser()).resolve()
 			await output_file.parent.mkdir(parents=True, exist_ok=True)
 			await output_file.write_text(json.dumps(storage_state, indent=2, ensure_ascii=False), encoding='utf-8')
 			self.logger.info(f'💾 Exported {len(cookies)} cookies to {output_file}')

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -122,12 +122,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		else:
 			browser_path = self._find_lightpanda_path()
 			if not browser_path:
-				self.logger.info('[LocalBrowserWatchdog] 🐼 Lightpanda not found, installing...')
-				browser_path = await self._install_lightpanda()
-			if not browser_path:
 				raise RuntimeError(
-					'Lightpanda binary not found and auto-install failed.\n'
-					'Install manually: curl -fsSL https://pkg.lightpanda.io/install.sh | bash\n'
+					'Lightpanda binary not found.\n'
+					'Install it: curl -fsSL https://pkg.lightpanda.io/install.sh | bash\n'
 					'Or set executable_path / LIGHTPANDA_BINARY_PATH.'
 				)
 
@@ -451,51 +448,6 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				return path
 
 		return None
-
-	async def _install_lightpanda(self) -> str | None:
-		"""Install Lightpanda using the official install script.
-
-		Runs: curl -fsSL https://pkg.lightpanda.io/install.sh | bash
-
-		Returns:
-			Path to the installed lightpanda binary, or None if installation failed.
-		"""
-		if sys.platform == 'win32':
-			raise RuntimeError(
-				'Lightpanda auto-installation is only supported on Unix-like systems (Linux/macOS).\n'
-				'Please install Lightpanda manually on Windows (e.g., via WSL) and set the LIGHTPANDA_BINARY_PATH.'
-			)
-
-		process = await asyncio.create_subprocess_exec(
-			'bash',
-			'-c',
-			'curl -fsSL https://pkg.lightpanda.io/install.sh | bash',
-			stdout=asyncio.subprocess.PIPE,
-			stderr=asyncio.subprocess.PIPE,
-		)
-
-		try:
-			stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=120.0)
-			self.logger.debug(f'[LocalBrowserWatchdog] 🐼 Lightpanda install output: {stdout.decode()}')
-			if process.returncode != 0:
-				self.logger.error(f'[LocalBrowserWatchdog] ❌ Lightpanda install failed:\n{stderr.decode()}')
-				return None
-			# After install, try to find the binary again
-			browser_path = self._find_lightpanda_path()
-			if browser_path:
-				self.logger.info(f'[LocalBrowserWatchdog] 🐼 Lightpanda installed at {browser_path}')
-				return browser_path
-			self.logger.error('[LocalBrowserWatchdog] ❌ Lightpanda install script succeeded but binary not found on PATH')
-			return None
-		except TimeoutError:
-			process.kill()
-			await process.wait()
-			raise RuntimeError('Lightpanda installation timed out after 120 seconds')
-		except Exception as e:
-			if process.returncode is None:
-				process.kill()
-				await process.wait()
-			raise RuntimeError(f'Error installing Lightpanda: {e}')
 
 	async def _install_browser_with_playwright(self) -> str:
 		"""Get browser executable path from playwright in a subprocess to avoid thread issues."""

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -23,7 +23,7 @@ from browser_use.browser.watchdog_base import BaseWatchdog
 from browser_use.observability import observe_debug
 
 if TYPE_CHECKING:
-	from browser_use.browser.profile import BrowserChannel
+	from browser_use.browser.profile import BrowserChannel, BrowserEngine
 
 
 class LocalBrowserWatchdog(BaseWatchdog):
@@ -98,6 +98,58 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		Returns:
 			Tuple of (psutil.Process, cdp_url)
 		"""
+		from browser_use.browser.profile import BrowserEngine
+
+		profile = self.browser_session.browser_profile
+
+		if profile.browser_engine == BrowserEngine.LIGHTPANDA:
+			return await self._launch_lightpanda()
+
+		return await self._launch_chromium(max_retries)
+
+	async def _launch_lightpanda(self) -> tuple[psutil.Process, str]:
+		"""Launch a Lightpanda browser process."""
+		profile = self.browser_session.browser_profile
+
+		# Get launch args from profile (user-provided extra args only)
+		launch_args = profile.get_args()
+
+		# Find Lightpanda binary
+		if profile.executable_path:
+			browser_path = str(profile.executable_path)
+			self.logger.debug(f'[LocalBrowserWatchdog] 📦 Using custom Lightpanda executable_path= {browser_path}')
+		else:
+			browser_path = self._find_lightpanda_path()
+			if not browser_path:
+				raise RuntimeError(
+					'Lightpanda binary not found. Install it or set executable_path / LIGHTPANDA_BINARY_PATH.\n'
+					'See: https://lightpanda.io'
+				)
+
+		debug_port = self._find_free_port()
+		launch_args.extend([
+			'serve',
+			'--host', '127.0.0.1',
+			'--port', str(debug_port),
+		])
+
+		self.logger.debug(f'[LocalBrowserWatchdog] 🚀 Launching Lightpanda with {len(launch_args)} args...')
+		subprocess = await asyncio.create_subprocess_exec(
+			browser_path,
+			*launch_args,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+		self.logger.debug(
+			f'[LocalBrowserWatchdog] 🐼 Lightpanda running with browser_pid= {subprocess.pid} 🔗 listening on CDP port :{debug_port}'
+		)
+
+		process = psutil.Process(subprocess.pid)
+		cdp_url = await self._wait_for_cdp_url(debug_port)
+		return process, cdp_url
+
+	async def _launch_chromium(self, max_retries: int = 3) -> tuple[psutil.Process, str]:
+		"""Launch a Chromium-based browser process with retry logic for user_data_dir issues."""
 		# Keep track of original user_data_dir to restore if needed
 		profile = self.browser_session.browser_profile
 		self._original_user_data_dir = str(profile.user_data_dir) if profile.user_data_dir else None
@@ -354,6 +406,40 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				# Direct path check
 				if expanded_pattern.exists() and expanded_pattern.is_file():
 					return str(expanded_pattern)
+
+		return None
+
+	@staticmethod
+	def _find_lightpanda_path() -> str | None:
+		"""Find the Lightpanda browser binary.
+
+		Priority:
+		1. LIGHTPANDA_BINARY_PATH environment variable
+		2. 'lightpanda' on PATH via shutil.which
+		3. Common installation paths
+
+		Returns:
+			Path to Lightpanda executable or None if not found
+		"""
+		# 1. Environment variable
+		env_path = os.environ.get('LIGHTPANDA_BINARY_PATH')
+		if env_path and Path(env_path).exists() and Path(env_path).is_file():
+			return env_path
+
+		# 2. On PATH
+		which_path = shutil.which('lightpanda')
+		if which_path:
+			return which_path
+
+		# 3. Common install locations
+		common_paths = [
+			'/usr/local/bin/lightpanda',
+			'/usr/bin/lightpanda',
+			str(Path.home() / '.local' / 'bin' / 'lightpanda'),
+		]
+		for path in common_paths:
+			if Path(path).exists() and Path(path).is_file():
+				return path
 
 		return None
 

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -496,15 +496,19 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		return port
 
 	@staticmethod
-	async def _wait_for_cdp_url(port: int, timeout: float = 30) -> str:
+	async def _wait_for_cdp_url(port: int, timeout: float = 60) -> str:
 		"""Wait for the browser to start and return the CDP URL."""
 		import aiohttp
 
 		start_time = asyncio.get_event_loop().time()
 
-		while asyncio.get_event_loop().time() - start_time < timeout:
+		while True:
+			remaining = timeout - (asyncio.get_event_loop().time() - start_time)
+			if remaining <= 0:
+				break
+			request_timeout = aiohttp.ClientTimeout(total=min(5, remaining))
 			try:
-				async with aiohttp.ClientSession() as session:
+				async with aiohttp.ClientSession(timeout=request_timeout) as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:
 						if resp.status == 200:
 							# Chrome is ready

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
-import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -121,9 +121,13 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		else:
 			browser_path = self._find_lightpanda_path()
 			if not browser_path:
+				self.logger.info('[LocalBrowserWatchdog] 🐼 Lightpanda not found, installing...')
+				browser_path = await self._install_lightpanda()
+			if not browser_path:
 				raise RuntimeError(
-					'Lightpanda binary not found. Install it or set executable_path / LIGHTPANDA_BINARY_PATH.\n'
-					'See: https://lightpanda.io'
+					'Lightpanda binary not found and auto-install failed.\n'
+					'Install manually: curl -fsSL https://pkg.lightpanda.io/install.sh | bash\n'
+					'Or set executable_path / LIGHTPANDA_BINARY_PATH.'
 				)
 
 		debug_port = self._find_free_port()
@@ -442,6 +446,43 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				return path
 
 		return None
+
+	async def _install_lightpanda(self) -> str | None:
+		"""Install Lightpanda using the official install script.
+
+		Runs: curl -fsSL https://pkg.lightpanda.io/install.sh | bash
+
+		Returns:
+			Path to the installed lightpanda binary, or None if installation failed.
+		"""
+		process = await asyncio.create_subprocess_exec(
+			'bash', '-c', 'curl -fsSL https://pkg.lightpanda.io/install.sh | bash',
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+
+		try:
+			stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=120.0)
+			self.logger.debug(f'[LocalBrowserWatchdog] 🐼 Lightpanda install output: {stdout.decode()}')
+			if process.returncode != 0:
+				self.logger.error(f'[LocalBrowserWatchdog] ❌ Lightpanda install failed:\n{stderr.decode()}')
+				return None
+			# After install, try to find the binary again
+			browser_path = self._find_lightpanda_path()
+			if browser_path:
+				self.logger.info(f'[LocalBrowserWatchdog] 🐼 Lightpanda installed at {browser_path}')
+				return browser_path
+			self.logger.error('[LocalBrowserWatchdog] ❌ Lightpanda install script succeeded but binary not found on PATH')
+			return None
+		except TimeoutError:
+			process.kill()
+			await process.wait()
+			raise RuntimeError('Lightpanda installation timed out after 120 seconds')
+		except Exception as e:
+			if process.returncode is None:
+				process.kill()
+				await process.wait()
+			raise RuntimeError(f'Error installing Lightpanda: {e}')
 
 	async def _install_browser_with_playwright(self) -> str:
 		"""Get browser executable path from playwright in a subprocess to avoid thread issues."""

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -129,15 +129,15 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				)
 
 		debug_port = self._find_free_port()
-		launch_args.extend(
-			[
-				'serve',
-				'--host',
-				'127.0.0.1',
-				'--port',
-				str(debug_port),
-			]
-		)
+		# 'serve' subcommand must come before all flags for correct CLI parsing
+		launch_args = [
+			'serve',
+			'--host',
+			'127.0.0.1',
+			'--port',
+			str(debug_port),
+			*launch_args,
+		]
 
 		self.logger.debug(f'[LocalBrowserWatchdog] 🚀 Launching Lightpanda with {len(launch_args)} args...')
 		subprocess = await asyncio.create_subprocess_exec(

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -23,7 +24,7 @@ from browser_use.browser.watchdog_base import BaseWatchdog
 from browser_use.observability import observe_debug
 
 if TYPE_CHECKING:
-	from browser_use.browser.profile import BrowserChannel, BrowserEngine
+	from browser_use.browser.profile import BrowserChannel
 
 
 class LocalBrowserWatchdog(BaseWatchdog):
@@ -131,11 +132,15 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				)
 
 		debug_port = self._find_free_port()
-		launch_args.extend([
-			'serve',
-			'--host', '127.0.0.1',
-			'--port', str(debug_port),
-		])
+		launch_args.extend(
+			[
+				'serve',
+				'--host',
+				'127.0.0.1',
+				'--port',
+				str(debug_port),
+			]
+		)
 
 		self.logger.debug(f'[LocalBrowserWatchdog] 🚀 Launching Lightpanda with {len(launch_args)} args...')
 		subprocess = await asyncio.create_subprocess_exec(
@@ -455,8 +460,16 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		Returns:
 			Path to the installed lightpanda binary, or None if installation failed.
 		"""
+		if sys.platform == 'win32':
+			raise RuntimeError(
+				'Lightpanda auto-installation is only supported on Unix-like systems (Linux/macOS).\n'
+				'Please install Lightpanda manually on Windows (e.g., via WSL) and set the LIGHTPANDA_BINARY_PATH.'
+			)
+
 		process = await asyncio.create_subprocess_exec(
-			'bash', '-c', 'curl -fsSL https://pkg.lightpanda.io/install.sh | bash',
+			'bash',
+			'-c',
+			'curl -fsSL https://pkg.lightpanda.io/install.sh | bash',
 			stdout=asyncio.subprocess.PIPE,
 			stderr=asyncio.subprocess.PIPE,
 		)

--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -45,7 +45,7 @@ def _parse_computed_styles(strings: list[str], style_indices: list[int]) -> dict
 
 
 def build_snapshot_lookup(
-	snapshot: CaptureSnapshotReturns,
+	snapshot: CaptureSnapshotReturns | None,
 	device_pixel_ratio: float = 1.0,
 ) -> dict[int, EnhancedSnapshotNode]:
 	"""Build a lookup table of backend node ID to enhanced snapshot data with everything calculated upfront."""
@@ -54,7 +54,7 @@ def build_snapshot_lookup(
 	logger = logging.getLogger('browser_use.dom.enhanced_snapshot')
 	snapshot_lookup: dict[int, EnhancedSnapshotNode] = {}
 
-	if not snapshot['documents']:
+	if snapshot is None or not snapshot['documents']:
 		return snapshot_lookup
 
 	strings = snapshot['strings']

--- a/browser_use/dom/serializer/code_use_serializer.py
+++ b/browser_use/dom/serializer/code_use_serializer.py
@@ -84,7 +84,7 @@ class DOMCodeAgentSerializer:
 
 		if node.original_node.node_type == NodeType.ELEMENT_NODE:
 			tag = node.original_node.tag_name.lower()
-			is_visible = node.original_node.snapshot_node and node.original_node.is_visible
+			is_visible = node.original_node.is_visible
 
 			# Skip invisible (except iframes)
 			if not is_visible and tag not in ['iframe', 'frame']:
@@ -245,7 +245,7 @@ class DOMCodeAgentSerializer:
 			tag = dom_node.tag_name.lower()
 
 			# Skip invisible
-			is_visible = dom_node.snapshot_node and dom_node.is_visible
+			is_visible = dom_node.is_visible
 			if not is_visible:
 				return
 

--- a/browser_use/dom/serializer/eval_serializer.py
+++ b/browser_use/dom/serializer/eval_serializer.py
@@ -139,7 +139,7 @@ class DOMEvalSerializer:
 
 		if node.original_node.node_type == NodeType.ELEMENT_NODE:
 			tag = node.original_node.tag_name.lower()
-			is_visible = node.original_node.snapshot_node and node.original_node.is_visible
+			is_visible = node.original_node.is_visible
 
 			# Container elements that should be shown even if invisible (might have visible children)
 			container_tags = {'html', 'body', 'div', 'main', 'section', 'article', 'aside', 'header', 'footer', 'nav'}
@@ -431,8 +431,8 @@ class DOMEvalSerializer:
 				# If no snapshot data, assume visible (cross-origin iframe content)
 				is_visible = (not dom_node.snapshot_node) or dom_node.is_visible
 			else:
-				# Regular strict visibility check
-				is_visible = dom_node.snapshot_node and dom_node.is_visible
+				# Regular visibility check (works with or without snapshot data)
+				is_visible = dom_node.is_visible
 
 			if not is_visible:
 				return

--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -533,7 +533,7 @@ class DOMTreeSerializer:
 					return simplified
 		elif node.node_type == NodeType.TEXT_NODE:
 			# Include meaningful text nodes
-			is_visible = node.snapshot_node and node.is_visible
+			is_visible = node.is_visible
 			if is_visible and node.node_value and node.node_value.strip() and len(node.node_value.strip()) > 1:
 				return SimplifiedNode(original_node=node, children=[])
 
@@ -554,7 +554,7 @@ class DOMTreeSerializer:
 		node.children = optimized_children
 
 		# Keep meaningful nodes
-		is_visible = node.original_node.snapshot_node and node.original_node.is_visible
+		is_visible = node.original_node.is_visible
 
 		# EXCEPTION: File inputs are often hidden with opacity:0 but are still functional
 		is_file_input = (
@@ -578,7 +578,7 @@ class DOMTreeSerializer:
 	def _collect_interactive_elements(self, node: SimplifiedNode, elements: list[SimplifiedNode]) -> None:
 		"""Recursively collect interactive elements that are also visible."""
 		is_interactive = self._is_interactive_cached(node.original_node)
-		is_visible = node.original_node.snapshot_node and node.original_node.is_visible
+		is_visible = node.original_node.is_visible
 
 		# Only collect elements that are both interactive AND visible
 		if is_interactive and is_visible:
@@ -623,7 +623,7 @@ class DOMTreeSerializer:
 		if not node.excluded_by_parent and not node.ignored_by_paint_order:
 			# Regular interactive element assignment (including enhanced compound controls)
 			is_interactive_assign = self._is_interactive_cached(node.original_node)
-			is_visible = node.original_node.snapshot_node and node.original_node.is_visible
+			is_visible = node.original_node.is_visible
 			is_scrollable = node.original_node.is_actually_scrollable
 
 			# DIAGNOSTIC: Log when interactive elements don't have snapshot_node
@@ -1048,7 +1048,7 @@ class DOMTreeSerializer:
 
 		elif node.original_node.node_type == NodeType.TEXT_NODE:
 			# Include visible text
-			is_visible = node.original_node.snapshot_node and node.original_node.is_visible
+			is_visible = node.original_node.is_visible
 			if (
 				is_visible
 				and node.original_node.node_value

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -252,7 +252,8 @@ class DomService:
 		"""
 
 		if not node.snapshot_node:
-			return False
+			# No snapshot data (e.g. Lightpanda) — assume visible since we can't check CSS/bounds
+			return True
 
 		computed_styles = node.snapshot_node.computed_styles or {}
 

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -560,7 +560,6 @@ class DomService:
 
 			# Retry mapping for pending tasks
 			retry_map = {
-				tasks['snapshot']: lambda: create_task_with_error_handling(create_snapshot_request(), name='get_snapshot_retry'),
 				tasks['dom_tree']: lambda: create_task_with_error_handling(create_dom_tree_request(), name='get_dom_tree_retry'),
 				tasks['ax_tree']: lambda: create_task_with_error_handling(
 					self._get_ax_tree_for_all_frames(target_id), name='get_ax_tree_retry'
@@ -569,6 +568,8 @@ class DomService:
 					self._get_viewport_ratio(target_id), name='get_viewport_ratio_retry'
 				),
 			}
+			if 'snapshot' in tasks:
+				retry_map[tasks['snapshot']] = lambda: create_task_with_error_handling(create_snapshot_request(), name='get_snapshot_retry')
 
 			# Create new tasks only for the ones that didn't complete
 			for key, task in tasks.items():

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -570,7 +570,9 @@ class DomService:
 				),
 			}
 			if 'snapshot' in tasks:
-				retry_map[tasks['snapshot']] = lambda: create_task_with_error_handling(create_snapshot_request(), name='get_snapshot_retry')
+				retry_map[tasks['snapshot']] = lambda: create_task_with_error_handling(
+					create_snapshot_request(), name='get_snapshot_retry'
+				)
 
 			# Create new tasks only for the ones that didn't complete
 			for key, task in tasks.items():

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -536,13 +536,19 @@ class DomService:
 
 		start_cdp_calls = time.time()
 
+		# Check if we should skip DOMSnapshot (Lightpanda doesn't support it)
+		from browser_use.browser.profile import BrowserEngine
+
+		skip_snapshot = self.browser_session.browser_profile.browser_engine == BrowserEngine.LIGHTPANDA
+
 		# Create initial tasks
 		tasks = {
-			'snapshot': create_task_with_error_handling(create_snapshot_request(), name='get_snapshot'),
 			'dom_tree': create_task_with_error_handling(create_dom_tree_request(), name='get_dom_tree'),
 			'ax_tree': create_task_with_error_handling(self._get_ax_tree_for_all_frames(target_id), name='get_ax_tree'),
 			'device_pixel_ratio': create_task_with_error_handling(self._get_viewport_ratio(target_id), name='get_viewport_ratio'),
 		}
+		if not skip_snapshot:
+			tasks['snapshot'] = create_task_with_error_handling(create_snapshot_request(), name='get_snapshot')
 
 		# Wait for all tasks with timeout
 		done, pending = await asyncio.wait(tasks.values(), timeout=10.0)
@@ -594,7 +600,7 @@ class DomService:
 		if failed:
 			raise TimeoutError(f'CDP requests failed or timed out: {", ".join(failed)}')
 
-		snapshot = results['snapshot']
+		snapshot = results.get('snapshot')
 		dom_tree = results['dom_tree']
 		ax_tree = results['ax_tree']
 		device_pixel_ratio = results['device_pixel_ratio']

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -195,7 +195,7 @@ class CurrentPageTargets:
 
 @dataclass
 class TargetAllTrees:
-	snapshot: CaptureSnapshotReturns
+	snapshot: CaptureSnapshotReturns | None
 	dom_tree: GetDocumentReturns
 	ax_tree: GetFullAXTreeReturns
 	device_pixel_ratio: float

--- a/tests/ci/browser/test_lightpanda.py
+++ b/tests/ci/browser/test_lightpanda.py
@@ -1,6 +1,5 @@
 """Tests for Lightpanda browser engine integration."""
 
-
 from browser_use.browser.profile import BrowserEngine, BrowserProfile
 from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
 

--- a/tests/ci/browser/test_lightpanda.py
+++ b/tests/ci/browser/test_lightpanda.py
@@ -1,0 +1,102 @@
+"""Tests for Lightpanda browser engine integration."""
+
+import pytest
+
+from browser_use.browser.profile import BrowserEngine, BrowserProfile
+from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+
+class TestLightpandaProfile:
+	"""Test BrowserProfile behavior with browser_engine='lightpanda'."""
+
+	def test_lightpanda_engine_enum(self):
+		"""BrowserEngine enum has chromium and lightpanda values."""
+		assert BrowserEngine.CHROMIUM == 'chromium'
+		assert BrowserEngine.LIGHTPANDA == 'lightpanda'
+
+	def test_default_engine_is_chromium(self):
+		"""Default browser engine should be chromium."""
+		profile = BrowserProfile()
+		assert profile.browser_engine == BrowserEngine.CHROMIUM
+
+	def test_lightpanda_forces_headless(self):
+		"""Lightpanda should force headless=True even if False is requested."""
+		profile = BrowserProfile(browser_engine='lightpanda', headless=False)
+		assert profile.headless is True
+
+	def test_lightpanda_disables_extensions(self):
+		"""Lightpanda should disable extensions (no Chrome extension support)."""
+		profile = BrowserProfile(browser_engine='lightpanda', enable_default_extensions=True)
+		assert profile.enable_default_extensions is False
+
+	def test_lightpanda_disables_demo_mode(self):
+		"""Lightpanda should disable demo mode (no rendering)."""
+		profile = BrowserProfile(browser_engine='lightpanda', demo_mode=True)
+		assert profile.demo_mode is False
+
+	def test_lightpanda_disables_highlight_elements(self):
+		"""Lightpanda should disable element highlighting (no rendering)."""
+		profile = BrowserProfile(browser_engine='lightpanda', highlight_elements=True)
+		assert profile.highlight_elements is False
+
+	def test_lightpanda_disables_deterministic_rendering(self):
+		"""Lightpanda should disable deterministic rendering (irrelevant without rendering)."""
+		profile = BrowserProfile(browser_engine='lightpanda', deterministic_rendering=True)
+		assert profile.deterministic_rendering is False
+
+	def test_lightpanda_get_args_no_chrome_flags(self):
+		"""Lightpanda args should not contain any Chrome-specific flags."""
+		profile = BrowserProfile(browser_engine='lightpanda')
+		args = profile.get_args()
+		# Should not contain Chrome-specific flags
+		args_str = ' '.join(args)
+		assert '--user-data-dir' not in args_str
+		assert '--remote-debugging-port' not in args_str
+		assert '--headless' not in args_str
+		assert '--no-first-run' not in args_str
+		assert '--disable-gpu' not in args_str
+
+	def test_lightpanda_get_args_passes_extra_args(self):
+		"""Extra user args should be passed through for Lightpanda."""
+		profile = BrowserProfile(browser_engine='lightpanda', args=['--some-custom-flag'])
+		args = profile.get_args()
+		assert '--some-custom-flag' in args
+
+	def test_chromium_get_args_unchanged(self, tmp_path):
+		"""Chromium args should still work as before."""
+		profile = BrowserProfile(browser_engine='chromium', user_data_dir=str(tmp_path))
+		args = profile.get_args()
+		args_str = ' '.join(args)
+		assert '--user-data-dir' in args_str
+
+	def test_lightpanda_string_value(self):
+		"""Should accept string 'lightpanda' for browser_engine."""
+		profile = BrowserProfile(browser_engine='lightpanda')
+		assert profile.browser_engine == BrowserEngine.LIGHTPANDA
+
+	def test_lightpanda_skips_profile_copy(self):
+		"""Lightpanda should skip display detection and profile copying (no user_data_dir concept)."""
+		# This should not raise even though Lightpanda doesn't use user_data_dir the same way
+		profile = BrowserProfile(browser_engine='lightpanda')
+		# Just verify it was created successfully without errors
+		assert profile.browser_engine == BrowserEngine.LIGHTPANDA
+
+
+class TestLightpandaBinaryDiscovery:
+	"""Test Lightpanda binary discovery logic."""
+
+	def test_find_lightpanda_path_returns_none_when_not_installed(self, monkeypatch):
+		"""Should return None when Lightpanda is not installed anywhere."""
+		monkeypatch.delenv('LIGHTPANDA_BINARY_PATH', raising=False)
+		# Only test that it returns str or None (don't assume it's not installed)
+		result = LocalBrowserWatchdog._find_lightpanda_path()
+		assert result is None or isinstance(result, str)
+
+	def test_find_lightpanda_path_from_env(self, monkeypatch, tmp_path):
+		"""Should find Lightpanda from LIGHTPANDA_BINARY_PATH env var."""
+		fake_binary = tmp_path / 'lightpanda'
+		fake_binary.touch()
+		monkeypatch.setenv('LIGHTPANDA_BINARY_PATH', str(fake_binary))
+
+		result = LocalBrowserWatchdog._find_lightpanda_path()
+		assert result == str(fake_binary)

--- a/tests/ci/browser/test_lightpanda.py
+++ b/tests/ci/browser/test_lightpanda.py
@@ -5,7 +5,7 @@ from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWat
 
 
 class TestLightpandaProfile:
-	"""Test BrowserProfile behavior with browser_engine='lightpanda'."""
+	"""Test BrowserProfile behavior with browser_engine=BrowserEngine.LIGHTPANDA."""
 
 	def test_lightpanda_engine_enum(self):
 		"""BrowserEngine enum has chromium and lightpanda values."""
@@ -19,32 +19,32 @@ class TestLightpandaProfile:
 
 	def test_lightpanda_forces_headless(self):
 		"""Lightpanda should force headless=True even if False is requested."""
-		profile = BrowserProfile(browser_engine='lightpanda', headless=False)
+		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA, headless=False)
 		assert profile.headless is True
 
 	def test_lightpanda_disables_extensions(self):
 		"""Lightpanda should disable extensions (no Chrome extension support)."""
-		profile = BrowserProfile(browser_engine='lightpanda', enable_default_extensions=True)
+		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA, enable_default_extensions=True)
 		assert profile.enable_default_extensions is False
 
 	def test_lightpanda_disables_demo_mode(self):
 		"""Lightpanda should disable demo mode (no rendering)."""
-		profile = BrowserProfile(browser_engine='lightpanda', demo_mode=True)
+		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA, demo_mode=True)
 		assert profile.demo_mode is False
 
 	def test_lightpanda_disables_highlight_elements(self):
 		"""Lightpanda should disable element highlighting (no rendering)."""
-		profile = BrowserProfile(browser_engine='lightpanda', highlight_elements=True)
+		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA, highlight_elements=True)
 		assert profile.highlight_elements is False
 
 	def test_lightpanda_disables_deterministic_rendering(self):
 		"""Lightpanda should disable deterministic rendering (irrelevant without rendering)."""
-		profile = BrowserProfile(browser_engine='lightpanda', deterministic_rendering=True)
+		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA, deterministic_rendering=True)
 		assert profile.deterministic_rendering is False
 
 	def test_lightpanda_get_args_no_chrome_flags(self):
 		"""Lightpanda args should not contain any Chrome-specific flags."""
-		profile = BrowserProfile(browser_engine='lightpanda')
+		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA)
 		args = profile.get_args()
 		# Should not contain Chrome-specific flags
 		args_str = ' '.join(args)
@@ -56,26 +56,26 @@ class TestLightpandaProfile:
 
 	def test_lightpanda_get_args_passes_extra_args(self):
 		"""Extra user args should be passed through for Lightpanda."""
-		profile = BrowserProfile(browser_engine='lightpanda', args=['--some-custom-flag'])
+		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA, args=['--some-custom-flag'])
 		args = profile.get_args()
 		assert '--some-custom-flag' in args
 
 	def test_chromium_get_args_unchanged(self, tmp_path):
 		"""Chromium args should still work as before."""
-		profile = BrowserProfile(browser_engine='chromium', user_data_dir=str(tmp_path))
+		profile = BrowserProfile(browser_engine=BrowserEngine.CHROMIUM, user_data_dir=str(tmp_path))
 		args = profile.get_args()
 		args_str = ' '.join(args)
 		assert '--user-data-dir' in args_str
 
 	def test_lightpanda_string_value(self):
 		"""Should accept string 'lightpanda' for browser_engine."""
-		profile = BrowserProfile(browser_engine='lightpanda')
+		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA)
 		assert profile.browser_engine == BrowserEngine.LIGHTPANDA
 
 	def test_lightpanda_skips_profile_copy(self):
 		"""Lightpanda should skip display detection and profile copying (no user_data_dir concept)."""
 		# This should not raise even though Lightpanda doesn't use user_data_dir the same way
-		profile = BrowserProfile(browser_engine='lightpanda')
+		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA)
 		# Just verify it was created successfully without errors
 		assert profile.browser_engine == BrowserEngine.LIGHTPANDA
 

--- a/tests/ci/browser/test_lightpanda.py
+++ b/tests/ci/browser/test_lightpanda.py
@@ -1,6 +1,5 @@
 """Tests for Lightpanda browser engine integration."""
 
-import pytest
 
 from browser_use.browser.profile import BrowserEngine, BrowserProfile
 from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog

--- a/tests/ci/browser/test_lightpanda.py
+++ b/tests/ci/browser/test_lightpanda.py
@@ -69,7 +69,7 @@ class TestLightpandaProfile:
 
 	def test_lightpanda_string_value(self):
 		"""Should accept string 'lightpanda' for browser_engine."""
-		profile = BrowserProfile(browser_engine=BrowserEngine.LIGHTPANDA)
+		profile = BrowserProfile(browser_engine='lightpanda')  # type: ignore[arg-type]
 		assert profile.browser_engine == BrowserEngine.LIGHTPANDA
 
 	def test_lightpanda_skips_profile_copy(self):


### PR DESCRIPTION
### Summary

Fix #2441

- Add `BrowserEngine` enum (`chromium` | `lightpanda`) to `BrowserProfile`, defaulting to `chromium`
- Launch Lightpanda via `lightpanda serve --host --port` with CDP polling on `/json/version`
- Auto-discover binary via `LIGHTPANDA_BINARY_PATH` env var or `PATH`
- Auto-install via `curl -fsSL https://pkg.lightpanda.io/install.sh | bash` if not found
- Skip `DOMSnapshot.captureSnapshot` (unsupported by Lightpanda); DOM tree + accessibility tree still provide usable element info through existing `None` guards
- Force `use_vision=False` on Agent (screenshots exist but are blank without rendering)
- Enforce Lightpanda constraints: `headless=True`, no extensions, no demo mode, no element highlighting

### Usage

```python
import asyncio
from browser_use import BrowserSession, DomService

async def main():
	session = BrowserSession(browser_engine='lightpanda')
	await session.start()
	await session.navigate_to('https://example.com')

	target_id = session.agent_focus_target_id
	dom_service = DomService(session)
	dom_tree, timing = await dom_service.get_dom_tree(target_id)
	print(f'DOM tree: {dom_tree.tag_name}, children={len(dom_tree.children)}')
	print(f'Timing: {timing}')
	await session.stop()

asyncio.run(main())
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Lightpanda as an alternative headless browser engine so you can run CDP sessions without Chrome while keeping navigation, DOM, and AX tree features. Also move screenshots, storage state, and agent GIF outputs to `anyio` for non-blocking I/O, and increase startup reliability with a 60s browser start timeout and a 5s per-request CDP readiness poll timeout.

- **New Features**
  - New `BrowserEngine` enum with `chromium` (default) and `lightpanda`; selectable via `BrowserProfile` or `BrowserSession(browser_engine='lightpanda')`.
  - Launches Lightpanda with `lightpanda serve --host --port` (subcommand comes before user args), discovers the binary via `LIGHTPANDA_BINARY_PATH`, `PATH`, or common install paths, and connects by polling `/json/version` with a capped 5s per-request timeout until 60s.
  - On Lightpanda, skips `DOMSnapshot.captureSnapshot`; runs in degraded mode with DOM + AX trees; serializers now check `is_visible` directly and treat missing snapshot data as visible so interactive elements aren’t dropped; forces `use_vision=False` (no rendering).

- **Migration**
  - Set `browser_engine='lightpanda'` (string or `BrowserEngine.LIGHTPANDA`) when creating a `BrowserSession` or on `BrowserProfile`.
  - No auto-install. Install `lightpanda` and ensure it’s on `PATH` or set `LIGHTPANDA_BINARY_PATH`.
  - Constraints: always headless; no extensions, demo mode, element highlighting, or deterministic rendering; `use_vision` is off.

<sup>Written for commit 3ab7c9a29d1f6062f13486449ddeda6cc85bff52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

