### PR TITLE
fix: properly handle empty string in boolean env variable parsing

### DIFF
--- a/browser_use/code_use/notebook_export.py
+++ b/browser_use/code_use/notebook_export.py
@@ -185,6 +185,9 @@ def session_to_python_script(agent: CodeAgent) -> str:
 	Returns:
 		Python script as a string
 
+	Raises:
+		TypeError: If agent is not a CodeAgent instance
+
 	Example:
 		```python
 	        await agent.run()
@@ -192,6 +195,13 @@ def session_to_python_script(agent: CodeAgent) -> str:
 	        print(script)
 		```
 	"""
+	# Type check to provide helpful error message
+	if not isinstance(agent, CodeAgent):
+		raise TypeError(
+			f"Expected a CodeAgent instance, got {type(agent).__name__}. "
+			"Use CodeAgent from browser_use.code_use instead of Agent."
+		)
+
 	lines = []
 
 	lines.append('# Generated from browser-use code-use session\n')

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -44,6 +44,26 @@ def is_running_in_docker() -> bool:
 	return False
 
 
+def _parse_bool_env(key: str, default: str) -> bool:
+	"""Parse boolean environment variable properly.
+
+	Handles empty strings correctly - an empty string is treated as unset
+	and returns the default value, instead of incorrectly returning True.
+
+	Args:
+		key: Environment variable name
+		default: Default value ('true' or 'false')
+
+	Returns:
+		Boolean value of the environment variable
+	"""
+	value = os.getenv(key, default)
+	# Empty string should return default, not True
+	if not value:
+		return default.lower()[:1] in 'ty1'
+	return value.lower()[:1] in 'ty1'
+
+
 class OldConfig:
 	"""Original lazy-loading configuration class for environment variables."""
 
@@ -56,11 +76,11 @@ class OldConfig:
 
 	@property
 	def ANONYMIZED_TELEMETRY(self) -> bool:
-		return os.getenv('ANONYMIZED_TELEMETRY', 'true').lower()[:1] in 'ty1'
+		return _parse_bool_env('ANONYMIZED_TELEMETRY', 'true')
 
 	@property
 	def BROWSER_USE_CLOUD_SYNC(self) -> bool:
-		return os.getenv('BROWSER_USE_CLOUD_SYNC', str(self.ANONYMIZED_TELEMETRY)).lower()[:1] in 'ty1'
+		return _parse_bool_env('BROWSER_USE_CLOUD_SYNC', str(self.ANONYMIZED_TELEMETRY))
 
 	@property
 	def BROWSER_USE_CLOUD_API_URL(self) -> str:
@@ -157,7 +177,7 @@ class OldConfig:
 
 	@property
 	def SKIP_LLM_API_KEY_VERIFICATION(self) -> bool:
-		return os.getenv('SKIP_LLM_API_KEY_VERIFICATION', 'false').lower()[:1] in 'ty1'
+		return _parse_bool_env('SKIP_LLM_API_KEY_VERIFICATION', 'false')
 
 	@property
 	def DEFAULT_LLM(self) -> str:
@@ -166,15 +186,15 @@ class OldConfig:
 	# Runtime hints
 	@property
 	def IN_DOCKER(self) -> bool:
-		return os.getenv('IN_DOCKER', 'false').lower()[:1] in 'ty1' or is_running_in_docker()
+		return _parse_bool_env('IN_DOCKER', 'false') or is_running_in_docker()
 
 	@property
 	def IS_IN_EVALS(self) -> bool:
-		return os.getenv('IS_IN_EVALS', 'false').lower()[:1] in 'ty1'
+		return _parse_bool_env('IS_IN_EVALS', 'false')
 
 	@property
 	def BROWSER_USE_VERSION_CHECK(self) -> bool:
-		return os.getenv('BROWSER_USE_VERSION_CHECK', 'true').lower()[:1] in 'ty1'
+		return _parse_bool_env('BROWSER_USE_VERSION_CHECK', 'true')
 
 	@property
 	def WIN_FONT_DIR(self) -> str:


### PR DESCRIPTION
## Summary

This PR fixes a bug where empty environment variables incorrectly return `True` when parsed as boolean values.

## Bug Description

In Python, an empty string is a substring of any string:
```python
>>> "" in "ty1"
True
```

The original code used `.lower()[:1] in "ty1"` to parse boolean env vars:
```python
return os.getenv("ANONYMIZED_TELEMETRY", "true").lower()[:1] in "ty1"
```

When an env var is set to empty string (`""`), this returns `True` instead of `False`.

## Fix

Added a helper function `_parse_bool_env()` that properly checks for empty strings before checking the first character. Empty strings are treated as unset and resolve to the default value.

## Affected Properties

- `ANONYMIZED_TELEMETRY`
- `BROWSER_USE_CLOUD_SYNC`
- `SKIP_LLM_API_KEY_VERIFICATION`
- `IN_DOCKER`
- `IS_IN_EVALS`
- `BROWSER_USE_VERSION_CHECK`

---

Closes #4343

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes boolean env var parsing so empty strings no longer evaluate to true. Also adds a clear TypeError when the wrong agent is passed to `session_to_python_script`.

- **Bug Fixes**
  - Introduced `_parse_bool_env(key, default)` to correctly parse boolean env vars; empty strings now use the default. Applied to: `ANONYMIZED_TELEMETRY`, `BROWSER_USE_CLOUD_SYNC`, `SKIP_LLM_API_KEY_VERIFICATION`, `IN_DOCKER`, `IS_IN_EVALS`, `BROWSER_USE_VERSION_CHECK`.
  - Added `isinstance` check in `session_to_python_script` to require a `CodeAgent`, raising a helpful TypeError if not.

<sup>Written for commit e00a5c272681e29e2696729627084a4cbbb2418e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

