### PR TITLE
feat: Add environment variable support for custom Chrome/Chromium path

### DIFF
--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -203,7 +203,21 @@ def cleanup_session_files(session: str) -> None:
 
 
 def find_chrome_executable() -> str | None:
-	"""Find Chrome/Chromium executable on the system."""
+	"""Find Chrome/Chromium executable on the system.
+	
+	Supports environment variables:
+	- BROWSERUSE_CHROME_PATH: Custom path to Chrome executable
+	- BROWSERUSE_CHROMIUM_PATH: Custom path to Chromium executable
+	"""
+	# Check environment variables first
+	chrome_path = os.environ.get('BROWSERUSE_CHROME_PATH')
+	if chrome_path and os.path.exists(chrome_path):
+		return chrome_path
+	
+	chromium_path = os.environ.get('BROWSERUSE_CHROMIUM_PATH')
+	if chromium_path and os.path.exists(chromium_path):
+		return chromium_path
+	
 	system = platform.system()
 
 	if system == 'Darwin':

--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -204,7 +204,7 @@ def cleanup_session_files(session: str) -> None:
 
 def find_chrome_executable() -> str | None:
 	"""Find Chrome/Chromium executable on the system.
-	
+
 	Supports environment variables:
 	- BROWSERUSE_CHROME_PATH: Custom path to Chrome executable
 	- BROWSERUSE_CHROMIUM_PATH: Custom path to Chromium executable
@@ -213,11 +213,11 @@ def find_chrome_executable() -> str | None:
 	chrome_path = os.environ.get('BROWSERUSE_CHROME_PATH')
 	if chrome_path and os.path.exists(chrome_path):
 		return chrome_path
-	
+
 	chromium_path = os.environ.get('BROWSERUSE_CHROMIUM_PATH')
 	if chromium_path and os.path.exists(chromium_path):
 		return chromium_path
-	
+
 	system = platform.system()
 
 	if system == 'Darwin':


### PR DESCRIPTION
## Summary

This PR adds support for customizing Chrome/Chromium executable path via environment variables, as requested in Issue #4347.

## Changes

- Added support for  environment variable
- Added support for  environment variable
- Environment variables are checked first before falling back to system defaults
- This allows users to specify custom browser executables without modifying code

## Usage



## Testing

The implementation follows the existing pattern in the codebase and maintains backward compatibility - if environment variables are not set, it falls back to the existing auto-detection logic.

Closes #4347

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for custom Chrome/Chromium executable paths via environment variables so users can choose a specific browser without code changes. Env vars are checked first, then OS detection runs as a fallback; includes a minor lint cleanup.

- **New Features**
  - `find_chrome_executable()` now reads `BROWSERUSE_CHROME_PATH` and `BROWSERUSE_CHROMIUM_PATH`.
  - Uses the provided path if it exists; otherwise falls back to system defaults.

<sup>Written for commit 1ec799e6dd687380176cf5b6540c43b7576982c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

