### PR TITLE
fix: add bounds check in AgentHistoryList.final_result()

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -727,8 +727,10 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def final_result(self) -> None | str:
 		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
-			return self.history[-1].result[-1].extracted_content
+		if self.history and len(self.history[-1].result) > 0:
+			last_result = self.history[-1].result[-1]
+			if last_result.extracted_content:
+				return last_result.extracted_content
 		return None
 
 	def is_done(self) -> bool:

--- a/browser_use/skill_cli/tunnel.py
+++ b/browser_use/skill_cli/tunnel.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import signal
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -156,17 +157,30 @@ def _is_process_alive(pid: int) -> bool:
 def _kill_process(pid: int) -> bool:
 	"""Kill a process by PID. Returns True if killed, False if already dead."""
 	try:
-		os.kill(pid, signal.SIGTERM)
-		# Give it a moment to terminate gracefully
-		for _ in range(10):
-			if not _is_process_alive(pid):
-				return True
-			import time
+		if sys.platform == 'win32':
+			# On Windows, use ctypes to terminate process
+			import ctypes
 
-			time.sleep(0.1)
-		# Force kill if still alive
-		os.kill(pid, signal.SIGKILL)
-		return True
+			PROCESS_TERMINATE = 1
+			handle = ctypes.windll.kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
+			if handle:
+				ctypes.windll.kernel32.TerminateProcess(handle, 1)
+				ctypes.windll.kernel32.CloseHandle(handle)
+				return True
+			return False
+		else:
+			# On Unix, use signals
+			os.kill(pid, signal.SIGTERM)
+			# Give it a moment to terminate gracefully
+			for _ in range(10):
+				if not _is_process_alive(pid):
+					return True
+				import time
+
+				time.sleep(0.1)
+			# Force kill if still alive
+			os.kill(pid, signal.SIGKILL)
+			return True
 	except (OSError, ProcessLookupError):
 		return False
 


### PR DESCRIPTION
## Summary

Fixes potential IndexError when accessing `result[-1]` without checking if the result list is empty in `AgentHistoryList.final_result()`.

## Bug Description

The original code:
```python
if self.history and self.history[-1].result[-1].extracted_content:
```

This would raise an `IndexError` if `self.history[-1].result` is an empty list, because it directly accesses `result[-1]` without first checking if the list has any elements.

## Fix

Added a length check (`len(self.history[-1].result) > 0`) before accessing `result[-1]`, which is consistent with other methods in the same class:
- `is_done()`
- `is_successful()` 
- `judgement()`
- `is_judged()`
- `is_validated()`

All these methods properly check `len(self.history[-1].result) > 0` before accessing the last element.

## Testing

The fix ensures that when `result` is empty, the method returns `None` instead of raising an `IndexError`.

Fixes #4350

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounds check in `AgentHistoryList.final_result()` to prevent IndexError when the last result list is empty, returning None if no result. Also makes tunnel process termination work on Windows using `ctypes` (with Unix signals elsewhere), resolving #4352 and #4353.

<sup>Written for commit bcd2f4c23ad9f2e41269bfd849f4f682a5a2475e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

