### PR TITLE
fix: add BROWSER_USE_CHROME_PATH and BROWSER_USE_CHROMIUM_PATH env vars support

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -24,6 +24,21 @@ def _get_enable_default_extensions_default() -> bool:
 	return True
 
 
+def _get_executable_path_default() -> str | Path | None:
+	"""Get the default browser executable path from environment variables.
+	
+	Supports BROWSERUSE_CHROME_PATH and BROWSERUSE_CHROMIUM_PATH env vars.
+	BROWSERUSE_CHROME_PATH takes precedence over BROWSERUSE_CHROMIUM_PATH.
+	"""
+	chrome_path = os.getenv('BROWSERUSE_CHROME_PATH')
+	if chrome_path:
+		return chrome_path
+	chromium_path = os.getenv('BROWSERUSE_CHROMIUM_PATH')
+	if chromium_path:
+		return chromium_path
+	return None
+
+
 CHROME_DEBUG_PORT = 9242  # use a non-default port to avoid conflicts with other tools / devs using 9222
 DOMAIN_OPTIMIZATION_THRESHOLD = 100  # Convert domain lists to sets for O(1) lookup when >= this size
 CHROME_DISABLED_COMPONENTS = [
@@ -379,9 +394,9 @@ class BrowserLaunchArgs(BaseModel):
 		description='Extra environment variables to set when launching the browser. If None, inherits from the current process.',
 	)
 	executable_path: str | Path | None = Field(
-		default=None,
+		default_factory=_get_executable_path_default,
 		validation_alias=AliasChoices('browser_binary_path', 'chrome_binary_path'),
-		description='Path to the chromium-based browser executable to use.',
+		description='Path to the chromium-based browser executable to use. Can be set via BROWSERUSE_CHROME_PATH or BROWSERUSE_CHROMIUM_PATH environment variables.',
 	)
 	headless: bool | None = Field(default=None, description='Whether to run the browser in headless or windowed mode.')
 	args: list[CliArgStr] = Field(


### PR DESCRIPTION
## Summary

Add support for customizing the browser executable path via environment variables, addressing Issue #4347.

## Changes

- Add _get_executable_path_default() function to read browser path from environment variables
- Support BROWSERUSE_CHROME_PATH and BROWSERUSE_CHROMIUM_PATH environment variables
- BROWSERUSE_CHROME_PATH takes precedence over BROWSERUSE_CHROMIUM_PATH

## Usage

Set either environment variable before running your script:

`ash
export BROWSERUSE_CHROME_PATH=/path/to/chrome
# or
export BROWSERUSE_CHROMIUM_PATH=/path/to/chromium
`

This allows users on multi-browser machines to specify which browser to use without modifying code.

Closes #4347

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds env var support to set the Chromium-based browser executable path, so users can choose Chrome or Chromium without code changes. Addresses #4347.

- **New Features**
  - Resolve path from `BROWSERUSE_CHROME_PATH` or `BROWSERUSE_CHROMIUM_PATH`; `BROWSERUSE_CHROME_PATH` takes precedence.
  - Added `_get_executable_path_default()` and set it as the default for `BrowserLaunchArgs.executable_path`.
  - Updated `executable_path` field description to document the env vars.

<sup>Written for commit aa32a6a512202887e984848426487c706853aa83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

