### PR TITLE
fix: add bounds check in AgentHistoryList.final_result()

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1610,7 +1610,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		judgement = await self._judge_trace()
 
 		# Attach judgement to last action result
-		if self.history.history[-1].result[-1].is_done:
+		if (
+			self.history.history
+			and self.history.history[-1].result
+			and len(self.history.history[-1].result) > 0
+			and self.history.history[-1].result[-1].is_done
+		):
 			last_result = self.history.history[-1].result[-1]
 			last_result.judgement = judgement
 

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -727,8 +727,10 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def final_result(self) -> None | str:
 		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
-			return self.history[-1].result[-1].extracted_content
+		if self.history and len(self.history[-1].result) > 0:
+			last_result = self.history[-1].result[-1]
+			if last_result.extracted_content:
+				return last_result.extracted_content
 		return None
 
 	def is_done(self) -> bool:

--- a/browser_use/code_use/views.py
+++ b/browser_use/code_use/views.py
@@ -216,7 +216,7 @@ class CodeAgentHistoryList:
 
 	def final_result(self) -> None | str:
 		"""Final result from history."""
-		if self._complete_history and self._complete_history[-1].result:
+		if self._complete_history and len(self._complete_history[-1].result) > 0:
 			return self._complete_history[-1].result[-1].extracted_content
 		return None
 

--- a/examples/integrations/discord/discord_api.py
+++ b/examples/integrations/discord/discord_api.py
@@ -112,7 +112,7 @@ class DiscordBot(commands.Bot):
 
 			agent_message = None
 			if result.is_done():
-				agent_message = result.history[-1].result[0].extracted_content
+				agent_message = result.final_result()
 
 			if agent_message is None:
 				agent_message = 'Oops! Something went wrong while running Browser-Use.'

--- a/examples/integrations/slack/slack_api.py
+++ b/examples/integrations/slack/slack_api.py
@@ -88,7 +88,7 @@ class SlackBot:
 
 			agent_message = None
 			if result.is_done():
-				agent_message = result.history[-1].result[0].extracted_content
+				agent_message = result.final_result()
 
 			if agent_message is None:
 				agent_message = 'Oops! Something went wrong while running Browser-Use.'


### PR DESCRIPTION
## Summary
Fixes potential IndexError when accessing `result[-1]` without checking if the result list is empty.

## Changes
- Added `len(self.history[-1].result) > 0` check before accessing `result[-1]`
- Added `last_result` variable to avoid repeated list access
- Matches the pattern used by other methods in the same class (`is_done`, `is_successful`, `judgement`, `is_judged`, `is_validated`)

## Bug Details
The `final_result()` method was accessing `self.history[-1].result[-1]` without first checking if `result` list is non-empty, which could cause an IndexError when the result list is empty. Other similar methods in the class properly check `len(self.history[-1].result) > 0` before accessing the last element.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented IndexError by adding bounds checks when reading the last result across history and judgement. `final_result()` now safely returns None when there are no results, and integrations use it instead of direct indexing.

- **Bug Fixes**
  - Add `len()` checks before accessing `result[-1]` in `AgentHistoryList.final_result()`, `CodeAgentHistoryList.final_result()`, and `AgentService._judge_and_log()`.
  - Update `examples/integrations/discord` and `slack` to call `result.final_result()` and cache `last_result` to avoid repeated indexing.

<sup>Written for commit 031ce9ed88f6fccf0d1e6051c39c5db1dc9e8dd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

