### PR TITLE
fix: address Copilot review feedback for Windows compatibility

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -24,6 +24,21 @@ def _get_enable_default_extensions_default() -> bool:
 	return True
 
 
+def _get_executable_path_default() -> str | None:
+	"""Get the default browser executable path from environment variables.
+
+	Supports BROWSER_USE_CHROME_PATH and BROWSER_USE_CHROMIUM_PATH env vars.
+	BROWSER_USE_CHROME_PATH takes precedence over BROWSER_USE_CHROMIUM_PATH.
+	"""
+	chrome_path = os.getenv('BROWSER_USE_CHROME_PATH')
+	if chrome_path:
+		return chrome_path
+	chromium_path = os.getenv('BROWSER_USE_CHROMIUM_PATH')
+	if chromium_path:
+		return chromium_path
+	return None
+
+
 CHROME_DEBUG_PORT = 9242  # use a non-default port to avoid conflicts with other tools / devs using 9222
 DOMAIN_OPTIMIZATION_THRESHOLD = 100  # Convert domain lists to sets for O(1) lookup when >= this size
 CHROME_DISABLED_COMPONENTS = [
@@ -379,9 +394,9 @@ class BrowserLaunchArgs(BaseModel):
 		description='Extra environment variables to set when launching the browser. If None, inherits from the current process.',
 	)
 	executable_path: str | Path | None = Field(
-		default=None,
+		default_factory=_get_executable_path_default,
 		validation_alias=AliasChoices('browser_binary_path', 'chrome_binary_path'),
-		description='Path to the chromium-based browser executable to use.',
+		description='Path to the chromium-based browser executable to use. Can be set via BROWSER_USE_CHROME_PATH or BROWSER_USE_CHROMIUM_PATH environment variables.',
 	)
 	headless: bool | None = Field(default=None, description='Whether to run the browser in headless or windowed mode.')
 	args: list[CliArgStr] = Field(

--- a/browser_use/skill_cli/tunnel.py
+++ b/browser_use/skill_cli/tunnel.py
@@ -146,6 +146,23 @@ def _delete_tunnel_info(port: int) -> None:
 
 def _is_process_alive(pid: int) -> bool:
 	"""Check if a process is still running."""
+	import sys
+
+	# On Windows, os.kill doesn't work reliably, use ctypes instead
+	if sys.platform == 'win32':
+		try:
+			import ctypes
+
+			PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+			handle = ctypes.windll.kernel32.OpenProcess(
+				PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+			)
+			if handle:
+				ctypes.windll.kernel32.CloseHandle(handle)
+				return True
+			return False
+		except Exception:
+			return False
 	try:
 		os.kill(pid, 0)
 		return True
@@ -205,8 +222,16 @@ async def start_tunnel(port: int) -> dict[str, Any]:
 	log_file = open(log_file_path, 'w')  # noqa: ASYNC230
 
 	# Spawn cloudflared as a daemon
-	# - start_new_session=True: survives parent exit
-	# - stderr to file: avoids SIGPIPE when parent's pipe closes
+	# - On Unix: start_new_session=True survives parent exit
+	# - On Windows: use CREATE_NEW_PROCESS_GROUP flag
+	import sys
+	import subprocess
+
+	start_new_session = sys.platform != 'win32'
+	creationflags = 0
+	if sys.platform == 'win32':
+		creationflags = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
+
 	process = await asyncio.create_subprocess_exec(
 		cloudflared_binary,
 		'tunnel',
@@ -214,7 +239,8 @@ async def start_tunnel(port: int) -> dict[str, Any]:
 		f'http://localhost:{port}',
 		stdout=asyncio.subprocess.DEVNULL,
 		stderr=log_file,
-		start_new_session=True,
+		start_new_session=start_new_session,
+		creationflags=creationflags,
 	)
 
 	# Poll the log file until we find the tunnel URL


### PR DESCRIPTION
## Summary

This PR addresses Copilot's review feedback on PRs #4354 and #4357:

### Changes

**tunnel.py (Windows compatibility):**
- Use sys.platform == 'win32' check in _is_process_alive() instead of catching SystemError - consistent with main.py and utils.py patterns
- Add creationflags for Windows process detachment (CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW)

**profile.py (env var naming):**
- Rename env vars to BROWSER_USE_CHROME_PATH and BROWSER_USE_CHROMIUM_PATH - consistent with codebase conventions like BROWSER_USE_DISABLE_EXTENSIONS
- Fix return type to str | None instead of str | Path | None

### Why

Copilot noted that:
1. The original SystemError catch could miss certain Windows edge cases
2. The original env var prefix BROWSERUSE_ didn't match the codebase convention BROWSER_USE_
3. The return type annotation was inaccurate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Windows compatibility for tunnel processes and align browser executable env vars with project conventions. This makes process checks more reliable on Windows and simplifies configuration via environment variables.

- **Bug Fixes**
  - Windows: use `sys.platform == 'win32'` and a `ctypes` `OpenProcess` check in `_is_process_alive`.
  - Windows: detach `cloudflared` with `CREATE_NEW_PROCESS_GROUP` and `CREATE_NO_WINDOW`; keep `start_new_session` for Unix only.
  - Browser profile: read `BROWSER_USE_CHROME_PATH` or `BROWSER_USE_CHROMIUM_PATH` for `executable_path` by default; correct type to `str | None`.

- **Migration**
  - Replace any `BROWSERUSE_*` vars with `BROWSER_USE_CHROME_PATH` or `BROWSER_USE_CHROMIUM_PATH`.

<sup>Written for commit 0263c8feaf123e7467d8cf2e411b70f4377b7dc0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

