### PR TITLE
fix: add Windows support for _kill_process in tunnel.py

### DIFF
--- a/browser_use/skill_cli/tunnel.py
+++ b/browser_use/skill_cli/tunnel.py
@@ -155,6 +155,26 @@ def _is_process_alive(pid: int) -> bool:
 
 def _kill_process(pid: int) -> bool:
 	"""Kill a process by PID. Returns True if killed, False if already dead."""
+	import sys
+
+	# On Windows, use ctypes instead of signals
+	if sys.platform == 'win32':
+		try:
+			import ctypes
+			from ctypes import wintypes
+
+			PROCESS_TERMINATE = 0x0001
+			handle = ctypes.windll.kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
+			if not handle:
+				return False
+			try:
+				ctypes.windll.kernel32.TerminateProcess(handle, 1)
+				return True
+			finally:
+				ctypes.windll.kernel32.CloseHandle(handle)
+		except Exception:
+			return False
+
 	try:
 		os.kill(pid, signal.SIGTERM)
 		# Give it a moment to terminate gracefully


### PR DESCRIPTION
## Summary

Fixes a bug reported by Copilot in PR #4359.

## Problem

On Windows, os.kill with SIGTERM/SIGKILL doesn't work - Windows doesn't support Unix signals. This means tunnels started on Windows cannot be reliably stopped.

## Solution

Added a Windows-specific branch in _kill_process() that uses ctypes:
- OpenProcess with PROCESS_TERMINATE flag
- TerminateProcess to kill the process
- Proper handle cleanup with CloseHandle

This is consistent with the pattern used in rowser_use/skill_cli/utils.py.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable reliable tunnel shutdown on Windows by adding a Windows-specific path to _kill_process in `browser_use/skill_cli/tunnel.py`. This fixes termination failures caused by unsupported Unix signals on Windows.

- **Bug Fixes**
  - On Windows, use Win32 APIs via `ctypes`: `OpenProcess(PROCESS_TERMINATE)`, `TerminateProcess`, `CloseHandle`.
  - Keep existing Unix behavior using `os.kill(SIGTERM)`.
  - Aligns with the approach in `browser_use/skill_cli/utils.py`.

<sup>Written for commit 5e000fdec4aba75274116b60720be0d00ca8a9ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

