### PR TITLE
fix: address Copilot/cubic review feedback for Windows process management

### DIFF
--- a/browser_use/skill_cli/tunnel.py
+++ b/browser_use/skill_cli/tunnel.py
@@ -208,14 +208,18 @@ def _is_process_alive_unix(pid: int) -> bool:
 def _is_process_alive_windows(pid: int) -> bool:
 	"""Check if a process is still running on Windows.
 
-	Uses WaitForSingleObject to properly detect if process is alive,
-	avoiding false positives from zombie process handles.
+	Uses WaitForSingleObject with SYNCHRONIZE access to properly detect if
+	process is alive, avoiding false positives from zombie process handles.
 	"""
 	try:
 		kernel32 = _setup_windows_ctypes()
+		# SYNCHRONIZE (0x00100000) is required for WaitForSingleObject to work
+		# PROCESS_QUERY_LIMITED_INFORMATION (0x1000) allows querying exit code
 		PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+		SYNCHRONIZE = 0x00100000
+		access = PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE
 
-		handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+		handle = kernel32.OpenProcess(access, False, pid)
 		if not handle:
 			return False
 
@@ -260,6 +264,10 @@ def _kill_process_windows(pid: int) -> bool:
 	Uses TerminateProcess and waits for actual termination to avoid race
 	conditions where the caller might delete PID files while process is
 	still running.
+
+	Returns:
+		True if the process was successfully killed, False if the process
+		is still running or could not be terminated.
 	"""
 	try:
 		kernel32 = _setup_windows_ctypes()
@@ -267,6 +275,7 @@ def _kill_process_windows(pid: int) -> bool:
 
 		handle = kernel32.OpenProcess(PROCESS_TERMINATE, False, pid)
 		if not handle:
+			# Process doesn't exist or we lack permission - treat as dead
 			return False
 
 		try:
@@ -279,10 +288,11 @@ def _kill_process_windows(pid: int) -> bool:
 			# (similar to Unix implementation's wait loop)
 			for _ in range(10):
 				if not _is_process_alive(pid):
-					return True
+					return True  # Successfully killed
 				time.sleep(0.1)
 
-			return True  # TerminateProcess called, let caller decide
+			# Process is still alive after all retries - return False per docstring
+			return False
 		finally:
 			kernel32.CloseHandle(handle)
 	except Exception:

--- a/tests/ci/test_tunnel.py
+++ b/tests/ci/test_tunnel.py
@@ -212,3 +212,26 @@ class TestKillProcessWindows:
 			result = _kill_process(12345)
 
 			assert result is False
+
+	@patch('sys.platform', 'win32')
+	def test_kill_process_windows_still_alive_after_retries(self):
+		"""Test _kill_process returns False when process is still alive after all retries."""
+		from browser_use.skill_cli.tunnel import _kill_process
+
+		import browser_use.skill_cli.tunnel as tunnel_module
+		tunnel_module._ctypes_initialized = False
+
+		with patch.object(tunnel_module, '_setup_windows_ctypes') as mock_setup:
+			mock_kernel32 = MagicMock()
+			mock_kernel32.OpenProcess.return_value = 1234
+			mock_kernel32.TerminateProcess.return_value = True
+			# Process keeps returning "still running" (WAIT_TIMEOUT) for all 10 retries
+			mock_kernel32.WaitForSingleObject.return_value = 0x102
+			mock_setup.return_value = mock_kernel32
+
+			result = _kill_process(12345)
+
+			# Should return False because process is still alive after all retries
+			assert result is False
+			# Verify all 10 retries were attempted
+			assert mock_kernel32.WaitForSingleObject.call_count == 10


### PR DESCRIPTION
## Summary

This PR addresses the review feedback from Copilot and cubic-dev-ai on PRs #4362 and #4363:

### Issues Fixed:

1. **Extract ctypes setup to shared helper** - Created _setup_windows_ctypes() function to avoid duplicating argtypes/restype definitions between _is_process_alive and _kill_process

2. **Add try/except to _is_process_alive Windows branch** - Now catches exceptions and returns False instead of propagating

3. **Add wait loop to _kill_process Windows branch** - Added similar wait loop to Unix implementation to avoid race conditions where caller might delete PID files while process is still running

4. **Use WaitForSingleObject for proper liveness check** - Changed from just checking if OpenProcess succeeds to using WaitForSingleObject to avoid false positives from zombie process handles

5. **Fix test mocking strategy** - Tests now properly mock _setup_windows_ctypes helper instead of trying to mock ctypes module (which doesn't work with local imports)

### Files Changed:
- rowser_use/skill_cli/tunnel.py - Main fixes
- 	ests/ci/test_tunnel.py - Added Windows unit tests

### Testing:
Added 6 new Windows-specific unit tests covering both _is_process_alive and _kill_process functions.

---

@copilot-pull-request-reviewer @cubic-dev-ai

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows process liveness and termination in the tunnel by using `WaitForSingleObject` with `SYNCHRONIZE`, adding a wait loop in `_kill_process`, and centralizing ctypes. Adds Windows unit tests for `_is_process_alive` and `_kill_process`, including the “still alive after retries” path.

- **Bug Fixes**
  - Use `WaitForSingleObject` + `SYNCHRONIZE` for accurate liveness checks to avoid zombie-handle false positives.
  - Add try/except in Windows `_is_process_alive` to return `False` on errors.
  - Wait after `TerminateProcess` and return `False` if the process is still alive after all retries.

- **Refactors**
  - Extract Windows ctypes setup to `_setup_windows_ctypes()` and set argtypes/restype once.
  - Move `ctypes`/`wintypes` imports to module level for testability.

<sup>Written for commit 38a0996fbcb4248f00b739539aad48548e21fbd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

