### PR TITLE
fix: add bounds check for empty response content in Anthropic chat

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1610,7 +1610,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		judgement = await self._judge_trace()
 
 		# Attach judgement to last action result
-		if self.history.history[-1].result[-1].is_done:
+		if (
+			self.history.history
+			and self.history.history[-1].result
+			and len(self.history.history[-1].result) > 0
+			and self.history.history[-1].result[-1].is_done
+		):
 			last_result = self.history.history[-1].result[-1]
 			last_result.judgement = judgement
 

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -727,8 +727,10 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def final_result(self) -> None | str:
 		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
-			return self.history[-1].result[-1].extracted_content
+		if self.history and len(self.history[-1].result) > 0:
+			last_result = self.history[-1].result[-1]
+			if last_result.extracted_content:
+				return last_result.extracted_content
 		return None
 
 	def is_done(self) -> bool:

--- a/browser_use/code_use/views.py
+++ b/browser_use/code_use/views.py
@@ -216,7 +216,7 @@ class CodeAgentHistoryList:
 
 	def final_result(self) -> None | str:
 		"""Final result from history."""
-		if self._complete_history and self._complete_history[-1].result:
+		if self._complete_history and len(self._complete_history[-1].result) > 0:
 			return self._complete_history[-1].result[-1].extracted_content
 		return None
 

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -160,12 +160,13 @@ class ChatAnthropic(BaseChatModel):
 				usage = self._get_usage(response)
 
 				# Extract text from the first content block
-				first_content = response.content[0]
-				if isinstance(first_content, TextBlock):
-					response_text = first_content.text
+				if not response.content:
+					response_text = ""
+				elif isinstance(response.content[0], TextBlock):
+					response_text = response.content[0].text
 				else:
 					# If it's not a text block, convert to string
-					response_text = str(first_content)
+					response_text = str(response.content[0])
 
 				return ChatInvokeCompletion(
 					completion=response_text,

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -172,12 +172,13 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 				usage = self._get_usage(response)
 
 				# Extract text from the first content block
-				first_content = response.content[0]
-				if isinstance(first_content, TextBlock):
-					response_text = first_content.text
+				if not response.content:
+					response_text = ""
+				elif isinstance(response.content[0], TextBlock):
+					response_text = response.content[0].text
 				else:
 					# If it's not a text block, convert to string
-					response_text = str(first_content)
+					response_text = str(response.content[0])
 
 				return ChatInvokeCompletion(
 					completion=response_text,

--- a/examples/integrations/discord/discord_api.py
+++ b/examples/integrations/discord/discord_api.py
@@ -112,7 +112,7 @@ class DiscordBot(commands.Bot):
 
 			agent_message = None
 			if result.is_done():
-				agent_message = result.history[-1].result[0].extracted_content
+				agent_message = result.final_result()
 
 			if agent_message is None:
 				agent_message = 'Oops! Something went wrong while running Browser-Use.'

--- a/examples/integrations/slack/slack_api.py
+++ b/examples/integrations/slack/slack_api.py
@@ -88,7 +88,7 @@ class SlackBot:
 
 			agent_message = None
 			if result.is_done():
-				agent_message = result.history[-1].result[0].extracted_content
+				agent_message = result.final_result()
 
 			if agent_message is None:
 				agent_message = 'Oops! Something went wrong while running Browser-Use.'


### PR DESCRIPTION
## Description

Previously, the code accessed `response.content[0]` without checking if the content list is empty, which could cause an `IndexError` when the Anthropic API returns an empty content list.

This fix adds a check for empty content before accessing the first element, returning an empty string if content is empty.

## Changes

- `browser_use/llm/anthropic/chat.py`: Added bounds check before accessing `response.content[0]`
- `browser_use/llm/aws/chat_anthropic.py`: Added bounds check before accessing `response.content[0]`

## Risk

Low - This is a defensive fix that prevents a potential IndexError in edge cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent IndexError by adding bounds checks for empty Anthropic response content and empty agent result lists. Also switch Discord/Slack integrations to a safe `final_result()` accessor.

- **Bug Fixes**
  - Anthropic chat: return empty string when `response.content` is empty; safely read the first block otherwise.
  - Agent history: check `result` length before accessing the last item in `_judge_and_log` and `final_result()` methods.
  - Integrations: use `result.final_result()` in Discord and Slack instead of direct indexing.

<sup>Written for commit ea759f5776de14d362d2bb8bcc45b70a09ca8d32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

