### PR TITLE
feat(browser): configurable download timeout

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -663,6 +663,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	# --- Downloads ---
 	auto_download_pdfs: bool = Field(default=True, description='Automatically download PDFs when navigating to PDF viewer pages.')
+	download_timeout: float = Field(
+		default=30.0,
+		description='Maximum time in seconds to wait for a download to complete after it starts. Increase for large file downloads.',
+	)
 
 	profile_directory: str = 'Default'  # e.g. 'Profile 1', 'Profile 2', 'Custom Profile', etc.
 

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -665,7 +665,9 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	auto_download_pdfs: bool = Field(default=True, description='Automatically download PDFs when navigating to PDF viewer pages.')
 	download_timeout: float = Field(
 		default=30.0,
-		description='Maximum time in seconds to wait for a download to complete after it starts. Increase for large file downloads.',
+		ge=0.0,
+		le=600.0,
+		description='Maximum time in seconds to wait for a download to complete after it starts. Increase for large file downloads. Range: 0-600.',
 	)
 
 	profile_directory: str = 'Default'  # e.g. 'Profile 1', 'Profile 2', 'Custom Profile', etc.

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -152,6 +152,7 @@ class BrowserSession(BaseModel):
 		wait_between_actions: float | None = None,
 		captcha_solver: bool | None = None,
 		auto_download_pdfs: bool | None = None,
+		download_timeout: float | None = None,
 		cookie_whitelist_domains: list[str] | None = None,
 		cross_origin_iframes: bool | None = None,
 		highlight_elements: bool | None = None,
@@ -185,6 +186,7 @@ class BrowserSession(BaseModel):
 		wait_for_network_idle_page_load_time: float | None = None,
 		wait_between_actions: float | None = None,
 		auto_download_pdfs: bool | None = None,
+		download_timeout: float | None = None,
 		cookie_whitelist_domains: list[str] | None = None,
 		cross_origin_iframes: bool | None = None,
 		highlight_elements: bool | None = None,
@@ -292,6 +294,7 @@ class BrowserSession(BaseModel):
 		wait_between_actions: float | None = None,
 		filter_highlight_ids: bool | None = None,
 		auto_download_pdfs: bool | None = None,
+		download_timeout: float | None = None,
 		profile_directory: str | None = None,
 		cookie_whitelist_domains: list[str] | None = None,
 		# DOM extraction layer configuration

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -368,7 +368,10 @@ class DefaultActionWatchdog(BaseWatchdog):
 					self.logger.warning('⚠️ PDF generation failed, falling back to regular click')
 
 			# Execute click with automatic download detection
-			click_metadata = await self._execute_click_with_download_detection(self._click_element_node_impl(element_node))
+			click_metadata = await self._execute_click_with_download_detection(
+				self._click_element_node_impl(element_node),
+				download_complete_timeout=self.browser_session.browser_profile.download_timeout,
+			)
 
 			# Check for validation errors
 			if isinstance(click_metadata, dict) and 'validation_error' in click_metadata:
@@ -399,7 +402,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 			if event.force:
 				self.logger.debug(f'Force clicking at coordinates ({event.coordinate_x}, {event.coordinate_y})')
 				return await self._execute_click_with_download_detection(
-					self._click_on_coordinate(event.coordinate_x, event.coordinate_y, force=True)
+					self._click_on_coordinate(event.coordinate_x, event.coordinate_y, force=True),
+					download_complete_timeout=self.browser_session.browser_profile.download_timeout,
 				)
 
 			# Get element at coordinates for safety checks
@@ -410,7 +414,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 					f'No element found at coordinates ({event.coordinate_x}, {event.coordinate_y}), proceeding with click anyway'
 				)
 				return await self._execute_click_with_download_detection(
-					self._click_on_coordinate(event.coordinate_x, event.coordinate_y, force=False)
+					self._click_on_coordinate(event.coordinate_x, event.coordinate_y, force=False),
+					download_complete_timeout=self.browser_session.browser_profile.download_timeout,
 				)
 
 			# Safety check: file input
@@ -442,7 +447,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# All safety checks passed, click at coordinates (with download detection)
 			return await self._execute_click_with_download_detection(
-				self._click_on_coordinate(event.coordinate_x, event.coordinate_y, force=False)
+				self._click_on_coordinate(event.coordinate_x, event.coordinate_y, force=False),
+				download_complete_timeout=self.browser_session.browser_profile.download_timeout,
 			)
 
 		except Exception:

--- a/tests/ci/test_download_timeout.py
+++ b/tests/ci/test_download_timeout.py
@@ -1,0 +1,34 @@
+"""Tests for configurable download timeout (issue #3168)."""
+
+from browser_use.browser import BrowserProfile, BrowserSession
+
+
+def test_download_timeout_default():
+	"""Default download_timeout should be 30.0 seconds."""
+	profile = BrowserProfile()
+	assert profile.download_timeout == 30.0
+
+
+def test_download_timeout_custom():
+	"""Custom download_timeout should be stored in profile."""
+	profile = BrowserProfile(download_timeout=120.0)
+	assert profile.download_timeout == 120.0
+
+
+def test_download_timeout_passthrough_via_session():
+	"""download_timeout passed to BrowserSession should propagate to BrowserProfile."""
+	session = BrowserSession(download_timeout=60.0)
+	assert session.browser_profile.download_timeout == 60.0
+
+
+def test_download_timeout_session_default():
+	"""BrowserSession without download_timeout should use BrowserProfile default."""
+	session = BrowserSession()
+	assert session.browser_profile.download_timeout == 30.0
+
+
+def test_download_timeout_profile_on_session():
+	"""BrowserSession with explicit BrowserProfile should use profile's download_timeout."""
+	profile = BrowserProfile(download_timeout=90.0)
+	session = BrowserSession(browser_profile=profile)
+	assert session.browser_profile.download_timeout == 90.0


### PR DESCRIPTION
## Summary

- Adds `download_timeout` field to `BrowserProfile` (default 30.0s, backward compatible)
- Passes the configured timeout through to all 4 `_execute_click_with_download_detection()` call sites in `DefaultActionWatchdog`
- Adds `download_timeout` passthrough parameter to `BrowserSession` for convenience

Users can set a longer timeout for large file downloads:
```python
session = BrowserSession(download_timeout=120.0)
# or
profile = BrowserProfile(download_timeout=120.0)
```

**Evidence:**
- `browser_use/browser/watchdogs/default_action_watchdog.py:47-48` had hardcoded 30s timeout
- `browser_use/browser/profile.py:664` already had a Downloads section with `auto_download_pdfs`
- Issue #3168 has 3 commenters confirming 30s is too short for large downloads

Closes #3168

## Test plan

- [x] `tests/ci/test_download_timeout.py` - verifies default (30.0s), custom values, and session passthrough
- [x] `uv run ruff check` passes
- [x] `uv run pyright` passes (0 errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the download-complete timeout configurable to support large files. Adds `download_timeout` to `BrowserProfile` (default 30s) and wires it through `DefaultActionWatchdog`; fixes large-download timeouts reported in #3168.

- **New Features**
  - `download_timeout` on `BrowserProfile` (default 30.0s, validated 0–600s) applied to all `_execute_click_with_download_detection(...)` call sites in `DefaultActionWatchdog`.
  - Optional `download_timeout` on `BrowserSession` that sets the profile value.
  - Usage: `BrowserSession(download_timeout=120.0)` or `BrowserProfile(download_timeout=120.0)`.

<sup>Written for commit 0dd819753a95298f3ccc2baf6c1553901a185352. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

