### PR TITLE
feat(browser): make window resize optional

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -615,6 +615,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		description='List of domains to whitelist in the "I still don\'t care about cookies" extension, preventing automatic cookie banner handling on these sites.',
 	)
 
+	manage_window_size: bool = Field(
+		default=True,
+		description='Whether to manage browser window size and position. Set to False when connecting to an existing browser to preserve its current window layout.',
+	)
 	window_size: ViewportSize | None = Field(
 		default=None,
 		description='Browser window size to use when headless=False.',
@@ -865,12 +869,12 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			*(CHROME_DETERMINISTIC_RENDERING_ARGS if self.deterministic_rendering else []),
 			*(
 				[f'--window-size={self.window_size["width"]},{self.window_size["height"]}']
-				if self.window_size
-				else (['--start-maximized'] if not self.headless else [])
+				if self.window_size and self.manage_window_size
+				else (['--start-maximized'] if not self.headless and self.manage_window_size else [])
 			),
 			*(
 				[f'--window-position={self.window_position["width"]},{self.window_position["height"]}']
-				if self.window_position
+				if self.window_position and self.manage_window_size
 				else []
 			),
 			*(self._get_extension_args() if self.enable_default_extensions else []),
@@ -1188,7 +1192,8 @@ async function initialize(checkInitialized, magic) {{
 			self.no_viewport = False
 		else:
 			# Headful mode: respect user's viewport preference
-			self.window_size = self.window_size or self.screen
+			if self.manage_window_size:
+				self.window_size = self.window_size or self.screen
 
 			if user_provided_viewport:
 				# User explicitly set viewport - enable viewport mode

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -220,6 +220,7 @@ class BrowserSession(BaseModel):
 		captcha_solver: bool | None = None,
 		window_size: dict | None = None,
 		window_position: dict | None = None,
+		manage_window_size: bool | None = None,
 		filter_highlight_ids: bool | None = None,
 		profile_directory: str | None = None,
 	) -> None: ...
@@ -287,6 +288,7 @@ class BrowserSession(BaseModel):
 		captcha_solver: bool | None = None,
 		window_size: dict | None = None,
 		window_position: dict | None = None,
+		manage_window_size: bool | None = None,
 		minimum_wait_page_load_time: float | None = None,
 		wait_for_network_idle_page_load_time: float | None = None,
 		wait_between_actions: float | None = None,

--- a/tests/ci/test_manage_window_size.py
+++ b/tests/ci/test_manage_window_size.py
@@ -1,0 +1,52 @@
+"""Tests for optional window size management (issue #3303)."""
+
+import tempfile
+
+from browser_use.browser import BrowserProfile, BrowserSession
+
+
+def test_manage_window_size_default_true():
+	"""manage_window_size should default to True."""
+	profile = BrowserProfile()
+	assert profile.manage_window_size is True
+
+
+def test_manage_window_size_false_skips_window_size_in_headful():
+	"""When manage_window_size=False in headful mode, window_size should not be auto-set."""
+	profile = BrowserProfile(headless=False, manage_window_size=False)
+	# window_size should remain None since we told it not to manage
+	assert profile.window_size is None
+
+
+def test_manage_window_size_false_omits_chrome_args():
+	"""When manage_window_size=False, --window-size and --window-position should not appear in launch args."""
+	with tempfile.TemporaryDirectory() as tmpdir:
+		profile = BrowserProfile(headless=False, manage_window_size=False, user_data_dir=tmpdir)
+		args = profile.get_args()
+		arg_str = ' '.join(args)
+		assert '--window-size' not in arg_str
+		assert '--window-position' not in arg_str
+		assert '--start-maximized' not in arg_str
+
+
+def test_manage_window_size_true_includes_chrome_args():
+	"""When manage_window_size=True (default), window args should appear normally."""
+	with tempfile.TemporaryDirectory() as tmpdir:
+		profile = BrowserProfile(headless=False, manage_window_size=True, user_data_dir=tmpdir)
+		args = profile.get_args()
+		arg_str = ' '.join(args)
+		# Should have either --window-size or --start-maximized
+		assert '--window-size' in arg_str or '--start-maximized' in arg_str
+
+
+def test_manage_window_size_passthrough_via_session():
+	"""manage_window_size passed to BrowserSession should propagate to BrowserProfile."""
+	session = BrowserSession(manage_window_size=False)
+	assert session.browser_profile.manage_window_size is False
+
+
+def test_manage_window_size_false_still_sets_viewport():
+	"""When manage_window_size=False, viewport and screen should still be configured for content rendering."""
+	profile = BrowserProfile(headless=True, manage_window_size=False)
+	# In headless mode, viewport should still be set for content rendering
+	assert profile.viewport is not None


### PR DESCRIPTION
## Summary

- Adds `manage_window_size` field to `BrowserProfile` (default `True`, backward compatible)
- When `False`, skips auto-setting `window_size` in `detect_display_configuration()` and omits `--window-size`/`--window-position`/`--start-maximized` from Chrome launch args
- Still detects `screen`/`viewport` for content rendering - only the OS window manipulation is skipped
- Adds `manage_window_size` passthrough to `BrowserSession`

This is useful when connecting to an existing browser via `cdp_url` where the user wants to preserve their current window layout:
```python
session = BrowserSession(cdp_url="ws://...", manage_window_size=False)
```

**Evidence:**
- `browser_use/browser/profile.py:1166-1219` - `detect_display_configuration()` unconditionally sets `window_size` and `window_position`
- `browser_use/browser/profile.py:867-868` - `--window-size` Chrome arg always generated
- Issue #3303: user reports window size is "messed with" when connecting to existing browser

Closes #3303

## Test plan

- [x] `tests/ci/test_manage_window_size.py` - 6 tests covering default, headful skip, chrome args omission, passthrough, viewport preservation
- [x] `uv run ruff check` passes
- [x] `uv run pyright` passes (0 errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make browser window resizing optional to preserve existing layouts when attaching to an existing Chrome instance. Adds a `manage_window_size` flag to control whether we set window size/position or pass Chrome window args.

- **New Features**
  - Added `manage_window_size` to `BrowserProfile` (default `True`) to control window size and position management.
  - When `False`, skip auto-setting `window_size` in `detect_display_configuration()` and omit `--window-size`, `--window-position`, and `--start-maximized` from Chrome args.
  - Still detects `screen` and `viewport` for rendering; only OS window manipulation is skipped.
  - Exposed `manage_window_size` in `BrowserSession`. Example: `BrowserSession(cdp_url="ws://...", manage_window_size=False)`.

<sup>Written for commit 32579340fb1928c8713b2e93e3fd5bb9418f04f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

