### PR TITLE
feat(agent): support callable values in sensitive_data

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -572,12 +572,20 @@ class MessageManager:
 				if isinstance(content, dict):
 					# Already in new format: {domain: {key: value}}
 					for key, val in content.items():
-						resolved = str(val()) if callable(val) else val
+						try:
+							resolved = str(val()) if callable(val) else val
+						except Exception:
+							logger.warning(f'Failed to resolve callable sensitive_data key={key}, skipping')
+							continue
 						if resolved:  # Skip empty values
 							sensitive_values[key] = resolved
 				elif content:  # Old format: {key: value} - convert to new format internally
 					# We treat this as if it was {'http*://*': {key_or_domain: content}}
-					resolved = str(content()) if callable(content) else content
+					try:
+						resolved = str(content()) if callable(content) else content
+					except Exception:
+						logger.warning(f'Failed to resolve callable sensitive_data key={key_or_domain}, skipping')
+						continue
 					if resolved:
 						sensitive_values[key_or_domain] = resolved
 

--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal
+from typing import Any, Literal
 
 from browser_use.agent.message_manager.views import (
 	HistoryItem,
@@ -107,7 +107,7 @@ class MessageManager:
 		state: MessageManagerState = MessageManagerState(),
 		use_thinking: bool = True,
 		include_attributes: list[str] | None = None,
-		sensitive_data: dict[str, str | dict[str, str]] | None = None,
+		sensitive_data: dict[str, Any] | None = None,
 		max_history_items: int | None = None,
 		vision_detail_level: Literal['auto', 'low', 'high'] = 'auto',
 		include_tool_call_examples: bool = False,
@@ -572,11 +572,14 @@ class MessageManager:
 				if isinstance(content, dict):
 					# Already in new format: {domain: {key: value}}
 					for key, val in content.items():
-						if val:  # Skip empty values
-							sensitive_values[key] = val
+						resolved = str(val()) if callable(val) else val
+						if resolved:  # Skip empty values
+							sensitive_values[key] = resolved
 				elif content:  # Old format: {key: value} - convert to new format internally
 					# We treat this as if it was {'http*://*': {key_or_domain: content}}
-					sensitive_values[key_or_domain] = content
+					resolved = str(content()) if callable(content) else content
+					if resolved:
+						sensitive_values[key_or_domain] = resolved
 
 			# If there are no valid sensitive data entries, just return the original value
 			if not sensitive_values:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -145,7 +145,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		skills: list[str | Literal['*']] | None = None,  # Alias for skill_ids
 		skill_service: Any | None = None,
 		# Initial agent run parameters
-		sensitive_data: dict[str, str | dict[str, str]] | None = None,
+		sensitive_data: dict[str, str | Callable[[], str] | dict[str, str | Callable[[], str]]] | None = None,
 		initial_actions: list[dict[str, dict[str, Any]]] | None = None,
 		# Cloud Callbacks
 		register_new_step_callback: (

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -520,12 +520,20 @@ class AgentHistory(BaseModel):
 			if isinstance(content, dict):
 				# Already in new format: {domain: {key: value}}
 				for key, val in content.items():
-					resolved = str(val()) if callable(val) else val
+					try:
+						resolved = str(val()) if callable(val) else val
+					except Exception:
+						logger.warning(f'Failed to resolve callable sensitive_data key={key}, skipping')
+						continue
 					if resolved:  # Skip empty values
 						sensitive_values[key] = resolved
 			elif content:  # Old format: {key: value} - convert to new format internally
 				# We treat this as if it was {'http*://*': {key_or_domain: content}}
-				resolved = str(content()) if callable(content) else content
+				try:
+					resolved = str(content()) if callable(content) else content
+				except Exception:
+					logger.warning(f'Failed to resolve callable sensitive_data key={key_or_domain}, skipping')
+					continue
 				if resolved:
 					sensitive_values[key_or_domain] = resolved
 

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -507,7 +507,7 @@ class AgentHistory(BaseModel):
 				elements.append(None)
 		return elements
 
-	def _filter_sensitive_data_from_string(self, value: str, sensitive_data: dict[str, str | dict[str, str]] | None) -> str:
+	def _filter_sensitive_data_from_string(self, value: str, sensitive_data: dict[str, Any] | None) -> str:
 		"""Filter out sensitive data from a string value"""
 		if not sensitive_data:
 			return value
@@ -520,11 +520,14 @@ class AgentHistory(BaseModel):
 			if isinstance(content, dict):
 				# Already in new format: {domain: {key: value}}
 				for key, val in content.items():
-					if val:  # Skip empty values
-						sensitive_values[key] = val
+					resolved = str(val()) if callable(val) else val
+					if resolved:  # Skip empty values
+						sensitive_values[key] = resolved
 			elif content:  # Old format: {key: value} - convert to new format internally
 				# We treat this as if it was {'http*://*': {key_or_domain: content}}
-				sensitive_values[key_or_domain] = content
+				resolved = str(content()) if callable(content) else content
+				if resolved:
+					sensitive_values[key_or_domain] = resolved
 
 		# If there are no valid sensitive data entries, just return the original value
 		if not sensitive_values:
@@ -536,9 +539,7 @@ class AgentHistory(BaseModel):
 
 		return value
 
-	def _filter_sensitive_data_from_dict(
-		self, data: dict[str, Any], sensitive_data: dict[str, str | dict[str, str]] | None
-	) -> dict[str, Any]:
+	def _filter_sensitive_data_from_dict(self, data: dict[str, Any], sensitive_data: dict[str, Any] | None) -> dict[str, Any]:
 		"""Recursively filter sensitive data from a dictionary"""
 		if not sensitive_data:
 			return data
@@ -562,7 +563,7 @@ class AgentHistory(BaseModel):
 				filtered_data[key] = value
 		return filtered_data
 
-	def model_dump(self, sensitive_data: dict[str, str | dict[str, str]] | None = None, **kwargs) -> dict[str, Any]:
+	def model_dump(self, sensitive_data: dict[str, Any] | None = None, **kwargs) -> dict[str, Any]:
 		"""Custom serialization handling circular references and filtering sensitive data"""
 
 		# Handle action serialization
@@ -639,7 +640,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 		"""Representation of the AgentHistoryList object"""
 		return self.__str__()
 
-	def save_to_file(self, filepath: str | Path, sensitive_data: dict[str, str | dict[str, str]] | None = None) -> None:
+	def save_to_file(self, filepath: str | Path, sensitive_data: dict[str, Any] | None = None) -> None:
 		"""Save history to JSON file with proper serialization and optional sensitive data filtering"""
 		try:
 			Path(filepath).parent.mkdir(parents=True, exist_ok=True)

--- a/browser_use/code_use/namespace.py
+++ b/browser_use/code_use/namespace.py
@@ -259,7 +259,7 @@ def create_namespace(
 	page_extraction_llm: BaseChatModel | None = None,
 	file_system: FileSystem | None = None,
 	available_file_paths: list[str] | None = None,
-	sensitive_data: dict[str, str | dict[str, str]] | None = None,
+	sensitive_data: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
 	"""
 	Create a namespace with all browser tools available as functions.

--- a/browser_use/code_use/service.py
+++ b/browser_use/code_use/service.py
@@ -73,7 +73,7 @@ class CodeAgent:
 		page_extraction_llm: BaseChatModel | None = None,
 		file_system: FileSystem | None = None,
 		available_file_paths: list[str] | None = None,
-		sensitive_data: dict[str, str | dict[str, str]] | None = None,
+		sensitive_data: dict[str, Any] | None = None,
 		max_steps: int = 100,
 		max_failures: int = 8,
 		max_validations: int = 0,

--- a/browser_use/code_use/views.py
+++ b/browser_use/code_use/views.py
@@ -396,7 +396,7 @@ class CodeAgentHistoryList:
 		"""Save history to JSON file."""
 		try:
 			Path(filepath).parent.mkdir(parents=True, exist_ok=True)
-			data = self.model_dump()
+			data = self.model_dump(sensitive_data=sensitive_data)
 			with open(filepath, 'w', encoding='utf-8') as f:
 				json.dump(data, f, indent=2, ensure_ascii=False)
 		except Exception as e:

--- a/browser_use/code_use/views.py
+++ b/browser_use/code_use/views.py
@@ -392,7 +392,7 @@ class CodeAgentHistoryList:
 			'usage': self._usage_summary.model_dump() if self._usage_summary else None,
 		}
 
-	def save_to_file(self, filepath: str | Path, sensitive_data: dict[str, str | dict[str, str]] | None = None) -> None:
+	def save_to_file(self, filepath: str | Path, sensitive_data: dict[str, Any] | None = None) -> None:
 		"""Save history to JSON file."""
 		try:
 			Path(filepath).parent.mkdir(parents=True, exist_ok=True)

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -334,7 +334,7 @@ class Registry(Generic[Context]):
 		browser_session: BrowserSession | None = None,
 		page_extraction_llm: BaseChatModel | None = None,
 		file_system: FileSystem | None = None,
-		sensitive_data: dict[str, str | dict[str, str]] | None = None,
+		sensitive_data: dict[str, Any] | None = None,
 		available_file_paths: list[str] | None = None,
 		extraction_schema: dict | None = None,
 	) -> Any:
@@ -461,11 +461,13 @@ class Registry(Generic[Context]):
 				for placeholder in matches:
 					if placeholder in applicable_secrets:
 						# generate a totp code if secret is suffixed with bu_2fa_code
+						raw_value = applicable_secrets[placeholder]
+						resolved_value = str(raw_value()) if callable(raw_value) else raw_value
 						if placeholder.endswith('bu_2fa_code'):
-							totp = pyotp.TOTP(applicable_secrets[placeholder], digits=6)
+							totp = pyotp.TOTP(resolved_value, digits=6)
 							replacement_value = totp.now()
 						else:
-							replacement_value = applicable_secrets[placeholder]
+							replacement_value = resolved_value
 
 						value = value.replace(f'<secret>{placeholder}</secret>', replacement_value)
 						replaced_placeholders.add(placeholder)
@@ -477,11 +479,13 @@ class Registry(Generic[Context]):
 				# This handles cases where the LLM forgets to use tags but uses the exact placeholder name
 				if value in applicable_secrets:
 					placeholder_name = value
+					raw_value = applicable_secrets[placeholder_name]
+					resolved_value = str(raw_value()) if callable(raw_value) else raw_value
 					if placeholder_name.endswith('bu_2fa_code'):
-						totp = pyotp.TOTP(applicable_secrets[placeholder_name], digits=6)
+						totp = pyotp.TOTP(resolved_value, digits=6)
 						value = totp.now()
 					else:
-						value = applicable_secrets[placeholder_name]
+						value = resolved_value
 					replaced_placeholders.add(placeholder_name)
 
 				return value

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 import anyio
 
@@ -74,7 +74,7 @@ Context = TypeVar('Context')
 T = TypeVar('T', bound=BaseModel)
 
 
-def _detect_sensitive_key_name(text: str, sensitive_data: dict[str, str | dict[str, str]] | None) -> str | None:
+def _detect_sensitive_key_name(text: str, sensitive_data: dict[str, Any] | None) -> str | None:
 	"""Detect which sensitive key name corresponds to the given text value."""
 	if not sensitive_data or not text:
 		return None
@@ -658,7 +658,7 @@ class Tools(Generic[Context]):
 			params: InputTextAction,
 			browser_session: BrowserSession,
 			has_sensitive_data: bool = False,
-			sensitive_data: dict[str, str | dict[str, str]] | None = None,
+			sensitive_data: dict[str, Any] | None = None,
 		):
 			# Look up the node from the selector map
 			node = await browser_session.get_element_by_index(params.index)
@@ -2044,7 +2044,7 @@ Validated Code (after quote fixing):
 		action: ActionModel,
 		browser_session: BrowserSession,
 		page_extraction_llm: BaseChatModel | None = None,
-		sensitive_data: dict[str, str | dict[str, str]] | None = None,
+		sensitive_data: dict[str, Any] | None = None,
 		available_file_paths: list[str] | None = None,
 		file_system: FileSystem | None = None,
 		extraction_schema: dict | None = None,

--- a/examples/features/sensitive_data.py
+++ b/examples/features/sensitive_data.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import sys
+from collections.abc import Callable
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
@@ -20,11 +21,14 @@ llm = ChatOpenAI(
 
 # Advanced case: domain-specific credentials with reusable data
 # Define a single credential set that can be reused
-company_credentials: dict[str, str] = {'telephone': '9123456789', 'email': 'user@example.com', 'name': 'John Doe'}
+company_credentials: dict[str, str | Callable[[], str]] = {
+	'telephone': '9123456789',
+	'email': 'user@example.com',
+	'name': 'John Doe',
+}
 
 # Map the same credentials to multiple domains for secure access control
-# Type annotation to satisfy pyright
-sensitive_data: dict[str, str | dict[str, str]] = {
+sensitive_data: dict[str, str | Callable[[], str] | dict[str, str | Callable[[], str]]] = {
 	# 'https://example.com': company_credentials,
 	# 'https://admin.example.com': company_credentials,
 	# 'https://*.example-staging.com': company_credentials,

--- a/tests/ci/test_dynamic_sensitive_data.py
+++ b/tests/ci/test_dynamic_sensitive_data.py
@@ -1,5 +1,6 @@
 """Tests for dynamic sensitive_data callable support (issue #2861)."""
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 from pydantic import BaseModel
@@ -15,10 +16,10 @@ class MockBrowserSession:
 	pass
 
 
-def _make_registry():
+def _make_registry() -> Registry[object]:
 	"""Create a minimal Registry for testing _replace_sensitive_data."""
 	registry = Registry.__new__(Registry)
-	registry.browser_session = MockBrowserSession()
+	object.__setattr__(registry, 'browser_session', MockBrowserSession())
 	return registry
 
 
@@ -26,7 +27,7 @@ def test_static_string_values_still_work():
 	"""Static string values should work unchanged."""
 	registry = _make_registry()
 	params = MockParams(text='<secret>password</secret>')
-	result = registry._replace_sensitive_data(params, {'password': 'hunter2'})
+	result = cast(MockParams, registry._replace_sensitive_data(params, {'password': 'hunter2'}))
 	assert result.text == 'hunter2'
 
 
@@ -35,17 +36,17 @@ def test_callable_values_are_resolved():
 	registry = _make_registry()
 	counter = {'n': 0}
 
-	def get_totp():
+	def get_totp() -> str:
 		counter['n'] += 1
 		return f'code-{counter["n"]}'
 
 	params = MockParams(text='<secret>totp_code</secret>')
-	result = registry._replace_sensitive_data(params, {'totp_code': get_totp})
+	result = cast(MockParams, registry._replace_sensitive_data(params, {'totp_code': get_totp}))
 	assert result.text == 'code-1'
 
 	# Call again - should get a fresh value
 	params2 = MockParams(text='<secret>totp_code</secret>')
-	result2 = registry._replace_sensitive_data(params2, {'totp_code': get_totp})
+	result2 = cast(MockParams, registry._replace_sensitive_data(params2, {'totp_code': get_totp}))
 	assert result2.text == 'code-2'
 
 
@@ -53,19 +54,19 @@ def test_domain_scoped_callable_values():
 	"""Callable values inside domain-scoped dicts should be resolved."""
 	registry = _make_registry()
 
-	def get_token():
+	def get_token() -> str:
 		return 'dynamic-token-123'
 
-	sensitive = {'https://example.com': {'api_key': get_token}}
+	sensitive: dict[str, Any] = {'https://example.com': {'api_key': get_token}}
 	params = MockParams(text='<secret>api_key</secret>')
-	result = registry._replace_sensitive_data(params, sensitive, current_url='https://example.com/page')
+	result = cast(MockParams, registry._replace_sensitive_data(params, sensitive, current_url='https://example.com/page'))
 	assert result.text == 'dynamic-token-123'
 
 
 def test_callable_not_called_for_wrong_domain():
 	"""Callable values should not be called when domain doesn't match."""
 	spy = MagicMock(return_value='secret-value')
-	sensitive = {'https://other.com': {'api_key': spy}}
+	sensitive: dict[str, Any] = {'https://other.com': {'api_key': spy}}
 	registry = _make_registry()
 	params = MockParams(text='<secret>api_key</secret>')
 	registry._replace_sensitive_data(params, sensitive, current_url='https://example.com/page')
@@ -75,19 +76,19 @@ def test_callable_not_called_for_wrong_domain():
 def test_mixed_static_and_callable():
 	"""Mix of static strings and callables should both work."""
 	registry = _make_registry()
-	sensitive = {
+	sensitive: dict[str, Any] = {
 		'username': 'alice',
 		'otp': lambda: '123456',
 	}
 	params = MockParams(text='<secret>username</secret> <secret>otp</secret>')
-	result = registry._replace_sensitive_data(params, sensitive)
+	result = cast(MockParams, registry._replace_sensitive_data(params, sensitive))
 	assert result.text == 'alice 123456'
 
 
 def test_literal_secret_callable_resolution():
 	"""When LLM forgets tags and uses literal placeholder name, callables should still resolve."""
 	registry = _make_registry()
-	sensitive = {'token': lambda: 'resolved-token'}
+	sensitive: dict[str, Any] = {'token': lambda: 'resolved-token'}
 	params = MockParams(text='token')
-	result = registry._replace_sensitive_data(params, sensitive)
+	result = cast(MockParams, registry._replace_sensitive_data(params, sensitive))
 	assert result.text == 'resolved-token'

--- a/tests/ci/test_dynamic_sensitive_data.py
+++ b/tests/ci/test_dynamic_sensitive_data.py
@@ -1,0 +1,93 @@
+"""Tests for dynamic sensitive_data callable support (issue #2861)."""
+
+from unittest.mock import MagicMock
+
+from pydantic import BaseModel
+
+from browser_use.tools.registry.service import Registry
+
+
+class MockParams(BaseModel):
+	text: str
+
+
+class MockBrowserSession:
+	pass
+
+
+def _make_registry():
+	"""Create a minimal Registry for testing _replace_sensitive_data."""
+	registry = Registry.__new__(Registry)
+	registry.browser_session = MockBrowserSession()
+	return registry
+
+
+def test_static_string_values_still_work():
+	"""Static string values should work unchanged."""
+	registry = _make_registry()
+	params = MockParams(text='<secret>password</secret>')
+	result = registry._replace_sensitive_data(params, {'password': 'hunter2'})
+	assert result.text == 'hunter2'
+
+
+def test_callable_values_are_resolved():
+	"""Callable values should be called at replacement time."""
+	registry = _make_registry()
+	counter = {'n': 0}
+
+	def get_totp():
+		counter['n'] += 1
+		return f'code-{counter["n"]}'
+
+	params = MockParams(text='<secret>totp_code</secret>')
+	result = registry._replace_sensitive_data(params, {'totp_code': get_totp})
+	assert result.text == 'code-1'
+
+	# Call again - should get a fresh value
+	params2 = MockParams(text='<secret>totp_code</secret>')
+	result2 = registry._replace_sensitive_data(params2, {'totp_code': get_totp})
+	assert result2.text == 'code-2'
+
+
+def test_domain_scoped_callable_values():
+	"""Callable values inside domain-scoped dicts should be resolved."""
+	registry = _make_registry()
+
+	def get_token():
+		return 'dynamic-token-123'
+
+	sensitive = {'https://example.com': {'api_key': get_token}}
+	params = MockParams(text='<secret>api_key</secret>')
+	result = registry._replace_sensitive_data(params, sensitive, current_url='https://example.com/page')
+	assert result.text == 'dynamic-token-123'
+
+
+def test_callable_not_called_for_wrong_domain():
+	"""Callable values should not be called when domain doesn't match."""
+	spy = MagicMock(return_value='secret-value')
+	sensitive = {'https://other.com': {'api_key': spy}}
+	registry = _make_registry()
+	params = MockParams(text='<secret>api_key</secret>')
+	registry._replace_sensitive_data(params, sensitive, current_url='https://example.com/page')
+	spy.assert_not_called()
+
+
+def test_mixed_static_and_callable():
+	"""Mix of static strings and callables should both work."""
+	registry = _make_registry()
+	sensitive = {
+		'username': 'alice',
+		'otp': lambda: '123456',
+	}
+	params = MockParams(text='<secret>username</secret> <secret>otp</secret>')
+	result = registry._replace_sensitive_data(params, sensitive)
+	assert result.text == 'alice 123456'
+
+
+def test_literal_secret_callable_resolution():
+	"""When LLM forgets tags and uses literal placeholder name, callables should still resolve."""
+	registry = _make_registry()
+	sensitive = {'token': lambda: 'resolved-token'}
+	params = MockParams(text='token')
+	result = registry._replace_sensitive_data(params, sensitive)
+	assert result.text == 'resolved-token'


### PR DESCRIPTION
## Summary

- `sensitive_data` values can now be callables (`Callable[[], str]`) in addition to static strings
- Callables are resolved lazily at replacement time, so TOTP codes and rotating tokens are always fresh when used
- All masking/filtering in message logs and history dumps also resolves callables so secrets are properly redacted
- Static string values continue to work unchanged (fully backward compatible)

```python
import pyotp
totp = pyotp.TOTP("JBSWY3DPEHPK3PXP")
agent = Agent(
    sensitive_data={
        "username": "alice",                    # static string (unchanged)
        "otp_code": totp.now,                   # callable - resolved when needed
        "api_token": lambda: get_fresh_token(),  # lambda works too
    }
)
```

Domain-scoped callables also work:
```python
sensitive_data = {
    "https://example.com": {
        "totp": totp.now,  # only resolved for matching domains
    }
}
```

**Evidence:**
- `browser_use/tools/registry/service.py:417-498` - `_replace_sensitive_data()` did string replacement with static values only
- Issue #2861: clear use case for TOTP, rotating tokens
- PR #2915 was reviewed positively by @gregpr07 ("would love to have this") but closed due to CLA timeout
- `pyotp==2.9.0` is already a project dependency

**Files changed:**
- `browser_use/agent/service.py` - updated `sensitive_data` type signature
- `browser_use/tools/registry/service.py` - resolve callables in `_replace_sensitive_data()`
- `browser_use/agent/message_manager/service.py` - resolve callables in `_filter_sensitive_data()`
- `browser_use/agent/views.py` - resolve callables in `_filter_sensitive_data_from_string()`
- `browser_use/tools/service.py` - updated type signature
- `browser_use/code_use/service.py`, `namespace.py`, `views.py` - updated type annotations

Closes #2861

## Test plan

- [x] `tests/ci/test_dynamic_sensitive_data.py` - 6 tests: static values, callable resolution, domain-scoped callables, wrong-domain skip, mixed types, literal placeholder callables
- [x] `uv run ruff check` passes
- [x] `uv run pyright` passes (0 errors)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for callables in `sensitive_data` so TOTP codes and rotating tokens are fetched at use time. Calls are guarded to avoid crashes, and saved histories now redact dynamic secrets; static strings keep working.

- **New Features**
  - Accept `Callable[[], str]` in `sensitive_data` (including domain-scoped); resolve lazily during replacement (works with `pyotp`).
  - Redaction resolves callables in logs and exports, masking dynamic secrets.

- **Bug Fixes**
  - Wrap callable resolution in try/except and skip failing providers to keep runs stable.
  - Ensure redaction in saved history by passing `sensitive_data` to `CodeAgentHistoryList.model_dump()` during `save_to_file()`.

<sup>Written for commit 34ec0ef95080a909b2b29df12f27f0ffd669de07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

