### PR TITLE
fix: resolve type checking errors when running uv run ty check

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -24,7 +24,7 @@ from asyncio import base_subprocess
 _original_del = base_subprocess.BaseSubprocessTransport.__del__
 
 
-def _patched_del(self):
+def _patched_del(self) -> None:
 	"""Patched __del__ that handles closed event loops without throwing noisy red-herring errors like RuntimeError: Event loop is closed"""
 	try:
 		# Check if the event loop is closed before calling the original

--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -1,7 +1,7 @@
 """Element class for element operations."""
 
 import asyncio
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal, Union, cast
 
 from cdp_use.client import logger
 from typing_extensions import TypedDict
@@ -388,7 +388,7 @@ class Element:
 					session_id=session_id,
 				)
 				if bounds_result.get('result', {}).get('value'):
-					bounds = bounds_result['result']['value']  # type: ignore
+					bounds = bounds_result['result']['value']
 					center_x = bounds['x'] + bounds['width'] / 2
 					center_y = bounds['y'] + bounds['height'] / 2
 					input_coordinates = {'input_x': center_x, 'input_y': center_y}
@@ -605,8 +605,10 @@ class Element:
 
 		# Get target coordinates
 		if isinstance(target, dict) and 'x' in target and 'y' in target:
-			target_x = target['x']
-			target_y = target['y']
+			# Cast to Position since we've verified it's a dict with 'x' and 'y' keys
+			position_target = cast(Position, target)
+			target_x = position_target['x']
+			target_y = position_target['y']
 		else:
 			if target_position:
 				target_box = await target.get_bounding_box()


### PR DESCRIPTION
Running `uv run ty check` reported three type errors in `browser_use/__init__.py` and `browser_use/actor/element.py`.

- Added explicit `-> None` return type to `_patched_del` to fix the invalid assignment error
- Removed unused `# type: ignore` comment in element.py
- Added `cast(Position, target)` to help the type checker understand the dict access in `drag_to`

Fixes #4383

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4383 by resolving three type-checking errors reported by `uv run ty check` in `browser_use/__init__.py` and `browser_use/actor/element.py`. Type checks now pass.

- **Bug Fixes**
  - Add `-> None` to `_patched_del` to satisfy `__del__` typing.
  - Remove unused `# type: ignore` in bounds handling.
  - Cast `target` to `Position` in `drag_to` before dict access.

<sup>Written for commit c3593f6d7b9064dd0ca0133e4d170ce405b5aa81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

