### PR TITLE
fix: add enable_signal_handler option to allow opt-out for server embeddings

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -87,6 +87,7 @@ class SignalHandler:
 		custom_exit_callback: Callable[[], None] | None = None,
 		exit_on_second_int: bool = True,
 		interruptible_task_patterns: list[str] | None = None,
+		enable_signal_handler: bool = True,
 	):
 		"""
 		Initialize the signal handler.
@@ -99,6 +100,8 @@ class SignalHandler:
 			exit_on_second_int: Whether to exit on second SIGINT (Ctrl+C)
 			interruptible_task_patterns: List of patterns to match task names that should be
 										 canceled on first Ctrl+C (default: ['step', 'multi_act', 'get_next_action'])
+			enable_signal_handler: Whether to register signal handlers (default: True).
+								   Set to False to disable signal handling for server embeddings.
 		"""
 		self.loop = loop or asyncio.get_event_loop()
 		self.pause_callback = pause_callback
@@ -107,6 +110,7 @@ class SignalHandler:
 		self.exit_on_second_int = exit_on_second_int
 		self.interruptible_task_patterns = interruptible_task_patterns or ['step', 'multi_act', 'get_next_action']
 		self.is_windows = platform.system() == 'Windows'
+		self.enable_signal_handler = enable_signal_handler
 
 		# Initialize loop state attributes
 		self._initialize_loop_state()
@@ -122,6 +126,10 @@ class SignalHandler:
 
 	def register(self) -> None:
 		"""Register signal handlers for SIGINT and SIGTERM."""
+		# Skip signal handler registration if disabled (for server embeddings)
+		if not self.enable_signal_handler:
+			return
+
 		try:
 			if self.is_windows:
 				# On Windows, use simple signal handling with immediate exit on Ctrl+C
@@ -147,6 +155,10 @@ class SignalHandler:
 
 	def unregister(self) -> None:
 		"""Unregister signal handlers and restore original handlers if possible."""
+		# Skip if signal handlers were never registered
+		if not self.enable_signal_handler:
+			return
+
 		try:
 			if self.is_windows:
 				# On Windows, just restore the original SIGINT handler


### PR DESCRIPTION
## Problem

Fixes #4385

SignalHandler in `browser_use/utils.py` always registers SIGINT/SIGTERM handlers when `Agent.run()` is called. This breaks server embeddings (uvicorn, FastAPI, etc.) that need to control their own signal lifecycle for graceful shutdown.

On Windows, it uses `os._exit(0)` which skips all cleanup including open browser sessions.

## Solution

Add a new `enable_signal_handler` parameter to SignalHandler that defaults to `True` (preserving existing behavior). When set to `False`, signal handlers are not registered.

```python
# For server embeddings that want to opt-out:
signal_handler = SignalHandler(
    enable_signal_handler=False,
    ...
)
```

## Changes

- Added `enable_signal_handler: bool = True` parameter to `SignalHandler.__init__`
- Added early return in `register()` when `enable_signal_handler=False`
- Added early return in `unregister()` when `enable_signal_handler=False`

No breaking changes - defaults preserve existing behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-out flag to `SignalHandler` so server-embedded agents don’t override SIGINT/SIGTERM. Defaults to enabled for backward compatibility. Fixes #4385.

- **New Features**
  - Added `enable_signal_handler` to `SignalHandler`.
  - When `False`, `register()`/`unregister()` are skipped to avoid conflicts with `uvicorn`/`FastAPI`.

- **Migration**
  - For server embeddings, use `SignalHandler(enable_signal_handler=False)` to let the host manage signals.

<sup>Written for commit 666a915e304d384fdc05f82179687e0fd52117b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

