### PR TITLE
Fix click() using stale coordinates and add missing scroll in hover()

### DIFF
--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -99,6 +99,15 @@ class Element:
 		"""Click the element using the advanced watchdog implementation."""
 
 		try:
+			# Scroll element into view before getting coordinates
+			try:
+				await self._client.send.DOM.scrollIntoViewIfNeeded(
+					params={'backendNodeId': self._backend_node_id}, session_id=self._session_id
+				)
+				await asyncio.sleep(0.05)  # Wait for scroll to complete
+			except Exception:
+				pass
+
 			# Get viewport dimensions for visibility checks
 			layout_metrics = await self._client.send.Page.getLayoutMetrics(session_id=self._session_id)
 			viewport_width = layout_metrics['layoutViewport']['clientWidth']
@@ -255,15 +264,6 @@ class Element:
 			# Ensure click point is within viewport bounds
 			center_x = max(0, min(viewport_width - 1, center_x))
 			center_y = max(0, min(viewport_height - 1, center_y))
-
-			# Scroll element into view
-			try:
-				await self._client.send.DOM.scrollIntoViewIfNeeded(
-					params={'backendNodeId': self._backend_node_id}, session_id=self._session_id
-				)
-				await asyncio.sleep(0.05)  # Wait for scroll to complete
-			except Exception:
-				pass
 
 			# Calculate modifier bitmask for CDP
 			modifier_value = 0
@@ -508,6 +508,15 @@ class Element:
 
 	async def hover(self) -> None:
 		"""Hover over the element."""
+		# Scroll element into view before getting coordinates
+		try:
+			await self._client.send.DOM.scrollIntoViewIfNeeded(
+				params={'backendNodeId': self._backend_node_id}, session_id=self._session_id
+			)
+			await asyncio.sleep(0.05)  # Wait for scroll to complete
+		except Exception:
+			pass
+
 		box = await self.get_bounding_box()
 		if not box:
 			raise RuntimeError('Element is not visible or has no bounding box')


### PR DESCRIPTION
## Summary

`click()` fetches element coordinates **before** calling `scrollIntoViewIfNeeded()`. When the target element is outside the viewport, the scroll changes its position but the click still uses the pre-scroll coordinates — clicking the wrong location.

`hover()` is missing `scrollIntoViewIfNeeded()` entirely, unlike `click()` and `fill()`, so hovering over an off-screen element uses incorrect coordinates.

## Changes

- **`click()`**: Move `scrollIntoViewIfNeeded()` before coordinate calculation, matching the order used by `fill()`
- **`hover()`**: Add `scrollIntoViewIfNeeded()` before `get_bounding_box()`, matching `click()` and `fill()`

### Before (`click()`)
```
1. Get element coordinates (quads/box model/getBoundingClientRect)
2. scrollIntoViewIfNeeded  ← scroll may change element position
3. Click at old coordinates ← wrong location
```

### After (`click()`)
```
1. scrollIntoViewIfNeeded  ← scroll first
2. Get element coordinates  ← coordinates are now correct
3. Click at correct coordinates
```

### Reference: `fill()` (already correct)
```python
# Scroll element into view
await cdp_client.send.DOM.scrollIntoViewIfNeeded(...)
await asyncio.sleep(0.01)
# ...
# Get element coordinates for focus
bounds_result = await cdp_client.send.Runtime.callFunctionOn(...)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scroll before measuring element coordinates in `click()` and `hover()` to prevent wrong positions when targets are off-screen. Aligns behavior with `fill()` for consistent interactions.

- **Bug Fixes**
  - `click()`: Call `scrollIntoViewIfNeeded()` before reading geometry to avoid stale coordinates.
  - `hover()`: Add `scrollIntoViewIfNeeded()` before `get_bounding_box()` so hover targets the correct spot.
  - Wait 50ms after scroll to let layout settle.

<sup>Written for commit b25d2cd5dd733e5dad4ac93edb8a109a97eef3d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

