### PR TITLE
Fix type annotations for _patched_del to resolve ty check errors

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -20,11 +20,12 @@ else:
 
 # Monkeypatch BaseSubprocessTransport.__del__ to handle closed event loops gracefully
 from asyncio import base_subprocess
+from typing import Optional
 
 _original_del = base_subprocess.BaseSubprocessTransport.__del__
 
 
-def _patched_del(self):
+def _patched_del(self: base_subprocess.BaseSubprocessTransport) -> None:
 	"""Patched __del__ that handles closed event loops without throwing noisy red-herring errors like RuntimeError: Event loop is closed"""
 	try:
 		# Check if the event loop is closed before calling the original


### PR DESCRIPTION
## Summary
Add proper type annotations to _patched_del function to fix invalid-assignment error when running `uv run ty check`.

## Bug Description
```
error[invalid-assignment]: Object of type `def _patched_del(self) -> Unknown` is not assignable to attribute `__del__` of type `def __del__(self) -> None`
  --> browser_use/__init__.py:43:1
```

## Fix
Added:
- Explicit type hint for self parameter: `self: base_subprocess.BaseSubprocessTransport`
- Return type annotation: `-> None`

This satisfies the type checker and maintains the monkeypatch functionality.

## Related Issue
Fixes #4383

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix type annotations for `_patched_del` to match `asyncio.base_subprocess.BaseSubprocessTransport.__del__`, resolving the invalid-assignment error in `uv run ty check` while preserving the monkeypatch behavior (fixes #4383).

<sup>Written for commit 3f778edaa2c44f70425b503b2487251dba9e2caa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

