### PR TITLE
fix: add type annotations to _patched_del to resolve type check errors

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -24,7 +24,7 @@ from asyncio import base_subprocess
 _original_del = base_subprocess.BaseSubprocessTransport.__del__
 
 
-def _patched_del(self):
+def _patched_del(self: base_subprocess.BaseSubprocessTransport) -> None:
 	"""Patched __del__ that handles closed event loops without throwing noisy red-herring errors like RuntimeError: Event loop is closed"""
 	try:
 		# Check if the event loop is closed before calling the original


### PR DESCRIPTION
## Summary
Add proper type annotations to _patched_del function to fix invalid-assignment error when running `uv run ty check`.

## Bug Description
```
error[invalid-assignment]: Object of type `def _patched_del(self) -> Unknown` is not assignable to attribute `__del__` of type `def __del__(self) -> None`
  --> browser_use/__init__.py:43:1
```

## Fix
- Added explicit type hint for self parameter: `self: base_subprocess.BaseSubprocessTransport`
- Added return type annotation: `-> None`

This satisfies the type checker and resolves the error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit type annotations to `_patched_del` to match `base_subprocess.BaseSubprocessTransport.__del__`, fixing the invalid-assignment error seen in `uv run ty check`.

- **Bug Fixes**
  - Set `self: base_subprocess.BaseSubprocessTransport` and `-> None` to align with `__del__` signature.

<sup>Written for commit e78e1a1e791dd82f1b6935311e40c61ad8efe862. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

