### PR TITLE
fix(tools): fix wait action off-by-one and use safe task creation for coordinate click highlight

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -485,12 +485,7 @@ class Tools(Generic[Context]):
 
 		@self.registry.action('Wait for x seconds.')
 		async def wait(seconds: int = 3):
-			# Cap wait time at maximum 30 seconds
-			# Reduce the wait time by 3 seconds to account for the llm call which takes at least 3 seconds
-			# So if the model decides to wait for 5 seconds, the llm call took at least 3 seconds, so we only need to wait for 2 seconds
-			# Note by Mert: the above doesnt make sense because we do the LLM call right after this or this could be followed by another action after which we would like to wait
-			# so I revert this.
-			actual_seconds = min(max(seconds - 1, 0), 30)
+			actual_seconds = min(max(seconds, 0), 30)
 			memory = f'Waited for {seconds} seconds'
 			logger.info(f'🕒 waited for {seconds} second{"" if seconds == 1 else "s"}')
 			await asyncio.sleep(actual_seconds)
@@ -551,7 +546,9 @@ class Tools(Generic[Context]):
 				tabs_before = {t.target_id for t in await browser_session.get_tabs()}
 
 				# Highlight the coordinate being clicked (truly non-blocking)
-				asyncio.create_task(browser_session.highlight_coordinate_click(actual_x, actual_y))
+				create_task_with_error_handling(
+					browser_session.highlight_coordinate_click(actual_x, actual_y), name='highlight_coordinate_click', suppress_exceptions=True
+				)
 
 				# Dispatch ClickCoordinateEvent - handler will check for safety and click
 				event = browser_session.event_bus.dispatch(


### PR DESCRIPTION
## Summary
- The `wait` action subtracted 1 from the requested seconds despite a comment from a maintainer explicitly saying "I revert this". When `seconds=1`, the agent would not wait at all (`actual_seconds=0`) while reporting "Waited for 1 seconds" to the LLM, creating an incorrect feedback loop.
- The coordinate click highlight used raw `asyncio.create_task()` while every other fire-and-forget task in the file uses `create_task_with_error_handling()`. Unhandled exceptions in the raw task would be silently swallowed with only a Python runtime warning.

## Changes
- Removed the `-1` from wait duration calculation: `min(max(seconds, 0), 30)` instead of `min(max(seconds - 1, 0), 30)`
- Replaced `asyncio.create_task(...)` with `create_task_with_error_handling(...)` for coordinate click highlight, matching every other usage in the file

## Test plan
- Verify `wait(seconds=1)` actually sleeps for 1 second (not 0)
- Verify `wait(seconds=3)` sleeps for 3 seconds (not 2)
- Verify coordinate click highlighting exceptions are logged properly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an off-by-one in the wait action so requested seconds are respected. Uses safe task creation for coordinate click highlight to surface errors.

- **Bug Fixes**
  - Wait action now sleeps exactly the requested time, capped at 0–30s (`min(max(seconds, 0), 30)`); previously `seconds=1` slept 0s while reporting 1s.
  - Replaced `asyncio.create_task(...)` with `create_task_with_error_handling(..., name='highlight_coordinate_click', suppress_exceptions=True)` to properly log highlight task errors.

<sup>Written for commit 033f7dc5eae1e8092b75b27255365d00a28dac5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

