### PR TITLE
fix(llm): fix client parameter errors in OpenRouter, Anthropic, and Google providers

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -71,10 +71,9 @@ class ChatAnthropic(BaseChatModel):
 			'http_client': self.http_client,
 		}
 
-		# Create client_params dict with non-None values and non-NotGiven values
 		client_params = {}
 		for k, v in base_params.items():
-			if v is not None and v is not NotGiven():
+			if v is not None and not isinstance(v, NotGiven):
 				client_params[k] = v
 
 		return client_params

--- a/browser_use/llm/google/serializer.py
+++ b/browser_use/llm/google/serializer.py
@@ -98,19 +98,15 @@ class GoogleMessageSerializer:
 						elif part.type == 'refusal':
 							message_parts.append(Part.from_text(text=f'[Refusal] {part.refusal}'))
 						elif part.type == 'image_url':
-							# Handle images
 							url = part.image_url.url
-
-							# Format: data:image/jpeg;base64,<data>
-							header, data = url.split(',', 1)
-							# Decode base64 to bytes
-							image_bytes = base64.b64decode(data)
-
-							# Use the media_type from ImageURL, which correctly identifies the image format
 							mime_type = part.image_url.media_type
 
-							# Add image part
-							image_part = Part.from_bytes(data=image_bytes, mime_type=mime_type)
+							if url.startswith('data:'):
+								_header, data = url.split(',', 1)
+								image_bytes = base64.b64decode(data)
+								image_part = Part.from_bytes(data=image_bytes, mime_type=mime_type)
+							else:
+								image_part = Part.from_uri(file_uri=url, mime_type=mime_type)
 
 							message_parts.append(image_part)
 

--- a/browser_use/llm/openrouter/chat.py
+++ b/browser_use/llm/openrouter/chat.py
@@ -66,8 +66,6 @@ class ChatOpenRouter(BaseChatModel):
 			'default_headers': self.default_headers,
 			'default_query': self.default_query,
 			'_strict_response_validation': self._strict_response_validation,
-			'top_p': self.top_p,
-			'seed': self.seed,
 		}
 
 		# Create client_params dict with non-None values


### PR DESCRIPTION
## Summary
Three independent bugs across LLM provider implementations:

1. **OpenRouter**: `top_p` and `seed` were included in `_get_client_params()` which feeds into `AsyncOpenAI(**client_params)`. These are per-request parameters for `chat.completions.create()`, not valid `AsyncOpenAI` constructor arguments. When set to non-None values, `get_client()` would raise `TypeError`. (They are correctly passed in `_call_api()` already.)

2. **Anthropic**: `NotGiven` filtering used identity check (`v is not NotGiven()`) which creates a new `NotGiven` instance each evaluation. Since `is` checks object identity, this comparison was always `True` — `NotGiven` values were never filtered out. Changed to `isinstance(v, NotGiven)`.

3. **Google serializer**: Image URL handling unconditionally split on comma assuming base64 data URL format. Regular HTTP image URLs (e.g., `https://example.com/image.png`) have no comma and would raise `ValueError: not enough values to unpack`. Added data URL detection with `url.startswith('data:')`, falling back to `Part.from_uri()` for regular URLs.

## Changes
- Removed `top_p` and `seed` from OpenRouter's `_get_client_params()` (they remain in `_call_api()`)
- Changed Anthropic's NotGiven filter from `is not NotGiven()` to `not isinstance(v, NotGiven)`
- Added URL format detection in Google serializer before attempting base64 decode

## Test plan
- Verify OpenRouter client creation succeeds when `top_p` or `seed` are set
- Verify Anthropic client creation filters out `NotGiven` default values
- Verify Google serializer handles both `data:image/...;base64,...` URLs and regular `https://...` image URLs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parameter handling across the OpenRouter, Anthropic, and Google LLM providers to prevent client init errors and image URL parsing crashes.

- **Bug Fixes**
  - OpenRouter: removed `top_p` and `seed` from client params (they’re per-request) to avoid `TypeError` in `AsyncOpenAI(**client_params)`.
  - Anthropic: correctly drop `NotGiven` defaults using `isinstance(v, NotGiven)`.
  - Google: detect `data:` URLs before base64 decode; use `Part.from_uri` for regular HTTP image URLs to avoid unpack errors.

<sup>Written for commit 700ea63bf778d63ebcac1df7ac48738aa4a9c74e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

