### PR TITLE
fix(dom): prevent in-place mutation of node bounds and fix disabled attribute check

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -269,8 +269,13 @@ class DomService:
 		except (ValueError, TypeError):
 			pass
 
-		# Start with the element's local bounds (in its own frame's coordinate system)
-		current_bounds = node.snapshot_node.bounds
+		# Copy bounds to avoid mutating the original node data during coordinate transforms
+		current_bounds = DOMRect(
+			x=node.snapshot_node.bounds.x,
+			y=node.snapshot_node.bounds.y,
+			width=node.snapshot_node.bounds.width,
+			height=node.snapshot_node.bounds.height,
+		)
 
 		if not current_bounds:
 			return False  # If there are no bounds, the element is not visible
@@ -1097,7 +1102,7 @@ class DomService:
 
 			# Check if it's disabled
 			is_disabled = (
-				node.attributes.get('disabled') == 'true'
+				'disabled' in node.attributes
 				or node.attributes.get('aria-disabled') == 'true'
 				or 'disabled' in class_name
 			)


### PR DESCRIPTION
## Summary
- `is_element_visible_according_to_all_parents()` took a direct reference to `node.snapshot_node.bounds` and mutated `x`/`y` in-place during iframe and scroll coordinate transforms. After the method returned, the node's original bounds were permanently corrupted. This affected downstream paint-order filtering, hidden element detection, and any subsequent bounds reads on the same node.
- `detect_pagination_buttons()` checked `node.attributes.get('disabled') == 'true'`, but the HTML `disabled` attribute is a boolean attribute — CDP reports it as `''` (empty string) or `'disabled'`, never `'true'`. This meant the disabled check never matched standard HTML disabled elements, so disabled pagination buttons could be incorrectly reported as active.

## Changes
- Created a `DOMRect` copy of bounds before mutation to preserve original node data
- Changed `disabled` check from `== 'true'` to `'disabled' in node.attributes` to match HTML boolean attribute semantics (the `aria-disabled` check was already correct)

## Test plan
- Verify that after calling `is_element_visible_according_to_all_parents()`, `node.snapshot_node.bounds` retains its original values
- Verify that elements with `disabled` attribute (without value or with value `"disabled"`) are correctly identified as disabled in pagination detection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop mutating node bounds during visibility checks and fix disabled attribute detection for pagination buttons. This prevents corrupted geometry and correctly filters disabled controls.

- **Bug Fixes**
  - Copy bounds into a new `DOMRect` before iframe/scroll transforms in `is_element_visible_according_to_all_parents()` to avoid mutating `node.snapshot_node.bounds`. Restores reliable paint-order and visibility checks.
  - Treat HTML `disabled` as a boolean attribute in `detect_pagination_buttons()`: check for `'disabled'` in `node.attributes` (keep `aria-disabled='true'` and class check). Previously compared to `'true'`, which missed real disabled elements.

<sup>Written for commit 76ca3cfd39a1aaa18392fa54e4132e0058ab86f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

