### PR TITLE
fix(agent): add missing guard in final_result() and serialize usage in model_dump()

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -685,6 +685,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 		"""Custom serialization that properly uses AgentHistory's model_dump"""
 		return {
 			'history': [h.model_dump(**kwargs) for h in self.history],
+			'usage': self.usage.model_dump(**kwargs) if self.usage else None,
 		}
 
 	@classmethod
@@ -727,7 +728,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def final_result(self) -> None | str:
 		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
+		if self.history and len(self.history[-1].result) > 0 and self.history[-1].result[-1].extracted_content:
 			return self.history[-1].result[-1].extracted_content
 		return None
 


### PR DESCRIPTION
## Summary
- `final_result()` accessed `result[-1]` without checking `len(result) > 0`, unlike sibling methods `is_done()`, `is_successful()`, `judgement()`, and `is_judged()` which all guard against empty result lists. This would raise `IndexError` if an `AgentHistory` had an empty result list.
- `model_dump()` only serialized the `history` field, silently dropping the `usage` (`UsageSummary`) field. This caused token usage/cost data to be permanently lost when saving history to disk via `save_to_file()`.

## Changes
- Added `len(self.history[-1].result) > 0` guard to `final_result()` consistent with all sibling methods
- Added `usage` field serialization to `model_dump()` so `save_to_file()` / `load_from_file()` roundtrip preserves token cost data

## Test plan
- Verify `final_result()` returns `None` instead of raising `IndexError` when `result` list is empty
- Verify `model_dump()` output includes `usage` key
- Verify `save_to_file()` + `load_from_file()` preserves usage summary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `final_result()` when the last step has no results and ensures `model_dump()` includes `usage` so token/cost data persists across save/load.

- **Bug Fixes**
  - Added empty-result guard in `final_result()` to return `None` instead of raising `IndexError`.
  - Included `usage` (`UsageSummary` or `None`) in `model_dump()` to preserve data via `save_to_file()` / `load_from_file()`.

<sup>Written for commit c1e6fd12c31e97ec05af586146127f05760e9b1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

