### PR TITLE
fix: prevent KeyError in AgentHistoryList.load_from_dict

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1610,7 +1610,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		judgement = await self._judge_trace()
 
 		# Attach judgement to last action result
-		if self.history.history[-1].result[-1].is_done:
+		if (
+			self.history.history
+			and self.history.history[-1].result
+			and len(self.history.history[-1].result) > 0
+			and self.history.history[-1].result[-1].is_done
+		):
 			last_result = self.history.history[-1].result[-1]
 			last_result.judgement = judgement
 

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -690,7 +690,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 	@classmethod
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
 		# loop through history and validate output_model actions to enrich with custom actions
-		for h in data['history']:
+		for h in data.get('history', []):
 			if h['model_output']:
 				if isinstance(h['model_output'], dict):
 					h['model_output'] = output_model.model_validate(h['model_output'])

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -691,13 +691,18 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
 		# loop through history and validate output_model actions to enrich with custom actions
 		for h in data.get('history', []):
-			if h['model_output']:
-				if isinstance(h['model_output'], dict):
-					h['model_output'] = output_model.model_validate(h['model_output'])
+			# Safely check if model_output exists and is truthy
+			model_output = h.get('model_output')
+			if model_output:
+				if isinstance(model_output, dict):
+					h['model_output'] = output_model.model_validate(model_output)
 				else:
 					h['model_output'] = None
-			if 'interacted_element' not in h['state']:
-				h['state']['interacted_element'] = None
+			# Safely check if state exists and interacted_element is missing
+			state = h.get('state', {})
+			if 'interacted_element' not in state:
+				state['interacted_element'] = None
+				h['state'] = state
 
 		history = cls.model_validate(data)
 		return history

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -727,8 +727,10 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def final_result(self) -> None | str:
 		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
-			return self.history[-1].result[-1].extracted_content
+		if self.history and len(self.history[-1].result) > 0:
+			last_result = self.history[-1].result[-1]
+			if last_result.extracted_content:
+				return last_result.extracted_content
 		return None
 
 	def is_done(self) -> bool:

--- a/browser_use/code_use/views.py
+++ b/browser_use/code_use/views.py
@@ -216,7 +216,7 @@ class CodeAgentHistoryList:
 
 	def final_result(self) -> None | str:
 		"""Final result from history."""
-		if self._complete_history and self._complete_history[-1].result:
+		if self._complete_history and len(self._complete_history[-1].result) > 0:
 			return self._complete_history[-1].result[-1].extracted_content
 		return None
 

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -160,12 +160,13 @@ class ChatAnthropic(BaseChatModel):
 				usage = self._get_usage(response)
 
 				# Extract text from the first content block
-				first_content = response.content[0]
-				if isinstance(first_content, TextBlock):
-					response_text = first_content.text
+				if not response.content:
+					response_text = ""
+				elif isinstance(response.content[0], TextBlock):
+					response_text = response.content[0].text
 				else:
 					# If it's not a text block, convert to string
-					response_text = str(first_content)
+					response_text = str(response.content[0])
 
 				return ChatInvokeCompletion(
 					completion=response_text,

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -172,12 +172,13 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 				usage = self._get_usage(response)
 
 				# Extract text from the first content block
-				first_content = response.content[0]
-				if isinstance(first_content, TextBlock):
-					response_text = first_content.text
+				if not response.content:
+					response_text = ""
+				elif isinstance(response.content[0], TextBlock):
+					response_text = response.content[0].text
 				else:
 					# If it's not a text block, convert to string
-					response_text = str(first_content)
+					response_text = str(response.content[0])
 
 				return ChatInvokeCompletion(
 					completion=response_text,

--- a/browser_use/llm/cerebras/chat.py
+++ b/browser_use/llm/cerebras/chat.py
@@ -120,6 +120,8 @@ class ChatCerebras(BaseChatModel):
 					messages=cerebras_messages,  # type: ignore
 					**common,
 				)
+				if not resp.choices:
+					raise ModelProviderError('Cerebras returned no choices', model=self.name)
 				usage = self._get_usage(resp)
 				return ChatInvokeCompletion(
 					completion=resp.choices[0].message.content or '',
@@ -166,6 +168,8 @@ Your response must be valid JSON only, no other text.
 					messages=cerebras_messages,  # type: ignore
 					**common,
 				)
+				if not resp.choices:
+					raise ModelProviderError('Cerebras returned no choices', model=self.name)
 				content = resp.choices[0].message.content
 				if not content:
 					raise ModelProviderError('Empty JSON content in Cerebras response', model=self.name)

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -123,6 +123,14 @@ class ChatDeepSeek(BaseChatModel):
 					messages=ds_messages,  # type: ignore
 					**common,
 				)
+
+				if not resp.choices:
+					raise ModelProviderError(
+						message='No choices in model response',
+						status_code=500,
+						model=self.name,
+					)
+
 				return ChatInvokeCompletion(
 					completion=resp.choices[0].message.content or '',
 					usage=None,
@@ -161,6 +169,14 @@ class ChatDeepSeek(BaseChatModel):
 					tool_choice=tool_choice,  # type: ignore
 					**common,
 				)
+
+				if not resp.choices:
+					raise ModelProviderError(
+						message='No choices in model response',
+						status_code=500,
+						model=self.name,
+					)
+
 				msg = resp.choices[0].message
 				if not msg.tool_calls:
 					raise ValueError('Expected tool_calls in response but got none')
@@ -197,6 +213,14 @@ class ChatDeepSeek(BaseChatModel):
 					response_format={'type': 'json_object'},
 					**common,
 				)
+
+				if not resp.choices:
+					raise ModelProviderError(
+						message='No choices in model response',
+						status_code=500,
+						model=self.name,
+					)
+
 				content = resp.choices[0].message.content
 				if not content:
 					raise ModelProviderError('Empty JSON content in DeepSeek response', model=self.name)

--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -159,6 +159,14 @@ class ChatGroq(BaseChatModel):
 			seed=self.seed,
 		)
 		usage = self._get_usage(chat_completion)
+
+		if not chat_completion.choices:
+			raise ModelProviderError(
+				message='No choices in model response',
+				status_code=500,
+				model=self.name,
+			)
+
 		return ChatInvokeCompletion(
 			completion=chat_completion.choices[0].message.content or '',
 			usage=usage,
@@ -172,6 +180,13 @@ class ChatGroq(BaseChatModel):
 			response = await self._invoke_with_tool_calling(groq_messages, output_format, schema)
 		else:
 			response = await self._invoke_with_json_schema(groq_messages, output_format, schema)
+
+		if not response.choices:
+			raise ModelProviderError(
+				message='No choices in model response',
+				status_code=500,
+				model=self.name,
+			)
 
 		if not response.choices[0].message.content:
 			raise ModelProviderError(

--- a/browser_use/llm/openrouter/chat.py
+++ b/browser_use/llm/openrouter/chat.py
@@ -154,6 +154,13 @@ class ChatOpenRouter(BaseChatModel):
 					**(self.extra_body or {}),
 				)
 
+				if not response.choices:
+					raise ModelProviderError(
+						message='No choices in model response',
+						status_code=500,
+						model=self.name,
+					)
+
 				usage = self._get_usage(response)
 				return ChatInvokeCompletion(
 					completion=response.choices[0].message.content or '',
@@ -184,6 +191,13 @@ class ChatOpenRouter(BaseChatModel):
 					extra_headers=extra_headers,
 					**(self.extra_body or {}),
 				)
+
+				if not response.choices:
+					raise ModelProviderError(
+						message='No choices in model response',
+						status_code=500,
+						model=self.name,
+					)
 
 				if response.choices[0].message.content is None:
 					raise ModelProviderError(

--- a/examples/integrations/discord/discord_api.py
+++ b/examples/integrations/discord/discord_api.py
@@ -112,7 +112,7 @@ class DiscordBot(commands.Bot):
 
 			agent_message = None
 			if result.is_done():
-				agent_message = result.history[-1].result[0].extracted_content
+				agent_message = result.final_result()
 
 			if agent_message is None:
 				agent_message = 'Oops! Something went wrong while running Browser-Use.'

--- a/examples/integrations/slack/slack_api.py
+++ b/examples/integrations/slack/slack_api.py
@@ -88,7 +88,7 @@ class SlackBot:
 
 			agent_message = None
 			if result.is_done():
-				agent_message = result.history[-1].result[0].extracted_content
+				agent_message = result.final_result()
 
 			if agent_message is None:
 				agent_message = 'Oops! Something went wrong while running Browser-Use.'


### PR DESCRIPTION
## Description
Fixed a potential KeyError when loading agent history from dict/file.

## Problem
The original code directly accessed `h['model_output']` and `h['state']` without checking if these keys exist, which could cause KeyError when the history data is incomplete or malformed.

## Solution
- Use `h.get()` instead of direct dict access for `model_output`
- Use `h.get()` with default empty dict for `state`
- Initialize `interacted_element` in state only when state exists

## Testing
- Verified Python syntax is valid
- Code follows existing patterns in the codebase

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes when loading agent history and handling LLM responses by adding safe dict access and bounds checks across the agent and provider modules. History loading now tolerates missing keys, and providers handle empty responses consistently.

- **Bug Fixes**
  - History loading: `AgentHistoryList.load_from_dict` uses `data.get('history', [])`, `h.get('model_output')`, default `state`, and sets `interacted_element` when missing.
  - Result access: Guard `result[-1]` reads with length checks in agent/service and views; `final_result()` returns `None` when absent.
  - Integrations: Discord/Slack examples now use `result.final_result()` for safe access.
  - LLM providers: Validate empty `content`/`choices` and raise `ModelProviderError` (or return empty string) in `anthropic`, `aws` (Anthropic), `cerebras`, `deepseek`, `groq`, and `openrouter`.

<sup>Written for commit 0338fabaaed25db7a61db6b5bdeac2445a617b5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

