### PR TITLE
fix: allow opting out of SignalHandler to prevent host app conflicts

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -201,6 +201,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		planning_exploration_limit: int = 5,
 		loop_detection_window: int = 20,
 		loop_detection_enabled: bool = True,
+		enable_signal_handling: bool = True,
 		llm_screenshot_size: tuple[int, int] | None = None,
 		message_compaction: MessageCompactionSettings | bool | None = True,
 		max_clickable_elements_length: int = 40000,
@@ -410,6 +411,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			loop_detection_enabled=loop_detection_enabled,
 			message_compaction=message_compaction,
 			max_clickable_elements_length=max_clickable_elements_length,
+			enable_signal_handling=enable_signal_handling,
 		)
 
 		# Token cost service
@@ -2476,25 +2478,27 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self._force_exit_telemetry_logged = False  # ADDED: Flag for custom telemetry on force exit
 		should_delay_close = False
 
-		# Set up the  signal handler with callbacks specific to this agent
-		from browser_use.utils import SignalHandler
+		# Set up the signal handler with callbacks specific to this agent (if enabled)
+		signal_handler = None
+		if self.settings.enable_signal_handling:
+			from browser_use.utils import SignalHandler
 
-		# Define the custom exit callback function for second CTRL+C
-		def on_force_exit_log_telemetry():
-			self._log_agent_event(max_steps=max_steps, agent_run_error='SIGINT: Cancelled by user')
-			# NEW: Call the flush method on the telemetry instance
-			if hasattr(self, 'telemetry') and self.telemetry:
-				self.telemetry.flush()
-			self._force_exit_telemetry_logged = True  # Set the flag
+			# Define the custom exit callback function for second CTRL+C
+			def on_force_exit_log_telemetry():
+				self._log_agent_event(max_steps=max_steps, agent_run_error='SIGINT: Cancelled by user')
+				# NEW: Call the flush method on the telemetry instance
+				if hasattr(self, 'telemetry') and self.telemetry:
+					self.telemetry.flush()
+				self._force_exit_telemetry_logged = True  # Set the flag
 
-		signal_handler = SignalHandler(
-			loop=loop,
-			pause_callback=self.pause,
-			resume_callback=self.resume,
-			custom_exit_callback=on_force_exit_log_telemetry,  # Pass the new telemetrycallback
-			exit_on_second_int=True,
-		)
-		signal_handler.register()
+			signal_handler = SignalHandler(
+				loop=loop,
+				pause_callback=self.pause,
+				resume_callback=self.resume,
+				custom_exit_callback=on_force_exit_log_telemetry,  # Pass the new telemetrycallback
+				exit_on_second_int=True,
+			)
+			signal_handler.register()
 
 		try:
 			await self._log_agent_run()
@@ -2629,8 +2633,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			# Log token usage summary
 			await self.token_cost_service.log_usage_summary()
 
-			# Unregister signal handlers before cleanup
-			signal_handler.unregister()
+			# Unregister signal handlers before cleanup (if they were registered)
+			if signal_handler:
+				signal_handler.unregister()
 
 			if not self._force_exit_telemetry_logged:  # MODIFIED: Check the flag
 				try:

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -90,6 +90,9 @@ class AgentSettings(BaseModel):
 	loop_detection_enabled: bool = True  # Whether to enable loop detection nudges
 	max_clickable_elements_length: int = 40000  # Max characters for clickable elements in prompt
 
+	# Signal handling settings
+	enable_signal_handling: bool = True  # If False, disables SIGINT/SIGTERM signal handlers (for server embeddings)
+
 
 class PageFingerprint(BaseModel):
 	"""Lightweight fingerprint of the browser page state."""


### PR DESCRIPTION
Fixes #4385

## Problem
The SignalHandler class in browser_use/utils.py automatically registers SIGINT/SIGTERM signal handlers when Agent.run() executes. This overrides any existing signal handlers set up by the host application, making graceful shutdown impossible for server embeddings (uvicorn, FastAPI, etc.).

## Solution
Add an `enable_signal_handling` parameter to the Agent class that allows users to opt out of signal handler registration:

- Added `enable_signal_handling: bool = True` to `AgentSettings` (default True for backward compatibility)
- Added `enable_signal_handling` parameter to `Agent.__init__`
- Modified `Agent.run()` to only create and register SignalHandler when `enable_signal_handling=True`

## Usage
For server embeddings that need to control their own signal lifecycle:

```python
agent = Agent(
    task="...",
    enable_signal_handling=False,  # Disable signal handling
)
```

## Changes
- `browser_use/agent/views.py`: Added `enable_signal_handling` field to `AgentSettings`
- `browser_use/agent/service.py`: 
  - Added `enable_signal_handling` parameter to `Agent.__init__`
  - Modified `run()` to conditionally register/unregister signal handlers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-out for internal SIGINT/SIGTERM handling so host apps can control signals. Prevents `Agent.run()` from overriding existing handlers in servers like `uvicorn` and `FastAPI`.

- **Bug Fixes**
  - Added `enable_signal_handling` to `AgentSettings` and `Agent.__init__` (default True).
  - `Agent.run()` only registers `SignalHandler` when enabled; unregister is guarded.
  - For server embeddings, set `enable_signal_handling=False` to let the host manage shutdown.

<sup>Written for commit 62970bcd9a8980639ed3f756397a1afaa65842a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

