### PR TITLE
fix(aws): ChatAWSBedrock structured output for non-Anthropic models

### DIFF
--- a/browser_use/code_use/notebook_export.py
+++ b/browser_use/code_use/notebook_export.py
@@ -192,6 +192,16 @@ def session_to_python_script(agent: CodeAgent) -> str:
 	        print(script)
 		```
 	"""
+	# Check if agent is a CodeAgent instance
+	from browser_use.code_use.service import CodeAgent as CodeAgentClass
+
+	if not isinstance(agent, CodeAgentClass):
+		raise TypeError(
+			f"session_to_python_script() requires a CodeAgent instance, got {type(agent).__name__}. "
+			"Use 'from browser_use import CodeAgent' to create a code execution agent, "
+			"not the regular 'Agent' class."
+		)
+
 	lines = []
 
 	lines.append('# Generated from browser-use code-use session\n')

--- a/browser_use/llm/aws/chat_bedrock.py
+++ b/browser_use/llm/aws/chat_bedrock.py
@@ -114,29 +114,27 @@ class ChatAWSBedrock(BaseChatModel):
 			config['seed'] = self.seed
 		return config
 
+	def _is_anthropic_model(self) -> bool:
+		"""Check if the model is an Anthropic model (for tool choice handling)."""
+		model_lower = self.model.lower()
+		return 'anthropic' in model_lower or 'claude' in model_lower or model_lower.startswith('apac.anthropic')
+
 	def _format_tools_for_request(self, output_format: type[BaseModel]) -> list[dict[str, Any]]:
 		"""Format a Pydantic model as a tool for structured output."""
+		# Use the full schema instead of rebuilding it manually
+		# This preserves items (for list fields), $defs (for nested models), and anyOf (for Optional fields)
 		schema = output_format.model_json_schema()
 
-		# Convert Pydantic schema to Bedrock tool format
-		properties = {}
-		required = []
-
-		for prop_name, prop_info in schema.get('properties', {}).items():
-			properties[prop_name] = {
-				'type': prop_info.get('type', 'string'),
-				'description': prop_info.get('description', ''),
-			}
-
-		# Add required fields
-		required = schema.get('required', [])
+		# Remove title from schema if present (Bedrock doesn't like it in parameters)
+		if 'title' in schema:
+			del schema['title']
 
 		return [
 			{
 				'toolSpec': {
 					'name': f'extract_{output_format.__name__.lower()}',
 					'description': f'Extract information in the format of {output_format.__name__}',
-					'inputSchema': {'json': {'type': 'object', 'properties': properties, 'required': required}},
+					'inputSchema': {'json': schema},
 				}
 			}
 		]
@@ -198,9 +196,13 @@ class ChatAWSBedrock(BaseChatModel):
 				body['inferenceConfig'] = inference_config
 
 			# Handle structured output via tool calling
+			# Only add toolConfig for Anthropic models (toolChoice is Anthropic-specific)
+			# Non-Anthropic models may not support forced tool use but can still return JSON
 			if output_format is not None:
 				tools = self._format_tools_for_request(output_format)
-				body['toolConfig'] = {'tools': tools}
+				# Only add toolConfig for Anthropic models - others may not support toolChoice
+				if self._is_anthropic_model():
+					body['toolConfig'] = {'tools': tools}
 
 			# Add any additional request parameters
 			if self.request_params:
@@ -260,6 +262,34 @@ class ChatAWSBedrock(BaseChatModel):
 									message=f'Failed to validate structured output: {str(e)}',
 									model=self.name,
 								) from e
+
+					# For non-Anthropic models, try to parse JSON from text response
+					# Some models return structured output as plain text instead of toolUse
+					if not self._is_anthropic_model():
+						for item in content:
+							if 'text' in item:
+								text = item.get('text', '')
+								# Try to find and parse JSON in the text
+								try:
+									# Try direct parsing first
+									data = json.loads(text.strip())
+									return ChatInvokeCompletion(
+										completion=output_format.model_validate(data),
+										usage=usage,
+									)
+								except (json.JSONDecodeError, ValueError):
+									# Try to extract JSON from text using regex
+									import re
+									json_match = re.search(r'\{[^{}]*\}', text)
+									if json_match:
+										try:
+											data = json.loads(json_match.group())
+											return ChatInvokeCompletion(
+												completion=output_format.model_validate(data),
+												usage=usage,
+											)
+										except (json.JSONDecodeError, ValueError):
+											pass
 
 					# If no tool use found but output_format was requested
 					raise ModelProviderError(


### PR DESCRIPTION
## Summary

This PR fixes issue #4411 - ChatAWSBedrock structured output fails with non-Anthropic models (Qwen, Llama, Mistral) on Bedrock Converse API.

## Changes

1. **Use full Pydantic schema**: Instead of manually rebuilding the schema (which drops `items`, `$defs`, `anyOf`), we now use the full `output_format.model_json_schema()` directly.

2. **Only add toolConfig for Anthropic models**: The `toolChoice` parameter is Anthropic-specific. Non-Anthropic models may ignore it or return plain text instead of toolUse.

3. **Add JSON fallback parsing**: For non-Anthropic models, try to parse JSON from the text response when no toolUse is found.

## Bug Fixes

- **Bug 1**: `list[str]` fields now work correctly (previously lost `items` property)
- **Bug 2**: Non-Anthropic models (Qwen, Llama, Mistral) can now return structured output as plain JSON text

## Testing

This fix addresses both errors described in #4411:
- Error 1: `Input should be a valid list` - Fixed by preserving schema
- Error 2: `Expected structured output but no tool use found in response` - Fixed by JSON fallback

---
Fixes #4411

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix structured output on Bedrock Converse for non-Anthropic models (Qwen, Llama, Mistral) by sending the full Pydantic schema, gating toolChoice to Anthropic-only, and adding a JSON fallback. Also add a clear type check in session_to_python_script for wrong agent types.

- **Bug Fixes**
  - Use `output_format.model_json_schema()` as the tool input schema (preserves `items`, `$defs`, `anyOf`; strips `title`).
  - Only set `toolConfig`/`toolChoice` for Anthropic models to avoid ignored tool calls or plain-text responses.
  - For non-Anthropic models, parse JSON directly from text responses (with regex fallback) when no `toolUse` is returned.
  - Raise a helpful TypeError in `session_to_python_script()` when a non-`CodeAgent` is passed, with guidance to use `CodeAgent`.

<sup>Written for commit e2ba3616b81427317529bb92ad34cca3f3ede1c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

