### PR TITLE
fix: add enabled parameter to SignalHandler for opt-out capability

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -87,6 +87,7 @@ class SignalHandler:
 		custom_exit_callback: Callable[[], None] | None = None,
 		exit_on_second_int: bool = True,
 		interruptible_task_patterns: list[str] | None = None,
+		enabled: bool = True,
 	):
 		"""
 		Initialize the signal handler.
@@ -99,6 +100,8 @@ class SignalHandler:
 			exit_on_second_int: Whether to exit on second SIGINT (Ctrl+C)
 			interruptible_task_patterns: List of patterns to match task names that should be
 										 canceled on first Ctrl+C (default: ['step', 'multi_act', 'get_next_action'])
+			enabled: Whether to register signal handlers (default: True). Set to False to disable
+					 signal handling, useful for server embeddings where the host controls signals.
 		"""
 		self.loop = loop or asyncio.get_event_loop()
 		self.pause_callback = pause_callback
@@ -106,6 +109,7 @@ class SignalHandler:
 		self.custom_exit_callback = custom_exit_callback
 		self.exit_on_second_int = exit_on_second_int
 		self.interruptible_task_patterns = interruptible_task_patterns or ['step', 'multi_act', 'get_next_action']
+		self.enabled = enabled
 		self.is_windows = platform.system() == 'Windows'
 
 		# Initialize loop state attributes
@@ -122,6 +126,9 @@ class SignalHandler:
 
 	def register(self) -> None:
 		"""Register signal handlers for SIGINT and SIGTERM."""
+		if not self.enabled:
+			return
+
 		try:
 			if self.is_windows:
 				# On Windows, use simple signal handling with immediate exit on Ctrl+C
@@ -147,6 +154,9 @@ class SignalHandler:
 
 	def unregister(self) -> None:
 		"""Unregister signal handlers and restore original handlers if possible."""
+		if not self.enabled:
+			return
+
 		try:
 			if self.is_windows:
 				# On Windows, just restore the original SIGINT handler


### PR DESCRIPTION
## Summary

Add `enabled` parameter to SignalHandler class that defaults to True for backward compatibility. When set to False, `register()` and `unregister()` become no-ops, allowing server embeddings (uvicorn, FastAPI, etc.) to control their own signal handling without browser-use overriding it.

## Fixes

Fixes issue #4385

## Changes

- Add `enabled: bool = True` parameter to SignalHandler.__init__()
- Add early return in register() when enabled=False
- Add early return in unregister() when enabled=False

## Usage



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an `enabled` flag to SignalHandler so hosts can opt out of installing signal handlers. This prevents conflicts with server runtimes (e.g., `uvicorn`, `FastAPI`) while keeping existing behavior by default.

- **Bug Fixes**
  - New `enabled: bool = True` init param; set to False to disable signal handling.
  - `register()` and `unregister()` are no-ops when disabled.
  - Fixes conflicts with server-managed signals (fixes #4385).

<sup>Written for commit 8caa2f4c6bb784678c8bc0ff9dde43eacb868291. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

