### PR TITLE
Add Agent Burner integration — disposable email, no API key

### DIFF
--- a/examples/integrations/agentburner/README.md
+++ b/examples/integrations/agentburner/README.md
@@ -23,7 +23,7 @@ agent = Agent(task="Sign up for ...", tools=tools, llm=llm, browser=browser)
 await agent.run()
 ```
 
-Or copy `email_tools.py` directly into your project — it's a single file with no dependencies beyond `httpx`.
+Or copy `email_tools.py` directly into your project — it depends on `browser_use` (for the `Tools` base class) and `httpx`.
 
 ## Available tools
 

--- a/examples/integrations/agentburner/README.md
+++ b/examples/integrations/agentburner/README.md
@@ -11,10 +11,11 @@ pip install browser-use httpx
 ## Usage
 
 ```python
-from examples.integrations.agentburner.email_tools import EmailTools
+# Copy email_tools.py into your project, or run from the repo root
+from email_tools import EmailTools
 
 tools = EmailTools()
-agent = Agent(task="...", tools=tools, llm=llm, browser=browser)
+agent = Agent(task='...', tools=tools, llm=llm, browser=browser)
 await agent.run()
 ```
 

--- a/examples/integrations/agentburner/README.md
+++ b/examples/integrations/agentburner/README.md
@@ -15,12 +15,15 @@ That's it. No API key needed.
 Agent Burner provides throwaway email inboxes via REST API. The agent creates an inbox, uses the address for signup, polls for verification emails, and extracts OTP codes or verification links automatically.
 
 ```python
+# Run from the repo root, or add the repo root to sys.path
 from examples.integrations.agentburner.email_tools import EmailTools
 
 tools = EmailTools()
 agent = Agent(task="Sign up for ...", tools=tools, llm=llm, browser=browser)
 await agent.run()
 ```
+
+Or copy `email_tools.py` directly into your project — it's a single file with no dependencies beyond `httpx`.
 
 ## Available tools
 

--- a/examples/integrations/agentburner/README.md
+++ b/examples/integrations/agentburner/README.md
@@ -1,6 +1,6 @@
 # Agent Burner Integration
 
-Disposable email for browser-use agents. No API key, no signup, no SDK.
+Disposable email for browser-use agents. No API key, no signup.
 
 ## Setup
 
@@ -8,47 +8,39 @@ Disposable email for browser-use agents. No API key, no signup, no SDK.
 pip install browser-use httpx
 ```
 
-That's it. No API key needed.
-
-## How it works
-
-Agent Burner provides throwaway email inboxes via REST API. The agent creates an inbox, uses the address for signup, polls for verification emails, and extracts OTP codes or verification links automatically.
+## Usage
 
 ```python
-# Run from the repo root, or add the repo root to sys.path
 from examples.integrations.agentburner.email_tools import EmailTools
 
 tools = EmailTools()
-agent = Agent(task="Sign up for ...", tools=tools, llm=llm, browser=browser)
+agent = Agent(task="...", tools=tools, llm=llm, browser=browser)
 await agent.run()
 ```
 
-Or copy `email_tools.py` directly into your project — it depends on `browser_use` (for the `Tools` base class) and `httpx`.
+## Tools
 
-## Available tools
+| Tool | Maps to | Description |
+|------|---------|-------------|
+| `create_inbox` | `POST /inbox` | Create a disposable inbox, returns the email address |
+| `list_emails` | `GET /inbox/:key` | List received emails (id, from, subject) |
+| `get_email` | `GET /inbox/:key/:id` | Get full email (body, html, urls[]) |
+| `delete_inbox` | `DELETE /inbox/:key` | Delete inbox (optional — auto-expires in 1h) |
 
-| Tool | Description |
-|------|-------------|
-| `create_email` | Create a disposable email address |
-| `get_email_address` | Get the current email address (creates one if needed) |
-| `get_verification_email` | Poll for and return the latest email with extracted OTP codes and URLs |
-| `get_verification_link` | Get just the first URL from the latest email |
-| `delete_inbox` | Delete the inbox (optional — auto-expires in 1 hour) |
+The tools mirror the API 1:1. No abstractions, no magic. The agent decides what to do with the data.
 
-## Comparison with AgentMail integration
+## vs AgentMail
 
 | | Agent Burner | AgentMail |
 |---|---|---|
-| API key required | No | Yes |
-| pip install | `httpx` (standard HTTP) | `agentmail` (custom SDK) |
-| Email creation | `POST /inbox` | SDK call + API key |
-| URL extraction | Built in (`urls[]`) | Manual parsing |
-| Inbox lifespan | 1 hour (auto-expires) | Permanent |
+| Auth | None | API key |
+| Dependencies | `httpx` | `agentmail` SDK |
+| Inbox lifespan | 1 hour | Permanent |
 | Send email | No | Yes |
 | Cost | Free | Per-mailbox |
 
-Use Agent Burner for throwaway signups and verification flows. Use AgentMail if you need persistent inboxes or outbound email.
+Agent Burner for throwaway inboxes. AgentMail for persistent email identity.
 
 ## API docs
 
-Full reference: [agentburner.com/skill.md](https://agentburner.com/skill.md)
+[agentburner.com/skill.md](https://agentburner.com/skill.md)

--- a/examples/integrations/agentburner/README.md
+++ b/examples/integrations/agentburner/README.md
@@ -1,0 +1,51 @@
+# Agent Burner Integration
+
+Disposable email for browser-use agents. No API key, no signup, no SDK.
+
+## Setup
+
+```bash
+pip install browser-use httpx
+```
+
+That's it. No API key needed.
+
+## How it works
+
+Agent Burner provides throwaway email inboxes via REST API. The agent creates an inbox, uses the address for signup, polls for verification emails, and extracts OTP codes or verification links automatically.
+
+```python
+from examples.integrations.agentburner.email_tools import EmailTools
+
+tools = EmailTools()
+agent = Agent(task="Sign up for ...", tools=tools, llm=llm, browser=browser)
+await agent.run()
+```
+
+## Available tools
+
+| Tool | Description |
+|------|-------------|
+| `create_email` | Create a disposable email address |
+| `get_email_address` | Get the current email address (creates one if needed) |
+| `get_verification_email` | Poll for and return the latest email with extracted OTP codes and URLs |
+| `get_verification_link` | Get just the first URL from the latest email |
+| `delete_inbox` | Delete the inbox (optional — auto-expires in 1 hour) |
+
+## Comparison with AgentMail integration
+
+| | Agent Burner | AgentMail |
+|---|---|---|
+| API key required | No | Yes |
+| pip install | `httpx` (standard HTTP) | `agentmail` (custom SDK) |
+| Email creation | `POST /inbox` | SDK call + API key |
+| URL extraction | Built in (`urls[]`) | Manual parsing |
+| Inbox lifespan | 1 hour (auto-expires) | Permanent |
+| Send email | No | Yes |
+| Cost | Free | Per-mailbox |
+
+Use Agent Burner for throwaway signups and verification flows. Use AgentMail if you need persistent inboxes or outbound email.
+
+## API docs
+
+Full reference: [agentburner.com/skill.md](https://agentburner.com/skill.md)

--- a/examples/integrations/agentburner/email_tools.py
+++ b/examples/integrations/agentburner/email_tools.py
@@ -42,6 +42,8 @@ class EmailTools(Tools):
 			async with httpx.AsyncClient() as client:
 				resp = await client.get(f'{API}/inbox/{self.inbox_key}')
 				if resp.status_code == 404:
+					self.inbox_address = None
+					self.inbox_key = None
 					return 'Inbox expired or not found.'
 				resp.raise_for_status()
 			return resp.text
@@ -53,7 +55,7 @@ class EmailTools(Tools):
 			async with httpx.AsyncClient() as client:
 				resp = await client.get(f'{API}/inbox/{self.inbox_key}/{email_id}')
 				if resp.status_code == 404:
-					return 'Email not found.'
+					return 'Email or inbox not found.'
 				resp.raise_for_status()
 			return resp.text
 

--- a/examples/integrations/agentburner/email_tools.py
+++ b/examples/integrations/agentburner/email_tools.py
@@ -1,0 +1,115 @@
+"""
+Disposable email for browser-use agents via Agent Burner.
+No API key, no signup, no dependencies beyond httpx.
+
+API docs: https://agentburner.com/skill.md
+"""
+
+import asyncio
+import logging
+import re
+
+import httpx
+
+from browser_use import Tools
+
+logger = logging.getLogger(__name__)
+
+API = "https://api.agentburner.com"
+
+
+class EmailTools(Tools):
+	def __init__(self, poll_interval: float = 3.0, poll_timeout: float = 60.0):
+		super().__init__()
+		self.poll_interval = poll_interval
+		self.poll_timeout = poll_timeout
+		self.inbox_address: str | None = None
+		self.inbox_key: str | None = None
+		self.register_email_tools()
+
+	def register_email_tools(self):
+		@self.action("Create a disposable email address. Use this when you need to sign up for a service.")
+		async def create_email() -> str:
+			async with httpx.AsyncClient() as client:
+				resp = await client.post(f"{API}/inbox")
+				data = resp.json()
+			self.inbox_address = data["address"]
+			self.inbox_key = data["key"]
+			logger.info(f"Created burner inbox: {self.inbox_address}")
+			return self.inbox_address
+
+		@self.action("Get the current disposable email address.")
+		async def get_email_address() -> str:
+			if not self.inbox_address:
+				return await create_email()
+			return self.inbox_address
+
+		@self.action("Wait for a verification email and return its contents. Use after signing up to get OTP codes or verification links.")
+		async def get_verification_email() -> str:
+			if not self.inbox_key:
+				return "No inbox created yet. Call create_email first."
+
+			elapsed = 0.0
+			async with httpx.AsyncClient() as client:
+				while elapsed < self.poll_timeout:
+					resp = await client.get(f"{API}/inbox/{self.inbox_key}")
+					if resp.status_code == 404:
+						return "Inbox expired or not found."
+					data = resp.json()
+					if data.get("entries"):
+						entry = data["entries"][0]
+						email_resp = await client.get(f"{API}/inbox/{self.inbox_key}/{entry['id']}")
+						email = email_resp.json()
+
+						parts = []
+						parts.append(f"From: {email.get('from', '')}")
+						parts.append(f"Subject: {email.get('subject', '')}")
+						parts.append(f"Body: {email.get('body', '')}")
+						if email.get("urls"):
+							parts.append(f"URLs: {', '.join(email['urls'])}")
+
+						# Extract OTP codes (4-8 digit numbers)
+						codes = re.findall(r"\b\d{4,8}\b", email.get("body", ""))
+						if codes:
+							parts.append(f"Verification codes found: {', '.join(codes)}")
+
+						logger.info(f"Received email from {email.get('from', '')} with subject: {email.get('subject', '')}")
+						return "\n".join(parts)
+
+					await asyncio.sleep(self.poll_interval)
+					elapsed += self.poll_interval
+
+			return f"No email received after {self.poll_timeout}s."
+
+		@self.action("Get the verification link from the latest email. Returns the first URL found.")
+		async def get_verification_link() -> str:
+			if not self.inbox_key:
+				return "No inbox created yet. Call create_email first."
+
+			async with httpx.AsyncClient() as client:
+				resp = await client.get(f"{API}/inbox/{self.inbox_key}")
+				if resp.status_code == 404:
+					return "Inbox expired or not found."
+				data = resp.json()
+				if not data.get("entries"):
+					return "No emails received yet."
+
+				entry = data["entries"][0]
+				email_resp = await client.get(f"{API}/inbox/{self.inbox_key}/{entry['id']}")
+				email = email_resp.json()
+
+				urls = email.get("urls", [])
+				if urls:
+					return urls[0]
+				return "No URLs found in email."
+
+		@self.action("Delete the disposable inbox. Call this when done with the email.")
+		async def delete_inbox() -> str:
+			if not self.inbox_key:
+				return "No inbox to delete."
+			async with httpx.AsyncClient() as client:
+				await client.delete(f"{API}/inbox/{self.inbox_key}")
+			logger.info(f"Deleted inbox: {self.inbox_address}")
+			self.inbox_address = None
+			self.inbox_key = None
+			return "Inbox deleted."

--- a/examples/integrations/agentburner/email_tools.py
+++ b/examples/integrations/agentburner/email_tools.py
@@ -108,7 +108,9 @@ class EmailTools(Tools):
 			if not self.inbox_key:
 				return "No inbox to delete."
 			async with httpx.AsyncClient() as client:
-				await client.delete(f"{API}/inbox/{self.inbox_key}")
+				resp = await client.delete(f"{API}/inbox/{self.inbox_key}")
+				if resp.status_code not in (200, 404):
+					return f"Failed to delete inbox: HTTP {resp.status_code}"
 			logger.info(f"Deleted inbox: {self.inbox_address}")
 			self.inbox_address = None
 			self.inbox_key = None

--- a/examples/integrations/agentburner/email_tools.py
+++ b/examples/integrations/agentburner/email_tools.py
@@ -1,13 +1,11 @@
 """
 Disposable email for browser-use agents via Agent Burner.
-No API key, no signup, no dependencies beyond httpx.
+No API key, no signup, no SDK — just HTTP.
 
 API docs: https://agentburner.com/skill.md
 """
 
-import asyncio
 import logging
-import re
 
 import httpx
 
@@ -15,103 +13,59 @@ from browser_use import Tools
 
 logger = logging.getLogger(__name__)
 
-API = "https://api.agentburner.com"
+API = 'https://api.agentburner.com'
 
 
 class EmailTools(Tools):
-	def __init__(self, poll_interval: float = 3.0, poll_timeout: float = 60.0):
+	def __init__(self) -> None:
 		super().__init__()
-		self.poll_interval = poll_interval
-		self.poll_timeout = poll_timeout
 		self.inbox_address: str | None = None
 		self.inbox_key: str | None = None
-		self.register_email_tools()
+		self._register()
 
-	def register_email_tools(self):
-		@self.action("Create a disposable email address. Use this when you need to sign up for a service.")
-		async def create_email() -> str:
+	def _register(self) -> None:
+		@self.action('Create a disposable email inbox. Returns the email address.')
+		async def create_inbox() -> str:
 			async with httpx.AsyncClient() as client:
-				resp = await client.post(f"{API}/inbox")
+				resp = await client.post(f'{API}/inbox')
+				resp.raise_for_status()
 				data = resp.json()
-			self.inbox_address = data["address"]
-			self.inbox_key = data["key"]
-			logger.info(f"Created burner inbox: {self.inbox_address}")
-			return self.inbox_address
+			self.inbox_address = data['address']
+			self.inbox_key = data['key']
+			logger.info(f'Created inbox: {self.inbox_address}')
+			return str(self.inbox_address)
 
-		@self.action("Get the current disposable email address.")
-		async def get_email_address() -> str:
-			if not self.inbox_address:
-				return await create_email()
-			return self.inbox_address
-
-		@self.action("Wait for a verification email and return its contents. Use after signing up to get OTP codes or verification links.")
-		async def get_verification_email() -> str:
+		@self.action('List emails in the inbox. Returns a JSON string with entries (id, from, subject, receivedAt).')
+		async def list_emails() -> str:
 			if not self.inbox_key:
-				return "No inbox created yet. Call create_email first."
-
-			elapsed = 0.0
+				return 'No inbox created. Call create_inbox first.'
 			async with httpx.AsyncClient() as client:
-				while elapsed < self.poll_timeout:
-					resp = await client.get(f"{API}/inbox/{self.inbox_key}")
-					if resp.status_code == 404:
-						return "Inbox expired or not found."
-					data = resp.json()
-					if data.get("entries"):
-						entry = data["entries"][0]
-						email_resp = await client.get(f"{API}/inbox/{self.inbox_key}/{entry['id']}")
-						email = email_resp.json()
-
-						parts = []
-						parts.append(f"From: {email.get('from', '')}")
-						parts.append(f"Subject: {email.get('subject', '')}")
-						parts.append(f"Body: {email.get('body', '')}")
-						if email.get("urls"):
-							parts.append(f"URLs: {', '.join(email['urls'])}")
-
-						# Extract OTP codes (4-8 digit numbers)
-						codes = re.findall(r"\b\d{4,8}\b", email.get("body", ""))
-						if codes:
-							parts.append(f"Verification codes found: {', '.join(codes)}")
-
-						logger.info(f"Received email from {email.get('from', '')} with subject: {email.get('subject', '')}")
-						return "\n".join(parts)
-
-					await asyncio.sleep(self.poll_interval)
-					elapsed += self.poll_interval
-
-			return f"No email received after {self.poll_timeout}s."
-
-		@self.action("Get the verification link from the latest email. Returns the first URL found.")
-		async def get_verification_link() -> str:
-			if not self.inbox_key:
-				return "No inbox created yet. Call create_email first."
-
-			async with httpx.AsyncClient() as client:
-				resp = await client.get(f"{API}/inbox/{self.inbox_key}")
+				resp = await client.get(f'{API}/inbox/{self.inbox_key}')
 				if resp.status_code == 404:
-					return "Inbox expired or not found."
-				data = resp.json()
-				if not data.get("entries"):
-					return "No emails received yet."
+					return 'Inbox expired or not found.'
+				resp.raise_for_status()
+			return resp.text
 
-				entry = data["entries"][0]
-				email_resp = await client.get(f"{API}/inbox/{self.inbox_key}/{entry['id']}")
-				email = email_resp.json()
+		@self.action('Get a full email by ID. Returns JSON with body, html, urls[], from, subject.')
+		async def get_email(email_id: str) -> str:
+			if not self.inbox_key:
+				return 'No inbox created. Call create_inbox first.'
+			async with httpx.AsyncClient() as client:
+				resp = await client.get(f'{API}/inbox/{self.inbox_key}/{email_id}')
+				if resp.status_code == 404:
+					return 'Email not found.'
+				resp.raise_for_status()
+			return resp.text
 
-				urls = email.get("urls", [])
-				if urls:
-					return urls[0]
-				return "No URLs found in email."
-
-		@self.action("Delete the disposable inbox. Call this when done with the email.")
+		@self.action('Delete the inbox. Optional — inboxes auto-expire in 1 hour.')
 		async def delete_inbox() -> str:
 			if not self.inbox_key:
-				return "No inbox to delete."
+				return 'No inbox to delete.'
 			async with httpx.AsyncClient() as client:
-				resp = await client.delete(f"{API}/inbox/{self.inbox_key}")
+				resp = await client.delete(f'{API}/inbox/{self.inbox_key}')
 				if resp.status_code not in (200, 404):
-					return f"Failed to delete inbox: HTTP {resp.status_code}"
-			logger.info(f"Deleted inbox: {self.inbox_address}")
+					return f'Failed to delete: HTTP {resp.status_code}'
+			logger.info(f'Deleted inbox: {self.inbox_address}')
 			self.inbox_address = None
 			self.inbox_key = None
-			return "Inbox deleted."
+			return 'Inbox deleted.'

--- a/examples/integrations/agentburner/signup_example.py
+++ b/examples/integrations/agentburner/signup_example.py
@@ -11,7 +11,8 @@ import asyncio
 import os
 import sys
 
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+# Add repo root to path so examples can import each other
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 
 from browser_use import Agent, Browser, ChatBrowserUse
 from examples.integrations.agentburner.email_tools import EmailTools
@@ -38,7 +39,10 @@ async def main():
 	await agent.run()
 
 	# Cleanup
-	await tools.inbox_key and tools.delete_inbox()
+	if tools.inbox_key:
+		# Access the registered action by calling it through the tools registry
+		async with __import__("httpx").AsyncClient() as client:
+			await client.delete(f"https://api.agentburner.com/inbox/{tools.inbox_key}")
 
 
 if __name__ == "__main__":

--- a/examples/integrations/agentburner/signup_example.py
+++ b/examples/integrations/agentburner/signup_example.py
@@ -1,0 +1,45 @@
+"""
+Sign up for a service using a disposable email from Agent Burner.
+No API key needed. No pip install beyond browser-use + httpx.
+
+Usage:
+    pip install browser-use httpx
+    python signup_example.py
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from browser_use import Agent, Browser, ChatBrowserUse
+from examples.integrations.agentburner.email_tools import EmailTools
+
+TASK = """
+Go to todoist.com/users/showregister, create a new account:
+1. Use create_email to get a disposable email address
+2. Make up a password (at least 8 characters)
+3. Sign up with the email and password
+4. Use get_verification_email to get the verification code
+5. Enter the verification code to complete signup
+"""
+
+
+async def main():
+	tools = EmailTools()
+
+	llm = ChatBrowserUse(model="bu-2-0")
+
+	browser = Browser()
+
+	agent = Agent(task=TASK, tools=tools, llm=llm, browser=browser)
+
+	await agent.run()
+
+	# Cleanup
+	await tools.inbox_key and tools.delete_inbox()
+
+
+if __name__ == "__main__":
+	asyncio.run(main())

--- a/examples/integrations/agentburner/signup_example.py
+++ b/examples/integrations/agentburner/signup_example.py
@@ -19,7 +19,7 @@ from examples.integrations.agentburner.email_tools import EmailTools
 TASK = """
 1. Use create_inbox to get a disposable email address
 2. Go to https://buttondown.com/register
-3. Fill the signup form with username 'abtestbu2026', the email, and password 'TestPass123!'
+3. Fill the signup form with a random username, the disposable email, and a strong password
 4. Submit the form
 5. Use list_emails to check for incoming mail (retry a few times if empty)
 6. Use get_email with the email ID to read the full email

--- a/examples/integrations/agentburner/signup_example.py
+++ b/examples/integrations/agentburner/signup_example.py
@@ -38,11 +38,14 @@ async def main():
 
 	await agent.run()
 
-	# Cleanup
+	# Cleanup (optional — inboxes auto-expire in 1 hour)
 	if tools.inbox_key:
-		# Access the registered action by calling it through the tools registry
-		async with __import__("httpx").AsyncClient() as client:
-			await client.delete(f"https://api.agentburner.com/inbox/{tools.inbox_key}")
+		import httpx
+		async with httpx.AsyncClient() as client:
+			resp = await client.delete(f"https://api.agentburner.com/inbox/{tools.inbox_key}")
+			if resp.status_code == 200:
+				tools.inbox_address = None
+				tools.inbox_key = None
 
 
 if __name__ == "__main__":

--- a/examples/integrations/agentburner/signup_example.py
+++ b/examples/integrations/agentburner/signup_example.py
@@ -1,6 +1,6 @@
 """
 Sign up for a service using a disposable email from Agent Burner.
-No API key needed. No pip install beyond browser-use + httpx.
+No API key needed.
 
 Usage:
     pip install browser-use httpx
@@ -11,42 +11,30 @@ import asyncio
 import os
 import sys
 
-# Add repo root to path so examples can import each other
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 
 from browser_use import Agent, Browser, ChatBrowserUse
 from examples.integrations.agentburner.email_tools import EmailTools
 
 TASK = """
-Go to todoist.com/users/showregister, create a new account:
-1. Use create_email to get a disposable email address
-2. Make up a password (at least 8 characters)
-3. Sign up with the email and password
-4. Use get_verification_email to get the verification code
-5. Enter the verification code to complete signup
+1. Use create_inbox to get a disposable email address
+2. Go to https://buttondown.com/register
+3. Fill the signup form with username 'abtestbu2026', the email, and password 'TestPass123!'
+4. Submit the form
+5. Use list_emails to check for incoming mail (retry a few times if empty)
+6. Use get_email with the email ID to read the full email
+7. Find the confirmation URL in the response and navigate to it
+8. Report what happened
 """
 
 
 async def main():
 	tools = EmailTools()
-
-	llm = ChatBrowserUse(model="bu-2-0")
-
+	llm = ChatBrowserUse(model='bu-2-0')
 	browser = Browser()
-
 	agent = Agent(task=TASK, tools=tools, llm=llm, browser=browser)
-
 	await agent.run()
 
-	# Cleanup (optional — inboxes auto-expire in 1 hour)
-	if tools.inbox_key:
-		import httpx
-		async with httpx.AsyncClient() as client:
-			resp = await client.delete(f"https://api.agentburner.com/inbox/{tools.inbox_key}")
-			if resp.status_code == 200:
-				tools.inbox_address = None
-				tools.inbox_key = None
 
-
-if __name__ == "__main__":
+if __name__ == '__main__':
 	asyncio.run(main())


### PR DESCRIPTION
Adds an Agent Burner integration for disposable email in browser-use agents.

Four tools that mirror the API 1:1:
- create_inbox → POST /inbox
- list_emails → GET /inbox/:key
- get_email → GET /inbox/:key/:id
- delete_inbox → DELETE /inbox/:key

No API key. No SDK. Just httpx. Inboxes auto-expire in 1 hour.

Tested end-to-end: agent created inbox, signed up for Buttondown,
received verification email, extracted confirmation URL, verified account.

Agent SKILL.md: https://agentburner.com/skill.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Agent Burner integration so browser-use agents can create and use disposable inboxes without an API key or SDK. Enables full signup flows (e.g., Buttondown) by receiving and parsing verification emails.

- New Features
  - `EmailTools` with 1:1 API actions (`create_inbox`, `list_emails`, `get_email`, `delete_inbox`) via `httpx`; inboxes auto-expire in 1 hour.
  - Added `README.md` and `signup_example.py` showing a full verification flow.

- Bug Fixes
  - Clears stale inbox state on 404; example uses a random username and README import is corrected.

<sup>Written for commit 2600275a94f41a6358a9a78a6faaae0d8cc57809. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

