### PR TITLE
feat(examples): add multi-provider support to UI examples

### DIFF
--- a/examples/ui/command_line.py
+++ b/examples/ui/command_line.py
@@ -10,6 +10,12 @@ python command_line.py --query "go to google and search for browser-use"
 Example 3: Using Anthropic's Claude Model with a Custom Query
 python command_line.py --query "find latest Python tutorials on Medium" --provider anthropic
 
+Example 4: Using DeepSeek
+python command_line.py --query "search for AI news" --provider deepseek
+
+Example 5: Using Ollama (local model, no API key needed)
+python command_line.py --query "search for AI news" --provider ollama
+
 """
 
 import argparse
@@ -28,25 +34,52 @@ from browser_use import Agent
 from browser_use.browser import BrowserSession
 from browser_use.tools.service import Tools
 
+SUPPORTED_PROVIDERS = ['openai', 'anthropic', 'deepseek', 'google', 'groq', 'ollama']
+
+# Providers that do not support vision (screenshots in prompts)
+NO_VISION_PROVIDERS = {'deepseek', 'groq', 'ollama'}
+
+PROVIDER_ENV_KEYS: dict[str, str] = {
+	'openai': 'OPENAI_API_KEY',
+	'anthropic': 'ANTHROPIC_API_KEY',
+	'deepseek': 'DEEPSEEK_API_KEY',
+	'google': 'GOOGLE_API_KEY',
+	'groq': 'GROQ_API_KEY',
+	'ollama': '',
+}
+
 
 def get_llm(provider: str):
-	if provider == 'anthropic':
-		from browser_use.llm import ChatAnthropic
-
-		api_key = os.getenv('ANTHROPIC_API_KEY')
+	env_key = PROVIDER_ENV_KEYS.get(provider, '')
+	if env_key:
+		api_key = os.getenv(env_key)
 		if not api_key:
-			raise ValueError('Error: ANTHROPIC_API_KEY is not set. Please provide a valid API key.')
+			raise ValueError(f'Error: {env_key} is not set. Please provide a valid API key.')
 
-		return ChatAnthropic(model='claude-3-5-sonnet-20240620', temperature=0.0)
-	elif provider == 'openai':
+	if provider == 'openai':
 		from browser_use import ChatOpenAI
 
-		api_key = os.getenv('OPENAI_API_KEY')
-		if not api_key:
-			raise ValueError('Error: OPENAI_API_KEY is not set. Please provide a valid API key.')
-
 		return ChatOpenAI(model='gpt-4.1', temperature=0.0)
+	elif provider == 'anthropic':
+		from browser_use.llm import ChatAnthropic
 
+		return ChatAnthropic(model='claude-sonnet-4-6', temperature=0.0)
+	elif provider == 'deepseek':
+		from browser_use.llm import ChatDeepSeek
+
+		return ChatDeepSeek(model='deepseek-chat')
+	elif provider == 'google':
+		from browser_use.llm import ChatGoogle
+
+		return ChatGoogle(model='gemini-3-flash-preview')
+	elif provider == 'groq':
+		from browser_use.llm import ChatGroq
+
+		return ChatGroq(model='mixtral-8x7b-32768')
+	elif provider == 'ollama':
+		from browser_use.llm import ChatOllama
+
+		return ChatOllama(model='llama3')
 	else:
 		raise ValueError(f'Unsupported provider: {provider}')
 
@@ -60,7 +93,7 @@ def parse_arguments():
 	parser.add_argument(
 		'--provider',
 		type=str,
-		choices=['openai', 'anthropic'],
+		choices=SUPPORTED_PROVIDERS,
 		default='openai',
 		help='The model provider to use (default: openai)',
 	)
@@ -72,13 +105,14 @@ def initialize_agent(query: str, provider: str):
 	llm = get_llm(provider)
 	tools = Tools()
 	browser_session = BrowserSession()
+	use_vision = provider not in NO_VISION_PROVIDERS
 
 	return Agent(
 		task=query,
 		llm=llm,
 		tools=tools,
 		browser_session=browser_session,
-		use_vision=True,
+		use_vision=use_vision,
 		max_actions_per_step=1,
 	), browser_session
 

--- a/examples/ui/command_line.py
+++ b/examples/ui/command_line.py
@@ -67,7 +67,7 @@ def get_llm(provider: str):
 	elif provider == 'deepseek':
 		from browser_use.llm import ChatDeepSeek
 
-		return ChatDeepSeek(model='deepseek-chat')
+		return ChatDeepSeek(model='deepseek-chat', api_key=os.getenv('DEEPSEEK_API_KEY'))
 	elif provider == 'google':
 		from browser_use.llm import ChatGoogle
 

--- a/examples/ui/command_line.py
+++ b/examples/ui/command_line.py
@@ -71,11 +71,11 @@ def get_llm(provider: str):
 	elif provider == 'google':
 		from browser_use.llm import ChatGoogle
 
-		return ChatGoogle(model='gemini-3-flash-preview')
+		return ChatGoogle(model='gemini-3-flash-preview', temperature=0.0)
 	elif provider == 'groq':
 		from browser_use.llm import ChatGroq
 
-		return ChatGroq(model='mixtral-8x7b-32768')
+		return ChatGroq(model='mixtral-8x7b-32768', temperature=0.0)
 	elif provider == 'ollama':
 		from browser_use.llm import ChatOllama
 

--- a/examples/ui/gradio_demo.py
+++ b/examples/ui/gradio_demo.py
@@ -2,7 +2,6 @@
 import asyncio
 import os
 import sys
-from dataclasses import dataclass
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
@@ -12,9 +11,6 @@ load_dotenv()
 
 # Third-party imports
 import gradio as gr  # type: ignore
-from rich.console import Console
-from rich.panel import Panel
-from rich.text import Text
 
 # Local module imports
 from browser_use import Agent

--- a/examples/ui/gradio_demo.py
+++ b/examples/ui/gradio_demo.py
@@ -54,7 +54,7 @@ def get_llm(provider: str, model: str, api_key: str):
 	elif provider == 'deepseek':
 		from browser_use.llm import ChatDeepSeek
 
-		return ChatDeepSeek(model=model)
+		return ChatDeepSeek(model=model, api_key=os.getenv('DEEPSEEK_API_KEY') or api_key)
 	elif provider == 'google':
 		from browser_use.llm import ChatGoogle
 

--- a/examples/ui/gradio_demo.py
+++ b/examples/ui/gradio_demo.py
@@ -37,32 +37,40 @@ PROVIDER_ENV_KEYS: dict[str, str] = {
 NO_VISION_PROVIDERS = {'deepseek', 'groq', 'ollama'}
 
 
+def _resolve_api_key(provider: str, ui_api_key: str) -> str | None:
+	"""Resolve API key: prefer UI input, fall back to environment variable."""
+	if ui_api_key.strip():
+		return ui_api_key.strip()
+	env_key = PROVIDER_ENV_KEYS.get(provider, '')
+	if env_key:
+		return os.getenv(env_key)
+	return None
+
+
 def get_llm(provider: str, model: str, api_key: str):
 	"""Create an LLM instance for the given provider and model."""
-	env_key = PROVIDER_ENV_KEYS.get(provider, '')
-	if env_key and api_key.strip():
-		os.environ[env_key] = api_key
+	resolved_key = _resolve_api_key(provider, api_key)
 
 	if provider == 'openai':
 		from browser_use import ChatOpenAI
 
-		return ChatOpenAI(model=model, temperature=0.0)
+		return ChatOpenAI(model=model, temperature=0.0, api_key=resolved_key)
 	elif provider == 'anthropic':
 		from browser_use.llm import ChatAnthropic
 
-		return ChatAnthropic(model=model, temperature=0.0)
+		return ChatAnthropic(model=model, temperature=0.0, api_key=resolved_key)
 	elif provider == 'deepseek':
 		from browser_use.llm import ChatDeepSeek
 
-		return ChatDeepSeek(model=model, api_key=os.getenv('DEEPSEEK_API_KEY') or api_key)
+		return ChatDeepSeek(model=model, api_key=resolved_key)
 	elif provider == 'google':
 		from browser_use.llm import ChatGoogle
 
-		return ChatGoogle(model=model)
+		return ChatGoogle(model=model, api_key=resolved_key)
 	elif provider == 'groq':
 		from browser_use.llm import ChatGroq
 
-		return ChatGroq(model=model)
+		return ChatGroq(model=model, api_key=resolved_key)
 	elif provider == 'ollama':
 		from browser_use.llm import ChatOllama
 

--- a/examples/ui/gradio_demo.py
+++ b/examples/ui/gradio_demo.py
@@ -17,62 +17,85 @@ from rich.panel import Panel
 from rich.text import Text
 
 # Local module imports
-from browser_use import Agent, ChatOpenAI
+from browser_use import Agent
+
+PROVIDER_MODELS: dict[str, list[str]] = {
+	'openai': ['gpt-4.1-mini', 'gpt-4.1', 'gpt-5-mini', 'gpt-5', 'o3'],
+	'anthropic': ['claude-sonnet-4-6', 'claude-opus-4-6', 'claude-haiku-4-5'],
+	'deepseek': ['deepseek-chat', 'deepseek-reasoner'],
+	'google': ['gemini-3-flash-preview', 'gemini-3-pro'],
+	'groq': ['mixtral-8x7b-32768', 'llama-3.3-70b-versatile'],
+	'ollama': ['llama3', 'mistral', 'qwen2.5'],
+}
+
+PROVIDER_ENV_KEYS: dict[str, str] = {
+	'openai': 'OPENAI_API_KEY',
+	'anthropic': 'ANTHROPIC_API_KEY',
+	'deepseek': 'DEEPSEEK_API_KEY',
+	'google': 'GOOGLE_API_KEY',
+	'groq': 'GROQ_API_KEY',
+	'ollama': '',
+}
+
+# Providers that do not support vision (screenshots in prompts)
+NO_VISION_PROVIDERS = {'deepseek', 'groq', 'ollama'}
 
 
-@dataclass
-class ActionResult:
-	is_done: bool
-	extracted_content: str | None
-	error: str | None
-	include_in_memory: bool
+def get_llm(provider: str, model: str, api_key: str):
+	"""Create an LLM instance for the given provider and model."""
+	env_key = PROVIDER_ENV_KEYS.get(provider, '')
+	if env_key and api_key.strip():
+		os.environ[env_key] = api_key
 
+	if provider == 'openai':
+		from browser_use import ChatOpenAI
 
-@dataclass
-class AgentHistoryList:
-	all_results: list[ActionResult]
-	all_model_outputs: list[dict]
+		return ChatOpenAI(model=model, temperature=0.0)
+	elif provider == 'anthropic':
+		from browser_use.llm import ChatAnthropic
 
+		return ChatAnthropic(model=model, temperature=0.0)
+	elif provider == 'deepseek':
+		from browser_use.llm import ChatDeepSeek
 
-def parse_agent_history(history_str: str) -> None:
-	console = Console()
+		return ChatDeepSeek(model=model)
+	elif provider == 'google':
+		from browser_use.llm import ChatGoogle
 
-	# Split the content into sections based on ActionResult entries
-	sections = history_str.split('ActionResult(')
+		return ChatGoogle(model=model)
+	elif provider == 'groq':
+		from browser_use.llm import ChatGroq
 
-	for i, section in enumerate(sections[1:], 1):  # Skip first empty section
-		# Extract relevant information
-		content = ''
-		if 'extracted_content=' in section:
-			content = section.split('extracted_content=')[1].split(',')[0].strip("'")
+		return ChatGroq(model=model)
+	elif provider == 'ollama':
+		from browser_use.llm import ChatOllama
 
-		if content:
-			header = Text(f'Step {i}', style='bold blue')
-			panel = Panel(content, title=header, border_style='blue')
-			console.print(panel)
-			console.print()
-
-	return None
+		return ChatOllama(model=model)
+	else:
+		raise ValueError(f'Unsupported provider: {provider}')
 
 
 async def run_browser_task(
 	task: str,
+	provider: str,
 	api_key: str,
-	model: str = 'gpt-4.1',
+	model: str,
 	headless: bool = True,
 ) -> str:
-	if not api_key.strip():
-		return 'Please provide an API key'
-
-	os.environ['OPENAI_API_KEY'] = api_key
+	if provider != 'ollama' and not api_key.strip():
+		env_key = PROVIDER_ENV_KEYS.get(provider, '')
+		if env_key and not os.getenv(env_key):
+			return f'Please provide an API key or set {env_key} in your environment'
 
 	try:
+		llm = get_llm(provider, model, api_key)
+		use_vision = provider not in NO_VISION_PROVIDERS
 		agent = Agent(
 			task=task,
-			llm=ChatOpenAI(model='gpt-4.1-mini'),
+			llm=llm,
+			use_vision=use_vision,
 		)
 		result = await agent.run()
-		#  TODO: The result could be parsed better
 		return str(result)
 	except Exception as e:
 		return f'Error: {str(e)}'
@@ -84,22 +107,37 @@ def create_ui():
 
 		with gr.Row():
 			with gr.Column():
-				api_key = gr.Textbox(label='OpenAI API Key', placeholder='sk-...', type='password')
+				provider = gr.Dropdown(
+					choices=list(PROVIDER_MODELS.keys()),
+					label='Provider',
+					value='openai',
+				)
+				model = gr.Dropdown(
+					choices=PROVIDER_MODELS['openai'],
+					label='Model',
+					value='gpt-4.1-mini',
+				)
+				api_key = gr.Textbox(label='API Key', placeholder='sk-...', type='password')
 				task = gr.Textbox(
 					label='Task Description',
 					placeholder='E.g., Find flights from New York to London for next week',
 					lines=3,
 				)
-				model = gr.Dropdown(choices=['gpt-4.1-mini', 'gpt-5', 'o3', 'gpt-5-mini'], label='Model', value='gpt-4.1-mini')
 				headless = gr.Checkbox(label='Run Headless', value=False)
 				submit_btn = gr.Button('Run Task')
 
 			with gr.Column():
 				output = gr.Textbox(label='Output', lines=10, interactive=False)
 
+		def update_models(selected_provider: str):
+			models = PROVIDER_MODELS.get(selected_provider, [])
+			return gr.update(choices=models, value=models[0] if models else '')
+
+		provider.change(fn=update_models, inputs=provider, outputs=model)
+
 		submit_btn.click(
 			fn=lambda *args: asyncio.run(run_browser_task(*args)),
-			inputs=[task, api_key, model, headless],
+			inputs=[task, provider, api_key, model, headless],
 			outputs=output,
 		)
 

--- a/examples/ui/streamlit_demo.py
+++ b/examples/ui/streamlit_demo.py
@@ -25,26 +25,52 @@ if os.name == 'nt':
 	asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
 
+# Providers that do not support vision (screenshots in prompts)
+NO_VISION_PROVIDERS = {'deepseek', 'groq', 'ollama'}
+
+PROVIDER_ENV_KEYS: dict[str, str] = {
+	'openai': 'OPENAI_API_KEY',
+	'anthropic': 'ANTHROPIC_API_KEY',
+	'deepseek': 'DEEPSEEK_API_KEY',
+	'google': 'GOOGLE_API_KEY',
+	'groq': 'GROQ_API_KEY',
+	'ollama': '',
+}
+
+
 # Function to get the LLM based on provider
 def get_llm(provider: str):
-	if provider == 'anthropic':
-		from browser_use.llm import ChatAnthropic
-
-		api_key = os.getenv('ANTHROPIC_API_KEY')
+	env_key = PROVIDER_ENV_KEYS.get(provider, '')
+	if env_key:
+		api_key = os.getenv(env_key)
 		if not api_key:
-			st.error('Error: ANTHROPIC_API_KEY is not set. Please provide a valid API key.')
+			st.error(f'Error: {env_key} is not set. Please provide a valid API key.')
 			st.stop()
 
-		return ChatAnthropic(model='claude-3-5-sonnet-20240620', temperature=0.0)
-	elif provider == 'openai':
+	if provider == 'openai':
 		from browser_use import ChatOpenAI
 
-		api_key = os.getenv('OPENAI_API_KEY')
-		if not api_key:
-			st.error('Error: OPENAI_API_KEY is not set. Please provide a valid API key.')
-			st.stop()
-
 		return ChatOpenAI(model='gpt-4.1', temperature=0.0)
+	elif provider == 'anthropic':
+		from browser_use.llm import ChatAnthropic
+
+		return ChatAnthropic(model='claude-sonnet-4-6', temperature=0.0)
+	elif provider == 'deepseek':
+		from browser_use.llm import ChatDeepSeek
+
+		return ChatDeepSeek(model='deepseek-chat')
+	elif provider == 'google':
+		from browser_use.llm import ChatGoogle
+
+		return ChatGoogle(model='gemini-3-flash-preview')
+	elif provider == 'groq':
+		from browser_use.llm import ChatGroq
+
+		return ChatGroq(model='mixtral-8x7b-32768')
+	elif provider == 'ollama':
+		from browser_use.llm import ChatOllama
+
+		return ChatOllama(model='llama3')
 	else:
 		st.error(f'Unsupported provider: {provider}')
 		st.stop()
@@ -56,13 +82,14 @@ def initialize_agent(query: str, provider: str):
 	llm = get_llm(provider)
 	tools = Tools()
 	browser_session = BrowserSession()
+	use_vision = provider not in NO_VISION_PROVIDERS
 
 	return Agent(
 		task=query,
 		llm=llm,  # type: ignore
 		tools=tools,
 		browser_session=browser_session,
-		use_vision=True,
+		use_vision=use_vision,
 		max_actions_per_step=1,
 	), browser_session
 
@@ -71,7 +98,7 @@ def initialize_agent(query: str, provider: str):
 st.title('Automated Browser Agent with LLMs 🤖')
 
 query = st.text_input('Enter your query:', 'go to reddit and search for posts about browser-use')
-provider = st.radio('Select LLM Provider:', ['openai', 'anthropic'], index=0)
+provider = st.radio('Select LLM Provider:', list(PROVIDER_ENV_KEYS.keys()), index=0)
 
 if st.button('Run Agent'):
 	st.write('Initializing agent...')

--- a/examples/ui/streamlit_demo.py
+++ b/examples/ui/streamlit_demo.py
@@ -62,11 +62,11 @@ def get_llm(provider: str):
 	elif provider == 'google':
 		from browser_use.llm import ChatGoogle
 
-		return ChatGoogle(model='gemini-3-flash-preview')
+		return ChatGoogle(model='gemini-3-flash-preview', temperature=0.0)
 	elif provider == 'groq':
 		from browser_use.llm import ChatGroq
 
-		return ChatGroq(model='mixtral-8x7b-32768')
+		return ChatGroq(model='mixtral-8x7b-32768', temperature=0.0)
 	elif provider == 'ollama':
 		from browser_use.llm import ChatOllama
 

--- a/examples/ui/streamlit_demo.py
+++ b/examples/ui/streamlit_demo.py
@@ -58,7 +58,7 @@ def get_llm(provider: str):
 	elif provider == 'deepseek':
 		from browser_use.llm import ChatDeepSeek
 
-		return ChatDeepSeek(model='deepseek-chat')
+		return ChatDeepSeek(model='deepseek-chat', api_key=os.getenv('DEEPSEEK_API_KEY'))
 	elif provider == 'google':
 		from browser_use.llm import ChatGoogle
 


### PR DESCRIPTION
## Summary
- Add DeepSeek, Google, Groq, and Ollama as provider options to all three UI examples (`gradio_demo.py`, `streamlit_demo.py`, `command_line.py`)
- Automatically set `use_vision=False` for providers that don't support it (DeepSeek, Groq, Ollama)
- Gradio demo gets dynamic model list that updates when provider changes
- Update Anthropic model from deprecated `claude-3-5-sonnet-20240620` to `claude-sonnet-4-6`
- Remove unused `ActionResult`/`AgentHistoryList` dataclasses and `parse_agent_history` from Gradio demo

## Changes
| File | What changed |
|------|-------------|
| `examples/ui/gradio_demo.py` | Full rewrite: provider selector with dynamic model dropdown, multi-provider `get_llm()`, removed dead code |
| `examples/ui/streamlit_demo.py` | Extended `get_llm()` with 4 new providers, added `NO_VISION_PROVIDERS` handling |
| `examples/ui/command_line.py` | Extended `get_llm()` with 4 new providers, added `--provider` choices, updated docstring examples |

## Test plan
- [ ] Run `python examples/ui/gradio_demo.py` and verify provider/model switching works
- [ ] Run `python -m streamlit run examples/ui/streamlit_demo.py` and verify new providers appear
- [ ] Run `python examples/ui/command_line.py --provider deepseek` with `DEEPSEEK_API_KEY` set
- [ ] Verify `use_vision=False` is applied for DeepSeek/Groq/Ollama providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-provider support to the UI examples with DeepSeek, Google, Groq, and Ollama, plus dynamic model selection and automatic vision handling. Updates Anthropic to `claude-sonnet-4-6`, avoids env pollution by passing API keys directly in Gradio, and standardizes temperature for Google and Groq.

- New Features
  - Multi-provider support in `gradio_demo.py`, `streamlit_demo.py`, and `command_line.py`.
  - Auto-disable vision for `deepseek`, `groq`, `ollama`; central `NO_VISION_PROVIDERS`.
  - Gradio: provider dropdown with dynamic model list; per-provider API key via `PROVIDER_ENV_KEYS`.
  - CLI: `--provider` supports all providers with updated examples and help.

- Bug Fixes
  - Pass `DEEPSEEK_API_KEY` explicitly to `ChatDeepSeek` to avoid `OPENAI_API_KEY` fallback.
  - Gradio: pass API keys to LLM constructors (no `os.environ` writes) to prevent credential leakage.
  - Add `temperature=0.0` for `google` and `groq` providers for consistent behavior.
  - Removed unused imports in `gradio_demo.py` flagged by ruff.

<sup>Written for commit d88b687ff1905d3317792c8a227c73c0c28070de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

