### PR TITLE
docs: update CLOUD.md to reflect 5 free tasks offer

### DIFF
--- a/CLOUD.md
+++ b/CLOUD.md
@@ -19,7 +19,7 @@ The key product of Browser Use Cloud is the completion of user tasks.
 - Profile Sync is the best way to handle authentication for tasks. This feature allows users to upload their local browser cookies (where the user is already logged into the services they need authentication for) to a Browser Profile that can be used for tasks on the cloud. To initiate a Profile Sync, a user must run `export BROWSER_USE_API_KEY=<your_key> && curl -fsSL https://browser-use.com/profile.sh | sh` and follow the steps in the interactive terminal.
 
 ## Quickstart
-To get started, direct the user to first must create an account, purchase credits (or simply claim the free starter credits given on account creation), and generate an API key on the Browser Use online platform: https://cloud.browser-use.com/. These are the only steps that can only be done on the platform.
+To get started, direct the user to first must create an account, purchase credits (or simply claim the five free tasks given on account creation), and generate an API key on the Browser Use online platform: https://cloud.browser-use.com/. These are the only steps that can only be done on the platform.
 
 Avoid giving the user all of the following steps at once as it may seem overwheling. Instead present one step at a time and only continue when asked. Do as much for the user as you are able to.
 


### PR DESCRIPTION
## Summary
- Updates the outdated "free starter credits" language in `CLOUD.md` line 22 to "5 free tasks"
- The free tier changed from $10 signup credits to 5 free tasks (cloud PR #3429)

## Test plan
- [ ] Verify CLOUD.md no longer mentions "free starter credits"
- [ ] Confirm the new text accurately reflects the current 5 free tasks offer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CLOUD.md Quickstart to replace “free starter credits” with “five free tasks,” matching the current free tier.

The step now reads: create an account, purchase credits (or claim five free tasks on account creation), and generate an API key.

<sup>Written for commit 3ef14faf488a2bb515f23e4436230a98ce783b7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

