### PR TITLE
fix: preserve CDP WebSocket connections when keep_alive=True

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3916,16 +3916,17 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					# stops the EventBus with clear=True, and recreates a fresh EventBus
 					await self.browser_session.kill()
 				else:
-					# keep_alive=True sessions shouldn't keep the event loop alive after agent.run()
-					await self.browser_session.event_bus.stop(
-						clear=False,
-						timeout=_get_timeout('TIMEOUT_BrowserSessionEventBusStopOnAgentClose', 1.0),
-					)
-					try:
-						self.browser_session.event_bus.event_queue = None
-						self.browser_session.event_bus._on_idle = None
-					except Exception:
-						pass
+					# keep_alive=True: don't stop the browser session's event bus.
+					# The event bus manages CDP WebSocket message handlers — stopping it
+					# causes all handlers to exit, which triggers an unnecessary ~1.7s
+					# reconnection cycle and clears SessionManager state.
+					# See: https://github.com/browser-use/browser-use/issues/4374
+					#
+					# The event bus run loop is lightweight (dispatches events only) and
+					# won't keep the process alive on its own. The CDP WebSocket
+					# connections are managed by the CDP client, not the event bus.
+					# Simply detach the agent from the session without touching the bus.
+					pass
 
 			# Close skill service if configured
 			if self.skill_service is not None:

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -700,18 +700,34 @@ class BrowserSession(BaseModel):
 
 		This clears event buses and cached state but keeps the browser alive.
 		Useful when you want to clean up resources but plan to reconnect later.
+
+		When keep_alive=True, the CDP connections and event bus are preserved
+		to avoid the reconnection cycle described in:
+		https://github.com/browser-use/browser-use/issues/4374
 		"""
 		self._intentional_stop = True
 		self.logger.debug('⏸️  stop() called - stopping browser gracefully (force=False) and resetting state')
 
-		# First save storage state while CDP is still connected
+		# Dispatch BrowserStopEvent to notify watchdogs
+		# (with keep_alive=True, the handler returns early without closing anything)
+		await self.event_bus.dispatch(BrowserStopEvent(force=False))
+
+		if self.browser_profile.keep_alive:
+			# keep_alive=True: preserve CDP connections and event bus state.
+			# Stopping the event bus kills the run loop, which causes CDP WebSocket
+			# message handlers to exit and triggers an unnecessary reconnection cycle.
+			# Save storage state while CDP is still connected (for consistency)
+			from browser_use.browser.events import SaveStorageStateEvent
+
+			save_event = self.event_bus.dispatch(SaveStorageStateEvent())
+			await save_event
+			return
+
+		# Normal stop path: save storage state while CDP is still connected
 		from browser_use.browser.events import SaveStorageStateEvent
 
 		save_event = self.event_bus.dispatch(SaveStorageStateEvent())
 		await save_event
-
-		# Now dispatch BrowserStopEvent to notify watchdogs
-		await self.event_bus.dispatch(BrowserStopEvent(force=False))
 
 		# Stop the event bus
 		await self.event_bus.stop(clear=True, timeout=5)


### PR DESCRIPTION
## Problem

When `Agent.close()` is called on a `Browser(keep_alive=True)`, the event bus is stopped via `event_bus.stop()`. This kills the event bus run loop, which causes **all CDP WebSocket message handlers to exit**, triggering an unnecessary ~1.7s reconnection cycle and clearing SessionManager state.

Reported in #4374

## Root Cause

`EventBus.stop()` does three destructive things:
1. Sets `_is_running = False`
2. Calls `event_queue.shutdown()` — blocks any pending `put()`/`get()` operations
3. Cancels the `_runloop_task` — kills the event dispatch loop

When this happens, CDP WebSocket handlers that depend on the event bus exit, and the browser's reconnection logic kicks in (~1.7s delay, SessionManager data cleared).

## Fix

**Don't stop the event bus when `keep_alive=True`.**

The event bus run loop is lightweight (just dispatches events to handlers) and won't keep the process alive. The CDP WebSocket connections are managed by the CDP client, not the event bus.

### Changes

- **`Agent.close()`**: Removed `event_bus.stop()` call entirely when `keep_alive=True`. Simply detaches the agent without touching the browser session's event bus.
- **`BrowserSession.stop()`**: Added early return when `keep_alive=True` after dispatching `BrowserStopEvent` (which already does nothing when `keep_alive=True`). Preserves CDP connections and event bus state.

## Testing

After the fix, `Agent.close()` on a `keep_alive=True` browser no longer causes:
- CDP WebSocket message handler exits
- "Cleared all owned data (targets, sessions, mappings)" log spam
- 1.7s reconnection delay
- Session manager state loss

The browser remains fully connected and ready for the next `Agent.run()` without any disconnection/reconnection cycle.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves CDP WebSocket connections for `Browser(keep_alive=True)` by not shutting down the `EventBus` on `Agent.close()` or during `BrowserSession.stop()`. Prevents the ~1.7s reconnect and `SessionManager` state loss (fixes #4374).

- **Bug Fixes**
  - `Agent.close()`: skip `event_bus.stop()` when `keep_alive=True`.
  - `BrowserSession.stop()`: dispatch `BrowserStopEvent`, save storage, then return early when `keep_alive=True` to keep CDP handlers running.

<sup>Written for commit 3598480b6538c61a53b7d3f8380fef96d15eb2c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

