### PR TITLE
fix: use ctypes for Windows process kill in tunnel.py

### DIFF
--- a/browser_use/skill_cli/tunnel.py
+++ b/browser_use/skill_cli/tunnel.py
@@ -6,9 +6,13 @@ Cloudflared must be installed via install.sh or manually by the user.
 Tunnels are managed independently of browser sessions - they are purely
 a network utility for exposing local ports via Cloudflare quick tunnels.
 
-Tunnels survive CLI process exit by:
-1. Spawning cloudflared as a daemon (start_new_session=True)
-2. Tracking tunnel info via PID files in ~/.browser-use/tunnels/.
+Tunnels survive CLI process exit by spawning cloudflared as a detached daemon
+process that is tracked via PID files in ~/.browser-use/tunnels/.
+
+Platform-specific daemonization:
+- POSIX:  uses start_new_session=True to detach from controlling terminal
+- Windows: uses creationflags=CREATE_NEW_PROCESS_GROUP|CREATE_NO_WINDOW
+          (start_new_session is not supported on win32)
 """
 
 import asyncio
@@ -18,6 +22,8 @@ import os
 import re
 import shutil
 import signal
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -227,16 +233,27 @@ async def start_tunnel(port: int) -> dict[str, Any]:
     log_file = open(log_file_path, 'w')  # noqa: ASYNC230
 
     # Spawn cloudflared as a daemon
-    # - start_new_session=True: survives parent exit
+    # - start_new_session=True (POSIX): detaches from controlling terminal
+    # - creationflags (Windows): CREATE_NEW_PROCESS_GROUP|CREATE_NO_WINDOW
     # - stderr to file: avoids SIGPIPE when parent's pipe closes
-    process = await asyncio.create_subprocess_exec(
-        cloudflared_binary,
-        'tunnel',
-        '--url', f'http://localhost:{port}',
-        stdout=asyncio.subprocess.DEVNULL,
-        stderr=log_file,
-        start_new_session=True,
-    )
+    if sys.platform == 'win32':
+        process = await asyncio.create_subprocess_exec(
+            cloudflared_binary,
+            'tunnel',
+            '--url', f'http://localhost:{port}',
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=log_file,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW,
+        )
+    else:
+        process = await asyncio.create_subprocess_exec(
+            cloudflared_binary,
+            'tunnel',
+            '--url', f'http://localhost:{port}',
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=log_file,
+            start_new_session=True,
+        )
 
     # Poll the log file until we find the tunnel URL
     url: str | None = None


### PR DESCRIPTION
## Summary
Fixes Windows compatibility for `browser_use/skill_cli/tunnel.py` - process management APIs now work on Windows using ctypes.

## Changes
- `_is_process_alive()`: delegates to `utils.is_process_alive()` (already Windows-compatible via ctypes OpenProcess)
- `_kill_process()`: uses `ctypes` `TerminateProcess` on Windows instead of `os.kill(signal.SIGTERM/SIGKILL)` which are Unix-only

## Why
`tunnel.py` used Unix-only `signal.SIGTERM` and `signal.SIGKILL` which are not available on Windows. This caused all tunnel CLI commands to crash on Windows.

## Test plan
- [x] Existing tests pass on CI (Linux/macOS)
- [x] Windows: `browser-use tunnel <port>`, `tunnel list`, `tunnel stop` now work

Closes #4352

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows support in the tunnel CLI by using Win32 `ctypes` for process management and proper daemon spawning. `browser-use tunnel` start/list/stop now work on Windows.

- **Bug Fixes**
  - `_kill_process()` uses `TerminateProcess` via `ctypes` on Windows; keeps `SIGTERM`/`SIGKILL` on Unix.
  - `_is_process_alive()` now delegates to `utils.is_process_alive()` (Windows-compatible).
  - Windows daemon spawn uses `creationflags=CREATE_NEW_PROCESS_GROUP|CREATE_NO_WINDOW` (instead of `start_new_session`); docstring documents this behavior.
  - Tunnel URL regex updated to match both `http` and `https` from cloudflared output.

<sup>Written for commit e1316030065e90f0cbdb7978dd91fe3e7998a38a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

