### PR TITLE
fix(tunnel): add Windows compatibility for process kill in _kill_process

### DIFF
--- a/browser_use/skill_cli/tunnel.py
+++ b/browser_use/skill_cli/tunnel.py
@@ -18,6 +18,8 @@ import os
 import re
 import shutil
 import signal
+import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -156,7 +158,7 @@ def _is_process_alive(pid: int) -> bool:
 
 
 def _kill_process(pid: int) -> bool:
-	"""Kill a process by PID. Returns True if killed, False if already dead."""
+	"""Kill a process by PID. Returns True if killed, False otherwise (not alive or insufficient privileges)."""
 	if sys.platform == 'win32':
 		import ctypes
 		from ctypes import wintypes
@@ -184,8 +186,6 @@ def _kill_process(pid: int) -> bool:
 			for _ in range(10):
 				if not _is_process_alive(pid):
 					return True
-				import time
-
 				time.sleep(0.1)
 			# Force kill if still alive
 			os.kill(pid, signal.SIGKILL)


### PR DESCRIPTION
## Fix: Windows compatibility for tunnel.py process management

### Problem

The _kill_process() function in skill_cli/tunnel.py uses os.kill(pid, signal.SIGTERM) and os.kill(pid, signal.SIGKILL) which are Unix-only APIs. On Windows, these calls raise OSError since Windows doesn't support POSIX signals.

This causes rowser-use tunnel stop and related commands to fail on Windows.

### Solution

Add Windows-specific process termination using ctypes (following the same pattern already established in skill_cli/main.py and skill_cli/utils.py):

- Use OpenProcess(PROCESS_TERMINATE, False, pid) to get a handle
- Use TerminateProcess(handle, exit_code) to terminate
- Use CloseHandle(handle) to clean up

### Related

- Fixes #4352
- Related to #3912 (broader Windows compatibility)
- Closes PR #4357 (closed due to conflicts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tunnel process termination work on Windows by using Win32 APIs in `_kill_process`. This fixes tunnel stop commands failing on Windows while keeping Unix behavior unchanged.

- **Bug Fixes**
  - On Windows, use `OpenProcess(PROCESS_TERMINATE)` + `TerminateProcess` + `CloseHandle` via `ctypes`.
  - Keep Unix flow: send `SIGTERM`, wait briefly, then `SIGKILL`; move `time` import out of the loop.
  - Clarify behavior and fix NameError: add missing `sys` import; return True only on successful termination, False if already dead or the handle can’t be opened.

<sup>Written for commit b788c2087312827a84d4e973d23e1eee71e0bdf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

