### PR TITLE
fix: Agent.close() should not stop event_bus when keep_alive=True

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3916,16 +3916,13 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					# stops the EventBus with clear=True, and recreates a fresh EventBus
 					await self.browser_session.kill()
 				else:
-					# keep_alive=True sessions shouldn't keep the event loop alive after agent.run()
-					await self.browser_session.event_bus.stop(
-						clear=False,
-						timeout=_get_timeout('TIMEOUT_BrowserSessionEventBusStopOnAgentClose', 1.0),
-					)
-					try:
-						self.browser_session.event_bus.event_queue = None
-						self.browser_session.event_bus._on_idle = None
-					except Exception:
-						pass
+					# keep_alive=True: Do NOT stop the event bus.
+					# Stopping the event_bus shuts down its queue, which wakes up CDP WebSocket
+					# handlers with QueueShutDown, causing them to think the connection is dead
+					# and trigger an unnecessary reconnection cycle (~1.7s delay).
+					# The CDP WebSocket connections themselves keep the event loop alive,
+					# so there's no need to stop the event bus here.
+					pass
 
 			# Close skill service if configured
 			if self.skill_service is not None:


### PR DESCRIPTION
When keep_alive=True, Agent.close() was calling event_bus.stop(clear=False) which shuts down the event queue. This wakes up CDP WebSocket message handlers with a QueueShutDown exception, causing them to think the connection is dead and trigger an unnecessary reconnection cycle (~1.7s delay).

With keep_alive=True, the browser stays alive and CDP WebSocket connections are preserved. The CDP connections themselves keep the asyncio event loop alive, so there is no need to stop the event bus.

Fixes browser-use/browser-use#4374

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop shutting down the event bus when `Agent.close()` is called with `keep_alive=True` to prevent CDP reconnection delays (~1.7s). Keeps the browser and CDP WebSocket connections alive as expected. Fixes #4374.

- **Bug Fixes**
  - When `keep_alive=True`, skip `event_bus.stop(...)` to avoid `QueueShutDown` and unnecessary reconnection.
  - CDP WebSocket connections now keep the asyncio loop alive while the agent exits cleanly.

<sup>Written for commit 0e01163e97ecd9fc661dadeeba6fdde0d538c5c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

