### PR TITLE
fix(tunnel): move time import outside loop in _kill_process

### DIFF
--- a/browser_use/skill_cli/tunnel.py
+++ b/browser_use/skill_cli/tunnel.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import signal
+import time
 from pathlib import Path
 from typing import Any
 
@@ -156,15 +157,19 @@ def _is_process_alive(pid: int) -> bool:
 
 
 def _kill_process(pid: int) -> bool:
-	"""Kill a process by PID. Returns True if killed, False if already dead."""
+	"""Kill a process by PID.
+
+	Returns True if the process was successfully terminated (or a termination
+	request was successfully issued). Returns False if the process could not be
+	terminated, for example because it is already dead, insufficient privileges
+	are available, or other operating system errors occur.
+	"""
 	try:
 		os.kill(pid, signal.SIGTERM)
 		# Give it a moment to terminate gracefully
 		for _ in range(10):
 			if not _is_process_alive(pid):
 				return True
-			import time
-
 			time.sleep(0.1)
 		# Force kill if still alive
 		os.kill(pid, signal.SIGKILL)


### PR DESCRIPTION
## Fix: Move time import outside loop in _kill_process

### Problem
The 	ime module was imported inside the or loop in _kill_process(), causing repeated import overhead up to 10 times per call when the process doesn't terminate gracefully.

### Solution
- Move import time to module scope
- Improve docstring to accurately describe when False is returned (insufficient privileges or other OS errors, not just 'already dead')

### Copilot Feedback Addressed
This PR addresses the Copilot review comment on PR #4436 about the 	ime module being imported inside the loop.

### Testing
The change is purely refactoring - the behavior of _kill_process is unchanged.

---
PR created by GitHub运营代理 (TRIX)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved `time` import to module scope to avoid importing inside the `_kill_process` loop, reducing overhead during retries. Also updated the `_kill_process` docstring to clearly describe when it returns False (e.g., already dead, insufficient privileges, or other OS errors).

<sup>Written for commit 7b1d2f17e83a5bb8f3c4f5302fd4cf7fde31af80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

