### PR TITLE
fix: only use playwright --with-deps on Debian/Ubuntu Linux

### DIFF
--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -361,9 +361,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		"""Get browser executable path from playwright in a subprocess to avoid thread issues."""
 		import platform
 
-		# Build command - only use --with-deps on Linux (it fails on Windows/macOS)
+		# Build command - only use --with-deps on Debian/Ubuntu Linux (apt-get required by Playwright)
 		cmd = ['uvx', 'playwright', 'install', 'chrome']
-		if platform.system() == 'Linux':
+		if platform.system() == 'Linux' and shutil.which('apt-get'):
 			cmd.append('--with-deps')
 
 		# Run in subprocess with timeout

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -14,14 +14,15 @@ if '--mcp' in sys.argv:
 # Special case: install command doesn't need CLI dependencies
 if len(sys.argv) > 1 and sys.argv[1] == 'install':
 	import platform
+	import shutil
 	import subprocess
 
 	print('📦 Installing Chromium browser + system dependencies...')
 	print('⏳ This may take a few minutes...\n')
 
-	# Build command - only use --with-deps on Linux (it fails on Windows/macOS)
+	# Build command - only use --with-deps on Debian/Ubuntu Linux (apt-get required)
 	cmd = ['uvx', 'playwright', 'install', 'chromium']
-	if platform.system() == 'Linux':
+	if platform.system() == 'Linux' and shutil.which('apt-get'):
 		cmd.append('--with-deps')
 	cmd.append('--no-shell')
 

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -345,16 +345,28 @@ install_chromium() {
 
 	activate_venv
 
-	# Build command - only use --with-deps on Linux (it fails on Windows/macOS)
+	# Build command - only use --with-deps on Linux with apt-get available
+	# (Playwright's --with-deps only supports Debian/Ubuntu via apt-get)
 	local cmd="uvx playwright install chromium"
-	if [ "$PLATFORM" = "linux" ]; then
+	if [ "$PLATFORM" = "linux" ] && command -v apt-get &> /dev/null; then
 		cmd="$cmd --with-deps"
 	fi
 	cmd="$cmd --no-shell"
 
-	eval $cmd
-
-	log_success "Chromium installed"
+	if eval $cmd; then
+		log_success "Chromium installed"
+	else
+		# If --with-deps failed, retry without it
+		log_warn "Chromium installation with system deps failed, retrying without --with-deps..."
+		if uvx playwright install chromium --no-shell; then
+			log_success "Chromium installed (without system dependencies)"
+			log_warn "You may need to install system dependencies manually (e.g., nss, atk, cups)."
+			log_warn "See: https://playwright.dev/docs/intro#system-requirements"
+		else
+			log_error "Chromium installation failed"
+			exit 1
+		fi
+	fi
 }
 
 install_profile_use() {

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -52,13 +52,14 @@ def _get_subcommand() -> str | None:
 # Handle 'install' command - installs Chromium browser + system dependencies
 if _get_subcommand() == 'install':
 	import platform
+	import shutil
 
 	print('📦 Installing Chromium browser + system dependencies...')
 	print('⏳ This may take a few minutes...\n')
 
-	# Build command - only use --with-deps on Linux (it fails on Windows/macOS)
+	# Build command - only use --with-deps on Debian/Ubuntu Linux (apt-get required)
 	cmd = ['uvx', 'playwright', 'install', 'chromium']
-	if platform.system() == 'Linux':
+	if platform.system() == 'Linux' and shutil.which('apt-get'):
 		cmd.append('--with-deps')
 	cmd.append('--no-shell')
 


### PR DESCRIPTION
## Summary

- Playwright's `--with-deps` flag uses `apt-get` to install system dependencies, which only works on Debian/Ubuntu
- On non-Debian Linux distros (Arch, Fedora, openSUSE, etc.), the installer fails with `apt-get: command not found` (exit code 127)
- This PR checks for `apt-get` availability before using `--with-deps` across all 4 code paths:
  - `install.sh` — bootstrap installer (also adds a fallback retry without `--with-deps`)
  - `cli.py` — `browser-use install` command
  - `skill_cli/main.py` — `browser-use install` command (alternate entry point)
  - `local_browser_watchdog.py` — runtime auto-install

## Reproduction

On Arch Linux (or any non-Debian distro):
```
curl -fsSL https://browser-use.com/cli/install.sh | bash
```

Fails at the Chromium install step:
```
BEWARE: your OS is not officially supported by Playwright; installing dependencies for ubuntu24.04-x64 as a fallback.
sh: line 1: apt-get: command not found
Failed to install browsers
Error: Installation process exited with code: 127
```

## Test plan

- [ ] Verify install succeeds on Arch Linux / Fedora (no `apt-get`)
- [ ] Verify install still uses `--with-deps` on Ubuntu/Debian
- [ ] Verify `browser-use install` CLI command works on non-Debian Linux
- [ ] Verify runtime auto-install in `local_browser_watchdog.py` works on non-Debian Linux

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `playwright install` with `--with-deps` only on Debian/Ubuntu where `apt-get` is available, preventing failures on other Linux distros. Adds a fallback in the installer to retry without deps so installs complete on Arch/Fedora/openSUSE.

- **Bug Fixes**
  - Check for `apt-get` before adding `--with-deps` in `browser_use/skill_cli/install.sh`, `browser_use/cli.py`, `browser_use/skill_cli/main.py`, and `browser_use/browser/watchdogs/local_browser_watchdog.py`.
  - In `install.sh`, retry `uvx playwright install chromium --no-shell` if the deps install fails, and show a link to Playwright system requirements.
  - Keeps `--with-deps` on Debian/Ubuntu; skips it on other Linux. Windows/macOS unchanged.

<sup>Written for commit f930a858c430ff425418b8e5c3d1da153c006895. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

