### PR TITLE
fix: add missing awaitPromise to CLI eval command

### DIFF
--- a/browser_use/skill_cli/commands/browser.py
+++ b/browser_use/skill_cli/commands/browser.py
@@ -44,7 +44,7 @@ async def _execute_js(session: SessionInfo, js: str) -> Any:
 		raise RuntimeError('No active browser session')
 
 	result = await cdp_session.cdp_client.send.Runtime.evaluate(
-		params={'expression': js, 'returnByValue': True},
+		params={'expression': js, 'returnByValue': True, 'awaitPromise': True},
 		session_id=cdp_session.session_id,
 	)
 	return result.get('result', {}).get('value')


### PR DESCRIPTION
## Summary

- The `_execute_js` helper in `browser_use/skill_cli/commands/browser.py` is missing `awaitPromise: True` in its CDP `Runtime.evaluate` params
- This causes the `browser-use eval` CLI command to return `{}` (empty object) for any async JavaScript — `fetch().then(...)`, `async/await`, or any expression that returns a Promise
- Every other `Runtime.evaluate` call site in the codebase already includes `awaitPromise: True` (see `tools/service.py`, `actor/page.py`, `actor/element.py`, `downloads_watchdog.py`). There's even a comment in `tools/service.py:1698` noting *"Always use awaitPromise=True - it's ignored for non-promises"*

## Fix

One-line addition of `'awaitPromise': True` to the params dict on line 47 of `browser_use/skill_cli/commands/browser.py`.

## How to reproduce

```bash
# Before fix — returns {"result": {}} (empty object)
browser-use eval "fetch('https://httpbin.org/get').then(r => r.json())"

# After fix — returns the resolved JSON response
browser-use eval "fetch('https://httpbin.org/get').then(r => r.json())"
```

## Why this is safe

`awaitPromise` is ignored by CDP when the evaluated expression does not return a Promise, so this change has zero impact on synchronous eval calls. All other eval paths in the codebase already use it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `browser-use eval` command so async JavaScript returns resolved values by adding `awaitPromise: True` to CDP `Runtime.evaluate`. Matches other call sites and does not affect sync expressions.

<sup>Written for commit f99e2b5855680059333fc056dd4f5416686568fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

