### PR TITLE
fix: support Chromium on Linux by passing executable_path to get_chrome_profile_path

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -689,6 +690,8 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	@classmethod
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
+		# Use deep copy to avoid mutating the caller's input
+		data = copy.deepcopy(data)
 		# loop through history and validate output_model actions to enrich with custom actions
 		for h in data['history']:
 			if h['model_output']:

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -692,14 +692,19 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
 		# Use deep copy to avoid mutating the caller's input
 		data = copy.deepcopy(data)
+		# Filter out malformed history items (non-dict entries) before processing
+		data['history'] = [h for h in data['history'] if isinstance(h, dict)]
 		# loop through history and validate output_model actions to enrich with custom actions
 		for h in data['history']:
-			if h['model_output']:
+			if 'model_output' in h and h['model_output']:
 				if isinstance(h['model_output'], dict):
-					h['model_output'] = output_model.model_validate(h['model_output'])
+					try:
+						h['model_output'] = output_model.model_validate(h['model_output'])
+					except (ValidationError, TypeError, AttributeError):
+						h['model_output'] = None
 				else:
 					h['model_output'] = None
-			if 'interacted_element' not in h['state']:
+			if 'state' in h and 'interacted_element' not in h['state']:
 				h['state']['interacted_element'] = None
 
 		history = cls.model_validate(data)

--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -11,19 +11,36 @@ import zlib
 from pathlib import Path
 
 
+def _get_windll():
+	"""Return ctypes.windll with a guard for non-Windows platforms.
+
+	Accessing ctypes.windll on e.g. Linux raises AttributeError.  Always use
+	this helper instead of bare ``ctypes.windll`` so that platform-spoofed
+	tests (sys.platform = "win32" on a Linux runner) fail safely.
+	"""
+	import ctypes
+
+	try:
+		return ctypes.windll
+	except AttributeError:
+		return None
+
+
 def is_process_alive(pid: int) -> bool:
 	"""Check if a process is still running.
 
 	On Windows, os.kill(pid, 0) calls TerminateProcess — so we use
-	OpenProcess via ctypes instead.
+	OpenProcess via ctypes instead.  Uses _get_windll() to avoid AttributeError
+	on non-Windows when sys.platform is spoofed in tests.
 	"""
 	if sys.platform == 'win32':
-		import ctypes
-
+		windll = _get_windll()
+		if windll is None:
+			return False
 		PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-		handle = ctypes.windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+		handle = windll.kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
 		if handle:
-			ctypes.windll.kernel32.CloseHandle(handle)
+			windll.kernel32.CloseHandle(handle)
 			return True
 		return False
 	else:
@@ -104,7 +121,10 @@ def is_daemon_alive(session: str = 'default') -> bool:
 			return False
 		s = None
 		try:
-			s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+			af_unix = getattr(socket, 'AF_UNIX', None)
+			if af_unix is None:
+				return False
+			s = socket.socket(af_unix, socket.SOCK_STREAM)
 			s.settimeout(0.5)
 			s.connect(sock_path)
 			return True


### PR DESCRIPTION
## Summary

On Linux, Chrome and Chromium use different profile directories:
- **Chrome**: \~/.config/google-chrome\
- **Chromium**: \~/.config/chromium\

When \BrowserSession\ detects a Chromium executable, it now passes the \executable_path\ to \get_chrome_profile_path()\ so the correct profile directory is used. Previously, it always defaulted to the Chrome path, causing issues when Chromium was the detected browser (issue #4448).

## Changes

- **\_is_chromium_browser()\**: New helper that identifies Chromium-based browsers (Chromium, Chromium-Browser, Brave, Edge) by executable name
- **\get_chrome_profile_path()\**: Added \executable_path\ parameter; on Linux this selects between \google-chrome\ and \chromium\ profile directories
- **\BrowserSession\**: Updated to pass \executable_path\ to \get_chrome_profile_path()\
- **\create_browser_session\ (sessions.py)**: Updated to pass \chrome_path\ (the detected Chrome executable) to \get_chrome_profile_path()\
- **Tests**: Added comprehensive tests for \get_chrome_user_data_dirs()\ and \get_chrome_profile_path()\ including the new Linux Chromium behavior

## Testing

The key challenge was mocking \Path.is_dir()\ without causing infinite recursion (since \exists()\ internally calls \is_dir()\). The correct pattern is to use a side_effect function that calls the real \Path.is_dir\ method directly, bypassing the mock.

All tests verified via standalone runner (pytest has a pre-existing pydantic/bubus compatibility issue in this environment unrelated to this change).

Closes #4448

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux profile detection and profile listing by using the detected browser executable, adding Brave/Edge support so sessions and profile listing work across platforms. Also hardens history loading and process/daemon checks to avoid input mutation and cross‑platform errors.

- **Bug Fixes**
  - Pass `executable_path` to `get_chrome_profile_path` and `list_chrome_profiles` in `BrowserSession` and CLI; use detected `chrome_path` consistently.
  - Correct Linux user-data dirs by executable: `google-chrome` -> `~/.config/google-chrome`, `chromium`/`chromium-browser` -> `~/.config/chromium`, `brave-browser` -> `~/.config/BraveSoftware/Brave-Browser`, `microsoft-edge` -> `~/.config/microsoft-edge`.
  - `list_chrome_profiles` reads from the correct dir on Linux; passing `None` is allowed but deprecated and emits a warning.
  - Make history loading resilient: deep copy input in `load_from_dict`, drop non-dict history items, safely validate `model_output`, and default `state.interacted_element` to `None`.
  - Harden process/daemon checks: guard `ctypes.windll` on non-Windows and `socket.AF_UNIX` availability to avoid crashes on unsupported or spoofed platforms.

- **Migration**
  - Always pass the detected `executable_path` (from `find_chrome_executable()`) to `list_chrome_profiles()` to avoid warnings and ensure correct profile listing on Linux.

<sup>Written for commit 7b1b0b3ea56011232113e2956b277e2cf97a40b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

