### PR TITLE
fix: prevent browser auto-reconnect after agent close (keep_alive=True)

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3916,7 +3916,14 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					# stops the EventBus with clear=True, and recreates a fresh EventBus
 					await self.browser_session.kill()
 				else:
-					# keep_alive=True sessions shouldn't keep the event loop alive after agent.run()
+					# keep_alive=True: browser stays open but agent is done.
+					# Set _intentional_stop so that if the user manually closes the
+					# browser window the CDP-drop callback won't auto-reconnect.
+					self.browser_session._intentional_stop = True
+					# Cancel any pending reconnection task
+					if self.browser_session._reconnect_task and not self.browser_session._reconnect_task.done():
+						self.browser_session._reconnect_task.cancel()
+						self.browser_session._reconnect_task = None
 					await self.browser_session.event_bus.stop(
 						clear=False,
 						timeout=_get_timeout('TIMEOUT_BrowserSessionEventBusStopOnAgentClose', 1.0),

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -634,7 +634,14 @@ class BrowserSession(BaseModel):
 			self._demo_mode.reset()
 			self._demo_mode = None
 
-		self._intentional_stop = False
+		# NOTE: We intentionally do NOT reset _intentional_stop to False here.
+		# The flag is set True by kill()/stop()/Agent.close() to suppress the
+		# CDP WebSocket-drop auto-reconnect callback.  That callback may fire
+		# *after* reset() returns (it is an asyncio Future done-callback on the
+		# old message-handler task).  Clearing the flag here would re-enable
+		# reconnection, causing the browser to reopen after the user manually
+		# closes it.  The flag is cleared to False in start() when a new
+		# connection is actually desired.
 		self.logger.info('✅ Browser session reset complete')
 
 	def model_post_init(self, __context) -> None:
@@ -670,6 +677,8 @@ class BrowserSession(BaseModel):
 	@observe_debug(ignore_input=True, ignore_output=True, name='browser_session_start')
 	async def start(self) -> None:
 		"""Start the browser session."""
+		# Clear intentional-stop so auto-reconnect is armed for the new session
+		self._intentional_stop = False
 		start_event = self.event_bus.dispatch(BrowserStartEvent())
 		await start_event
 		# Ensure any exceptions from the event handler are propagated

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -677,12 +677,13 @@ class BrowserSession(BaseModel):
 	@observe_debug(ignore_input=True, ignore_output=True, name='browser_session_start')
 	async def start(self) -> None:
 		"""Start the browser session."""
-		# Clear intentional-stop so auto-reconnect is armed for the new session
-		self._intentional_stop = False
 		start_event = self.event_bus.dispatch(BrowserStartEvent())
 		await start_event
 		# Ensure any exceptions from the event handler are propagated
 		await start_event.event_result(raise_if_any=True, raise_if_none=False)
+		# Clear intentional-stop only after startup succeeds so that delayed
+		# WS-drop callbacks from a previous session cannot race with startup.
+		self._intentional_stop = False
 
 	async def kill(self) -> None:
 		"""Kill the browser session and reset all state."""

--- a/tests/ci/browser/test_no_reconnect_after_close.py
+++ b/tests/ci/browser/test_no_reconnect_after_close.py
@@ -1,6 +1,6 @@
 """Test that browser does not auto-reconnect after agent.close() with keep_alive=True.
 
-Regression test for: https://github.com/browser-use/browser-use/issues/XXXX
+Regression test for a browser-use keep_alive reconnect issue.
 When an agent finishes (keep_alive=True) and the user manually closes Chrome,
 the CDP WebSocket-drop callback must NOT trigger auto-reconnect.
 """
@@ -23,36 +23,28 @@ async def keep_alive_session():
 	)
 	await session.start()
 	yield session
-	# Ensure browser is killed even if test fails
-	try:
-		await session.kill()
-	except Exception:
-		pass
+	await session.kill()
 
 
 class TestNoReconnectAfterClose:
 	"""Verify _intentional_stop flag lifecycle prevents zombie reconnections."""
 
-	async def test_intentional_stop_set_after_agent_close_keep_alive(self, keep_alive_session: BrowserSession):
-		"""After Agent.close() with keep_alive=True, _intentional_stop must be True
+	async def test_agent_close_sets_intentional_stop(self, keep_alive_session: BrowserSession, mock_llm):
+		"""Agent.close() with keep_alive=True must set _intentional_stop=True
 		so that the CDP drop callback does NOT trigger auto-reconnect."""
-		session = keep_alive_session
+		from browser_use import Agent
 
-		# Simulate what Agent.close() does for keep_alive=True sessions
-		# (the actual Agent requires an LLM; we test the session-level contract directly)
+		session = keep_alive_session
 		assert session._intentional_stop is False, '_intentional_stop should be False during active session'
 
-		# --- Simulate Agent.close() keep_alive branch (our fix) ---
-		session._intentional_stop = True
-		if session._reconnect_task and not session._reconnect_task.done():
-			session._reconnect_task.cancel()
-			session._reconnect_task = None
-		await session.event_bus.stop(clear=False, timeout=1.0)
+		agent = Agent(task='Test task', llm=mock_llm, browser_session=session)
+		await agent.run()
 
-		# The critical assertion: flag must stay True after the close path
+		# Agent.close() is called in the finally block of run().
+		# With our fix, _intentional_stop must now be True.
 		assert session._intentional_stop is True, (
-			'_intentional_stop must remain True after agent close so that '
-			'CDP WebSocket-drop callback does not trigger auto-reconnect'
+			'_intentional_stop must be True after Agent.close() with keep_alive=True '
+			'so that CDP WebSocket-drop callback does not trigger auto-reconnect'
 		)
 
 	async def test_reset_preserves_intentional_stop(self, keep_alive_session: BrowserSession):
@@ -106,12 +98,14 @@ class TestNoReconnectAfterClose:
 		should_reconnect = not (session._intentional_stop or session._reconnecting or not session.cdp_url)
 		assert not should_reconnect, 'With _intentional_stop=True, the WS drop callback must NOT trigger reconnection'
 
-	async def test_sequential_reuse_after_fix(self):
+	async def test_sequential_reuse_with_agent(self, mock_llm):
 		"""Verify the session reuse pattern still works after the fix.
 
 		Pattern: session.start() -> agent1.run() -> agent1.close() ->
 		         agent2 reuses session -> agent2.run() -> agent2.close() -> session.kill()
 		"""
+		from browser_use import Agent
+
 		session = BrowserSession(
 			browser_profile=BrowserProfile(
 				headless=True,
@@ -121,21 +115,21 @@ class TestNoReconnectAfterClose:
 		)
 
 		try:
-			# First "agent" lifecycle
+			# First agent lifecycle
 			await session.start()
 			assert session._intentional_stop is False
-			assert session._cdp_client_root is not None
 
-			# Simulate Agent.close() keep_alive path (our fix)
-			session._intentional_stop = True
+			agent1 = Agent(task='First task', llm=mock_llm, browser_session=session)
+			await agent1.run()
 
-			# Second "agent" lifecycle — start() must re-arm reconnection
-			await session.start()
-			assert session._intentional_stop is False, 'start() must re-arm reconnection for reuse'
-			assert session._cdp_client_root is not None
+			# After agent1 close, flag must be True
+			assert session._intentional_stop is True
 
-			# Simulate second Agent.close()
-			session._intentional_stop = True
+			# Second agent lifecycle — start() re-arms reconnection
+			agent2 = Agent(task='Second task', llm=mock_llm, browser_session=session)
+			await agent2.run()
+
+			# After agent2 close, flag must be True again
 			assert session._intentional_stop is True
 
 		finally:

--- a/tests/ci/browser/test_no_reconnect_after_close.py
+++ b/tests/ci/browser/test_no_reconnect_after_close.py
@@ -1,0 +1,147 @@
+"""Test that browser does not auto-reconnect after agent.close() with keep_alive=True.
+
+Regression test for: https://github.com/browser-use/browser-use/issues/XXXX
+When an agent finishes (keep_alive=True) and the user manually closes Chrome,
+the CDP WebSocket-drop callback must NOT trigger auto-reconnect.
+"""
+
+import asyncio
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+
+
+@pytest.fixture(scope='function')
+async def keep_alive_session():
+	"""Create a keep_alive=True session, start it, yield, then kill."""
+	session = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=True,
+		),
+	)
+	await session.start()
+	yield session
+	# Ensure browser is killed even if test fails
+	try:
+		await session.kill()
+	except Exception:
+		pass
+
+
+class TestNoReconnectAfterClose:
+	"""Verify _intentional_stop flag lifecycle prevents zombie reconnections."""
+
+	async def test_intentional_stop_set_after_agent_close_keep_alive(self, keep_alive_session: BrowserSession):
+		"""After Agent.close() with keep_alive=True, _intentional_stop must be True
+		so that the CDP drop callback does NOT trigger auto-reconnect."""
+		session = keep_alive_session
+
+		# Simulate what Agent.close() does for keep_alive=True sessions
+		# (the actual Agent requires an LLM; we test the session-level contract directly)
+		assert session._intentional_stop is False, '_intentional_stop should be False during active session'
+
+		# --- Simulate Agent.close() keep_alive branch (our fix) ---
+		session._intentional_stop = True
+		if session._reconnect_task and not session._reconnect_task.done():
+			session._reconnect_task.cancel()
+			session._reconnect_task = None
+		await session.event_bus.stop(clear=False, timeout=1.0)
+
+		# The critical assertion: flag must stay True after the close path
+		assert session._intentional_stop is True, (
+			'_intentional_stop must remain True after agent close so that '
+			'CDP WebSocket-drop callback does not trigger auto-reconnect'
+		)
+
+	async def test_reset_preserves_intentional_stop(self, keep_alive_session: BrowserSession):
+		"""reset() must NOT clear _intentional_stop back to False.
+
+		Previously reset() unconditionally set _intentional_stop = False at the
+		end, which re-enabled auto-reconnect for delayed CDP callbacks.
+		"""
+		session = keep_alive_session
+
+		# Set flag as kill()/stop()/Agent.close() would
+		session._intentional_stop = True
+		await session.reset()
+
+		# After reset, the flag must still be True (our fix)
+		assert session._intentional_stop is True, (
+			'reset() must not clear _intentional_stop; '
+			'delayed CDP callbacks could re-trigger auto-reconnect'
+		)
+
+	async def test_start_clears_intentional_stop(self):
+		"""start() must clear _intentional_stop so auto-reconnect is armed
+		for the new session (needed for session reuse pattern)."""
+		session = BrowserSession(
+			browser_profile=BrowserProfile(
+				headless=True,
+				user_data_dir=None,
+				keep_alive=True,
+			),
+		)
+
+		# Simulate prior close that set the flag
+		session._intentional_stop = True
+
+		# Starting a new session must clear the flag
+		await session.start()
+		assert session._intentional_stop is False, (
+			'start() must clear _intentional_stop so auto-reconnect works for the new session'
+		)
+
+		await session.kill()
+
+	async def test_ws_drop_callback_respects_intentional_stop(self, keep_alive_session: BrowserSession):
+		"""The WebSocket-drop callback must be a no-op when _intentional_stop is True."""
+		session = keep_alive_session
+
+		# Set intentional stop (as Agent.close() now does)
+		session._intentional_stop = True
+
+		# Simulate what _on_message_handler_done checks
+		# This is the guard that must prevent reconnection
+		should_reconnect = not (session._intentional_stop or session._reconnecting or not session.cdp_url)
+		assert not should_reconnect, (
+			'With _intentional_stop=True, the WS drop callback must NOT trigger reconnection'
+		)
+
+	async def test_sequential_reuse_after_fix(self):
+		"""Verify the session reuse pattern still works after the fix.
+
+		Pattern: session.start() -> agent1.run() -> agent1.close() ->
+		         agent2 reuses session -> agent2.run() -> agent2.close() -> session.kill()
+		"""
+		session = BrowserSession(
+			browser_profile=BrowserProfile(
+				headless=True,
+				user_data_dir=None,
+				keep_alive=True,
+			),
+		)
+
+		try:
+			# First "agent" lifecycle
+			await session.start()
+			assert session._intentional_stop is False
+			assert session._cdp_client_root is not None
+
+			# Simulate Agent.close() keep_alive path (our fix)
+			session._intentional_stop = True
+
+			# Second "agent" lifecycle — start() must re-arm reconnection
+			await session.start()
+			assert session._intentional_stop is False, 'start() must re-arm reconnection for reuse'
+			assert session._cdp_client_root is not None
+
+			# Simulate second Agent.close()
+			session._intentional_stop = True
+			assert session._intentional_stop is True
+
+		finally:
+			await session.kill()

--- a/tests/ci/browser/test_no_reconnect_after_close.py
+++ b/tests/ci/browser/test_no_reconnect_after_close.py
@@ -5,8 +5,6 @@ When an agent finishes (keep_alive=True) and the user manually closes Chrome,
 the CDP WebSocket-drop callback must NOT trigger auto-reconnect.
 """
 
-import asyncio
-
 import pytest
 
 from browser_use.browser.profile import BrowserProfile
@@ -71,8 +69,7 @@ class TestNoReconnectAfterClose:
 
 		# After reset, the flag must still be True (our fix)
 		assert session._intentional_stop is True, (
-			'reset() must not clear _intentional_stop; '
-			'delayed CDP callbacks could re-trigger auto-reconnect'
+			'reset() must not clear _intentional_stop; delayed CDP callbacks could re-trigger auto-reconnect'
 		)
 
 	async def test_start_clears_intentional_stop(self):
@@ -107,9 +104,7 @@ class TestNoReconnectAfterClose:
 		# Simulate what _on_message_handler_done checks
 		# This is the guard that must prevent reconnection
 		should_reconnect = not (session._intentional_stop or session._reconnecting or not session.cdp_url)
-		assert not should_reconnect, (
-			'With _intentional_stop=True, the WS drop callback must NOT trigger reconnection'
-		)
+		assert not should_reconnect, 'With _intentional_stop=True, the WS drop callback must NOT trigger reconnection'
 
 	async def test_sequential_reuse_after_fix(self):
 		"""Verify the session reuse pattern still works after the fix.


### PR DESCRIPTION
## Problem

When using `browser-use` in **headed mode** with `keep_alive=True` (the CLI default), the browser becomes impossible to close manually:

1. Agent completes its task → `agent.run()` finishes → `Agent.close()` is called
2. Browser window stays open (expected with `keep_alive=True`)
3. User manually closes Chrome (clicks X)
4. **Chrome immediately reopens** with a blank tab ← **BUG**

This creates a frustrating experience where the browser fights the user — they close it, it comes right back.

## Root Cause Analysis

The bug is caused by two interacting issues in the `_intentional_stop` flag lifecycle:

### 1. `Agent.close()` never sets `_intentional_stop` when `keep_alive=True`

In `agent/service.py:3914-3928`, when `keep_alive=True`, `Agent.close()` only stops the event bus — it never calls `kill()` or `stop()`, and never sets `session._intentional_stop = True`. This leaves the CDP WebSocket-drop callback fully armed.

### 2. `reset()` clears `_intentional_stop` back to `False`

In `browser/session.py:637`, `reset()` unconditionally sets `self._intentional_stop = False` at the end. This means even `kill()` and `stop()` (which do set the flag) are vulnerable: if a CDP `Future.done()` callback fires *after* `reset()` completes, it sees `_intentional_stop=False` and triggers reconnection.

### The chain reaction

```
Agent.close() [keep_alive=True]
  └─ Only stops event_bus, does NOT set _intentional_stop=True
      └─ User closes Chrome window
          └─ CDP WebSocket drops
              └─ _on_message_handler_done() callback fires
                  └─ Guard check: _intentional_stop=False → PASSES
                      └─ _auto_reconnect() → Chrome reopens
```

## Fix

Three minimal, targeted changes:

### 1. `Agent.close()` — set `_intentional_stop=True` in keep_alive branch
```python
# browser_use/agent/service.py
else:
    # keep_alive=True: browser stays open but agent is done.
    # Set _intentional_stop so that if the user manually closes the
    # browser window the CDP-drop callback won't auto-reconnect.
    self.browser_session._intentional_stop = True
    # Cancel any pending reconnection task
    if self.browser_session._reconnect_task and not self.browser_session._reconnect_task.done():
        self.browser_session._reconnect_task.cancel()
        self.browser_session._reconnect_task = None
    await self.browser_session.event_bus.stop(...)
```

### 2. `BrowserSession.reset()` — stop clearing `_intentional_stop`
The flag is now preserved across `reset()` to prevent delayed CDP callbacks from bypassing the guard.

### 3. `BrowserSession.start()` — clear `_intentional_stop` here instead
Moving the flag reset to `start()` ensures auto-reconnect is re-armed only when a new connection is actually desired. This preserves the session-reuse pattern (Agent1 → close → Agent2 → start → works).

## Testing

### New tests (`tests/ci/browser/test_no_reconnect_after_close.py`)
- `test_intentional_stop_set_after_agent_close_keep_alive` — verifies flag is set after close
- `test_reset_preserves_intentional_stop` — verifies reset() no longer clears the flag
- `test_start_clears_intentional_stop` — verifies start() re-arms for new sessions
- `test_ws_drop_callback_respects_intentional_stop` — verifies the guard logic
- `test_sequential_reuse_after_fix` — verifies session reuse pattern still works

### Existing tests (no regressions)
- `test_session_start.py` — 9/9 pass (includes `test_sequential_agents_same_profile_same_browser`)
- `test_tabs.py` — 5/5 pass (uses `keep_alive=True`)

### Manual headed-mode test
Launched Chromium in headed mode with `keep_alive=True`, simulated agent close, manually closed Chrome → **browser stayed closed, no auto-reconnect triggered** (verified over 20-second monitoring window).

## Impact

- **Fixes**: Browser reopening after manual close in headed mode
- **Preserves**: `keep_alive=True` session reuse pattern (Agent1 → Agent2)
- **Preserves**: Auto-reconnect during active agent runs (transient network drops)
- **No breaking changes**: All existing tests pass unchanged

## Files Changed

| File | Change |
|------|--------|
| `browser_use/agent/service.py` | Set `_intentional_stop=True` in `close()` keep_alive branch |
| `browser_use/browser/session.py` | Remove unconditional flag clear in `reset()`, add flag clear in `start()` |
| `tests/ci/browser/test_no_reconnect_after_close.py` | 5 new regression tests |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the browser reopening after a manual close with `keep_alive=True`. Manual closes now stay closed; auto-reconnect during runs and session reuse still work.

- **Bug Fixes**
  - In `Agent.close()` with `keep_alive=True`, set `BrowserSession._intentional_stop = True` and cancel any pending `_reconnect_task` before stopping the event bus.
  - Keep `_intentional_stop` intact in `BrowserSession.reset()` to avoid late WS callbacks triggering a reconnect.
  - In `BrowserSession.start()`, clear `_intentional_stop` only after startup succeeds to safely re-arm reconnect.
  - Added regression tests in `tests/ci/browser/test_no_reconnect_after_close.py` to cover flag lifecycle and prevent auto-reconnect.

<sup>Written for commit d835e974a32c2a9df1597f2f59a4d9b599b4e63e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

