### PR TITLE
fix: add delay before first-char check on contenteditable to prevent duplication

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1934,18 +1934,29 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 				# After first char on contenteditable: check if dropped and retype if needed
 				if i == 0 and _check_first_char and _first_char:
-					# Brief delay so React (and similar frameworks) can flush the
-					# virtual DOM after the key event.  Without this the
-					# textContent check races with the framework's async re-render
-					# and falsely reports the first char as missing, causing a
-					# duplicate first character.  See #4461.
-					await asyncio.sleep(0.1)
-					check_result = await cdp_session.cdp_client.send.Runtime.evaluate(
-						params={'expression': 'document.activeElement.textContent'},
-						session_id=cdp_session.session_id,
-					)
-					content = check_result.get('result', {}).get('value', '')
-					if _first_char not in content:
+					# Poll for the first char to appear instead of paying a fixed delay.
+					# On the happy path (char already visible) this costs a single
+					# textContent read and no sleep. When a framework (React/Vue/Angular)
+					# re-renders asynchronously the char may not be present immediately,
+					# so poll briefly and early-exit as soon as it appears -- a slow
+					# flush on a loaded/slow browser must not be mistaken for a drop.
+					# The grace sleep is always followed by another check (never sleep
+					# then retype on stale state), so a char that flushes inside the
+					# final window is still seen. Only a char missing on the last check
+					# is treated as the leaf-start drop and retyped. See #4461.
+					_first_char_present = False
+					for _first_char_attempt in range(6):  # check at 0,100,...,500ms (5 x 100ms grace)
+						check_result = await cdp_session.cdp_client.send.Runtime.evaluate(
+							params={'expression': 'document.activeElement.textContent'},
+							session_id=cdp_session.session_id,
+						)
+						content = check_result.get('result', {}).get('value', '')
+						if _first_char in content:
+							_first_char_present = True
+							break
+						if _first_char_attempt < 5:  # wait then re-check; no sleep after the final check
+							await asyncio.sleep(0.1)
+					if not _first_char_present:
 						self.logger.debug(f'🎯 First char "{_first_char}" was dropped (leaf-start bug), retyping')
 						# Retype the first character - cursor now past leaf-start
 						modifiers, vk_code, base_key = self._get_char_modifiers_and_vk(_first_char)

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1934,6 +1934,12 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 				# After first char on contenteditable: check if dropped and retype if needed
 				if i == 0 and _check_first_char and _first_char:
+					# Brief delay so React (and similar frameworks) can flush the
+					# virtual DOM after the key event.  Without this the
+					# textContent check races with the framework's async re-render
+					# and falsely reports the first char as missing, causing a
+					# duplicate first character.  See #4461.
+					await asyncio.sleep(0.1)
 					check_result = await cdp_session.cdp_client.send.Runtime.evaluate(
 						params={'expression': 'document.activeElement.textContent'},
 						session_id=cdp_session.session_id,

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1944,13 +1944,44 @@ class DefaultActionWatchdog(BaseWatchdog):
 					# then retype on stale state), so a char that flushes inside the
 					# final window is still seen. Only a char missing on the last check
 					# is treated as the leaf-start drop and retyped. See #4461.
+					# Detect the first char from the INSERTION-ADJACENT code point only, not
+					# activeElement.textContent over the whole focused host. textContent on a
+					# nested custom control can (a) never surface a visible, in-DOM typed char
+					# (false drop -> unwanted retype -> duplication, the bug a maintainer hit) or
+					# (b) include unrelated placeholder/label/chrome text -- or the same char
+					# elsewhere in the subtree -- that matches even when it truly dropped (false
+					# present -> the leaf-start drop #4461 reappears). So look only at the single
+					# code point immediately before the caret, via the form-field value or the
+					# caret's own text node; Array.from(...).pop() keeps astral chars (emoji)
+					# intact rather than splitting a surrogate pair. Ambiguous cases fall through
+					# to a (harmless) retype. The whole probe is wrapped so a throwing custom
+					# getter degrades to '' not a CDP error.
+					_first_char_probe_js = (
+						'(() => {'
+						' try {'
+						' let s = "";'
+						' const el = document.activeElement;'
+						' if (el && typeof el.value === "string" && typeof el.selectionEnd === "number" && el.selectionEnd > 0) {'
+						' s += Array.from(el.value.slice(0, el.selectionEnd)).pop() || "";'
+						' }'
+						' const sel = document.getSelection && document.getSelection();'
+						' if (sel && sel.anchorNode && sel.anchorNode.nodeType === 3 && sel.anchorOffset > 0) {'
+						' const t = sel.anchorNode.textContent || "";'
+						' s += Array.from(t.slice(0, sel.anchorOffset)).pop() || "";'
+						' }'
+						' return s;'
+						' } catch (e) { return ""; }'
+						'})()'
+					)
 					_first_char_present = False
 					for _first_char_attempt in range(6):  # check at 0,100,...,500ms (5 x 100ms grace)
 						check_result = await cdp_session.cdp_client.send.Runtime.evaluate(
-							params={'expression': 'document.activeElement.textContent'},
+							params={'expression': _first_char_probe_js},
 							session_id=cdp_session.session_id,
 						)
 						content = check_result.get('result', {}).get('value', '')
+						if not isinstance(content, str):
+							content = ''
 						if _first_char in content:
 							_first_char_present = True
 							break


### PR DESCRIPTION
## Fixes #4461

### Problem
On React contenteditable elements (X.com, Slack, Notion, etc.), the first character was consistently duplicated when using `input_text` with `clear=True`. For example, typing "Hello" produced "HHello".

### Root Cause
The leaf-start retype check in `default_action_watchdog.py` reads `document.activeElement.textContent` **immediately** after dispatching the first key event. With React, the virtual DOM has not yet flushed to the real DOM at this point, so `textContent` appears empty. The check interprets this as the first character being "dropped" by the leaf-start bug and retypes it. React then processes both keystrokes, resulting in a duplicated first character.

### Fix
Added a 100ms `asyncio.sleep(0.1)` before the first-char check on contenteditable elements. This gives React (and similar frameworks) time to reconcile the virtual DOM with the real DOM before the check runs.

### Scope
- **6 lines added** to a single file (`browser_use/browser/watchdogs/default_action_watchdog.py`)
- Only affects the first character check on contenteditable elements
- No behavioral change for regular `<input>` or `<textarea>` elements
- No behavioral change for contenteditable elements where the char actually *is* dropped (the real leaf-start bug) -- the delay just ensures we only retype when it is genuinely missing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix duplicate first character in contenteditable editors by switching to a check-first bounded poll and an insertion-local, code-point-aware first-char check. No changes for `<input>` or `<textarea>`; fixes #4461.

- **Bug Fixes**
  - Contenteditable: poll at 0/100/…/500ms using an insertion-local probe (char before caret via value/selection) with early exit; only retype if still missing on the final check, avoiding false matches from host/placeholder text and preserving emoji.

<sup>Written for commit ac84f051bb765a6aa205382b6be7b4e147c37b9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

