### PR TITLE
fix: handle ValidationError in structured_output and get_structured_output

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -929,11 +929,15 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 		Returns:
 			The structured output if both final_result and _output_model_schema are available,
-			otherwise None
+			None if the result is missing, or None with a warning if the result cannot be parsed.
 		"""
 		final_result = self.final_result()
 		if final_result is not None and self._output_model_schema is not None:
-			return self._output_model_schema.model_validate_json(final_result)
+			try:
+				return self._output_model_schema.model_validate_json(final_result)
+			except ValidationError as e:
+				logger.warning(f'Failed to parse structured output: {e}')
+				return None
 
 		return None
 
@@ -947,11 +951,16 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 			output_model: The Pydantic model class to parse the output with
 
 		Returns:
-			The parsed structured output, or None if no final result exists
+			The parsed structured output, None if no final result exists,
+			or None with a warning if the result cannot be parsed.
 		"""
 		final_result = self.final_result()
 		if final_result is not None:
-			return output_model.model_validate_json(final_result)
+			try:
+				return output_model.model_validate_json(final_result)
+			except ValidationError as e:
+				logger.warning(f'Failed to parse structured output: {e}')
+				return None
 		return None
 
 


### PR DESCRIPTION
## Problem

`structured_output` and `get_structured_output` call `model_validate_json()` which can raise `ValidationError` if the agent's final result is malformed or non-JSON content.

This contradicts their return type annotations (`AgentStructuredOutput | None`) which imply they should return `None` on failure rather than raising.

### When does this happen?

- Agent uses a weaker model that doesn't consistently produce valid JSON for structured output
- LLM judge appended text to `extracted_content`, corrupting the JSON (related to #4103)
- Any other scenario where the agent's final result is not valid JSON

### Example

```python
history = await agent.run()
output = history.structured_output  # Raises ValidationError instead of returning None!
```

## Fix

Wrap `model_validate_json` calls in try/except in both methods:
- Log a warning with the parse error details for debugging
- Return `None` consistently with the method signatures

## Changes

- `structured_output` property: add try/except around `model_validate_json`
- `get_structured_output` method: add try/except around `model_validate_json`

Note: The related `final_result()` IndexError bug is addressed separately in #4464.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make structured output access safe by catching validation errors. Both methods now return None on malformed or non-JSON results and log a warning.

- **Bug Fixes**
  - Wrap `model_validate_json` calls in try/except for `ValidationError` in `structured_output` and `get_structured_output`; log a warning and return None to match method signatures.

<sup>Written for commit de784534e927065e261a7bf6e22cf55db3a52f05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

