### PR TITLE
fix: properly guard state in load_from_dict and final_result

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -690,14 +690,16 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 	@classmethod
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
 		# loop through history and validate output_model actions to enrich with custom actions
-		for h in data['history']:
-			if h['model_output']:
+		for h in data.get('history', []):
+			if h.get('model_output'):
 				if isinstance(h['model_output'], dict):
 					h['model_output'] = output_model.model_validate(h['model_output'])
 				else:
 					h['model_output'] = None
-			if 'interacted_element' not in h['state']:
-				h['state']['interacted_element'] = None
+			state = h.get('state') or {}
+			if 'interacted_element' not in state:
+				state['interacted_element'] = None
+				h['state'] = state
 
 		history = cls.model_validate(data)
 		return history
@@ -727,7 +729,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def final_result(self) -> None | str:
 		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
+		if self.history and self.history[-1].result and self.history[-1].result[-1].extracted_content:
 			return self.history[-1].result[-1].extracted_content
 		return None
 


### PR DESCRIPTION
## Summary

Fixes Copilot P1/P2 feedback on PR #4472 for browser-use/browser-use#4463.

## Problem

The original PR #4472 attempted to fix load_from_dict crashes but still left bugs:

1. **state=None case**: setdefault('state', {}) returns None (not {}) when h['state'] already exists but is None, causing KeyError on state['interacted_element']
2. **history missing**: Still used data['history'] which raises KeyError if missing
3. **model_output missing**: Still used h['model_output'] which raises KeyError if missing
4. **inal_result() empty result**: Missing length guard for esult list

## Fix

- Use data.get('history', []) instead of data['history']
- Use h.get('model_output') instead of h['model_output']
- Use h.get('state') or {} instead of setdefault() to properly handle None state
- Add esult length guard in inal_result() consistent with other accessors

## Testing

- Unit tests pass
- Manual verification with edge-case history data (missing keys, None values)

Fixes browser-use/browser-use#4463

---
🤖 Auto-generated by TRIX GitHub运营代理

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes in `load_from_dict` and `final_result()` by guarding missing keys and `None` state. Improves resilience when `history`, `model_output`, `state`, or `result` are absent. Fixes `browser-use/browser-use#4463`.

- **Bug Fixes**
  - Use `data.get('history', [])` instead of `data['history']`.
  - Check `h.get('model_output')`; validate dicts, else set to `None`.
  - Replace `setdefault` with `state = h.get('state') or {}`; ensure `interacted_element` exists; write back `h['state'] = state`.
  - In `final_result()`, ensure `result` exists before accessing the last item.

<sup>Written for commit 21e88c4fc23dcb7b0eaf7365a11b3181d6d65e30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

