### PR TITLE
fix(tools): auto-attach browser downloads in default done action

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1908,7 +1908,7 @@ Validated Code (after quote fixing):
 				'Complete task. Only report actions you performed and data you extracted in this session.',
 				param_model=DoneAction,
 			)
-			async def done(params: DoneAction, file_system: FileSystem):
+			async def done(params: DoneAction, file_system: FileSystem, browser_session: BrowserSession):
 				user_message = params.text
 
 				len_text = len(params.text)
@@ -1938,6 +1938,14 @@ Validated Code (after quote fixing):
 								attachments.append(file_name)
 
 				attachments = [str(file_system.get_dir() / file_name) for file_name in attachments]
+
+				# Auto-attach actual session downloads (CDP-tracked browser downloads)
+				session_downloads = browser_session.downloaded_files
+				if session_downloads:
+					existing = set(attachments)
+					for file_path in session_downloads:
+						if file_path not in existing:
+							attachments.append(file_path)
 
 				return ActionResult(
 					is_done=True,


### PR DESCRIPTION
## Summary

- Add `browser_session: BrowserSession` parameter to the non-structured (default) done handler
- Auto-attach `browser_session.downloaded_files`, matching the structured done handler

Fixes #4482

## What changed

```diff
- async def done(params: DoneAction, file_system: FileSystem):
+ async def done(params: DoneAction, file_system: FileSystem, browser_session: BrowserSession):
      # ... existing file display logic ...
      attachments = [str(file_system.get_dir() / file_name) for file_name in attachments]
+
+     # Auto-attach actual session downloads (CDP-tracked browser downloads)
+     session_downloads = browser_session.downloaded_files
+     if session_downloads:
+         existing = set(attachments)
+         for file_path in session_downloads:
+             if file_path not in existing:
+                 attachments.append(file_path)

      return ActionResult(...)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-attaches CDP-tracked browser downloads in the default (non-structured) done action so users receive downloaded files in the final result.

- **Bug Fixes**
  - Added `browser_session: BrowserSession` to the default `done` handler in `browser_use/tools/service.py`.
  - Merges `browser_session.downloaded_files` into `attachments` while skipping duplicates.
  - Matches the structured done handler behavior; users without an `output_model` now get downloaded files.

<sup>Written for commit d91c99762257109e471ce62e3574e1b40e5c261d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

