### PR TITLE
fix: address cubic review feedback for PR #4479

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -696,6 +696,9 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 					h['model_output'] = output_model.model_validate(h['model_output'])
 				else:
 					h['model_output'] = None
+			# Guard: ensure result is a list so downstream methods don't crash on None
+			if 'result' not in h or not isinstance(h['result'], list):
+				h['result'] = []
 			if 'interacted_element' not in h['state']:
 				h['state']['interacted_element'] = None
 
@@ -719,7 +722,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 		"""Get all errors from history, with None for steps without errors"""
 		errors = []
 		for h in self.history:
-			step_errors = [r.error for r in h.result if r.error]
+			step_errors = [r.error for r in h.result if r.error] if h.result else []
 
 			# each step can have only one error
 			errors.append(step_errors[0] if step_errors else None)
@@ -727,7 +730,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def final_result(self) -> None | str:
 		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
+		if self.history and self.history[-1].result and self.history[-1].result[-1].extracted_content:
 			return self.history[-1].result[-1].extracted_content
 		return None
 
@@ -740,7 +743,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def is_successful(self) -> bool | None:
 		"""Check if the agent completed successfully - the agent decides in the last step if it was successful or not. None if not done yet."""
-		if self.history and len(self.history[-1].result) > 0:
+		if self.history and self.history[-1].result and len(self.history[-1].result) > 0:
 			last_result = self.history[-1].result[-1]
 			if last_result.is_done is True:
 				return last_result.success
@@ -752,7 +755,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def judgement(self) -> dict | None:
 		"""Get the judgement result as a dictionary if it exists"""
-		if self.history and len(self.history[-1].result) > 0:
+		if self.history and self.history[-1].result and len(self.history[-1].result) > 0:
 			last_result = self.history[-1].result[-1]
 			if last_result.judgement:
 				return last_result.judgement.model_dump()
@@ -760,14 +763,14 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def is_judged(self) -> bool:
 		"""Check if the agent trace has been judged"""
-		if self.history and len(self.history[-1].result) > 0:
+		if self.history and self.history[-1].result and len(self.history[-1].result) > 0:
 			last_result = self.history[-1].result[-1]
 			return last_result.judgement is not None
 		return False
 
 	def is_validated(self) -> bool | None:
 		"""Check if the judge validated the agent execution (verdict is True). Returns None if not judged yet."""
-		if self.history and len(self.history[-1].result) > 0:
+		if self.history and self.history[-1].result and len(self.history[-1].result) > 0:
 			last_result = self.history[-1].result[-1]
 			if last_result.judgement:
 				return last_result.judgement.verdict

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -413,7 +413,7 @@ class BrowserSession(BaseModel):
 			)
 
 		# Auto-select profile if not specified
-		profiles = list_chrome_profiles()
+		profiles = list_chrome_profiles(executable_path)
 		if profile_directory is None:
 			if profiles:
 				# Use first available profile
@@ -434,9 +434,10 @@ class BrowserSession(BaseModel):
 	@classmethod
 	def list_chrome_profiles(cls) -> list[dict[str, str]]:
 		"""List available Chrome profiles on the system"""
-		from browser_use.skill_cli.utils import list_chrome_profiles
+		from browser_use.skill_cli.utils import find_chrome_executable, list_chrome_profiles
 
-		return list_chrome_profiles()
+		executable = find_chrome_executable()
+		return list_chrome_profiles(executable)
 
 	# Convenience properties for common browser settings
 	@property

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -402,7 +402,7 @@ class BrowserSession(BaseModel):
 				'  Windows: C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe'
 			)
 
-		user_data_dir = get_chrome_profile_path(None)
+		user_data_dir = get_chrome_profile_path(None, executable_path)
 		if user_data_dir is None:
 			raise RuntimeError(
 				'Could not detect Chrome profile directory for your platform.\n'

--- a/browser_use/skill_cli/sessions.py
+++ b/browser_use/skill_cli/sessions.py
@@ -68,7 +68,7 @@ async def create_browser_session(
 	# Resolve profile: accept directory names ("Default", "Profile 1") and
 	# display names ("Person 1", "Work"). Directory names take precedence.
 	# If profile metadata can't be read, fall back to using the value as-is.
-	known_profiles = list_chrome_profiles()
+	known_profiles = list_chrome_profiles(chrome_path)
 	directory_names = {p['directory'] for p in known_profiles}
 
 	if not known_profiles or profile in directory_names:

--- a/browser_use/skill_cli/sessions.py
+++ b/browser_use/skill_cli/sessions.py
@@ -62,8 +62,8 @@ async def create_browser_session(
 	if not chrome_path:
 		raise RuntimeError('Could not find Chrome executable. Please install Chrome or omit --profile to use Chromium.')
 
-	# Always get the Chrome user data directory (not the profile subdirectory)
-	user_data_dir = get_chrome_profile_path(None)
+	# Get the Chrome user data directory for the detected executable (handles Chrome vs Chromium on Linux)
+	user_data_dir = get_chrome_profile_path(None, chrome_path)
 
 	# Resolve profile: accept directory names ("Default", "Profile 1") and
 	# display names ("Person 1", "Work"). Directory names take precedence.

--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -202,17 +202,42 @@ def find_chrome_executable() -> str | None:
 	return None
 
 
-def get_chrome_profile_path(profile: str | None) -> str | None:
+def _is_chromium_browser(executable_path: str | None) -> bool:
+	"""Check if the executable is a Chromium-based browser (not Google Chrome).
+
+	On Linux, both Chrome and Chromium may be installed. This function
+	determines which one was found so we can use the correct profile path.
+	"""
+	if not executable_path:
+		return False
+	# Check by executable name/path for Chromium-based browsers
+	executable_lower = executable_path.lower()
+	chromium_names = ('chromium', 'chromium-browser', 'brave', 'edge')
+	return any(name in executable_lower for name in chromium_names)
+
+
+def get_chrome_profile_path(profile: str | None, executable_path: str | None = None) -> str | None:
 	"""Get Chrome user data directory for a profile.
 
-	If profile is None, returns the default Chrome user data directory.
+	If profile is None, returns the default user data directory for the
+	detected browser (Chrome or Chromium). Uses executable_path to determine
+	which browser was found on Linux to return the matching profile path.
+
+	Args:
+		profile: Profile name/subdirectory, or None for default profile.
+		executable_path: Optional path to the detected Chrome/Chromium executable.
+			Used on Linux to select the correct profile directory when both
+			Chrome and Chromium are installed.
 	"""
 	if profile is None:
-		# Use default Chrome profile location
 		system = platform.system()
 		if system == 'Darwin':
 			return str(Path.home() / 'Library' / 'Application Support' / 'Google' / 'Chrome')
 		elif system == 'Linux':
+			# On Linux, the profile directory differs between Chrome and Chromium.
+			# Use the executable path to determine which browser was detected.
+			if _is_chromium_browser(executable_path):
+				return str(Path.home() / '.config' / 'chromium')
 			return str(Path.home() / '.config' / 'google-chrome')
 		elif system == 'Windows':
 			return os.path.expandvars(r'%LocalAppData%\Google\Chrome\User Data')

--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -203,16 +203,20 @@ def find_chrome_executable() -> str | None:
 
 
 def _is_chromium_browser(executable_path: str | None) -> bool:
-	"""Check if the executable is a Chromium-based browser (not Google Chrome).
+	"""Check if the executable is a generic Chromium-based browser (not Google Chrome, Brave, or Edge).
 
-	On Linux, both Chrome and Chromium may be installed. This function
-	determines which one was found so we can use the correct profile path.
+	On Linux, Chrome, Chromium, Brave, and Edge may all be installed. This function
+	determines whether the detected browser is generic Chromium (as opposed to Chrome),
+	so that the correct profile path can be selected. Brave and Edge are handled
+	separately via explicit mapping in get_chrome_profile_path().
 	"""
 	if not executable_path:
 		return False
 	# Check by executable name/path for Chromium-based browsers
+	# Note: Brave and Edge are handled explicitly in get_chrome_profile_path(),
+	# so they are NOT included here to avoid double-classification.
 	executable_lower = executable_path.lower()
-	chromium_names = ('chromium', 'chromium-browser', 'brave', 'edge')
+	chromium_names = ('chromium', 'chromium-browser')
 	return any(name in executable_lower for name in chromium_names)
 
 

--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -236,8 +236,14 @@ def get_chrome_profile_path(profile: str | None, executable_path: str | None = N
 		elif system == 'Linux':
 			# On Linux, the profile directory differs between Chrome and Chromium.
 			# Use the executable path to determine which browser was detected.
-			if _is_chromium_browser(executable_path):
-				return str(Path.home() / '.config' / 'chromium')
+			if executable_path:
+				exe_name = Path(executable_path).name.lower()
+				if 'brave' in exe_name:
+					return str(Path.home() / '.config' / 'BraveSoftware' / 'Brave-Browser')
+				if 'microsoft-edge' in exe_name or 'edge' in exe_name:
+					return str(Path.home() / '.config' / 'microsoft-edge')
+				if 'chromium' in exe_name:
+					return str(Path.home() / '.config' / 'chromium')
 			return str(Path.home() / '.config' / 'google-chrome')
 		elif system == 'Windows':
 			return os.path.expandvars(r'%LocalAppData%\Google\Chrome\User Data')

--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -360,8 +360,12 @@ def discover_chrome_cdp_url() -> str:
 	)
 
 
-def list_chrome_profiles() -> list[dict[str, str]]:
+def list_chrome_profiles(executable_path: str | None = None) -> list[dict[str, str]]:
 	"""List available Chrome profiles with their names.
+
+	Args:
+		executable_path: Optional path to the detected Chrome/Chromium/Brave/Edge executable.
+			Used on Linux to list profiles from the correct browser's user-data directory.
 
 	Returns:
 		List of dicts with 'directory' and 'name' keys, ex:
@@ -369,7 +373,7 @@ def list_chrome_profiles() -> list[dict[str, str]]:
 	"""
 	import json
 
-	user_data_dir = get_chrome_profile_path(None)
+	user_data_dir = get_chrome_profile_path(None, executable_path)
 	if user_data_dir is None:
 		return []
 

--- a/tests/ci/test_sandbox_structured_output.py
+++ b/tests/ci/test_sandbox_structured_output.py
@@ -225,3 +225,129 @@ class TestStructuredOutputPropertyFallback:
 		explicit_result = history.get_structured_output(ExtractedData)
 		assert explicit_result is not None
 		assert explicit_result.title == 'Test'
+
+
+class TestAgentHistoryListResultNone:
+	"""Test that AgentHistoryList methods handle result=None gracefully.
+
+	This guards against crashes when history is loaded from malformed or
+	incomplete JSON where a history item's result field is None instead of
+	a list. See cubic issue: load_from_dict can crash when history item
+	result=None because code iterates item[result] without validating type.
+
+	Note: AgentHistory model (pydantic) rejects result=None at construction
+	time via direct instantiation -- the bug only manifests when loading from
+	a dict (e.g. from a JSON file), where pydantic will try to coerce None
+	to list[ActionResult]. load_from_dict fixes this by replacing None/[]
+	_before_ model_validate runs.
+	"""
+
+	def _make_history(self, result_list: list) -> AgentHistoryList:
+		"""Helper: build a minimal AgentHistoryList with the given result list."""
+		return AgentHistoryList(
+			history=[
+				AgentHistory(
+					model_output=None,
+					result=result_list,
+					state=BrowserStateHistory(
+						url='https://example.com',
+						title='Test',
+						tabs=[],
+						interacted_element=[],
+					),
+				)
+			]
+		)
+
+	def test_errors_returns_none_when_result_is_empty_list(self):
+		"""errors() must return [None] when h.result is an empty list."""
+		history = self._make_history([])
+		assert history.errors() == [None]
+
+	def test_errors_returns_error_from_result_list(self):
+		"""errors() must extract the first error from result when result is populated."""
+		history = self._make_history(
+			[ActionResult(error='something went wrong'), ActionResult(error=None)]
+		)
+		assert history.errors() == ['something went wrong']
+
+	def test_final_result_returns_none_when_result_is_empty(self):
+		"""final_result() must return None when h.result is an empty list."""
+		history = self._make_history([])
+		assert history.final_result() is None
+
+	def test_is_done_returns_false_when_result_is_empty(self):
+		"""is_done() must return False when h.result is an empty list."""
+		history = self._make_history([])
+		assert history.is_done() is False
+
+	def test_is_successful_returns_none_when_result_is_empty(self):
+		"""is_successful() must return None when h.result is an empty list."""
+		history = self._make_history([])
+		assert history.is_successful() is None
+
+	def test_judgement_returns_none_when_result_is_empty(self):
+		"""judgement() must return None when h.result is an empty list."""
+		history = self._make_history([])
+		assert history.judgement() is None
+
+	def test_is_judged_returns_false_when_result_is_empty(self):
+		"""is_judged() must return False when h.result is an empty list."""
+		history = self._make_history([])
+		assert history.is_judged() is False
+
+	def test_is_validated_returns_none_when_result_is_empty(self):
+		"""is_validated() must return None when h.result is an empty list."""
+		history = self._make_history([])
+		assert history.is_validated() is None
+
+	def test_load_from_dict_replaces_result_none_with_empty_list(self):
+		"""load_from_dict must replace a None result with [] so downstream methods don't crash.
+
+		Before the fix, this would cause errors() to raise:
+		TypeError: 'NoneType' object is not iterable
+		"""
+		from browser_use.agent.views import AgentOutput
+
+		data = {
+			'history': [
+				{
+					'model_output': None,
+					'result': None,  # malformed - should be a list
+					'state': {
+						'url': 'https://example.com',
+						'title': 'Test',
+						'tabs': [],
+						'interacted_element': [],
+					},
+				}
+			]
+		}
+		history = AgentHistoryList.load_from_dict(data, AgentOutput)
+		# Must not raise; errors() would have crashed before the fix
+		assert history.errors() == [None]
+		assert history.final_result() is None
+		assert history.is_successful() is None
+		assert history.is_judged() is False
+
+	def test_load_from_dict_handles_missing_result_key(self):
+		"""load_from_dict must handle history items that omit the result key entirely."""
+		from browser_use.agent.views import AgentOutput
+
+		data = {
+			'history': [
+				{
+					'model_output': None,
+					# 'result' key is missing
+					'state': {
+						'url': 'https://example.com',
+						'title': 'Test',
+						'tabs': [],
+						'interacted_element': [],
+					},
+				}
+			]
+		}
+		history = AgentHistoryList.load_from_dict(data, AgentOutput)
+		assert history.errors() == [None]
+		assert history.final_result() is None

--- a/tests/ci/test_utils.py
+++ b/tests/ci/test_utils.py
@@ -154,10 +154,17 @@ class TestGetChromeProfilePath:
         assert result == expected
 
     def test_linux_brave_profile_path(self):
-        """On Linux with Brave executable, return the Chromium profile path (Brave uses Chromium)."""
+        """On Linux with Brave executable, return Brave's own profile path."""
         with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
             result = get_chrome_profile_path(None, executable_path='/usr/bin/brave-browser')
-        expected = str(Path.home() / '.config' / 'chromium')
+        expected = str(Path.home() / '.config' / 'BraveSoftware' / 'Brave-Browser')
+        assert result == expected
+
+    def test_linux_edge_profile_path(self):
+        """On Linux with Microsoft Edge executable, return Edge's own profile path."""
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+            result = get_chrome_profile_path(None, executable_path='/usr/bin/microsoft-edge')
+        expected = str(Path.home() / '.config' / 'microsoft-edge')
         assert result == expected
 
     def test_linux_no_executable_path_defaults_to_chrome(self):

--- a/tests/ci/test_utils.py
+++ b/tests/ci/test_utils.py
@@ -1,0 +1,195 @@
+"""Tests for browser_use/skill_cli/utils.py"""
+
+import platform
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from browser_use.skill_cli.utils import (
+    _is_chromium_browser,
+    get_chrome_profile_path,
+    get_chrome_user_data_dirs,
+)
+
+
+def _normalize_path(p: Path) -> str:
+    """Normalize a Path to forward-slash string for cross-platform test comparisons."""
+    return p.as_posix()
+
+
+class TestGetChromeUserDataDirs:
+    """Test get_chrome_user_data_dirs() correctly filters by is_dir()."""
+
+    def test_linux_returns_only_existing_dirs(self):
+        """Only directories that actually exist (is_dir returns True) are returned.
+
+        The key issue this tests resolves: a naive mock that calls self.exists()
+        inside the fake is_dir function causes infinite recursion because
+        exists() internally uses is_dir(). The correct approach stores the real
+        Path.is_dir method and calls it via a side_effect that bypasses the mock.
+        """
+        def fake_is_dir(self):
+            # Use as_posix() for cross-platform path normalization
+            path_str = self.as_posix()
+            existing = {
+                '/home/user/.config/google-chrome',
+                '/home/user/.config/chromium',
+            }
+            return path_str in existing
+
+        mock_home = Path('/home/user')
+        candidates_checked = []
+
+        def tracking_is_dir(self):
+            candidates_checked.append(str(self))
+            return fake_is_dir(self)
+
+        with patch.object(Path, 'home', return_value=mock_home):
+            with patch.object(Path, 'is_dir', tracking_is_dir):
+                with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+                    result = get_chrome_user_data_dirs()
+
+        # Verify correct candidates were checked
+        normalized_checked = [_normalize_path(Path(c)) for c in candidates_checked]
+        assert '/home/user/.config/google-chrome' in normalized_checked
+        assert '/home/user/.config/chromium' in normalized_checked
+        assert '/home/user/.config/BraveSoftware/Brave-Browser' in normalized_checked
+
+        # Only existing dirs should be in result
+        result_strs = [_normalize_path(p) for p in result]
+        assert '/home/user/.config/google-chrome' in result_strs
+        assert '/home/user/.config/chromium' in result_strs
+        assert '/home/user/.config/BraveSoftware/Brave-Browser' not in result_strs
+
+    def test_macos_returns_only_existing_dirs(self):
+        """On macOS only existing directories under ~/Library/Application Support are returned."""
+        def fake_is_dir(self):
+            path_str = self.as_posix()
+            existing = {'/home/user/Library/Application Support/Google/Chrome'}
+            return path_str in existing
+
+        mock_home = Path('/home/user')
+
+        with patch.object(Path, 'home', return_value=mock_home):
+            with patch.object(Path, 'is_dir', fake_is_dir):
+                with patch('browser_use.skill_cli.utils.platform.system', return_value='Darwin'):
+                    result = get_chrome_user_data_dirs()
+
+        result_strs = [_normalize_path(p) for p in result]
+        assert '/home/user/Library/Application Support/Google/Chrome' in result_strs
+        assert '/home/user/Library/Application Support/Chromium' not in result_strs
+
+    def test_windows_returns_only_existing_dirs(self):
+        """On Windows only existing directories under %LOCALAPPDATA% are returned."""
+        def fake_is_dir(self):
+            path_str = _normalize_path(self)
+            existing = {'C:/Users/user/AppData/Local/Google/Chrome/User Data'}
+            return path_str in existing
+
+        mock_home = Path('C:/Users/user')
+
+        with patch.object(Path, 'home', return_value=mock_home):
+            with patch.object(Path, 'is_dir', fake_is_dir):
+                with patch('browser_use.skill_cli.utils.platform.system', return_value='Windows'):
+                    with patch('browser_use.skill_cli.utils.os.environ.get', side_effect=lambda k, d=None: {
+                        'LOCALAPPDATA': 'C:\\Users\\user\\AppData\\Local',
+                    }.get(k, d)):
+                        result = get_chrome_user_data_dirs()
+
+        result_strs = [_normalize_path(p) for p in result]
+        assert 'C:/Users/user/AppData/Local/Google/Chrome/User Data' in result_strs
+        assert 'C:/Users/user/AppData/Local/Chromium/User Data' not in result_strs
+
+
+class TestIsChromiumBrowser:
+    """Test _is_chromium_browser() correctly identifies Chromium-based browsers."""
+
+    def test_none_returns_false(self):
+        assert _is_chromium_browser(None) is False
+
+    def test_chromium_returns_true(self):
+        assert _is_chromium_browser('/usr/bin/chromium') is True
+        assert _is_chromium_browser('/usr/bin/chromium-browser') is True
+
+    def test_google_chrome_returns_false(self):
+        assert _is_chromium_browser('/usr/bin/google-chrome') is False
+        assert _is_chromium_browser('/usr/bin/google-chrome-stable') is False
+
+    def test_brave_returns_true(self):
+        assert _is_chromium_browser('/usr/bin/brave-browser') is True
+
+    def test_edge_returns_true(self):
+        assert _is_chromium_browser('/usr/bin/microsoft-edge') is True
+
+    def test_windows_chrome_returns_false(self):
+        assert _is_chromium_browser('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe') is False
+
+    def test_windows_chromium_returns_true(self):
+        assert _is_chromium_browser('C:\\Program Files\\Chromium\\Application\\chrome.exe') is True
+
+
+class TestGetChromeProfilePath:
+    """Test get_chrome_profile_path() with the executable_path parameter on Linux."""
+
+    def test_linux_chromium_profile_path(self):
+        """On Linux with Chromium executable, return the Chromium profile path."""
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+            result = get_chrome_profile_path(None, executable_path='/usr/bin/chromium')
+        expected = str(Path.home() / '.config' / 'chromium')
+        assert result == expected
+
+    def test_linux_chromium_browser_profile_path(self):
+        """On Linux with chromium-browser executable, return the Chromium profile path."""
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+            result = get_chrome_profile_path(None, executable_path='/usr/bin/chromium-browser')
+        expected = str(Path.home() / '.config' / 'chromium')
+        assert result == expected
+
+    def test_linux_google_chrome_profile_path(self):
+        """On Linux with google-chrome executable, return the Google Chrome profile path."""
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+            result = get_chrome_profile_path(None, executable_path='/usr/bin/google-chrome')
+        expected = str(Path.home() / '.config' / 'google-chrome')
+        assert result == expected
+
+    def test_linux_brave_profile_path(self):
+        """On Linux with Brave executable, return the Chromium profile path (Brave uses Chromium)."""
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+            result = get_chrome_profile_path(None, executable_path='/usr/bin/brave-browser')
+        expected = str(Path.home() / '.config' / 'chromium')
+        assert result == expected
+
+    def test_linux_no_executable_path_defaults_to_chrome(self):
+        """On Linux with no executable_path, default to Google Chrome profile path."""
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+            result = get_chrome_profile_path(None, executable_path=None)
+        expected = str(Path.home() / '.config' / 'google-chrome')
+        assert result == expected
+
+    def test_macos_profile_path(self):
+        """On macOS, return the Chrome Application Support directory."""
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Darwin'):
+            result = get_chrome_profile_path(None)
+        expected = str(Path.home() / 'Library' / 'Application Support' / 'Google' / 'Chrome')
+        assert result == expected
+
+    def test_windows_profile_path(self):
+        """On Windows, return the Chrome User Data directory under %LOCALAPPDATA%."""
+        import os
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Windows'):
+            result = get_chrome_profile_path(None)
+        expected = os.path.expandvars(r'%LocalAppData%\Google\Chrome\User Data')
+        assert result == expected
+
+    def test_named_profile_returns_profile_name(self):
+        """When a profile name is given, return it directly (Chrome uses it as subdirectory)."""
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+            result = get_chrome_profile_path('work-profile')
+        assert result == 'work-profile'
+
+    def test_named_profile_macos(self):
+        """On macOS, named profile returns the profile name directly."""
+        with patch('browser_use.skill_cli.utils.platform.system', return_value='Darwin'):
+            result = get_chrome_profile_path('my-profile')
+        assert result == 'my-profile'

--- a/tests/ci/test_utils.py
+++ b/tests/ci/test_utils.py
@@ -19,12 +19,12 @@ class TestGetChromeUserDataDirs:
 	"""Test get_chrome_user_data_dirs() correctly filters by is_dir()."""
 
 	def test_linux_returns_only_existing_dirs(self):
-		"""Only directories that actually exist (is_dir returns True) are returned.
+		"""Only directories that the mocked is_dir reports as existing are returned.
 
-		The key issue this tests resolves: a naive mock that calls self.exists()
-		inside the fake is_dir function causes infinite recursion because
-		exists() internally uses is_dir(). The correct approach stores the real
-		Path.is_dir method and calls it via a side_effect that bypasses the mock.
+		This test patches Path.is_dir with a tracking function that records all
+		candidate paths checked and returns True only for a predefined set of
+		Linux Chrome/Chromium user-data directories. The result should include
+		only those mocked-as-existing directories.
 		"""
 
 		def fake_is_dir(self):
@@ -119,11 +119,13 @@ class TestIsChromiumBrowser:
 		assert _is_chromium_browser('/usr/bin/google-chrome') is False
 		assert _is_chromium_browser('/usr/bin/google-chrome-stable') is False
 
-	def test_brave_returns_true(self):
-		assert _is_chromium_browser('/usr/bin/brave-browser') is True
+	def test_brave_returns_false(self):
+		"""Brave is handled via explicit mapping in get_chrome_profile_path(), not via _is_chromium_browser."""
+		assert _is_chromium_browser('/usr/bin/brave-browser') is False
 
-	def test_edge_returns_true(self):
-		assert _is_chromium_browser('/usr/bin/microsoft-edge') is True
+	def test_edge_returns_false(self):
+		"""Edge is handled via explicit mapping in get_chrome_profile_path(), not via _is_chromium_browser."""
+		assert _is_chromium_browser('/usr/bin/microsoft-edge') is False
 
 	def test_windows_chrome_returns_false(self):
 		assert _is_chromium_browser('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe') is False

--- a/tests/ci/test_utils.py
+++ b/tests/ci/test_utils.py
@@ -1,202 +1,206 @@
 """Tests for browser_use/skill_cli/utils.py"""
 
-import platform
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from browser_use.skill_cli.utils import (
-    _is_chromium_browser,
-    get_chrome_profile_path,
-    get_chrome_user_data_dirs,
+	_is_chromium_browser,
+	get_chrome_profile_path,
+	get_chrome_user_data_dirs,
 )
 
 
 def _normalize_path(p: Path) -> str:
-    """Normalize a Path to forward-slash string for cross-platform test comparisons."""
-    return p.as_posix()
+	"""Normalize a Path to forward-slash string for cross-platform test comparisons."""
+	return p.as_posix()
 
 
 class TestGetChromeUserDataDirs:
-    """Test get_chrome_user_data_dirs() correctly filters by is_dir()."""
+	"""Test get_chrome_user_data_dirs() correctly filters by is_dir()."""
 
-    def test_linux_returns_only_existing_dirs(self):
-        """Only directories that actually exist (is_dir returns True) are returned.
+	def test_linux_returns_only_existing_dirs(self):
+		"""Only directories that actually exist (is_dir returns True) are returned.
 
-        The key issue this tests resolves: a naive mock that calls self.exists()
-        inside the fake is_dir function causes infinite recursion because
-        exists() internally uses is_dir(). The correct approach stores the real
-        Path.is_dir method and calls it via a side_effect that bypasses the mock.
-        """
-        def fake_is_dir(self):
-            # Use as_posix() for cross-platform path normalization
-            path_str = self.as_posix()
-            existing = {
-                '/home/user/.config/google-chrome',
-                '/home/user/.config/chromium',
-            }
-            return path_str in existing
+		The key issue this tests resolves: a naive mock that calls self.exists()
+		inside the fake is_dir function causes infinite recursion because
+		exists() internally uses is_dir(). The correct approach stores the real
+		Path.is_dir method and calls it via a side_effect that bypasses the mock.
+		"""
 
-        mock_home = Path('/home/user')
-        candidates_checked = []
+		def fake_is_dir(self):
+			# Use as_posix() for cross-platform path normalization
+			path_str = self.as_posix()
+			existing = {
+				'/home/user/.config/google-chrome',
+				'/home/user/.config/chromium',
+			}
+			return path_str in existing
 
-        def tracking_is_dir(self):
-            candidates_checked.append(str(self))
-            return fake_is_dir(self)
+		mock_home = Path('/home/user')
+		candidates_checked = []
 
-        with patch.object(Path, 'home', return_value=mock_home):
-            with patch.object(Path, 'is_dir', tracking_is_dir):
-                with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
-                    result = get_chrome_user_data_dirs()
+		def tracking_is_dir(self):
+			candidates_checked.append(str(self))
+			return fake_is_dir(self)
 
-        # Verify correct candidates were checked
-        normalized_checked = [_normalize_path(Path(c)) for c in candidates_checked]
-        assert '/home/user/.config/google-chrome' in normalized_checked
-        assert '/home/user/.config/chromium' in normalized_checked
-        assert '/home/user/.config/BraveSoftware/Brave-Browser' in normalized_checked
+		with patch.object(Path, 'home', return_value=mock_home):
+			with patch.object(Path, 'is_dir', tracking_is_dir):
+				with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+					result = get_chrome_user_data_dirs()
 
-        # Only existing dirs should be in result
-        result_strs = [_normalize_path(p) for p in result]
-        assert '/home/user/.config/google-chrome' in result_strs
-        assert '/home/user/.config/chromium' in result_strs
-        assert '/home/user/.config/BraveSoftware/Brave-Browser' not in result_strs
+		# Verify correct candidates were checked
+		normalized_checked = [_normalize_path(Path(c)) for c in candidates_checked]
+		assert '/home/user/.config/google-chrome' in normalized_checked
+		assert '/home/user/.config/chromium' in normalized_checked
+		assert '/home/user/.config/BraveSoftware/Brave-Browser' in normalized_checked
 
-    def test_macos_returns_only_existing_dirs(self):
-        """On macOS only existing directories under ~/Library/Application Support are returned."""
-        def fake_is_dir(self):
-            path_str = self.as_posix()
-            existing = {'/home/user/Library/Application Support/Google/Chrome'}
-            return path_str in existing
+		# Only existing dirs should be in result
+		result_strs = [_normalize_path(p) for p in result]
+		assert '/home/user/.config/google-chrome' in result_strs
+		assert '/home/user/.config/chromium' in result_strs
+		assert '/home/user/.config/BraveSoftware/Brave-Browser' not in result_strs
 
-        mock_home = Path('/home/user')
+	def test_macos_returns_only_existing_dirs(self):
+		"""On macOS only existing directories under ~/Library/Application Support are returned."""
 
-        with patch.object(Path, 'home', return_value=mock_home):
-            with patch.object(Path, 'is_dir', fake_is_dir):
-                with patch('browser_use.skill_cli.utils.platform.system', return_value='Darwin'):
-                    result = get_chrome_user_data_dirs()
+		def fake_is_dir(self):
+			path_str = self.as_posix()
+			existing = {'/home/user/Library/Application Support/Google/Chrome'}
+			return path_str in existing
 
-        result_strs = [_normalize_path(p) for p in result]
-        assert '/home/user/Library/Application Support/Google/Chrome' in result_strs
-        assert '/home/user/Library/Application Support/Chromium' not in result_strs
+		mock_home = Path('/home/user')
 
-    def test_windows_returns_only_existing_dirs(self):
-        """On Windows only existing directories under %LOCALAPPDATA% are returned."""
-        def fake_is_dir(self):
-            path_str = _normalize_path(self)
-            existing = {'C:/Users/user/AppData/Local/Google/Chrome/User Data'}
-            return path_str in existing
+		with patch.object(Path, 'home', return_value=mock_home):
+			with patch.object(Path, 'is_dir', fake_is_dir):
+				with patch('browser_use.skill_cli.utils.platform.system', return_value='Darwin'):
+					result = get_chrome_user_data_dirs()
 
-        mock_home = Path('C:/Users/user')
+		result_strs = [_normalize_path(p) for p in result]
+		assert '/home/user/Library/Application Support/Google/Chrome' in result_strs
+		assert '/home/user/Library/Application Support/Chromium' not in result_strs
 
-        with patch.object(Path, 'home', return_value=mock_home):
-            with patch.object(Path, 'is_dir', fake_is_dir):
-                with patch('browser_use.skill_cli.utils.platform.system', return_value='Windows'):
-                    with patch('browser_use.skill_cli.utils.os.environ.get', side_effect=lambda k, d=None: {
-                        'LOCALAPPDATA': 'C:\\Users\\user\\AppData\\Local',
-                    }.get(k, d)):
-                        result = get_chrome_user_data_dirs()
+	def test_windows_returns_only_existing_dirs(self):
+		"""On Windows only existing directories under %LOCALAPPDATA% are returned."""
 
-        result_strs = [_normalize_path(p) for p in result]
-        assert 'C:/Users/user/AppData/Local/Google/Chrome/User Data' in result_strs
-        assert 'C:/Users/user/AppData/Local/Chromium/User Data' not in result_strs
+		def fake_is_dir(self):
+			path_str = _normalize_path(self)
+			existing = {'C:/Users/user/AppData/Local/Google/Chrome/User Data'}
+			return path_str in existing
+
+		mock_home = Path('C:/Users/user')
+
+		with patch.object(Path, 'home', return_value=mock_home):
+			with patch.object(Path, 'is_dir', fake_is_dir):
+				with patch('browser_use.skill_cli.utils.platform.system', return_value='Windows'):
+					with patch(
+						'browser_use.skill_cli.utils.os.environ.get',
+						side_effect=lambda k, d=None: {
+							'LOCALAPPDATA': 'C:\\Users\\user\\AppData\\Local',
+						}.get(k, d),
+					):
+						result = get_chrome_user_data_dirs()
+
+		result_strs = [_normalize_path(p) for p in result]
+		assert 'C:/Users/user/AppData/Local/Google/Chrome/User Data' in result_strs
+		assert 'C:/Users/user/AppData/Local/Chromium/User Data' not in result_strs
 
 
 class TestIsChromiumBrowser:
-    """Test _is_chromium_browser() correctly identifies Chromium-based browsers."""
+	"""Test _is_chromium_browser() correctly identifies Chromium-based browsers."""
 
-    def test_none_returns_false(self):
-        assert _is_chromium_browser(None) is False
+	def test_none_returns_false(self):
+		assert _is_chromium_browser(None) is False
 
-    def test_chromium_returns_true(self):
-        assert _is_chromium_browser('/usr/bin/chromium') is True
-        assert _is_chromium_browser('/usr/bin/chromium-browser') is True
+	def test_chromium_returns_true(self):
+		assert _is_chromium_browser('/usr/bin/chromium') is True
+		assert _is_chromium_browser('/usr/bin/chromium-browser') is True
 
-    def test_google_chrome_returns_false(self):
-        assert _is_chromium_browser('/usr/bin/google-chrome') is False
-        assert _is_chromium_browser('/usr/bin/google-chrome-stable') is False
+	def test_google_chrome_returns_false(self):
+		assert _is_chromium_browser('/usr/bin/google-chrome') is False
+		assert _is_chromium_browser('/usr/bin/google-chrome-stable') is False
 
-    def test_brave_returns_true(self):
-        assert _is_chromium_browser('/usr/bin/brave-browser') is True
+	def test_brave_returns_true(self):
+		assert _is_chromium_browser('/usr/bin/brave-browser') is True
 
-    def test_edge_returns_true(self):
-        assert _is_chromium_browser('/usr/bin/microsoft-edge') is True
+	def test_edge_returns_true(self):
+		assert _is_chromium_browser('/usr/bin/microsoft-edge') is True
 
-    def test_windows_chrome_returns_false(self):
-        assert _is_chromium_browser('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe') is False
+	def test_windows_chrome_returns_false(self):
+		assert _is_chromium_browser('C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe') is False
 
-    def test_windows_chromium_returns_true(self):
-        assert _is_chromium_browser('C:\\Program Files\\Chromium\\Application\\chrome.exe') is True
+	def test_windows_chromium_returns_true(self):
+		assert _is_chromium_browser('C:\\Program Files\\Chromium\\Application\\chrome.exe') is True
 
 
 class TestGetChromeProfilePath:
-    """Test get_chrome_profile_path() with the executable_path parameter on Linux."""
+	"""Test get_chrome_profile_path() with the executable_path parameter on Linux."""
 
-    def test_linux_chromium_profile_path(self):
-        """On Linux with Chromium executable, return the Chromium profile path."""
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
-            result = get_chrome_profile_path(None, executable_path='/usr/bin/chromium')
-        expected = str(Path.home() / '.config' / 'chromium')
-        assert result == expected
+	def test_linux_chromium_profile_path(self):
+		"""On Linux with Chromium executable, return the Chromium profile path."""
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+			result = get_chrome_profile_path(None, executable_path='/usr/bin/chromium')
+		expected = str(Path.home() / '.config' / 'chromium')
+		assert result == expected
 
-    def test_linux_chromium_browser_profile_path(self):
-        """On Linux with chromium-browser executable, return the Chromium profile path."""
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
-            result = get_chrome_profile_path(None, executable_path='/usr/bin/chromium-browser')
-        expected = str(Path.home() / '.config' / 'chromium')
-        assert result == expected
+	def test_linux_chromium_browser_profile_path(self):
+		"""On Linux with chromium-browser executable, return the Chromium profile path."""
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+			result = get_chrome_profile_path(None, executable_path='/usr/bin/chromium-browser')
+		expected = str(Path.home() / '.config' / 'chromium')
+		assert result == expected
 
-    def test_linux_google_chrome_profile_path(self):
-        """On Linux with google-chrome executable, return the Google Chrome profile path."""
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
-            result = get_chrome_profile_path(None, executable_path='/usr/bin/google-chrome')
-        expected = str(Path.home() / '.config' / 'google-chrome')
-        assert result == expected
+	def test_linux_google_chrome_profile_path(self):
+		"""On Linux with google-chrome executable, return the Google Chrome profile path."""
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+			result = get_chrome_profile_path(None, executable_path='/usr/bin/google-chrome')
+		expected = str(Path.home() / '.config' / 'google-chrome')
+		assert result == expected
 
-    def test_linux_brave_profile_path(self):
-        """On Linux with Brave executable, return Brave's own profile path."""
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
-            result = get_chrome_profile_path(None, executable_path='/usr/bin/brave-browser')
-        expected = str(Path.home() / '.config' / 'BraveSoftware' / 'Brave-Browser')
-        assert result == expected
+	def test_linux_brave_profile_path(self):
+		"""On Linux with Brave executable, return Brave's own profile path."""
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+			result = get_chrome_profile_path(None, executable_path='/usr/bin/brave-browser')
+		expected = str(Path.home() / '.config' / 'BraveSoftware' / 'Brave-Browser')
+		assert result == expected
 
-    def test_linux_edge_profile_path(self):
-        """On Linux with Microsoft Edge executable, return Edge's own profile path."""
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
-            result = get_chrome_profile_path(None, executable_path='/usr/bin/microsoft-edge')
-        expected = str(Path.home() / '.config' / 'microsoft-edge')
-        assert result == expected
+	def test_linux_edge_profile_path(self):
+		"""On Linux with Microsoft Edge executable, return Edge's own profile path."""
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+			result = get_chrome_profile_path(None, executable_path='/usr/bin/microsoft-edge')
+		expected = str(Path.home() / '.config' / 'microsoft-edge')
+		assert result == expected
 
-    def test_linux_no_executable_path_defaults_to_chrome(self):
-        """On Linux with no executable_path, default to Google Chrome profile path."""
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
-            result = get_chrome_profile_path(None, executable_path=None)
-        expected = str(Path.home() / '.config' / 'google-chrome')
-        assert result == expected
+	def test_linux_no_executable_path_defaults_to_chrome(self):
+		"""On Linux with no executable_path, default to Google Chrome profile path."""
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+			result = get_chrome_profile_path(None, executable_path=None)
+		expected = str(Path.home() / '.config' / 'google-chrome')
+		assert result == expected
 
-    def test_macos_profile_path(self):
-        """On macOS, return the Chrome Application Support directory."""
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Darwin'):
-            result = get_chrome_profile_path(None)
-        expected = str(Path.home() / 'Library' / 'Application Support' / 'Google' / 'Chrome')
-        assert result == expected
+	def test_macos_profile_path(self):
+		"""On macOS, return the Chrome Application Support directory."""
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Darwin'):
+			result = get_chrome_profile_path(None)
+		expected = str(Path.home() / 'Library' / 'Application Support' / 'Google' / 'Chrome')
+		assert result == expected
 
-    def test_windows_profile_path(self):
-        """On Windows, return the Chrome User Data directory under %LOCALAPPDATA%."""
-        import os
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Windows'):
-            result = get_chrome_profile_path(None)
-        expected = os.path.expandvars(r'%LocalAppData%\Google\Chrome\User Data')
-        assert result == expected
+	def test_windows_profile_path(self):
+		"""On Windows, return the Chrome User Data directory under %LOCALAPPDATA%."""
+		import os
 
-    def test_named_profile_returns_profile_name(self):
-        """When a profile name is given, return it directly (Chrome uses it as subdirectory)."""
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
-            result = get_chrome_profile_path('work-profile')
-        assert result == 'work-profile'
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Windows'):
+			result = get_chrome_profile_path(None)
+		expected = os.path.expandvars(r'%LocalAppData%\Google\Chrome\User Data')
+		assert result == expected
 
-    def test_named_profile_macos(self):
-        """On macOS, named profile returns the profile name directly."""
-        with patch('browser_use.skill_cli.utils.platform.system', return_value='Darwin'):
-            result = get_chrome_profile_path('my-profile')
-        assert result == 'my-profile'
+	def test_named_profile_returns_profile_name(self):
+		"""When a profile name is given, return it directly (Chrome uses it as subdirectory)."""
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Linux'):
+			result = get_chrome_profile_path('work-profile')
+		assert result == 'work-profile'
+
+	def test_named_profile_macos(self):
+		"""On macOS, named profile returns the profile name directly."""
+		with patch('browser_use.skill_cli.utils.platform.system', return_value='Darwin'):
+			result = get_chrome_profile_path('my-profile')
+		assert result == 'my-profile'


### PR DESCRIPTION
Addresses cubic review feedback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened agent history handling and fixed Linux profile detection for Chrome/Chromium/Brave/Edge. Guards prevent crashes on empty/None results, and profile listing now uses the detected executable.

- **Bug Fixes**
  - History loading: deep-copy input; drop non-dict items; normalize state fields; coerce invalid/non-list result to []; validate/normalize model_output; replace cleaned history before validation.
  - Guard AgentHistoryList methods to handle empty/None results in errors(), final_result(), is_successful(), judgement(), is_judged(), and is_validated().
  - Linux profiles: pass executable_path to get_chrome_profile_path() and list_chrome_profiles(); correct user-data dirs for Chrome (~/.config/google-chrome), Chromium (~/.config/chromium), Brave (~/.config/BraveSoftware/Brave-Browser), and Edge (~/.config/microsoft-edge); CLI and BrowserSession now pass the detected chrome_path for consistent profile listing.
  - Session cleanup: also close chrome-extension:// tabs.
  - Installer: export PATH after installing `uv`.
  - Tests: added coverage for malformed/None results and executable-aware profile detection, including get_chrome_user_data_dirs() and Linux Brave/Edge paths; verified round-trips.

- **Dependencies**
  - Add `litellm>=1.82.2`.
  - Version set to `0.12.5` to align with main.

<sup>Written for commit a767457d2230bf2dd2f0db81d4164c56414084ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

