### PR TITLE
WIP: Add fish shell support to CLI installer

### DIFF
--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -376,33 +376,69 @@ install_profile_use() {
 # =============================================================================
 
 configure_path() {
-	local shell_rc=""
 	local bin_path=$(get_venv_bin_dir)
 	local local_bin="$HOME/.local/bin"
+	local shell_name=$(get_user_shell_name)
+	local shell_rc=$(get_shell_rc_path "$shell_name")
 
-	# Detect shell
-	if [ -n "$BASH_VERSION" ]; then
-		shell_rc="$HOME/.bashrc"
-	elif [ -n "$ZSH_VERSION" ]; then
-		shell_rc="$HOME/.zshrc"
-	else
-		shell_rc="$HOME/.profile"
+	if [ "$shell_name" = "fish" ]; then
+		mkdir -p "$(dirname "$shell_rc")"
 	fi
 
 	# Check if already in PATH (browser-use-env matches both /bin and /Scripts)
 	if grep -q "browser-use-env" "$shell_rc" 2>/dev/null; then
 		log_info "PATH already configured in $shell_rc"
 	else
-		# Add to shell config (includes ~/.local/bin for tools)
-		echo "" >> "$shell_rc"
-		echo "# Browser-Use" >> "$shell_rc"
-		echo "export PATH=\"$bin_path:$local_bin:\$PATH\"" >> "$shell_rc"
+		append_path_config "$shell_name" "$shell_rc" "$bin_path" "$local_bin"
 		log_success "Added to PATH in $shell_rc"
 	fi
 
 	# On Windows, also configure PowerShell profile
 	if [ "$PLATFORM" = "windows" ]; then
 		configure_powershell_path
+	fi
+}
+
+get_user_shell_name() {
+	if [ -n "$SHELL" ]; then
+		basename "$SHELL"
+	else
+		echo "sh"
+	fi
+}
+
+get_shell_rc_path() {
+	local shell_name="$1"
+
+	case "$shell_name" in
+		fish)
+			echo "$HOME/.config/fish/config.fish"
+			;;
+		bash)
+			echo "$HOME/.bashrc"
+			;;
+		zsh)
+			echo "$HOME/.zshrc"
+			;;
+		*)
+			echo "$HOME/.profile"
+			;;
+	esac
+}
+
+append_path_config() {
+	local shell_name="$1"
+	local shell_rc="$2"
+	local bin_path="$3"
+	local local_bin="$4"
+
+	echo "" >> "$shell_rc"
+	echo "# Browser-Use" >> "$shell_rc"
+
+	if [ "$shell_name" = "fish" ]; then
+		echo "set -gx PATH \"$bin_path\" \"$local_bin\" \$PATH" >> "$shell_rc"
+	else
+		echo "export PATH=\"$bin_path:$local_bin:\$PATH\"" >> "$shell_rc"
 	fi
 }
 
@@ -455,11 +491,8 @@ validate() {
 # =============================================================================
 
 print_next_steps() {
-	# Detect shell for source command
-	local shell_rc=".bashrc"
-	if [ -n "$ZSH_VERSION" ]; then
-		shell_rc=".zshrc"
-	fi
+	local shell_name=$(get_user_shell_name)
+	local shell_rc=$(get_shell_rc_path "$shell_name")
 
 	echo ""
 	echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -471,7 +504,7 @@ print_next_steps() {
 	if [ "$PLATFORM" = "windows" ]; then
 		echo "  1. Restart PowerShell (PATH is now configured automatically)"
 	else
-		echo "  1. Restart your shell or run: source ~/$shell_rc"
+		echo "  1. Restart your shell or run: source $shell_rc"
 	fi
 	echo "  2. Try: browser-use open https://example.com"
 

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -382,6 +382,7 @@ configure_path() {
 	local shell_rc=$(get_shell_rc_path "$shell_name")
 
 	if [ "$shell_name" = "fish" ]; then
+		# Fish stores user config under ~/.config/fish/, which may not exist yet.
 		mkdir -p "$(dirname "$shell_rc")"
 	fi
 


### PR DESCRIPTION
Add support for the fish shell and creates the config.fish file [if it does not already exist](https://fishshell.com/docs/current/tutorial.html#:~:text=Fish%20starts%20by%20executing%20commands%20in%20~/.config/fish/config.fish.%20You%20can%20create%20it%20if%20it%20does%20not%20exist.) 

WIP: working on testing this before requesting review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add fish shell support to the CLI installer. It detects fish, creates `~/.config/fish/config.fish` if missing, and appends PATH using fish syntax. Post-install messaging now matches the user’s shell.

- **New Features**
  - Detects the user’s shell and selects the right rc file (`fish`, `bash`, `zsh`, fallback to `.profile`).
  - Creates `~/.config/fish/config.fish` for fish users when absent.
  - Appends PATH with fish-compatible `set -gx PATH ...` or `export` for POSIX shells.
  - Updates next-step instructions to source the correct rc file.

<sup>Written for commit 1b215b566aa27d5d0d6bb8cddde6146221b96cf2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

