### PR TITLE
fix(cli): increase daemon startup timeout and disable default extensions

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -303,10 +303,10 @@ def ensure_daemon(
 		)
 
 	# Wait for daemon to be ready
-	for _ in range(100):  # 5 seconds max
+	for _ in range(300):  # 30 seconds max
 		if _is_daemon_alive(session):
 			return
-		time.sleep(0.05)
+		time.sleep(0.1)
 
 	print('Error: Failed to start daemon', file=sys.stderr)
 	sys.exit(1)

--- a/browser_use/skill_cli/sessions.py
+++ b/browser_use/skill_cli/sessions.py
@@ -39,10 +39,10 @@ async def create_browser_session(
 	- No profile: Playwright-managed Chromium (default)
 	"""
 	if cdp_url is not None:
-		return BrowserSession(cdp_url=cdp_url)
+		return BrowserSession(cdp_url=cdp_url, enable_default_extensions=False)
 
 	if use_cloud:
-		kwargs: dict = {'use_cloud': True}
+		kwargs: dict = {'use_cloud': True, 'enable_default_extensions': False}
 		if cloud_timeout is not None:
 			kwargs['cloud_timeout'] = cloud_timeout
 		if cloud_proxy_country_code is not None:
@@ -54,6 +54,7 @@ async def create_browser_session(
 	if profile is None:
 		return BrowserSession(
 			headless=not headed,
+			enable_default_extensions=False,
 		)
 
 	from browser_use.skill_cli.utils import find_chrome_executable, get_chrome_profile_path, list_chrome_profiles
@@ -99,4 +100,5 @@ async def create_browser_session(
 		user_data_dir=user_data_dir,
 		profile_directory=profile_directory,
 		headless=not headed,
+		enable_default_extensions=False,
 	)


### PR DESCRIPTION
## Summary

This PR fixes two issues that cause the browser-use CLI to timeout or hang:

### Problem
When running `browser-use open <url>` or other CLI commands, users frequently encounter:
1. **"Failed to start daemon"** error - daemon startup timeout after 5 seconds
2. **Indefinite hanging** - caused by browser extension downloads timing out

### Solution

#### 1. Increase daemon startup timeout (`main.py`)
- **Before:** 100 iterations × 0.05s = **5 seconds max**
- **After:** 300 iterations × 0.1s = **30 seconds max**
- Also increased sleep interval to reduce CPU usage during polling

Some systems (especially first-run or slower machines) need more time to:
- Initialize the Python environment
- Import heavy dependencies (Playwright, CDP, etc.)
- Start the browser process

#### 2. Disable default browser extensions (`sessions.py`)
Added `enable_default_extensions=False` to all `BrowserSession` creations:
- CDP URL mode
- Cloud browser mode  
- Local Chromium mode (headless/headed)
- Chrome profile mode

**Why:** browser-use by default attempts to download uBlock Origin Lite and other extensions from the Chrome Web Store. This download:
- Can timeout on slow or restricted networks
- Blocks the entire browser startup process
- Is unnecessary for most automation use cases

Users who need extensions can still enable them via the Python API.

### Testing

Tested on macOS with Python 3.12:
- ✅ `browser-use doctor` - passes all checks
- ✅ `browser-use open https://github.com` - successfully opens page
- ✅ `browser-use state` - returns element indices
- ✅ `browser-use screenshot` - captures screenshot
- ✅ `browser-use close` - cleanly shuts down

### Related Issues

Fixes timeout issues reported by users on systems with:
- Slower startup times
- Network restrictions or slow connections
- First-time installations

---
**Note:** This is a minimal change focused on CLI stability. The `enable_default_extensions` parameter already exists in the `BrowserSession` API - we're just passing `False` in the CLI context where extensions are typically not needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents CLI timeouts and hangs by increasing the daemon startup wait to 30s and disabling default browser extensions during session creation. Improves reliability on first run and slow or restricted networks for commands like open, state, screenshot.

- **Bug Fixes**
  - Increase daemon startup wait from 5s to 30s (300 × 0.1s); reduces CPU during polling.
  - Disable default extensions in all `BrowserSession` modes (CDP, cloud, local, Chrome profile) to avoid Web Store download delays; still configurable via the Python API.

<sup>Written for commit 1111dd4407a1b2f8190b78afda8486d975e0bf22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

