### PR TITLE
Remove 5s reload retry from empty DOM health check

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -423,36 +423,21 @@ class Tools(Generic[Context]):
 				await event.event_result(raise_if_any=True, raise_if_none=False)
 
 				# Health check: detect empty DOM for http/https pages and retry once.
-				# Uses _root is None (truly blank) OR empty llm_representation() (no actionable
-				# content for the LLM, e.g. SPA not yet rendered, empty body).
-				# NOTE: llm_representation() returns a non-empty placeholder when _root is None,
-				# so we must check _root is None separately — not rely on the repr string alone.
-				def _page_appears_empty(s) -> bool:
-					return s.dom_state._root is None or not s.dom_state.llm_representation().strip()
-
 				if not params.new_tab:
 					state = await browser_session.get_browser_state_summary(include_screenshot=False)
 					url_is_http = state.url.lower().startswith(('http://', 'https://'))
-					if url_is_http and _page_appears_empty(state):
+					if url_is_http and state.dom_state._root is None:
 						browser_session.logger.warning(
 							f'⚠️ Empty DOM detected after navigation to {params.url}, waiting 3s and rechecking...'
 						)
 						await asyncio.sleep(3.0)
 						state = await browser_session.get_browser_state_summary(include_screenshot=False)
-						if state.url.lower().startswith(('http://', 'https://')) and _page_appears_empty(state):
-							# Second attempt: reload the page and wait longer
-							browser_session.logger.warning(f'⚠️ Still empty after 3s, attempting page reload for {params.url}...')
-							reload_event = browser_session.event_bus.dispatch(NavigateToUrlEvent(url=params.url, new_tab=False))
-							await reload_event
-							await reload_event.event_result(raise_if_any=False, raise_if_none=False)
-							await asyncio.sleep(5.0)
-							state = await browser_session.get_browser_state_summary(include_screenshot=False)
-							if state.url.lower().startswith(('http://', 'https://')) and state.dom_state._root is None:
-								return ActionResult(
-									error=f'Page loaded but returned empty content for {params.url}. '
-									f'The page may require JavaScript that failed to render, use anti-bot measures, '
-									f'or have a connection issue (e.g. tunnel/proxy error). Try a different URL or approach.'
-								)
+						if state.url.lower().startswith(('http://', 'https://')) and state.dom_state._root is None:
+							return ActionResult(
+								error=f'Page loaded but returned empty content for {params.url}. '
+								f'The page may require JavaScript that failed to render, use anti-bot measures, '
+								f'or have a connection issue (e.g. tunnel/proxy error). Try a different URL or approach.'
+							)
 
 				if params.new_tab:
 					memory = f'Opened new tab with URL {params.url}'


### PR DESCRIPTION
## Summary

- Remove the second retry (reload + 5s wait) from the empty DOM health check after navigation
- Revert to checking `_root is None` only instead of the broader `llm_representation()` check which triggers too eagerly on SPAs still rendering
- Keep the original 3s wait + single recheck behavior

## Why

The expanded retry adds up to **8 seconds of blocking** on navigations where the DOM appears empty:
1. Wait 3s → recheck
2. Reload page → wait **5s** → recheck

This is too aggressive — slow-loading SPAs that would render fine in 1-2s get penalized with a full reload + 5s sleep. The broader `_page_appears_empty()` check (empty `llm_representation()`) also triggers on pages that have a DOM root but haven't fully hydrated, causing unnecessary retries on normal pages.

The original behavior (3s wait, single recheck, fail if truly empty) is sufficient. If the page is genuinely broken (proxy error, connection reset), the agent gets the error and can try a different approach.

## Test plan

- [ ] Navigate to a fast-loading static page — no retry triggered
- [ ] Navigate to a slow SPA (React app) — no unnecessary 8s delay
- [ ] Navigate to a truly broken URL — still gets error after 3s retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core navigation behavior: fewer retries and narrower empty-page detection may change how often navigations fail fast vs eventually succeed on slow/JS-heavy pages.
> 
> **Overview**
> Simplifies the post-navigation *empty DOM* health check in `tools.navigate()` by removing the reload + 5s wait second retry and returning an error after the existing 3s recheck.
> 
> Narrows the emptiness condition to only `state.dom_state._root is None`, dropping the prior `llm_representation()`-based check that could trigger on partially-rendered SPAs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04a551b755b7ad59b13700f2592ca6822ce628bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the reload + 5s retry in the empty DOM health check to avoid 8s delays on navigation. Restore the original 3s wait + single recheck and only treat pages as empty when `_root is None`.

- **Bug Fixes**
  - Remove reload + 5s sleep; after a 3s wait and recheck, return an error if still empty.
  - Revert emptiness check to `state.dom_state._root is None`; drop `llm_representation()` to avoid false positives on SPAs.
  - Results: faster navigations on slow SPAs; genuinely broken pages still surface errors.

<sup>Written for commit 04a551b755b7ad59b13700f2592ca6822ce628bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

