### PR TITLE
refactor(mcp): remove internal LLM, expose direct browser control via…

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -354,7 +354,10 @@ class BrowserUseServer:
 					inputSchema={
 						'type': 'object',
 						'properties': {
-							'keys': {'type': 'string', 'description': 'Key or key combination to send (e.g. "Enter", "Tab", "ctrl+a", "cmd+c")'},
+							'keys': {
+								'type': 'string',
+								'description': 'Key or key combination to send (e.g. "Enter", "Tab", "ctrl+a", "cmd+c")',
+							},
 						},
 						'required': ['keys'],
 					},
@@ -375,7 +378,10 @@ class BrowserUseServer:
 					inputSchema={
 						'type': 'object',
 						'properties': {
-							'index': {'type': 'integer', 'description': 'The index of the dropdown element (from browser_get_state)'},
+							'index': {
+								'type': 'integer',
+								'description': 'The index of the dropdown element (from browser_get_state)',
+							},
 						},
 						'required': ['index'],
 					},
@@ -386,7 +392,10 @@ class BrowserUseServer:
 					inputSchema={
 						'type': 'object',
 						'properties': {
-							'index': {'type': 'integer', 'description': 'The index of the dropdown element (from browser_get_state)'},
+							'index': {
+								'type': 'integer',
+								'description': 'The index of the dropdown element (from browser_get_state)',
+							},
 							'text': {'type': 'string', 'description': 'The exact text of the option to select'},
 						},
 						'required': ['index', 'text'],
@@ -882,7 +891,9 @@ class BrowserUseServer:
 			return 'Error: No active CDP session'
 
 		if selector:
-			js = f'(function(){{ const el = document.querySelector({json.dumps(selector)}); return el ? el.innerText : null; }})()'
+			js = (
+				f'(function(){{ const el = document.querySelector({json.dumps(selector)}); return el ? el.innerText : null; }})()'
+			)
 		else:
 			js = 'document.body.innerText'
 
@@ -1123,7 +1134,7 @@ class BrowserUseServer:
 			# If this was the current session, clear it
 			if self.browser_session and self.browser_session.id == session_id:
 				self.browser_session = None
-		
+
 			return f'Successfully closed session {session_id}'
 		except Exception as e:
 			return f'Error closing session {session_id}: {str(e)}'

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -37,8 +37,6 @@ import time
 from pathlib import Path
 from typing import Any
 
-from browser_use.llm import ChatAWSBedrock
-
 # Configure logging for MCP mode - redirect to stderr but preserve critical diagnostics
 logging.basicConfig(
 	stream=sys.stderr, level=logging.WARNING, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', force=True
@@ -90,12 +88,8 @@ _configure_mcp_server_logging()
 logging.disable(logging.CRITICAL)
 
 # Import browser_use modules
-from browser_use import ActionModel, Agent
 from browser_use.browser import BrowserProfile, BrowserSession
-from browser_use.config import get_default_llm, get_default_profile, load_browser_use_config
-from browser_use.filesystem.file_system import FileSystem
-from browser_use.llm.openai.chat import ChatOpenAI
-from browser_use.tools.service import Tools
+from browser_use.config import get_default_profile, load_browser_use_config
 
 logger = logging.getLogger(__name__)
 
@@ -193,11 +187,7 @@ class BrowserUseServer:
 
 		self.server = Server('browser-use')
 		self.config = load_browser_use_config()
-		self.agent: Agent | None = None
 		self.browser_session: BrowserSession | None = None
-		self.tools: Tools | None = None
-		self.llm: ChatOpenAI | None = None
-		self.file_system: FileSystem | None = None
 		self._telemetry = ProductTelemetry()
 		self._start_time = time.time()
 
@@ -290,19 +280,16 @@ class BrowserUseServer:
 					},
 				),
 				types.Tool(
-					name='browser_extract_content',
-					description='Extract structured content from the current page based on a query',
+					name='browser_get_text',
+					description='Get the visible text content of the current page, cleaned of HTML tags',
 					inputSchema={
 						'type': 'object',
 						'properties': {
-							'query': {'type': 'string', 'description': 'What information to extract from the page'},
-							'extract_links': {
-								'type': 'boolean',
-								'description': 'Whether to include links in the extraction',
-								'default': False,
+							'selector': {
+								'type': 'string',
+								'description': 'Optional CSS selector to get text of a specific element. If omitted, returns full page text.',
 							},
 						},
-						'required': ['query'],
 					},
 				),
 				types.Tool(
@@ -352,6 +339,60 @@ class BrowserUseServer:
 					description='Go back to the previous page',
 					inputSchema={'type': 'object', 'properties': {}},
 				),
+				types.Tool(
+					name='browser_go_forward',
+					description='Go forward to the next page in browser history',
+					inputSchema={'type': 'object', 'properties': {}},
+				),
+				types.Tool(
+					name='browser_refresh',
+					description='Refresh/reload the current page',
+					inputSchema={'type': 'object', 'properties': {}},
+				),
+				types.Tool(
+					name='browser_send_keys',
+					description='Send keyboard keys or shortcuts to the browser (e.g. "Enter", "Escape", "ctrl+a", "ctrl+c")',
+					inputSchema={
+						'type': 'object',
+						'properties': {
+							'keys': {'type': 'string', 'description': 'Key or key combination to send (e.g. "Enter", "Tab", "ctrl+a", "cmd+c")'},
+						},
+						'required': ['keys'],
+					},
+				),
+				types.Tool(
+					name='browser_wait',
+					description='Wait for a specified number of seconds',
+					inputSchema={
+						'type': 'object',
+						'properties': {
+							'seconds': {'type': 'number', 'description': 'Number of seconds to wait (max 10)', 'default': 2},
+						},
+					},
+				),
+				types.Tool(
+					name='browser_get_dropdown_options',
+					description='Get all available options from a dropdown/select element by its index',
+					inputSchema={
+						'type': 'object',
+						'properties': {
+							'index': {'type': 'integer', 'description': 'The index of the dropdown element (from browser_get_state)'},
+						},
+						'required': ['index'],
+					},
+				),
+				types.Tool(
+					name='browser_select_option',
+					description='Select an option from a dropdown/select element by its index and the option text',
+					inputSchema={
+						'type': 'object',
+						'properties': {
+							'index': {'type': 'integer', 'description': 'The index of the dropdown element (from browser_get_state)'},
+							'text': {'type': 'string', 'description': 'The exact text of the option to select'},
+						},
+						'required': ['index', 'text'],
+					},
+				),
 				# Tab management
 				types.Tool(
 					name='browser_list_tabs', description='List all open tabs', inputSchema={'type': 'object', 'properties': {}}
@@ -382,40 +423,6 @@ class BrowserUseServer:
 				# 		"properties": {}
 				# 	}
 				# ),
-				types.Tool(
-					name='retry_with_browser_use_agent',
-					description='Retry a task using the browser-use agent. Only use this as a last resort if you fail to interact with a page multiple times.',
-					inputSchema={
-						'type': 'object',
-						'properties': {
-							'task': {
-								'type': 'string',
-								'description': 'The high-level goal and detailed step-by-step description of the task the AI browser agent needs to attempt, along with any relevant data needed to complete the task and info about previous attempts.',
-							},
-							'max_steps': {
-								'type': 'integer',
-								'description': 'Maximum number of steps an agent can take.',
-								'default': 100,
-							},
-							'model': {
-								'type': 'string',
-								'description': 'LLM model to use (e.g., gpt-4o, claude-3-opus-20240229). Defaults to the configured model.',
-							},
-							'allowed_domains': {
-								'type': 'array',
-								'items': {'type': 'string'},
-								'description': 'List of domains the agent is allowed to visit (security feature)',
-								'default': [],
-							},
-							'use_vision': {
-								'type': 'boolean',
-								'description': 'Whether to use vision capabilities (screenshots) for the agent',
-								'default': True,
-							},
-						},
-						'required': ['task'],
-					},
-				),
 				# Browser session management tools
 				types.Tool(
 					name='browser_list_sessions',
@@ -485,16 +492,6 @@ class BrowserUseServer:
 	) -> str | list[types.TextContent | types.ImageContent]:
 		"""Execute a browser-use tool. Returns str for most tools, or a content list for tools with image output."""
 
-		# Agent-based tools
-		if tool_name == 'retry_with_browser_use_agent':
-			return await self._retry_with_browser_use_agent(
-				task=arguments['task'],
-				max_steps=arguments.get('max_steps', 100),
-				model=arguments.get('model'),
-				allowed_domains=arguments.get('allowed_domains', []),
-				use_vision=arguments.get('use_vision', True),
-			)
-
 		# Browser session management tools (don't require active session)
 		if tool_name == 'browser_list_sessions':
 			return await self._list_sessions()
@@ -542,14 +539,32 @@ class BrowserUseServer:
 					content.append(types.ImageContent(type='image', data=screenshot_b64, mimeType='image/png'))
 				return content
 
-			elif tool_name == 'browser_extract_content':
-				return await self._extract_content(arguments['query'], arguments.get('extract_links', False))
+			elif tool_name == 'browser_get_text':
+				return await self._get_text(arguments.get('selector'))
 
 			elif tool_name == 'browser_scroll':
 				return await self._scroll(arguments.get('direction', 'down'))
 
 			elif tool_name == 'browser_go_back':
 				return await self._go_back()
+
+			elif tool_name == 'browser_go_forward':
+				return await self._go_forward()
+
+			elif tool_name == 'browser_refresh':
+				return await self._refresh()
+
+			elif tool_name == 'browser_send_keys':
+				return await self._send_keys(arguments['keys'])
+
+			elif tool_name == 'browser_wait':
+				return await self._wait(arguments.get('seconds', 2))
+
+			elif tool_name == 'browser_get_dropdown_options':
+				return await self._get_dropdown_options(arguments['index'])
+
+			elif tool_name == 'browser_select_option':
+				return await self._select_option(arguments['index'], arguments['text'])
 
 			elif tool_name == 'browser_close':
 				return await self._close_browser()
@@ -608,129 +623,7 @@ class BrowserUseServer:
 		# Track the session for management
 		self._track_session(self.browser_session)
 
-		# Create tools for direct actions
-		self.tools = Tools()
-
-		# Initialize LLM from config
-		llm_config = get_default_llm(self.config)
-		base_url = llm_config.get('base_url', None)
-		kwargs = {}
-		if base_url:
-			kwargs['base_url'] = base_url
-		if api_key := llm_config.get('api_key'):
-			self.llm = ChatOpenAI(
-				model=llm_config.get('model', 'gpt-o4-mini'),
-				api_key=api_key,
-				temperature=llm_config.get('temperature', 0.7),
-				**kwargs,
-			)
-
-		# Initialize FileSystem for extraction actions
-		file_system_path = profile_config.get('file_system_path', '~/.browser-use-mcp')
-		self.file_system = FileSystem(base_dir=Path(file_system_path).expanduser())
-
 		logger.debug('Browser session initialized')
-
-	async def _retry_with_browser_use_agent(
-		self,
-		task: str,
-		max_steps: int = 100,
-		model: str | None = None,
-		allowed_domains: list[str] | None = None,
-		use_vision: bool = True,
-	) -> str:
-		"""Run an autonomous agent task."""
-		logger.debug(f'Running agent task: {task}')
-
-		# Get LLM config
-		llm_config = get_default_llm(self.config)
-
-		# Get LLM provider
-		model_provider = llm_config.get('model_provider') or os.getenv('MODEL_PROVIDER')
-
-		# Get Bedrock-specific config
-		if model_provider and model_provider.lower() == 'bedrock':
-			llm_model = llm_config.get('model') or os.getenv('MODEL') or 'us.anthropic.claude-sonnet-4-20250514-v1:0'
-			aws_region = llm_config.get('region') or os.getenv('REGION')
-			if not aws_region:
-				aws_region = 'us-east-1'
-			aws_sso_auth = llm_config.get('aws_sso_auth', False)
-			llm = ChatAWSBedrock(
-				model=llm_model,  # or any Bedrock model
-				aws_region=aws_region,
-				aws_sso_auth=aws_sso_auth,
-			)
-		else:
-			api_key = llm_config.get('api_key') or os.getenv('OPENAI_API_KEY')
-			if not api_key:
-				return 'Error: OPENAI_API_KEY not set in config or environment'
-
-			# Use explicit model from tool call, otherwise fall back to configured default
-			llm_model = model or llm_config.get('model', 'gpt-4o')
-
-			base_url = llm_config.get('base_url', None)
-			kwargs = {}
-			if base_url:
-				kwargs['base_url'] = base_url
-			llm = ChatOpenAI(
-				model=llm_model,
-				api_key=api_key,
-				temperature=llm_config.get('temperature', 0.7),
-				**kwargs,
-			)
-
-		# Get profile config and merge with tool parameters
-		profile_config = get_default_profile(self.config)
-
-		# Override allowed_domains if provided in tool call
-		if allowed_domains is not None:
-			profile_config['allowed_domains'] = allowed_domains
-
-		# Create browser profile using config
-		profile = BrowserProfile(**profile_config)
-
-		# Create and run agent
-		agent = Agent(
-			task=task,
-			llm=llm,
-			browser_profile=profile,
-			use_vision=use_vision,
-		)
-
-		try:
-			history = await agent.run(max_steps=max_steps)
-
-			# Format results
-			results = []
-			results.append(f'Task completed in {len(history.history)} steps')
-			results.append(f'Success: {history.is_successful()}')
-
-			# Get final result if available
-			final_result = history.final_result()
-			if final_result:
-				results.append(f'\nFinal result:\n{final_result}')
-
-			# Include any errors
-			errors = history.errors()
-			if errors:
-				results.append(f'\nErrors encountered:\n{json.dumps(errors, indent=2)}')
-
-			# Include URLs visited
-			urls = history.urls()
-			if urls:
-				# Filter out None values and convert to strings
-				valid_urls = [str(url) for url in urls if url is not None]
-				if valid_urls:
-					results.append(f'\nURLs visited: {", ".join(valid_urls)}')
-
-			return '\n'.join(results)
-
-		except Exception as e:
-			logger.error(f'Agent task failed: {e}', exc_info=True)
-			return f'Agent task failed: {str(e)}'
-		finally:
-			# Clean up
-			await agent.close()
 
 	async def _navigate(self, url: str, new_tab: bool = False) -> str:
 		"""Navigate to a URL."""
@@ -974,47 +867,30 @@ class BrowserUseServer:
 			}
 		return json.dumps(result), b64
 
-	async def _extract_content(self, query: str, extract_links: bool = False) -> str:
-		"""Extract content from current page."""
-		if not self.llm:
-			return 'Error: LLM not initialized (set OPENAI_API_KEY)'
-
-		if not self.file_system:
-			return 'Error: FileSystem not initialized'
-
+	async def _get_text(self, selector: str | None = None) -> str:
+		"""Get visible text content of the page or a specific element, stripped of HTML tags."""
 		if not self.browser_session:
 			return 'Error: No browser session active'
 
-		if not self.tools:
-			return 'Error: Tools not initialized'
+		self._update_session_activity(self.browser_session.id)
 
-		state = await self.browser_session.get_browser_state_summary()
+		cdp_session = await self.browser_session.get_or_create_cdp_session(target_id=None, focus=False)
+		if not cdp_session:
+			return 'Error: No active CDP session'
 
-		# Use the extract action
-		# Create a dynamic action model that matches the tools's expectations
-		from pydantic import create_model
+		if selector:
+			js = f'(function(){{ const el = document.querySelector({json.dumps(selector)}); return el ? el.innerText : null; }})()'
+		else:
+			js = 'document.body.innerText'
 
-		# Create action model dynamically
-		ExtractAction = create_model(
-			'ExtractAction',
-			__base__=ActionModel,
-			extract=dict[str, Any],
+		result = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': js, 'returnByValue': True},
+			session_id=cdp_session.session_id,
 		)
-
-		# Use model_validate because Pyright does not understand the dynamic model
-		action = ExtractAction.model_validate(
-			{
-				'extract': {'query': query, 'extract_links': extract_links},
-			}
-		)
-		action_result = await self.tools.act(
-			action=action,
-			browser_session=self.browser_session,
-			page_extraction_llm=self.llm,
-			file_system=self.file_system,
-		)
-
-		return action_result.extracted_content or 'No content extracted'
+		text = result.get('result', {}).get('value')
+		if text is None:
+			return f'No element found for selector: {selector}' if selector else 'Error: Could not get page text'
+		return text
 
 	async def _scroll(self, direction: str = 'down') -> str:
 		"""Scroll the page."""
@@ -1044,6 +920,80 @@ class BrowserUseServer:
 		await event
 		return 'Navigated back'
 
+	async def _go_forward(self) -> str:
+		"""Go forward in browser history."""
+		if not self.browser_session:
+			return 'Error: No browser session active'
+
+		from browser_use.browser.events import GoForwardEvent
+
+		event = self.browser_session.event_bus.dispatch(GoForwardEvent())
+		await event
+		return 'Navigated forward'
+
+	async def _refresh(self) -> str:
+		"""Refresh the current page."""
+		if not self.browser_session:
+			return 'Error: No browser session active'
+
+		from browser_use.browser.events import RefreshEvent
+
+		event = self.browser_session.event_bus.dispatch(RefreshEvent())
+		await event
+		return 'Page refreshed'
+
+	async def _send_keys(self, keys: str) -> str:
+		"""Send keyboard keys or shortcuts."""
+		if not self.browser_session:
+			return 'Error: No browser session active'
+
+		from browser_use.browser.events import SendKeysEvent
+
+		event = self.browser_session.event_bus.dispatch(SendKeysEvent(keys=keys))
+		await event
+		return f'Sent keys: {keys}'
+
+	async def _wait(self, seconds: float) -> str:
+		"""Wait for a number of seconds."""
+		if not self.browser_session:
+			return 'Error: No browser session active'
+
+		from browser_use.browser.events import WaitEvent
+
+		event = self.browser_session.event_bus.dispatch(WaitEvent(seconds=min(seconds, 10)))
+		await event
+		return f'Waited {min(seconds, 10)} seconds'
+
+	async def _get_dropdown_options(self, index: int) -> str:
+		"""Get all options from a dropdown element."""
+		if not self.browser_session:
+			return 'Error: No browser session active'
+
+		element = await self.browser_session.get_dom_element_by_index(index)
+		if not element:
+			return f'Element with index {index} not found'
+
+		from browser_use.browser.events import GetDropdownOptionsEvent
+
+		event = self.browser_session.event_bus.dispatch(GetDropdownOptionsEvent(node=element))
+		result = await event
+		return json.dumps(result, indent=2) if result else 'No options found'
+
+	async def _select_option(self, index: int, text: str) -> str:
+		"""Select an option from a dropdown element by text."""
+		if not self.browser_session:
+			return 'Error: No browser session active'
+
+		element = await self.browser_session.get_dom_element_by_index(index)
+		if not element:
+			return f'Element with index {index} not found'
+
+		from browser_use.browser.events import SelectDropdownOptionEvent
+
+		event = self.browser_session.event_bus.dispatch(SelectDropdownOptionEvent(node=element, text=text))
+		result = await event
+		return json.dumps(result, indent=2) if result else f'Selected option: {text}'
+
 	async def _close_browser(self) -> str:
 		"""Close the browser session."""
 		if self.browser_session:
@@ -1052,7 +1002,6 @@ class BrowserUseServer:
 			event = self.browser_session.event_bus.dispatch(BrowserStopEvent())
 			await event
 			self.browser_session = None
-			self.tools = None
 			return 'Browser closed'
 		return 'No browser session to close'
 
@@ -1155,8 +1104,7 @@ class BrowserUseServer:
 			# If this was the current session, clear it
 			if self.browser_session and self.browser_session.id == session_id:
 				self.browser_session = None
-				self.tools = None
-
+		
 			return f'Successfully closed session {session_id}'
 		except Exception as e:
 			return f'Error closing session {session_id}: {str(e)}'
@@ -1181,7 +1129,6 @@ class BrowserUseServer:
 
 		# Clear current session references
 		self.browser_session = None
-		self.tools = None
 
 		result = f'Closed {closed_count} sessions'
 		if errors:

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -206,7 +206,6 @@ class BrowserUseServer:
 		async def handle_list_tools() -> list[types.Tool]:
 			"""List all available browser-use tools."""
 			return [
-				# Agent tools
 				# Direct browser control tools
 				types.Tool(
 					name='browser_navigate',
@@ -719,6 +718,8 @@ class BrowserUseServer:
 		if not self.browser_session:
 			return 'Error: No browser session active'
 
+		self._update_session_activity(self.browser_session.id)
+
 		element = await self.browser_session.get_dom_element_by_index(index)
 		if not element:
 			return f'Element with index {index} not found'
@@ -764,6 +765,8 @@ class BrowserUseServer:
 		"""Get current browser state. Returns (state_json, screenshot_b64 | None)."""
 		if not self.browser_session:
 			return 'Error: No browser session active', None
+
+		self._update_session_activity(self.browser_session.id)
 
 		state = await self.browser_session.get_browser_state_summary()
 
@@ -897,6 +900,8 @@ class BrowserUseServer:
 		if not self.browser_session:
 			return 'Error: No browser session active'
 
+		self._update_session_activity(self.browser_session.id)
+
 		from browser_use.browser.events import ScrollEvent
 
 		# Scroll by a standard amount (500 pixels)
@@ -914,6 +919,8 @@ class BrowserUseServer:
 		if not self.browser_session:
 			return 'Error: No browser session active'
 
+		self._update_session_activity(self.browser_session.id)
+
 		from browser_use.browser.events import GoBackEvent
 
 		event = self.browser_session.event_bus.dispatch(GoBackEvent())
@@ -924,6 +931,8 @@ class BrowserUseServer:
 		"""Go forward in browser history."""
 		if not self.browser_session:
 			return 'Error: No browser session active'
+
+		self._update_session_activity(self.browser_session.id)
 
 		from browser_use.browser.events import GoForwardEvent
 
@@ -936,6 +945,8 @@ class BrowserUseServer:
 		if not self.browser_session:
 			return 'Error: No browser session active'
 
+		self._update_session_activity(self.browser_session.id)
+
 		from browser_use.browser.events import RefreshEvent
 
 		event = self.browser_session.event_bus.dispatch(RefreshEvent())
@@ -946,6 +957,8 @@ class BrowserUseServer:
 		"""Send keyboard keys or shortcuts."""
 		if not self.browser_session:
 			return 'Error: No browser session active'
+
+		self._update_session_activity(self.browser_session.id)
 
 		from browser_use.browser.events import SendKeysEvent
 
@@ -958,6 +971,8 @@ class BrowserUseServer:
 		if not self.browser_session:
 			return 'Error: No browser session active'
 
+		self._update_session_activity(self.browser_session.id)
+
 		from browser_use.browser.events import WaitEvent
 
 		event = self.browser_session.event_bus.dispatch(WaitEvent(seconds=min(seconds, 10)))
@@ -968,6 +983,8 @@ class BrowserUseServer:
 		"""Get all options from a dropdown element."""
 		if not self.browser_session:
 			return 'Error: No browser session active'
+
+		self._update_session_activity(self.browser_session.id)
 
 		element = await self.browser_session.get_dom_element_by_index(index)
 		if not element:
@@ -983,6 +1000,8 @@ class BrowserUseServer:
 		"""Select an option from a dropdown element by text."""
 		if not self.browser_session:
 			return 'Error: No browser session active'
+
+		self._update_session_activity(self.browser_session.id)
 
 		element = await self.browser_session.get_dom_element_by_index(index)
 		if not element:

--- a/tests/ci/test_mcp_distributed_agents.py
+++ b/tests/ci/test_mcp_distributed_agents.py
@@ -1,0 +1,284 @@
+"""Distributed agents test for the MCP server.
+
+Tests multiple BrowserUseServer instances operating concurrently:
+- Each server manages its own browser session independently
+- Concurrent navigation, content extraction, and session lifecycle
+- Session tracking and cleanup across parallel agents
+"""
+
+import asyncio
+import json
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.mcp.server import BrowserUseServer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='session')
+def test_server():
+	"""Shared HTTP server serving pages for distributed agent tests."""
+	server = HTTPServer()
+	server.start()
+
+	server.expect_request('/').respond_with_data(
+		'<html><body><h1>Home</h1><p id="content">Welcome</p></body></html>',
+		content_type='text/html',
+	)
+	server.expect_request('/task-a').respond_with_data(
+		'<html><body><h1>Task A</h1><p id="result">Result: alpha</p></body></html>',
+		content_type='text/html',
+	)
+	server.expect_request('/task-b').respond_with_data(
+		'<html><body><h1>Task B</h1><p id="result">Result: beta</p></body></html>',
+		content_type='text/html',
+	)
+	server.expect_request('/task-c').respond_with_data(
+		'<html><body><h1>Task C</h1><p id="result">Result: gamma</p></body></html>',
+		content_type='text/html',
+	)
+	server.expect_request('/form').respond_with_data(
+		"""<html><body>
+		<form>
+			<input id="q" type="text" name="q" />
+			<select id="sel" name="sel">
+				<option value="1">Option 1</option>
+				<option value="2">Option 2</option>
+			</select>
+		</form>
+		</body></html>""",
+		content_type='text/html',
+	)
+
+	yield server
+	server.stop()
+
+
+async def _make_server_with_session(profile: BrowserProfile) -> BrowserUseServer:
+	"""Create a BrowserUseServer and inject a pre-started session directly."""
+	server = BrowserUseServer(session_timeout_minutes=5)
+
+	session = BrowserSession(browser_profile=profile)
+	await session.start()
+
+	server.browser_session = session
+	server._track_session(session)
+
+	return server
+
+
+async def _cleanup_server(server: BrowserUseServer) -> None:
+	"""Kill all tracked sessions inside a server."""
+	for session_data in list(server.active_sessions.values()):
+		s = session_data['session']
+		try:
+			await s.kill()
+		except Exception:
+			pass
+	server.active_sessions.clear()
+	server.browser_session = None
+
+
+def _headless_profile() -> BrowserProfile:
+	return BrowserProfile(
+		headless=True,
+		keep_alive=False,
+		user_data_dir=None,
+		disable_security=True,
+	)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_single_agent_navigate_and_get_text(test_server: HTTPServer):
+	"""Sanity check: one server can navigate and read page text."""
+	server = await _make_server_with_session(_headless_profile())
+	try:
+		url = test_server.url_for('/task-a')
+		nav_result = await server._navigate(url)
+		assert 'navigated' in nav_result.lower() or 'http' in nav_result.lower()
+
+		text = await server._get_text()
+		assert 'Task A' in text
+		assert 'alpha' in text
+	finally:
+		await _cleanup_server(server)
+
+
+async def test_three_agents_concurrent_navigation(test_server: HTTPServer):
+	"""Three independent servers navigate to different pages simultaneously."""
+	paths = ['/task-a', '/task-b', '/task-c']
+	expected_texts = ['alpha', 'beta', 'gamma']
+
+	servers = await asyncio.gather(*[_make_server_with_session(_headless_profile()) for _ in paths])
+
+	async def agent_task(srv: BrowserUseServer, path: str) -> str:
+		url = test_server.url_for(path)
+		await srv._navigate(url)
+		return await srv._get_text()
+
+	try:
+		results = await asyncio.gather(*[agent_task(srv, path) for srv, path in zip(servers, paths)])
+
+		for result, expected in zip(results, expected_texts):
+			assert expected in result, f'Expected "{expected}" in page text, got: {result!r}'
+	finally:
+		await asyncio.gather(*[_cleanup_server(srv) for srv in servers])
+
+
+async def test_concurrent_session_tracking(test_server: HTTPServer):
+	"""Multiple servers each track their own session independently."""
+	n = 3
+	servers = await asyncio.gather(*[_make_server_with_session(_headless_profile()) for _ in range(n)])
+
+	try:
+		# Each server should track exactly one session
+		for srv in servers:
+			assert len(srv.active_sessions) == 1
+
+		# Each server's session ID should be unique across all servers
+		all_ids = [list(srv.active_sessions.keys())[0] for srv in servers]
+		assert len(set(all_ids)) == n, 'Session IDs must be unique across agents'
+
+		# _list_sessions returns valid JSON with the tracked session
+		for srv in servers:
+			listing = await srv._list_sessions()
+			sessions = json.loads(listing)
+			assert len(sessions) == 1
+			assert sessions[0]['session_id'] in srv.active_sessions
+	finally:
+		await asyncio.gather(*[_cleanup_server(srv) for srv in servers])
+
+
+async def test_concurrent_html_extraction(test_server: HTTPServer):
+	"""Multiple agents extract HTML from different pages simultaneously."""
+	pages = [('/task-a', 'alpha'), ('/task-b', 'beta'), ('/task-c', 'gamma')]
+
+	servers = await asyncio.gather(*[_make_server_with_session(_headless_profile()) for _ in pages])
+
+	async def navigate_and_extract(srv: BrowserUseServer, path: str) -> str:
+		await srv._navigate(test_server.url_for(path))
+		return await srv._get_html()
+
+	try:
+		htmls = await asyncio.gather(*[navigate_and_extract(srv, path) for srv, (path, _) in zip(servers, pages)])
+
+		for html, (_, keyword) in zip(htmls, pages):
+			assert keyword in html
+	finally:
+		await asyncio.gather(*[_cleanup_server(srv) for srv in servers])
+
+
+async def test_agent_back_forward_navigation(test_server: HTTPServer):
+	"""Single agent navigates forward/back between pages."""
+	server = await _make_server_with_session(_headless_profile())
+	try:
+		await server._navigate(test_server.url_for('/task-a'))
+		await server._navigate(test_server.url_for('/task-b'))
+
+		back_result = await server._go_back()
+		assert 'Error' not in back_result
+
+		text_after_back = await server._get_text()
+		assert 'Task A' in text_after_back
+
+		fwd_result = await server._go_forward()
+		assert 'Error' not in fwd_result
+
+		text_after_fwd = await server._get_text()
+		assert 'Task B' in text_after_fwd
+	finally:
+		await _cleanup_server(server)
+
+
+async def test_session_close_and_list(test_server: HTTPServer):
+	"""Closing a session removes it from tracking."""
+	server = await _make_server_with_session(_headless_profile())
+	try:
+		session_id = list(server.active_sessions.keys())[0]
+
+		# Verify it's listed
+		listing_before = await server._list_sessions()
+		data = json.loads(listing_before)
+		assert any(s['session_id'] == session_id for s in data)
+
+		# Close it
+		close_result = await server._close_session(session_id)
+		assert 'Successfully closed' in close_result
+
+		# Should no longer appear
+		listing_after = await server._list_sessions()
+		assert 'No active' in listing_after or session_id not in listing_after
+
+		# current session ref cleared
+		assert server.browser_session is None
+	except Exception:
+		# Already cleaned by close_session, avoid double-kill
+		server.active_sessions.clear()
+		server.browser_session = None
+		raise
+
+
+async def test_close_all_sessions(test_server: HTTPServer):
+	"""_close_all_sessions closes every tracked session at once."""
+	# One server, but inject two sessions manually
+	server = BrowserUseServer(session_timeout_minutes=5)
+
+	sessions = []
+	for _ in range(2):
+		s = BrowserSession(browser_profile=_headless_profile())
+		await s.start()
+		sessions.append(s)
+		server._track_session(s)
+
+	server.browser_session = sessions[0]
+
+	try:
+		assert len(server.active_sessions) == 2
+		result = await server._close_all_sessions()
+		assert 'Closed 2 sessions' in result
+		assert len(server.active_sessions) == 0
+		assert server.browser_session is None
+	except Exception:
+		for s in sessions:
+			try:
+				await s.kill()
+			except Exception:
+				pass
+		raise
+
+
+async def test_expired_session_cleanup():
+	"""Sessions past the timeout are cleaned up by _cleanup_expired_sessions."""
+	import time
+
+	server = BrowserUseServer(session_timeout_minutes=1)
+
+	s = BrowserSession(browser_profile=_headless_profile())
+	await s.start()
+	server._track_session(s)
+	server.browser_session = s
+
+	session_id = s.id
+
+	# Wind the clock back so the session looks expired
+	server.active_sessions[session_id]['last_activity'] -= 120  # 2 minutes ago
+
+	try:
+		await server._cleanup_expired_sessions()
+		assert session_id not in server.active_sessions, 'Expired session should be removed'
+	except Exception:
+		try:
+			await s.kill()
+		except Exception:
+			pass
+		raise


### PR DESCRIPTION
… MCP

- Remove `retry_with_browser_use_agent` tool — LLM-driven autonomous agent no longer runs inside the server
- Remove `browser_extract_content` (required internal LLM) → replace with `browser_get_text` (pure DOM innerText, no LLM needed)
- Drop all LLM imports/initialization from server: ChatAWSBedrock, ChatOpenAI, get_default_llm, Agent, ActionModel, FileSystem, Tools
- Add 6 new direct browser control tools so the external LLM has full control:
  - `browser_go_forward` — history forward
  - `browser_refresh` — reload page
  - `browser_send_keys` — keyboard shortcuts (Enter, Tab, ctrl+a, etc.)
  - `browser_wait` — wait N seconds (capped at 10)
  - `browser_get_dropdown_options` — list options from a <select>/ARIA dropdown by element index
  - `browser_select_option` — select a dropdown option by exact text

The MCP server now requires zero LLM configuration and zero API keys. The external model (Claude, GPT-4o, etc.) drives the browser directly via MCP tools.

https://claude.ai/code/session_01N5XCTbXNdBQefm6tkA5MBP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the internal language model from the MCP server and exposed direct browser control tools. Setup is now keyless, and action methods keep sessions active to prevent timeouts.

- **Refactors**
  - Removed `retry_with_browser_use_agent`.
  - Replaced `browser_extract_content` with `browser_get_text` (returns page or element `innerText`; optional `selector`).
  - Dropped all language-model code and deps (`ChatOpenAI`, `ChatAWSBedrock`, `get_default_llm`, `Agent`, `ActionModel`, `FileSystem`, `Tools`).
  - Added session activity updates to all action methods to avoid premature session timeout.
  - Formatting fixes for ruff/CI in `_get_text` and `_close_session`.

- **New Features**
  - `browser_go_forward`, `browser_refresh`, `browser_send_keys`.
  - `browser_wait` (max 10s), `browser_get_dropdown_options`, `browser_select_option`.

<sup>Written for commit a6e40c6d51327d84519806334dbcf0c1e1bb95e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

