### PR TITLE
feat: add disabled flag to SignalHandler for server embedding opt-out

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -87,6 +87,7 @@ class SignalHandler:
 		custom_exit_callback: Callable[[], None] | None = None,
 		exit_on_second_int: bool = True,
 		interruptible_task_patterns: list[str] | None = None,
+		disabled: bool = False,
 	):
 		"""
 		Initialize the signal handler.
@@ -99,6 +100,10 @@ class SignalHandler:
 			exit_on_second_int: Whether to exit on second SIGINT (Ctrl+C)
 			interruptible_task_patterns: List of patterns to match task names that should be
 										 canceled on first Ctrl+C (default: ['step', 'multi_act', 'get_next_action'])
+			disabled: If True, register() installs no signal handlers at all, leaving
+					  the host application's existing handlers in place. Useful for
+					  server embeddings (uvicorn, FastAPI, etc.) that manage their own
+					  shutdown lifecycle. Default: False.
 		"""
 		self.loop = loop or asyncio.get_event_loop()
 		self.pause_callback = pause_callback
@@ -106,6 +111,7 @@ class SignalHandler:
 		self.custom_exit_callback = custom_exit_callback
 		self.exit_on_second_int = exit_on_second_int
 		self.interruptible_task_patterns = interruptible_task_patterns or ['step', 'multi_act', 'get_next_action']
+		self.disabled = disabled
 		self.is_windows = platform.system() == 'Windows'
 
 		# Initialize loop state attributes
@@ -122,6 +128,8 @@ class SignalHandler:
 
 	def register(self) -> None:
 		"""Register signal handlers for SIGINT and SIGTERM."""
+		if self.disabled:
+			return
 		try:
 			if self.is_windows:
 				# On Windows, use simple signal handling with immediate exit on Ctrl+C
@@ -147,6 +155,8 @@ class SignalHandler:
 
 	def unregister(self) -> None:
 		"""Unregister signal handlers and restore original handlers if possible."""
+		if self.disabled:
+			return
 		try:
 			if self.is_windows:
 				# On Windows, just restore the original SIGINT handler

--- a/tests/test_signal_handler.py
+++ b/tests/test_signal_handler.py
@@ -1,0 +1,58 @@
+"""Tests for SignalHandler — particularly the disabled opt-out flag."""
+import asyncio
+import signal
+from unittest.mock import MagicMock
+
+import pytest
+
+from browser_use.utils import SignalHandler
+
+
+class TestSignalHandlerDisabled:
+    """Tests for SignalHandler(disabled=True) opt-out behaviour.
+    
+    Refs: https://github.com/browser-use/browser-use/issues/4385
+    """
+
+    def test_disabled_does_not_register_any_signal_handlers(self) -> None:
+        """When disabled=True, register() must be a no-op so host apps keep control."""
+        handler = SignalHandler(
+            loop=asyncio.new_event_loop(),
+            disabled=True,
+        )
+        # register() should not raise and should not touch any signal
+        handler.register()
+        # If we got here without an exception, the test passes.
+        # The real check is that no signal handler was installed.
+        # We verify by checking that original_sigint_handler stays None.
+        assert handler.original_sigint_handler is None
+
+    def test_disabled_unregister_is_also_noop(self) -> None:
+        """unregister() on a disabled handler must also be a no-op."""
+        handler = SignalHandler(
+            loop=asyncio.new_event_loop(),
+            disabled=True,
+        )
+        # Must not raise
+        handler.unregister()
+
+    def test_enabled_registers_sigint_handler(self) -> None:
+        """Smoke test: enabled=True (default) should attempt to register."""
+        loop = asyncio.new_event_loop()
+        handler = SignalHandler(
+            loop=loop,
+            disabled=False,
+        )
+        # We expect no exception from register() even if signals aren't
+        # fully available in the test environment.
+        try:
+            handler.register()
+        except Exception:
+            # SignalHandler silently swallows exceptions (see source)
+            pass
+        finally:
+            try:
+                handler.unregister()
+            except Exception:
+                pass
+            loop.close()


### PR DESCRIPTION
## Bug Fix: SignalHandler blocks graceful shutdown in server embeddings

**Issue:** #4385

### Problem

`SignalHandler.register()` unconditionally overwrites SIGINT/SIGTERM handlers with no opt-out:

- **Windows:** calls `os._exit(0)` on first Ctrl+C, skipping all cleanup (browser sessions, atexit handlers)
- **Unix:** `loop.add_signal_handler(SIGINT, ...)` replaces the host's handler; first Ctrl+C pauses the agent instead of triggering graceful shutdown

This makes browser-use unusable inside servers (uvicorn, FastAPI, etc.) that need to control their own shutdown lifecycle.

### Fix

Add `disabled: bool = False` parameter to `SignalHandler.__init__()`.

When `disabled=True`, both `register()` and `unregister()` become no-ops, leaving the host application's signal handlers fully intact.

```python
# Server embedding can now opt out:
signal_handler = SignalHandler(
    loop=loop,
    pause_callback=self.pause,
    resume_callback=self.resume,
    custom_exit_callback=on_force_exit_log_telemetry,
    disabled=True,  # host app handles signals
)
signal_handler.register()  # no-op when disabled=True
```

### Testing

- Added `tests/test_signal_handler.py` with 3 tests covering disabled/no-op behaviour
- All 3 tests pass

---

Fixes #4385

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `disabled` flag to `SignalHandler` so embedded servers (e.g., uvicorn, FastAPI) can opt out of our SIGINT/SIGTERM handlers and preserve graceful shutdown. Fixes #4385.

- **Bug Fixes**
  - New `disabled` param on `SignalHandler.__init__()`. When `True`, `register()` and `unregister()` are no-ops, leaving host signal handlers intact on Windows and Unix.
  - Added tests for the disabled no-op behavior and a basic enabled registration smoke check.

<sup>Written for commit f9c48685d98f6c7a9ba5b04e7a2d9c5a4906f6cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

