### PR TITLE
Remove litellm from dependencies (supply chain attack)

### DIFF
--- a/browser_use/llm/litellm/chat.py
+++ b/browser_use/llm/litellm/chat.py
@@ -1,3 +1,12 @@
+"""
+ChatLiteLLM - LiteLLM chat model wrapper.
+
+Requires the `litellm` package to be installed separately:
+    pip install litellm
+
+Note: litellm is NOT included as a dependency of browser-use.
+"""
+
 import logging
 from dataclasses import dataclass, field
 from typing import Any, TypeVar, overload
@@ -33,7 +42,7 @@ class ChatLiteLLM(BaseChatModel):
 	def __post_init__(self) -> None:
 		"""Resolve provider info from the model string via litellm."""
 		try:
-			from litellm import get_llm_provider
+			from litellm import get_llm_provider  # type: ignore[reportMissingImports]
 
 			self._clean_model, self._provider_name, _, _ = get_llm_provider(self.model)
 		except Exception:
@@ -108,9 +117,9 @@ class ChatLiteLLM(BaseChatModel):
 		output_format: type[T] | None = None,
 		**kwargs: Any,
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
-		from litellm import acompletion
-		from litellm.exceptions import APIConnectionError, APIError, RateLimitError, Timeout
-		from litellm.types.utils import ModelResponse
+		from litellm import acompletion  # type: ignore[reportMissingImports]
+		from litellm.exceptions import APIConnectionError, APIError, RateLimitError, Timeout  # type: ignore[reportMissingImports]
+		from litellm.types.utils import ModelResponse  # type: ignore[reportMissingImports]
 
 		litellm_messages = LiteLLMMessageSerializer.serialize(messages)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.12.4"
+version = "0.12.5"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [
@@ -46,7 +46,6 @@ dependencies = [
     "markdownify==1.2.2",
     "python-docx==1.2.0",
     "browser-use-sdk==2.0.15",
-    "litellm==1.82.2",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
## Summary

Remove `litellm` from `pyproject.toml` dependencies entirely. `ChatLiteLLM` wrapper is kept but requires manual installation:

```
pip install litellm
```

## What changed

- **pyproject.toml**: `litellm==1.82.2` removed from core dependencies
- **browser_use/llm/litellm/chat.py**: Added docstring noting manual install requirement, added `# type: ignore` for pyright since litellm is no longer in the environment
- **ChatLiteLLM stays in the public API** — it already lazy-imports litellm inside methods, so users who don't use it are never affected

## Context

litellm versions 1.82.7 and 1.82.8 were backdoored on March 24, 2026 by TeamPCP via a compromised Trivy CI/CD pipeline. `browser-use==0.12.3` shipped `litellm>=1.82.2` (unpinned) as a core dependency, and BigQuery analysis shows ~6,900 installs pulled the backdoored litellm during the 4-hour attack window.

By removing it from dependencies entirely, `pip install browser-use` no longer pulls litellm, and browser-use will not appear in litellm's dependency graph.

## References

- [TeamPCP Backdoors LiteLLM — The Hacker News](https://thehackernews.com/2026/03/teampcp-backdoors-litellm-versions.html)
- [LiteLLM infected via Trivy — The Register](https://www.theregister.com/2026/03/24/trivy_compromise_litellm/)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because removing `litellm` from required dependencies can break existing installs that relied on `ChatLiteLLM` working out-of-the-box; runtime imports now require manual installation.
> 
> **Overview**
> Stops installing `litellm` as a core dependency (and bumps the package version to `0.12.5`), requiring users to install it explicitly when using the LiteLLM integration.
> 
> Keeps `ChatLiteLLM` but adds a module docstring documenting the manual install and updates `litellm` imports with `# type: ignore` to avoid type-check failures when `litellm` is absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4b9e30188ef263dd0667030cdd3d58448652e95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->