### PR TITLE
Add environment protection to PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,7 @@ jobs:
 
   publish_to_pypi:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    environment: pypi-publish
     runs-on: ubuntu-latest
     env:
       IN_DOCKER: 'True'


### PR DESCRIPTION
## Summary

Adds `environment: pypi-publish` to the publish workflow so all PyPI publishes require manual approval.

## 1-line change

```yaml
publish_to_pypi:
    environment: pypi-publish  # <-- added
```

## Setup required after merging

1. Go to **GitHub → Settings → Environments → New environment**
2. Name it `pypi-publish`
3. Add **required reviewers** (yourself + trusted maintainers)
4. Under deployment branches, restrict to `main` and tags only
5. Update the **PyPI trusted publisher** to include `environment: pypi-publish`

## Why

Even with trusted publishing (no stored API token), anyone with a GitHub token that has `contents: write` can create a release via API, which triggers the publish workflow. With environment protection, the workflow pauses and waits for a human to approve before publishing to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release pipeline by gating `publish_to_pypi` behind a protected GitHub environment, which can block or delay publishes if the `pypi-publish` environment/reviewers aren’t configured correctly.
> 
> **Overview**
> Adds `environment: pypi-publish` to the `publish_to_pypi` GitHub Actions job so PyPI publishing runs are subject to GitHub Environment protection (e.g., required reviewer approval) before deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068f464eadd772deb02fab493eb2316644d8432a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require manual approval for PyPI publishing by adding `environment: pypi-publish` to the `publish_to_pypi` job. This stops unauthorized publishes even if write access is abused.

- **Migration**
  - Create `pypi-publish` in GitHub → Settings → Environments
  - Add required reviewers (trusted maintainers)
  - Restrict deployments to `main` and tags
  - Update the PyPI Trusted Publisher to include `environment: pypi-publish`

<sup>Written for commit 068f464eadd772deb02fab493eb2316644d8432a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

