### PR TITLE
Fix JSONDecodeError when done-text contains literal newlines (#4510)

### DIFF
--- a/tests/ci/test_json_newline_fix_4510.py
+++ b/tests/ci/test_json_newline_fix_4510.py
@@ -1,0 +1,64 @@
+"""Regression test for issue #4510: JSON string with literal newlines breaks parsing."""
+
+import json
+import pytest
+
+
+def clean_input_for_json(s: str) -> str:
+    """Escape literal newlines/tabs that break JSON parsing."""
+    return s.replace("\r", "\\r").replace("\n", "\\n").replace("\t", "\\t")
+
+
+class TestIssue4510JsonNewlineCrash:
+    """Test that multi-line JSON strings in tool input are parsed correctly."""
+
+    def test_json_string_with_literal_newlines_in_value(self):
+        """JSON value containing literal newline characters should parse correctly.
+
+        When the LLM generates multi-line done-text, the resulting JSON string
+        contains literal chr(10) newlines inside string values. json.loads()
+        rejects these unless they are escaped.
+        """
+        # The \n here is a literal newline character (chr(10)), not \\n
+        tool_input = '{"result": "summary\nwith\nnewlines"}'
+        cleaned = clean_input_for_json(tool_input)
+        parsed = json.loads(cleaned)
+        assert parsed["result"] == "summary\nwith\nnewlines"
+
+    def test_json_string_with_windows_crlf_in_value(self):
+        """JSON value with Windows CRLF in string should parse correctly."""
+        tool_input = '{"result": "line1\r\nline2"}'
+        cleaned = clean_input_for_json(tool_input)
+        parsed = json.loads(cleaned)
+        assert parsed["result"] == "line1\r\nline2"
+
+    def test_json_string_with_tabs_in_value(self):
+        """JSON value with literal tabs in string should parse correctly."""
+        tool_input = '{"result": "col1\tcol2"}'
+        cleaned = clean_input_for_json(tool_input)
+        parsed = json.loads(cleaned)
+        assert parsed["result"] == "col1\tcol2"
+
+    def test_normal_json_still_works(self):
+        """Normal JSON without special characters should still parse correctly."""
+        tool_input = '{"result": "normal text"}'
+        cleaned = clean_input_for_json(tool_input)
+        parsed = json.loads(cleaned)
+        assert parsed["result"] == "normal text"
+
+    def test_properly_escaped_json_still_works(self):
+        """JSON with properly escaped \\n (backslash-n) still parses correctly."""
+        # This is what correctly-formed JSON looks like in Python string form
+        tool_input = '{"result": "line1\\nline2"}'  # \\n is backslash + n
+        cleaned = clean_input_for_json(tool_input)
+        # Our clean shouldn't affect this since there are no literal newlines
+        parsed = json.loads(cleaned)
+        assert parsed["result"] == "line1\nline2"
+
+    def test_ai_done_summary_multiline(self):
+        """Simulate AI returning a done summary with markdown table (literal newlines)."""
+        tool_input = '{"result": "## Summary\n| Col1 | Col2 |\n|------|------|\n| val | data |"}'
+        cleaned = clean_input_for_json(tool_input)
+        parsed = json.loads(cleaned)
+        assert "## Summary" in parsed["result"]
+        assert "| Col1 |" in parsed["result"]


### PR DESCRIPTION
## Summary

When Claude returns a multi-line done-text (e.g. markdown tables with | separators), the tool input JSON string contains literal chr(10) newlines inside string values. json.loads() rejects these unescaped control characters.

## Fix

Escape chr(10), chr(13), chr(9) before calling json.loads() in both:
- browser_use/llm/anthropic/chat.py
- browser_use/llm/aws/chat_anthropic.py



## Testing

Added regression test test_json_newline_fix_4510.py covering literal newlines, CRLF, tabs, and already-escaped strings.

Fixes #4510

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape literal newlines, CRLF, and tabs in tool input before JSON parsing to prevent JSONDecodeError in the Anthropic clients. Fixes #4510 and stops crashes on multi-line done-text (e.g., markdown tables).

- **Bug Fixes**
  - Escape chr(10), chr(13), and chr(9) before json.loads() in `browser_use/llm/anthropic/chat.py` and `browser_use/llm/aws/chat_anthropic.py`.
  - Add regression test `tests/ci/test_json_newline_fix_4510.py` covering literal newlines, CRLF, tabs, and already-escaped strings.

<sup>Written for commit 077c7bd7d62ba8f4b53790f5c042a750ccd86293. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

