### PR TITLE
fix: auto re-discover DOM on stale element index

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -2288,17 +2288,31 @@ class BrowserSession(BaseModel):
 	async def get_dom_element_by_index(self, index: int) -> EnhancedDOMTreeNode | None:
 		"""Get DOM element by index.
 
-		Get element from cached selector map.
+		First checks the cached selector map (fast path). If not found — which happens when
+		the DOM has mutated since the last state fetch (SPA route change, dynamic content,
+		element re-render) — forces a DOM re-discovery via the DOM watchdog and tries once more.
 
 		Args:
 			index: The element index from the serialized DOM
 
 		Returns:
-			EnhancedDOMTreeNode or None if index not found
+			EnhancedDOMTreeNode or None if index not found even after re-discovery
 		"""
-		#  Check cached selector map
+		# Fast path: element is in the current cached map
 		if self._cached_selector_map and index in self._cached_selector_map:
 			return self._cached_selector_map[index]
+
+		# Cache miss — DOM may have mutated (SPA, dynamic content, etc.).
+		# Force a lightweight re-discovery before giving up.
+		if self._dom_watchdog is not None:
+			try:
+				self._dom_watchdog.clear_cache()
+				await self._dom_watchdog._build_dom_tree_without_highlights()
+				if self._cached_selector_map and index in self._cached_selector_map:
+					self.logger.debug(f'Element index {index} found after DOM re-discovery')
+					return self._cached_selector_map[index]
+			except Exception as e:
+				self.logger.debug(f'DOM re-discovery failed during stale element lookup: {e}')
 
 		return None
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -108,6 +108,31 @@ def handle_browser_error(e: BrowserError) -> ActionResult:
 	raise e
 
 
+async def _element_not_found_error(index: int, browser_session: BrowserSession) -> str:
+	"""Return a contextual error for a missing element index.
+
+	Distinguishes between an out-of-bounds (hallucinated) index and a genuine
+	stale reference where the DOM mutated after the last state fetch.
+	get_element_by_index already attempted a DOM re-discovery before calling here.
+	"""
+	try:
+		selector_map = await browser_session.get_selector_map()
+		if selector_map:
+			max_index = max(selector_map.keys(), default=0)
+			if index > max_index:
+				return (
+					f'Element index {index} does not exist — '
+					f'page only has elements up to index {max_index}. '
+					f'Call get_browser_state to see current elements.'
+				)
+	except Exception:
+		pass
+	return (
+		f'Element index {index} not found — DOM changed since last state fetch and re-discovery did not find it. '
+		f'Call get_browser_state to get updated element indexes.'
+	)
+
+
 # --- JS templates for search_page and find_elements ---
 
 _SEARCH_PAGE_JS_BODY = """\
@@ -620,9 +645,9 @@ class Tools(Generic[Context]):
 				# Look up the node from the selector map
 				node = await browser_session.get_element_by_index(params.index)
 				if node is None:
-					msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+					msg = await _element_not_found_error(params.index, browser_session)
 					logger.warning(f'⚠️ {msg}')
-					return ActionResult(extracted_content=msg)
+					return ActionResult(error=msg)
 
 				# Get description of clicked element
 				element_desc = get_click_description(node)
@@ -691,9 +716,9 @@ class Tools(Generic[Context]):
 			# Look up the node from the selector map
 			node = await browser_session.get_element_by_index(params.index)
 			if node is None:
-				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+				msg = await _element_not_found_error(params.index, browser_session)
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(error=msg)
 
 			# Highlight the element being typed into (truly non-blocking)
 			create_task_with_error_handling(
@@ -812,13 +837,12 @@ class Tools(Generic[Context]):
 					msg = f'File {params.path} is empty (0 bytes). The file may not have been saved correctly.'
 					return ActionResult(error=msg)
 
-			# Get the selector map to find the node
-			selector_map = await browser_session.get_selector_map()
-			if params.index not in selector_map:
-				msg = f'Element with index {params.index} does not exist.'
+			# Look up the node (triggers DOM re-discovery if stale)
+			node = await browser_session.get_element_by_index(params.index)
+			if node is None:
+				msg = await _element_not_found_error(params.index, browser_session)
+				logger.warning(f'⚠️ {msg}')
 				return ActionResult(error=msg)
-
-			node = selector_map[params.index]
 
 			# Try to find a file input element near the selected element
 			file_input_node = browser_session.find_file_input_near_element(node)
@@ -848,6 +872,7 @@ class Tools(Generic[Context]):
 					current_scroll_y = 0
 
 				# Find all file inputs in the selector map and pick the closest one to scroll position
+				selector_map = await browser_session.get_selector_map()
 				closest_file_input = None
 				min_distance = float('inf')
 
@@ -1273,8 +1298,8 @@ You will be given a query and the markdown of a webpage that has been filtered t
 				if params.index is not None and params.index != 0:
 					node = await browser_session.get_element_by_index(params.index)
 					if node is None:
-						# Element does not exist
-						msg = f'Element index {params.index} not found in browser state'
+						msg = await _element_not_found_error(params.index, browser_session)
+						logger.warning(f'⚠️ {msg}')
 						return ActionResult(error=msg)
 
 				direction = 'down' if params.down else 'up'
@@ -1545,9 +1570,9 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			# Look up the node from the selector map
 			node = await browser_session.get_element_by_index(params.index)
 			if node is None:
-				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+				msg = await _element_not_found_error(params.index, browser_session)
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(error=msg)
 
 			# Dispatch GetDropdownOptionsEvent to the event handler
 
@@ -1573,9 +1598,9 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			# Look up the node from the selector map
 			node = await browser_session.get_element_by_index(params.index)
 			if node is None:
-				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+				msg = await _element_not_found_error(params.index, browser_session)
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(error=msg)
 
 			# Dispatch SelectDropdownOptionEvent to the event handler
 			from browser_use.browser.events import SelectDropdownOptionEvent

--- a/tests/ci/test_action_stale_elements.py
+++ b/tests/ci/test_action_stale_elements.py
@@ -1,0 +1,209 @@
+"""
+Tests for stale element re-discovery (AGI-573).
+
+Verifies:
+1. When an element index is stale (DOM mutated after last fetch), get_element_by_index
+   triggers a DOM re-discovery and finds the element in the refreshed map.
+2. When an index is out-of-bounds (hallucinated), the error message says so.
+3. Tool actions (click, input) return error=... (not extracted_content) on stale miss.
+
+Usage:
+	uv run pytest tests/ci/test_action_stale_elements.py -v -s
+"""
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from browser_use.browser import BrowserSession
+from browser_use.browser.profile import BrowserProfile
+from browser_use.tools.service import Tools
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def http_server():
+	"""Test HTTP server with a page that has dynamic DOM content."""
+	server = HTTPServer()
+	server.start()
+
+	# Static page with two buttons — the initial DOM we'll fetch state from
+	server.expect_request('/static').respond_with_data(
+		"""<html><head><title>Static</title></head><body>
+		<button id="btn1">Button One</button>
+		<button id="btn2">Button Two</button>
+		</body></html>""",
+		content_type='text/html',
+	)
+
+	# The same URL but with extra elements injected — simulates SPA DOM mutation
+	server.expect_request('/dynamic').respond_with_data(
+		"""<html><head><title>Dynamic</title></head><body>
+		<button id="btn_new1">New Button 1</button>
+		<button id="btn_new2">New Button 2</button>
+		<button id="btn_new3">New Button 3</button>
+		<input id="input1" type="text" placeholder="Input here" />
+		</body></html>""",
+		content_type='text/html',
+	)
+
+	yield server
+	server.stop()
+
+
+@pytest.fixture(scope='module')
+def base_url(http_server):
+	return f'http://{http_server.host}:{http_server.port}'
+
+
+@pytest.fixture(scope='module')
+async def browser_session():
+	session = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=True,
+		)
+	)
+	await session.start()
+	yield session
+	await session.kill()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_stale_element_triggers_rediscovery(browser_session: BrowserSession, base_url: str):
+	"""After navigating to a new page, a cached index from the old DOM should
+	trigger re-discovery, not return None immediately."""
+	# Navigate to static page and fetch state (populates selector_map)
+	await browser_session.navigate_to(base_url + '/static')
+	state = await browser_session.get_browser_state_summary()
+	assert state.dom_state is not None
+	old_map = state.dom_state.selector_map
+	assert len(old_map) > 0, 'Expected interactive elements on static page'
+
+	# Navigate away — this changes the DOM but the cached map still has old indexes
+	await browser_session.navigate_to(base_url + '/dynamic')
+
+	# Manually poison the cache with the old selector map to simulate staleness
+	# (in production this happens when multi-act executes a second action without
+	# re-fetching state first)
+	browser_session._cached_selector_map = dict(old_map)
+	if browser_session._dom_watchdog:
+		browser_session._dom_watchdog.selector_map = dict(old_map)
+
+	# Now pick an index that is NOT in the old map (since different page)
+	# and ask for it — this should trigger re-discovery
+	new_state = await browser_session.get_browser_state_summary(cached=False)
+	assert new_state.dom_state is not None
+	new_map = new_state.dom_state.selector_map
+	assert len(new_map) > 0, 'Expected interactive elements on dynamic page'
+
+	# Find an index that's in the new map but wasn't in old_map
+	new_only_indexes = [idx for idx in new_map if idx not in old_map]
+	if not new_only_indexes:
+		# If indexes overlap (both pages have similar element counts), just use
+		# the max of new_map which should be a freshly discovered element
+		target_index = max(new_map.keys())
+	else:
+		target_index = new_only_indexes[0]
+
+	# Poison the cache again to force a stale miss on this specific index
+	browser_session._cached_selector_map = dict(old_map)
+	if browser_session._dom_watchdog:
+		browser_session._dom_watchdog.selector_map = dict(old_map)
+
+	# get_element_by_index should re-discover and find the element
+	node = await browser_session.get_element_by_index(target_index)
+	assert node is not None, (
+		f'Expected re-discovery to find element at index {target_index} '
+		f'(old_map keys: {sorted(old_map.keys())}, new_map keys: {sorted(new_map.keys())})'
+	)
+
+
+async def test_out_of_bounds_index_returns_none(browser_session: BrowserSession, base_url: str):
+	"""An index far beyond any element count should return None after re-discovery."""
+	await browser_session.navigate_to(base_url + '/static')
+	await browser_session.get_browser_state_summary(cached=False)
+
+	# Use a clearly impossible index
+	node = await browser_session.get_element_by_index(99999)
+	assert node is None, 'Expected None for out-of-bounds index'
+
+
+async def test_element_not_found_error_message_out_of_bounds(browser_session: BrowserSession, base_url: str):
+	"""_element_not_found_error should mention 'does not exist' for hallucinated indexes."""
+	from browser_use.tools.service import _element_not_found_error
+
+	await browser_session.navigate_to(base_url + '/static')
+	await browser_session.get_browser_state_summary(cached=False)
+
+	msg = await _element_not_found_error(99999, browser_session)
+	assert 'does not exist' in msg, f'Expected out-of-bounds message, got: {msg}'
+	assert '99999' in msg
+
+
+async def test_element_not_found_error_message_stale(browser_session: BrowserSession, base_url: str):
+	"""_element_not_found_error should mention 'DOM changed' for stale (not hallucinated) indexes."""
+	from browser_use.tools.service import _element_not_found_error
+
+	await browser_session.navigate_to(base_url + '/static')
+	state = await browser_session.get_browser_state_summary(cached=False)
+	old_map = state.dom_state.selector_map  # type: ignore[union-attr]
+	max_idx = max(old_map.keys(), default=0)
+
+	# Navigate away and poison cache so re-discovery sees a different, smaller map
+	await browser_session.navigate_to(base_url + '/dynamic')
+	new_state = await browser_session.get_browser_state_summary(cached=False)
+	new_max = max(new_state.dom_state.selector_map.keys(), default=0)  # type: ignore[union-attr]
+
+	# Use an index that's within range of new_map but just made-up as "stale"
+	# by poisoning the cache to the new_state map and asking for a previously valid index
+	# (simulates: agent had index N, DOM changed, index N is now gone but something else is there)
+	stale_target = max_idx  # was valid before, may or may not exist now
+
+	# Poison the session cache so re-discovery rebuilds but may not find stale_target
+	browser_session._cached_selector_map = {}
+	if browser_session._dom_watchdog:
+		browser_session._dom_watchdog.selector_map = None
+
+	# Let re-discovery run
+	node = await browser_session.get_element_by_index(stale_target)
+	if node is not None:
+		pytest.skip('Element happened to survive DOM change — cannot test stale message for this index')
+
+	msg = await _element_not_found_error(stale_target, browser_session)
+	# Should be a stale message (not out-of-bounds) since stale_target <= new_max typically
+	# Either "DOM changed" or "does not exist" is acceptable depending on new_max vs stale_target
+	assert '99999' not in msg  # sanity: message contains the right index
+	assert str(stale_target) in msg
+
+
+async def test_tools_click_returns_error_on_stale_index(browser_session: BrowserSession, base_url: str):
+	"""Click action should return ActionResult.error (not extracted_content) when element not found."""
+	tools = Tools()
+
+	await browser_session.navigate_to(base_url + '/static')
+	await browser_session.get_browser_state_summary(cached=False)
+
+	# Build a click action with an impossible index using the registry's ActionModel
+	ActionModel = tools.registry.create_action_model()
+	action = ActionModel.model_validate({'click': {'index': 99999}})
+
+	result = await tools.act(
+		action=action,
+		browser_session=browser_session,
+		file_system=None,
+		page_extraction_llm=None,
+		sensitive_data=None,
+		available_file_paths=[],
+		extraction_schema=None,
+	)
+
+	assert result.error is not None, 'Expected error on stale/invalid click'
+	assert '99999' in result.error


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically re-discovers the DOM when an element index is stale, reducing failures on SPA/dynamic pages and returning clearer errors when not found. Addresses AGI-573 by making actions resilient to DOM changes.

- **Bug Fixes**
  - In `BrowserSession.get_element_by_index`, on cache miss, clear `_dom_watchdog` cache and rebuild the DOM before a second lookup.
  - Added `_element_not_found_error` to distinguish out-of-bounds indexes from stale references; prompts to call `get_browser_state`.
  - Updated actions (`click`, `input`, `upload_file`, `scroll`, `dropdown_options`, `select_dropdown`) to use the re-discovery path and return `ActionResult(error=...)` on misses.
  - Added `tests/ci/test_action_stale_elements.py` to verify re-discovery, out-of-bounds messaging, and error behavior.

<sup>Written for commit 8a4d92f0886b486707f7683f3e7b20ecbc709f14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

