### PR TITLE
rm pass

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -68,7 +68,6 @@ class SecurityWatchdog(BaseWatchdog):
 				await session.cdp_client.send.Page.navigate(params={'url': 'about:blank'}, session_id=session.session_id)
 				self.logger.info(f'⛔️ Navigated to about:blank after blocked URL: {event.url}')
 			except Exception as e:
-				pass
 				self.logger.error(f'⛔️ Failed to navigate to about:blank: {type(e).__name__} {e}')
 
 	async def on_TabCreatedEvent(self, event: TabCreatedEvent) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed a redundant pass in the exception handler of `SecurityWatchdog.on_NavigationCompleteEvent`, simplifying the code while keeping error logging intact. No behavior change.

<sup>Written for commit 393d2c5b0f6906d8bdc1fb2ba4f1dfd0d98eb38e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

