### PR TITLE
fix daemon orphaning when external browser dies on --connect/--cdp-url

### DIFF
--- a/browser_use/skill_cli/daemon.py
+++ b/browser_use/skill_cli/daemon.py
@@ -13,7 +13,6 @@ import json
 import logging
 import os
 import signal
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -347,17 +346,19 @@ def main() -> None:
 		session=args.session,
 	)
 
+	exit_code = 0
 	try:
 		asyncio.run(daemon.run())
 	except KeyboardInterrupt:
 		logger.info('Interrupted')
 	except Exception as e:
 		logger.exception(f'Daemon error: {e}')
-		sys.exit(1)
+		exit_code = 1
 	finally:
-		# Force-exit to prevent daemon from becoming an orphan
+		# asyncio.run() may hang trying to cancel lingering tasks
+		# Force-exit to prevent the daemon from becoming an orphan
 		logger.info('Daemon process exiting')
-		os._exit(0)
+		os._exit(exit_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #4492

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes daemon orphaning when the external browser or CDP connection dies (with `--connect`, `--cdp-url`, or cloud). Adds safer connection watching, bounded cleanup, and a hard exit that preserves the exit code. Resolves #4492.

- **Bug Fixes**
  - Skip shutdown while the browser is reconnecting; shut down only when CDP stays disconnected.
  - Prevent duplicate shutdowns by scheduling a single shutdown task.
  - Add 10s timeouts around `browser_session.stop()`/`kill()` to avoid hangs; log on timeout.
  - Force process exit in `finally` via `os._exit(exit_code)` to preserve error status and prevent orphaned daemons.

<sup>Written for commit a31809b83d22adabba31fba7029053da7730a459. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

