### PR TITLE
  fix: make MCP browser_click schema compatible with AWS Bedrock

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -232,7 +232,7 @@ class BrowserUseServer:
 				),
 				types.Tool(
 					name='browser_click',
-					description='Click an element by index or at specific viewport coordinates. Use index for elements from browser_get_state, or coordinate_x/coordinate_y for pixel-precise clicking.',
+					description='Click an element by index or at specific viewport coordinates. Provide either index, or both coordinate_x and coordinate_y. Use index for elements from browser_get_state, or coordinates for pixel-precise clicking.',
 					inputSchema={
 						'type': 'object',
 						'properties': {
@@ -254,10 +254,6 @@ class BrowserUseServer:
 								'default': False,
 							},
 						},
-						'oneOf': [
-							{'required': ['index']},
-							{'required': ['coordinate_x', 'coordinate_y']},
-						],
 					},
 				),
 				types.Tool(


### PR DESCRIPTION
  ## Why

  AWS Bedrock rejects tool schemas that contain top-level JSON Schema combinators like `oneOf`.
  The MCP `browser_click` tool used a top-level `oneOf` in its input schema, which caused compatibility issues when using Browser Use through Bedrock.

  This PR removes that incompatibility.

  ## What Changed

  - Updated the `browser_click` MCP tool schema in `browser_use/mcp/server.py`
  - Removed the top-level `oneOf` constraint from the schema
  - Clarified the tool description so the expected inputs are still explicit:
    - pass `index`, or
    - pass both `coordinate_x` and `coordinate_y`

  ## Validation

  - Added a targeted MCP schema test for `browser_click`
  - Confirmed the schema remains an object schema without top-level `oneOf`, `anyOf`, `allOf`, or `not`
