### PR TITLE
fix: pin 19 unpinned action(s),extract 4 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       IS_SANDBOX: '1'
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
           activate-environment: true
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: "claude-opus-4-20250514"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,19 +30,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Compute Docker tags based on tag/branch
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
             browseruse/browseruse
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           platforms: linux/amd64,linux/arm64
           context: .

--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -23,7 +23,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "🚀 Triggering evaluation - PR #${{ github.event.pull_request.number }}"
-          echo "Commit: ${{ github.event.pull_request.head.sha }}"
+          echo "Commit: ${PR_HEAD_SHA}"
 
           # You can customize the test here
           TEST_CASE="${{ vars.EVAL_TEST_CASE }}"
@@ -32,13 +32,13 @@ jobs:
           fi
 
           response=$(curl -X POST \
-            "${{ secrets.EVAL_PLATFORM_URL }}/api/triggerInteractionTasksV6" \
-            -H "Authorization: Bearer ${{ secrets.EVAL_PLATFORM_KEY }}" \
+            "${EVAL_PLATFORM_URL}/api/triggerInteractionTasksV6" \
+            -H "Authorization: Bearer ${EVAL_PLATFORM_KEY}" \
             -H "Content-Type: application/json" \
             -d "{
-              \"commitSha\": \"${{ github.event.pull_request.head.sha }}\",
+              \"commitSha\": \"${PR_HEAD_SHA}\",
               \"prNumber\": ${{ github.event.pull_request.number }},
-              \"branchName\": \"${{ github.event.pull_request.head.ref }}\",
+              \"branchName\": \"${PR_HEAD_REF}\",
               \"testCase\": \"${TEST_CASE}\",
               \"githubRepo\": \"${{ github.repository }}\"
             }" -s)
@@ -54,3 +54,9 @@ jobs:
             echo "$response"
             exit 1
           fi
+
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          EVAL_PLATFORM_URL: ${{ secrets.EVAL_PLATFORM_URL }}
+          EVAL_PLATFORM_KEY: ${{ secrets.EVAL_PLATFORM_KEY }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
       - run: uv run ruff check --no-fix --select PLE
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
       - run: uv python install 3.11
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
       - run: uv sync --dev --all-extras  # install extras for examples to avoid pyright missing imports errors-

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - run: uv build --python 3.12
       - uses: actions/upload-artifact@v4
         with:
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - uses: actions/download-artifact@v4
         with:
           name: dist-artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,7 +75,7 @@ jobs:
       ANONYMIZED_TELEMETRY: 'false'
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
           activate-environment: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Get week number for cache key
         id: week
@@ -114,7 +114,7 @@ jobs:
           fi
 
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
           activate-environment: true
@@ -174,7 +174,7 @@ jobs:
 
       - name: Run test with retry
         if: steps.check-file.outputs.exists == 'true'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 4
           max_attempts: 1
@@ -198,7 +198,7 @@ jobs:
       BROWSER_USE_API_KEY: ${{ secrets.BROWSER_USE_API_KEY }}
     steps:
       - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           enable-cache: true
           activate-environment: true
@@ -244,7 +244,7 @@ jobs:
 
       - name: Run agent tasks evaluation and capture score
         id: eval
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 4
           max_attempts: 1


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/claude.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/docker.yml` | Pinned 6 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/eval-on-pr.yml` | Extracted 4 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/lint.yml` | Pinned 3 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/package.yaml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/publish.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/test.yaml` | Pinned 5 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-004 | high | `.github/workflows/claude.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-018 | high | `.github/workflows/install-script.yml` | Suspicious Payload Execution Pattern |
| RGS-018 | high | `.github/workflows/install-script.yml` | Suspicious Payload Execution Pattern |
| RGS-018 | high | `.github/workflows/install-script.yml` | Suspicious Payload Execution Pattern |
| RGS-003 | high | `.github/workflows/test.yaml` | Filename Injection via Git Diff or File Listing |
| RGS-005 | medium | `.github/workflows/claude.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens GitHub Actions by pinning 19 third-party actions to commit SHAs and moving 4 unsafe expressions into env vars. This reduces supply-chain and shell-injection risk without changing workflow behavior.

- **Bug Fixes**
  - `eval-on-pr.yml`: moved `${{ github.event.pull_request.head.sha }}`, `${{ github.event.pull_request.head.ref }}`, `${{ secrets.EVAL_PLATFORM_URL }}`, and `${{ secrets.EVAL_PLATFORM_KEY }}` to `env:` and updated echo/curl to use `${VAR}`.

- **Dependencies**
  - Pinned actions in `claude.yml`, `docker.yml`, `lint.yml`, `package.yaml`, `publish.yml`, `test.yaml` (e.g., `astral-sh/setup-uv`, `docker/*`, `nick-fields/retry`, `anthropics/claude-code-action`) to immutable commit SHAs.

<sup>Written for commit c3abf12db2f9226054b333d1c9b64f9f24e387f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

