### PR TITLE
fix: skip pointer-events:none elements in paint order occlusion filter

### DIFF
--- a/browser_use/dom/serializer/paint_order.py
+++ b/browser_use/dom/serializer/paint_order.py
@@ -177,15 +177,23 @@ class PaintOrderRemover:
 				if rect_union.contains(rect):
 					node.ignored_by_paint_order = True
 
-				# don't add to the nodes if opacity is less then 0.95 or background-color is transparent
+				# don't add to the nodes if opacity is less than 0.8, background-color is transparent,
+				# or pointer-events is none (element doesn't block interaction or occlude content)
 				if (
-					node.original_node.snapshot_node.computed_styles
-					and node.original_node.snapshot_node.computed_styles.get('background-color', 'rgba(0, 0, 0, 0)')
-					== 'rgba(0, 0, 0, 0)'
-				) or (
-					node.original_node.snapshot_node.computed_styles
-					and float(node.original_node.snapshot_node.computed_styles.get('opacity', '1'))
-					< 0.8  # this is highly vibes based number
+					(
+						node.original_node.snapshot_node.computed_styles
+						and node.original_node.snapshot_node.computed_styles.get('background-color', 'rgba(0, 0, 0, 0)')
+						== 'rgba(0, 0, 0, 0)'
+					)
+					or (
+						node.original_node.snapshot_node.computed_styles
+						and float(node.original_node.snapshot_node.computed_styles.get('opacity', '1'))
+						< 0.8  # this is highly vibes based number
+					)
+					or (
+						node.original_node.snapshot_node.computed_styles
+						and node.original_node.snapshot_node.computed_styles.get('pointer-events', 'auto') == 'none'
+					)
 				):
 					continue
 


### PR DESCRIPTION
## Problem

The paint order filter in `PaintOrderRemover` incorrectly treats elements with `pointer-events: none` as occluding content behind them. This causes interactive elements (buttons, inputs, links) to be marked as `ignored_by_paint_order` and excluded from the DOM tree sent to the LLM.

This is a common pattern in SaaS applications where chat/help widgets (Voiceflow, Intercom, Zendesk, Drift, etc.) use a full-viewport overlay container with:
- `position: fixed`
- `z-index: 10000+`
- `pointer-events: none` (so it doesn't block interaction with the page)

Inside these containers, child elements (chat messages, etc.) can have opaque backgrounds and large bounding rects. The paint order filter sees these as covering page elements underneath, even though the `pointer-events: none` means they don't actually block anything.

## Root Cause

In `paint_order.py`, the filter already skips adding transparent (`background-color: rgba(0,0,0,0)`) and nearly-invisible (`opacity < 0.8`) elements to the occlusion union. However, it did not check `pointer-events: none`, which is the standard CSS mechanism for making overlay containers non-interactive and non-occluding.

## Fix

Added one condition to the existing skip logic: elements with `pointer-events: none` are not added to the occlusion rectangle union, so they cannot hide elements behind them.

The `pointer-events` property is already captured in `REQUIRED_COMPUTED_STYLES` in `enhanced_snapshot.py`, so no additional data collection is needed.

## Testing

Tested on Voiceflow Creator (`creator.voiceflow.com`), which has a `#voiceflow-chat` shadow DOM widget covering the entire viewport with `pointer-events: none` and `z-index: 10000`.

**Before fix:** The "Run" button was not indexed (marked as hidden by paint order). The agent tried clicking index 1245 (a wrapper `<div>`) 7 times, always hitting the wrong element.

**After fix:** The "Run" button is correctly indexed at 1255. The agent clicks it on the first try, types into the chat input, and completes the task in 6 steps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `pointer-events: none` elements in the paint order occlusion filter so overlay containers don’t hide interactive elements behind them. Fixes false `ignored_by_paint_order` on pages with full-viewport chat/help widgets.

- **Bug Fixes**
  - Exclude nodes with `pointer-events: none` from the occlusion union in `paint_order.py`.
  - Verified on Voiceflow Creator: the overlay no longer hides underlying UI; the "Run" button is indexed and clickable.

<sup>Written for commit 75a1f83a46eba628b891429ef41223eae5730294. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

