### PR TITLE
new-tab command

### DIFF
--- a/browser_use/skill_cli/commands/browser.py
+++ b/browser_use/skill_cli/commands/browser.py
@@ -12,6 +12,7 @@ logger = logging.getLogger(__name__)
 
 COMMANDS = {
 	'open',
+	'new-tab',
 	'click',
 	'type',
 	'input',
@@ -99,6 +100,14 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 
 			result['live_url'] = f'https://live.browser-use.com/?wss={quote(bs.cdp_url, safe="")}'
 		return result
+
+	elif action == 'new-tab':
+		from browser_use.browser.events import AgentFocusChangedEvent, SwitchTabEvent
+
+		page = await bs.new_page('about:blank')
+		await bs.event_bus.dispatch(SwitchTabEvent(target_id=page._target_id))
+		await bs.event_bus.dispatch(AgentFocusChangedEvent(target_id=page._target_id, url='about:blank'))
+		return {'url': 'about:blank'}
 
 	elif action == 'click':
 		args = params.get('args', [])

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -427,6 +427,9 @@ Setup:
 	p = subparsers.add_parser('open', help='Navigate to URL')
 	p.add_argument('url', help='URL to navigate to')
 
+	# new-tab
+	subparsers.add_parser('new-tab', help='Open a new blank tab')
+
 	# click <index> OR click <x> <y>
 	p = subparsers.add_parser('click', help='Click element by index or coordinates (x y)')
 	p.add_argument('args', nargs='+', type=int, help='Element index OR x y coordinates')

--- a/tests/ci/test_cli_new_tab_command.py
+++ b/tests/ci/test_cli_new_tab_command.py
@@ -1,0 +1,35 @@
+"""Tests for splitting 'open --new-tab' into separate 'new-tab' and 'open' commands."""
+
+from browser_use.skill_cli.main import build_parser
+
+
+def test_new_tab_command_exists():
+	"""new-tab is a standalone subcommand with no required arguments."""
+	parser = build_parser()
+	args = parser.parse_args(['new-tab'])
+	assert args.command == 'new-tab'
+
+
+def test_open_command_has_no_new_tab_flag():
+	"""open no longer accepts --new-tab / -n flags."""
+	parser = build_parser()
+	# should parse without error and have no new_tab attribute
+	args = parser.parse_args(['open', 'http://example.com'])
+	assert not hasattr(args, 'new_tab')
+
+
+def test_open_command_still_works():
+	"""open <url> continues to work as before."""
+	parser = build_parser()
+	args = parser.parse_args(['open', 'http://example.com'])
+	assert args.command == 'open'
+	assert args.url == 'http://example.com'
+
+
+def test_new_tab_with_global_flags():
+	"""new-tab works alongside global flags like --headed and --session."""
+	parser = build_parser()
+	args = parser.parse_args(['--headed', '-s', 'mysession', 'new-tab'])
+	assert args.command == 'new-tab'
+	assert args.headed is True
+	assert args.session == 'mysession'


### PR DESCRIPTION
add new-tab command to the CLI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `new-tab` CLI command that opens a blank tab and makes it the active tab. The `open` command no longer supports `--new-tab`/`-n`.

- **Migration**
  - Replace `open --new-tab <url>` (or `open -n <url>`) with `new-tab` then `open <url>`.
  - `new-tab` supports global flags like `--headed` and `-s <session>`.

<sup>Written for commit 046d19fae06f6900f5719b039fb881bdcbeae0ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

