### PR TITLE
fix: compute step_interval as gap between steps, not step duration

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1354,8 +1354,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 				if last_history_item.metadata:
 					previous_end_time = last_history_item.metadata.step_end_time
-					previous_start_time = last_history_item.metadata.step_start_time
-					step_interval = max(0, previous_end_time - previous_start_time)
+					step_interval = max(0, self.step_start_time - previous_end_time)
 			metadata = StepMetadata(
 				step_number=self.state.n_steps,
 				step_start_time=self.step_start_time,

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -364,7 +364,7 @@ class StepMetadata(BaseModel):
 	step_start_time: float
 	step_end_time: float
 	step_number: int
-	step_interval: float | None = None
+	step_interval: float | None = None  # Gap between this step's start and the previous step's end
 
 	@property
 	def duration_seconds(self) -> float:


### PR DESCRIPTION
## Problem

`StepMetadata.step_interval` is currently calculated as `previous_end_time - previous_start_time`, which gives the **duration of the previous step** rather than the **gap between steps**.

This field is used during replay to reproduce timing between actions. Using the previous step's duration instead of the actual inter-step gap means replay timing doesn't match the original execution.

## Fix

Changed the calculation in `_finalize()` from:

```python
step_interval = max(0, previous_end_time - previous_start_time)
```

to:

```python
step_interval = max(0, self.step_start_time - previous_end_time)
```

This correctly computes the elapsed time between when the previous step finished and when the current step started.

Also added a clarifying comment on the `step_interval` field in `StepMetadata` and removed the now-unused `previous_start_time` variable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compute `StepMetadata.step_interval` as the gap between the previous step’s end and the current step’s start to fix replay timing.

This corrects timing reproduction during replay, removes an unused variable, and adds a clarifying comment on the field’s meaning.

<sup>Written for commit bcc3fad3231a28c100387b337c57339d556170a0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

