### PR TITLE
fix: resolve top-level oneOf incompatibility with Claude API in browser_click schema

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -238,15 +238,15 @@ class BrowserUseServer:
 						'properties': {
 							'index': {
 								'type': 'integer',
-								'description': 'The index of the element to click (from browser_get_state). Use this OR coordinates.',
+								'description': 'The index of the element to click (from browser_get_state). Provide this OR coordinate_x+coordinate_y.',
 							},
 							'coordinate_x': {
 								'type': 'integer',
-								'description': 'X coordinate (pixels from left edge of viewport). Use with coordinate_y.',
+								'description': 'X coordinate in pixels from the left edge of the viewport. Must be used together with coordinate_y. Provide this OR index.',
 							},
 							'coordinate_y': {
 								'type': 'integer',
-								'description': 'Y coordinate (pixels from top edge of viewport). Use with coordinate_x.',
+								'description': 'Y coordinate in pixels from the top edge of the viewport. Must be used together with coordinate_x. Provide this OR index.',
 							},
 							'new_tab': {
 								'type': 'boolean',
@@ -254,10 +254,6 @@ class BrowserUseServer:
 								'default': False,
 							},
 						},
-						'oneOf': [
-							{'required': ['index']},
-							{'required': ['coordinate_x', 'coordinate_y']},
-						],
 					},
 				),
 				types.Tool(


### PR DESCRIPTION
## Problem

The `browser_click` tool's `inputSchema` in `browser_use/mcp/server.py` uses a top-level `oneOf` to express mutual exclusivity between `index` and `coordinate_x`/`coordinate_y`:

```python
'oneOf': [
    {'required': ['index']},
    {'required': ['coordinate_x', 'coordinate_y']},
],
```

Claude's API (and other strict JSON Schema validators) reject `oneOf`, `allOf`, or `anyOf` at the top level of a tool input schema with a 400 error, which breaks all MCP tools registered in the same session.

## Fix

- Remove the top-level `oneOf` constraint from `browser_click`'s `inputSchema`
- Clarify the either/or usage pattern in the parameter descriptions so the LLM understands the expected input
- The `_click()` handler already validates at runtime and returns a clear error when neither `index` nor `coordinate_x`/`coordinate_y` are provided, so the schema-level `oneOf` constraint was redundant

## Testing

- Verified the schema no longer contains `oneOf` at the top level
- Verified the `_click()` method still returns proper error messages for invalid input
- The schema is now compatible with Claude API and other strict JSON Schema validators

Fixes #4538

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the top-level `oneOf` from the `browser_click` tool input schema to restore compatibility with the Claude API and other strict validators. Clarified either/or usage so clicks can be sent by index or by coordinates without breaking MCP sessions.

- **Bug Fixes**
  - Removed top-level `oneOf`; rely on existing `_click()` runtime validation.
  - Reworded `index`, `coordinate_x`, and `coordinate_y` descriptions to explain either/or usage; schema now accepted by the Claude API.

<sup>Written for commit 2027455b686935ac8126fd169a425daea38cc1e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

