### PR TITLE
fix: attach browser-downloaded files in non-structured done handler

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1908,7 +1908,7 @@ Validated Code (after quote fixing):
 				'Complete task. Only report actions you performed and data you extracted in this session.',
 				param_model=DoneAction,
 			)
-			async def done(params: DoneAction, file_system: FileSystem):
+			async def done(params: DoneAction, file_system: FileSystem, browser_session: BrowserSession):
 				user_message = params.text
 
 				len_text = len(params.text)
@@ -1938,6 +1938,14 @@ Validated Code (after quote fixing):
 								attachments.append(file_name)
 
 				attachments = [str(file_system.get_dir() / file_name) for file_name in attachments]
+
+				# Auto-attach actual session downloads (CDP-tracked browser downloads)
+				session_downloads = browser_session.downloaded_files
+				if session_downloads:
+					existing = set(attachments)
+					for file_path in session_downloads:
+						if file_path not in existing:
+							attachments.append(file_path)
 
 				return ActionResult(
 					is_done=True,


### PR DESCRIPTION
## Problem

The non-structured `done` handler (used when no `output_model_schema` is provided) does not accept `browser_session`, so it never sees or attaches files downloaded by the browser during the session. The structured done handler already does this correctly.

Fixes #4482

## Changes

- Added `browser_session: BrowserSession` parameter to the non-structured done handler
- Added the same auto-attachment logic for `browser_session.downloaded_files` that the structured path already has

## Before

```python
async def done(params: DoneAction, file_system: FileSystem):
    # ... no download attachment logic
```

## After

```python
async def done(params: DoneAction, file_system: FileSystem, browser_session: BrowserSession):
    # ... existing attachment logic ...

    # Auto-attach actual session downloads (CDP-tracked browser downloads)
    session_downloads = browser_session.downloaded_files
    if session_downloads:
        existing = set(attachments)
        for file_path in session_downloads:
            if file_path not in existing:
                attachments.append(file_path)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach browser-downloaded files in the non-structured `done` handler so session downloads appear in `ActionResult.attachments` when no `output_model_schema` is used. This aligns behavior with the structured path.

- **Bug Fixes**
  - Added `browser_session: BrowserSession` to the non-structured `done` handler.
  - Auto-attach `browser_session.downloaded_files` to the result attachments.

<sup>Written for commit 509497f4283cc76a2b6868d16a09a0eaa728c031. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

