### PR TITLE
fix: handle missing keys in load_from_dict and empty result in final_result

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -690,13 +690,13 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 	@classmethod
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
 		# loop through history and validate output_model actions to enrich with custom actions
-		for h in data['history']:
-			if h['model_output']:
+		for h in data.get('history', []):
+			if h.get('model_output'):
 				if isinstance(h['model_output'], dict):
 					h['model_output'] = output_model.model_validate(h['model_output'])
 				else:
 					h['model_output'] = None
-			if 'interacted_element' not in h['state']:
+			if 'state' in h and 'interacted_element' not in h['state']:
 				h['state']['interacted_element'] = None
 
 		history = cls.model_validate(data)
@@ -727,7 +727,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def final_result(self) -> None | str:
 		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
+		if self.history and len(self.history[-1].result) > 0 and self.history[-1].result[-1].extracted_content:
 			return self.history[-1].result[-1].extracted_content
 		return None
 


### PR DESCRIPTION
Fixes #4463

Two related bugs in `AgentHistoryList`:

### 1. `load_from_dict()` — KeyError on missing keys

Changed bracket access (`data['history']`, `h['model_output']`, `h['state']`) to safe `.get()` access with defaults. This handles:
- History files from older browser-use versions that lack newer keys
- Partially written history steps
- Missing `state` or `model_output` fields

### 2. `final_result()` — IndexError on empty result list

Added `len(self.history[-1].result) > 0` guard before accessing `result[-1]`. This matches the pattern used by every other accessor in the class (`is_done()`, `is_successful()`, `judgement()`, `is_judged()`, `is_validated()`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes in `AgentHistoryList` by safely handling missing keys in `load_from_dict()` and empty result lists in `final_result()`. Improves compatibility with older history files and partially written steps.

- **Bug Fixes**
  - Use `.get()` with defaults for `history`, `model_output`, and `state` to avoid `KeyError`.
  - Add a length check before accessing `result[-1]` in `final_result()` to prevent `IndexError`.

<sup>Written for commit 64fe4d505a1f5c431bf0222bb7978ffbfa6ad776. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

