### PR TITLE
Fix step_interval calculation and add download attachments to non-structured done action

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1355,7 +1355,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				if last_history_item.metadata:
 					previous_end_time = last_history_item.metadata.step_end_time
 					previous_start_time = last_history_item.metadata.step_start_time
-					step_interval = max(0, previous_end_time - previous_start_time)
+					step_interval = max(0, self.step_start_time - previous_end_time)
 			metadata = StepMetadata(
 				step_number=self.state.n_steps,
 				step_start_time=self.step_start_time,

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1908,7 +1908,7 @@ Validated Code (after quote fixing):
 				'Complete task. Only report actions you performed and data you extracted in this session.',
 				param_model=DoneAction,
 			)
-			async def done(params: DoneAction, file_system: FileSystem):
+			async def done(params: DoneAction, file_system: FileSystem, browser_session: BrowserSession):
 				user_message = params.text
 
 				len_text = len(params.text)
@@ -1938,6 +1938,14 @@ Validated Code (after quote fixing):
 								attachments.append(file_name)
 
 				attachments = [str(file_system.get_dir() / file_name) for file_name in attachments]
+
+				# Auto-attach actual session downloads (CDP-tracked browser downloads)
+				session_downloads = browser_session.downloaded_files
+				if session_downloads:
+					existing = set(attachments)
+					for file_path in session_downloads:
+						if file_path not in existing:
+							attachments.append(file_path)
 
 				return ActionResult(
 					is_done=True,


### PR DESCRIPTION
Two related fixes:

**1. Fix StepMetadata.step_interval calculation** (#4484)

The formula in  was computing the duration of the previous step instead of the idle time gap between steps.

Before: `step_interval = max(0, previous_end_time - previous_start_time)` — this gives the previous step's duration.

After: `step_interval = max(0, self.step_start_time - previous_end_time)` — this gives the actual gap between the previous step ending and the current step starting.

**2. Add download attachment logic to non-structured done handler** (#4482)

The structured done handler (with `output_model`) correctly accepts `browser_session` and auto-attaches `browser_session.downloaded_files` to result attachments. However, the default non-structured done handler was missing this entirely — it didn't accept `browser_session` as a parameter and had no download attachment logic.

This meant any files downloaded during a browser session (the default code path for most users) were never included in `ActionResult.attachments`.

Fix: Added `browser_session: BrowserSession` parameter to the non-structured done handler and the same auto-attachment logic from the structured path.

Closes #4484, Closes #4482

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes step idle-time calculation and ensures files downloaded during a browser session are included in non-structured `done` results.

- **Bug Fixes**
  - Corrected `StepMetadata.step_interval` to measure the gap between steps: `max(0, self.step_start_time - previous_end_time)`.
  - Non-structured `done` now accepts `browser_session` and appends `browser_session.downloaded_files` to `ActionResult.attachments` (parity with the structured path).

<sup>Written for commit 6b574a518b7e8e0d1251d92ce10b134d28b6e1e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

