### PR TITLE
fix(cli): show helpful error on Windows when Chrome profile is locked

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -834,8 +834,8 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 				if getattr(e, 'winerror', None) == 32:
 					raise RuntimeError(
 						f"Failed to copy Chrome profile '{self.profile_directory}' — another Chrome process is using it.\n"
-						f'Please close all Chrome windows first, or use --cdp-url to connect to an existing Chrome instance.\n'
-						f'Example: browser-use --cdp-url http://localhost:9222'
+						'Please close all Chrome windows first, or use --cdp-url to connect to an existing Chrome instance.\n'
+						'Example: browser-use --cdp-url http://localhost:9222'
 					) from e
 				raise
 			local_state_src = path_original_user_data / 'Local State'
@@ -846,9 +846,9 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 				except OSError as e:
 					if getattr(e, 'winerror', None) == 32:
 						raise RuntimeError(
-							f"Failed to copy Chrome 'Local State' file — another Chrome process is using it.\n"
-							f'Please close all Chrome windows first, or use --cdp-url to connect to an existing Chrome instance.\n'
-							f'Example: browser-use --cdp-url http://localhost:9222'
+							"Failed to copy Chrome 'Local State' file — another Chrome process is using it.\n"
+							'Please close all Chrome windows first, or use --cdp-url to connect to an existing Chrome instance.\n'
+							'Example: browser-use --cdp-url http://localhost:9222'
 						) from e
 					raise
 			logger.info(f'Copied profile ({self.profile_directory}) and Local State to temp directory: {temp_dir}')


### PR DESCRIPTION
## Problem

On Windows, when using `--profile "Default"` with Chrome already running, `shutil.copytree` fails with `OSError: [WinError 32] The process cannot access the file because it is being used by another process` — a confusing error with no guidance.

## Fix

Adds detection for WinError 32 in the `_copy_profile()` method of `BrowserProfile`. When the error is caught, a clear `RuntimeError` is raised telling the user to:
- Close all Chrome windows first, or
- Use `--cdp-url` to connect to an existing Chrome instance

This is a minimal, safe change — no logic changes, only improved error handling.

Fixes #4546

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On Windows, the CLI now shows a clear error when the Chrome profile or “Local State” file is locked, instead of surfacing WinError 32. It tells users to close Chrome or connect via `--cdp-url`, and removes an unnecessary f-prefix.

<sup>Written for commit 2295f52c08e96671371c2ba1c2fc2b26fe2b4bdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

