### PR TITLE
fix(cli): ensure close --all terminates daemon and temp-profile Chrome processes

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -761,13 +761,158 @@ def _handle_sessions(args: argparse.Namespace) -> int:
 	return 0
 
 
+def _kill_process_tree(pid: int) -> None:
+	"""Kill a process and all its children. Cross-platform."""
+	if sys.platform == 'win32':
+		# On Windows, use taskkill to kill the process tree
+		try:
+			subprocess.run(
+				['taskkill', '/F', '/T', '/PID', str(pid)],
+				capture_output=True,
+				timeout=10,
+			)
+		except Exception:
+			pass
+	else:
+		# On Unix, kill the process group
+		try:
+			import signal
+
+			# Try to kill the whole process group first
+			try:
+				os.killpg(pid, signal.SIGTERM)
+			except ProcessLookupError:
+				return  # Already dead
+			except PermissionError:
+				# Not a process group leader, kill just the process
+				try:
+					os.kill(pid, signal.SIGTERM)
+				except ProcessLookupError:
+					return
+
+			# Wait up to 3 seconds for graceful shutdown
+			for _ in range(30):
+				try:
+					os.kill(pid, 0)  # Check if alive
+				except ProcessLookupError:
+					return
+				time.sleep(0.1)
+
+			# Force kill if still alive
+			try:
+				os.killpg(pid, signal.SIGKILL)
+			except ProcessLookupError:
+				return
+			except PermissionError:
+				try:
+					os.kill(pid, signal.SIGKILL)
+				except ProcessLookupError:
+					return
+		except Exception:
+			pass
+
+
+def _cleanup_orphaned_chrome() -> int:
+	"""Find and kill Chrome processes using browseruse-tmp profiles.
+
+	Returns the number of processes killed.
+	"""
+	killed = 0
+
+	if sys.platform == 'win32':
+		# On Windows, use wmic to find Chrome processes with temp profiles
+		try:
+			result = subprocess.run(
+				['wmic', 'process', 'where',
+				 "name='chrome.exe' or name='chromium.exe' or name='Google Chrome'",
+				 'get', 'ProcessId,CommandLine', '/FORMAT:CSV'],
+				capture_output=True,
+				text=True,
+				timeout=10,
+			)
+			for line in result.stdout.splitlines():
+				if 'browseruse-tmp-' in line:
+					parts = line.strip().split(',')
+					if len(parts) >= 3:
+						try:
+							chrome_pid = int(parts[-1].strip())
+							subprocess.run(['taskkill', '/F', '/PID', str(chrome_pid)], capture_output=True, timeout=5)
+							killed += 1
+						except (ValueError, Exception):
+							pass
+		except Exception:
+			pass
+	else:
+		# On Unix, use ps to find Chrome processes with temp profiles
+		try:
+			result = subprocess.run(
+				['ps', 'aux'],
+				capture_output=True,
+				text=True,
+				timeout=10,
+			)
+			for line in result.stdout.splitlines():
+				if 'browseruse-tmp-' in line and ('chrome' in line.lower() or 'chromium' in line.lower()):
+					parts = line.split()
+					if len(parts) >= 2:
+						try:
+							chrome_pid = int(parts[1])
+							os.kill(chrome_pid, 15)  # SIGTERM
+							killed += 1
+						except (ValueError, ProcessLookupError, Exception):
+							pass
+		except Exception:
+			pass
+
+	return killed
+
+
+def _cleanup_temp_dirs() -> int:
+	"""Clean up leftover browseruse-tmp- directories in the system temp dir.
+
+	Returns the number of directories cleaned up.
+	"""
+	import shutil
+
+	cleaned = 0
+	temp_base = Path(tempfile.gettempdir())
+
+	try:
+		for entry in temp_base.iterdir():
+			if entry.is_dir() and 'browseruse-tmp-' in entry.name:
+				try:
+					shutil.rmtree(entry, ignore_errors=True)
+					cleaned += 1
+				except Exception:
+					pass
+	except Exception:
+		pass
+
+	# Also clean up in the browser-use home directory
+	home_dir = _get_home_dir()
+	try:
+		for entry in home_dir.iterdir():
+			if entry.is_dir() and 'browseruse-tmp-' in entry.name:
+				try:
+					shutil.rmtree(entry, ignore_errors=True)
+					cleaned += 1
+				except Exception:
+					pass
+	except Exception:
+		pass
+
+	return cleaned
+
+
 def _handle_close_all(args: argparse.Namespace) -> int:
-	"""Close all active sessions."""
+	"""Close all active sessions, killing daemon and Chrome processes."""
 	home_dir = _get_home_dir()
 	# Snapshot the list first to avoid mutating during iteration
 	pid_files = list(home_dir.glob('*.pid'))
 	closed = 0
+	killed = 0
 
+	# Phase 1: Try graceful shutdown via socket
 	for pid_file in pid_files:
 		name = pid_file.stem
 		if not name:
@@ -780,11 +925,79 @@ def _handle_close_all(args: argparse.Namespace) -> int:
 			except Exception:
 				pass
 
+	# Phase 2: Wait for daemons to exit, then force-kill any survivors
+	for pid_file in pid_files:
+		name = pid_file.stem
+		if not name:
+			continue
+
+		try:
+			pid = int(pid_file.read_text().strip())
+		except (OSError, ValueError):
+			pid_file.unlink(missing_ok=True)
+			continue
+
+		# Wait up to 3 seconds for the daemon to exit
+		daemon_exited = False
+		for _ in range(30):
+			try:
+				if sys.platform == 'win32':
+					import ctypes
+
+					_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+					handle = ctypes.windll.kernel32.OpenProcess(
+						_PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+					)
+					if handle:
+						ctypes.windll.kernel32.CloseHandle(handle)
+					else:
+						daemon_exited = True
+						break
+				else:
+					os.kill(pid, 0)  # Check if alive
+			except (ProcessLookupError, OSError):
+				daemon_exited = True
+				break
+			time.sleep(0.1)
+
+		if not daemon_exited:
+			# Force kill daemon and its children
+			_kill_process_tree(pid)
+			killed += 1
+
+		# Clean up PID file
+		pid_file.unlink(missing_ok=True)
+
+		# Clean up socket file on Unix
+		sock_path = _get_socket_path(name)
+		if not sock_path.startswith('tcp://'):
+			Path(sock_path).unlink(missing_ok=True)
+
+	# Phase 3: Kill orphaned Chrome processes using temp profiles
+	chrome_killed = _cleanup_orphaned_chrome()
+
+	# Phase 4: Clean up temp directories
+	dirs_cleaned = _cleanup_temp_dirs()
+
 	if args.json:
-		print(json.dumps({'closed': closed}))
+		print(json.dumps({
+			'closed': closed,
+			'force_killed': killed,
+			'chrome_killed': chrome_killed,
+			'dirs_cleaned': dirs_cleaned,
+		}))
 	else:
-		if closed:
-			print(f'Closed {closed} session(s)')
+		if closed or killed or chrome_killed or dirs_cleaned:
+			parts = []
+			if closed:
+				parts.append(f'{closed} session(s) shut down gracefully')
+			if killed:
+				parts.append(f'{killed} daemon(s) force-killed')
+			if chrome_killed:
+				parts.append(f'{chrome_killed} orphaned Chrome process(es) killed')
+			if dirs_cleaned:
+				parts.append(f'{dirs_cleaned} temp director(ies) cleaned up')
+			print(f'Cleanup complete: {", ".join(parts)}')
 		else:
 			print('No active sessions')
 

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -761,18 +761,61 @@ def _handle_sessions(args: argparse.Namespace) -> int:
 	return 0
 
 
-def _kill_process_tree(pid: int) -> None:
-	"""Kill a process and all its children. Cross-platform."""
+def _is_our_process(pid: int, expected_name: str) -> bool:
+	"""Verify that the given PID actually belongs to our daemon.
+
+	Checks /proc on Linux or uses ps on other Unix/macOS to confirm
+	the process command line contains the expected session name,
+	preventing accidental kills of unrelated processes due to PID reuse.
+	"""
+	if sys.platform == 'win32':
+		# On Windows, check via wmic
+		try:
+			result = subprocess.run(
+				['wmic', 'process', 'where', f'ProcessId={pid}',
+				 'get', 'CommandLine', '/FORMAT:VALUE'],
+				capture_output=True, text=True, timeout=5,
+			)
+			return expected_name in result.stdout or 'browser_use' in result.stdout
+		except Exception:
+			return False  # Can't verify — don't kill
+	# On Linux, check /proc first (fastest path)
+	try:
+		cmdline = Path(f'/proc/{pid}/cmdline').read_bytes().decode(errors='replace')
+		if expected_name in cmdline or 'browser_use' in cmdline or 'skill_cli' in cmdline:
+			return True
+		# If cmdline exists but doesn't match, this is NOT our process
+		return False
+	except (FileNotFoundError, PermissionError):
+		pass
+	# Fallback: use ps
+	try:
+		result = subprocess.run(
+			['ps', '-p', str(pid), '-o', 'args='],
+			capture_output=True, text=True, timeout=5,
+		)
+		cmdline = result.stdout
+		return expected_name in cmdline or 'browser_use' in cmdline or 'skill_cli' in cmdline
+	except Exception:
+		return False  # Can't verify — don't kill
+
+
+def _kill_process_tree(pid: int) -> bool:
+	"""Kill a process and all its children. Cross-platform.
+
+	Returns True if the process was actually killed, False if it was
+	already dead or kill was skipped.
+	"""
 	if sys.platform == 'win32':
 		# On Windows, use taskkill to kill the process tree
 		try:
-			subprocess.run(
+			result = subprocess.run(
 				['taskkill', '/F', '/T', '/PID', str(pid)],
-				capture_output=True,
-				timeout=10,
+				capture_output=True, timeout=10,
 			)
+			return result.returncode == 0
 		except Exception:
-			pass
+			return False
 	else:
 		# On Unix, kill the process group
 		try:
@@ -782,40 +825,76 @@ def _kill_process_tree(pid: int) -> None:
 			try:
 				os.killpg(pid, signal.SIGTERM)
 			except ProcessLookupError:
-				return  # Already dead
+				return False  # Already dead
 			except PermissionError:
 				# Not a process group leader, kill just the process
 				try:
 					os.kill(pid, signal.SIGTERM)
 				except ProcessLookupError:
-					return
+					return False
 
 			# Wait up to 3 seconds for graceful shutdown
 			for _ in range(30):
 				try:
 					os.kill(pid, 0)  # Check if alive
 				except ProcessLookupError:
-					return
+					return True  # Exited gracefully
 				time.sleep(0.1)
 
 			# Force kill if still alive
 			try:
 				os.killpg(pid, signal.SIGKILL)
 			except ProcessLookupError:
-				return
+				return True
 			except PermissionError:
 				try:
 					os.kill(pid, signal.SIGKILL)
 				except ProcessLookupError:
-					return
+					return True
+			# Verify it's actually dead
+			try:
+				os.kill(pid, 0)
+				return False  # Still alive after SIGKILL
+			except ProcessLookupError:
+				return True
 		except Exception:
-			pass
+			return False
+
+
+def _kill_chrome_process(chrome_pid: int) -> bool:
+	"""Kill a single Chrome process with verification.
+
+	Sends SIGTERM, waits up to 2s, then SIGKILL if still alive.
+	Returns True only if the process was actually terminated.
+	"""
+	try:
+		import signal as _sig
+
+		os.kill(chrome_pid, _sig.SIGTERM)
+		for _ in range(20):  # Wait up to 2s
+			try:
+				os.kill(chrome_pid, 0)
+			except ProcessLookupError:
+				return True
+			time.sleep(0.1)
+		# Still alive — escalate
+		os.kill(chrome_pid, _sig.SIGKILL)
+		time.sleep(0.3)
+		try:
+			os.kill(chrome_pid, 0)
+			return False  # Survived SIGKILL
+		except ProcessLookupError:
+			return True
+	except ProcessLookupError:
+		return False  # Already gone (not our kill)
+	except Exception:
+		return False
 
 
 def _cleanup_orphaned_chrome() -> int:
 	"""Find and kill Chrome processes using browseruse-tmp profiles.
 
-	Returns the number of processes killed.
+	Returns the number of processes actually terminated.
 	"""
 	killed = 0
 
@@ -836,8 +915,9 @@ def _cleanup_orphaned_chrome() -> int:
 					if len(parts) >= 3:
 						try:
 							chrome_pid = int(parts[-1].strip())
-							subprocess.run(['taskkill', '/F', '/PID', str(chrome_pid)], capture_output=True, timeout=5)
-							killed += 1
+							r = subprocess.run(['taskkill', '/F', '/PID', str(chrome_pid)], capture_output=True, timeout=5)
+							if r.returncode == 0:
+								killed += 1
 						except (ValueError, Exception):
 							pass
 		except Exception:
@@ -857,9 +937,9 @@ def _cleanup_orphaned_chrome() -> int:
 					if len(parts) >= 2:
 						try:
 							chrome_pid = int(parts[1])
-							os.kill(chrome_pid, 15)  # SIGTERM
-							killed += 1
-						except (ValueError, ProcessLookupError, Exception):
+							if _kill_chrome_process(chrome_pid):
+								killed += 1
+						except (ValueError, Exception):
 							pass
 		except Exception:
 			pass
@@ -961,9 +1041,12 @@ def _handle_close_all(args: argparse.Namespace) -> int:
 			time.sleep(0.1)
 
 		if not daemon_exited:
-			# Force kill daemon and its children
-			_kill_process_tree(pid)
-			killed += 1
+			# Verify PID actually belongs to our daemon before killing
+			# (guards against PID reuse making stale PID files dangerous)
+			if _is_our_process(pid, name):
+				if _kill_process_tree(pid):
+					killed += 1
+			# else: PID was reused by another process — skip kill, just clean files
 
 		# Clean up PID file
 		pid_file.unlink(missing_ok=True)


### PR DESCRIPTION
## Problem

`browser-use close --all` only sends shutdown commands to daemons via socket and immediately returns. This leaves daemon processes and their spawned Chrome processes alive when:

- The daemon is unresponsive or stuck
- The shutdown command is sent but the daemon doesn't exit in time
- Chrome processes are orphaned after daemon crashes

## Solution

The fix implements a thorough 4-phase cleanup in `_handle_close_all`:

1. **Graceful shutdown**: Send shutdown command to each daemon via socket (existing behavior)
2. **Force-kill survivors**: Wait up to 3 seconds per daemon, then kill the process tree (daemon + children) using `os.killpg` on Unix or `taskkill /T` on Windows
3. **Orphan cleanup**: Find and kill Chrome processes using `browseruse-tmp-` temp profile directories (via `ps aux` on Unix, `wmic` on Windows)
4. **Temp dir cleanup**: Remove leftover `browseruse-tmp-*` directories from system temp and browser-use home

## Changes

- Added `_kill_process_tree(pid)`: Cross-platform process tree killer (Unix: SIGTERM -> wait -> SIGKILL via os.killpg; Windows: taskkill /F /T)
- Added `_cleanup_orphaned_chrome()`: Finds Chrome/Chromium processes with `browseruse-tmp-` in their command line and kills them
- Added `_cleanup_temp_dirs()`: Removes `browseruse-tmp-*` directories from temp locations
- Modified `_handle_close_all` to use all three helpers and report detailed stats

## Testing

The fix is cross-platform (macOS/Linux/Windows) and handles edge cases like:
- Daemon process already dead (ProcessLookupError)
- Chrome process already exited
- Permission denied (non-owner process)
- Stale PID files from crashed daemons

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `close --all` safely clean up. It now terminates daemons, kills temp-profile Chrome, and removes leftover temp dirs to prevent orphans and free resources.

- **Bug Fixes**
  - 4-phase cleanup: graceful shutdown, 3s wait then process-tree kill, kill Chrome using `browseruse-tmp-` profiles, remove temp dirs.
  - Validate PID belongs to our daemon before kill to avoid PID reuse; handles stale PID files, already-dead processes, and permission errors.
  - Cross-platform kill: Unix `os.killpg`; Windows `taskkill /T`.
  - Chrome cleanup sends SIGTERM -> wait -> SIGKILL and only counts if termination is confirmed; JSON/console report: closed, force_killed, chrome_killed, dirs_cleaned.

<sup>Written for commit 24553891f8163d23a0f3c338eb6b088b65af8a31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

