### PR TITLE
fix(browser): show actionable error on Windows WinError 32 when Chrome profile is locked

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -827,7 +827,21 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		if path_original_profile.exists():
 			import shutil
 
-			shutil.copytree(path_original_profile, path_temp_profile)
+			try:
+				shutil.copytree(path_original_profile, path_temp_profile)
+			except OSError as e:
+				shutil.rmtree(temp_dir, ignore_errors=True)
+				if sys.platform == 'win32' and getattr(e, 'winerror', None) == 32:
+					msg = (
+						"Cannot copy Chrome profile while Chrome is running (WinError 32).\n"
+						f"Profile: {path_original_profile}\n\n"
+						"Options:\n"
+						"  1. Quit Chrome completely, then retry\n"
+						"  2. Use --connect with a Chrome instance started with --remote-debugging-port=9222\n"
+						"  3. Use --headless (no profile needed)"
+					)
+					raise RuntimeError(msg) from e
+				raise
 			local_state_src = path_original_user_data / 'Local State'
 			local_state_dst = Path(temp_dir) / 'Local State'
 			if local_state_src.exists():


### PR DESCRIPTION
Fixes #4546

## Problem

When `--profile` is used on Windows while Chrome is running, `shutil.copytree` fails with WinError 32 (ERROR_SHARING_VIOLATION) because Chrome holds exclusive locks on profile files (Cookies, Safe Browsing, Sessions, etc.). The user gets a raw traceback with no guidance.

## Fix

Catch `OSError` in `_copy_profile()` and, on Windows with winerror 32, raise a `RuntimeError` with clear instructions:

1. Quit Chrome completely, then retry
2. Use `--connect` with a Chrome instance started with `--remote-debugging-port=9222`
3. Use `--headless` (no profile needed)

The temp directory is cleaned up before raising so we don't leak empty dirs.

## Changes

- Wrapped `shutil.copytree` in try/except
- On WinError 32: clean up temp dir, raise descriptive RuntimeError
- On other OSError: re-raise as-is (no behavior change)
- Non-Windows platforms: unchanged behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear, actionable error on Windows when a Chrome profile copy fails with WinError 32 (profile locked) instead of a traceback. Cleans up the temp profile directory and guides users on how to proceed.

- **Bug Fixes**
  - Catch `OSError` in `_copy_profile()`; on `win32` with `winerror == 32`, raise a descriptive `RuntimeError`.
  - Provide next steps: quit Chrome, use `--connect` with `--remote-debugging-port=9222`, or run `--headless`.
  - Remove the temporary profile directory before raising.
  - No behavior changes for other errors or non-Windows.

<sup>Written for commit 1d2f5290669300244918106ff4ae0dcee20f6d8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

