### PR TITLE
fix: preserve CDP WebSocket connections on Agent.close() with keep_alive=True

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3933,16 +3933,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					# stops the EventBus with clear=True, and recreates a fresh EventBus
 					await self.browser_session.kill()
 				else:
-					# keep_alive=True sessions shouldn't keep the event loop alive after agent.run()
-					await self.browser_session.event_bus.stop(
-						clear=False,
-						timeout=_get_timeout('TIMEOUT_BrowserSessionEventBusStopOnAgentClose', 1.0),
-					)
-					try:
-						self.browser_session.event_bus.event_queue = None
-						self.browser_session.event_bus._on_idle = None
-					except Exception:
-						pass
+					# keep_alive=True: preserve the event bus and CDP WebSocket connections
+					# so the browser session remains fully connected and ready for the next agent.
+					# Stopping the event bus or nullifying the event queue would cause CDP
+					# WebSocket message handlers to exit, triggering unnecessary reconnection
+					# cycles that clear session manager data (targets, sessions, mappings).
+					pass
 
 			# Close skill service if configured
 			if self.skill_service is not None:

--- a/tests/ci/browser/test_session_start.py
+++ b/tests/ci/browser/test_session_start.py
@@ -227,6 +227,61 @@ class TestBrowserSessionReusePatterns:
 		finally:
 			await reused_session.kill()
 
+	async def test_keep_alive_preserves_event_bus_and_cdp(self, mock_llm):
+		"""Test that Agent.close() with keep_alive=True preserves CDP WebSocket connections.
+
+		Regression test for https://github.com/browser-use/browser-use/issues/4374
+		When keep_alive=True, Agent.close() should NOT stop the event bus or null
+		the event queue, as that causes CDP WebSocket handlers to exit and triggers
+		unnecessary reconnection cycles that clear session manager data.
+		"""
+		from browser_use import Agent, BrowserSession
+
+		session = BrowserSession(
+			browser_profile=BrowserProfile(
+				user_data_dir=None,
+				headless=True,
+				keep_alive=True,
+			),
+		)
+
+		try:
+			await session.start()
+
+			# Capture event bus state before agent run
+			event_bus_before = session.event_bus
+			cdp_client_before = session._cdp_client_root
+
+			agent = Agent(
+				task='Navigate somewhere',
+				llm=mock_llm,
+				browser_session=session,
+			)
+			await agent.run()
+
+			# After agent.close(), event bus should be the same object and still functional
+			assert session.event_bus is event_bus_before, 'Event bus was replaced after Agent.close()'
+			assert session.event_bus.event_queue is not None, 'Event queue was nullified after Agent.close()'
+
+			# CDP client should still be connected
+			assert session._cdp_client_root is not None, 'CDP client was lost after Agent.close()'
+			assert session._cdp_client_root is cdp_client_before, 'CDP client was replaced after Agent.close()'
+
+			# The session should still be usable for another agent
+			agent2 = Agent(
+				task='Do another thing',
+				llm=mock_llm,
+				browser_session=session,
+			)
+			await agent2.run()
+
+			# Still connected after second agent
+			assert session._cdp_client_root is not None
+			assert session.event_bus.event_queue is not None
+
+		finally:
+			await session.kill()
+
 
 class TestBrowserSessionEventSystem:
 	"""Tests for the new event system integration in BrowserSession."""


### PR DESCRIPTION
## Summary

- **Fixes the root cause of CDP WebSocket disconnection/reconnection cycles** when `Agent.close()` is called with `keep_alive=True`
- Previously, `Agent.close()` stopped the event bus and nullified the event queue even for `keep_alive=True` sessions, causing CDP WebSocket message handlers to exit and triggering ~1.7s reconnection delays that cleared all session manager data
- The fix skips event bus teardown entirely when `keep_alive=True`, keeping the browser session fully connected and ready for the next agent

## Root Cause

In `agent/service.py`, the `keep_alive=True` path in `close()` called:
1. `event_bus.stop(clear=False)` — stops the event bus processing loop
2. `event_bus.event_queue = None` — removes the event queue

This cascaded into CDP WebSocket message handlers exiting. Since `_intentional_stop` was never set in this code path, the `_on_message_handler_done` callback fired auto-reconnect, which cleared all `SessionManager` data (targets, sessions, mappings).

## Changes

- `browser_use/agent/service.py`: Replace event bus stop + queue nullification with a `pass` (no-op) for `keep_alive=True` sessions
- `tests/ci/browser/test_session_start.py`: Add regression test verifying event bus, event queue, and CDP client are preserved across sequential agent runs on a `keep_alive=True` session

## Test plan

- [x] New test `test_keep_alive_preserves_event_bus_and_cdp` passes
- [x] All 3 existing `TestBrowserSessionReusePatterns` tests pass
- [x] `ruff check` passes on both changed files

Closes #4374

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CDP WebSocket disconnect/reconnect loops when `Agent.close()` runs with `keep_alive=True` by preserving the event bus and queue. The browser session now stays connected and ready for the next agent, avoiding delays and state loss.

- **Bug Fixes**
  - Keep-alive path in `Agent.close()` no longer stops the event bus or nullifies its queue, preventing CDP handler exit and SessionManager state resets.
  - Added a regression test to verify the event bus, event queue, and root CDP client persist across sequential agents on a `keep_alive=True` session.

<sup>Written for commit e85b20b9b77e39ff06472fccaf21012bdebed8f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

