### PR TITLE
feat: add AgentSIM phone verification integration

### DIFF
--- a/examples/integrations/agentsim/phone_tools.py
+++ b/examples/integrations/agentsim/phone_tools.py
@@ -72,7 +72,7 @@ class PhoneTools(Tools):
 				)
 			try:
 				otp: OtpResult = await session.wait_for_otp(timeout=timeout_seconds)
-				logger.info(f"OTP received for session {session_id}: {otp.otp_code}")
+				logger.info(f"OTP received for session {session_id}")
 				return ActionResult(
 					extracted_content=(
 						f"OTP received: {otp.otp_code}. "
@@ -96,9 +96,10 @@ class PhoneTools(Tools):
 			)
 		)
 		async def release_phone_number(session_id: str) -> ActionResult:
-			session = self._sessions.pop(session_id, None)
+			session = self._sessions.get(session_id)
 			if session:
 				await session.release()
+				self._sessions.pop(session_id, None)
 				logger.info(f"Released session {session_id}")
 			return ActionResult(
 				extracted_content=f"Phone number released (session {session_id}).",

--- a/examples/integrations/agentsim/phone_tools.py
+++ b/examples/integrations/agentsim/phone_tools.py
@@ -1,0 +1,106 @@
+"""
+Phone verification tools for Browser Use using AgentSIM.
+
+AgentSIM provides real carrier-grade (T-Mobile) phone numbers that pass
+carrier lookup checks as line_type: mobile. Unlike VoIP numbers (Twilio,
+Google Voice), these numbers work with services that block virtual numbers.
+
+Install: pip install agentsim-sdk
+API key: https://agentsim.dev/dashboard
+"""
+
+import asyncio
+import logging
+
+import agentsim
+from agentsim.types import OtpResult, PhoneSession
+
+from browser_use import ActionResult, Tools
+
+logger = logging.getLogger(__name__)
+
+
+class PhoneTools(Tools):
+	"""Browser Use tools for phone number provisioning and OTP verification via AgentSIM."""
+
+	def __init__(self, api_key: str | None = None, default_country: str = "US"):
+		super().__init__()
+		if api_key:
+			agentsim.configure(api_key=api_key)
+		self.default_country = default_country
+		self._sessions: dict[str, PhoneSession] = {}
+		self._register_tools()
+
+	def _register_tools(self) -> None:
+		@self.action(
+			description=(
+				"Provision a real carrier-grade mobile phone number via AgentSIM. "
+				"Call this BEFORE entering a phone number on any SMS verification page. "
+				"Returns the phone number in E.164 format (e.g. +14155551234) and a "
+				"session_id needed for OTP retrieval. The number is a real T-Mobile SIM "
+				"that passes carrier lookup checks — not VoIP."
+			)
+		)
+		async def provision_phone_number(country: str = self.default_country) -> ActionResult:
+			session = await agentsim.provision_number(agent_id="browser-use", country=country)
+			self._sessions[session.session_id] = session
+			logger.info(f"Provisioned {session.number} (session: {session.session_id})")
+			return ActionResult(
+				extracted_content=(
+					f"Provisioned phone number: {session.number} "
+					f"(session_id: {session.session_id}). "
+					f"Enter this number in the phone field and submit the form. "
+					f"Then call wait_for_otp with session_id={session.session_id}."
+				),
+				include_in_memory=True,
+			)
+
+		@self.action(
+			description=(
+				"Wait for an SMS OTP to arrive on a provisioned AgentSIM number. "
+				"Call this AFTER the phone number form has been submitted. "
+				"Returns the OTP code to enter in the verification field. "
+				"Waits up to timeout_seconds (default 60)."
+			)
+		)
+		async def wait_for_otp(session_id: str, timeout_seconds: int = 60) -> ActionResult:
+			session = self._sessions.get(session_id)
+			if not session:
+				return ActionResult(
+					extracted_content=f"No active session found for {session_id}. Provision a number first.",
+					include_in_memory=True,
+				)
+			try:
+				otp: OtpResult = await session.wait_for_otp(timeout=timeout_seconds)
+				logger.info(f"OTP received for session {session_id}: {otp.otp_code}")
+				return ActionResult(
+					extracted_content=(
+						f"OTP received: {otp.otp_code}. "
+						f"Enter this code in the verification/OTP field and submit."
+					),
+					include_in_memory=True,
+				)
+			except agentsim.OtpTimeoutError:
+				return ActionResult(
+					extracted_content=(
+						"OTP timed out — the SMS may not have been sent yet. "
+						"Make sure you submitted the form with the phone number, then try again."
+					),
+					include_in_memory=True,
+				)
+
+		@self.action(
+			description=(
+				"Release an AgentSIM phone number back to the pool. "
+				"Call this after SMS verification is complete to avoid extra charges."
+			)
+		)
+		async def release_phone_number(session_id: str) -> ActionResult:
+			session = self._sessions.pop(session_id, None)
+			if session:
+				await session.release()
+				logger.info(f"Released session {session_id}")
+			return ActionResult(
+				extracted_content=f"Phone number released (session {session_id}).",
+				include_in_memory=True,
+			)

--- a/examples/integrations/agentsim/signup_verification.py
+++ b/examples/integrations/agentsim/signup_verification.py
@@ -1,0 +1,55 @@
+"""
+AgentSIM + Browser Use: Automated Signup with Real Phone Verification
+
+Demonstrates a Browser Use agent that navigates to a signup page, provisions
+a real carrier-grade mobile number via AgentSIM, fills the form, captures
+the OTP, and completes registration.
+
+Unlike VoIP numbers, AgentSIM numbers pass carrier lookup checks (line_type:
+mobile) so they work with Google, Stripe, WhatsApp, and other services that
+block virtual numbers.
+
+Requirements:
+    pip install browser-use agentsim-sdk
+    playwright install chromium
+
+Environment:
+    OPENAI_API_KEY=sk-...
+    AGENTSIM_API_KEY=asm_live_...  (get one at https://agentsim.dev/dashboard)
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use import Agent
+from browser_use.chat import ChatBrowserUse
+from examples.integrations.agentsim.phone_tools import PhoneTools
+
+TASK = """\
+Go to https://example.com/signup and complete the registration:
+1. Fill in the form with test details (make up a name and email).
+2. When the form asks for a phone number, call provision_phone_number to get a real US mobile number.
+3. Enter the provisioned number in the phone field and submit.
+4. Call wait_for_otp to get the verification code.
+5. Enter the OTP code and complete registration.
+6. Call release_phone_number to clean up.
+7. Report whether registration succeeded.
+"""
+
+
+async def main():
+	tools = PhoneTools(api_key=os.environ["AGENTSIM_API_KEY"])
+	llm = ChatBrowserUse(model="bu-2-0")
+
+	agent = Agent(task=TASK, tools=tools, llm=llm)
+	await agent.run()
+
+
+if __name__ == "__main__":
+	asyncio.run(main())

--- a/examples/integrations/agentsim/signup_verification.py
+++ b/examples/integrations/agentsim/signup_verification.py
@@ -22,7 +22,8 @@ import asyncio
 import os
 import sys
 
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+# Add the repo root to sys.path so 'examples.integrations...' imports work
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -48,7 +49,15 @@ async def main():
 	llm = ChatBrowserUse(model="bu-2-0")
 
 	agent = Agent(task=TASK, tools=tools, llm=llm)
-	await agent.run()
+	try:
+		await agent.run()
+	finally:
+		# Ensure all provisioned numbers are released even if the agent errors
+		for sid, session in list(tools._sessions.items()):
+			try:
+				await session.release()
+			except Exception:
+				pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## AgentSIM Phone Verification Integration

Adds an integration example for [AgentSIM](https://agentsim.dev) — real SIM-backed phone numbers for AI agents to complete SMS/OTP verification flows.

### What it does
- `PhoneTools` class wrapping the AgentSIM SDK for Browser Use's custom function system
- End-to-end example of automated signup with phone verification

### Why it's useful
Many services detect and reject VoIP/virtual numbers during phone verification. AgentSIM provides real mobile carrier numbers that pass these checks, enabling Browser Use agents to complete SMS-based auth flows.

### Files
- `examples/integrations/agentsim/phone_tools.py` — PhoneTools class
- `examples/integrations/agentsim/signup_verification.py` — Full example

### Links
- [Documentation](https://docs.agentsim.dev/mcp/overview)
- [Repository](https://github.com/agentsimdev/agentsim-mcp)
- [PyPI](https://pypi.org/project/agentsim-sdk/)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AgentSIM phone verification integration for Browser Use. Agents can provision real SIM-backed numbers, receive OTPs, and complete SMS verification on services that block VoIP.

- **New Features**
  - `examples/integrations/agentsim/phone_tools.py`: `PhoneTools` wrapping `agentsim-sdk` with actions to provision a number, wait for OTP, and release the number.
  - `examples/integrations/agentsim/signup_verification.py`: End-to-end example that completes a signup flow with SMS verification.

- **Bug Fixes**
  - Removed OTPs from logs, made session removal happen only after a successful release, fixed example `sys.path` to repo root, and added try/finally cleanup to always release numbers on errors.

<sup>Written for commit f8775a14e3b391ae0e35123e7e5946a749f0e361. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

