### PR TITLE
feat: Agent-Trust-Score header — multi-provider trust verification for browser agents

### DIFF
--- a/browser_use/integrations/trust/__init__.py
+++ b/browser_use/integrations/trust/__init__.py
@@ -1,0 +1,30 @@
+"""
+AgentID Trust Provider for Browser Use
+
+Provides trust verification for AI agents using the AgentID protocol.
+Agents present Agent-Trust-Score JWTs that site operators can evaluate
+against configurable policies before granting access.
+
+Usage:
+	from agentid_trust_provider import AgentIDTrustProvider, TrustPolicy
+
+	# Initialize provider
+	provider = AgentIDTrustProvider()
+
+	# Get a trust JWT for an agent
+	jwt = await provider.get_trust_jwt("agent_abc123")
+
+	# Verify and evaluate against policy
+	claims = await provider.verify_trust_jwt(jwt)
+	policy = TrustPolicy({"min_trust_score": 50})
+	result = policy.evaluate(claims)
+"""
+
+try:
+	from .agentid_trust_provider import AgentIDTrustProvider, TrustClaims, TrustProvider
+	from .policy_engine import TrustPolicy
+except ImportError:
+	from agentid_trust_provider import AgentIDTrustProvider, TrustClaims, TrustProvider
+	from policy_engine import TrustPolicy
+
+__all__ = ['AgentIDTrustProvider', 'TrustClaims', 'TrustPolicy', 'TrustProvider']

--- a/browser_use/integrations/trust/__init__.py
+++ b/browser_use/integrations/trust/__init__.py
@@ -6,7 +6,7 @@ Agents present Agent-Trust-Score JWTs that site operators can evaluate
 against configurable policies before granting access.
 
 Usage:
-	from agentid_trust_provider import AgentIDTrustProvider, TrustPolicy
+	from browser_use.integrations.trust import AgentIDTrustProvider, TrustPolicy
 
 	# Initialize provider
 	provider = AgentIDTrustProvider()
@@ -20,11 +20,14 @@ Usage:
 	result = policy.evaluate(claims)
 """
 
-try:
-	from .agentid_trust_provider import AgentIDTrustProvider, TrustClaims, TrustProvider
-	from .policy_engine import TrustPolicy
-except ImportError:
-	from agentid_trust_provider import AgentIDTrustProvider, TrustClaims, TrustProvider
-	from policy_engine import TrustPolicy
+from .policy import PolicyResult, TrustPolicy, TrustPolicyChain
+from .service import AgentIDTrustProvider, TrustClaims, TrustProvider
 
-__all__ = ['AgentIDTrustProvider', 'TrustClaims', 'TrustPolicy', 'TrustProvider']
+__all__ = [
+	'AgentIDTrustProvider',
+	'TrustClaims',
+	'TrustProvider',
+	'TrustPolicy',
+	'TrustPolicyChain',
+	'PolicyResult',
+]

--- a/browser_use/integrations/trust/__init__.py
+++ b/browser_use/integrations/trust/__init__.py
@@ -6,7 +6,7 @@ Agents present Agent-Trust-Score JWTs that site operators can evaluate
 against configurable policies before granting access.
 
 Usage:
-	from browser_use.integrations.trust import AgentIDTrustProvider, TrustPolicy
+	from browser_use.integrations.trust import AgentIDTrustProvider, TrustPolicy, TrustPolicyChain
 
 	# Initialize provider
 	provider = AgentIDTrustProvider()
@@ -20,8 +20,25 @@ Usage:
 	result = policy.evaluate(claims)
 """
 
-from .policy import PolicyResult, TrustPolicy, TrustPolicyChain
-from .service import AgentIDTrustProvider, TrustClaims, TrustProvider
+try:
+	from .policy import PolicyResult, TrustPolicy, TrustPolicyChain
+except ImportError as e:
+	if 'pydantic' in str(e):
+		raise ImportError(
+			'browser_use.integrations.trust requires pydantic. '
+			'Install it with: pip install pydantic'
+		) from e
+	raise
+
+try:
+	from .service import AgentIDTrustProvider, TrustClaims, TrustProvider
+except ImportError as e:
+	if 'httpx' in str(e):
+		raise ImportError(
+			'browser_use.integrations.trust requires httpx. '
+			'Install it with: pip install httpx'
+		) from e
+	raise
 
 __all__ = [
 	'AgentIDTrustProvider',

--- a/browser_use/integrations/trust/__init__.py
+++ b/browser_use/integrations/trust/__init__.py
@@ -24,20 +24,14 @@ try:
 	from .policy import PolicyResult, TrustPolicy, TrustPolicyChain
 except ImportError as e:
 	if 'pydantic' in str(e):
-		raise ImportError(
-			'browser_use.integrations.trust requires pydantic. '
-			'Install it with: pip install pydantic'
-		) from e
+		raise ImportError('browser_use.integrations.trust requires pydantic. Install it with: pip install pydantic') from e
 	raise
 
 try:
 	from .service import AgentIDTrustProvider, TrustClaims, TrustProvider
 except ImportError as e:
 	if 'httpx' in str(e):
-		raise ImportError(
-			'browser_use.integrations.trust requires httpx. '
-			'Install it with: pip install httpx'
-		) from e
+		raise ImportError('browser_use.integrations.trust requires httpx. Install it with: pip install httpx') from e
 	raise
 
 __all__ = [

--- a/browser_use/integrations/trust/policy.py
+++ b/browser_use/integrations/trust/policy.py
@@ -1,0 +1,158 @@
+"""
+Policy engine for evaluating trust claims against site operator thresholds.
+
+Site operators define policies specifying minimum trust scores, maximum risk
+thresholds, and required attestations. The engine evaluates incoming agent
+trust claims against these policies and returns allow/block/degrade decisions.
+
+Example:
+	policy = TrustPolicy({
+		"min_trust_score": 60,
+		"max_risk_score": 30,
+		"required_attestations": ["identity_verified"],
+		"action_on_fail": "block",
+	})
+	result = policy.evaluate(claims)
+	if result["action"] == "block":
+		# deny the agent
+"""
+
+import logging
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+try:
+	from .agentid_trust_provider import TrustClaims
+except ImportError:
+	from agentid_trust_provider import TrustClaims
+
+logger = logging.getLogger(__name__)
+
+ActionType = Literal['allow', 'block', 'degrade', 'log']
+
+
+class PolicyResult(BaseModel):
+	"""Result of evaluating trust claims against a policy."""
+
+	model_config = ConfigDict(extra='forbid')
+
+	passed: bool
+	action: ActionType
+	failures: list[str] = Field(default_factory=list)
+	trust_level: str = ''
+	provider: str = ''
+
+
+class TrustPolicy:
+	"""
+	Evaluates TrustClaims against configurable thresholds.
+
+	Supports four failure actions:
+	- block: reject the agent entirely
+	- degrade: allow with reduced capabilities
+	- log: allow but log the policy violation
+	- allow: (only returned on pass)
+	"""
+
+	def __init__(self, config: dict | None = None):
+		config = config or {}
+		self.min_trust_score: int = config.get('min_trust_score', 0)
+		self.max_scarring_score: int = config.get('max_scarring_score', 999)
+		self.max_risk_score: int = config.get('max_risk_score', 100)
+		self.required_attestations: list[str] = config.get('required_attestations', [])
+		self.action_on_fail: ActionType = config.get('action_on_fail', 'log')
+
+	def evaluate(self, claims: TrustClaims) -> PolicyResult:
+		"""
+		Evaluate trust claims against this policy.
+
+		Args:
+			claims: Decoded TrustClaims from a verified JWT.
+
+		Returns:
+			PolicyResult indicating whether the agent passed and what action to take.
+		"""
+		failures: list[str] = []
+
+		if claims.trust_score < self.min_trust_score:
+			failures.append(
+				f'trust_score {claims.trust_score} < min {self.min_trust_score}'
+			)
+
+		if claims.scarring_score > self.max_scarring_score:
+			failures.append(
+				f'scarring_score {claims.scarring_score} > max {self.max_scarring_score}'
+			)
+
+		if claims.risk_score > self.max_risk_score:
+			failures.append(
+				f'risk_score {claims.risk_score} > max {self.max_risk_score}'
+			)
+
+		for req in self.required_attestations:
+			if req not in claims.attestations:
+				failures.append(f'missing attestation: {req}')
+
+		passed = len(failures) == 0
+
+		if not passed:
+			logger.info(
+				f'Policy check failed for agent {claims.agent_id}: '
+				f'{", ".join(failures)} -> action={self.action_on_fail}'
+			)
+
+		return PolicyResult(
+			passed=passed,
+			action='allow' if passed else self.action_on_fail,
+			failures=failures,
+			trust_level=claims.trust_level,
+			provider=claims.provider,
+		)
+
+
+class TrustPolicyChain:
+	"""
+	Evaluate claims against multiple policies in sequence.
+
+	The most restrictive result wins — if any policy returns 'block',
+	the overall result is 'block'. 'degrade' takes precedence over 'log'.
+	"""
+
+	ACTION_PRIORITY: dict[ActionType, int] = {
+		'allow': 0,
+		'log': 1,
+		'degrade': 2,
+		'block': 3,
+	}
+
+	def __init__(self, policies: list[TrustPolicy] | None = None):
+		self.policies = policies or []
+
+	def add(self, policy: TrustPolicy) -> None:
+		self.policies.append(policy)
+
+	def evaluate(self, claims: TrustClaims) -> PolicyResult:
+		"""Evaluate all policies and return the most restrictive result."""
+		assert self.policies, 'Policy chain must have at least one policy'
+
+		results = [p.evaluate(claims) for p in self.policies]
+
+		# Merge: collect all failures, use most restrictive action
+		all_failures: list[str] = []
+		worst_action: ActionType = 'allow'
+
+		for result in results:
+			all_failures.extend(result.failures)
+			if self.ACTION_PRIORITY.get(result.action, 0) > self.ACTION_PRIORITY.get(worst_action, 0):
+				worst_action = result.action
+
+		passed = worst_action == 'allow'
+
+		return PolicyResult(
+			passed=passed,
+			action=worst_action,
+			failures=all_failures,
+			trust_level=claims.trust_level,
+			provider=claims.provider,
+		)

--- a/browser_use/integrations/trust/policy.py
+++ b/browser_use/integrations/trust/policy.py
@@ -20,7 +20,13 @@ Example:
 import logging
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+try:
+	from pydantic import BaseModel, ConfigDict, Field
+except ImportError as e:
+	raise ImportError(
+		'browser_use.integrations.trust.policy requires pydantic. '
+		'Install it with: pip install pydantic'
+	) from e
 
 from .service import TrustClaims
 
@@ -66,13 +72,19 @@ class TrustPolicy:
 		self.action_on_fail: ActionType = action
 
 		if not isinstance(self.min_trust_score, int):
-			raise TypeError(f'min_trust_score must be int, got {type(self.min_trust_score).__name__}')
+			raise ValueError(f'min_trust_score must be int, got {type(self.min_trust_score).__name__}')
 		if not isinstance(self.max_scarring_score, int):
-			raise TypeError(f'max_scarring_score must be int, got {type(self.max_scarring_score).__name__}')
+			raise ValueError(f'max_scarring_score must be int, got {type(self.max_scarring_score).__name__}')
 		if not isinstance(self.max_risk_score, int):
-			raise TypeError(f'max_risk_score must be int, got {type(self.max_risk_score).__name__}')
+			raise ValueError(f'max_risk_score must be int, got {type(self.max_risk_score).__name__}')
 		if not isinstance(self.required_attestations, list):
-			raise TypeError(f'required_attestations must be list, got {type(self.required_attestations).__name__}')
+			raise ValueError(f'required_attestations must be list, got {type(self.required_attestations).__name__}')
+		if self.min_trust_score < 0:
+			raise ValueError(f'min_trust_score must be >= 0, got {self.min_trust_score}')
+		if self.max_scarring_score < 0:
+			raise ValueError(f'max_scarring_score must be >= 0, got {self.max_scarring_score}')
+		if self.max_risk_score < 0:
+			raise ValueError(f'max_risk_score must be >= 0, got {self.max_risk_score}')
 
 	def evaluate(self, claims: TrustClaims) -> PolicyResult:
 		"""

--- a/browser_use/integrations/trust/policy.py
+++ b/browser_use/integrations/trust/policy.py
@@ -22,10 +22,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-try:
-	from .agentid_trust_provider import TrustClaims
-except ImportError:
-	from agentid_trust_provider import TrustClaims
+from .service import TrustClaims
 
 logger = logging.getLogger(__name__)
 
@@ -55,13 +52,27 @@ class TrustPolicy:
 	- allow: (only returned on pass)
 	"""
 
+	VALID_ACTIONS: set[str] = {'allow', 'block', 'degrade', 'log'}
+
 	def __init__(self, config: dict | None = None):
 		config = config or {}
 		self.min_trust_score: int = config.get('min_trust_score', 0)
 		self.max_scarring_score: int = config.get('max_scarring_score', 999)
 		self.max_risk_score: int = config.get('max_risk_score', 100)
 		self.required_attestations: list[str] = config.get('required_attestations', [])
-		self.action_on_fail: ActionType = config.get('action_on_fail', 'log')
+		action = config.get('action_on_fail', 'log')
+		if action not in self.VALID_ACTIONS:
+			raise ValueError(f'Invalid action_on_fail: {action!r}. Must be one of {self.VALID_ACTIONS}')
+		self.action_on_fail: ActionType = action
+
+		if not isinstance(self.min_trust_score, int):
+			raise TypeError(f'min_trust_score must be int, got {type(self.min_trust_score).__name__}')
+		if not isinstance(self.max_scarring_score, int):
+			raise TypeError(f'max_scarring_score must be int, got {type(self.max_scarring_score).__name__}')
+		if not isinstance(self.max_risk_score, int):
+			raise TypeError(f'max_risk_score must be int, got {type(self.max_risk_score).__name__}')
+		if not isinstance(self.required_attestations, list):
+			raise TypeError(f'required_attestations must be list, got {type(self.required_attestations).__name__}')
 
 	def evaluate(self, claims: TrustClaims) -> PolicyResult:
 		"""
@@ -76,19 +87,13 @@ class TrustPolicy:
 		failures: list[str] = []
 
 		if claims.trust_score < self.min_trust_score:
-			failures.append(
-				f'trust_score {claims.trust_score} < min {self.min_trust_score}'
-			)
+			failures.append(f'trust_score {claims.trust_score} < min {self.min_trust_score}')
 
 		if claims.scarring_score > self.max_scarring_score:
-			failures.append(
-				f'scarring_score {claims.scarring_score} > max {self.max_scarring_score}'
-			)
+			failures.append(f'scarring_score {claims.scarring_score} > max {self.max_scarring_score}')
 
 		if claims.risk_score > self.max_risk_score:
-			failures.append(
-				f'risk_score {claims.risk_score} > max {self.max_risk_score}'
-			)
+			failures.append(f'risk_score {claims.risk_score} > max {self.max_risk_score}')
 
 		for req in self.required_attestations:
 			if req not in claims.attestations:
@@ -97,10 +102,7 @@ class TrustPolicy:
 		passed = len(failures) == 0
 
 		if not passed:
-			logger.info(
-				f'Policy check failed for agent {claims.agent_id}: '
-				f'{", ".join(failures)} -> action={self.action_on_fail}'
-			)
+			logger.info(f'Policy check failed for agent {claims.agent_id}: {", ".join(failures)} -> action={self.action_on_fail}')
 
 		return PolicyResult(
 			passed=passed,
@@ -134,7 +136,8 @@ class TrustPolicyChain:
 
 	def evaluate(self, claims: TrustClaims) -> PolicyResult:
 		"""Evaluate all policies and return the most restrictive result."""
-		assert self.policies, 'Policy chain must have at least one policy'
+		if not self.policies:
+			raise ValueError('Policy chain must have at least one policy')
 
 		results = [p.evaluate(claims) for p in self.policies]
 

--- a/browser_use/integrations/trust/policy.py
+++ b/browser_use/integrations/trust/policy.py
@@ -84,6 +84,18 @@ class TrustPolicy:
 		Returns:
 			PolicyResult indicating whether the agent passed and what action to take.
 		"""
+		# Short-circuit when no trust data is available
+		if claims.no_trust_data:
+			reason = claims.reason or 'no trust data available'
+			logger.warning(f'No trust data for agent {claims.agent_id}: {reason} -> action={self.action_on_fail}')
+			return PolicyResult(
+				passed=False,
+				action=self.action_on_fail,
+				failures=[f'no_trust_data: {reason}'],
+				trust_level=claims.trust_level,
+				provider=claims.provider,
+			)
+
 		failures: list[str] = []
 
 		if claims.trust_score < self.min_trust_score:

--- a/browser_use/integrations/trust/policy.py
+++ b/browser_use/integrations/trust/policy.py
@@ -23,10 +23,7 @@ from typing import Literal
 try:
 	from pydantic import BaseModel, ConfigDict, Field
 except ImportError as e:
-	raise ImportError(
-		'browser_use.integrations.trust.policy requires pydantic. '
-		'Install it with: pip install pydantic'
-	) from e
+	raise ImportError('browser_use.integrations.trust.policy requires pydantic. Install it with: pip install pydantic') from e
 
 from .service import TrustClaims
 

--- a/browser_use/integrations/trust/service.py
+++ b/browser_use/integrations/trust/service.py
@@ -1,0 +1,203 @@
+"""
+AgentID Trust Provider — generates and verifies Agent-Trust-Score JWTs.
+
+This module implements the TrustProvider interface for the AgentID protocol.
+Browser-use agents attach these JWTs to requests so site operators can make
+trust-based access decisions.
+
+Protocol spec: https://getagentid.dev/docs/trust-protocol
+"""
+
+import base64
+import json
+import logging
+import time
+from abc import ABC, abstractmethod
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+logger = logging.getLogger(__name__)
+
+
+class TrustClaims(BaseModel):
+	"""Decoded trust claims from an Agent-Trust-Score JWT."""
+
+	model_config = ConfigDict(extra='allow')
+
+	agent_id: str = ''
+	trust_score: int = 0
+	trust_level: str = 'L1'
+	scarring_score: int = 0
+	risk_score: int = 0
+	attestations: list[str] = Field(default_factory=list)
+	attestation_count: int = 0
+	provider: str = ''
+	iat: int = 0
+	exp: int = 0
+
+	@field_validator('trust_level')
+	@classmethod
+	def validate_trust_level(cls, v: str) -> str:
+		valid_levels = {'L0', 'L1', 'L2', 'L3', 'L4'}
+		if v not in valid_levels:
+			raise ValueError(f'Invalid trust level: {v}. Must be one of {valid_levels}')
+		return v
+
+	@property
+	def is_expired(self) -> bool:
+		return time.time() > self.exp
+
+	def meets_policy(self, policy: dict) -> bool:
+		"""Check if claims meet a threshold policy dict."""
+		if policy.get('min_trust_score') and self.trust_score < policy['min_trust_score']:
+			return False
+		if policy.get('max_scarring_score') and self.scarring_score > policy['max_scarring_score']:
+			return False
+		if policy.get('max_risk_score') and self.risk_score > policy['max_risk_score']:
+			return False
+		required = policy.get('required_attestations', [])
+		for req in required:
+			if req not in self.attestations:
+				return False
+		return True
+
+
+class TrustProvider(ABC):
+	"""Abstract base class for trust providers."""
+
+	@abstractmethod
+	async def get_trust_jwt(self, agent_id: str) -> str:
+		"""Get a signed trust JWT for the given agent."""
+		...
+
+	@abstractmethod
+	async def verify_trust_jwt(self, jwt: str) -> TrustClaims:
+		"""Decode and verify a trust JWT, returning claims."""
+		...
+
+
+class AgentIDTrustProvider(TrustProvider):
+	"""
+	AgentID trust provider — generates and verifies Agent-Trust-Score JWTs.
+
+	The provider fetches signed JWTs from the AgentID API and caches them.
+	JWTs contain trust scores, scarring data, and attestation lists that
+	site operators use to make access control decisions.
+
+	Example:
+		provider = AgentIDTrustProvider(api_key="key_...")
+		jwt = await provider.get_trust_jwt("agent_abc123")
+		claims = await provider.verify_trust_jwt(jwt)
+		print(f"Trust score: {claims.trust_score}, Level: {claims.trust_level}")
+	"""
+
+	BASE_URL = 'https://getagentid.dev/api/v1'
+	CACHE_TTL_SECONDS = 3500  # slightly under 1 hour
+
+	def __init__(self, api_key: str | None = None, base_url: str | None = None):
+		self.api_key = api_key
+		if base_url:
+			self.BASE_URL = base_url
+		self._cache: dict[str, tuple[str, float]] = {}
+
+	async def get_trust_jwt(self, agent_id: str) -> str:
+		"""
+		Get a signed Agent-Trust-Score JWT for an agent.
+
+		Checks the local cache first. If the cached JWT is still valid, returns it.
+		Otherwise fetches a fresh JWT from the AgentID API.
+
+		Args:
+			agent_id: The agent's unique identifier.
+
+		Returns:
+			A signed JWT string suitable for the Agent-Trust-Score header.
+
+		Raises:
+			httpx.HTTPStatusError: If the API returns a non-200 status.
+			Exception: If the response is missing the expected 'header' field.
+		"""
+		assert agent_id, 'agent_id must not be empty'
+
+		# Check cache
+		if agent_id in self._cache:
+			jwt, expiry = self._cache[agent_id]
+			if time.time() < expiry:
+				logger.debug(f'Cache hit for agent {agent_id}')
+				return jwt
+
+		headers = {}
+		if self.api_key:
+			headers['Authorization'] = f'Bearer {self.api_key}'
+
+		async with httpx.AsyncClient() as client:
+			resp = await client.get(
+				f'{self.BASE_URL}/agents/trust-header',
+				params={'agent_id': agent_id},
+				headers=headers,
+				timeout=10,
+			)
+			resp.raise_for_status()
+
+			data = resp.json()
+			jwt = data.get('header')
+			if not jwt:
+				raise Exception(f'API response missing "header" field: {data}')
+
+			# Cache it
+			self._cache[agent_id] = (jwt, time.time() + self.CACHE_TTL_SECONDS)
+			logger.info(f'Fetched trust JWT for agent {agent_id}')
+
+			return jwt
+
+	async def verify_trust_jwt(self, jwt: str) -> TrustClaims:
+		"""
+		Decode and verify an Agent-Trust-Score JWT.
+
+		Performs local decoding of the JWT payload (base64url) and validates
+		basic structural requirements. Does NOT verify the cryptographic
+		signature — that should be done server-side or with the public key.
+
+		Args:
+			jwt: The raw JWT string (three dot-separated base64url segments).
+
+		Returns:
+			TrustClaims with decoded payload data.
+
+		Raises:
+			ValueError: If the JWT format is invalid, expired, or from an unknown provider.
+		"""
+		assert jwt, 'jwt must not be empty'
+
+		parts = jwt.split('.')
+		if len(parts) != 3:
+			raise ValueError(f'Invalid JWT format: expected 3 parts, got {len(parts)}')
+
+		# Decode payload (base64url -> JSON)
+		payload_b64 = parts[1]
+		# Add padding for base64
+		payload_b64 += '=' * (-len(payload_b64) % 4)
+		try:
+			payload_json = base64.urlsafe_b64decode(payload_b64)
+			payload = json.loads(payload_json)
+		except Exception as e:
+			raise ValueError(f'Failed to decode JWT payload: {e}')
+
+		claims = TrustClaims(**payload)
+
+		if claims.is_expired:
+			raise ValueError(f'JWT expired at {claims.exp}, current time is {int(time.time())}')
+
+		if claims.provider and claims.provider != 'agentid':
+			raise ValueError(f'Unknown provider: {claims.provider}')
+
+		return claims
+
+	def clear_cache(self) -> None:
+		"""Clear the JWT cache."""
+		self._cache.clear()
+
+	def remove_from_cache(self, agent_id: str) -> None:
+		"""Remove a specific agent from the cache."""
+		self._cache.pop(agent_id, None)

--- a/browser_use/integrations/trust/service.py
+++ b/browser_use/integrations/trust/service.py
@@ -33,6 +33,8 @@ class TrustClaims(BaseModel):
 	attestations: list[str] = Field(default_factory=list)
 	attestation_count: int = 0
 	provider: str = ''
+	no_trust_data: bool = False
+	reason: str = ''
 	iat: int = 0
 	exp: int = 0
 
@@ -101,6 +103,41 @@ class AgentIDTrustProvider(TrustProvider):
 			self.BASE_URL = base_url
 		self._cache: dict[str, tuple[str, float]] = {}
 
+	async def get_no_trust_header(self, reason: str = 'provider_unreachable') -> str:
+		"""Return a minimal JWT indicating no trust data is available.
+
+		Sites need to distinguish 'no data' from 'low trust'. This produces
+		an unsigned JWT with ``no_trust_data: true`` so recipients can apply
+		their ``action_on_fail`` policy immediately.
+
+		Args:
+			reason: Human-readable explanation (e.g. the exception message).
+
+		Returns:
+			An unsigned JWT string with ``alg: none``.
+		"""
+		payload = {
+			'agent_id': 'unknown',
+			'trust_score': 0,
+			'trust_level': 'L0',
+			'scarring_score': 0,
+			'risk_score': 1.0,
+			'attestations': [],
+			'attestation_count': 0,
+			'provider': 'agentid',
+			'no_trust_data': True,
+			'reason': reason,
+			'iat': int(time.time()),
+			'exp': int(time.time()) + 300,  # 5 min expiry for no-data headers
+		}
+		header = base64.urlsafe_b64encode(
+			json.dumps({'alg': 'none', 'typ': 'Agent-Trust-Score'}).encode()
+		).decode().rstrip('=')
+		body = base64.urlsafe_b64encode(
+			json.dumps(payload).encode()
+		).decode().rstrip('=')
+		return f'{header}.{body}.'
+
 	async def get_trust_jwt(self, agent_id: str) -> str:
 		"""
 		Get a signed Agent-Trust-Score JWT for an agent.
@@ -108,49 +145,53 @@ class AgentIDTrustProvider(TrustProvider):
 		Checks the local cache first. If the cached JWT is still valid, returns it.
 		Otherwise fetches a fresh JWT from the AgentID API.
 
+		If the provider is unreachable or any error occurs, returns a no-trust-data
+		header instead of raising, so callers always get a usable JWT.
+
 		Args:
 			agent_id: The agent's unique identifier.
 
 		Returns:
-			A signed JWT string suitable for the Agent-Trust-Score header.
-
-		Raises:
-			httpx.HTTPStatusError: If the API returns a non-200 status.
-			Exception: If the response is missing the expected 'header' field.
+			A signed JWT string suitable for the Agent-Trust-Score header,
+			or an unsigned no-trust-data JWT on failure.
 		"""
 		if not agent_id:
 			raise ValueError('agent_id must not be empty')
 
-		# Check cache
-		if agent_id in self._cache:
-			jwt, expiry = self._cache[agent_id]
-			if time.time() < expiry:
-				logger.debug(f'Cache hit for agent {agent_id}')
+		try:
+			# Check cache
+			if agent_id in self._cache:
+				jwt, expiry = self._cache[agent_id]
+				if time.time() < expiry:
+					logger.debug(f'Cache hit for agent {agent_id}')
+					return jwt
+
+			headers = {}
+			if self.api_key:
+				headers['Authorization'] = f'Bearer {self.api_key}'
+
+			async with httpx.AsyncClient() as client:
+				resp = await client.get(
+					f'{self.BASE_URL}/agents/trust-header',
+					params={'agent_id': agent_id},
+					headers=headers,
+					timeout=10,
+				)
+				resp.raise_for_status()
+
+				data = resp.json()
+				jwt = data.get('header')
+				if not jwt:
+					raise Exception(f'API response missing "header" field: {data}')
+
+				# Cache it
+				self._cache[agent_id] = (jwt, time.time() + self.CACHE_TTL_SECONDS)
+				logger.info(f'Fetched trust JWT for agent {agent_id}')
+
 				return jwt
-
-		headers = {}
-		if self.api_key:
-			headers['Authorization'] = f'Bearer {self.api_key}'
-
-		async with httpx.AsyncClient() as client:
-			resp = await client.get(
-				f'{self.BASE_URL}/agents/trust-header',
-				params={'agent_id': agent_id},
-				headers=headers,
-				timeout=10,
-			)
-			resp.raise_for_status()
-
-			data = resp.json()
-			jwt = data.get('header')
-			if not jwt:
-				raise Exception(f'API response missing "header" field: {data}')
-
-			# Cache it
-			self._cache[agent_id] = (jwt, time.time() + self.CACHE_TTL_SECONDS)
-			logger.info(f'Fetched trust JWT for agent {agent_id}')
-
-			return jwt
+		except Exception as e:
+			logger.warning(f'Failed to fetch trust JWT for agent {agent_id}: {e}')
+			return await self.get_no_trust_header(reason=str(e))
 
 	async def verify_trust_jwt(self, jwt: str) -> TrustClaims:
 		"""

--- a/browser_use/integrations/trust/service.py
+++ b/browser_use/integrations/trust/service.py
@@ -52,11 +52,11 @@ class TrustClaims(BaseModel):
 
 	def meets_policy(self, policy: dict) -> bool:
 		"""Check if claims meet a threshold policy dict."""
-		if 'min_trust_score' in policy and self.trust_score < policy['min_trust_score']:
+		if policy.get('min_trust_score') is not None and self.trust_score < policy['min_trust_score']:
 			return False
-		if 'max_scarring_score' in policy and self.scarring_score > policy['max_scarring_score']:
+		if policy.get('max_scarring_score') is not None and self.scarring_score > policy['max_scarring_score']:
 			return False
-		if 'max_risk_score' in policy and self.risk_score > policy['max_risk_score']:
+		if policy.get('max_risk_score') is not None and self.risk_score > policy['max_risk_score']:
 			return False
 		required = policy.get('required_attestations', [])
 		for req in required:
@@ -193,9 +193,13 @@ class AgentIDTrustProvider(TrustProvider):
 		"""
 		Decode and verify an Agent-Trust-Score JWT.
 
-		Performs local decoding of the JWT payload (base64url) and validates
-		basic structural requirements. Does NOT verify the cryptographic
-		signature — that should be done server-side or with the public key.
+		Decodes the JWT header and payload, validates structural requirements,
+		and checks the ``alg`` field. Unsigned JWTs (``alg: none``) are only
+		accepted when the payload carries ``no_trust_data: true`` — all other
+		JWTs must have a non-empty signature segment.
+
+		Full cryptographic signature verification should be done server-side
+		or with the provider's public key.
 
 		Args:
 			jwt: The raw JWT string (three dot-separated base64url segments).
@@ -213,6 +217,14 @@ class AgentIDTrustProvider(TrustProvider):
 		if len(parts) != 3:
 			raise ValueError(f'Invalid JWT format: expected 3 parts, got {len(parts)}')
 
+		# Decode header to inspect alg
+		header_b64 = parts[0]
+		header_b64 += '=' * (-len(header_b64) % 4)
+		try:
+			header = json.loads(base64.urlsafe_b64decode(header_b64))
+		except Exception as e:
+			raise ValueError(f'Failed to decode JWT header: {e}')
+
 		# Decode payload (base64url -> JSON)
 		payload_b64 = parts[1]
 		# Add padding for base64
@@ -222,6 +234,18 @@ class AgentIDTrustProvider(TrustProvider):
 			payload = json.loads(payload_json)
 		except Exception as e:
 			raise ValueError(f'Failed to decode JWT payload: {e}')
+
+		alg = header.get('alg', '')
+		signature_segment = parts[2]
+		is_no_trust = payload.get('no_trust_data', False)
+
+		# Reject unsigned JWTs that claim to carry real trust data
+		if alg == 'none' or not signature_segment:
+			if not is_no_trust:
+				raise ValueError(
+					'Unsigned JWT (alg=none / empty signature) is only accepted '
+					'for no_trust_data payloads — refusing unverified trust claims'
+				)
 
 		claims = TrustClaims(**payload)
 

--- a/browser_use/integrations/trust/service.py
+++ b/browser_use/integrations/trust/service.py
@@ -50,11 +50,11 @@ class TrustClaims(BaseModel):
 
 	def meets_policy(self, policy: dict) -> bool:
 		"""Check if claims meet a threshold policy dict."""
-		if policy.get('min_trust_score') and self.trust_score < policy['min_trust_score']:
+		if 'min_trust_score' in policy and self.trust_score < policy['min_trust_score']:
 			return False
-		if policy.get('max_scarring_score') and self.scarring_score > policy['max_scarring_score']:
+		if 'max_scarring_score' in policy and self.scarring_score > policy['max_scarring_score']:
 			return False
-		if policy.get('max_risk_score') and self.risk_score > policy['max_risk_score']:
+		if 'max_risk_score' in policy and self.risk_score > policy['max_risk_score']:
 			return False
 		required = policy.get('required_attestations', [])
 		for req in required:
@@ -118,7 +118,8 @@ class AgentIDTrustProvider(TrustProvider):
 			httpx.HTTPStatusError: If the API returns a non-200 status.
 			Exception: If the response is missing the expected 'header' field.
 		"""
-		assert agent_id, 'agent_id must not be empty'
+		if not agent_id:
+			raise ValueError('agent_id must not be empty')
 
 		# Check cache
 		if agent_id in self._cache:
@@ -168,7 +169,8 @@ class AgentIDTrustProvider(TrustProvider):
 		Raises:
 			ValueError: If the JWT format is invalid, expired, or from an unknown provider.
 		"""
-		assert jwt, 'jwt must not be empty'
+		if not jwt:
+			raise ValueError('jwt must not be empty')
 
 		parts = jwt.split('.')
 		if len(parts) != 3:

--- a/browser_use/integrations/trust/service.py
+++ b/browser_use/integrations/trust/service.py
@@ -130,12 +130,8 @@ class AgentIDTrustProvider(TrustProvider):
 			'iat': int(time.time()),
 			'exp': int(time.time()) + 300,  # 5 min expiry for no-data headers
 		}
-		header = base64.urlsafe_b64encode(
-			json.dumps({'alg': 'none', 'typ': 'Agent-Trust-Score'}).encode()
-		).decode().rstrip('=')
-		body = base64.urlsafe_b64encode(
-			json.dumps(payload).encode()
-		).decode().rstrip('=')
+		header = base64.urlsafe_b64encode(json.dumps({'alg': 'none', 'typ': 'Agent-Trust-Score'}).encode()).decode().rstrip('=')
+		body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
 		return f'{header}.{body}.'
 
 	async def get_trust_jwt(self, agent_id: str) -> str:

--- a/browser_use/integrations/trust/service.py
+++ b/browser_use/integrations/trust/service.py
@@ -17,7 +17,23 @@ from abc import ABC, abstractmethod
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+# Ed25519 verification is optional at import time (mirrors the pydantic/httpx
+# guard pattern in this package): we only need it when actually verifying a
+# signed JWT, and we raise a clear, actionable error at that point if missing.
+try:
+	from cryptography.exceptions import InvalidSignature
+	from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+	_HAS_CRYPTO = True
+except ImportError:
+	_HAS_CRYPTO = False
+
 logger = logging.getLogger(__name__)
+
+
+def _b64url_decode(segment: str) -> bytes:
+	"""Decode a base64url JWT segment, restoring stripped padding."""
+	return base64.urlsafe_b64decode(segment + '=' * (-len(segment) % 4))
 
 
 class TrustClaims(BaseModel):
@@ -97,11 +113,24 @@ class AgentIDTrustProvider(TrustProvider):
 	BASE_URL = 'https://getagentid.dev/api/v1'
 	CACHE_TTL_SECONDS = 3500  # slightly under 1 hour
 
-	def __init__(self, api_key: str | None = None, base_url: str | None = None):
+	JWKS_TTL_SECONDS = 86400  # cache the provider key for 24h (spec §4.1)
+
+	def __init__(self, api_key: str | None = None, base_url: str | None = None, public_key_b64: str | None = None):
+		"""
+		Args:
+			api_key: Optional bearer token for the AgentID API.
+			base_url: Override the API base URL (defaults to the public endpoint).
+			public_key_b64: Optional base64url Ed25519 public key (32 bytes) to verify
+				signatures against. When omitted, the provider's key is fetched from its
+				JWKS and cached. Inject it to verify offline / in tests without a network call.
+		"""
 		self.api_key = api_key
 		if base_url:
 			self.BASE_URL = base_url
 		self._cache: dict[str, tuple[str, float]] = {}
+		# Pinned/injected verification key, plus a (raw_key, expiry) JWKS cache.
+		self._pinned_key_b64 = public_key_b64
+		self._verify_key_cache: tuple[bytes, float] | None = None
 
 	async def get_no_trust_header(self, reason: str = 'provider_unreachable') -> str:
 		"""Return a minimal JWT indicating no trust data is available.
@@ -189,17 +218,42 @@ class AgentIDTrustProvider(TrustProvider):
 			logger.warning(f'Failed to fetch trust JWT for agent {agent_id}: {e}')
 			return await self.get_no_trust_header(reason=str(e))
 
+	async def _resolve_verify_key(self) -> bytes:
+		"""Return the provider's raw 32-byte Ed25519 public key.
+
+		Uses the pinned/injected key if one was given; otherwise fetches the
+		provider's JWKS (cached for JWKS_TTL_SECONDS) and extracts the Ed25519 key.
+		"""
+		if self._pinned_key_b64:
+			return _b64url_decode(self._pinned_key_b64)
+		now = time.time()
+		if self._verify_key_cache and now < self._verify_key_cache[1]:
+			return self._verify_key_cache[0]
+		root = self.BASE_URL.split('/api/')[0].rstrip('/')
+		jwks_url = f'{root}/.well-known/jwks.json'
+		async with httpx.AsyncClient() as client:
+			resp = await client.get(jwks_url, timeout=10)
+			resp.raise_for_status()
+			jwks = resp.json()
+		keys = jwks.get('keys', []) if isinstance(jwks, dict) else []
+		ed = next((k for k in keys if k.get('kty') == 'OKP' and k.get('crv') == 'Ed25519' and k.get('x')), None)
+		if not ed:
+			raise ValueError(f'No Ed25519 key found in provider JWKS at {jwks_url}')
+		raw = _b64url_decode(ed['x'])
+		if len(raw) != 32:
+			raise ValueError(f'Provider Ed25519 key has wrong length: {len(raw)} bytes')
+		self._verify_key_cache = (raw, now + self.JWKS_TTL_SECONDS)
+		return raw
+
 	async def verify_trust_jwt(self, jwt: str) -> TrustClaims:
 		"""
-		Decode and verify an Agent-Trust-Score JWT.
+		Decode and cryptographically verify an Agent-Trust-Score JWT.
 
-		Decodes the JWT header and payload, validates structural requirements,
-		and checks the ``alg`` field. Unsigned JWTs (``alg: none``) are only
-		accepted when the payload carries ``no_trust_data: true`` — all other
-		JWTs must have a non-empty signature segment.
-
-		Full cryptographic signature verification should be done server-side
-		or with the provider's public key.
+		Decodes the header + payload, then for any signed JWT verifies the Ed25519
+		signature against the provider's public key (injected, or fetched from its
+		JWKS and cached) BEFORE trusting any field (spec CR-4). Unsigned JWTs
+		(``alg: none`` / empty signature) are only accepted when the payload carries
+		``no_trust_data: true``; a forged or unverifiable signature is rejected.
 
 		Args:
 			jwt: The raw JWT string (three dot-separated base64url segments).
@@ -239,13 +293,29 @@ class AgentIDTrustProvider(TrustProvider):
 		signature_segment = parts[2]
 		is_no_trust = payload.get('no_trust_data', False)
 
-		# Reject unsigned JWTs that claim to carry real trust data
 		if alg == 'none' or not signature_segment:
+			# Unsigned: only ever acceptable as an explicit "no trust data" signal.
 			if not is_no_trust:
 				raise ValueError(
 					'Unsigned JWT (alg=none / empty signature) is only accepted '
 					'for no_trust_data payloads — refusing unverified trust claims'
 				)
+		else:
+			# Signed trust claim — the signature MUST be verified before any field
+			# is trusted (spec CR-4). Only Ed25519/EdDSA is supported.
+			if alg not in ('EdDSA', 'Ed25519'):
+				raise ValueError(f'Unsupported JWT alg {alg!r}: only Ed25519/EdDSA signatures are verifiable')
+			if not _HAS_CRYPTO:
+				raise ImportError(
+					'Verifying signed Agent-Trust-Score JWTs requires the "cryptography" package. '
+					'Install it with: pip install cryptography'
+				)
+			try:
+				raw_key = await self._resolve_verify_key()
+				signature = _b64url_decode(signature_segment)
+				Ed25519PublicKey.from_public_bytes(raw_key).verify(signature, f'{parts[0]}.{parts[1]}'.encode('ascii'))
+			except InvalidSignature:
+				raise ValueError('JWT signature verification failed — refusing forged trust claims')
 
 		claims = TrustClaims(**payload)
 

--- a/tests/ci/conftest_trust.py
+++ b/tests/ci/conftest_trust.py
@@ -1,0 +1,7 @@
+"""Test configuration — add the parent directory to sys.path for imports."""
+
+import sys
+from pathlib import Path
+
+# Add the integration root to path so `from agentid_trust_provider import ...` works
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/tests/ci/test_trust_provider.py
+++ b/tests/ci/test_trust_provider.py
@@ -1,0 +1,287 @@
+"""
+Tests for AgentID TrustProvider and Policy Engine.
+
+Tests use locally-constructed JWTs — no network calls or mocks required.
+"""
+
+import base64
+import json
+import time
+
+import pytest
+
+from agentid_trust_provider import AgentIDTrustProvider, TrustClaims
+from policy_engine import PolicyResult, TrustPolicy, TrustPolicyChain
+
+
+def _make_jwt(payload: dict) -> str:
+	"""Build a fake JWT with the given payload (no real signature)."""
+	header = base64.urlsafe_b64encode(json.dumps({'alg': 'HS256', 'typ': 'JWT'}).encode()).rstrip(b'=').decode()
+	body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b'=').decode()
+	sig = base64.urlsafe_b64encode(b'fakesig').rstrip(b'=').decode()
+	return f'{header}.{body}.{sig}'
+
+
+def _default_payload(**overrides) -> dict:
+	"""Return a valid payload dict with sensible defaults."""
+	payload = {
+		'agent_id': 'agent_test_001',
+		'trust_score': 75,
+		'trust_level': 'L2',
+		'scarring_score': 5,
+		'risk_score': 10,
+		'attestations': ['identity_verified', 'code_audit'],
+		'attestation_count': 2,
+		'provider': 'agentid',
+		'iat': int(time.time()),
+		'exp': int(time.time()) + 3600,
+	}
+	payload.update(overrides)
+	return payload
+
+
+# ---------------------------------------------------------------------------
+# TrustClaims
+# ---------------------------------------------------------------------------
+
+
+class TestTrustClaims:
+	def test_parse_valid_claims(self):
+		claims = TrustClaims(**_default_payload())
+		assert claims.agent_id == 'agent_test_001'
+		assert claims.trust_score == 75
+		assert claims.trust_level == 'L2'
+		assert claims.scarring_score == 5
+		assert claims.risk_score == 10
+		assert 'identity_verified' in claims.attestations
+		assert claims.attestation_count == 2
+		assert claims.provider == 'agentid'
+
+	def test_not_expired(self):
+		claims = TrustClaims(**_default_payload())
+		assert not claims.is_expired
+
+	def test_expired(self):
+		claims = TrustClaims(**_default_payload(exp=int(time.time()) - 100))
+		assert claims.is_expired
+
+	def test_meets_policy_passing(self):
+		claims = TrustClaims(**_default_payload())
+		assert claims.meets_policy({'min_trust_score': 50, 'max_risk_score': 20})
+
+	def test_meets_policy_failing_trust(self):
+		claims = TrustClaims(**_default_payload(trust_score=30))
+		assert not claims.meets_policy({'min_trust_score': 50})
+
+	def test_meets_policy_failing_attestation(self):
+		claims = TrustClaims(**_default_payload())
+		assert not claims.meets_policy({'required_attestations': ['sandbox_certified']})
+
+	def test_invalid_trust_level_rejected(self):
+		with pytest.raises(Exception):
+			TrustClaims(**_default_payload(trust_level='INVALID'))
+
+	def test_extra_fields_allowed(self):
+		"""Extra fields in the JWT payload should not cause validation errors."""
+		claims = TrustClaims(**_default_payload(custom_field='hello'))
+		assert claims.agent_id == 'agent_test_001'
+
+
+# ---------------------------------------------------------------------------
+# AgentIDTrustProvider — verify_trust_jwt (local, no network)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTrustJWT:
+	async def test_verify_valid_jwt(self):
+		provider = AgentIDTrustProvider()
+		jwt = _make_jwt(_default_payload())
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.agent_id == 'agent_test_001'
+		assert claims.trust_score == 75
+		assert claims.provider == 'agentid'
+
+	async def test_verify_expired_jwt_raises(self):
+		provider = AgentIDTrustProvider()
+		jwt = _make_jwt(_default_payload(exp=int(time.time()) - 100))
+		with pytest.raises(ValueError, match='expired'):
+			await provider.verify_trust_jwt(jwt)
+
+	async def test_verify_bad_format_raises(self):
+		provider = AgentIDTrustProvider()
+		with pytest.raises(ValueError, match='Invalid JWT format'):
+			await provider.verify_trust_jwt('not.a.valid.jwt.at.all')
+
+	async def test_verify_unknown_provider_raises(self):
+		provider = AgentIDTrustProvider()
+		jwt = _make_jwt(_default_payload(provider='unknown_provider'))
+		with pytest.raises(ValueError, match='Unknown provider'):
+			await provider.verify_trust_jwt(jwt)
+
+	async def test_verify_empty_jwt_raises(self):
+		provider = AgentIDTrustProvider()
+		with pytest.raises(AssertionError):
+			await provider.verify_trust_jwt('')
+
+	async def test_verify_no_provider_field_ok(self):
+		"""A JWT with empty provider should pass (backwards compatibility)."""
+		provider = AgentIDTrustProvider()
+		jwt = _make_jwt(_default_payload(provider=''))
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.provider == ''
+
+
+# ---------------------------------------------------------------------------
+# AgentIDTrustProvider — cache behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+	def test_clear_cache(self):
+		provider = AgentIDTrustProvider()
+		provider._cache['agent_1'] = ('jwt_value', time.time() + 3600)
+		assert 'agent_1' in provider._cache
+		provider.clear_cache()
+		assert len(provider._cache) == 0
+
+	def test_remove_from_cache(self):
+		provider = AgentIDTrustProvider()
+		provider._cache['agent_1'] = ('jwt_value', time.time() + 3600)
+		provider._cache['agent_2'] = ('jwt_value2', time.time() + 3600)
+		provider.remove_from_cache('agent_1')
+		assert 'agent_1' not in provider._cache
+		assert 'agent_2' in provider._cache
+
+	def test_custom_base_url(self):
+		provider = AgentIDTrustProvider(base_url='https://custom.example.com/api')
+		assert provider.BASE_URL == 'https://custom.example.com/api'
+
+
+# ---------------------------------------------------------------------------
+# TrustPolicy
+# ---------------------------------------------------------------------------
+
+
+class TestTrustPolicy:
+	def test_default_policy_passes_everything(self):
+		policy = TrustPolicy()
+		claims = TrustClaims(**_default_payload())
+		result = policy.evaluate(claims)
+		assert result.passed
+		assert result.action == 'allow'
+		assert result.failures == []
+
+	def test_min_trust_score_fail(self):
+		policy = TrustPolicy({'min_trust_score': 90})
+		claims = TrustClaims(**_default_payload(trust_score=50))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert 'trust_score' in result.failures[0]
+
+	def test_max_scarring_score_fail(self):
+		policy = TrustPolicy({'max_scarring_score': 3})
+		claims = TrustClaims(**_default_payload(scarring_score=10))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert 'scarring_score' in result.failures[0]
+
+	def test_max_risk_score_fail(self):
+		policy = TrustPolicy({'max_risk_score': 5})
+		claims = TrustClaims(**_default_payload(risk_score=20))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert 'risk_score' in result.failures[0]
+
+	def test_required_attestation_missing(self):
+		policy = TrustPolicy({'required_attestations': ['sandbox_certified']})
+		claims = TrustClaims(**_default_payload())
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert 'missing attestation' in result.failures[0]
+
+	def test_required_attestation_present(self):
+		policy = TrustPolicy({'required_attestations': ['identity_verified']})
+		claims = TrustClaims(**_default_payload())
+		result = policy.evaluate(claims)
+		assert result.passed
+
+	def test_action_on_fail_block(self):
+		policy = TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'block'})
+		claims = TrustClaims(**_default_payload(trust_score=50))
+		result = policy.evaluate(claims)
+		assert result.action == 'block'
+
+	def test_action_on_fail_degrade(self):
+		policy = TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'degrade'})
+		claims = TrustClaims(**_default_payload(trust_score=50))
+		result = policy.evaluate(claims)
+		assert result.action == 'degrade'
+
+	def test_multiple_failures(self):
+		policy = TrustPolicy({
+			'min_trust_score': 90,
+			'max_risk_score': 5,
+			'required_attestations': ['sandbox_certified'],
+		})
+		claims = TrustClaims(**_default_payload(trust_score=50, risk_score=20))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert len(result.failures) == 3
+
+	def test_result_includes_metadata(self):
+		policy = TrustPolicy()
+		claims = TrustClaims(**_default_payload())
+		result = policy.evaluate(claims)
+		assert result.trust_level == 'L2'
+		assert result.provider == 'agentid'
+
+
+# ---------------------------------------------------------------------------
+# TrustPolicyChain
+# ---------------------------------------------------------------------------
+
+
+class TestTrustPolicyChain:
+	def test_all_pass(self):
+		chain = TrustPolicyChain([
+			TrustPolicy({'min_trust_score': 50}),
+			TrustPolicy({'max_risk_score': 30}),
+		])
+		claims = TrustClaims(**_default_payload())
+		result = chain.evaluate(claims)
+		assert result.passed
+		assert result.action == 'allow'
+
+	def test_block_wins_over_degrade(self):
+		chain = TrustPolicyChain([
+			TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'degrade'}),
+			TrustPolicy({'max_risk_score': 1, 'action_on_fail': 'block'}),
+		])
+		claims = TrustClaims(**_default_payload(trust_score=50, risk_score=20))
+		result = chain.evaluate(claims)
+		assert not result.passed
+		assert result.action == 'block'
+
+	def test_degrade_wins_over_log(self):
+		chain = TrustPolicyChain([
+			TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'log'}),
+			TrustPolicy({'max_risk_score': 1, 'action_on_fail': 'degrade'}),
+		])
+		claims = TrustClaims(**_default_payload(trust_score=50, risk_score=20))
+		result = chain.evaluate(claims)
+		assert result.action == 'degrade'
+
+	def test_failures_aggregated(self):
+		chain = TrustPolicyChain([
+			TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'log'}),
+			TrustPolicy({'max_risk_score': 1, 'action_on_fail': 'log'}),
+		])
+		claims = TrustClaims(**_default_payload(trust_score=50, risk_score=20))
+		result = chain.evaluate(claims)
+		assert len(result.failures) == 2
+
+	def test_empty_chain_raises(self):
+		chain = TrustPolicyChain()
+		claims = TrustClaims(**_default_payload())
+		with pytest.raises(AssertionError):
+			chain.evaluate(claims)

--- a/tests/ci/test_trust_provider.py
+++ b/tests/ci/test_trust_provider.py
@@ -10,8 +10,8 @@ import time
 
 import pytest
 
-from agentid_trust_provider import AgentIDTrustProvider, TrustClaims
-from policy_engine import PolicyResult, TrustPolicy, TrustPolicyChain
+from browser_use.integrations.trust.policy import TrustPolicy, TrustPolicyChain
+from browser_use.integrations.trust.service import AgentIDTrustProvider, TrustClaims
 
 
 def _make_jwt(payload: dict) -> str:
@@ -120,7 +120,7 @@ class TestVerifyTrustJWT:
 
 	async def test_verify_empty_jwt_raises(self):
 		provider = AgentIDTrustProvider()
-		with pytest.raises(AssertionError):
+		with pytest.raises(ValueError, match='jwt must not be empty'):
 			await provider.verify_trust_jwt('')
 
 	async def test_verify_no_provider_field_ok(self):
@@ -218,11 +218,13 @@ class TestTrustPolicy:
 		assert result.action == 'degrade'
 
 	def test_multiple_failures(self):
-		policy = TrustPolicy({
-			'min_trust_score': 90,
-			'max_risk_score': 5,
-			'required_attestations': ['sandbox_certified'],
-		})
+		policy = TrustPolicy(
+			{
+				'min_trust_score': 90,
+				'max_risk_score': 5,
+				'required_attestations': ['sandbox_certified'],
+			}
+		)
 		claims = TrustClaims(**_default_payload(trust_score=50, risk_score=20))
 		result = policy.evaluate(claims)
 		assert not result.passed
@@ -243,39 +245,47 @@ class TestTrustPolicy:
 
 class TestTrustPolicyChain:
 	def test_all_pass(self):
-		chain = TrustPolicyChain([
-			TrustPolicy({'min_trust_score': 50}),
-			TrustPolicy({'max_risk_score': 30}),
-		])
+		chain = TrustPolicyChain(
+			[
+				TrustPolicy({'min_trust_score': 50}),
+				TrustPolicy({'max_risk_score': 30}),
+			]
+		)
 		claims = TrustClaims(**_default_payload())
 		result = chain.evaluate(claims)
 		assert result.passed
 		assert result.action == 'allow'
 
 	def test_block_wins_over_degrade(self):
-		chain = TrustPolicyChain([
-			TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'degrade'}),
-			TrustPolicy({'max_risk_score': 1, 'action_on_fail': 'block'}),
-		])
+		chain = TrustPolicyChain(
+			[
+				TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'degrade'}),
+				TrustPolicy({'max_risk_score': 1, 'action_on_fail': 'block'}),
+			]
+		)
 		claims = TrustClaims(**_default_payload(trust_score=50, risk_score=20))
 		result = chain.evaluate(claims)
 		assert not result.passed
 		assert result.action == 'block'
 
 	def test_degrade_wins_over_log(self):
-		chain = TrustPolicyChain([
-			TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'log'}),
-			TrustPolicy({'max_risk_score': 1, 'action_on_fail': 'degrade'}),
-		])
+		chain = TrustPolicyChain(
+			[
+				TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'log'}),
+				TrustPolicy({'max_risk_score': 1, 'action_on_fail': 'degrade'}),
+			]
+		)
 		claims = TrustClaims(**_default_payload(trust_score=50, risk_score=20))
 		result = chain.evaluate(claims)
 		assert result.action == 'degrade'
 
 	def test_failures_aggregated(self):
-		chain = TrustPolicyChain([
-			TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'log'}),
-			TrustPolicy({'max_risk_score': 1, 'action_on_fail': 'log'}),
-		])
+		chain = TrustPolicyChain(
+			[
+				TrustPolicy({'min_trust_score': 100, 'action_on_fail': 'log'}),
+				TrustPolicy({'max_risk_score': 1, 'action_on_fail': 'log'}),
+			]
+		)
 		claims = TrustClaims(**_default_payload(trust_score=50, risk_score=20))
 		result = chain.evaluate(claims)
 		assert len(result.failures) == 2
@@ -283,5 +293,5 @@ class TestTrustPolicyChain:
 	def test_empty_chain_raises(self):
 		chain = TrustPolicyChain()
 		claims = TrustClaims(**_default_payload())
-		with pytest.raises(AssertionError):
+		with pytest.raises(ValueError, match='Policy chain must have at least one policy'):
 			chain.evaluate(claims)

--- a/tests/ci/test_trust_provider.py
+++ b/tests/ci/test_trust_provider.py
@@ -78,7 +78,7 @@ class TestTrustClaims:
 		assert not claims.meets_policy({'required_attestations': ['sandbox_certified']})
 
 	def test_invalid_trust_level_rejected(self):
-		with pytest.raises(Exception):
+		with pytest.raises(ValueError, match='Invalid trust level'):
 			TrustClaims(**_default_payload(trust_level='INVALID'))
 
 	def test_extra_fields_allowed(self):

--- a/tests/ci/test_trust_provider.py
+++ b/tests/ci/test_trust_provider.py
@@ -86,6 +86,16 @@ class TestTrustClaims:
 		claims = TrustClaims(**_default_payload(custom_field='hello'))
 		assert claims.agent_id == 'agent_test_001'
 
+	def test_no_trust_data_defaults_false(self):
+		claims = TrustClaims(**_default_payload())
+		assert claims.no_trust_data is False
+		assert claims.reason == ''
+
+	def test_no_trust_data_flag(self):
+		claims = TrustClaims(**_default_payload(no_trust_data=True, reason='provider_unreachable'))
+		assert claims.no_trust_data is True
+		assert claims.reason == 'provider_unreachable'
+
 
 # ---------------------------------------------------------------------------
 # AgentIDTrustProvider — verify_trust_jwt (local, no network)
@@ -129,6 +139,61 @@ class TestVerifyTrustJWT:
 		jwt = _make_jwt(_default_payload(provider=''))
 		claims = await provider.verify_trust_jwt(jwt)
 		assert claims.provider == ''
+
+
+# ---------------------------------------------------------------------------
+# AgentIDTrustProvider — no-trust-data header
+# ---------------------------------------------------------------------------
+
+
+class TestNoTrustDataHeader:
+	async def test_get_no_trust_header_structure(self):
+		"""The no-trust header should be a valid 3-part JWT with empty signature."""
+		provider = AgentIDTrustProvider()
+		jwt = await provider.get_no_trust_header(reason='test_reason')
+		parts = jwt.split('.')
+		assert len(parts) == 3
+		assert parts[2] == ''  # empty signature for alg:none
+
+	async def test_get_no_trust_header_payload(self):
+		"""Payload should contain no_trust_data=True and the supplied reason."""
+		provider = AgentIDTrustProvider()
+		jwt = await provider.get_no_trust_header(reason='connection_timeout')
+		# Decode the payload
+		payload_b64 = jwt.split('.')[1]
+		payload_b64 += '=' * (-len(payload_b64) % 4)
+		payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+		assert payload['no_trust_data'] is True
+		assert payload['reason'] == 'connection_timeout'
+		assert payload['agent_id'] == 'unknown'
+		assert payload['trust_score'] == 0
+		assert payload['trust_level'] == 'L0'
+
+	async def test_get_no_trust_header_decodable_by_verify(self):
+		"""verify_trust_jwt should successfully decode a no-trust header."""
+		provider = AgentIDTrustProvider()
+		jwt = await provider.get_no_trust_header(reason='test')
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.no_trust_data is True
+		assert claims.reason == 'test'
+		assert claims.trust_level == 'L0'
+
+	async def test_get_no_trust_header_default_reason(self):
+		provider = AgentIDTrustProvider()
+		jwt = await provider.get_no_trust_header()
+		payload_b64 = jwt.split('.')[1]
+		payload_b64 += '=' * (-len(payload_b64) % 4)
+		payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+		assert payload['reason'] == 'provider_unreachable'
+
+	async def test_get_trust_jwt_returns_no_trust_on_failure(self):
+		"""When the API is unreachable, get_trust_jwt should return a no-trust header."""
+		provider = AgentIDTrustProvider(base_url='https://localhost:1')  # unreachable
+		jwt = await provider.get_trust_jwt('agent_test')
+		# Should be a valid JWT, not an exception
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.no_trust_data is True
+		assert claims.agent_id == 'unknown'
 
 
 # ---------------------------------------------------------------------------
@@ -236,6 +301,41 @@ class TestTrustPolicy:
 		result = policy.evaluate(claims)
 		assert result.trust_level == 'L2'
 		assert result.provider == 'agentid'
+
+	def test_no_trust_data_triggers_action_on_fail_block(self):
+		"""Claims with no_trust_data should immediately fail with the configured action."""
+		policy = TrustPolicy({'min_trust_score': 50, 'action_on_fail': 'block'})
+		claims = TrustClaims(**_default_payload(no_trust_data=True, reason='provider_unreachable'))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert result.action == 'block'
+		assert 'no_trust_data' in result.failures[0]
+
+	def test_no_trust_data_triggers_action_on_fail_degrade(self):
+		policy = TrustPolicy({'action_on_fail': 'degrade'})
+		claims = TrustClaims(**_default_payload(no_trust_data=True, reason='timeout'))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert result.action == 'degrade'
+		assert 'timeout' in result.failures[0]
+
+	def test_no_trust_data_triggers_action_on_fail_log(self):
+		policy = TrustPolicy({'action_on_fail': 'log'})
+		claims = TrustClaims(**_default_payload(no_trust_data=True, reason='dns_failure'))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert result.action == 'log'
+
+	def test_no_trust_data_skips_normal_checks(self):
+		"""Even with high trust_score in payload, no_trust_data should short-circuit."""
+		policy = TrustPolicy({'min_trust_score': 10, 'action_on_fail': 'block'})
+		claims = TrustClaims(**_default_payload(trust_score=99, no_trust_data=True, reason='test'))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert result.action == 'block'
+		# Should only have the no_trust_data failure, not any threshold failures
+		assert len(result.failures) == 1
+		assert 'no_trust_data' in result.failures[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_trust_provider.py
+++ b/tests/ci/test_trust_provider.py
@@ -9,9 +9,28 @@ import json
 import time
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from browser_use.integrations.trust.policy import TrustPolicy, TrustPolicyChain
 from browser_use.integrations.trust.service import AgentIDTrustProvider, TrustClaims
+
+# Real Ed25519 test keypair — sign JWTs the way the AgentID endpoint does, and
+# inject the matching public key into the provider so verification runs offline.
+_TEST_SK = Ed25519PrivateKey.generate()
+_TEST_PUB_B64 = base64.urlsafe_b64encode(_TEST_SK.public_key().public_bytes_raw()).rstrip(b'=').decode()
+
+
+def _sign_jwt(payload: dict) -> str:
+	"""Build a real Ed25519-signed Agent-Trust-Score JWT for the test key."""
+	header = base64.urlsafe_b64encode(json.dumps({'alg': 'Ed25519', 'typ': 'Agent-Trust-Score'}).encode()).rstrip(b'=').decode()
+	body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b'=').decode()
+	sig = base64.urlsafe_b64encode(_TEST_SK.sign(f'{header}.{body}'.encode('ascii'))).rstrip(b'=').decode()
+	return f'{header}.{body}.{sig}'
+
+
+def _signed_provider() -> AgentIDTrustProvider:
+	"""Provider that verifies against the injected test public key (no network)."""
+	return AgentIDTrustProvider(public_key_b64=_TEST_PUB_B64)
 
 
 def _make_jwt(payload: dict) -> str:
@@ -103,41 +122,53 @@ class TestTrustClaims:
 
 
 class TestVerifyTrustJWT:
-	async def test_verify_valid_jwt(self):
-		provider = AgentIDTrustProvider()
-		jwt = _make_jwt(_default_payload())
-		claims = await provider.verify_trust_jwt(jwt)
+	async def test_verify_valid_signed_jwt(self):
+		provider = _signed_provider()
+		claims = await provider.verify_trust_jwt(_sign_jwt(_default_payload()))
 		assert claims.agent_id == 'agent_test_001'
 		assert claims.trust_score == 75
 		assert claims.provider == 'agentid'
 
+	async def test_verify_forged_signature_raises(self):
+		"""A signed JWT whose signature doesn't match must be rejected, not trusted."""
+		provider = _signed_provider()
+		header, body, _sig = _sign_jwt(_default_payload()).split('.')
+		forged = f'{header}.{body}.' + base64.urlsafe_b64encode(b'\x00' * 64).rstrip(b'=').decode()
+		with pytest.raises(ValueError, match='signature verification failed'):
+			await provider.verify_trust_jwt(forged)
+
+	async def test_verify_fake_unsigned_trust_claim_rejected(self):
+		"""A fake-signed (alg:HS256) JWT carrying real trust data is refused."""
+		provider = _signed_provider()
+		with pytest.raises(ValueError, match='Unsupported JWT alg'):
+			await provider.verify_trust_jwt(_make_jwt(_default_payload()))
+
 	async def test_verify_expired_jwt_raises(self):
-		provider = AgentIDTrustProvider()
-		jwt = _make_jwt(_default_payload(exp=int(time.time()) - 100))
+		provider = _signed_provider()
+		jwt = _sign_jwt(_default_payload(exp=int(time.time()) - 100))
 		with pytest.raises(ValueError, match='expired'):
 			await provider.verify_trust_jwt(jwt)
 
 	async def test_verify_bad_format_raises(self):
-		provider = AgentIDTrustProvider()
+		provider = _signed_provider()
 		with pytest.raises(ValueError, match='Invalid JWT format'):
 			await provider.verify_trust_jwt('not.a.valid.jwt.at.all')
 
 	async def test_verify_unknown_provider_raises(self):
-		provider = AgentIDTrustProvider()
-		jwt = _make_jwt(_default_payload(provider='unknown_provider'))
+		provider = _signed_provider()
+		jwt = _sign_jwt(_default_payload(provider='unknown_provider'))
 		with pytest.raises(ValueError, match='Unknown provider'):
 			await provider.verify_trust_jwt(jwt)
 
 	async def test_verify_empty_jwt_raises(self):
-		provider = AgentIDTrustProvider()
+		provider = _signed_provider()
 		with pytest.raises(ValueError, match='jwt must not be empty'):
 			await provider.verify_trust_jwt('')
 
 	async def test_verify_no_provider_field_ok(self):
-		"""A JWT with empty provider should pass (backwards compatibility)."""
-		provider = AgentIDTrustProvider()
-		jwt = _make_jwt(_default_payload(provider=''))
-		claims = await provider.verify_trust_jwt(jwt)
+		"""A signed JWT with empty provider should pass (backwards compatibility)."""
+		provider = _signed_provider()
+		claims = await provider.verify_trust_jwt(_sign_jwt(_default_payload(provider='')))
 		assert claims.provider == ''
 
 


### PR DESCRIPTION
## Summary
Adds a trust verification layer so browser agents can prove trustworthiness to websites via a standardized HTTP header.

- **TrustProvider** abstract base class + **AgentID** reference implementation
- **Policy engine** with configurable thresholds: `block` / `degrade` / `log`
- **PolicyChain** for composing multiple policies (most restrictive wins)
- **32 tests**, all passing

## Architecture
1. Agent fetches signed JWT from trust provider (e.g. AgentID, SATP)
2. JWT attached as `Agent-Trust-Score` HTTP header on every request
3. Site operator configures threshold policy (`min_trust_score`, `max_scarring_score`, etc.)
4. Policy engine evaluates claims → allow/block/degrade/log

## Multi-provider
Any system implementing `TrustProvider` interface works. Ships with AgentID reference implementation. Other providers (SATP, AgentScore) can add theirs as additional implementations.

## Config example
```yaml
trust_policy:
  min_trust_score: 60
  max_scarring_score: 5
  required_attestations: ["wallet_linked"]
  action_on_fail: "degrade"
```

## Test plan
- [x] 32 unit tests covering TrustProvider, PolicyEngine, PolicyChain
- [x] No mocks — real objects only (per CLAUDE.md)
- [x] Tabs for indentation, Pydantic v2, async, modern typing

Closes #4563
Co-authored with @0xbrainkid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-provider trust layer for browser agents via an `Agent-Trust-Score` HTTP header, now with cryptographic verification for signed JWTs and a safe “no trust data” fallback. Sites can apply simple policies to allow, degrade, block, or log based on verified claims or no-data cases.

- **New Features**
  - `TrustProvider` interface and `AgentIDTrustProvider` with JWT fetch, local decode/expiry checks, and caching.
  - Policy engine: `TrustPolicy` thresholds (`min_trust_score`, `max_scarring_score`, `required_attestations`, `action_on_fail`) and `TrustPolicyChain` (most restrictive wins).
  - No-data support: `get_no_trust_header()` returns unsigned JWT with `no_trust_data: true`; `get_trust_jwt()` falls back on provider failure; policies short-circuit on `no_trust_data`.
  - 43 tests covering signature verification, provider flows, policies, chaining, and no-data.

- **Bug Fixes**
  - Verify Ed25519/EdDSA signatures for signed tokens before trusting any field; reject unsupported algs (e.g., HS256) and forged signatures. JWKS is fetched and cached for 24h, or an injected `public_key_b64` is used.
  - Reject unsigned JWTs unless payload sets `no_trust_data: true`.
  - `TrustPolicyChain.evaluate` raises `ValueError` for empty chains; threshold checks honor 0 values.
  - Clear install errors for missing `pydantic`, `httpx`, or `cryptography`; minor import/doc cleanup.

<sup>Written for commit 2aa804ce44ca30988dabd365f43d2eb67a067a1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

