### PR TITLE
[codex] Harden AgentHistoryList edge cases

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -690,14 +690,17 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 	@classmethod
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
 		# loop through history and validate output_model actions to enrich with custom actions
+		data.setdefault('history', [])
 		for h in data['history']:
-			if h['model_output']:
-				if isinstance(h['model_output'], dict):
-					h['model_output'] = output_model.model_validate(h['model_output'])
+			model_output = h.setdefault('model_output', None)
+			if model_output:
+				if isinstance(model_output, dict):
+					h['model_output'] = output_model.model_validate(model_output)
 				else:
 					h['model_output'] = None
-			if 'interacted_element' not in h['state']:
-				h['state']['interacted_element'] = None
+			state = h.get('state')
+			if isinstance(state, dict) and 'interacted_element' not in state:
+				state['interacted_element'] = []
 
 		history = cls.model_validate(data)
 		return history
@@ -727,7 +730,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def final_result(self) -> None | str:
 		"""Final result from history"""
-		if self.history and self.history[-1].result[-1].extracted_content:
+		if self.history and len(self.history[-1].result) > 0 and self.history[-1].result[-1].extracted_content:
 			return self.history[-1].result[-1].extracted_content
 		return None
 

--- a/tests/ci/test_sandbox_structured_output.py
+++ b/tests/ci/test_sandbox_structured_output.py
@@ -8,7 +8,7 @@ through serialization/deserialization.
 
 from pydantic import BaseModel
 
-from browser_use.agent.views import ActionResult, AgentHistory, AgentHistoryList, BrowserStateHistory
+from browser_use.agent.views import ActionModel, ActionResult, AgentHistory, AgentHistoryList, AgentOutput, BrowserStateHistory
 from browser_use.sandbox.sandbox import _parse_with_type_annotation
 
 
@@ -225,3 +225,44 @@ class TestStructuredOutputPropertyFallback:
 		explicit_result = history.get_structured_output(ExtractedData)
 		assert explicit_result is not None
 		assert explicit_result.title == 'Test'
+
+
+class TestAgentHistoryListDefensiveLoading:
+	"""Regression tests for partially-populated history payloads."""
+
+	def test_load_from_dict_handles_missing_model_output_and_interacted_element(self):
+		data = {
+			'history': [
+				{
+					'result': [],
+					'state': {'url': 'https://example.com', 'title': 'Test', 'tabs': []},
+				}
+			]
+		}
+
+		output_model = AgentOutput.type_with_custom_actions(ActionModel)
+		history = AgentHistoryList.load_from_dict(data, output_model)
+
+		assert len(history.history) == 1
+		assert history.history[0].model_output is None
+		assert history.history[0].state.interacted_element == []
+
+	def test_load_from_dict_defaults_missing_history_to_empty_list(self):
+		output_model = AgentOutput.type_with_custom_actions(ActionModel)
+
+		history = AgentHistoryList.load_from_dict({}, output_model)
+
+		assert history.history == []
+
+	def test_final_result_returns_none_when_last_step_has_no_results(self):
+		history = AgentHistoryList(
+			history=[
+				AgentHistory(
+					model_output=None,
+					result=[],
+					state=BrowserStateHistory(url='https://example.com', title='Test', tabs=[], interacted_element=[]),
+				)
+			]
+		)
+
+		assert history.final_result() is None


### PR DESCRIPTION
## Summary
- harden `AgentHistoryList.load_from_dict()` against missing `history` and `model_output` keys
- backfill missing `interacted_element` values with an empty list before validation
- guard `final_result()` when the last step has no action results and add regression coverage

## Root cause
`AgentHistoryList.load_from_dict()` indexed directly into partially populated history payloads, which raised `KeyError` before validation could run. `final_result()` also assumed the last history item always had at least one result, so empty result lists raised `IndexError`.

## Testing
- `uv run pytest tests/ci/test_sandbox_structured_output.py -q`
- `uv run ruff check browser_use/agent/views.py tests/ci/test_sandbox_structured_output.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened AgentHistoryList loading and final result handling to gracefully support missing fields and empty results. Prevents KeyError/IndexError when parsing partial history payloads.

- **Bug Fixes**
  - Default missing `history` to `[]` and missing `model_output` to `None` in `load_from_dict`.
  - Validate `model_output` only when it’s a dict.
  - Backfill missing `state.interacted_element` with `[]`.
  - Guard `final_result` when the last step has no results.

- **Tests**
  - Added regression tests for partial histories and empty results.

<sup>Written for commit 8d7a08852cfb4d62b91d79d56b3e0e957800d4de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

