### PR TITLE
workflow to flag modifying/adding sensitive files

### DIFF
--- a/.github/workflows/security-check.yml
+++ b/.github/workflows/security-check.yml
@@ -43,12 +43,12 @@ jobs:
             'browser_use/skill_cli/install.sh'
           )
 
-          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
-          NEW_FILES=$(git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA")
+          readarray -d '' CHANGED_FILES < <(git diff --name-only -z "$BASE_SHA" "$HEAD_SHA")
+          readarray -d '' NEW_FILES < <(git diff --name-only -z --diff-filter=A "$BASE_SHA" "$HEAD_SHA")
           FLAGGED=""
 
           # Check for changes to sensitive paths
-          for file in $CHANGED_FILES; do
+          for file in "${CHANGED_FILES[@]}"; do
             for pattern in "${SENSITIVE_PATTERNS[@]}"; do
               if [[ "$file" == ${pattern}* ]]; then
                 FLAGGED="${FLAGGED}  ⚠️  ${file}\n"
@@ -58,7 +58,7 @@ jobs:
           done
 
           # Check for new executable/script files anywhere in the repo
-          for file in $NEW_FILES; do
+          for file in "${NEW_FILES[@]}"; do
             if [[ "$file" == *.sh || "$file" == *.bash || "$file" == *.dockerfile ]]; then
               FLAGGED="${FLAGGED}  ⚠️  ${file} (new script/executable file)\n"
             fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a GitHub Actions workflow to warn when PRs change or add sensitive files. It’s robust to filenames with spaces and helps reviewers spot risky changes across CI, dependencies, Docker, env, and core `browser_use` paths.

- **New Features**
  - Runs on `pull_request`; uses full git history to diff `base` and `head`.
  - Flags changes in sensitive paths: `.github/`, `.claude/`, `CLAUDE.md`, `Dockerfile`, `docker/`, `docker-compose`, `.env`, `.gitignore`, `.pre-commit-config.yaml`, `pyproject.toml`, `uv.lock`, `bin/`, and key `browser_use` files.
  - Marks newly added `*.sh`, `*.bash`, and `*.dockerfile` scripts anywhere in the repo.
  - Posts GitHub workflow warnings with a concise summary; does not fail the job or block merges.

<sup>Written for commit 72d2b52404e608c4c2427b72eb3426a4ebba39f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

