### PR TITLE
examples/observability: add Assay receipt instrumentation

### DIFF
--- a/examples/observability/assay_audit.py
+++ b/examples/observability/assay_audit.py
@@ -34,12 +34,11 @@ confirm who signed it. For CI-bound signing, see T1 in the Assay docs.
 """
 
 import asyncio
-import os
 
 from dotenv import load_dotenv
 
 try:
-	from assay.integrations.anthropic import get_trace_id, patch
+	from assay.integrations.anthropic import get_trace_id, patch  # type: ignore[import-untyped]
 except ImportError:
 	print('assay-ai is not installed. Run: pip install assay-ai')
 	exit(1)

--- a/examples/observability/assay_audit.py
+++ b/examples/observability/assay_audit.py
@@ -1,0 +1,75 @@
+"""
+Assay evidence trail for browser-use agents.
+
+Records Anthropic API calls made through the patched SDK path. Each call
+produces one receipt: model ID, token counts, latency, and SHA-256
+hashes of the input and output content.
+
+Setup:
+    pip install assay-ai
+    export ANTHROPIC_API_KEY=...
+
+Run (raw receipts only):
+    python assay_audit.py
+    assay verify <trace_id>          # structural check
+
+Run (signed proof pack — tamper-evident, verifiable offline):
+    assay run -- python assay_audit.py
+    assay verify-pack ./proof_pack_<trace_id>/   # integrity + signature check
+
+What each receipt contains:
+    - model_id, input_tokens, output_tokens, latency_ms
+    - SHA-256 hash of input and output content
+    - callsite location (file:line)
+
+What assay run adds (signed pack only):
+    - SHA-256 manifest over all receipts
+    - Ed25519 signature over the manifest
+    - Any tampered or missing receipt fails verification
+    - Pack verifiable by any party with the public key — no server access
+
+Trust tier: T0 — locally generated signing key, no external trust anchor.
+Verification confirms the pack was not modified after signing; it does not
+confirm who signed it. For CI-bound signing, see T1 in the Assay docs.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+try:
+	from assay.integrations.anthropic import get_trace_id, patch
+except ImportError:
+	print('assay-ai is not installed. Run: pip install assay-ai')
+	exit(1)
+
+from browser_use import Agent
+from browser_use.llm import ChatAnthropic
+
+load_dotenv()
+
+# Patch the Anthropic SDK before any client is created.
+# Every messages.create() call now emits a receipt automatically.
+patch()
+
+
+async def main():
+	llm = ChatAnthropic(model='claude-sonnet-4-0', temperature=0.0)
+	agent = Agent(
+		task='Go to github.com/browser-use/browser-use and report the current number of GitHub stars',
+		llm=llm,
+	)
+
+	result = await agent.run(max_steps=10)
+
+	trace_id = get_trace_id()
+	if trace_id:
+		print(f'\nReceipts logged to trace: {trace_id}')
+		print(f'Verify: assay verify {trace_id}')
+
+	return result
+
+
+if __name__ == '__main__':
+	asyncio.run(main())


### PR DESCRIPTION
## What this adds

A new example in `examples/observability/assay_audit.py` showing how to instrument browser-use's Anthropic wrapper path with Assay so Anthropic API calls can emit Assay receipts.

## Scope

This example is scoped to browser-use's Anthropic wrapper path. Calls through `browser_use.llm.ChatAnthropic` emit Assay receipts. It does not claim full multi-turn `Agent.run()` receipt accounting or coverage of the structured-output branch.

## How it works

The example uses `assay.integrations.anthropic.patch()` so calls through `browser_use.llm.ChatAnthropic` emit Assay receipts. It supports two modes:

```bash
# Raw receipts (structural verification)
python examples/observability/assay_audit.py
assay verify <trace_id>

# Signed proof pack (tamper-evident, offline-verifiable)
assay run -- python examples/observability/assay_audit.py
assay verify-pack ./proof_pack_<trace_id>/
```

## Validation

Verified on a wrapper-path specimen: receipt attribution resolved to `browser_use/llm/anthropic/chat.py:145`, and a signed proof pack from the same path passed `assay verify-pack` with integrity PASS.

## Setup

```bash
pip install assay-ai
export ANTHROPIC_API_KEY=...
python examples/observability/assay_audit.py
```

## Trust tier

T0 (local self-signed key, no external anchor). Verification confirms the pack was not modified after signing; it does not establish signer identity.

## What this does not claim

- Full multi-turn `Agent.run()` receipt accounting has not been separately validated in this PR
- Structured-output branch (`chat.py:196`) has not been tested

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an observability example that instruments the `browser_use` Anthropic wrapper with Assay so Anthropic API calls emit receipts. Supports raw receipts and signed proof packs for offline verification.

- **New Features**
  - Adds `examples/observability/assay_audit.py`; applies `assay.integrations.anthropic.patch()` so `browser_use.llm.ChatAnthropic` calls emit receipts.
  - Two modes: raw (`python examples/observability/assay_audit.py` → `assay verify <trace_id>`) and signed packs (`assay run -- python ...` → `assay verify-pack ./proof_pack_<trace_id>/`).

- **Bug Fixes**
  - Removes an unused import and adds `# type: ignore` on the optional `assay-ai` import to suppress pyright unresolved-import errors (matching the `openLLMetry.py` pattern).

<sup>Written for commit b3b6161fa041f4674fcbfde89dcdd93da7d26667. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

