### PR TITLE
fix: close httpx client pool on session stop to prevent OOM on Lambda

### DIFF
--- a/browser_use/browser/cloud/cloud.py
+++ b/browser_use/browser/cloud/cloud.py
@@ -192,7 +192,10 @@ class CloudBrowserClient:
 			raise CloudBrowserError(f'Unexpected error stopping cloud browser: {e}')
 
 	async def close(self):
-		"""Close the HTTP client and cleanup any active sessions."""
+		"""Close the HTTP client and cleanup any active sessions.
+
+		Safe to call multiple times — subsequent calls are no-ops.
+		"""
 		# Try to stop current session if active
 		if self.current_session_id:
 			try:
@@ -200,4 +203,5 @@ class CloudBrowserClient:
 			except Exception as e:
 				logger.debug(f'Failed to stop cloud browser session during cleanup: {e}')
 
-		await self.client.aclose()
+		if not self.client.is_closed:
+			await self.client.aclose()

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1217,6 +1217,12 @@ class BrowserSession(BaseModel):
 					self.logger.info(f'🌤️ Cloud browser session cleaned up: {cloud_session_id}')
 				except Exception as e:
 					self.logger.debug(f'Failed to cleanup cloud browser session {cloud_session_id}: {e}')
+				finally:
+					# Always close the httpx client to free connection pool memory
+					try:
+						await self._cloud_browser_client.close()
+					except Exception:
+						pass
 
 			# Clear CDP session cache before stopping
 			self.logger.info(


### PR DESCRIPTION
## Summary
- Close `CloudBrowserClient`'s httpx connection pool in `on_BrowserStopEvent` after `stop_browser()` completes
- Make `CloudBrowserClient.close()` idempotent (safe to call multiple times)

## Problem
`BrowserSession.on_BrowserStopEvent` calls `stop_browser()` to end the cloud session but never calls `_cloud_browser_client.close()`. The underlying `httpx.AsyncClient` connection pool stays alive in memory.

On AWS Lambda with provisioned concurrency, the same container handles many invocations sequentially. Each invocation creates a new `BrowserSession` → new `CloudBrowserClient` → new `httpx.AsyncClient`, but the old ones are never cleaned up. Memory climbs from ~1.3GB to the 3GB ceiling over hours, triggering OOM kills.

**Observed in production**: 21 `Runtime.ExitError` crashes in 6 hours, `aws.lambda.enhanced.max_memory_used` saturated at 3,009 MB (the Lambda limit), 3 confirmed `out_of_memory` events.

## Test plan
- [ ] Run `tests/ci` suite to verify no regressions
- [ ] Verify cloud browser sessions still clean up properly (`stop_browser` + `close`)
- [ ] Verify calling `close()` twice doesn't raise


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Close the `httpx` client pool when a cloud browser session stops to prevent memory leaks and OOM on AWS Lambda. Also makes `CloudBrowserClient.close()` safe to call multiple times.

- **Bug Fixes**
  - Always call `_cloud_browser_client.close()` in `BrowserSession.on_BrowserStopEvent` after `stop_browser()` (in finally) to free the `httpx.AsyncClient` pool.
  - Make `CloudBrowserClient.close()` idempotent by checking `client.is_closed` before `aclose()`.

<sup>Written for commit 5e644981e82cc1276aca768b27df54155d9ddc3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

