### PR TITLE
Fix/remove len guard serializer

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -534,7 +534,7 @@ class DOMTreeSerializer:
 		elif node.node_type == NodeType.TEXT_NODE:
 			# Include meaningful text nodes
 			is_visible = node.snapshot_node and node.is_visible
-			if is_visible and node.node_value and node.node_value.strip() and len(node.node_value.strip()) > 1:
+			if is_visible and node.node_value and node.node_value.strip():
 				return SimplifiedNode(original_node=node, children=[])
 
 		return None
@@ -1049,12 +1049,7 @@ class DOMTreeSerializer:
 		elif node.original_node.node_type == NodeType.TEXT_NODE:
 			# Include visible text
 			is_visible = node.original_node.snapshot_node and node.original_node.is_visible
-			if (
-				is_visible
-				and node.original_node.node_value
-				and node.original_node.node_value.strip()
-				and len(node.original_node.node_value.strip()) > 1
-			):
+			if is_visible and node.original_node.node_value and node.original_node.node_value.strip():
 				clean_text = node.original_node.node_value.strip()
 				formatted_text.append(f'{depth_str}{clean_text}')
 

--- a/tests/ci/browser/test_dom_serializer.py
+++ b/tests/ci/browser/test_dom_serializer.py
@@ -524,6 +524,47 @@ class TestDOMSerializer:
 		print('   ✓ Cross-origin iframe extraction works (CDP target switching enabled)')
 		print('   ✓ Truly nested structure works: Open Shadow → Closed Shadow → Iframe')
 
+	async def test_single_char_text_nodes_included(self, browser_session, http_server):
+		"""Verify single-character text nodes are included in the serialized DOM.
+
+		Regression test for the len() > 1 guard that was incorrectly filtering out
+		meaningful single-character content like digits, currency symbols, and punctuation.
+		"""
+		import asyncio
+
+		from browser_use.tools.service import Tools
+
+		# Serve a page with visible single-character text nodes
+		html = """<!DOCTYPE html>
+<html><body>
+  <p id="price"><span id="currency">$</span>9.99</p>
+  <p id="step">Step <span id="num">1</span> of 3</p>
+  <nav id="breadcrumb">Home <span id="sep">&gt;</span> Products</nav>
+  <button id="label-btn">A</button>
+</body></html>"""
+
+		http_server.expect_ordered_request('/single-char-test').respond_with_data(html, content_type='text/html')
+		base_url = f'http://{http_server.host}:{http_server.port}'
+
+		tools = Tools()
+		await tools.navigate(url=f'{base_url}/single-char-test', new_tab=False, browser_session=browser_session)
+		await asyncio.sleep(0.5)
+
+		browser_state = await browser_session.get_browser_state_summary(
+			include_screenshot=False,
+			include_recent_events=False,
+		)
+
+		serialized = browser_state.dom_state.llm_representation()
+		print(f'\nSerialized DOM:\n{serialized}')
+
+		# All of these single-char strings must appear in the output
+		for char in ['$', '1', '>', 'A']:
+			assert char in serialized, f"Single-character '{char}' should be visible in serialized DOM but was missing"
+			print(f"   ✓ '{char}' found in serialized output")
+
+		print('\n✅ Single-character text node test passed!')
+
 
 if __name__ == '__main__':
 	"""Run test in debug mode with manual fixture setup."""


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stale element handling by auto re-discovering the DOM and surfacing clear, contextual errors. Also includes single-character text in DOM serialization and hardens TOTP secret validation.

- **Bug Fixes**
  - Auto re-discover DOM in `get_element_by_index` when the selector map is stale; tools (`click`, `input`, `scroll`, `dropdown_options`, `select_dropdown`, `upload_file`) now return `ActionResult.error` on misses.
  - `_element_not_found_error` distinguishes out-of-bounds indexes from stale references and guides calling `get_browser_state`.
  - Serialize single-character text nodes by removing the length guard (in `_create_simplified_tree` and `serialize_tree`).
  - Validate `bu_2fa_code` seeds; raise a clear `ValueError` on invalid TOTP input.
  - Tests for re-discovery, out-of-bounds messaging, tool error paths, and single-character text serialization (addresses AGI-573).

<sup>Written for commit 6e0f38e00d596d1ec3b4e49538ed2115ca932b12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

