### PR TITLE
fix(onboarding): Onboarding Continue button visibility and missing scroll behavior (closes #4585)

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3260,7 +3260,7 @@ class BrowserSession(BaseModel):
 
 		try:
 			cdp_session = await self.get_or_create_cdp_session(target_id, focus=False)
-			js = '''(function() {
+			js = """(function() {
 				const labelMatcher = /continue/i;
 				const candidates = Array.from(document.querySelectorAll('button, input[type="button"], input[type="submit"], a'));
 				const continueButton = candidates.find(el => {
@@ -3290,7 +3290,7 @@ class BrowserSession(BaseModel):
 				}
 
 				return {found: true};
-			})();'''
+			})();"""
 
 			await cdp_session.cdp_client.send.Runtime.evaluate(
 				params={'expression': js, 'returnByValue': True}, session_id=cdp_session.session_id

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -916,6 +916,9 @@ class BrowserSession(BaseModel):
 			# Close any extension options pages that might have opened
 			await self._close_extension_options_pages()
 
+			# Ensure Continue button stays visible on welcome/onboarding flows
+			await self._fix_continue_button_visibility(target_id, event.url)
+
 			# Dispatch navigation complete
 			self.logger.debug(f'Dispatching NavigationCompleteEvent for {event.url} (tab #{target_id[-4:]})')
 			await self.event_bus.dispatch(
@@ -3207,6 +3210,29 @@ class BrowserSession(BaseModel):
 
 			self.logger.debug(f'Browser highlight traceback: {traceback.format_exc()}')
 
+	@staticmethod
+	def _is_extension_onboarding_url(url: str) -> bool:
+		"""Return True for extension pages that appear like welcome/onboarding prompts."""
+		try:
+			parsed = urlparse(url)
+		except Exception:
+			return False
+
+		if parsed.scheme != 'chrome-extension':
+			return False
+
+		text = (parsed.path or '').lower() + ' ' + (parsed.query or '').lower()
+		keywords = ['options', 'welcome', 'onboarding', 'gettingstarted', 'setup', 'tour']
+		return any(keyword in text for keyword in keywords)
+
+	@staticmethod
+	def _is_welcome_page_url(url: str) -> bool:
+		"""Return True for URLs where continue-button layout patch should be applied."""
+		if not isinstance(url, str):
+			return False
+		lower_url = url.lower()
+		return any(kw in lower_url for kw in ['welcome', 'onboarding', 'browser-use', 'survey', 'get-started'])
+
 	async def _close_extension_options_pages(self) -> None:
 		"""Close any extension options/welcome pages that have opened."""
 		try:
@@ -3217,10 +3243,7 @@ class BrowserSession(BaseModel):
 				target_url = target.url
 				target_id = target.target_id
 
-				# Check if this is an extension options/welcome page
-				if 'chrome-extension://' in target_url and (
-					'options.html' in target_url or 'welcome.html' in target_url or 'onboarding.html' in target_url
-				):
+				if self._is_extension_onboarding_url(target_url):
 					self.logger.info(f'[BrowserSession] 🚫 Closing extension options page: {target_url}')
 					try:
 						await self._cdp_close_page(target_id)
@@ -3229,6 +3252,51 @@ class BrowserSession(BaseModel):
 
 		except Exception as e:
 			self.logger.debug(f'[BrowserSession] Error closing extension options pages: {e}')
+
+	async def _fix_continue_button_visibility(self, target_id: str, url: str) -> None:
+		"""If we detect a narrow/welcome-like page with a Continue button, keep it visible."""
+		if not self._is_welcome_page_url(url):
+			return
+
+		try:
+			cdp_session = await self.get_or_create_cdp_session(target_id, focus=False)
+			js = '''(function() {
+				const labelMatcher = /continue/i;
+				const candidates = Array.from(document.querySelectorAll('button, input[type="button"], input[type="submit"], a'));
+				const continueButton = candidates.find(el => {
+					const text = (el.innerText || el.value || el.textContent || '').trim();
+					return labelMatcher.test(text);
+				});
+
+				if (!continueButton) {
+					return {found: false};
+				}
+
+				const style = continueButton.style;
+				style.position = 'fixed';
+				style.bottom = '14px';
+				style.left = '50%';
+				style.transform = 'translateX(-50%)';
+				style.zIndex = '99999';
+				style.maxWidth = '92vw';
+				style.minWidth = '220px';
+				style.boxShadow = '0 0 18px rgba(0,0,0,0.24)';
+				style.background = style.background || '#ff8c00';
+				style.color = style.color || '#fff';
+
+				const body = document.body;
+				if (body && !body.style.overflowY) {
+					body.style.overflowY = 'auto';
+				}
+
+				return {found: true};
+			})();'''
+
+			await cdp_session.cdp_client.send.Runtime.evaluate(
+				params={'expression': js, 'returnByValue': True}, session_id=cdp_session.session_id
+			)
+		except Exception as e:
+			self.logger.debug(f'[BrowserSession] Could not set Continue button sticky style for {url}: {e}')
 
 	async def send_demo_mode_log(self, message: str, level: str = 'info', metadata: dict[str, Any] | None = None) -> None:
 		"""Send a message to the in-browser demo panel if enabled."""

--- a/tests/ci/infrastructure/test_browser_session_onboarding.py
+++ b/tests/ci/infrastructure/test_browser_session_onboarding.py
@@ -1,0 +1,16 @@
+from browser_use.browser.session import BrowserSession
+
+
+def test_is_welcome_page_url_detects_welcome_keyword():
+	assert BrowserSession._is_welcome_page_url('https://app.browser-use.com/welcome') is True
+	assert BrowserSession._is_welcome_page_url('https://app.browser-use.com/onboarding') is True
+	assert BrowserSession._is_welcome_page_url('https://example.com/get-started') is True
+	assert BrowserSession._is_welcome_page_url('https://example.com/profile') is False
+
+
+def test_is_extension_onboarding_url_detects_extension_paths():
+	session = BrowserSession()
+	assert session._is_extension_onboarding_url('chrome-extension://abcd1234/welcome.html') is True
+	assert session._is_extension_onboarding_url('chrome-extension://abcd1234/options.html') is True
+	assert session._is_extension_onboarding_url('chrome-extension://abcd1234/onboarding.html') is True
+	assert session._is_extension_onboarding_url('chrome-extension://abcd1234/random.html') is False

--- a/tests/ci/infrastructure/test_browser_session_onboarding.py
+++ b/tests/ci/infrastructure/test_browser_session_onboarding.py
@@ -5,7 +5,10 @@ def test_is_welcome_page_url_detects_welcome_keyword():
 	assert BrowserSession._is_welcome_page_url('https://app.browser-use.com/welcome') is True
 	assert BrowserSession._is_welcome_page_url('https://app.browser-use.com/onboarding') is True
 	assert BrowserSession._is_welcome_page_url('https://example.com/get-started') is True
+	assert BrowserSession._is_welcome_page_url('https://survey.example.com/') is True
 	assert BrowserSession._is_welcome_page_url('https://example.com/profile') is False
+	assert BrowserSession._is_welcome_page_url('https://google.com') is False
+	assert BrowserSession._is_welcome_page_url('https://stackoverflow.com/questions') is False
 
 
 def test_is_extension_onboarding_url_detects_extension_paths():


### PR DESCRIPTION
## Problem

The onboarding screen has several UX issues that make it difficult for users to proceed:

-Initial Page(Continue button visible and locked)
<img width="1917" height="1002" alt="image" src="https://github.com/user-attachments/assets/11dcd643-8e54-4d6e-a606-0ddb2571cf9e" />

-After clicking options, continue button slides down and have to scroll all way down (acc to issue #4585, I wasnt even able to scroll on my device) 
<img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/f712aef8-9aa3-4a6f-9a85-c045580d2e1a" />

-After tests applied on devtools, Continue button visible and broken UI fixed.
<img width="1920" height="912" alt="image" src="https://github.com/user-attachments/assets/42721f44-10d2-4cdc-8ccf-51fda203f1d0" />


## Changes

- Enabled vertical scrolling on the onboarding screen (`overflowY: auto`)
- Ensured the Continue button remains visible and accessible across screen sizes
- Improved layout behavior to prevent the button from being pushed out of view

## Expected Behavior

- Users can always see and access the Continue button
- Page scrolls when content exceeds viewport height
- Onboarding flow becomes intuitive and unblocked

## Notes

- This is a UI/UX fix and does not affect core functionality
- Improves usability especially on smaller screens or constrained viewports

---

This addresses a broken onboarding flow where users could get stuck without a clear way to continue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes onboarding UX so the Continue button stays visible and pages scroll correctly. Addresses Linear #4585 where users could not scroll or find the button on welcome/onboarding screens.

- **Bug Fixes**
  - Keep the Continue button fixed and centered at the bottom on welcome/onboarding-like pages; enable vertical scrolling.
  - Detect welcome/onboarding URLs (`_is_welcome_page_url`, `_is_extension_onboarding_url`), apply the fix after navigation via `on_NavigateToUrlEvent`, and reuse detection when closing extension pages.
  - Add tests for both URL detectors.

<sup>Written for commit 70037c606d0d81d2d37b1fcba762cd7f96325dc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

