### PR TITLE
fix: add error handling for CDP /json/version endpoint in connect()

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1749,7 +1749,29 @@ class BrowserSession(BaseModel):
 				headers.setdefault('User-Agent', f'browser-use/{get_browser_use_version()}')
 				version_info = await client.get(url, headers=headers)
 				self.logger.debug(f'Raw version info: {str(version_info)}')
-				self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
+
+				if not version_info.is_success:
+					raise RuntimeError(
+						f'CDP /json/version request to {url} failed with HTTP {version_info.status_code}. '
+						f'Response: {version_info.text[:500]}'
+					)
+
+				try:
+					version_data = version_info.json()
+				except Exception as e:
+					raise RuntimeError(
+						f'CDP /json/version response from {url} is not valid JSON: {e}. '
+						f'Response (HTTP {version_info.status_code}): {version_info.text[:500]}'
+					) from e
+
+				ws_url = version_data.get('webSocketDebuggerUrl')
+				if not ws_url:
+					raise RuntimeError(
+						f'CDP /json/version response from {url} is missing "webSocketDebuggerUrl". '
+						f'Available keys: {list(version_data.keys())}'
+					)
+
+				self.browser_profile.cdp_url = ws_url
 
 		assert self.cdp_url is not None, 'CDP URL is None.'
 

--- a/tests/ci/browser/test_cdp_version_error_handling.py
+++ b/tests/ci/browser/test_cdp_version_error_handling.py
@@ -1,0 +1,136 @@
+"""
+Test that CDP /json/version endpoint errors produce clear error messages
+instead of cryptic JSONDecodeError or KeyError.
+
+This tests the fix for: When connecting to a remote browser via HTTP CDP URL,
+if the /json/version endpoint returns a non-200 status, non-JSON body, or
+a JSON response missing 'webSocketDebuggerUrl', the user should get a clear
+RuntimeError instead of an unhelpful low-level exception.
+
+Reproduces the scenario from issue #4050 where users connecting through
+proxies or to misconfigured remote browsers got JSONDecodeError.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+
+
+def _make_mock_response(status_code: int, text: str, json_data: dict | None = None) -> MagicMock:
+    """Create a mock httpx.Response with the given status, text, and optional JSON."""
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.text = text
+    if json_data is not None:
+        resp.json.return_value = json_data
+    else:
+        resp.json.side_effect = Exception(f'Expecting value: line 1 column 1 (char 0)')
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_cdp_version_non_200_raises_clear_error():
+    """HTTP 502 from /json/version should raise RuntimeError with status code, not JSONDecodeError."""
+    session = BrowserSession(cdp_url='http://remote-browser:9222')
+
+    mock_response = _make_mock_response(
+        status_code=502,
+        text='<html><body>Bad Gateway</body></html>',
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch('browser_use.browser.session.httpx.AsyncClient', return_value=mock_client):
+        with pytest.raises(RuntimeError, match=r'HTTP 502'):
+            await session.connect()
+
+
+@pytest.mark.asyncio
+async def test_cdp_version_non_json_raises_clear_error():
+    """Non-JSON response body should raise RuntimeError mentioning 'not valid JSON'."""
+    session = BrowserSession(cdp_url='http://remote-browser:9222')
+
+    mock_response = _make_mock_response(
+        status_code=200,
+        text='This is not JSON',
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch('browser_use.browser.session.httpx.AsyncClient', return_value=mock_client):
+        with pytest.raises(RuntimeError, match=r'not valid JSON'):
+            await session.connect()
+
+
+@pytest.mark.asyncio
+async def test_cdp_version_missing_ws_url_raises_clear_error():
+    """JSON response without 'webSocketDebuggerUrl' should raise RuntimeError with available keys."""
+    session = BrowserSession(cdp_url='http://remote-browser:9222')
+
+    mock_response = _make_mock_response(
+        status_code=200,
+        text='{"Browser": "Chrome/120"}',
+        json_data={'Browser': 'Chrome/120'},
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch('browser_use.browser.session.httpx.AsyncClient', return_value=mock_client):
+        with pytest.raises(RuntimeError, match=r'missing "webSocketDebuggerUrl"'):
+            await session.connect()
+
+
+@pytest.mark.asyncio
+async def test_cdp_version_success_sets_ws_url():
+    """Valid /json/version response should set cdp_url to the WebSocket URL."""
+    ws_url = 'ws://remote-browser:9222/devtools/browser/abc123'
+    session = BrowserSession(cdp_url='http://remote-browser:9222')
+
+    mock_response = _make_mock_response(
+        status_code=200,
+        text=f'{{"webSocketDebuggerUrl": "{ws_url}", "Browser": "Chrome/120"}}',
+        json_data={'webSocketDebuggerUrl': ws_url, 'Browser': 'Chrome/120'},
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch('browser_use.browser.session.httpx.AsyncClient', return_value=mock_client):
+        with patch('browser_use.browser.session.CDPClient') as mock_cdp_class:
+            mock_cdp = AsyncMock()
+            mock_cdp_class.return_value = mock_cdp
+            mock_cdp.start = AsyncMock()
+            mock_cdp.stop = AsyncMock()
+            mock_cdp.send = MagicMock()
+            mock_cdp.send.Target = MagicMock()
+            mock_cdp.send.Target.setAutoAttach = AsyncMock()
+            mock_cdp.send.Target.getTargets = AsyncMock(return_value={'targetInfos': []})
+            mock_cdp.send.Target.createTarget = AsyncMock(return_value={'targetId': 'test-id'})
+
+            with patch('browser_use.browser.session_manager.SessionManager') as mock_sm_class:
+                mock_sm = AsyncMock()
+                mock_sm_class.return_value = mock_sm
+
+                try:
+                    await session.connect()
+                except Exception:
+                    pass  # connect() may fail on later steps, that's fine
+
+                # The key assertion: cdp_url should be set to the WebSocket URL
+                assert session.browser_profile.cdp_url == ws_url


### PR DESCRIPTION
## Problem

Was debugging a connection issue with a remote browser behind an nginx proxy. When the proxy returned a 502, I got:

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Traced it to `session.py` in `connect()` — the `/json/version` HTTP response is parsed with `.json()['webSocketDebuggerUrl']` without checking the HTTP status code first or handling parse failures. This is the same root location reported in #4050.

The `trust_env` fix at line 1744 addressed the Windows proxy env var scenario, but the general error handling is still missing: any non-200 response, non-JSON body, or missing `webSocketDebuggerUrl` key still produces a cryptic low-level exception.

### Before

- HTTP 502 from reverse proxy → `JSONDecodeError: Expecting value: line 1 column 1`
- HTTP 403 from auth-gated endpoint → `JSONDecodeError` (HTML body)
- Valid JSON without `webSocketDebuggerUrl` → `KeyError: 'webSocketDebuggerUrl'`

### After

- HTTP 502 → `RuntimeError: CDP /json/version request to ... failed with HTTP 502. Response: <html>...`
- HTTP 403 → `RuntimeError: CDP /json/version request to ... failed with HTTP 403. Response: Forbidden`
- Missing key → `RuntimeError: CDP /json/version response from ... is missing "webSocketDebuggerUrl". Available keys: ['Browser', ...]`

## Changes

**`browser_use/browser/session.py`** — `connect()` method:
- Check `version_info.is_success` before parsing
- Wrap `.json()` in try/except with status code and response body in the error
- Use `.get('webSocketDebuggerUrl')` instead of `['webSocketDebuggerUrl']` with a clear error if missing

## Tests

Added `tests/ci/browser/test_cdp_version_error_handling.py` with four cases:
- Non-200 status (502) → expects `RuntimeError` matching "HTTP 502"
- Non-JSON 200 response → expects `RuntimeError` matching "not valid JSON"
- JSON missing `webSocketDebuggerUrl` → expects `RuntimeError` matching the key name
- Valid response → verifies `cdp_url` is set to the WebSocket URL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved error handling for the CDP `/json/version` request in `connect()` so users get clear RuntimeErrors instead of JSONDecodeError/KeyError when the endpoint fails. Added tests for key failure modes and the success path.

- **Bug Fixes**
  - Check HTTP success before parsing; include status and body snippet in the error.
  - Catch JSON parse failures with a clear message and response context.
  - Validate presence of `webSocketDebuggerUrl`; list available keys if missing.
  - Set `cdp_url` from the WebSocket URL when valid.
  - Added tests for non-200, non-JSON, missing key, and success cases.

<sup>Written for commit 188c776fd8d80ed8149548583211789499c745e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

