### PR TITLE
fix(llm): guard against empty choices in Groq, DeepSeek, and Cerebras providers

### DIFF
--- a/browser_use/llm/cerebras/chat.py
+++ b/browser_use/llm/cerebras/chat.py
@@ -120,9 +120,12 @@ class ChatCerebras(BaseChatModel):
 					messages=cerebras_messages,  # type: ignore
 					**common,
 				)
+				choice = resp.choices[0] if resp.choices else None
+				if choice is None:
+					raise ModelProviderError('Invalid Cerebras chat completion response: missing or empty `choices`.', model=self.name)
 				usage = self._get_usage(resp)
 				return ChatInvokeCompletion(
-					completion=resp.choices[0].message.content or '',
+					completion=choice.message.content or '',
 					usage=usage,
 				)
 			except RateLimitError as e:
@@ -166,7 +169,10 @@ Your response must be valid JSON only, no other text.
 					messages=cerebras_messages,  # type: ignore
 					**common,
 				)
-				content = resp.choices[0].message.content
+				choice = resp.choices[0] if resp.choices else None
+				if choice is None:
+					raise ModelProviderError('Invalid Cerebras chat completion response: missing or empty `choices`.', model=self.name)
+				content = choice.message.content
 				if not content:
 					raise ModelProviderError('Empty JSON content in Cerebras response', model=self.name)
 

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -123,8 +123,11 @@ class ChatDeepSeek(BaseChatModel):
 					messages=ds_messages,  # type: ignore
 					**common,
 				)
+				choice = resp.choices[0] if resp.choices else None
+				if choice is None:
+					raise ModelProviderError('Invalid DeepSeek chat completion response: missing or empty `choices`.', model=self.name)
 				return ChatInvokeCompletion(
-					completion=resp.choices[0].message.content or '',
+					completion=choice.message.content or '',
 					usage=None,
 				)
 			except RateLimitError as e:
@@ -161,7 +164,10 @@ class ChatDeepSeek(BaseChatModel):
 					tool_choice=tool_choice,  # type: ignore
 					**common,
 				)
-				msg = resp.choices[0].message
+				choice = resp.choices[0] if resp.choices else None
+				if choice is None:
+					raise ModelProviderError('Invalid DeepSeek chat completion response: missing or empty `choices`.', model=self.name)
+				msg = choice.message
 				if not msg.tool_calls:
 					raise ValueError('Expected tool_calls in response but got none')
 				raw_args = msg.tool_calls[0].function.arguments
@@ -197,7 +203,10 @@ class ChatDeepSeek(BaseChatModel):
 					response_format={'type': 'json_object'},
 					**common,
 				)
-				content = resp.choices[0].message.content
+				choice = resp.choices[0] if resp.choices else None
+				if choice is None:
+					raise ModelProviderError('Invalid DeepSeek chat completion response: missing or empty `choices`.', model=self.name)
+				content = choice.message.content
 				if not content:
 					raise ModelProviderError('Empty JSON content in DeepSeek response', model=self.name)
 				parsed = output_format.model_validate_json(content)

--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -158,9 +158,18 @@ class ChatGroq(BaseChatModel):
 			top_p=self.top_p,
 			seed=self.seed,
 		)
+
+		choice = chat_completion.choices[0] if chat_completion.choices else None
+		if choice is None:
+			raise ModelProviderError(
+				message='Invalid Groq chat completion response: missing or empty `choices`.',
+				status_code=502,
+				model=self.name,
+			)
+
 		usage = self._get_usage(chat_completion)
 		return ChatInvokeCompletion(
-			completion=chat_completion.choices[0].message.content or '',
+			completion=choice.message.content or '',
 			usage=usage,
 		)
 
@@ -173,14 +182,22 @@ class ChatGroq(BaseChatModel):
 		else:
 			response = await self._invoke_with_json_schema(groq_messages, output_format, schema)
 
-		if not response.choices[0].message.content:
+		choice = response.choices[0] if response.choices else None
+		if choice is None:
+			raise ModelProviderError(
+				message='Invalid Groq chat completion response: missing or empty `choices`.',
+				status_code=502,
+				model=self.name,
+			)
+
+		if not choice.message.content:
 			raise ModelProviderError(
 				message='No content in response',
 				status_code=500,
 				model=self.name,
 			)
 
-		parsed_response = output_format.model_validate_json(response.choices[0].message.content)
+		parsed_response = output_format.model_validate_json(choice.message.content)
 		usage = self._get_usage(response)
 
 		return ChatInvokeCompletion(

--- a/tests/ci/test_empty_choices_guard.py
+++ b/tests/ci/test_empty_choices_guard.py
@@ -1,0 +1,63 @@
+"""Test that LLM providers correctly handle empty choices in API responses.
+
+This tests the fix from PR #3899 which was applied to the OpenAI provider,
+extended here to Groq, DeepSeek, and Cerebras providers.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.messages import SystemMessage, UserMessage
+
+
+def _make_empty_choices_response():
+    """Create a mock chat completion response with an empty choices list."""
+    mock_resp = MagicMock()
+    mock_resp.choices = []
+    return mock_resp
+
+
+@pytest.mark.asyncio
+async def test_groq_empty_choices_regular():
+    """Groq provider raises ModelProviderError on empty choices for regular completion."""
+    from browser_use.llm.groq.chat import ChatGroq
+
+    llm = ChatGroq(model="llama-3.3-70b-versatile", api_key="test-key")
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=_make_empty_choices_response())
+
+    with patch.object(llm, "get_client", return_value=mock_client):
+        with pytest.raises(ModelProviderError, match="empty `choices`"):
+            await llm.ainvoke([UserMessage(content="hello")])
+
+
+@pytest.mark.asyncio
+async def test_deepseek_empty_choices_regular():
+    """DeepSeek provider raises ModelProviderError on empty choices for regular completion."""
+    from browser_use.llm.deepseek.chat import ChatDeepSeek
+
+    llm = ChatDeepSeek(model="deepseek-chat", api_key="test-key")
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=_make_empty_choices_response())
+
+    with patch.object(llm, "get_client", return_value=mock_client):
+        with pytest.raises(ModelProviderError, match="empty `choices`"):
+            await llm.ainvoke([UserMessage(content="hello")])
+
+
+@pytest.mark.asyncio
+async def test_cerebras_empty_choices_regular():
+    """Cerebras provider raises ModelProviderError on empty choices for regular completion."""
+    from browser_use.llm.cerebras.chat import ChatCerebras
+
+    llm = ChatCerebras(model="llama-3.3-70b", api_key="test-key")
+
+    mock_client = AsyncMock()
+    mock_client.chat.completions.create = AsyncMock(return_value=_make_empty_choices_response())
+
+    with patch.object(llm, "get_client", return_value=mock_client):
+        with pytest.raises(ModelProviderError, match="empty `choices`"):
+            await llm.ainvoke([UserMessage(content="hello")])


### PR DESCRIPTION
## Problem

Noticed while reading through the LLM provider code that #3899 added a guard for empty `choices` arrays in the OpenAI provider, but the same issue exists in the Groq, DeepSeek, and Cerebras providers. All three directly index `response.choices[0]` without checking whether the list is non-empty.

When an API returns an empty `choices` list (which can happen due to content filtering, a server-side error, or a misconfigured proxy), the `IndexError` is caught by the outer `except Exception` block but surfaces as:

```
ModelProviderError: list index out of range
```

This message gives the user no indication of what actually went wrong or how to fix it.

### Where the correct pattern already exists

The OpenAI provider at [`openai/chat.py` line 202](https://github.com/browser-use/browser-use/blob/main/browser_use/llm/openai/chat.py) already handles this correctly:

```python
choice = response.choices[0] if response.choices else None
if choice is None:
    raise ModelProviderError(
        message='Invalid OpenAI chat completion response: missing or empty `choices`...',
        status_code=502,
        model=self.name,
    )
```

## Fix

Applied the same pattern to all code paths in the three affected providers:

- **Groq** (`groq/chat.py`): `_invoke_regular_completion` and `_invoke_structured_output` — 2 call sites
- **DeepSeek** (`deepseek/chat.py`): regular text output, function calling, and JSON output paths — 3 call sites
- **Cerebras** (`cerebras/chat.py`): regular text output and JSON output paths — 2 call sites

### Before

```
ModelProviderError: list index out of range
```

### After

```
ModelProviderError: Invalid Groq chat completion response: missing or empty `choices`.
```

## Tests

Added `tests/ci/test_empty_choices_guard.py` with unit tests that mock an empty-choices API response for each of the three providers and verify that `ModelProviderError` is raised with a descriptive message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds guards for empty `choices` in the `Groq`, `DeepSeek`, and `Cerebras` chat providers to replace “list index out of range” with clear, provider-specific errors. Aligns behavior with the existing `OpenAI` provider.

- **Bug Fixes**
  - Check for empty `response.choices` before indexing in `groq/chat.py` (regular, structured), `deepseek/chat.py` (text, tools, JSON), and `cerebras/chat.py` (text, JSON); raise `ModelProviderError` with a descriptive message when missing.
  - Added `tests/ci/test_empty_choices_guard.py` to mock empty responses for each provider and assert the expected error message.

<sup>Written for commit 3bdb05fa0a7184474cad3c59c9f6bd498820cec5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

