### PR TITLE
fix: handle non-200 and malformed responses from CDP /json/version endpoint

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1749,7 +1749,29 @@ class BrowserSession(BaseModel):
 				headers.setdefault('User-Agent', f'browser-use/{get_browser_use_version()}')
 				version_info = await client.get(url, headers=headers)
 				self.logger.debug(f'Raw version info: {str(version_info)}')
-				self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
+
+				if version_info.status_code != 200:
+					raise RuntimeError(
+						f'CDP endpoint {url} returned HTTP {version_info.status_code}. '
+						f'Ensure the browser is running and the CDP endpoint is reachable.'
+					)
+
+				try:
+					version_data = version_info.json()
+				except Exception as e:
+					raise RuntimeError(
+						f'CDP endpoint {url} returned a non-JSON response (HTTP {version_info.status_code}). '
+						f'This usually means the URL is not a Chrome DevTools Protocol endpoint.'
+					) from e
+
+				ws_url = version_data.get('webSocketDebuggerUrl')
+				if not ws_url:
+					raise RuntimeError(
+						f'CDP endpoint {url} response is missing "webSocketDebuggerUrl". '
+						f'Response keys: {list(version_data.keys())}. '
+						f'Ensure the browser supports Chrome DevTools Protocol.'
+					)
+				self.browser_profile.cdp_url = ws_url
 
 		assert self.cdp_url is not None, 'CDP URL is None.'
 

--- a/tests/ci/browser/test_cdp_connect_errors.py
+++ b/tests/ci/browser/test_cdp_connect_errors.py
@@ -1,0 +1,108 @@
+"""
+Test error handling when connecting to a remote CDP endpoint via /json/version.
+
+Validates that connect() raises clear, actionable RuntimeError messages when
+the CDP endpoint returns non-200 status, non-JSON bodies, or is missing
+the required webSocketDebuggerUrl field.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from browser_use.browser.session import BrowserSession
+
+
+def _make_mock_httpx_client(mock_response):
+	"""Set up an httpx.AsyncClient mock that returns the given response from GET."""
+	mock_client = AsyncMock()
+	mock_client.get = AsyncMock(return_value=mock_response)
+
+	mock_client_class = MagicMock()
+	mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+	mock_client_class.return_value.__aexit__ = AsyncMock(return_value=False)
+	return mock_client_class
+
+
+@pytest.mark.asyncio
+async def test_connect_raises_on_non_200_status():
+	"""Non-200 response from /json/version should raise RuntimeError with the status code."""
+	session = BrowserSession(cdp_url='http://remote-browser:9222')
+
+	mock_response = MagicMock()
+	mock_response.status_code = 502
+
+	mock_client_class = _make_mock_httpx_client(mock_response)
+
+	with patch('browser_use.browser.session.httpx.AsyncClient', mock_client_class):
+		with pytest.raises(RuntimeError, match='HTTP 502'):
+			await session.connect()
+
+
+@pytest.mark.asyncio
+async def test_connect_raises_on_non_json_response():
+	"""HTML or other non-JSON response from /json/version should raise RuntimeError."""
+	session = BrowserSession(cdp_url='http://remote-browser:9222')
+
+	mock_response = MagicMock()
+	mock_response.status_code = 200
+	mock_response.json.side_effect = ValueError('No JSON object could be decoded')
+
+	mock_client_class = _make_mock_httpx_client(mock_response)
+
+	with patch('browser_use.browser.session.httpx.AsyncClient', mock_client_class):
+		with pytest.raises(RuntimeError, match='non-JSON response'):
+			await session.connect()
+
+
+@pytest.mark.asyncio
+async def test_connect_raises_on_missing_ws_url():
+	"""JSON response without webSocketDebuggerUrl should raise RuntimeError."""
+	session = BrowserSession(cdp_url='http://remote-browser:9222')
+
+	mock_response = MagicMock()
+	mock_response.status_code = 200
+	mock_response.json.return_value = {'Browser': 'Chrome/120.0', 'Protocol-Version': '1.3'}
+
+	mock_client_class = _make_mock_httpx_client(mock_response)
+
+	with patch('browser_use.browser.session.httpx.AsyncClient', mock_client_class):
+		with pytest.raises(RuntimeError, match='missing "webSocketDebuggerUrl"'):
+			await session.connect()
+
+
+@pytest.mark.asyncio
+async def test_connect_succeeds_with_valid_json_version_response():
+	"""Valid /json/version response should set cdp_url to the returned webSocketDebuggerUrl."""
+	session = BrowserSession(cdp_url='http://remote-browser:9222')
+
+	mock_response = MagicMock()
+	mock_response.status_code = 200
+	mock_response.json.return_value = {
+		'webSocketDebuggerUrl': 'ws://remote-browser:9222/devtools/browser/abc123',
+	}
+
+	mock_client_class = _make_mock_httpx_client(mock_response)
+
+	with patch('browser_use.browser.session.httpx.AsyncClient', mock_client_class):
+		with patch('browser_use.browser.session.CDPClient') as mock_cdp_class:
+			mock_cdp = AsyncMock()
+			mock_cdp_class.return_value = mock_cdp
+			mock_cdp.start = AsyncMock()
+			mock_cdp.send = MagicMock()
+			mock_cdp.send.Target = MagicMock()
+			mock_cdp.send.Target.setAutoAttach = AsyncMock()
+
+			with patch('browser_use.browser.session_manager.SessionManager') as mock_sm_class:
+				mock_sm = MagicMock()
+				mock_sm_class.return_value = mock_sm
+				mock_sm.start_monitoring = AsyncMock()
+				mock_sm.get_all_page_targets = MagicMock(return_value=[])
+
+				try:
+					await session.connect()
+				except Exception:
+					pass  # May fail due to incomplete mocking past the /json/version step
+
+				# The key assertion: cdp_url was updated to the websocket URL
+				assert session.browser_profile.cdp_url == 'ws://remote-browser:9222/devtools/browser/abc123'

--- a/tests/ci/browser/test_cdp_headers.py
+++ b/tests/ci/browser/test_cdp_headers.py
@@ -138,10 +138,11 @@ async def test_headers_used_for_json_version_endpoint():
 	with patch('browser_use.browser.session.httpx.AsyncClient') as mock_client_class:
 		mock_client = AsyncMock()
 		mock_client_class.return_value.__aenter__ = AsyncMock(return_value=mock_client)
-		mock_client_class.return_value.__aexit__ = AsyncMock()
+		mock_client_class.return_value.__aexit__ = AsyncMock(return_value=False)
 
 		# Mock the /json/version response
 		mock_response = MagicMock()
+		mock_response.status_code = 200
 		mock_response.json.return_value = {'webSocketDebuggerUrl': 'ws://remote-browser.example.com:9222/devtools/browser/abc'}
 		mock_client.get = AsyncMock(return_value=mock_response)
 


### PR DESCRIPTION
Was debugging a remote browser connection issue where the CDP endpoint was temporarily returning 502 responses. Instead of a clear error message, I was getting a raw `JSONDecodeError` from the `version_info.json()` call at the `/json/version` fetch in `BrowserSession.connect()`.

The original code at line 1752 did:
```python
self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
```

This has three failure modes that all produce cryptic errors:
1. **Non-200 HTTP response** (e.g., 502 Bad Gateway when the remote browser is restarting) → `JSONDecodeError` because the response body is HTML, not JSON
2. **Non-JSON response body** (e.g., connecting to a URL that isn't actually a CDP endpoint) → same `JSONDecodeError`
3. **Valid JSON but missing `webSocketDebuggerUrl` key** (e.g., incompatible endpoint) → `KeyError`

All three propagate as unhandled exceptions with no context about what the user should check.

### Fix

Added three explicit validation checks before assigning the WebSocket URL:

```python
if version_info.status_code != 200:
    raise RuntimeError(f'CDP endpoint {url} returned HTTP {status}. ...')

try:
    version_data = version_info.json()
except Exception as e:
    raise RuntimeError(f'CDP endpoint {url} returned a non-JSON response ...') from e

ws_url = version_data.get('webSocketDebuggerUrl')
if not ws_url:
    raise RuntimeError(f'CDP endpoint {url} response is missing "webSocketDebuggerUrl". ...')
```

Each raises a `RuntimeError` with actionable context (the URL, the status code, and what to check). Exception chaining (`from e`) preserves the original traceback for debugging.

Also fixed the existing `test_headers_used_for_json_version_endpoint` test mock to explicitly set `status_code=200` and corrected the `__aexit__` return value to `False` so exceptions aren't silently suppressed by the async context manager mock.

### Tests

Added 4 tests in `tests/ci/browser/test_cdp_connect_errors.py`:
- `test_connect_raises_on_non_200_status` — verifies HTTP 502 → clear RuntimeError
- `test_connect_raises_on_non_json_response` — verifies HTML body → clear RuntimeError
- `test_connect_raises_on_missing_ws_url` — verifies missing key → clear RuntimeError
- `test_connect_succeeds_with_valid_json_version_response` — verifies happy path still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle non-200 and malformed CDP `/json/version` responses in `BrowserSession.connect()` to show clear, actionable errors instead of cryptic JSON/Key errors. Adds focused tests and fixes a mock that was suppressing exceptions.

- **Bug Fixes**
  - Add three validations: non-200 status, non-JSON body, and missing `webSocketDebuggerUrl`.
  - Raise `RuntimeError` with URL, status, and guidance; preserve original exception via chaining.
  - Add tests for each failure mode and the success path; fix existing test to set `status_code=200` and return `False` from async `__aexit__`.

<sup>Written for commit 174127242a3aa68369feb72b90968f15171fc31b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

