### PR TITLE
perf(dom): single-pass sibling index for xpath

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -519,21 +519,19 @@ class EnhancedDOMTreeNode:
 		if not element.parent_node or not element.parent_node.children_nodes:
 			return 0
 
-		same_tag_siblings = [
-			child
-			for child in element.parent_node.children_nodes
-			if child.node_type == NodeType.ELEMENT_NODE and child.node_name.lower() == element.node_name.lower()
-		]
+		tag = element.node_name.lower()
+		same_tag_count = 0
+		position_one_based = 0
+		for child in element.parent_node.children_nodes:
+			if child.node_type != NodeType.ELEMENT_NODE or child.node_name.lower() != tag:
+				continue
+			same_tag_count += 1
+			if child is element:
+				position_one_based = same_tag_count
 
-		if len(same_tag_siblings) <= 1:
-			return 0  # No index needed if it's the only one
-
-		try:
-			# XPath is 1-indexed
-			position = same_tag_siblings.index(element) + 1
-			return position
-		except ValueError:
+		if same_tag_count <= 1:
 			return 0
+		return position_one_based if position_one_based > 0 else 0
 
 	def __json__(self) -> dict:
 		"""Serializes the node and its descendants to a dictionary, omitting parent references."""

--- a/tests/ci/test_dom_element_position.py
+++ b/tests/ci/test_dom_element_position.py
@@ -1,0 +1,68 @@
+"""Tests for EnhancedDOMTreeNode._get_element_position (xpath sibling index)."""
+
+from browser_use.dom.views import EnhancedDOMTreeNode, NodeType
+
+
+def _el(
+	node_id: int,
+	backend_node_id: int,
+	tag: str,
+	*,
+	parent: EnhancedDOMTreeNode | None = None,
+	children: list[EnhancedDOMTreeNode] | None = None,
+) -> EnhancedDOMTreeNode:
+	n = EnhancedDOMTreeNode(
+		node_id=node_id,
+		backend_node_id=backend_node_id,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name=tag.upper(),
+		node_value='',
+		attributes={},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=None,
+		target_id='t1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=parent,
+		children_nodes=children,
+		ax_node=None,
+		snapshot_node=None,
+	)
+	return n
+
+
+def test_single_same_tag_sibling_returns_zero():
+	body = _el(1, 1, 'body', children=[])
+	btn = _el(2, 2, 'button', parent=body)
+	body.children_nodes = [btn]
+	assert btn._get_element_position(btn) == 0
+
+
+def test_two_same_tag_siblings_one_based_indices():
+	body = _el(1, 1, 'body', children=[])
+	a = _el(2, 2, 'div', parent=body)
+	b = _el(3, 3, 'div', parent=body)
+	body.children_nodes = [a, b]
+	assert a._get_element_position(a) == 1
+	assert b._get_element_position(b) == 2
+
+
+def test_position_skips_non_element_and_other_tags():
+	body = _el(1, 1, 'body', children=[])
+	span = _el(2, 2, 'span', parent=body)
+	a = _el(3, 3, 'div', parent=body)
+	b = _el(4, 4, 'div', parent=body)
+	body.children_nodes = [span, a, b]
+	assert a._get_element_position(a) == 1
+	assert b._get_element_position(b) == 2
+
+
+def test_element_not_in_parent_children_returns_zero():
+	body = _el(1, 1, 'body', children=[])
+	orphan = _el(9, 9, 'div', parent=body)
+	body.children_nodes = []
+	assert orphan._get_element_position(orphan) == 0


### PR DESCRIPTION
Replace list + index in _get_element_position with one scan of parent children. Same 1-based semantics and empty index when only one same-tag sibling. Add unit tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes XPath sibling index calculation in `_get_element_position` by scanning siblings once instead of building a filtered list. Keeps the same 1-based behavior and returns 0 when only one same-tag sibling; adds tests.

- **Refactors**
  - Single-pass scan of `parent_node.children_nodes` to count same-tag elements and find position.
  - Skips non-element and other tags; returns 0 if only one match or element not found.
  - Adds unit tests covering single/multiple siblings, mixed node types, and orphan cases.

<sup>Written for commit 1aaa6b9dd4e77b4cdb189c39ad5b982f32e07812. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

