### PR TITLE
feat(dom): add debug logging for element exclusion in DOM serializer

### DIFF
--- a/browser_use/dom/serializer/paint_order.py
+++ b/browser_use/dom/serializer/paint_order.py
@@ -1,11 +1,14 @@
+"""
+Helper class for maintaining a union of rectangles (used for order of elements calculation)
+"""
+
+import logging
 from collections import defaultdict
 from dataclasses import dataclass
 
 from browser_use.dom.views import SimplifiedNode
 
-"""
-Helper class for maintaining a union of rectangles (used for order of elements calculation)
-"""
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -151,6 +154,26 @@ class PaintOrderRemover:
 	def __init__(self, root: SimplifiedNode):
 		self.root = root
 
+	@staticmethod
+	def _log_element_excluded_by_paint_order(node: 'SimplifiedNode', paint_order: int) -> None:
+		"""Log when an element is excluded because it is fully covered by higher paint-order elements."""
+		if not logger.isEnabledFor(logging.DEBUG):
+			return
+		snapshot = node.original_node.snapshot_node
+		if not snapshot or not snapshot.bounds:
+			return
+		attrs = node.original_node.attributes or {}
+		tag = (node.original_node.tag_name or 'unknown').lower()
+		bounds = snapshot.bounds
+		logger.debug(
+			f'Paint order filter: excluding <{tag}> '
+			f'id="{attrs.get("id", "")}" class="{attrs.get("class", "")}" '
+			f'backendNodeId={node.original_node.backend_node_id} | '
+			f'Fully covered by elements with higher paint order | '
+			f'Paint order: {paint_order} | '
+			f'Bounds: x={bounds.x:.1f} y={bounds.y:.1f} w={bounds.width:.1f} h={bounds.height:.1f}'
+		)
+
 	def calculate_paint_order(self) -> None:
 		all_simplified_nodes_with_paint_order: list[SimplifiedNode] = []
 
@@ -191,6 +214,7 @@ class PaintOrderRemover:
 
 				if rect_union.contains(rect):
 					node.ignored_by_paint_order = True
+					self._log_element_excluded_by_paint_order(node, paint_order)
 
 				# don't add to the nodes if opacity is less then 0.95 or background-color is transparent
 				if (

--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -1,5 +1,6 @@
 # @file purpose: Serializes enhanced DOM trees to string format for LLM consumption
 
+import logging
 from typing import Any
 
 from browser_use.dom.serializer.clickable_elements import ClickableElementDetector
@@ -14,6 +15,8 @@ from browser_use.dom.views import (
 	SerializedDOMState,
 	SimplifiedNode,
 )
+
+logger = logging.getLogger(__name__)
 
 DISABLED_ELEMENTS = {'style', 'script', 'head', 'meta', 'link', 'title'}
 
@@ -628,26 +631,7 @@ class DOMTreeSerializer:
 
 			# DIAGNOSTIC: Log when interactive elements don't have snapshot_node
 			if is_interactive_assign and not node.original_node.snapshot_node:
-				import logging
-
-				logger = logging.getLogger('browser_use.dom.serializer')
-				attrs = node.original_node.attributes or {}
-				attr_str = f'name={attrs.get("name", "")} id={attrs.get("id", "")} type={attrs.get("type", "")}'
-				in_shadow = self._is_inside_shadow_dom(node)
-				if (
-					in_shadow
-					and node.original_node.tag_name
-					and node.original_node.tag_name.lower() in ['input', 'button', 'select', 'textarea', 'a']
-				):
-					logger.debug(
-						f'🔍 INCLUDING shadow DOM <{node.original_node.tag_name}> (no snapshot_node but in shadow DOM): '
-						f'backendNodeId={node.original_node.backend_node_id} {attr_str}'
-					)
-				else:
-					logger.debug(
-						f'🔍 SKIPPING interactive <{node.original_node.tag_name}> (no snapshot_node, not in shadow DOM): '
-						f'backendNodeId={node.original_node.backend_node_id} {attr_str}'
-					)
+				self._log_interactive_no_snapshot(node)
 
 			# EXCEPTION: File inputs are often hidden with opacity:0 but are still functional
 			# Bootstrap and other frameworks use this pattern with custom-styled file pickers
@@ -722,6 +706,10 @@ class DOMTreeSerializer:
 					if node.original_node.backend_node_id not in previous_backend_node_ids:
 						node.is_new = True
 
+		# Log interactive elements that were excluded by bbox or paint order filtering
+		if node.excluded_by_parent or node.ignored_by_paint_order:
+			self._log_interactive_element_not_added(node)
+
 		# Process children
 		for child in node.children:
 			self._assign_interactive_indices_and_mark_new_nodes(child)
@@ -737,9 +725,7 @@ class DOMTreeSerializer:
 		# Log statistics
 		excluded_count = self._count_excluded_nodes(node)
 		if excluded_count > 0:
-			import logging
-
-			logging.debug(f'BBox filtering excluded {excluded_count} nodes')
+			logger.debug(f'BBox filtering excluded {excluded_count} nodes')
 
 		return node
 
@@ -835,6 +821,7 @@ class DOMTreeSerializer:
 				return False
 
 		# Default: exclude this child
+		self._log_element_excluded_by_bbox(node, active_bounds)
 		return True
 
 	def _is_contained(self, child: DOMRect, parent: DOMRect, threshold: float) -> bool:
@@ -864,6 +851,68 @@ class DOMTreeSerializer:
 		for child in node.children:
 			count = self._count_excluded_nodes(child, count)
 		return count
+
+	def _log_interactive_no_snapshot(self, node: SimplifiedNode) -> None:
+		"""Log when an interactive element has no snapshot_node."""
+		if not logger.isEnabledFor(logging.DEBUG):
+			return
+		attrs = node.original_node.attributes or {}
+		attr_str = f'name={attrs.get("name", "")} id={attrs.get("id", "")} type={attrs.get("type", "")}'
+		tag = node.original_node.tag_name or 'unknown'
+		in_shadow = self._is_inside_shadow_dom(node)
+		if in_shadow and tag.lower() in ['input', 'button', 'select', 'textarea', 'a']:
+			logger.debug(
+				f'Including shadow DOM <{tag}> (no snapshot_node but in shadow DOM): '
+				f'backendNodeId={node.original_node.backend_node_id} {attr_str}'
+			)
+		else:
+			logger.debug(
+				f'Skipping interactive <{tag}> (no snapshot_node, not in shadow DOM): '
+				f'backendNodeId={node.original_node.backend_node_id} {attr_str}'
+			)
+
+	def _log_element_excluded_by_bbox(self, node: SimplifiedNode, active_bounds: 'PropagatingBounds') -> None:
+		"""Log when an element is excluded by bounding box containment filtering."""
+		if not logger.isEnabledFor(logging.DEBUG):
+			return
+		snapshot = node.original_node.snapshot_node
+		if not snapshot or not snapshot.bounds:
+			return
+		attrs = node.original_node.attributes or {}
+		tag = (node.original_node.tag_name or 'unknown').lower()
+		child_bounds = snapshot.bounds
+		logger.debug(
+			f'BBox filter: excluding <{tag}> '
+			f'id="{attrs.get("id", "")}" class="{attrs.get("class", "")}" '
+			f'backendNodeId={node.original_node.backend_node_id} | '
+			f'Contained within parent <{active_bounds.tag}> (nodeId={active_bounds.node_id}) | '
+			f'Child bounds: x={child_bounds.x:.1f} y={child_bounds.y:.1f} '
+			f'w={child_bounds.width:.1f} h={child_bounds.height:.1f} | '
+			f'Parent bounds: x={active_bounds.bounds.x:.1f} y={active_bounds.bounds.y:.1f} '
+			f'w={active_bounds.bounds.width:.1f} h={active_bounds.bounds.height:.1f}'
+		)
+
+	def _log_interactive_element_not_added(self, node: SimplifiedNode) -> None:
+		"""Log when an interactive element is excluded from the selector map."""
+		if not logger.isEnabledFor(logging.DEBUG):
+			return
+		if not self._is_interactive_cached(node.original_node):
+			return
+		attrs = node.original_node.attributes or {}
+		tag = (node.original_node.tag_name or 'unknown').lower()
+		reasons: list[str] = []
+		if node.excluded_by_parent:
+			reasons.append('excluded_by_parent (bbox filtering)')
+		if node.ignored_by_paint_order:
+			reasons.append('ignored_by_paint_order (covered by overlay)')
+		if not reasons:
+			return
+		logger.debug(
+			f'Interactive element not added: <{tag}> '
+			f'id="{attrs.get("id", "")}" class="{attrs.get("class", "")}" '
+			f'backendNodeId={node.original_node.backend_node_id} | '
+			f'Reason: {", ".join(reasons)}'
+		)
 
 	def _is_propagating_element(self, attributes: dict[str, str | None]) -> bool:
 		"""


### PR DESCRIPTION
## Summary

Adds structured debug logs explaining why elements are excluded from the `selector_map` during DOM serialization. This helps users diagnose why certain page elements aren't detected by the agent.

Covers three exclusion scenarios:
- **BBox containment filtering** — element contained within a propagating parent (e.g., `<svg>` inside `<a>`)
- **Paint order occlusion** — element fully covered by higher z-index elements
- **Interactive element not added** — interactive element skipped due to bbox/paint-order exclusion

Closes #3913

## Changes

- `browser_use/dom/serializer/serializer.py`:
  - Added module-level `logger` (replacing inline `import logging` calls)
  - Refactored existing inline diagnostic logging into `_log_interactive_no_snapshot()` method
  - Added `_log_element_excluded_by_bbox()` and `_log_interactive_element_not_added()` methods
  - All logging methods follow the repo's `_log_` prefix convention per CLAUDE.md

- `browser_use/dom/serializer/paint_order.py`:
  - Added module-level `logger`
  - Added `_log_element_excluded_by_paint_order()` static method

## Design decisions

- **`_log_` methods** — per CLAUDE.md convention to keep logging logic out of main code paths
- **`logger.isEnabledFor(logging.DEBUG)` guard** — avoids expensive f-string formatting in hot loops when debug logging is off
- **Null-safe** — explicit checks for `snapshot_node` and `bounds` before accessing, so pyright passes with 0 errors
- **No emoji in new log messages** — kept consistent with the majority of debug logs in the codebase

## Test plan

- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — already formatted
- [x] `uv run pyright` on changed files — 0 errors, 0 warnings
- [x] `uv run pytest -vxs tests/ci/` — **772 passed**, 29 skipped, 0 failures
- [x] Specifically verified DOM-adjacent tests: `test_ax_name_matching`, `test_screenshot_exclusion`, `test_search_find`, `test_history_wait_time` — all pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured debug logs that explain why elements are excluded from the `selector_map` during DOM serialization. Helps diagnose why some elements aren’t detected.

- **New Features**
  - Logs when nodes are excluded: bounding-box containment, paint-order occlusion, and interactive elements skipped due to these filters.
  - Centralized `_log_*` helpers and module-level `logger` with DEBUG guards and null-safe checks to avoid overhead and errors.

<sup>Written for commit bb8fcfe22ed5c20e785de40087806dd28ebfceaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

