### PR TITLE
feat(mcp): expose LLM usage from browser_extract_content for adapters

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -198,6 +198,10 @@ class BrowserUseServer:
 		self.tools: Tools | None = None
 		self.llm: ChatOpenAI | None = None
 		self.file_system: FileSystem | None = None
+		# Last LLM usage from browser_extract_content (for HTTP / embedded adapters)
+		self._last_llm_usage: dict[str, Any] | None = None
+		self._last_llm_model: str | None = None
+		self._last_llm_provider: str | None = None
 		self._telemetry = ProductTelemetry()
 		self._start_time = time.time()
 
@@ -480,6 +484,10 @@ class BrowserUseServer:
 		self, tool_name: str, arguments: dict[str, Any]
 	) -> str | list[types.TextContent | types.ImageContent]:
 		"""Execute a browser-use tool. Returns str for most tools, or a content list for tools with image output."""
+
+		self._last_llm_usage = None
+		self._last_llm_model = None
+		self._last_llm_provider = None
 
 		# Agent-based tools
 		if tool_name == 'retry_with_browser_use_agent':
@@ -1009,6 +1017,12 @@ class BrowserUseServer:
 			page_extraction_llm=self.llm,
 			file_system=self.file_system,
 		)
+
+		if action_result.metadata and action_result.metadata.get('llm_usage'):
+			self._last_llm_usage = action_result.metadata['llm_usage']
+		if self.llm is not None:
+			self._last_llm_model = str(self.llm.model)
+			self._last_llm_provider = str(self.llm.provider)
 
 		return action_result.extracted_content or 'No content extracted'
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 import anyio
 
@@ -1115,15 +1115,17 @@ You will be given a query, a JSON Schema, and the markdown of a webpage that has
 
 					logger.info(f'📄 {memory}')
 					llm_usage_payload = response.usage.model_dump(mode='json') if response.usage else None
+					structured_meta: dict[str, Any] = {
+						'structured_extraction': True,
+						'extraction_result': extraction_meta.model_dump(mode='json'),
+					}
+					if llm_usage_payload is not None:
+						structured_meta['llm_usage'] = llm_usage_payload
 					return ActionResult(
 						extracted_content=extracted_content,
 						include_extracted_content_only_once=include_extracted_content_only_once,
 						long_term_memory=memory,
-						metadata={
-							'structured_extraction': True,
-							'extraction_result': extraction_meta.model_dump(mode='json'),
-							'llm_usage': llm_usage_payload,
-						},
+						metadata=structured_meta,
 					)
 				except Exception as e:
 					logger.debug(f'Error in structured extraction: {e}')
@@ -1188,7 +1190,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 					extracted_content=extracted_content,
 					include_extracted_content_only_once=include_extracted_content_only_once,
 					long_term_memory=memory,
-					metadata={'llm_usage': llm_usage_payload},
+					metadata={'llm_usage': llm_usage_payload} if llm_usage_payload is not None else None,
 				)
 			except Exception as e:
 				logger.debug(f'Error extracting content: {e}')

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1114,11 +1114,16 @@ You will be given a query, a JSON Schema, and the markdown of a webpage that has
 						include_extracted_content_only_once = True
 
 					logger.info(f'📄 {memory}')
+					llm_usage_payload = response.usage.model_dump(mode='json') if response.usage else None
 					return ActionResult(
 						extracted_content=extracted_content,
 						include_extracted_content_only_once=include_extracted_content_only_once,
 						long_term_memory=memory,
-						metadata={'structured_extraction': True, 'extraction_result': extraction_meta.model_dump(mode='json')},
+						metadata={
+							'structured_extraction': True,
+							'extraction_result': extraction_meta.model_dump(mode='json'),
+							'llm_usage': llm_usage_payload,
+						},
 					)
 				except Exception as e:
 					logger.debug(f'Error in structured extraction: {e}')
@@ -1178,10 +1183,12 @@ You will be given a query and the markdown of a webpage that has been filtered t
 					include_extracted_content_only_once = True
 
 				logger.info(f'📄 {memory}')
+				llm_usage_payload = response.usage.model_dump(mode='json') if response.usage else None
 				return ActionResult(
 					extracted_content=extracted_content,
 					include_extracted_content_only_once=include_extracted_content_only_once,
 					long_term_memory=memory,
+					metadata={'llm_usage': llm_usage_payload},
 				)
 			except Exception as e:
 				logger.debug(f'Error extracting content: {e}')


### PR DESCRIPTION
## Motivation
Hosts embedding `BrowserUseServer` or wrapping tool calls over HTTP need token usage (and model/provider) for billing and observability after `browser_extract_content`.

## Changes
- **Tools extract action** (structured + free-text paths): attach `response.usage` as a JSON-serializable dict under `ActionResult.metadata['llm_usage']` when available.
- **BrowserUseServer**: reset last-LLM fields at the start of each `_execute_tool`; after `_extract_content`, mirror `metadata['llm_usage']` and current `self.llm` model/provider so HTTP/embedded adapters can read `_last_llm_usage` / `_last_llm_model` / `_last_llm_provider`.

Refs: downstream control-plane billing integration.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose LLM usage and model/provider from content extraction so adapters can bill and monitor usage. `llm_usage` is only included when available; `BrowserUseServer` exposes the last usage/model/provider for HTTP/embedded integrations.

- **New Features**
  - Add `ActionResult.metadata['llm_usage']` by serializing `response.usage` for structured and free-text extraction when present.
  - In `BrowserUseServer`, reset last-LLM fields per tool call; after `_extract_content`, set `_last_llm_usage`, `_last_llm_model`, `_last_llm_provider` from the result and current `self.llm`.

- **Bug Fixes**
  - Omit `llm_usage` and keep `metadata=None` when usage is absent (e.g., free-text path with no usage).

<sup>Written for commit ee26c0cddb83c0f3539302784150bd4a63293623. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

