### PR TITLE
fix: update browser-use-sdk from 2.0.15 to 3.4.1

### DIFF
--- a/browser_use/skills/service.py
+++ b/browser_use/skills/service.py
@@ -4,9 +4,7 @@ import logging
 import os
 from typing import Any, Literal
 
-from browser_use_sdk import AsyncBrowserUse
-from browser_use_sdk.types.execute_skill_response import ExecuteSkillResponse
-from browser_use_sdk.types.skill_list_response import SkillListResponse
+from browser_use_sdk import AsyncBrowserUse, ExecuteSkillResponse, SkillListResponse
 from cdp_use.cdp.network import Cookie
 from pydantic import BaseModel, ValidationError
 
@@ -60,7 +58,7 @@ class SkillService:
 
 			if use_wildcard:
 				# Wildcard: fetch only first page (max 100 skills) to avoid LLM tool overload
-				skills_response: SkillListResponse = await self._client.skills.list_skills(
+				skills_response: SkillListResponse = await self._client.skills.list(
 					page_size=page_size,
 					page_number=1,
 					is_enabled=True,
@@ -81,7 +79,7 @@ class SkillService:
 				max_pages = 5  # Safety limit
 
 				while page <= max_pages:
-					skills_response = await self._client.skills.list_skills(
+					skills_response = await self._client.skills.list(
 						page_size=page_size,
 						page_number=page,
 						is_enabled=True,
@@ -89,7 +87,7 @@ class SkillService:
 					all_items.extend(skills_response.items)
 
 					# Check if we've found all requested skills
-					found_ids = {s.id for s in all_items if s.id in requested_ids}
+					found_ids = {str(s.id) for s in all_items if str(s.id) in requested_ids}
 					if found_ids == requested_ids:
 						break
 
@@ -104,7 +102,7 @@ class SkillService:
 				logger.debug(f'Fetched {len(all_items)} skills across {page} page(s)')
 
 			# Filter to only finished skills (is_enabled already filtered by API)
-			all_available_skills = [skill for skill in all_items if skill.status == 'finished']
+			all_available_skills = [skill for skill in all_items if skill.status.value == 'finished']
 
 			logger.info(f'Found {len(all_available_skills)} available skills from API')
 
@@ -114,10 +112,10 @@ class SkillService:
 				skills_to_load = all_available_skills
 			else:
 				# Load only the requested skill IDs
-				skills_to_load = [skill for skill in all_available_skills if skill.id in requested_ids]
+				skills_to_load = [skill for skill in all_available_skills if str(skill.id) in requested_ids]
 
 				# Warn about any requested skills that weren't found
-				found_ids = {skill.id for skill in skills_to_load}
+				found_ids = {str(skill.id) for skill in skills_to_load}
 				missing_ids = requested_ids - found_ids
 				if missing_ids:
 					logger.warning(f'Requested skills not found or not available: {missing_ids}')
@@ -256,8 +254,8 @@ class SkillService:
 		# Execute skill via API
 		try:
 			logger.info(f'Executing skill: {skill.title} ({skill_id})')
-			result: ExecuteSkillResponse = await self._client.skills.execute_skill(
-				skill_id=skill_id, parameters=validated_params_dict
+			result: ExecuteSkillResponse = await self._client.skills.execute(
+				skill_id, parameters=validated_params_dict
 			)
 
 			if result.success:

--- a/browser_use/skills/views.py
+++ b/browser_use/skills/views.py
@@ -2,8 +2,7 @@
 
 from typing import Any
 
-from browser_use_sdk.types.parameter_schema import ParameterSchema
-from browser_use_sdk.types.skill_response import SkillResponse
+from browser_use_sdk import ParameterSchema, SkillResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -40,7 +39,7 @@ class Skill(BaseModel):
 	def from_skill_response(response: SkillResponse) -> 'Skill':
 		"""Create a Skill from SDK SkillResponse"""
 		return Skill(
-			id=response.id,
+			id=str(response.id),
 			title=response.title,
 			description=response.description,
 			parameters=response.parameters,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "cloudpickle==3.1.2",
     "markdownify==1.2.2",
     "python-docx==1.2.0",
-    "browser-use-sdk==2.0.15",
+    "browser-use-sdk==3.4.1",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
Fixes #4588

## Problem
`browser-use-sdk` was pinned to `==2.0.15`, but no 2.x patch versions exist after 2.0.15 — the SDK went directly from 2.0.15 to 3.0.3. This pin prevented users from installing browser-use alongside other packages that require newer SDK versions.

## Solution
Updated the pin to `browser-use-sdk==3.4.1` (latest) and fixed the breaking API changes introduced in SDK 3.x:

| Change | Old (2.x) | New (3.x) |
|---|---|---|
| List skills method | `skills.list_skills()` | `skills.list()` |
| Execute skill method | `skills.execute_skill(skill_id=...)` | `skills.execute(skill_id, ...)` |
| `SkillResponse.id` type | `str` | `UUID` |
| `SkillsGenerationStatus` type | `Literal["finished", ...]` | `Enum` |
| Import paths | `browser_use_sdk.types.*` | `browser_use_sdk` (top-level) |

The old `browser_use_sdk.types.*` import paths still work via backward-compat stubs in 3.x, but they are deprecated and scheduled for removal, so this PR also migrates to the recommended top-level imports.

## Testing
- Verified import compatibility by inspecting the 3.4.1 wheel
- Confirmed `SkillListResponse.items`, `SkillResponse.parameters`, `ExecuteSkillResponse.success/error/latency_ms` fields are structurally identical
- The `types.*` stubs in 3.4.1 re-export from `generated.v2.models` confirming backward compatibility at the import level

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `browser-use-sdk` to `3.4.1` and update our skills code to the 3.x APIs to unblock installs with newer SDK versions. Fixes #4588.

- **Refactors**
  - Switched to top-level `browser_use_sdk` imports.
  - Updated calls: `skills.list(...)` (was `list_skills`) and `skills.execute(skill_id, ...)` (was `execute_skill`).
  - Coerce `SkillResponse.id` (UUID) to `str` for comparisons and serialization.
  - Use `status.value == "finished"` to handle the new Enum.

<sup>Written for commit 0bed616508c3a6f50c42118c73fd817b210729fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

