### PR TITLE
feat: Add VeroQ Shield TrustProvider — output accuracy verification

### DIFF
--- a/browser_use/integrations/trust/__init__.py
+++ b/browser_use/integrations/trust/__init__.py
@@ -1,0 +1,61 @@
+"""
+Trust Provider integrations for Browser Use.
+
+Provides trust verification for AI agents via the Agent-Trust-Score HTTP
+header. Multiple providers cover different trust dimensions:
+
+- **AgentID**: Identity resolution (is this agent who it claims to be?)
+- **VeroQ Shield**: Output accuracy (is the agent's output actually correct?)
+
+Usage:
+	from browser_use.integrations.trust import (
+		AgentIDTrustProvider,
+		VeroQShieldTrustProvider,
+		TrustPolicy,
+		TrustPolicyChain,
+	)
+
+	# Identity check
+	agentid = AgentIDTrustProvider(api_key="key_...")
+	jwt = await agentid.get_trust_jwt("agent_abc123")
+
+	# Output accuracy check
+	shield = VeroQShieldTrustProvider(api_key="vq_...")
+	jwt = await shield.get_trust_jwt(
+		agent_id="agent_abc123",
+		output_text="NVIDIA reported $22.1B in Q4 2024 revenue.",
+	)
+
+	# Evaluate against policy
+	claims = await shield.verify_trust_jwt(jwt)
+	policy = TrustPolicy({"min_trust_score": 50, "action_on_fail": "degrade"})
+	result = policy.evaluate(claims)
+"""
+
+try:
+	from .policy import PolicyResult, TrustPolicy, TrustPolicyChain
+except ImportError as e:
+	if 'pydantic' in str(e):
+		raise ImportError('browser_use.integrations.trust requires pydantic. Install it with: pip install pydantic') from e
+	raise
+
+try:
+	from .service import AgentIDTrustProvider, TrustClaims, TrustProvider
+except ImportError as e:
+	if 'httpx' in str(e):
+		raise ImportError('browser_use.integrations.trust requires httpx. Install it with: pip install httpx') from e
+	raise
+
+from .veroq import ClaimVerdict, ShieldVerification, VeroQShieldTrustProvider
+
+__all__ = [
+	'AgentIDTrustProvider',
+	'VeroQShieldTrustProvider',
+	'TrustClaims',
+	'TrustProvider',
+	'TrustPolicy',
+	'TrustPolicyChain',
+	'PolicyResult',
+	'ClaimVerdict',
+	'ShieldVerification',
+]

--- a/browser_use/integrations/trust/policy.py
+++ b/browser_use/integrations/trust/policy.py
@@ -1,0 +1,182 @@
+"""
+Policy engine for evaluating trust claims against site operator thresholds.
+
+Site operators define policies specifying minimum trust scores, maximum risk
+thresholds, and required attestations. The engine evaluates incoming agent
+trust claims against these policies and returns allow/block/degrade decisions.
+
+Example:
+	policy = TrustPolicy({
+		"min_trust_score": 60,
+		"max_risk_score": 30,
+		"required_attestations": ["identity_verified"],
+		"action_on_fail": "block",
+	})
+	result = policy.evaluate(claims)
+	if result["action"] == "block":
+		# deny the agent
+"""
+
+import logging
+from typing import Literal
+
+try:
+	from pydantic import BaseModel, ConfigDict, Field
+except ImportError as e:
+	raise ImportError('browser_use.integrations.trust.policy requires pydantic. Install it with: pip install pydantic') from e
+
+from .service import TrustClaims
+
+logger = logging.getLogger(__name__)
+
+ActionType = Literal['allow', 'block', 'degrade', 'log']
+
+
+class PolicyResult(BaseModel):
+	"""Result of evaluating trust claims against a policy."""
+
+	model_config = ConfigDict(extra='forbid')
+
+	passed: bool
+	action: ActionType
+	failures: list[str] = Field(default_factory=list)
+	trust_level: str = ''
+	provider: str = ''
+
+
+class TrustPolicy:
+	"""
+	Evaluates TrustClaims against configurable thresholds.
+
+	Supports four failure actions:
+	- block: reject the agent entirely
+	- degrade: allow with reduced capabilities
+	- log: allow but log the policy violation
+	- allow: (only returned on pass)
+	"""
+
+	VALID_ACTIONS: set[str] = {'allow', 'block', 'degrade', 'log'}
+
+	def __init__(self, config: dict | None = None):
+		config = config or {}
+		self.min_trust_score: int = config.get('min_trust_score', 0)
+		self.max_scarring_score: int = config.get('max_scarring_score', 999)
+		self.max_risk_score: int = config.get('max_risk_score', 100)
+		self.required_attestations: list[str] = config.get('required_attestations', [])
+		action = config.get('action_on_fail', 'log')
+		if action not in self.VALID_ACTIONS:
+			raise ValueError(f'Invalid action_on_fail: {action!r}. Must be one of {self.VALID_ACTIONS}')
+		self.action_on_fail: ActionType = action
+
+		if not isinstance(self.min_trust_score, int):
+			raise ValueError(f'min_trust_score must be int, got {type(self.min_trust_score).__name__}')
+		if not isinstance(self.max_scarring_score, int):
+			raise ValueError(f'max_scarring_score must be int, got {type(self.max_scarring_score).__name__}')
+		if not isinstance(self.max_risk_score, int):
+			raise ValueError(f'max_risk_score must be int, got {type(self.max_risk_score).__name__}')
+		if not isinstance(self.required_attestations, list):
+			raise ValueError(f'required_attestations must be list, got {type(self.required_attestations).__name__}')
+		if self.min_trust_score < 0:
+			raise ValueError(f'min_trust_score must be >= 0, got {self.min_trust_score}')
+		if self.max_scarring_score < 0:
+			raise ValueError(f'max_scarring_score must be >= 0, got {self.max_scarring_score}')
+		if self.max_risk_score < 0:
+			raise ValueError(f'max_risk_score must be >= 0, got {self.max_risk_score}')
+
+	def evaluate(self, claims: TrustClaims) -> PolicyResult:
+		"""
+		Evaluate trust claims against this policy.
+
+		Args:
+			claims: Decoded TrustClaims from a verified JWT.
+
+		Returns:
+			PolicyResult indicating whether the agent passed and what action to take.
+		"""
+		# Short-circuit when no trust data is available
+		if claims.no_trust_data:
+			reason = claims.reason or 'no trust data available'
+			logger.warning(f'No trust data for agent {claims.agent_id}: {reason} -> action={self.action_on_fail}')
+			return PolicyResult(
+				passed=False,
+				action=self.action_on_fail,
+				failures=[f'no_trust_data: {reason}'],
+				trust_level=claims.trust_level,
+				provider=claims.provider,
+			)
+
+		failures: list[str] = []
+
+		if claims.trust_score < self.min_trust_score:
+			failures.append(f'trust_score {claims.trust_score} < min {self.min_trust_score}')
+
+		if claims.scarring_score > self.max_scarring_score:
+			failures.append(f'scarring_score {claims.scarring_score} > max {self.max_scarring_score}')
+
+		if claims.risk_score > self.max_risk_score:
+			failures.append(f'risk_score {claims.risk_score} > max {self.max_risk_score}')
+
+		for req in self.required_attestations:
+			if req not in claims.attestations:
+				failures.append(f'missing attestation: {req}')
+
+		passed = len(failures) == 0
+
+		if not passed:
+			logger.info(f'Policy check failed for agent {claims.agent_id}: {", ".join(failures)} -> action={self.action_on_fail}')
+
+		return PolicyResult(
+			passed=passed,
+			action='allow' if passed else self.action_on_fail,
+			failures=failures,
+			trust_level=claims.trust_level,
+			provider=claims.provider,
+		)
+
+
+class TrustPolicyChain:
+	"""
+	Evaluate claims against multiple policies in sequence.
+
+	The most restrictive result wins — if any policy returns 'block',
+	the overall result is 'block'. 'degrade' takes precedence over 'log'.
+	"""
+
+	ACTION_PRIORITY: dict[ActionType, int] = {
+		'allow': 0,
+		'log': 1,
+		'degrade': 2,
+		'block': 3,
+	}
+
+	def __init__(self, policies: list[TrustPolicy] | None = None):
+		self.policies = policies or []
+
+	def add(self, policy: TrustPolicy) -> None:
+		self.policies.append(policy)
+
+	def evaluate(self, claims: TrustClaims) -> PolicyResult:
+		"""Evaluate all policies and return the most restrictive result."""
+		if not self.policies:
+			raise ValueError('Policy chain must have at least one policy')
+
+		results = [p.evaluate(claims) for p in self.policies]
+
+		# Merge: collect all failures, use most restrictive action
+		all_failures: list[str] = []
+		worst_action: ActionType = 'allow'
+
+		for result in results:
+			all_failures.extend(result.failures)
+			if self.ACTION_PRIORITY.get(result.action, 0) > self.ACTION_PRIORITY.get(worst_action, 0):
+				worst_action = result.action
+
+		passed = worst_action == 'allow'
+
+		return PolicyResult(
+			passed=passed,
+			action=worst_action,
+			failures=all_failures,
+			trust_level=claims.trust_level,
+			provider=claims.provider,
+		)

--- a/browser_use/integrations/trust/policy.py
+++ b/browser_use/integrations/trust/policy.py
@@ -171,7 +171,7 @@ class TrustPolicyChain:
 			if self.ACTION_PRIORITY.get(result.action, 0) > self.ACTION_PRIORITY.get(worst_action, 0):
 				worst_action = result.action
 
-		passed = worst_action == 'allow'
+		passed = all(r.passed for r in results)
 
 		return PolicyResult(
 			passed=passed,

--- a/browser_use/integrations/trust/service.py
+++ b/browser_use/integrations/trust/service.py
@@ -102,6 +102,17 @@ class AgentIDTrustProvider(TrustProvider):
 		if base_url:
 			self.BASE_URL = base_url
 		self._cache: dict[str, tuple[str, float]] = {}
+		self._last_prune: float = 0.0
+
+	def _prune_expired(self) -> None:
+		"""Remove expired entries from the cache. Runs at most once per 60 seconds."""
+		now = time.time()
+		if now - self._last_prune < 60:
+			return
+		self._last_prune = now
+		expired = [k for k, (_, expiry) in self._cache.items() if now > expiry]
+		for k in expired:
+			del self._cache[k]
 
 	async def get_no_trust_header(self, reason: str = 'provider_unreachable') -> str:
 		"""Return a minimal JWT indicating no trust data is available.
@@ -153,6 +164,8 @@ class AgentIDTrustProvider(TrustProvider):
 		"""
 		if not agent_id:
 			raise ValueError('agent_id must not be empty')
+
+		self._prune_expired()
 
 		try:
 			# Check cache
@@ -246,6 +259,11 @@ class AgentIDTrustProvider(TrustProvider):
 					'Unsigned JWT (alg=none / empty signature) is only accepted '
 					'for no_trust_data payloads — refusing unverified trust claims'
 				)
+
+		# Note: AgentID JWTs are signed by the AgentID server. The client api_key
+		# is a bearer token for API access, not the HMAC signing secret. Full
+		# cryptographic verification requires the provider's public key and should
+		# be done server-side. Client-side decoding here is for claim extraction only.
 
 		claims = TrustClaims(**payload)
 

--- a/browser_use/integrations/trust/service.py
+++ b/browser_use/integrations/trust/service.py
@@ -1,0 +1,266 @@
+"""
+AgentID Trust Provider — generates and verifies Agent-Trust-Score JWTs.
+
+This module implements the TrustProvider interface for the AgentID protocol.
+Browser-use agents attach these JWTs to requests so site operators can make
+trust-based access decisions.
+
+Protocol spec: https://getagentid.dev/docs/trust-protocol
+"""
+
+import base64
+import json
+import logging
+import time
+from abc import ABC, abstractmethod
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+logger = logging.getLogger(__name__)
+
+
+class TrustClaims(BaseModel):
+	"""Decoded trust claims from an Agent-Trust-Score JWT."""
+
+	model_config = ConfigDict(extra='allow')
+
+	agent_id: str = ''
+	trust_score: int = 0
+	trust_level: str = 'L1'
+	scarring_score: int = 0
+	risk_score: int = 0
+	attestations: list[str] = Field(default_factory=list)
+	attestation_count: int = 0
+	provider: str = ''
+	no_trust_data: bool = False
+	reason: str = ''
+	iat: int = 0
+	exp: int = 0
+
+	@field_validator('trust_level')
+	@classmethod
+	def validate_trust_level(cls, v: str) -> str:
+		valid_levels = {'L0', 'L1', 'L2', 'L3', 'L4'}
+		if v not in valid_levels:
+			raise ValueError(f'Invalid trust level: {v}. Must be one of {valid_levels}')
+		return v
+
+	@property
+	def is_expired(self) -> bool:
+		return time.time() > self.exp
+
+	def meets_policy(self, policy: dict) -> bool:
+		"""Check if claims meet a threshold policy dict."""
+		if policy.get('min_trust_score') is not None and self.trust_score < policy['min_trust_score']:
+			return False
+		if policy.get('max_scarring_score') is not None and self.scarring_score > policy['max_scarring_score']:
+			return False
+		if policy.get('max_risk_score') is not None and self.risk_score > policy['max_risk_score']:
+			return False
+		required = policy.get('required_attestations', [])
+		for req in required:
+			if req not in self.attestations:
+				return False
+		return True
+
+
+class TrustProvider(ABC):
+	"""Abstract base class for trust providers."""
+
+	@abstractmethod
+	async def get_trust_jwt(self, agent_id: str) -> str:
+		"""Get a signed trust JWT for the given agent."""
+		...
+
+	@abstractmethod
+	async def verify_trust_jwt(self, jwt: str) -> TrustClaims:
+		"""Decode and verify a trust JWT, returning claims."""
+		...
+
+
+class AgentIDTrustProvider(TrustProvider):
+	"""
+	AgentID trust provider — generates and verifies Agent-Trust-Score JWTs.
+
+	The provider fetches signed JWTs from the AgentID API and caches them.
+	JWTs contain trust scores, scarring data, and attestation lists that
+	site operators use to make access control decisions.
+
+	Example:
+		provider = AgentIDTrustProvider(api_key="key_...")
+		jwt = await provider.get_trust_jwt("agent_abc123")
+		claims = await provider.verify_trust_jwt(jwt)
+		print(f"Trust score: {claims.trust_score}, Level: {claims.trust_level}")
+	"""
+
+	BASE_URL = 'https://getagentid.dev/api/v1'
+	CACHE_TTL_SECONDS = 3500  # slightly under 1 hour
+
+	def __init__(self, api_key: str | None = None, base_url: str | None = None):
+		self.api_key = api_key
+		if base_url:
+			self.BASE_URL = base_url
+		self._cache: dict[str, tuple[str, float]] = {}
+
+	async def get_no_trust_header(self, reason: str = 'provider_unreachable') -> str:
+		"""Return a minimal JWT indicating no trust data is available.
+
+		Sites need to distinguish 'no data' from 'low trust'. This produces
+		an unsigned JWT with ``no_trust_data: true`` so recipients can apply
+		their ``action_on_fail`` policy immediately.
+
+		Args:
+			reason: Human-readable explanation (e.g. the exception message).
+
+		Returns:
+			An unsigned JWT string with ``alg: none``.
+		"""
+		payload = {
+			'agent_id': 'unknown',
+			'trust_score': 0,
+			'trust_level': 'L0',
+			'scarring_score': 0,
+			'risk_score': 1.0,
+			'attestations': [],
+			'attestation_count': 0,
+			'provider': 'agentid',
+			'no_trust_data': True,
+			'reason': reason,
+			'iat': int(time.time()),
+			'exp': int(time.time()) + 300,  # 5 min expiry for no-data headers
+		}
+		header = base64.urlsafe_b64encode(json.dumps({'alg': 'none', 'typ': 'Agent-Trust-Score'}).encode()).decode().rstrip('=')
+		body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
+		return f'{header}.{body}.'
+
+	async def get_trust_jwt(self, agent_id: str) -> str:
+		"""
+		Get a signed Agent-Trust-Score JWT for an agent.
+
+		Checks the local cache first. If the cached JWT is still valid, returns it.
+		Otherwise fetches a fresh JWT from the AgentID API.
+
+		If the provider is unreachable or any error occurs, returns a no-trust-data
+		header instead of raising, so callers always get a usable JWT.
+
+		Args:
+			agent_id: The agent's unique identifier.
+
+		Returns:
+			A signed JWT string suitable for the Agent-Trust-Score header,
+			or an unsigned no-trust-data JWT on failure.
+		"""
+		if not agent_id:
+			raise ValueError('agent_id must not be empty')
+
+		try:
+			# Check cache
+			if agent_id in self._cache:
+				jwt, expiry = self._cache[agent_id]
+				if time.time() < expiry:
+					logger.debug(f'Cache hit for agent {agent_id}')
+					return jwt
+
+			headers = {}
+			if self.api_key:
+				headers['Authorization'] = f'Bearer {self.api_key}'
+
+			async with httpx.AsyncClient() as client:
+				resp = await client.get(
+					f'{self.BASE_URL}/agents/trust-header',
+					params={'agent_id': agent_id},
+					headers=headers,
+					timeout=10,
+				)
+				resp.raise_for_status()
+
+				data = resp.json()
+				jwt = data.get('header')
+				if not jwt:
+					raise Exception(f'API response missing "header" field: {data}')
+
+				# Cache it
+				self._cache[agent_id] = (jwt, time.time() + self.CACHE_TTL_SECONDS)
+				logger.info(f'Fetched trust JWT for agent {agent_id}')
+
+				return jwt
+		except Exception as e:
+			logger.warning(f'Failed to fetch trust JWT for agent {agent_id}: {e}')
+			return await self.get_no_trust_header(reason=str(e))
+
+	async def verify_trust_jwt(self, jwt: str) -> TrustClaims:
+		"""
+		Decode and verify an Agent-Trust-Score JWT.
+
+		Decodes the JWT header and payload, validates structural requirements,
+		and checks the ``alg`` field. Unsigned JWTs (``alg: none``) are only
+		accepted when the payload carries ``no_trust_data: true`` — all other
+		JWTs must have a non-empty signature segment.
+
+		Full cryptographic signature verification should be done server-side
+		or with the provider's public key.
+
+		Args:
+			jwt: The raw JWT string (three dot-separated base64url segments).
+
+		Returns:
+			TrustClaims with decoded payload data.
+
+		Raises:
+			ValueError: If the JWT format is invalid, expired, or from an unknown provider.
+		"""
+		if not jwt:
+			raise ValueError('jwt must not be empty')
+
+		parts = jwt.split('.')
+		if len(parts) != 3:
+			raise ValueError(f'Invalid JWT format: expected 3 parts, got {len(parts)}')
+
+		# Decode header to inspect alg
+		header_b64 = parts[0]
+		header_b64 += '=' * (-len(header_b64) % 4)
+		try:
+			header = json.loads(base64.urlsafe_b64decode(header_b64))
+		except Exception as e:
+			raise ValueError(f'Failed to decode JWT header: {e}')
+
+		# Decode payload (base64url -> JSON)
+		payload_b64 = parts[1]
+		# Add padding for base64
+		payload_b64 += '=' * (-len(payload_b64) % 4)
+		try:
+			payload_json = base64.urlsafe_b64decode(payload_b64)
+			payload = json.loads(payload_json)
+		except Exception as e:
+			raise ValueError(f'Failed to decode JWT payload: {e}')
+
+		alg = header.get('alg', '')
+		signature_segment = parts[2]
+		is_no_trust = payload.get('no_trust_data', False)
+
+		# Reject unsigned JWTs that claim to carry real trust data
+		if alg == 'none' or not signature_segment:
+			if not is_no_trust:
+				raise ValueError(
+					'Unsigned JWT (alg=none / empty signature) is only accepted '
+					'for no_trust_data payloads — refusing unverified trust claims'
+				)
+
+		claims = TrustClaims(**payload)
+
+		if claims.is_expired:
+			raise ValueError(f'JWT expired at {claims.exp}, current time is {int(time.time())}')
+
+		if claims.provider and claims.provider != 'agentid':
+			raise ValueError(f'Unknown provider: {claims.provider}')
+
+		return claims
+
+	def clear_cache(self) -> None:
+		"""Clear the JWT cache."""
+		self._cache.clear()
+
+	def remove_from_cache(self, agent_id: str) -> None:
+		"""Remove a specific agent from the cache."""
+		self._cache.pop(agent_id, None)

--- a/browser_use/integrations/trust/veroq.py
+++ b/browser_use/integrations/trust/veroq.py
@@ -1,0 +1,466 @@
+"""
+VeroQ Shield Trust Provider — output accuracy verification for browser agents.
+
+The other trust providers answer "should I engage with this agent?" (identity,
+attestation, interaction history). This provider answers a different question:
+"is the agent's output actually accurate?" — post-call verification that
+catches hallucinations and factual drift even from well-identified, highly-
+attested agents.
+
+VeroQ Shield extracts verifiable claims from any LLM output, checks them
+against live evidence, and returns per-claim verdicts with confidence scores.
+Verification receipts provide a permanent, tamper-evident audit trail.
+
+API docs: https://veroq.ai/docs
+Python SDK: pip install veroq
+GitHub: https://github.com/veroq-ai/shield
+
+Usage:
+	from browser_use.integrations.trust import VeroQShieldTrustProvider
+
+	provider = VeroQShieldTrustProvider(api_key="vq_...")
+	jwt = await provider.get_trust_jwt(
+		agent_id="agent_abc123",
+		output_text="NVIDIA reported $22.1B in Q4 2024 revenue, up 265% YoY.",
+	)
+	claims = await provider.verify_trust_jwt(jwt)
+	print(f"Output trust: {claims.trust_score}/100, Level: {claims.trust_level}")
+"""
+
+import base64
+import hashlib
+import json
+import logging
+import time
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from .service import TrustClaims, TrustProvider
+
+logger = logging.getLogger(__name__)
+
+
+class ClaimVerdict(BaseModel):
+	"""Individual claim verdict from VeroQ Shield verification."""
+
+	model_config = ConfigDict(extra='allow')
+
+	text: str
+	category: str = 'general'
+	verdict: str = 'unverifiable'
+	confidence: float = 0.0
+	receipt_id: str | None = None
+	correction: str | None = None
+
+
+class ShieldVerification(BaseModel):
+	"""Full verification result from VeroQ Shield."""
+
+	model_config = ConfigDict(extra='allow')
+
+	claims: list[ClaimVerdict] = Field(default_factory=list)
+	claims_extracted: int = 0
+	claims_verified: int = 0
+	claims_supported: int = 0
+	claims_contradicted: int = 0
+	overall_confidence: float = 0.0
+	overall_verdict: str = 'unknown'
+	summary: str = ''
+	receipt_ids: list[str] = Field(default_factory=list)
+
+
+class VeroQShieldTrustProvider(TrustProvider):
+	"""
+	VeroQ Shield trust provider — output accuracy verification.
+
+	Unlike identity/attestation providers that gate *access*, Shield gates
+	*content accuracy*. It extracts verifiable claims from LLM output, checks
+	them against live evidence, and produces a trust score (0-100) reflecting
+	how well the output holds up under scrutiny.
+
+	The provider maps Shield's continuous confidence scores to the standard
+	trust level scale:
+		L4 (>= 85): all claims verified with high confidence
+		L3 (>= 70): mostly verified, minor gaps
+		L2 (>= 50): partially verified, some claims unverifiable
+		L1 (>= 25): low confidence or contradictions found
+		L0 (< 25):  output substantially contradicted or unverifiable
+
+	Each JWT includes claim-level verdicts and receipt IDs. Receipts are
+	permanent and publicly verifiable at:
+		https://api.veroq.ai/api/v1/verify/receipt/{receipt_id}
+
+	Example:
+		provider = VeroQShieldTrustProvider(api_key="vq_...")
+		jwt = await provider.get_trust_jwt(
+			agent_id="agent_abc123",
+			output_text="Tesla stock rose 8% after Q3 earnings beat.",
+		)
+		claims = await provider.verify_trust_jwt(jwt)
+		if claims.trust_score >= 70:
+			# output is trustworthy — act on it
+			...
+	"""
+
+	BASE_URL = 'https://api.veroq.ai'
+	CACHE_TTL_SECONDS = 1800  # 30 min — shorter than identity providers since outputs change
+	REQUEST_TIMEOUT_SECONDS = 20  # Shield does LLM + web search per claim
+
+	def __init__(
+		self,
+		api_key: str | None = None,
+		base_url: str | None = None,
+		max_claims: int = 5,
+	):
+		assert api_key is None or isinstance(api_key, str), 'api_key must be a string or None'
+		assert 1 <= max_claims <= 10, 'max_claims must be between 1 and 10'
+
+		self.api_key = api_key
+		if base_url:
+			self.BASE_URL = base_url
+		self.max_claims = max_claims
+		self._cache: dict[str, tuple[str, float]] = {}
+
+	@staticmethod
+	def _text_hash(text: str) -> str:
+		"""SHA-256 hash of text, used for cache keys and claim dedup."""
+		return hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]
+
+	@staticmethod
+	def _confidence_to_trust_score(confidence: float) -> int:
+		"""Map Shield's 0-1 confidence to 0-100 trust score."""
+		return max(0, min(100, int(round(confidence * 100))))
+
+	@staticmethod
+	def _score_to_level(score: int) -> str:
+		"""Map 0-100 trust score to L0-L4 trust level."""
+		if score >= 85:
+			return 'L4'
+		if score >= 70:
+			return 'L3'
+		if score >= 50:
+			return 'L2'
+		if score >= 25:
+			return 'L1'
+		return 'L0'
+
+	async def _call_shield(self, text: str, source: str | None = None) -> ShieldVerification:
+		"""Call VeroQ Shield verify/output endpoint.
+
+		Args:
+			text: LLM output to verify (20-10000 chars).
+			source: Optional LLM source identifier.
+
+		Returns:
+			ShieldVerification with claim-level verdicts.
+
+		Raises:
+			httpx.HTTPStatusError: On non-2xx response.
+			httpx.TimeoutException: On timeout.
+		"""
+		assert len(text) >= 20, 'text must be at least 20 characters'
+
+		headers: dict[str, str] = {'Content-Type': 'application/json'}
+		if self.api_key:
+			headers['X-API-Key'] = self.api_key
+
+		body: dict[str, str | int] = {
+			'text': text[:10000],
+			'max_claims': self.max_claims,
+		}
+		if source:
+			body['source'] = source
+
+		async with httpx.AsyncClient() as client:
+			resp = await client.post(
+				f'{self.BASE_URL}/api/v1/verify/output',
+				headers=headers,
+				json=body,
+				timeout=self.REQUEST_TIMEOUT_SECONDS,
+			)
+			resp.raise_for_status()
+			data = resp.json()
+
+		# Parse claim verdicts
+		claims = [
+			ClaimVerdict(
+				text=c.get('text', ''),
+				category=c.get('category', 'general'),
+				verdict=c.get('verdict', 'unverifiable'),
+				confidence=c.get('confidence', 0.0),
+				receipt_id=c.get('receipt_id'),
+				correction=c.get('correction'),
+			)
+			for c in data.get('claims', [])
+		]
+
+		receipt_ids = [c.receipt_id for c in claims if c.receipt_id]
+
+		return ShieldVerification(
+			claims=claims,
+			claims_extracted=data.get('claims_extracted', 0),
+			claims_verified=data.get('claims_verified', 0),
+			claims_supported=data.get('claims_supported', 0),
+			claims_contradicted=data.get('claims_contradicted', 0),
+			overall_confidence=data.get('overall_confidence', 0.0),
+			overall_verdict=data.get('overall_verdict', 'unknown'),
+			summary=data.get('summary', ''),
+			receipt_ids=receipt_ids,
+		)
+
+	async def get_no_trust_header(self, agent_id: str = 'unknown', reason: str = 'provider_unreachable') -> str:
+		"""Return a minimal JWT indicating no trust data is available.
+
+		Follows the same convention as AgentIDTrustProvider: unsigned JWT
+		with ``no_trust_data: true`` so the policy engine can apply
+		``action_on_fail`` immediately.
+
+		Args:
+			agent_id: The agent ID (included in payload for diagnostics).
+			reason: Human-readable explanation.
+
+		Returns:
+			An unsigned JWT string with ``alg: none``.
+		"""
+		payload = {
+			'agent_id': agent_id,
+			'trust_score': 0,
+			'trust_level': 'L0',
+			'scarring_score': 0,
+			'risk_score': 100,
+			'attestations': [],
+			'attestation_count': 0,
+			'provider': 'veroq_shield',
+			'no_trust_data': True,
+			'reason': reason,
+			'iat': int(time.time()),
+			'exp': int(time.time()) + 300,
+		}
+		header = base64.urlsafe_b64encode(
+			json.dumps({'alg': 'none', 'typ': 'Agent-Trust-Score'}).encode()
+		).decode().rstrip('=')
+		body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
+		return f'{header}.{body}.'
+
+	async def get_trust_jwt(self, agent_id: str, output_text: str | None = None, source: str | None = None) -> str:
+		"""
+		Get an Agent-Trust-Score JWT based on output accuracy verification.
+
+		If ``output_text`` is provided, Shield verifies its claims and produces
+		a trust score reflecting accuracy. If omitted or too short, returns a
+		no-trust-data header (since there's nothing to verify).
+
+		Results are cached by SHA-256(agent_id + text) for CACHE_TTL_SECONDS.
+		On any API failure, returns a no-trust-data JWT — never raises.
+
+		Args:
+			agent_id: The agent's unique identifier.
+			output_text: The LLM output to verify.
+			source: Optional LLM source identifier (e.g. "gpt-5.4").
+
+		Returns:
+			A signed JWT string suitable for the Agent-Trust-Score header,
+			or an unsigned no-trust-data JWT on failure.
+		"""
+		if not agent_id:
+			raise ValueError('agent_id must not be empty')
+
+		# No text to verify — return no-trust-data
+		if not output_text or len(output_text.strip()) < 20:
+			return await self.get_no_trust_header(
+				agent_id=agent_id,
+				reason='no output text provided for verification',
+			)
+
+		# Cache key: agent + text content hash
+		cache_key = f'{agent_id}:{self._text_hash(output_text)}'
+
+		try:
+			# Check cache
+			if cache_key in self._cache:
+				jwt, expiry = self._cache[cache_key]
+				if time.time() < expiry:
+					logger.debug(f'Cache hit for agent {agent_id} output verification')
+					return jwt
+
+			# Call Shield API
+			verification = await self._call_shield(output_text, source=source)
+
+			trust_score = self._confidence_to_trust_score(verification.overall_confidence)
+			trust_level = self._score_to_level(trust_score)
+
+			# Build attestation list from verification results
+			attestations: list[str] = ['output_verified']
+			if verification.claims_supported > 0:
+				attestations.append('claims_supported')
+			if verification.claims_contradicted == 0 and verification.claims_verified > 0:
+				attestations.append('no_contradictions')
+			if verification.receipt_ids:
+				attestations.append('receipt_available')
+
+			# Scarring: contradicted claims increase scarring score
+			scarring = min(verification.claims_contradicted * 3, 10)
+
+			# Risk: inverse of trust score, weighted by contradiction ratio
+			contradiction_ratio = (
+				verification.claims_contradicted / max(verification.claims_verified, 1)
+			)
+			risk_score = max(0, min(100, int(round(contradiction_ratio * 100))))
+
+			payload = {
+				'agent_id': agent_id,
+				'trust_score': trust_score,
+				'trust_level': trust_level,
+				'scarring_score': scarring,
+				'risk_score': risk_score,
+				'attestations': attestations,
+				'attestation_count': len(attestations),
+				'provider': 'veroq_shield',
+				'verification': {
+					'overall_verdict': verification.overall_verdict,
+					'claims_extracted': verification.claims_extracted,
+					'claims_verified': verification.claims_verified,
+					'claims_supported': verification.claims_supported,
+					'claims_contradicted': verification.claims_contradicted,
+					'receipt_ids': verification.receipt_ids,
+					'summary': verification.summary,
+					'claim_verdicts': [
+						{
+							'text': c.text,
+							'verdict': c.verdict,
+							'confidence': c.confidence,
+							'receipt_id': c.receipt_id,
+						}
+						for c in verification.claims
+					],
+				},
+				'iat': int(time.time()),
+				'exp': int(time.time()) + self.CACHE_TTL_SECONDS,
+			}
+
+			# Build JWT (HMAC signed if api_key available, unsigned otherwise)
+			header_data = {'alg': 'HS256', 'typ': 'Agent-Trust-Score'}
+			header = base64.urlsafe_b64encode(
+				json.dumps(header_data).encode()
+			).decode().rstrip('=')
+			body = base64.urlsafe_b64encode(
+				json.dumps(payload).encode()
+			).decode().rstrip('=')
+
+			if self.api_key:
+				import hmac
+				sig_input = f'{header}.{body}'.encode()
+				sig = hmac.new(
+					self.api_key.encode(), sig_input, hashlib.sha256,
+				).digest()
+				sig_b64 = base64.urlsafe_b64encode(sig).decode().rstrip('=')
+			else:
+				sig_b64 = base64.urlsafe_b64encode(b'unsigned').decode().rstrip('=')
+
+			jwt = f'{header}.{body}.{sig_b64}'
+
+			# Cache it
+			self._cache[cache_key] = (jwt, time.time() + self.CACHE_TTL_SECONDS)
+			logger.info(
+				f'Shield verification for agent {agent_id}: '
+				f'score={trust_score}, level={trust_level}, '
+				f'claims={verification.claims_verified}/{verification.claims_extracted}'
+			)
+
+			return jwt
+
+		except Exception as e:
+			logger.warning(f'Failed to verify output for agent {agent_id}: {e}')
+			return await self.get_no_trust_header(agent_id=agent_id, reason=str(e))
+
+	async def verify_trust_jwt(self, jwt: str) -> TrustClaims:
+		"""
+		Decode and verify a VeroQ Shield trust JWT.
+
+		Decodes the JWT payload and validates structure. Accepts JWTs from the
+		``veroq_shield`` provider. Unsigned JWTs (``alg: none``) are only
+		accepted when ``no_trust_data: true``.
+
+		The decoded claims include a ``verification`` extra field with
+		claim-level verdicts and receipt IDs for audit trail.
+
+		Args:
+			jwt: The raw JWT string (three dot-separated base64url segments).
+
+		Returns:
+			TrustClaims with decoded payload data. Access ``verification``
+			details via ``claims.model_extra['verification']``.
+
+		Raises:
+			ValueError: If the JWT format is invalid, expired, or wrong provider.
+		"""
+		if not jwt:
+			raise ValueError('jwt must not be empty')
+
+		parts = jwt.split('.')
+		if len(parts) != 3:
+			raise ValueError(f'Invalid JWT format: expected 3 parts, got {len(parts)}')
+
+		# Decode header
+		header_b64 = parts[0]
+		header_b64 += '=' * (-len(header_b64) % 4)
+		try:
+			header = json.loads(base64.urlsafe_b64decode(header_b64))
+		except Exception as e:
+			raise ValueError(f'Failed to decode JWT header: {e}')
+
+		# Decode payload
+		payload_b64 = parts[1]
+		payload_b64 += '=' * (-len(payload_b64) % 4)
+		try:
+			payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+		except Exception as e:
+			raise ValueError(f'Failed to decode JWT payload: {e}')
+
+		alg = header.get('alg', '')
+		signature_segment = parts[2]
+		is_no_trust = payload.get('no_trust_data', False)
+
+		# Reject unsigned JWTs that claim to carry real trust data
+		if alg == 'none' or not signature_segment:
+			if not is_no_trust:
+				raise ValueError(
+					'Unsigned JWT (alg=none / empty signature) is only accepted '
+					'for no_trust_data payloads — refusing unverified trust claims'
+				)
+
+		claims = TrustClaims(**payload)
+
+		if claims.is_expired:
+			raise ValueError(f'JWT expired at {claims.exp}, current time is {int(time.time())}')
+
+		if claims.provider and claims.provider != 'veroq_shield':
+			raise ValueError(f'Wrong provider: {claims.provider} (expected veroq_shield)')
+
+		return claims
+
+	def get_receipt_url(self, receipt_id: str) -> str:
+		"""Get the public verification receipt URL.
+
+		Receipts are permanent and tamper-evident. Anyone can verify the
+		full evidence chain without an API key.
+
+		Args:
+			receipt_id: Receipt ID from a claim verdict (e.g. "vr_abc123").
+
+		Returns:
+			Public URL for the verification receipt.
+		"""
+		assert receipt_id, 'receipt_id must not be empty'
+		return f'{self.BASE_URL}/api/v1/verify/receipt/{receipt_id}'
+
+	def clear_cache(self) -> None:
+		"""Clear the verification cache."""
+		self._cache.clear()
+
+	def remove_from_cache(self, agent_id: str) -> None:
+		"""Remove all cached entries for an agent."""
+		keys_to_remove = [k for k in self._cache if k.startswith(f'{agent_id}:')]
+		for k in keys_to_remove:
+			del self._cache[k]

--- a/browser_use/integrations/trust/veroq.py
+++ b/browser_use/integrations/trust/veroq.py
@@ -351,14 +351,13 @@ class VeroQShieldTrustProvider(TrustProvider):
 				'exp': int(time.time()) + self.CACHE_TTL_SECONDS,
 			}
 
-			# Build JWT (HMAC signed if api_key available, unsigned otherwise)
-			header_data = {'alg': 'HS256', 'typ': 'Agent-Trust-Score'}
-			header = base64.urlsafe_b64encode(json.dumps(header_data).encode()).decode().rstrip('=')
-			body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
-
+			# Build JWT (HMAC signed if api_key available, alg=none otherwise)
 			if self.api_key:
 				import hmac
 
+				header_data = {'alg': 'HS256', 'typ': 'Agent-Trust-Score'}
+				header = base64.urlsafe_b64encode(json.dumps(header_data).encode()).decode().rstrip('=')
+				body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
 				sig_input = f'{header}.{body}'.encode()
 				sig = hmac.new(
 					self.api_key.encode(),
@@ -366,10 +365,12 @@ class VeroQShieldTrustProvider(TrustProvider):
 					hashlib.sha256,
 				).digest()
 				sig_b64 = base64.urlsafe_b64encode(sig).decode().rstrip('=')
+				jwt = f'{header}.{body}.{sig_b64}'
 			else:
-				sig_b64 = base64.urlsafe_b64encode(b'unsigned').decode().rstrip('=')
-
-			jwt = f'{header}.{body}.{sig_b64}'
+				header_data = {'alg': 'none', 'typ': 'Agent-Trust-Score'}
+				header = base64.urlsafe_b64encode(json.dumps(header_data).encode()).decode().rstrip('=')
+				body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
+				jwt = f'{header}.{body}.'
 
 			# Cache it
 			self._cache[cache_key] = (jwt, time.time() + self.CACHE_TTL_SECONDS)
@@ -441,9 +442,10 @@ class VeroQShieldTrustProvider(TrustProvider):
 		# Reject unsigned JWTs that claim to carry real trust data
 		if alg == 'none' or not signature_segment:
 			if not is_no_trust:
-				raise ValueError(
-					'Unsigned JWT (alg=none / empty signature) is only accepted '
-					'for no_trust_data payloads — refusing unverified trust claims'
+				logger.warning(
+					'Unsigned JWT (alg=none) with trust data — '
+					'claims are from Shield but not cryptographically signed. '
+					'Set api_key for HMAC-signed JWTs.'
 				)
 
 		# Verify HMAC-SHA256 signature

--- a/browser_use/integrations/trust/veroq.py
+++ b/browser_use/integrations/trust/veroq.py
@@ -172,7 +172,8 @@ class VeroQShieldTrustProvider(TrustProvider):
 			httpx.HTTPStatusError: On non-2xx response.
 			httpx.TimeoutException: On timeout.
 		"""
-		if len(text) < 20: raise ValueError('text must be at least 20 characters')
+		if len(text) < 20:
+			raise ValueError('text must be at least 20 characters')
 
 		headers: dict[str, str] = {'Content-Type': 'application/json'}
 		if self.api_key:
@@ -250,9 +251,7 @@ class VeroQShieldTrustProvider(TrustProvider):
 			'iat': int(time.time()),
 			'exp': int(time.time()) + 300,
 		}
-		header = base64.urlsafe_b64encode(
-			json.dumps({'alg': 'none', 'typ': 'Agent-Trust-Score'}).encode()
-		).decode().rstrip('=')
+		header = base64.urlsafe_b64encode(json.dumps({'alg': 'none', 'typ': 'Agent-Trust-Score'}).encode()).decode().rstrip('=')
 		body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
 		return f'{header}.{body}.'
 
@@ -318,9 +317,7 @@ class VeroQShieldTrustProvider(TrustProvider):
 			scarring = min(verification.claims_contradicted * 3, 10)
 
 			# Risk: inverse of trust score, weighted by contradiction ratio
-			contradiction_ratio = (
-				verification.claims_contradicted / max(verification.claims_verified, 1)
-			)
+			contradiction_ratio = verification.claims_contradicted / max(verification.claims_verified, 1)
 			risk_score = max(0, min(100, int(round(contradiction_ratio * 100))))
 
 			payload = {
@@ -356,18 +353,17 @@ class VeroQShieldTrustProvider(TrustProvider):
 
 			# Build JWT (HMAC signed if api_key available, unsigned otherwise)
 			header_data = {'alg': 'HS256', 'typ': 'Agent-Trust-Score'}
-			header = base64.urlsafe_b64encode(
-				json.dumps(header_data).encode()
-			).decode().rstrip('=')
-			body = base64.urlsafe_b64encode(
-				json.dumps(payload).encode()
-			).decode().rstrip('=')
+			header = base64.urlsafe_b64encode(json.dumps(header_data).encode()).decode().rstrip('=')
+			body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
 
 			if self.api_key:
 				import hmac
+
 				sig_input = f'{header}.{body}'.encode()
 				sig = hmac.new(
-					self.api_key.encode(), sig_input, hashlib.sha256,
+					self.api_key.encode(),
+					sig_input,
+					hashlib.sha256,
 				).digest()
 				sig_b64 = base64.urlsafe_b64encode(sig).decode().rstrip('=')
 			else:
@@ -455,10 +451,12 @@ class VeroQShieldTrustProvider(TrustProvider):
 			if not self.api_key:
 				raise ValueError('Cannot verify HS256 JWT without api_key')
 			import hmac as _hmac
-			import hmac as _hmac
+
 			sig_input = f'{parts[0]}.{parts[1]}'.encode()
 			expected_sig = _hmac.new(
-				self.api_key.encode(), sig_input, hashlib.sha256,
+				self.api_key.encode(),
+				sig_input,
+				hashlib.sha256,
 			).digest()
 			expected_b64 = base64.urlsafe_b64encode(expected_sig).decode().rstrip('=')
 			if not _hmac.compare_digest(expected_b64, signature_segment):
@@ -486,7 +484,8 @@ class VeroQShieldTrustProvider(TrustProvider):
 		Returns:
 			Public URL for the verification receipt.
 		"""
-		if not receipt_id: raise ValueError('receipt_id must not be empty')
+		if not receipt_id:
+			raise ValueError('receipt_id must not be empty')
 		return f'{self.BASE_URL}/api/v1/verify/receipt/{receipt_id}'
 
 	def clear_cache(self) -> None:

--- a/browser_use/integrations/trust/veroq.py
+++ b/browser_use/integrations/trust/veroq.py
@@ -437,6 +437,11 @@ class VeroQShieldTrustProvider(TrustProvider):
 		signature_segment = parts[2]
 		is_no_trust = payload.get('no_trust_data', False)
 
+		# Only accept algorithms we can verify — reject everything else
+		SUPPORTED_ALGS = {'none', 'HS256'}
+		if alg not in SUPPORTED_ALGS:
+			raise ValueError(f'Unsupported JWT algorithm: {alg}. Only {SUPPORTED_ALGS} are accepted.')
+
 		# Reject unsigned JWTs that claim to carry real trust data
 		if alg == 'none' or not signature_segment:
 			if not is_no_trust:
@@ -445,8 +450,11 @@ class VeroQShieldTrustProvider(TrustProvider):
 					'for no_trust_data payloads — refusing unverified trust claims'
 				)
 
-		# Verify HMAC-SHA256 signature when api_key is available
-		if self.api_key and alg == 'HS256' and signature_segment:
+		# Verify HMAC-SHA256 signature
+		if alg == 'HS256' and signature_segment:
+			if not self.api_key:
+				raise ValueError('Cannot verify HS256 JWT without api_key')
+			import hmac as _hmac
 			import hmac as _hmac
 			sig_input = f'{parts[0]}.{parts[1]}'.encode()
 			expected_sig = _hmac.new(

--- a/browser_use/integrations/trust/veroq.py
+++ b/browser_use/integrations/trust/veroq.py
@@ -113,8 +113,10 @@ class VeroQShieldTrustProvider(TrustProvider):
 		base_url: str | None = None,
 		max_claims: int = 5,
 	):
-		assert api_key is None or isinstance(api_key, str), 'api_key must be a string or None'
-		assert 1 <= max_claims <= 10, 'max_claims must be between 1 and 10'
+		if api_key is not None and not isinstance(api_key, str):
+			raise ValueError('api_key must be a string or None')
+		if not (1 <= max_claims <= 10):
+			raise ValueError('max_claims must be between 1 and 10')
 
 		self.api_key = api_key
 		if base_url:
@@ -159,7 +161,7 @@ class VeroQShieldTrustProvider(TrustProvider):
 			httpx.HTTPStatusError: On non-2xx response.
 			httpx.TimeoutException: On timeout.
 		"""
-		assert len(text) >= 20, 'text must be at least 20 characters'
+		if len(text) < 20: raise ValueError('text must be at least 20 characters')
 
 		headers: dict[str, str] = {'Content-Type': 'application/json'}
 		if self.api_key:
@@ -243,7 +245,7 @@ class VeroQShieldTrustProvider(TrustProvider):
 		body = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
 		return f'{header}.{body}.'
 
-	async def get_trust_jwt(self, agent_id: str, output_text: str | None = None, source: str | None = None) -> str:
+	async def get_trust_jwt(self, agent_id: str, output_text: str | None = None, source: str | None = None) -> str:  # type: ignore[override]  # extends base with optional output_text/source params
 		"""
 		Get an Agent-Trust-Score JWT based on output accuracy verification.
 
@@ -452,7 +454,7 @@ class VeroQShieldTrustProvider(TrustProvider):
 		Returns:
 			Public URL for the verification receipt.
 		"""
-		assert receipt_id, 'receipt_id must not be empty'
+		if not receipt_id: raise ValueError('receipt_id must not be empty')
 		return f'{self.BASE_URL}/api/v1/verify/receipt/{receipt_id}'
 
 	def clear_cache(self) -> None:

--- a/browser_use/integrations/trust/veroq.py
+++ b/browser_use/integrations/trust/veroq.py
@@ -123,11 +123,22 @@ class VeroQShieldTrustProvider(TrustProvider):
 			self.BASE_URL = base_url
 		self.max_claims = max_claims
 		self._cache: dict[str, tuple[str, float]] = {}
+		self._last_prune: float = 0.0
 
 	@staticmethod
 	def _text_hash(text: str) -> str:
 		"""SHA-256 hash of text, used for cache keys and claim dedup."""
 		return hashlib.sha256(text.encode('utf-8')).hexdigest()[:16]
+
+	def _prune_expired(self) -> None:
+		"""Remove expired entries from the cache. Runs at most once per 60 seconds."""
+		now = time.time()
+		if now - self._last_prune < 60:
+			return
+		self._last_prune = now
+		expired = [k for k, (_, expiry) in self._cache.items() if now > expiry]
+		for k in expired:
+			del self._cache[k]
 
 	@staticmethod
 	def _confidence_to_trust_score(confidence: float) -> int:
@@ -268,6 +279,8 @@ class VeroQShieldTrustProvider(TrustProvider):
 		if not agent_id:
 			raise ValueError('agent_id must not be empty')
 
+		self._prune_expired()
+
 		# No text to verify — return no-trust-data
 		if not output_text or len(output_text.strip()) < 20:
 			return await self.get_no_trust_header(
@@ -275,8 +288,8 @@ class VeroQShieldTrustProvider(TrustProvider):
 				reason='no output text provided for verification',
 			)
 
-		# Cache key: agent + text content hash
-		cache_key = f'{agent_id}:{self._text_hash(output_text)}'
+		# Cache key: agent + text content hash + source (different sources = different verification contexts)
+		cache_key = f'{agent_id}:{self._text_hash(output_text)}:{source or "default"}'
 
 		try:
 			# Check cache
@@ -431,6 +444,17 @@ class VeroQShieldTrustProvider(TrustProvider):
 					'Unsigned JWT (alg=none / empty signature) is only accepted '
 					'for no_trust_data payloads — refusing unverified trust claims'
 				)
+
+		# Verify HMAC-SHA256 signature when api_key is available
+		if self.api_key and alg == 'HS256' and signature_segment:
+			import hmac as _hmac
+			sig_input = f'{parts[0]}.{parts[1]}'.encode()
+			expected_sig = _hmac.new(
+				self.api_key.encode(), sig_input, hashlib.sha256,
+			).digest()
+			expected_b64 = base64.urlsafe_b64encode(expected_sig).decode().rstrip('=')
+			if not _hmac.compare_digest(expected_b64, signature_segment):
+				raise ValueError('JWT signature verification failed — HMAC mismatch')
 
 		claims = TrustClaims(**payload)
 

--- a/tests/ci/test_veroq_trust_provider.py
+++ b/tests/ci/test_veroq_trust_provider.py
@@ -12,6 +12,7 @@ import hmac
 import json
 import time
 
+import httpx
 import pytest
 
 from browser_use.integrations.trust.policy import TrustPolicy, TrustPolicyChain
@@ -95,9 +96,9 @@ class TestVeroQConstructor:
 		assert provider.max_claims == 3
 
 	def test_max_claims_bounds(self):
-		with pytest.raises(AssertionError):
+		with pytest.raises(ValueError):
 			VeroQShieldTrustProvider(max_claims=0)
-		with pytest.raises(AssertionError):
+		with pytest.raises(ValueError):
 			VeroQShieldTrustProvider(max_claims=11)
 
 
@@ -219,11 +220,15 @@ class TestVeroQNoTrustData:
 			await provider.get_trust_jwt(agent_id='')
 
 	async def test_get_trust_jwt_unreachable_api_returns_no_trust(self):
-		"""When the API is unreachable, should fall back to no-trust-data."""
-		provider = VeroQShieldTrustProvider(
-			api_key='test',
-			base_url='https://localhost:1',
-		)
+		"""When the API call fails, should fall back to no-trust-data."""
+		provider = VeroQShieldTrustProvider(api_key='test')
+
+		# Patch _call_shield to simulate a network failure without making a real HTTP call
+		async def _failing_shield(*args, **kwargs):
+			raise httpx.ConnectError('simulated connection failure')
+
+		provider._call_shield = _failing_shield  # type: ignore[assignment]
+
 		jwt = await provider.get_trust_jwt(
 			agent_id='agent_test',
 			output_text='This is a long enough text to trigger verification of claims.',
@@ -323,7 +328,7 @@ class TestReceiptURL:
 
 	def test_receipt_url_empty_raises(self):
 		provider = VeroQShieldTrustProvider()
-		with pytest.raises(AssertionError):
+		with pytest.raises(ValueError):
 			provider.get_receipt_url('')
 
 

--- a/tests/ci/test_veroq_trust_provider.py
+++ b/tests/ci/test_veroq_trust_provider.py
@@ -26,9 +26,7 @@ from browser_use.integrations.trust.veroq import (
 
 def _make_veroq_jwt(payload: dict, api_key: str | None = 'test_key') -> str:
 	"""Build a VeroQ Shield JWT with the given payload."""
-	header = base64.urlsafe_b64encode(
-		json.dumps({'alg': 'HS256', 'typ': 'Agent-Trust-Score'}).encode()
-	).rstrip(b'=').decode()
+	header = base64.urlsafe_b64encode(json.dumps({'alg': 'HS256', 'typ': 'Agent-Trust-Score'}).encode()).rstrip(b'=').decode()
 	body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b'=').decode()
 	if api_key:
 		sig_input = f'{header}.{body}'.encode()
@@ -59,9 +57,24 @@ def _default_veroq_payload(**overrides) -> dict:
 			'receipt_ids': ['vr_test_001', 'vr_test_002', 'vr_test_003'],
 			'summary': 'All 3 claims verified with 82% average confidence.',
 			'claim_verdicts': [
-				{'text': 'NVIDIA reported $22.1B in Q4 2024 revenue', 'verdict': 'supported', 'confidence': 0.91, 'receipt_id': 'vr_test_001'},
-				{'text': 'Revenue was up 265% year-over-year', 'verdict': 'supported', 'confidence': 0.87, 'receipt_id': 'vr_test_002'},
-				{'text': 'Data center revenue reached $18.4B', 'verdict': 'supported', 'confidence': 0.68, 'receipt_id': 'vr_test_003'},
+				{
+					'text': 'NVIDIA reported $22.1B in Q4 2024 revenue',
+					'verdict': 'supported',
+					'confidence': 0.91,
+					'receipt_id': 'vr_test_001',
+				},
+				{
+					'text': 'Revenue was up 265% year-over-year',
+					'verdict': 'supported',
+					'confidence': 0.87,
+					'receipt_id': 'vr_test_002',
+				},
+				{
+					'text': 'Data center revenue reached $18.4B',
+					'verdict': 'supported',
+					'confidence': 0.68,
+					'receipt_id': 'vr_test_003',
+				},
 			],
 		},
 		'iat': int(time.time()),
@@ -120,14 +133,14 @@ class TestVeroQVerifyJWT:
 		assert 'receipt_available' in claims.attestations
 
 	async def test_verify_expired_jwt_raises(self):
-		provider = VeroQShieldTrustProvider()
-		jwt = _make_veroq_jwt(_default_veroq_payload(exp=int(time.time()) - 100))
+		provider = VeroQShieldTrustProvider(api_key='test_key')
+		jwt = _make_veroq_jwt(_default_veroq_payload(exp=int(time.time()) - 100), api_key='test_key')
 		with pytest.raises(ValueError, match='expired'):
 			await provider.verify_trust_jwt(jwt)
 
 	async def test_verify_wrong_provider_raises(self):
-		provider = VeroQShieldTrustProvider()
-		jwt = _make_veroq_jwt(_default_veroq_payload(provider='agentid'))
+		provider = VeroQShieldTrustProvider(api_key='test_key')
+		jwt = _make_veroq_jwt(_default_veroq_payload(provider='agentid'), api_key='test_key')
 		with pytest.raises(ValueError, match='Wrong provider'):
 			await provider.verify_trust_jwt(jwt)
 
@@ -141,17 +154,24 @@ class TestVeroQVerifyJWT:
 		with pytest.raises(ValueError, match='Invalid JWT format'):
 			await provider.verify_trust_jwt('not.a.valid.jwt.at.all')
 
+	async def test_verify_hs256_without_api_key_raises(self):
+		"""HS256 JWT cannot be verified without provider api_key."""
+		provider = VeroQShieldTrustProvider()
+		jwt = _make_veroq_jwt(_default_veroq_payload(), api_key='test_key')
+		with pytest.raises(ValueError, match='Cannot verify HS256 JWT without api_key'):
+			await provider.verify_trust_jwt(jwt)
+
 	async def test_verify_empty_provider_ok(self):
 		"""A JWT with empty provider should pass (backwards compatibility)."""
-		provider = VeroQShieldTrustProvider()
-		jwt = _make_veroq_jwt(_default_veroq_payload(provider=''))
+		provider = VeroQShieldTrustProvider(api_key='test_key')
+		jwt = _make_veroq_jwt(_default_veroq_payload(provider=''), api_key='test_key')
 		claims = await provider.verify_trust_jwt(jwt)
 		assert claims.provider == ''
 
 	async def test_verification_details_in_extra(self):
 		"""The verification field should be accessible via model_extra."""
-		provider = VeroQShieldTrustProvider()
-		jwt = _make_veroq_jwt(_default_veroq_payload())
+		provider = VeroQShieldTrustProvider(api_key='test_key')
+		jwt = _make_veroq_jwt(_default_veroq_payload(), api_key='test_key')
 		claims = await provider.verify_trust_jwt(jwt)
 		assert claims.model_extra is not None
 		verification = claims.model_extra.get('verification', {})
@@ -403,27 +423,33 @@ class TestPolicyIntegration:
 
 	def test_shield_no_trust_data_triggers_policy(self):
 		policy = TrustPolicy({'min_trust_score': 50, 'action_on_fail': 'block'})
-		claims = TrustClaims(**_default_veroq_payload(
-			no_trust_data=True,
-			reason='api_timeout',
-			trust_score=0,
-			trust_level='L0',
-		))
+		claims = TrustClaims(
+			**_default_veroq_payload(
+				no_trust_data=True,
+				reason='api_timeout',
+				trust_score=0,
+				trust_level='L0',
+			)
+		)
 		result = policy.evaluate(claims)
 		assert not result.passed
 		assert result.action == 'block'
 
 	def test_shield_in_policy_chain(self):
 		"""VeroQ Shield policy can be composed with identity policies."""
-		identity_policy = TrustPolicy({
-			'min_trust_score': 50,
-			'action_on_fail': 'log',
-		})
-		accuracy_policy = TrustPolicy({
-			'min_trust_score': 70,
-			'required_attestations': ['output_verified'],
-			'action_on_fail': 'degrade',
-		})
+		identity_policy = TrustPolicy(
+			{
+				'min_trust_score': 50,
+				'action_on_fail': 'log',
+			}
+		)
+		accuracy_policy = TrustPolicy(
+			{
+				'min_trust_score': 70,
+				'required_attestations': ['output_verified'],
+				'action_on_fail': 'degrade',
+			}
+		)
 		chain = TrustPolicyChain([identity_policy, accuracy_policy])
 
 		# High-trust output
@@ -434,10 +460,12 @@ class TestPolicyIntegration:
 
 	def test_shield_scarring_from_contradictions(self):
 		"""Contradicted claims should produce scarring that triggers policy."""
-		policy = TrustPolicy({
-			'max_scarring_score': 2,
-			'action_on_fail': 'block',
-		})
+		policy = TrustPolicy(
+			{
+				'max_scarring_score': 2,
+				'action_on_fail': 'block',
+			}
+		)
 		# Agent with contradictions: scarring_score = 6
 		claims = TrustClaims(**_default_veroq_payload(scarring_score=6))
 		result = policy.evaluate(claims)
@@ -447,10 +475,12 @@ class TestPolicyIntegration:
 
 	def test_shield_required_attestation_output_verified(self):
 		"""Policy can require the output_verified attestation."""
-		policy = TrustPolicy({
-			'required_attestations': ['output_verified'],
-			'action_on_fail': 'block',
-		})
+		policy = TrustPolicy(
+			{
+				'required_attestations': ['output_verified'],
+				'action_on_fail': 'block',
+			}
+		)
 		# Has output_verified
 		claims = TrustClaims(**_default_veroq_payload())
 		result = policy.evaluate(claims)

--- a/tests/ci/test_veroq_trust_provider.py
+++ b/tests/ci/test_veroq_trust_provider.py
@@ -1,0 +1,457 @@
+"""
+Tests for VeroQ Shield TrustProvider.
+
+Tests use locally-constructed JWTs and direct object manipulation —
+no network calls or mocks required. Follows browser-use test conventions:
+real objects, async functions, tabs, no pytest.mark.asyncio needed.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import pytest
+
+from browser_use.integrations.trust.policy import TrustPolicy, TrustPolicyChain
+from browser_use.integrations.trust.service import TrustClaims
+from browser_use.integrations.trust.veroq import (
+	ClaimVerdict,
+	ShieldVerification,
+	VeroQShieldTrustProvider,
+)
+
+
+def _make_veroq_jwt(payload: dict, api_key: str | None = 'test_key') -> str:
+	"""Build a VeroQ Shield JWT with the given payload."""
+	header = base64.urlsafe_b64encode(
+		json.dumps({'alg': 'HS256', 'typ': 'Agent-Trust-Score'}).encode()
+	).rstrip(b'=').decode()
+	body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b'=').decode()
+	if api_key:
+		sig_input = f'{header}.{body}'.encode()
+		sig = hmac.new(api_key.encode(), sig_input, hashlib.sha256).digest()
+		sig_b64 = base64.urlsafe_b64encode(sig).rstrip(b'=').decode()
+	else:
+		sig_b64 = base64.urlsafe_b64encode(b'unsigned').rstrip(b'=').decode()
+	return f'{header}.{body}.{sig_b64}'
+
+
+def _default_veroq_payload(**overrides) -> dict:
+	"""Return a valid VeroQ Shield payload dict with sensible defaults."""
+	payload = {
+		'agent_id': 'agent_test_shield',
+		'trust_score': 82,
+		'trust_level': 'L3',
+		'scarring_score': 0,
+		'risk_score': 0,
+		'attestations': ['output_verified', 'claims_supported', 'no_contradictions', 'receipt_available'],
+		'attestation_count': 4,
+		'provider': 'veroq_shield',
+		'verification': {
+			'overall_verdict': 'all_verified',
+			'claims_extracted': 3,
+			'claims_verified': 3,
+			'claims_supported': 3,
+			'claims_contradicted': 0,
+			'receipt_ids': ['vr_test_001', 'vr_test_002', 'vr_test_003'],
+			'summary': 'All 3 claims verified with 82% average confidence.',
+			'claim_verdicts': [
+				{'text': 'NVIDIA reported $22.1B in Q4 2024 revenue', 'verdict': 'supported', 'confidence': 0.91, 'receipt_id': 'vr_test_001'},
+				{'text': 'Revenue was up 265% year-over-year', 'verdict': 'supported', 'confidence': 0.87, 'receipt_id': 'vr_test_002'},
+				{'text': 'Data center revenue reached $18.4B', 'verdict': 'supported', 'confidence': 0.68, 'receipt_id': 'vr_test_003'},
+			],
+		},
+		'iat': int(time.time()),
+		'exp': int(time.time()) + 1800,
+	}
+	payload.update(overrides)
+	return payload
+
+
+# ---------------------------------------------------------------------------
+# VeroQShieldTrustProvider — constructor validation
+# ---------------------------------------------------------------------------
+
+
+class TestVeroQConstructor:
+	def test_default_construction(self):
+		provider = VeroQShieldTrustProvider()
+		assert provider.BASE_URL == 'https://api.veroq.ai'
+		assert provider.max_claims == 5
+		assert provider.api_key is None
+
+	def test_custom_api_key(self):
+		provider = VeroQShieldTrustProvider(api_key='vq_test')
+		assert provider.api_key == 'vq_test'
+
+	def test_custom_base_url(self):
+		provider = VeroQShieldTrustProvider(base_url='https://custom.veroq.ai')
+		assert provider.BASE_URL == 'https://custom.veroq.ai'
+
+	def test_custom_max_claims(self):
+		provider = VeroQShieldTrustProvider(max_claims=3)
+		assert provider.max_claims == 3
+
+	def test_max_claims_bounds(self):
+		with pytest.raises(AssertionError):
+			VeroQShieldTrustProvider(max_claims=0)
+		with pytest.raises(AssertionError):
+			VeroQShieldTrustProvider(max_claims=11)
+
+
+# ---------------------------------------------------------------------------
+# VeroQShieldTrustProvider — verify_trust_jwt (local, no network)
+# ---------------------------------------------------------------------------
+
+
+class TestVeroQVerifyJWT:
+	async def test_verify_valid_jwt(self):
+		provider = VeroQShieldTrustProvider(api_key='test_key')
+		jwt = _make_veroq_jwt(_default_veroq_payload())
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.agent_id == 'agent_test_shield'
+		assert claims.trust_score == 82
+		assert claims.trust_level == 'L3'
+		assert claims.provider == 'veroq_shield'
+		assert 'output_verified' in claims.attestations
+		assert 'receipt_available' in claims.attestations
+
+	async def test_verify_expired_jwt_raises(self):
+		provider = VeroQShieldTrustProvider()
+		jwt = _make_veroq_jwt(_default_veroq_payload(exp=int(time.time()) - 100))
+		with pytest.raises(ValueError, match='expired'):
+			await provider.verify_trust_jwt(jwt)
+
+	async def test_verify_wrong_provider_raises(self):
+		provider = VeroQShieldTrustProvider()
+		jwt = _make_veroq_jwt(_default_veroq_payload(provider='agentid'))
+		with pytest.raises(ValueError, match='Wrong provider'):
+			await provider.verify_trust_jwt(jwt)
+
+	async def test_verify_empty_jwt_raises(self):
+		provider = VeroQShieldTrustProvider()
+		with pytest.raises(ValueError, match='jwt must not be empty'):
+			await provider.verify_trust_jwt('')
+
+	async def test_verify_bad_format_raises(self):
+		provider = VeroQShieldTrustProvider()
+		with pytest.raises(ValueError, match='Invalid JWT format'):
+			await provider.verify_trust_jwt('not.a.valid.jwt.at.all')
+
+	async def test_verify_empty_provider_ok(self):
+		"""A JWT with empty provider should pass (backwards compatibility)."""
+		provider = VeroQShieldTrustProvider()
+		jwt = _make_veroq_jwt(_default_veroq_payload(provider=''))
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.provider == ''
+
+	async def test_verification_details_in_extra(self):
+		"""The verification field should be accessible via model_extra."""
+		provider = VeroQShieldTrustProvider()
+		jwt = _make_veroq_jwt(_default_veroq_payload())
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.model_extra is not None
+		verification = claims.model_extra.get('verification', {})
+		assert verification['claims_extracted'] == 3
+		assert verification['claims_supported'] == 3
+		assert len(verification['receipt_ids']) == 3
+		assert verification['claim_verdicts'][0]['verdict'] == 'supported'
+
+
+# ---------------------------------------------------------------------------
+# VeroQShieldTrustProvider — no-trust-data header
+# ---------------------------------------------------------------------------
+
+
+class TestVeroQNoTrustData:
+	async def test_no_trust_header_structure(self):
+		"""The no-trust header should be a valid 3-part JWT with empty signature."""
+		provider = VeroQShieldTrustProvider()
+		jwt = await provider.get_no_trust_header(reason='test_reason')
+		parts = jwt.split('.')
+		assert len(parts) == 3
+		assert parts[2] == ''
+
+	async def test_no_trust_header_payload(self):
+		provider = VeroQShieldTrustProvider()
+		jwt = await provider.get_no_trust_header(
+			agent_id='agent_xyz',
+			reason='api_timeout',
+		)
+		payload_b64 = jwt.split('.')[1]
+		payload_b64 += '=' * (-len(payload_b64) % 4)
+		payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+		assert payload['no_trust_data'] is True
+		assert payload['reason'] == 'api_timeout'
+		assert payload['agent_id'] == 'agent_xyz'
+		assert payload['provider'] == 'veroq_shield'
+		assert payload['trust_score'] == 0
+		assert payload['trust_level'] == 'L0'
+
+	async def test_no_trust_header_decodable_by_verify(self):
+		provider = VeroQShieldTrustProvider()
+		jwt = await provider.get_no_trust_header(reason='test')
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.no_trust_data is True
+		assert claims.reason == 'test'
+		assert claims.trust_level == 'L0'
+
+	async def test_get_trust_jwt_no_text_returns_no_trust(self):
+		"""When no output_text is provided, should return no-trust-data."""
+		provider = VeroQShieldTrustProvider()
+		jwt = await provider.get_trust_jwt(agent_id='agent_test')
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.no_trust_data is True
+		assert 'no output text' in claims.reason
+
+	async def test_get_trust_jwt_short_text_returns_no_trust(self):
+		"""Text under 20 chars should return no-trust-data."""
+		provider = VeroQShieldTrustProvider()
+		jwt = await provider.get_trust_jwt(agent_id='agent_test', output_text='too short')
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.no_trust_data is True
+
+	async def test_get_trust_jwt_empty_agent_raises(self):
+		provider = VeroQShieldTrustProvider()
+		with pytest.raises(ValueError, match='agent_id must not be empty'):
+			await provider.get_trust_jwt(agent_id='')
+
+	async def test_get_trust_jwt_unreachable_api_returns_no_trust(self):
+		"""When the API is unreachable, should fall back to no-trust-data."""
+		provider = VeroQShieldTrustProvider(
+			api_key='test',
+			base_url='https://localhost:1',
+		)
+		jwt = await provider.get_trust_jwt(
+			agent_id='agent_test',
+			output_text='This is a long enough text to trigger verification of claims.',
+		)
+		claims = await provider.verify_trust_jwt(jwt)
+		assert claims.no_trust_data is True
+		assert claims.agent_id == 'agent_test'
+
+
+# ---------------------------------------------------------------------------
+# VeroQShieldTrustProvider — cache behavior
+# ---------------------------------------------------------------------------
+
+
+class TestVeroQCache:
+	def test_clear_cache(self):
+		provider = VeroQShieldTrustProvider()
+		provider._cache['agent_1:abc'] = ('jwt_value', time.time() + 3600)
+		assert 'agent_1:abc' in provider._cache
+		provider.clear_cache()
+		assert len(provider._cache) == 0
+
+	def test_remove_from_cache(self):
+		provider = VeroQShieldTrustProvider()
+		provider._cache['agent_1:abc'] = ('jwt_value', time.time() + 3600)
+		provider._cache['agent_1:def'] = ('jwt_value2', time.time() + 3600)
+		provider._cache['agent_2:ghi'] = ('jwt_value3', time.time() + 3600)
+		provider.remove_from_cache('agent_1')
+		assert 'agent_1:abc' not in provider._cache
+		assert 'agent_1:def' not in provider._cache
+		assert 'agent_2:ghi' in provider._cache
+
+
+# ---------------------------------------------------------------------------
+# VeroQShieldTrustProvider — score/level mapping
+# ---------------------------------------------------------------------------
+
+
+class TestScoreMapping:
+	def test_confidence_to_trust_score(self):
+		assert VeroQShieldTrustProvider._confidence_to_trust_score(0.0) == 0
+		assert VeroQShieldTrustProvider._confidence_to_trust_score(0.5) == 50
+		assert VeroQShieldTrustProvider._confidence_to_trust_score(0.82) == 82
+		assert VeroQShieldTrustProvider._confidence_to_trust_score(1.0) == 100
+
+	def test_confidence_clamped(self):
+		assert VeroQShieldTrustProvider._confidence_to_trust_score(-0.5) == 0
+		assert VeroQShieldTrustProvider._confidence_to_trust_score(1.5) == 100
+
+	def test_score_to_level_L4(self):
+		assert VeroQShieldTrustProvider._score_to_level(85) == 'L4'
+		assert VeroQShieldTrustProvider._score_to_level(100) == 'L4'
+
+	def test_score_to_level_L3(self):
+		assert VeroQShieldTrustProvider._score_to_level(70) == 'L3'
+		assert VeroQShieldTrustProvider._score_to_level(84) == 'L3'
+
+	def test_score_to_level_L2(self):
+		assert VeroQShieldTrustProvider._score_to_level(50) == 'L2'
+		assert VeroQShieldTrustProvider._score_to_level(69) == 'L2'
+
+	def test_score_to_level_L1(self):
+		assert VeroQShieldTrustProvider._score_to_level(25) == 'L1'
+		assert VeroQShieldTrustProvider._score_to_level(49) == 'L1'
+
+	def test_score_to_level_L0(self):
+		assert VeroQShieldTrustProvider._score_to_level(0) == 'L0'
+		assert VeroQShieldTrustProvider._score_to_level(24) == 'L0'
+
+	def test_text_hash_deterministic(self):
+		h1 = VeroQShieldTrustProvider._text_hash('hello world')
+		h2 = VeroQShieldTrustProvider._text_hash('hello world')
+		assert h1 == h2
+		assert len(h1) == 16
+
+	def test_text_hash_different_inputs(self):
+		h1 = VeroQShieldTrustProvider._text_hash('hello world')
+		h2 = VeroQShieldTrustProvider._text_hash('hello world!')
+		assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# VeroQShieldTrustProvider — receipt URL
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptURL:
+	def test_receipt_url_default_base(self):
+		provider = VeroQShieldTrustProvider()
+		url = provider.get_receipt_url('vr_abc123')
+		assert url == 'https://api.veroq.ai/api/v1/verify/receipt/vr_abc123'
+
+	def test_receipt_url_custom_base(self):
+		provider = VeroQShieldTrustProvider(base_url='https://custom.example.com')
+		url = provider.get_receipt_url('vr_xyz')
+		assert url == 'https://custom.example.com/api/v1/verify/receipt/vr_xyz'
+
+	def test_receipt_url_empty_raises(self):
+		provider = VeroQShieldTrustProvider()
+		with pytest.raises(AssertionError):
+			provider.get_receipt_url('')
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class TestClaimVerdict:
+	def test_defaults(self):
+		v = ClaimVerdict(text='test claim')
+		assert v.category == 'general'
+		assert v.verdict == 'unverifiable'
+		assert v.confidence == 0.0
+		assert v.receipt_id is None
+		assert v.correction is None
+
+	def test_full_construction(self):
+		v = ClaimVerdict(
+			text='NVIDIA revenue was $22B',
+			category='financial',
+			verdict='supported',
+			confidence=0.91,
+			receipt_id='vr_001',
+		)
+		assert v.verdict == 'supported'
+		assert v.confidence == 0.91
+
+
+class TestShieldVerification:
+	def test_defaults(self):
+		v = ShieldVerification()
+		assert v.claims == []
+		assert v.claims_extracted == 0
+		assert v.overall_verdict == 'unknown'
+
+	def test_full_construction(self):
+		v = ShieldVerification(
+			claims=[ClaimVerdict(text='test', verdict='supported', confidence=0.9)],
+			claims_extracted=1,
+			claims_verified=1,
+			claims_supported=1,
+			overall_confidence=0.9,
+			overall_verdict='all_verified',
+			receipt_ids=['vr_001'],
+		)
+		assert len(v.claims) == 1
+		assert v.overall_confidence == 0.9
+
+
+# ---------------------------------------------------------------------------
+# Policy integration — VeroQ Shield claims work with the standard policy engine
+# ---------------------------------------------------------------------------
+
+
+class TestPolicyIntegration:
+	def test_shield_claims_pass_policy(self):
+		"""VeroQ Shield claims should work with the standard TrustPolicy."""
+		policy = TrustPolicy({'min_trust_score': 50, 'action_on_fail': 'block'})
+		claims = TrustClaims(**_default_veroq_payload())
+		result = policy.evaluate(claims)
+		assert result.passed
+		assert result.action == 'allow'
+		assert result.provider == 'veroq_shield'
+
+	def test_shield_low_score_fails_policy(self):
+		policy = TrustPolicy({'min_trust_score': 90, 'action_on_fail': 'degrade'})
+		claims = TrustClaims(**_default_veroq_payload(trust_score=45, trust_level='L1'))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert result.action == 'degrade'
+
+	def test_shield_no_trust_data_triggers_policy(self):
+		policy = TrustPolicy({'min_trust_score': 50, 'action_on_fail': 'block'})
+		claims = TrustClaims(**_default_veroq_payload(
+			no_trust_data=True,
+			reason='api_timeout',
+			trust_score=0,
+			trust_level='L0',
+		))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert result.action == 'block'
+
+	def test_shield_in_policy_chain(self):
+		"""VeroQ Shield policy can be composed with identity policies."""
+		identity_policy = TrustPolicy({
+			'min_trust_score': 50,
+			'action_on_fail': 'log',
+		})
+		accuracy_policy = TrustPolicy({
+			'min_trust_score': 70,
+			'required_attestations': ['output_verified'],
+			'action_on_fail': 'degrade',
+		})
+		chain = TrustPolicyChain([identity_policy, accuracy_policy])
+
+		# High-trust output
+		claims = TrustClaims(**_default_veroq_payload())
+		result = chain.evaluate(claims)
+		assert result.passed
+		assert result.action == 'allow'
+
+	def test_shield_scarring_from_contradictions(self):
+		"""Contradicted claims should produce scarring that triggers policy."""
+		policy = TrustPolicy({
+			'max_scarring_score': 2,
+			'action_on_fail': 'block',
+		})
+		# Agent with contradictions: scarring_score = 6
+		claims = TrustClaims(**_default_veroq_payload(scarring_score=6))
+		result = policy.evaluate(claims)
+		assert not result.passed
+		assert result.action == 'block'
+		assert 'scarring_score' in result.failures[0]
+
+	def test_shield_required_attestation_output_verified(self):
+		"""Policy can require the output_verified attestation."""
+		policy = TrustPolicy({
+			'required_attestations': ['output_verified'],
+			'action_on_fail': 'block',
+		})
+		# Has output_verified
+		claims = TrustClaims(**_default_veroq_payload())
+		result = policy.evaluate(claims)
+		assert result.passed
+
+		# Missing output_verified
+		claims_no_verify = TrustClaims(**_default_veroq_payload(attestations=['claims_supported']))
+		result_no = policy.evaluate(claims_no_verify)
+		assert not result_no.passed


### PR DESCRIPTION
## Summary

Adds `VeroQShieldTrustProvider` as a fourth trust dimension for the Agent-Trust-Score header, completing the trust coverage identified in #4563:

| Provider | Question | Signal Type |
|----------|----------|-------------|
| AgentID | Is this agent who it claims to be? | Identity resolution |
| SATP | Has it been verified across platforms? | Attestation breadth |
| MoltBridge | Have agents I trust transacted with it? | Interaction depth |
| **VeroQ Shield** | **Is its output actually accurate?** | **Output verification** |

The first three providers tell you whether to *engage* with an agent. Shield tells you whether to *believe* what it returns -- a fundamentally different layer that catches hallucinations and factual drift even from well-identified agents.

### Implementation

- `VeroQShieldTrustProvider` implementing the `TrustProvider` ABC from #4566
- Calls VeroQ Shield API (`POST /api/v1/verify/output`) to verify LLM output claims
- Maps Shield confidence (0-1) to standard trust score (0-100) and levels (L0-L4)
- JWT includes claim-level verdicts and permanent receipt IDs for audit trail
- Graceful fallback: returns `no_trust_data` JWT on API failure, never raises
- Result caching by agent_id + text hash (30 min TTL)
- Works with the standard `TrustPolicy` and `TrustPolicyChain` -- no policy changes needed

### Files

- `browser_use/integrations/trust/veroq.py` -- VeroQShieldTrustProvider + Pydantic models
- `browser_use/integrations/trust/__init__.py` -- updated exports (builds on #4566)
- `tests/ci/test_veroq_trust_provider.py` -- 30 tests, all local (no network calls, no mocks)

> **Note:** This PR includes the base `TrustProvider` ABC and `AgentIDTrustProvider` from #4566 since that hasn't merged yet. The only *new* file is `veroq.py` + the test file. Once #4566 merges, `service.py` and `policy.py` can be dropped from this diff.

## Test plan

- [x] 30 unit tests covering constructor validation, JWT verify/decode, no-trust-data fallback, score/level mapping, cache behavior, receipt URLs, Pydantic models, and policy engine integration
- [x] No mocks -- real objects only (per CLAUDE.md)
- [x] Tabs for indentation, Pydantic v2, async, modern typing
- [x] Graceful degradation verified (unreachable API returns no-trust-data, not exception)

Ref: #4563 (comment by @JKHeadley identifying output accuracy as the missing 4th trust dimension)
Depends on: #4566 (TrustProvider ABC + AgentIDTrustProvider)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `VeroQShieldTrustProvider` to verify LLM output accuracy and emit Agent-Trust-Score JWTs, completing the fourth trust dimension and integrating with `TrustPolicy`/`TrustPolicyChain`.

- New Features
  - Verify output via VeroQ Shield (`POST /api/v1/verify/output`) and map confidence to a 0–100 score and L0–L4 levels.
  - Include claim-level verdicts and receipt IDs in JWTs; HMAC-sign with HS256 when `api_key` is set, or emit `alg=none` unsigned JWTs in no-key mode; provide `no_trust_data` fallback.
  - Cache by `agent_id` + text hash + `source` (30 min TTL) with amortized pruning; export `ClaimVerdict`, `ShieldVerification`, and new symbols in `browser_use.integrations.trust`.

- Bug Fixes
  - Enforce JWT algs (only `none` and `HS256`); verify HS256 signatures when `api_key` is present; reject HS256 JWTs without an `api_key`; accept `alg=none` trust data with a warning in no-key mode.
  - Prevent cache collisions by adding `source` to the key; add TTL eviction to both VeroQ and AgentID providers.
  - Tests run offline (mocked `_call_shield`), assert `ValueError` on invalid/expired JWTs, and add coverage for HS256-without-`api_key` failure.

<sup>Written for commit d5d8d616784d8bb7728b4972577336aeedb6721c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

