### PR TITLE
Small refactor when checking if vysion is allowed for an llm by checking its name

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -465,15 +465,14 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self._verify_and_setup_llm()
 
 		# TODO: move this logic to the LLMs
+		model_name_lower = self.llm.model.lower()
 		# Handle users trying to use use_vision=True with DeepSeek models
-		if 'deepseek' in self.llm.model.lower():
+		if 'deepseek' in model_name_lower:
 			self.logger.warning('⚠️ DeepSeek models do not support use_vision=True yet. Setting use_vision=False for now...')
 			self.settings.use_vision = False
-
 		# Handle users trying to use use_vision=True with XAI models that don't support it
 		# grok-3 variants and grok-code don't support vision; grok-2 and grok-4 do
-		model_lower = self.llm.model.lower()
-		if 'grok-3' in model_lower or 'grok-code' in model_lower:
+		elif 'grok-3' in model_name_lower or 'grok-code' in model_name_lower:
 			self.logger.warning('⚠️ This XAI model does not support use_vision=True yet. Setting use_vision=False for now...')
 			self.settings.use_vision = False
 


### PR DESCRIPTION
This PR doesn't add any functionality, I was just looking at the code and I noticed how the check on the model name was repeated without an `elif` and that `self.llm.model.lower()` was recomputed.

So I lightly modified the code, I hope for better readability. The `elif` should avoid the check being repeated for grok models in case of a deepseek model.

Thanks for the project!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified the vision support checks for DeepSeek and XAI Grok models to reduce duplicate work and avoid double processing. This makes the logic clearer and prevents redundant warnings.

- **Refactors**
  - Compute `model_name_lower` once instead of calling `self.llm.model.lower()` twice.
  - Switch second condition to `elif` so Grok checks are skipped after a DeepSeek match.

<sup>Written for commit 7f06c5d52cafc2228e2b1dcbae198e54c552398f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

