### PR TITLE
fix: prefer Playwright's bundled Chromium over system Chrome by default

### DIFF
--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -126,7 +126,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 					self.logger.debug(f'[LocalBrowserWatchdog] 📦 Using custom local browser executable_path= {browser_path}')
 				else:
 					# self.logger.debug('[LocalBrowserWatchdog] 🔍 Looking for local browser binary path...')
-					# Try fallback paths first (system browsers preferred)
+					# Try fallback paths first (Playwright's Chromium preferred by default)
 					browser_path = self._find_installed_browser_path(channel=profile.channel)
 					if not browser_path:
 						self.logger.error(
@@ -224,9 +224,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		Falls back to all known browser paths if the channel-specific search fails.
 
 		Prioritizes:
-		1. Channel-specific paths (if channel is set)
-		2. System Chrome stable
-		3. Playwright chromium
+		1. Channel-specific paths (if channel is set to a non-default value)
+		2. Playwright bundled Chromium (when no channel or default channel specified)
+		3. System Chrome stable
 		4. Other system native browsers (Chromium -> Chrome Canary/Dev -> Brave -> Edge)
 		5. Playwright headless-shell fallback
 
@@ -313,14 +313,18 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			BrowserChannel.MSEDGE_CANARY: 'msedge',
 		}
 
-		# If a non-default channel is specified, put matching patterns first, then the rest as fallback
+		# Prioritize the target browser group first, then fall back to the rest.
+		# When no channel is specified (or default CHROMIUM channel), prefer Playwright's
+		# bundled Chromium over system Chrome. Using system Chrome in headless mode can
+		# block the user from opening Chrome GUI normally (e.g. on macOS, LaunchServices
+		# routes "open Chrome" Apple Events to the headless process instead of a new window).
 		if channel and channel != BROWSERUSE_DEFAULT_CHANNEL and channel in _channel_to_group:
 			target_group = _channel_to_group[channel]
-			prioritized = [p for g, p in all_patterns if g == target_group]
-			rest = [p for g, p in all_patterns if g != target_group]
-			patterns = prioritized + rest
 		else:
-			patterns = [p for _, p in all_patterns]
+			target_group = _channel_to_group[BROWSERUSE_DEFAULT_CHANNEL]  # 'chromium'
+		prioritized = [p for g, p in all_patterns if g == target_group]
+		rest = [p for g, p in all_patterns if g != target_group]
+		patterns = prioritized + rest
 
 		for pattern in patterns:
 			# Expand user home directory


### PR DESCRIPTION
Fixes #4610

## Problem

`_find_installed_browser_path` in `LocalBrowserWatchdog` prioritized system Chrome (`/Applications/Google Chrome.app/...`) over Playwright's bundled Chromium on all platforms, even when no specific channel was requested (the default).

On macOS this caused a real UX breakage: headless Chrome processes launched by browser-use register with LaunchServices under the same app bundle identifier as the user's normal Chrome install. macOS then routes any `open -a "Google Chrome"` Apple Event to the already-running headless process, so Chrome appears completely broken and won't open a GUI window while browser-use is active.

## Solution

When `channel` is `None` or equals `BROWSERUSE_DEFAULT_CHANNEL` (which is `BrowserChannel.CHROMIUM`), the fallback search now prefers Playwright's bundled Chromium paths over system Chrome paths. This aligns the actual fallback behavior with the stated default (`BROWSERUSE_DEFAULT_CHANNEL = BrowserChannel.CHROMIUM`).

Users who explicitly configure `channel=BrowserChannel.CHROME` or set `executable_path` directly are **completely unaffected** — the priority logic for explicit channels is unchanged.

## Testing

- Logic change only in `_find_installed_browser_path`: when `channel` is `None`, `target_group` is set to `'chromium'` (Playwright's group) instead of falling through to the original list order which had system Chrome first.
- On macOS: if `~/Library/Caches/ms-playwright/chromium-*/...` exists, it will be found before `/Applications/Google Chrome.app/...`.
- On Linux: if `~/.cache/ms-playwright/chromium-*/...` exists, it will be found before `/usr/bin/google-chrome-stable`.
- Users without Playwright Chromium installed fall through to system Chrome as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default browser resolution now prefers Playwright’s bundled Chromium when no channel is set, fixing macOS behavior where headless system Chrome blocked opening GUI Chrome. This aligns the fallback with `BROWSERUSE_DEFAULT_CHANNEL = BrowserChannel.CHROMIUM`.

- **Bug Fixes**
  - Updated `LocalBrowserWatchdog._find_installed_browser_path` to prioritize Playwright’s Chromium by default; system Chrome is now a fallback.
  - macOS/Linux: Playwright cache paths are checked before system Chrome paths.
  - Explicit `channel=BrowserChannel.CHROME` or custom `executable_path` remain unchanged.

<sup>Written for commit 8081d7399b6612165321204f2360418fca1b431d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

