### PR TITLE
ci: add concurrency group to eval-on-pr workflow

### DIFF
--- a/.github/workflows/eval-on-pr.yml
+++ b/.github/workflows/eval-on-pr.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Cancel in-progress runs when a new commit is pushed to the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   trigger-evaluation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `concurrency` block to `eval-on-pr.yml` so that redundant evaluation runs are cancelled when new commits are pushed to the same PR.

## Problem

`eval-on-pr.yml` triggers on every `synchronize` event (new push to a PR) but has no concurrency group. If a contributor pushes multiple commits in quick succession, each push triggers a separate evaluation API call to the external platform, and none of the previous runs get cancelled.

Every other CI workflow in this repo (`test.yaml`, `lint.yml`, `docker.yml`, `publish.yml`) already uses a concurrency group with `cancel-in-progress: true`. This workflow was missing it.

## Fix

Added a `concurrency` block using the same pattern as other workflows:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

This groups runs by PR number and cancels in-progress runs when a new one starts, preventing redundant evaluation API calls.

## Verification

- Push two commits quickly to a PR — the first evaluation run should be cancelled.
- The concurrency group key format matches all other workflows in the repo.

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a concurrency group to `eval-on-pr.yml` so evaluation runs for the same PR cancel when new commits are pushed, avoiding redundant external API calls. Matches other workflows by grouping on PR number and setting `cancel-in-progress: true`.

<sup>Written for commit 98ac1e5c83ea0c066338c6a3bb1df3d0298fc09b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

