### PR TITLE
fix(agent): validate MessageManager max_history_items with ValueError

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -116,6 +116,9 @@ class MessageManager:
 		llm_screenshot_size: tuple[int, int] | None = None,
 		max_clickable_elements_length: int = 40000,
 	):
+		if max_history_items is not None and max_history_items <= 5:
+			raise ValueError('max_history_items must be None or greater than 5')
+
 		self.task = task
 		self.state = state
 		self.system_prompt = system_message
@@ -129,8 +132,6 @@ class MessageManager:
 		self.sample_images = sample_images
 		self.llm_screenshot_size = llm_screenshot_size
 		self.max_clickable_elements_length = max_clickable_elements_length
-
-		assert max_history_items is None or max_history_items > 5, 'max_history_items must be None or greater than 5'
 
 		# Store settings as direct attributes instead of in a settings object
 		self.include_attributes = include_attributes or []

--- a/tests/ci/infrastructure/test_message_manager_validation.py
+++ b/tests/ci/infrastructure/test_message_manager_validation.py
@@ -1,0 +1,37 @@
+import os
+import tempfile
+import uuid
+
+import pytest
+
+from browser_use.agent.message_manager.service import MessageManager
+from browser_use.agent.views import MessageManagerState
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.llm import SystemMessage
+
+
+def _make_message_manager(**kwargs):
+	base_tmp = tempfile.gettempdir()
+	file_system_path = os.path.join(base_tmp, str(uuid.uuid4()))
+	defaults = {
+		'task': 't',
+		'system_message': SystemMessage(content='s'),
+		'state': MessageManagerState(),
+		'file_system': FileSystem(file_system_path),
+	}
+	defaults.update(kwargs)
+	return MessageManager(**defaults)
+
+
+def test_message_manager_max_history_items_none_ok():
+	_make_message_manager(max_history_items=None)
+
+
+def test_message_manager_max_history_items_above_five_ok():
+	_make_message_manager(max_history_items=6)
+
+
+@pytest.mark.parametrize('invalid', [0, 1, 5, -1])
+def test_message_manager_max_history_items_invalid_raises(invalid):
+	with pytest.raises(ValueError, match='max_history_items must be None or greater than 5'):
+		_make_message_manager(max_history_items=invalid)


### PR DESCRIPTION
## Summary
Replace `assert` with `ValueError` in `MessageManager.__init__` so `max_history_items` is enforced even when Python is run with `-O` (assertions stripped).

Validate before any `self.*` assignments so invalid input does not leave a partially initialized instance.

## Tests
- Add `tests/ci/infrastructure/test_message_manager_validation.py` covering `None`, valid integers > 5, and invalid values (0, 1, 5, -1).

<img width="1728" height="1117" alt="Screenshot 2026-04-07 at 3 39 05 PM" src="https://github.com/user-attachments/assets/4eb5021d-d7f2-4cd2-81d4-1a9f78c5b4c5" />


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `MessageManager` `max_history_items` with a `ValueError` so the rule (None or >5) is enforced even under Python `-O`. The check runs before any attributes are set to avoid partial initialization.

- **Bug Fixes**
  - Replaced `assert` with `ValueError` when `max_history_items` is not None and <= 5.
  - Performed validation before any `self.*` assignments.
  - Added tests for None, valid (>5), and invalid values.

<sup>Written for commit c882288030146aeb63e184401de940fa4410c87d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

