### PR TITLE
fix: validate ChatGoogle max_retries and cloud URLs with ValueError

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -10,7 +10,7 @@ from typing import Any
 from uuid import uuid4
 
 import psutil
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -65,7 +65,8 @@ class OldConfig:
 	@property
 	def BROWSER_USE_CLOUD_API_URL(self) -> str:
 		url = os.getenv('BROWSER_USE_CLOUD_API_URL', 'https://api.browser-use.com')
-		assert '://' in url, 'BROWSER_USE_CLOUD_API_URL must be a valid URL'
+		if '://' not in url:
+			raise ValueError('BROWSER_USE_CLOUD_API_URL must be a valid URL')
 		return url
 
 	@property
@@ -73,7 +74,7 @@ class OldConfig:
 		url = os.getenv('BROWSER_USE_CLOUD_UI_URL', '')
 		# Allow empty string as default, only validate if set
 		if url and '://' not in url:
-			raise AssertionError('BROWSER_USE_CLOUD_UI_URL must be a valid URL if set')
+			raise ValueError('BROWSER_USE_CLOUD_UI_URL must be a valid URL if set')
 		return url
 
 	@property
@@ -203,6 +204,20 @@ class FlatEnvConfig(BaseSettings):
 	BROWSER_USE_CLOUD_API_URL: str = Field(default='https://api.browser-use.com')
 	BROWSER_USE_CLOUD_UI_URL: str = Field(default='')
 	BROWSER_USE_MODEL_PRICING_URL: str = Field(default='')
+
+	@field_validator('BROWSER_USE_CLOUD_API_URL')
+	@classmethod
+	def _validate_cloud_api_url(cls, v: str) -> str:
+		if '://' not in v:
+			raise ValueError('BROWSER_USE_CLOUD_API_URL must be a valid URL')
+		return v
+
+	@field_validator('BROWSER_USE_CLOUD_UI_URL')
+	@classmethod
+	def _validate_cloud_ui_url(cls, v: str) -> str:
+		if v and '://' not in v:
+			raise ValueError('BROWSER_USE_CLOUD_UI_URL must be a valid URL if set')
+		return v
 
 	# Path configuration
 	XDG_CACHE_HOME: str = Field(default='~/.cache')

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -112,6 +112,10 @@ class ChatGoogle(BaseChatModel):
 	# Internal client cache to prevent connection issues
 	_client: genai.Client | None = None
 
+	def __post_init__(self) -> None:
+		if self.max_retries < 1:
+			raise ValueError('max_retries must be at least 1')
+
 	# Static
 	@property
 	def provider(self) -> str:
@@ -470,8 +474,6 @@ class ChatGoogle(BaseChatModel):
 				raise
 
 		# Retry logic for certain errors with exponential backoff
-		assert self.max_retries >= 1, 'max_retries must be at least 1'
-
 		for attempt in range(self.max_retries):
 			try:
 				return await _make_api_call()

--- a/tests/ci/infrastructure/test_config_cloud_url_validation.py
+++ b/tests/ci/infrastructure/test_config_cloud_url_validation.py
@@ -1,0 +1,48 @@
+import pytest
+from pydantic import ValidationError
+
+from browser_use.config import Config, FlatEnvConfig
+
+
+def test_config_invalid_cloud_api_url(monkeypatch):
+	monkeypatch.setenv('BROWSER_USE_CLOUD_API_URL', 'not-a-url')
+	c = Config()
+	with pytest.raises(ValueError, match='BROWSER_USE_CLOUD_API_URL must be a valid URL'):
+		_ = c.BROWSER_USE_CLOUD_API_URL
+
+
+def test_config_valid_cloud_api_url_default(monkeypatch):
+	monkeypatch.delenv('BROWSER_USE_CLOUD_API_URL', raising=False)
+	c = Config()
+	assert '://' in c.BROWSER_USE_CLOUD_API_URL
+
+
+def test_config_invalid_cloud_ui_url_when_set(monkeypatch):
+	monkeypatch.setenv('BROWSER_USE_CLOUD_UI_URL', 'not-a-url')
+	c = Config()
+	with pytest.raises(ValueError, match='BROWSER_USE_CLOUD_UI_URL must be a valid URL if set'):
+		_ = c.BROWSER_USE_CLOUD_UI_URL
+
+
+def test_config_cloud_ui_url_empty_ok(monkeypatch):
+	monkeypatch.delenv('BROWSER_USE_CLOUD_UI_URL', raising=False)
+	monkeypatch.setenv('BROWSER_USE_CLOUD_UI_URL', '')
+	c = Config()
+	assert c.BROWSER_USE_CLOUD_UI_URL == ''
+
+
+def test_flat_env_config_invalid_cloud_api_url(monkeypatch):
+	monkeypatch.setenv('BROWSER_USE_CLOUD_API_URL', 'not-a-url')
+	with pytest.raises(ValidationError, match='BROWSER_USE_CLOUD_API_URL must be a valid URL'):
+		FlatEnvConfig()
+
+
+def test_flat_env_config_invalid_cloud_ui_url_when_set(monkeypatch):
+	monkeypatch.setenv('BROWSER_USE_CLOUD_UI_URL', 'bad')
+	with pytest.raises(ValidationError, match='BROWSER_USE_CLOUD_UI_URL must be a valid URL if set'):
+		FlatEnvConfig()
+
+
+def test_flat_env_config_cloud_ui_url_empty_ok(monkeypatch):
+	monkeypatch.setenv('BROWSER_USE_CLOUD_UI_URL', '')
+	FlatEnvConfig()

--- a/tests/ci/infrastructure/test_llm_google_validation.py
+++ b/tests/ci/infrastructure/test_llm_google_validation.py
@@ -1,0 +1,13 @@
+import pytest
+
+from browser_use.llm.google.chat import ChatGoogle
+
+
+@pytest.mark.parametrize('invalid', [0, -1])
+def test_chat_google_max_retries_invalid_raises(invalid):
+	with pytest.raises(ValueError, match='max_retries must be at least 1'):
+		ChatGoogle(model='gemini-flash-latest', max_retries=invalid)
+
+
+def test_chat_google_max_retries_one_ok():
+	ChatGoogle(model='gemini-flash-latest', max_retries=1)


### PR DESCRIPTION
## Summary
- **ChatGoogle**: Validate `max_retries >= 1` in `__post_init__` with `ValueError`; remove `assert` before the retry loop (survives `python -O`).
- **Config**: `OldConfig` cloud API/UI URL checks use `ValueError` instead of `assert` / `AssertionError`; `FlatEnvConfig` adds matching `field_validator`s (Pydantic `ValidationError`).
- **Tests**: CI infrastructure tests for Google LLM and config URL validation (no API keys / browser).

## Motivation
Use explicit exceptions for user/env configuration instead of `assert`, which is stripped under `-O`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate Google chat retry count and cloud URL settings with explicit errors to avoid asserts being skipped under optimized Python. Adds `pydantic` field validators and CI tests for these checks.

- **Bug Fixes**
  - `ChatGoogle`: enforce `max_retries >= 1` in `__post_init__` with `ValueError`; removed assert from retry loop.
  - Config: raise `ValueError` for invalid `BROWSER_USE_CLOUD_API_URL`; allow empty `BROWSER_USE_CLOUD_UI_URL`, otherwise validate and raise `ValueError`.
  - `FlatEnvConfig`: added field validators for both URLs; invalid values raise `pydantic.ValidationError`.
  - Tests: added CI tests for Google LLM retry validation and cloud URL validation (no API keys required).

<sup>Written for commit b774a207542f5844b9ab43e22309ddcd96f50cbe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

