### PR TITLE
feat: expose video recording path in agent history

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1746,12 +1746,18 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		else:
 			self.logger.debug(f'📸 No screenshot in browser_state_summary for step {self.state.n_steps}')
 
+		# Get recording path from session if available
+		recording_path = None
+		if self.browser_session._recording_watchdog is not None:
+			recording_path = self.browser_session._recording_watchdog.recording_path
+
 		state_history = BrowserStateHistory(
 			url=browser_state_summary.url,
 			title=browser_state_summary.title,
 			tabs=browser_state_summary.tabs,
 			interacted_element=interacted_elements,
 			screenshot_path=screenshot_path,
+			recording_path=recording_path,
 		)
 
 		history_item = AgentHistory(

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -802,16 +802,13 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 		"""Get all recording paths from history"""
 		if n_last == 0:
 			return []
-		if n_last is None:
-			if return_none_if_not_recording:
-				return [h.state.recording_path if h.state.recording_path is not None else None for h in self.history]
-			else:
-				return [h.state.recording_path for h in self.history if h.state.recording_path is not None]
+
+		history_items = self.history if n_last is None else self.history[-n_last:]
+
+		if return_none_if_not_recording:
+			return [h.state.recording_path for h in history_items]
 		else:
-			if return_none_if_not_recording:
-				return [h.state.recording_path if h.state.recording_path is not None else None for h in self.history[-n_last:]]
-			else:
-				return [h.state.recording_path for h in self.history[-n_last:] if h.state.recording_path is not None]
+			return [h.state.recording_path for h in history_items if h.state.recording_path is not None]
 
 	def screenshots(self, n_last: int | None = None, return_none_if_not_screenshot: bool = True) -> list[str | None]:
 		"""Get all screenshots from history as base64 strings"""

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -798,6 +798,21 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 			else:
 				return [h.state.screenshot_path for h in self.history[-n_last:] if h.state.screenshot_path is not None]
 
+	def recording_paths(self, n_last: int | None = None, return_none_if_not_recording: bool = True) -> list[str | None]:
+		"""Get all recording paths from history"""
+		if n_last == 0:
+			return []
+		if n_last is None:
+			if return_none_if_not_recording:
+				return [h.state.recording_path if h.state.recording_path is not None else None for h in self.history]
+			else:
+				return [h.state.recording_path for h in self.history if h.state.recording_path is not None]
+		else:
+			if return_none_if_not_recording:
+				return [h.state.recording_path if h.state.recording_path is not None else None for h in self.history[-n_last:]]
+			else:
+				return [h.state.recording_path for h in self.history[-n_last:] if h.state.recording_path is not None]
+
 	def screenshots(self, n_last: int | None = None, return_none_if_not_screenshot: bool = True) -> list[str | None]:
 		"""Get all screenshots from history as base64 strings"""
 		if n_last == 0:

--- a/browser_use/browser/views.py
+++ b/browser_use/browser/views.py
@@ -119,6 +119,7 @@ class BrowserStateHistory:
 	tabs: list[TabInfo]
 	interacted_element: list[DOMInteractedElement | None] | list[None]
 	screenshot_path: str | None = None
+	recording_path: str | None = None
 
 	def get_screenshot(self) -> str | None:
 		"""Load screenshot from disk and return as base64 string"""
@@ -143,6 +144,7 @@ class BrowserStateHistory:
 		data = {}
 		data['tabs'] = [tab.model_dump() for tab in self.tabs]
 		data['screenshot_path'] = self.screenshot_path
+		data['recording_path'] = self.recording_path
 		data['interacted_element'] = [el.to_dict() if el else None for el in self.interacted_element]
 		data['url'] = self.url
 		data['title'] = self.title

--- a/browser_use/browser/watchdogs/recording_watchdog.py
+++ b/browser_use/browser/watchdogs/recording_watchdog.py
@@ -28,6 +28,13 @@ class RecordingWatchdog(BaseWatchdog):
 	_current_session_id: str | None = PrivateAttr(default=None)
 	_screencast_params: dict[str, Any] | None = PrivateAttr(default=None)
 
+	@property
+	def recording_path(self) -> str | None:
+		"""Return the output path of the active recording, or None if not recording."""
+		if self._recorder is not None:
+			return str(self._recorder.output_path)
+		return None
+
 	async def on_BrowserConnectedEvent(self, event: BrowserConnectedEvent) -> None:
 		"""
 		Starts video recording if it is configured in the browser profile.

--- a/tests/ci/browser/test_recording_path.py
+++ b/tests/ci/browser/test_recording_path.py
@@ -1,0 +1,126 @@
+"""Test recording_path exposure in BrowserStateHistory and AgentHistoryList."""
+
+from browser_use.agent.views import ActionResult, AgentHistory, AgentHistoryList
+from browser_use.browser.views import BrowserStateHistory
+
+
+def _make_history_item(recording_path: str | None = None, screenshot_path: str | None = None) -> AgentHistory:
+	return AgentHistory(
+		model_output=None,
+		result=[ActionResult(extracted_content='test')],
+		state=BrowserStateHistory(
+			url='http://localhost',
+			title='Test',
+			tabs=[],
+			interacted_element=[None],
+			screenshot_path=screenshot_path,
+			recording_path=recording_path,
+		),
+	)
+
+
+class TestRecordingPathInBrowserStateHistory:
+	def test_recording_path_defaults_to_none(self):
+		state = BrowserStateHistory(
+			url='http://localhost',
+			title='Test',
+			tabs=[],
+			interacted_element=[None],
+		)
+		assert state.recording_path is None
+
+	def test_recording_path_stored(self):
+		state = BrowserStateHistory(
+			url='http://localhost',
+			title='Test',
+			tabs=[],
+			interacted_element=[None],
+			recording_path='/tmp/video.mp4',
+		)
+		assert state.recording_path == '/tmp/video.mp4'
+
+	def test_to_dict_includes_recording_path(self):
+		state = BrowserStateHistory(
+			url='http://localhost',
+			title='Test',
+			tabs=[],
+			interacted_element=[None],
+			recording_path='/tmp/video.mp4',
+		)
+		d = state.to_dict()
+		assert 'recording_path' in d
+		assert d['recording_path'] == '/tmp/video.mp4'
+
+	def test_to_dict_recording_path_none(self):
+		state = BrowserStateHistory(
+			url='http://localhost',
+			title='Test',
+			tabs=[],
+			interacted_element=[None],
+		)
+		d = state.to_dict()
+		assert 'recording_path' in d
+		assert d['recording_path'] is None
+
+
+class TestRecordingPathsInAgentHistoryList:
+	def test_recording_paths_all_set(self):
+		history = AgentHistoryList(
+			history=[
+				_make_history_item(recording_path='/tmp/video.mp4'),
+				_make_history_item(recording_path='/tmp/video.mp4'),
+			]
+		)
+		paths = history.recording_paths()
+		assert paths == ['/tmp/video.mp4', '/tmp/video.mp4']
+
+	def test_recording_paths_none_when_disabled(self):
+		history = AgentHistoryList(
+			history=[
+				_make_history_item(),
+				_make_history_item(),
+			]
+		)
+		paths = history.recording_paths()
+		assert paths == [None, None]
+
+	def test_recording_paths_n_last(self):
+		history = AgentHistoryList(
+			history=[
+				_make_history_item(recording_path='/tmp/video.mp4'),
+				_make_history_item(recording_path='/tmp/video.mp4'),
+				_make_history_item(recording_path='/tmp/video.mp4'),
+			]
+		)
+		paths = history.recording_paths(n_last=2)
+		assert len(paths) == 2
+
+	def test_recording_paths_filter_none(self):
+		history = AgentHistoryList(
+			history=[
+				_make_history_item(),
+				_make_history_item(recording_path='/tmp/video.mp4'),
+			]
+		)
+		paths = history.recording_paths(return_none_if_not_recording=False)
+		assert paths == ['/tmp/video.mp4']
+
+	def test_recording_paths_empty(self):
+		history = AgentHistoryList(history=[])
+		assert history.recording_paths() == []
+
+	def test_recording_paths_n_last_zero(self):
+		history = AgentHistoryList(history=[_make_history_item(recording_path='/tmp/video.mp4')])
+		assert history.recording_paths(n_last=0) == []
+
+	def test_serialization_roundtrip(self):
+		"""Verify recording_path survives model_dump / model_validate."""
+		history = AgentHistoryList(
+			history=[
+				_make_history_item(recording_path='/tmp/video.mp4', screenshot_path='/tmp/step_0.png'),
+			]
+		)
+		data = history.model_dump()
+		restored = AgentHistoryList.model_validate(data)
+		assert restored.history[0].state.recording_path == '/tmp/video.mp4'
+		assert restored.history[0].state.screenshot_path == '/tmp/step_0.png'


### PR DESCRIPTION
Fixes #4623

`RecordingWatchdog` generates a uuid7-based `.mp4` path internally but never surfaces it. This adds a `recording_path` field following the same pattern as `screenshot_path`.

Changes:
- `recording_watchdog.py`: added `recording_path` property returning `str(self._recorder.output_path)` when active, `None` otherwise
- `browser/views.py`: added `recording_path: str | None = None` to `BrowserStateHistory`, included in `to_dict()`
- `agent/service.py`: reads `recording_path` from the watchdog during history creation and passes it through
- `agent/views.py`: added `recording_paths()` to `AgentHistoryList` with `n_last` and `return_none_if_not_recording` params, matching `screenshot_paths()` signature
- `tests/ci/browser/test_recording_path.py`: 11 tests covering default None, path storage, serialization, filtering, and roundtrip

Data flow: `RecordingWatchdog._recorder.output_path` -> `recording_path` property -> `_save_step_info()` -> `BrowserStateHistory.recording_path` -> `AgentHistoryList.recording_paths()`.

Fully backward compatible since `recording_path` defaults to `None` everywhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the video recording file path in agent history so clients can access saved `.mp4` recordings per step. Mirrors the existing `screenshot_path` flow. Fixes #4623.

- **New Features**
  - `RecordingWatchdog.recording_path` returns the active recorder output path or `None`.
  - Added `recording_path` to `BrowserStateHistory` and included in `to_dict()`.
  - Threaded the path through history creation in the service layer.
  - `AgentHistoryList.recording_paths(n_last, return_none_if_not_recording)` to fetch recent paths, matching `screenshot_paths()`.
  - Backward compatible: defaults to `None` when not recording.

<sup>Written for commit f38542bb61b2775b355ee263eabc8b8a22bff85b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

