### PR TITLE
chore: update browser-use-sdk from 2.0.15 to 3.4.2

### DIFF
--- a/browser_use/skills/service.py
+++ b/browser_use/skills/service.py
@@ -4,9 +4,7 @@ import logging
 import os
 from typing import Any, Literal
 
-from browser_use_sdk import AsyncBrowserUse
-from browser_use_sdk.types.execute_skill_response import ExecuteSkillResponse
-from browser_use_sdk.types.skill_list_response import SkillListResponse
+from browser_use_sdk import AsyncBrowserUse, ExecuteSkillResponse, SkillListResponse
 from cdp_use.cdp.network import Cookie
 from pydantic import BaseModel, ValidationError
 
@@ -89,7 +87,7 @@ class SkillService:
 					all_items.extend(skills_response.items)
 
 					# Check if we've found all requested skills
-					found_ids = {s.id for s in all_items if s.id in requested_ids}
+					found_ids = {str(s.id) for s in all_items if str(s.id) in requested_ids}
 					if found_ids == requested_ids:
 						break
 
@@ -114,10 +112,10 @@ class SkillService:
 				skills_to_load = all_available_skills
 			else:
 				# Load only the requested skill IDs
-				skills_to_load = [skill for skill in all_available_skills if skill.id in requested_ids]
+				skills_to_load = [skill for skill in all_available_skills if str(skill.id) in requested_ids]
 
 				# Warn about any requested skills that weren't found
-				found_ids = {skill.id for skill in skills_to_load}
+				found_ids = {str(skill.id) for skill in skills_to_load}
 				missing_ids = requested_ids - found_ids
 				if missing_ids:
 					logger.warning(f'Requested skills not found or not available: {missing_ids}')
@@ -272,7 +270,10 @@ class SkillService:
 			# Return error response
 			return ExecuteSkillResponse(
 				success=False,
+				result=None,
 				error=f'Failed to execute skill: {type(e).__name__}: {str(e)}',
+				stderr=None,
+				latencyMs=None,
 			)
 
 	async def close(self) -> None:

--- a/browser_use/skills/views.py
+++ b/browser_use/skills/views.py
@@ -2,8 +2,7 @@
 
 from typing import Any
 
-from browser_use_sdk.types.parameter_schema import ParameterSchema
-from browser_use_sdk.types.skill_response import SkillResponse
+from browser_use_sdk import ParameterSchema, SkillResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -40,7 +39,7 @@ class Skill(BaseModel):
 	def from_skill_response(response: SkillResponse) -> 'Skill':
 		"""Create a Skill from SDK SkillResponse"""
 		return Skill(
-			id=response.id,
+			id=str(response.id),
 			title=response.title,
 			description=response.description,
 			parameters=response.parameters,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "cloudpickle==3.1.2",
     "markdownify==1.2.2",
     "python-docx==1.2.0",
-    "browser-use-sdk==2.0.15",
+    "browser-use-sdk==3.4.2",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
## Summary
- Updates `browser-use-sdk` dependency from `2.0.15` to `3.4.2`
- All existing imports verified working with the new version

## Test plan
- [x] `uv sync` succeeds
- [x] All SDK imports (`AsyncBrowserUse`, type imports) verified working
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `browser-use-sdk` from 2.0.15 to 3.4.2 and align our code with v3 API changes. No behavior changes.

- **Dependencies**
  - Updated `browser-use-sdk` to `3.4.2` in `pyproject.toml`.

- **Refactors**
  - Moved to new top‑level SDK imports (`AsyncBrowserUse`, `ExecuteSkillResponse`, `SkillListResponse`, `ParameterSchema`, `SkillResponse`).
  - Handle UUID skill IDs from the SDK by casting to and comparing as `str`.
  - On error, return `ExecuteSkillResponse` with `result=None`, `stderr=None`, and `latencyMs=None` for schema compatibility.

<sup>Written for commit 1a94f96ce9c116700ac2fcb58bb0795cd607a7d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

