### PR TITLE
fix: resolve UnicodeEncodeError on Windows when state output contains emoji

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -1168,6 +1168,11 @@ def _migrate_legacy_files() -> None:
 
 def main() -> int:
 	"""Main entry point."""
+	# Ensure UTF-8 output on Windows (default cp1252 can't encode emoji/unicode from web pages)
+	if sys.platform == 'win32' and hasattr(sys.stdout, 'reconfigure'):
+		sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+		sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+
 	parser = build_parser()
 	args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- On Windows, Python defaults to cp1252 encoding for stdout, which cannot encode emoji or non-Latin characters commonly found in web page DOM output
- `browser-use state` crashes with `UnicodeEncodeError: 'charmap' codec can't encode character` on pages containing emoji (very common on modern sites)
- Fix: reconfigure stdout/stderr to UTF-8 on Windows at the start of `main()`

## Repro
1. On Windows, connect to any browser: `browser-use connect`
2. Open a page with emoji: `browser-use open https://reddit.com`
3. Run `browser-use state` -- crashes with UnicodeEncodeError

## Test plan
- [ ] Run `browser-use state` on Windows on a page containing emoji characters
- [ ] Verify output is printed correctly without crash
- [ ] Verify Linux/macOS behavior is unaffected (reconfigure only runs on win32)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows-only crash where `browser-use state` fails with UnicodeEncodeError when output includes emoji or other Unicode. On Windows, stdout and stderr are reconfigured to UTF-8 with errors='replace' at startup; Linux/macOS are unchanged.

<sup>Written for commit 9512900014cde9eef9a5092dbd7087ee63a79eb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

