### PR TITLE
feat: add text command for visible page text extraction

### DIFF
--- a/browser_use/skill_cli/commands/browser.py
+++ b/browser_use/skill_cli/commands/browser.py
@@ -177,6 +177,19 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 
 		return {'_raw_text': state_text}
 
+	elif action == 'text':
+		import json as json_module
+
+		selector = params.get('selector')
+		if selector:
+			js = f'(function(){{ const el = document.querySelector({json_module.dumps(selector)}); return el ? el.innerText : null; }})()'
+		else:
+			js = 'document.body.innerText'
+		text = await _execute_js(session, js)
+		if text is None:
+			return {'error': f'Selector {selector!r} not found' if selector else 'No text content found'}
+		return {'_raw_text': text}
+
 	elif action == 'tab':
 		tab_command = params.get('tab_command')
 

--- a/browser_use/skill_cli/commands/browser.py
+++ b/browser_use/skill_cli/commands/browser.py
@@ -31,6 +31,7 @@ COMMANDS = {
 	'dblclick',
 	'rightclick',
 	'get',
+	'text',
 }
 
 

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -733,6 +733,10 @@ Setup:
 	# state
 	subparsers.add_parser('state', help='Get browser state (URL, title, elements)')
 
+	# text
+	p = subparsers.add_parser('text', help='Get visible text content of the page')
+	p.add_argument('--selector', help='CSS selector to scope text extraction')
+
 	# tab (list, switch, close)
 	tab_p = subparsers.add_parser('tab', help='Tab management (list, switch, close)')
 	tab_sub = tab_p.add_subparsers(dest='tab_command')


### PR DESCRIPTION
## Summary
- Add `browser-use text` command that returns visible page text via `document.body.innerText`
- Supports `--selector` flag to scope extraction to a CSS selector (e.g. `browser-use text --selector '.comments'`)
- Much more efficient than `state` for content reading/scraping tasks where the full DOM element tree is unnecessary

## Motivation
When using the CLI for content extraction (e.g. scraping Reddit posts/comments), `state` returns massive output dominated by shadow DOM markers and structural elements. Users end up using `browser-use eval "document.body.innerText"` as a workaround. A dedicated `text` command is cleaner and more discoverable.

## Usage
```bash
browser-use text                          # full page visible text
browser-use text --selector '.article'    # scoped to CSS selector
```

## Test plan
- [ ] Run `browser-use text` on a content-rich page and verify clean text output
- [ ] Run `browser-use text --selector 'h1'` and verify scoped extraction
- [ ] Run `browser-use text --selector '.nonexistent'` and verify error message

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `browser-use text` to extract visible page text via `document.body.innerText`, with an optional `--selector` to target a specific element. This is faster and cleaner than `state` for reading or scraping content.

- **New Features**
  - New `text` CLI command for visible text extraction.
  - Returns `_raw_text`; if a selector is provided and not found, returns a clear error.

- **Bug Fixes**
  - Added `text` to the command allowlist so the CLI recognizes and runs it.

<sup>Written for commit 19e530278dc3cf66e63c5d15e0a985667bf4dffa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

