### PR TITLE
fix: strip empty shadow DOM containers from state output

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -1028,22 +1028,22 @@ class DOMTreeSerializer:
 				formatted_text.append(line)
 
 		elif node.original_node.node_type == NodeType.DOCUMENT_FRAGMENT_NODE:
-			# Shadow DOM representation - show clearly to LLM
-			if node.original_node.shadow_root_type and node.original_node.shadow_root_type.lower() == 'closed':
-				formatted_text.append(f'{depth_str}Closed Shadow')
-			else:
-				formatted_text.append(f'{depth_str}Open Shadow')
-
 			next_depth += 1
 
-			# Process shadow DOM children
+			# Process shadow DOM children first to check if any produce output
+			shadow_children_text = []
 			for child in node.children:
 				child_text = DOMTreeSerializer.serialize_tree(child, include_attributes, next_depth)
 				if child_text:
-					formatted_text.append(child_text)
+					shadow_children_text.append(child_text)
 
-			# Close shadow DOM indicator
-			if node.children:  # Only show close if we had content
+			# Only emit shadow DOM markers if children produced output
+			if shadow_children_text:
+				if node.original_node.shadow_root_type and node.original_node.shadow_root_type.lower() == 'closed':
+					formatted_text.append(f'{depth_str}Closed Shadow')
+				else:
+					formatted_text.append(f'{depth_str}Open Shadow')
+				formatted_text.extend(shadow_children_text)
 				formatted_text.append(f'{depth_str}Shadow End')
 
 		elif node.original_node.node_type == NodeType.TEXT_NODE:


### PR DESCRIPTION
## Summary
- Empty shadow DOM containers produce hundreds of `Open Shadow / Shadow End` pairs in the `state` output
- On modern sites using web components (Reddit, etc), these empty pairs make up 80%+ of the output while carrying zero useful information
- Fix: process shadow children first, only emit the Open/Close markers if children actually produced output

## Before
```
Open Shadow
    Open Shadow
    Shadow End
Shadow End
Open Shadow
Shadow End
Open Shadow
Shadow End
Open Shadow
Shadow End
```
(repeated hundreds of times on Reddit)

## After
Only shadow containers with actual content (text, interactive elements) are shown. Empty ones are silently omitted.

## Test plan
- [ ] Run `browser-use state` on a web-component-heavy site (Reddit, YouTube) and verify dramatically reduced output
- [ ] Verify that shadow DOM containers with actual content still display correctly
- [ ] Verify interactive elements inside shadow DOM are still shown with correct indices

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips empty shadow DOM containers from the state output to reduce noise and token usage. Shadow markers are only emitted when their children produce output.

- **Bug Fixes**
  - Process shadow children first; emit Open/Closed Shadow and Shadow End only if children produced content.
  - Dramatically reduces repeated empty pairs on web-component-heavy sites (e.g., Reddit, YouTube).
  - Preserves non-empty shadow roots and interactive elements with correct indices.

<sup>Written for commit 69dc556788d153e4fe3a03ce6cf83966dc9f0428. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

