### PR TITLE
fix: remove false-positive PID 1 substring matching in Docker detection

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -20,19 +20,28 @@ logger = logging.getLogger(__name__)
 def is_running_in_docker() -> bool:
 	"""Detect if we are running in a docker container, for the purpose of optimizing chrome launch flags (dev shm usage, gpu settings, etc.)"""
 	try:
-		if Path('/.dockerenv').exists() or 'docker' in Path('/proc/1/cgroup').read_text().lower():
+		if Path('/.dockerenv').exists():
 			return True
 	except Exception:
 		pass
 
 	try:
-		# if init proc (PID 1) looks like uvicorn/python/uv/etc. then we're in Docker
-		# if init proc (PID 1) looks like bash/systemd/init/etc. then we're probably NOT in Docker
-		init_cmd = ' '.join(psutil.Process(1).cmdline())
-		if ('py' in init_cmd) or ('uv' in init_cmd) or ('app' in init_cmd):
+		cgroup_text = Path('/proc/1/cgroup').read_text().lower()
+		if 'docker' in cgroup_text or 'containerd' in cgroup_text or 'kubepods' in cgroup_text:
 			return True
 	except Exception:
 		pass
+
+	# Podman uses /run/.containerenv instead of /.dockerenv
+	try:
+		if Path('/run/.containerenv').exists():
+			return True
+	except Exception:
+		pass
+
+	# Container runtime env vars (set by systemd-nspawn, Kubernetes, etc.)
+	if os.environ.get('container') or os.environ.get('KUBERNETES_SERVICE_HOST'):
+		return True
 
 	try:
 		# if less than 10 total running procs, then we're almost certainly in a container

--- a/tests/ci/test_docker_detection.py
+++ b/tests/ci/test_docker_detection.py
@@ -1,0 +1,137 @@
+"""Tests for is_running_in_docker() container detection logic."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from browser_use.config import is_running_in_docker
+
+
+def _detect_fresh(**overrides) -> bool:
+	"""Run is_running_in_docker with a clean cache.
+
+	Patches out all OS-level checks by default so each test controls exactly
+	which signals are present. Pass keyword arguments to override individual
+	checks (e.g. ``dockerenv_exists=True``).
+
+	Pass ``pid1_cmdline`` to simulate a PID 1 process with a specific command
+	(e.g. ``['/usr/bin/python3', 'app.py']``). When omitted, ``psutil.Process``
+	raises ``PermissionError`` so no PID 1 info is available.
+	"""
+	dockerenv = overrides.get('dockerenv_exists', False)
+	containerenv = overrides.get('containerenv_exists', False)
+	cgroup_text = overrides.get('cgroup_text', '')
+	env_vars = overrides.get('env_vars', {})
+	pid_count = overrides.get('pid_count', 100)
+	pid1_cmdline: list[str] | None = overrides.get('pid1_cmdline', None)
+
+	def fake_path_exists(self: Path) -> bool:
+		s = str(self)
+		if s == '/.dockerenv':
+			return dockerenv
+		if s == '/run/.containerenv':
+			return containerenv
+		return original_exists(self)
+
+	original_exists = Path.exists
+
+	# Build the psutil.Process mock: either return a fake with cmdline()
+	# or raise PermissionError (simulating restricted access to PID 1).
+	if pid1_cmdline is not None:
+		fake_proc = type('FakeProcess', (), {'cmdline': lambda self: pid1_cmdline})()
+		process_side_effect = None
+		process_return_value = fake_proc
+	else:
+		process_side_effect = PermissionError
+		process_return_value = None
+
+	# Clear the @cache so each call re-evaluates
+	is_running_in_docker.cache_clear()
+
+	with (
+		patch.object(Path, 'exists', fake_path_exists),
+		patch.object(Path, 'read_text', return_value=cgroup_text),
+		patch('psutil.pids', return_value=list(range(pid_count))),
+		patch('psutil.Process', side_effect=process_side_effect, return_value=process_return_value),
+		patch.dict(os.environ, env_vars, clear=False),
+	):
+		# Remove container-related env vars that might leak from the host
+		for key in ('container', 'KUBERNETES_SERVICE_HOST'):
+			if key not in env_vars:
+				os.environ.pop(key, None)
+		return is_running_in_docker()
+
+
+# ---------------------------------------------------------------------------
+# Positive signals — each should independently return True
+# ---------------------------------------------------------------------------
+
+
+def test_detects_dockerenv_file():
+	assert _detect_fresh(dockerenv_exists=True) is True
+
+
+def test_detects_docker_in_cgroup():
+	assert _detect_fresh(cgroup_text='12:devices:/docker/abc123\n') is True
+
+
+def test_detects_containerd_in_cgroup():
+	assert _detect_fresh(cgroup_text='0::/system.slice/containerd.service\n') is True
+
+
+def test_detects_kubepods_in_cgroup():
+	assert _detect_fresh(cgroup_text='12:memory:/kubepods/burstable/pod-xyz\n') is True
+
+
+def test_detects_podman_containerenv():
+	assert _detect_fresh(containerenv_exists=True) is True
+
+
+def test_detects_container_env_var():
+	assert _detect_fresh(env_vars={'container': 'lxc'}) is True
+
+
+def test_detects_kubernetes_env_var():
+	assert _detect_fresh(env_vars={'KUBERNETES_SERVICE_HOST': '10.0.0.1'}) is True
+
+
+def test_detects_low_process_count():
+	assert _detect_fresh(pid_count=5) is True
+
+
+# ---------------------------------------------------------------------------
+# Negative signals — bare-metal system should return False
+# ---------------------------------------------------------------------------
+
+
+def test_bare_metal_returns_false():
+	"""No container signals present → not in Docker."""
+	assert _detect_fresh() is False
+
+
+def test_many_processes_alone_not_enough():
+	"""High process count with no other signals → not in Docker."""
+	assert _detect_fresh(pid_count=200) is False
+
+
+# ---------------------------------------------------------------------------
+# Regression: PID 1 substring matching false positives (issue #4149)
+# ---------------------------------------------------------------------------
+
+
+def test_no_false_positive_from_pid1_python():
+	"""PID 1 running Python (e.g. bare-metal uWSGI) must NOT trigger detection."""
+	# The old code matched 'py' as a substring of the PID 1 command,
+	# producing false positives on bare-metal Linux servers running
+	# Python-based services as PID 1 (systemd unit with ExecStart=python).
+	assert _detect_fresh(pid1_cmdline=['/usr/bin/python3', '/opt/myapp/server.py'], pid_count=50) is False
+
+
+def test_no_false_positive_from_pid1_uv():
+	"""PID 1 running uv must NOT trigger detection."""
+	assert _detect_fresh(pid1_cmdline=['/usr/local/bin/uv', 'run', 'serve'], pid_count=50) is False
+
+
+def test_no_false_positive_from_pid1_app_path():
+	"""PID 1 with 'app' in the path must NOT trigger detection."""
+	assert _detect_fresh(pid1_cmdline=['/opt/application/start.sh'], pid_count=50) is False


### PR DESCRIPTION
## Problem

`is_running_in_docker()` uses broad substring matching on the PID 1 command line:

```python
init_cmd = ' '.join(psutil.Process(1).cmdline())
if ('py' in init_cmd) or ('uv' in init_cmd) or ('app' in init_cmd):
    return True
```

These substrings match far too liberally — any bare-metal Linux server running a Python service as PID 1 (via systemd `ExecStart=python`) triggers a false positive, since `'py'` appears in `python`, `'uv'` appears in `uv run`, and `'app'` appears in common paths like `/opt/app/...`.

The incorrect Docker detection then enables Docker-specific Chrome launch flags (`--disable-dev-shm-usage`, `--no-sandbox`, etc.) on non-container hosts, which degrades browser performance and security.

Fixes #4149

## Changes

**`browser_use/config.py`** — Replace the fragile PID 1 heuristic with reliable container runtime signals:

| Signal | Runtime |
|--------|---------|
| `/.dockerenv` | Docker (unchanged) |
| `/proc/1/cgroup` containing `docker` | Docker (unchanged) |
| `/proc/1/cgroup` containing `containerd` | containerd/CRI-O (new) |
| `/proc/1/cgroup` containing `kubepods` | Kubernetes (new) |
| `/run/.containerenv` | Podman (new) |
| `container` env var | systemd-nspawn, LXC (new) |
| `KUBERNETES_SERVICE_HOST` env var | Kubernetes (new) |
| Process count < 10 | General heuristic (unchanged) |

**`tests/ci/test_docker_detection.py`** — 13 tests covering every detection signal independently, bare-metal negative cases, and regression tests for the #4149 false positives (simulating PID 1 with Python/uv/app commands).

## Verification

```
=== OLD CODE behavior (false positives) ===
  /usr/bin/python3 /opt/myapp/server.py   -> is_docker=True   ← wrong
  /usr/local/bin/uv run serve             -> is_docker=True   ← wrong
  /opt/application/start.sh               -> is_docker=True   ← wrong

=== NEW CODE behavior ===
  /usr/bin/python3 /opt/myapp/server.py   -> is_docker=False  ← correct
  /usr/local/bin/uv run serve             -> is_docker=False  ← correct
  /opt/application/start.sh               -> is_docker=False  ← correct
```

## What this does NOT change

- The `/.dockerenv` check (standard Docker signal)
- The `/proc/1/cgroup` check (split into its own try-block, expanded to also match `containerd` and `kubepods`)
- The low process count heuristic (reasonable, low false-positive risk)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker detection by removing PID 1 substring matching and using reliable container runtime signals, preventing Docker-only Chrome flags on bare‑metal hosts. Fixes #4149.

- **Bug Fixes**
  - Replace the PID 1 heuristic with checks for: `/.dockerenv`; `/proc/1/cgroup` containing `docker`, `containerd`, or `kubepods`; `/run/.containerenv`; env vars `container` or `KUBERNETES_SERVICE_HOST`. Keep the low process count heuristic.
  - Add `tests/ci/test_docker_detection.py` to cover each signal and regressions for Python/uv/app false positives.

<sup>Written for commit de664764322031b7526300b06fa1452b799d1f13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

