### PR TITLE
Add AG2 multi-agent web research integration example

### DIFF
--- a/examples/integrations/ag2/README.md
+++ b/examples/integrations/ag2/README.md
@@ -42,7 +42,7 @@ The `browse_web` tool bridges AG2 (sync) and browser-use (async) — each call s
 ## Install
 
 ```bash
-pip install browser-use "ag2[openai]>=0.11.4,<1.0" langchain-openai
+pip install browser-use "ag2[openai]>=0.11.4,<1.0"
 playwright install chromium
 ```
 

--- a/examples/integrations/ag2/README.md
+++ b/examples/integrations/ag2/README.md
@@ -1,0 +1,77 @@
+# AG2 Multi-Agent Web Research
+
+Multi-agent web research system using [AG2](https://docs.ag2.ai) for agent coordination and [browser-use](https://docs.browser-use.com) for autonomous web browsing.
+
+## What It Does
+
+Three AG2 agents collaborate via GroupChat to research a topic:
+
+```
+User Question
+     |
+     v
++---------------------------+
+|  Planner Agent            |  Decomposes question into 2-4 browsing tasks
++---------------------------+
+     |
+     v
++---------------------------+
+|  Browser Agent            |  Calls browse_web() for each task
+|                           |       |
+|  browse_web(task) ------->|  browser-use Agent autonomously:
+|                           |    - navigates to websites
+|                           |    - extracts relevant data
+|                           |    - returns findings as text
++---------------------------+
+     |
+     v
++---------------------------+
+|  Synthesizer Agent        |  Combines all results into a report
+|                           |  Says TERMINATE when done
++---------------------------+
+```
+
+The `browse_web` tool bridges AG2 (sync) and browser-use (async) — each call spins up a fresh browser-use Agent with its own headless Chromium instance.
+
+## Prerequisites
+
+- Python 3.11+
+- `OPENAI_API_KEY` environment variable
+- Playwright browsers installed
+
+## Install
+
+```bash
+pip install browser-use "ag2[openai]>=0.11.4,<1.0" langchain-openai
+playwright install chromium
+```
+
+## Run
+
+```bash
+export OPENAI_API_KEY=sk-...
+python main.py
+```
+
+## Configuration
+
+| Environment Variable      | Default       | Description                          |
+|---------------------------|---------------|--------------------------------------|
+| `OPENAI_API_KEY`          | (required)    | OpenAI API key                       |
+| `OPENAI_MODEL`            | `gpt-4o-mini` | Model for both AG2 and browser-use   |
+| `BROWSER_USE_HEADLESS`    | `true`        | Set to `false` to see the browser UI |
+
+## How It Works
+
+1. **UserProxy** sends the research question to the GroupChat
+2. **Planner** breaks it into specific browsing tasks (e.g., "Go to provider X's pricing page and find GPU costs")
+3. **Browser Agent** calls `browse_web(task)` for each task — browser-use launches Chromium, navigates, extracts data, and returns results
+4. **Synthesizer** reads all browsing results and writes a structured report
+5. Synthesizer says `TERMINATE` to end the conversation
+
+Each `browse_web` call creates an isolated browser session that is cleaned up after use.
+
+## Links
+
+- [AG2 Documentation](https://docs.ag2.ai)
+- [browser-use Documentation](https://docs.browser-use.com)

--- a/examples/integrations/ag2/main.py
+++ b/examples/integrations/ag2/main.py
@@ -21,10 +21,9 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from autogen import AssistantAgent, GroupChat, GroupChatManager, LLMConfig, UserProxyAgent
-from langchain_openai import ChatOpenAI
 
 from browser_use import Agent as BrowserUseAgent
-from browser_use import Browser, BrowserProfile
+from browser_use import Browser, BrowserProfile, ChatOpenAI
 
 # --- Configuration ---
 
@@ -38,8 +37,8 @@ MODEL = os.getenv('OPENAI_MODEL', 'gpt-4o-mini')
 # AG2 LLM config (for agent reasoning)
 llm_config = LLMConfig({'model': MODEL, 'api_key': OPENAI_API_KEY, 'api_type': 'openai'})
 
-# browser-use LLM (LangChain ChatOpenAI, separate from AG2's config)
-browser_llm = ChatOpenAI(model=MODEL, api_key=OPENAI_API_KEY)  # type: ignore[arg-type]
+# browser-use LLM (browser-use's own ChatOpenAI, separate from AG2's config)
+browser_llm = ChatOpenAI(model=MODEL, api_key=OPENAI_API_KEY)
 
 
 # --- Termination ---
@@ -108,8 +107,8 @@ def browse_web(task: str) -> str:
 	async def _run() -> str:
 		browser = Browser(browser_profile=BrowserProfile(headless=HEADLESS))
 		try:
-			agent = BrowserUseAgent(task=task, llm=browser_llm, browser=browser)  # type: ignore[arg-type]
-			result = await agent.run()
+			agent = BrowserUseAgent(task=task, llm=browser_llm, browser=browser)
+			result = await agent.run(max_steps=50)
 			return result.final_result() or 'No results found.'
 		except Exception as e:
 			return f'Browsing error: {e}'

--- a/examples/integrations/ag2/main.py
+++ b/examples/integrations/ag2/main.py
@@ -1,0 +1,151 @@
+"""AG2 Multi-Agent Web Research with browser-use.
+
+Coordinates three AG2 agents to perform web research:
+- Planner: decomposes a research question into browsing tasks
+- Browser Agent: executes tasks via browser-use's autonomous browser
+- Synthesizer: combines results into a final report
+
+Usage:
+    export OPENAI_API_KEY=sk-...
+    python main.py
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from autogen import AssistantAgent, GroupChat, GroupChatManager, LLMConfig, UserProxyAgent
+from langchain_openai import ChatOpenAI
+
+from browser_use import Agent as BrowserUseAgent
+from browser_use import Browser, BrowserProfile
+
+# --- Configuration ---
+
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+if not OPENAI_API_KEY:
+	raise ValueError('OPENAI_API_KEY environment variable is required')
+
+HEADLESS = os.getenv('BROWSER_USE_HEADLESS', 'true').lower() != 'false'
+MODEL = os.getenv('OPENAI_MODEL', 'gpt-4o-mini')
+
+# AG2 LLM config (for agent reasoning)
+llm_config = LLMConfig({'model': MODEL, 'api_key': OPENAI_API_KEY, 'api_type': 'openai'})
+
+# browser-use LLM (LangChain ChatOpenAI, separate from AG2's config)
+browser_llm = ChatOpenAI(model=MODEL, api_key=OPENAI_API_KEY)  # type: ignore[arg-type]
+
+
+# --- Termination ---
+
+
+def is_termination(msg):
+	content = msg.get('content', '') or ''
+	return 'TERMINATE' in content
+
+
+# --- AG2 Agents ---
+
+user_proxy = UserProxyAgent(
+	name='user_proxy',
+	human_input_mode='NEVER',
+	max_consecutive_auto_reply=10,
+	code_execution_config=False,
+	is_termination_msg=is_termination,
+)
+
+planner = AssistantAgent(
+	name='planner',
+	system_message=(
+		'You are a research planner. Given a research question, decompose it into '
+		'2-4 specific web browsing tasks. Each task should be a clear, self-contained '
+		'instruction that a browser agent can execute (e.g., "Go to example.com and find X").\n'
+		'Output tasks as a numbered list. Do NOT execute tasks yourself — hand them '
+		'to the browser_agent.'
+	),
+	llm_config=llm_config,
+)
+
+browser_agent = AssistantAgent(
+	name='browser_agent',
+	system_message=(
+		'You execute web browsing tasks using the browse_web tool. '
+		'For each task given by the planner, call browse_web with a clear task description. '
+		'Report the results back to the group. Call browse_web once per task — do not '
+		'combine multiple tasks into one call.'
+	),
+	llm_config=llm_config,
+)
+
+synthesizer = AssistantAgent(
+	name='synthesizer',
+	system_message=(
+		'You synthesize research results into a clear, well-structured report. '
+		'Wait until the browser_agent has completed all browsing tasks before writing '
+		'your report. Once you have enough information, write a final summary.\n'
+		'When your report is complete, end your message with TERMINATE.'
+	),
+	llm_config=llm_config,
+)
+
+
+# --- browser-use Tool ---
+
+
+@user_proxy.register_for_execution()
+@browser_agent.register_for_llm(
+	description='Browse the web to complete a task. Pass a natural-language task description.',
+)
+def browse_web(task: str) -> str:
+	"""Use browser-use to autonomously browse the web and complete the given task."""
+
+	async def _run() -> str:
+		browser = Browser(browser_profile=BrowserProfile(headless=HEADLESS))
+		try:
+			agent = BrowserUseAgent(task=task, llm=browser_llm, browser=browser)  # type: ignore[arg-type]
+			result = await agent.run()
+			return result.final_result() or 'No results found.'
+		except Exception as e:
+			return f'Browsing error: {e}'
+		finally:
+			await browser.kill()
+
+	return asyncio.run(_run())
+
+
+# --- GroupChat ---
+
+group_chat = GroupChat(
+	agents=[user_proxy, planner, browser_agent, synthesizer],
+	messages=[],
+	max_round=15,
+)
+
+manager = GroupChatManager(
+	groupchat=group_chat,
+	llm_config=llm_config,
+	is_termination_msg=is_termination,
+)
+
+
+# --- Main ---
+
+
+def main():
+	task = (
+		'Compare the pricing and key features of the top 3 cloud GPU providers '
+		'for AI model training in 2026. Include per-hour GPU costs where available.'
+	)
+	print(f'Starting research: {task}\n')
+	user_proxy.run(manager, message=task).process()
+	print('\n--- Conversation complete ---')
+
+
+if __name__ == '__main__':
+	main()

--- a/examples/integrations/ag2/main.py
+++ b/examples/integrations/ag2/main.py
@@ -20,7 +20,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from autogen import AssistantAgent, GroupChat, GroupChatManager, LLMConfig, UserProxyAgent
+from autogen import AssistantAgent, GroupChat, GroupChatManager, LLMConfig, UserProxyAgent  # type: ignore[import-not-found]
 
 from browser_use import Agent as BrowserUseAgent
 from browser_use import Browser, BrowserProfile, ChatOpenAI

--- a/examples/integrations/ag2/main.py
+++ b/examples/integrations/ag2/main.py
@@ -45,8 +45,8 @@ browser_llm = ChatOpenAI(model=MODEL, api_key=OPENAI_API_KEY)
 
 
 def is_termination(msg):
-	content = msg.get('content', '') or ''
-	return 'TERMINATE' in content
+	content = (msg.get('content', '') or '').strip()
+	return content.endswith('TERMINATE')
 
 
 # --- AG2 Agents ---


### PR DESCRIPTION
## Summary
- Adds a new integration example in `examples/integrations/ag2/` demonstrating AG2 multi-agent coordination with browser-use for web research
- Three AG2 agents (planner, browser, synthesizer) collaborate via GroupChat — the browser agent calls a `browse_web` tool that wraps browser-use's autonomous Agent
- Each `browse_web` call creates an isolated headless Chromium session, extracts data, and cleans up via `browser.kill()`

## Architecture
```
User Question → AG2 Planner → decomposes into sub-tasks
                     ↓
              AG2 Browser Agent → calls browse_web("search for X on Y")
                     ↓
              browser-use Agent → autonomous browsing → returns extracted data
                     ↓
              AG2 Synthesizer → final report → TERMINATE
```

## Files
- `examples/integrations/ag2/main.py` — integration script
- `examples/integrations/ag2/README.md` — setup, usage, architecture docs

## Test plan
- [x] Syntax check (`python -c "import ast; ast.parse(...)"`), ruff lint, ruff format, pyright — all pass
- [x] Offline: all AG2 agents create, tools register, GroupChat initializes
- [x] E2E with real API: planner decomposes task, browser agent browses multiple sites via browser-use, results returned to AG2 conversation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `ag2` + `browser-use` multi-agent web research example that coordinates planner, browser, and synthesizer agents via GroupChat. Also fixes termination so chats only end when a message ends with "TERMINATE".

- **New Features**
  - Example in `examples/integrations/ag2/` (`main.py`, `README.md`) showing planner → browser → synthesizer flow.
  - Browser agent exposes a `browse_web` tool backed by `browser-use`’s Agent; each call starts a fresh headless Chromium session and cleans up with `browser.kill()`.
  - Uses `browser-use`’s `ChatOpenAI`, supports `OPENAI_MODEL` and `BROWSER_USE_HEADLESS`, and caps `max_steps=50`.

- **Bug Fixes**
  - Suppress `pyright` import error for optional `autogen` dependency.

<sup>Written for commit 25c9a6edd5858faa905e8152217ae5d82f180d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

