### PR TITLE
ci: pin stale workflow action

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           # General settings
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- pin the privileged stale workflow action to the immutable commit behind `actions/stale@v9`
- preserve current behavior by keeping the same major tag target and only removing tag-retarget drift
- leave existing workflow permissions and stale policy settings unchanged

## Why
This scheduled workflow runs with `issues: write` and `pull-requests: write`, so pinning the marketplace action to a commit reduces supply-chain drift without changing workflow behavior.

## Validation
- `git diff --check`
- `python -c "from pathlib import Path; import yaml; yaml.safe_load(Path('.github/workflows/stale-bot.yml').read_text(encoding='utf-8')); print('yaml-parse-ok')"`
- local PC Control review-coder queued against the staged diff; it remained running during push, so I treated it as degraded evidence and completed a bounded manual preflight on the one-line workflow change

## Notes
- This intentionally stays scoped to one workflow line.
- I did not change permissions, timing, or stale policy behavior.
- `uv` / `pre-commit` and `actionlint` were not available on this Windows shell, so I did not claim those checks ran locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `actions/stale` in the scheduled workflow to the immutable v9 commit to eliminate tag drift and reduce supply-chain risk. Behavior, permissions, schedule, and stale policy remain unchanged.

<sup>Written for commit b1f755d509198fbbcd80d3e066248ca1f4d9d0c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

