### PR TITLE
fix(mcp): reduce BrowserStartEvent startup timeouts on Windows

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -29,6 +29,9 @@ import sys
 # Set environment variables BEFORE any browser_use imports to prevent early logging
 os.environ['BROWSER_USE_LOGGING_LEVEL'] = 'critical'
 os.environ['BROWSER_USE_SETUP_LOGGING'] = 'false'
+# MCP startup can be slower on some Windows setups; use safer defaults unless user overrides.
+os.environ.setdefault('TIMEOUT_BrowserStartEvent', '60')
+os.environ.setdefault('TIMEOUT_BrowserLaunchEvent', '60')
 
 import asyncio
 import json
@@ -579,7 +582,9 @@ class BrowserUseServer:
 			'downloads_path': str(Path.home() / 'Downloads' / 'browser-use-mcp'),
 			'wait_between_actions': 0.5,
 			'keep_alive': True,
-			'user_data_dir': '~/.config/browseruse/profiles/default',
+			# Use a per-session temp profile by default.
+			# A fixed shared profile can cause startup hangs/timeouts on Windows when files are locked.
+			'user_data_dir': None,
 			'device_scale_factor': 1.0,
 			'disable_security': False,
 			'headless': False,


### PR DESCRIPTION
Fixes #4580

## Problem
On some Windows setups, MCP tool calls fail before navigation completes with:

`Event handler BrowserSession.on_BrowserStartEvent(...) timed out after 30.0s`

In the same environment, CLI usage can succeed while MCP startup is more likely to time out.

## Solution
This PR makes MCP startup defaults more resilient:

1. Increase MCP startup timeout defaults (without overriding user-provided env vars):
   - `TIMEOUT_BrowserStartEvent` -> `60`
   - `TIMEOUT_BrowserLaunchEvent` -> `60`
2. Stop forcing a shared persistent profile path in MCP defaults:
   - `user_data_dir` default changed from a fixed path to `None` (per-session temp profile)

Why this helps:
- Avoids startup flakiness from locked/shared profile state on Windows.
- Reduces false startup failures on slower machine/launch paths.

## Testing
- `ruff check` passes for changed file.
- `ruff format --check` passes for changed file.

## Notes
This was developed on macOS, so exact Windows repro validation should be confirmed by the issue reporter/maintainers on a Windows environment matching #4580.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make MCP startup more reliable on Windows to reduce `BrowserStartEvent` timeouts (fixes #4580). Sets default `TIMEOUT_BrowserStartEvent` and `TIMEOUT_BrowserLaunchEvent` to 60s unless overridden, and switches default `user_data_dir` to `None` to use a per-session temp profile and avoid profile lock issues.

<sup>Written for commit 6ed15377b6a197253237a2f2dcb33218f900c505. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

