### PR TITLE
fix(#4631): clear dom cache after scroll to prevent stale extract data

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -518,6 +518,11 @@ class DefaultActionWatchdog(BaseWatchdog):
 			raise BrowserError(error_msg)
 
 		try:
+
+			def invalidate_dom_cache() -> None:
+				if self.browser_session._dom_watchdog:
+					self.browser_session._dom_watchdog.clear_cache()
+
 			# Convert direction and amount to pixels
 			# Positive pixels = scroll down, negative = scroll up
 			pixels = event.amount if event.direction == 'down' else -event.amount
@@ -547,6 +552,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 						# Wait a bit for the scroll to settle and DOM to update
 						await asyncio.sleep(0.2)
 
+					invalidate_dom_cache()
 					return None
 
 			# Perform target-level scroll
@@ -554,6 +560,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# Note: We don't clear cached state here - let multi_act handle DOM change detection
 			# by explicitly rebuilding and comparing when needed
+			invalidate_dom_cache()
 
 			# Log success
 			self.logger.debug(f'📜 Scrolled {event.direction} by {event.amount} pixels')


### PR DESCRIPTION
Resolves #4631

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the DOM watchdog cache after scrolls to prevent stale extraction data and ensure DOM reads reflect the current page state. Addresses #4631 where post-scroll data could be outdated.

- **Bug Fixes**
  - Clear `_dom_watchdog` cache after both element-target and CDP gesture scrolls.
  - Wait ~200ms before clearing after element-target scroll so the DOM can settle.

<sup>Written for commit 60e7767228c6078dba22c320d9e006bf3aad5029. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

