### PR TITLE
fix asyncio.get_event_loop for python 3.14 compat

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -1222,8 +1222,7 @@ def main() -> int:
 	if args.command == 'doctor':
 		from browser_use.skill_cli.commands import doctor
 
-		loop = asyncio.get_event_loop()
-		result = loop.run_until_complete(doctor.handle())
+		result = asyncio.run(doctor.handle())
 
 		if args.json:
 			print(json.dumps(result))
@@ -1337,9 +1336,9 @@ def main() -> int:
 			port_arg = getattr(args, 'port_arg', None)
 			if getattr(args, 'all', False):
 				# stop --all
-				result = asyncio.get_event_loop().run_until_complete(tunnel.stop_all_tunnels())
+				result = asyncio.run(tunnel.stop_all_tunnels())
 			elif port_arg is not None:
-				result = asyncio.get_event_loop().run_until_complete(tunnel.stop_tunnel(port_arg))
+				result = asyncio.run(tunnel.stop_tunnel(port_arg))
 			else:
 				print('Usage: browser-use tunnel stop <port> | --all', file=sys.stderr)
 				return 1
@@ -1349,7 +1348,7 @@ def main() -> int:
 			except ValueError:
 				print(f'Unknown tunnel subcommand: {pos}', file=sys.stderr)
 				return 1
-			result = asyncio.get_event_loop().run_until_complete(tunnel.start_tunnel(port))
+			result = asyncio.run(tunnel.start_tunnel(port))
 		else:
 			print('Usage: browser-use tunnel <port> | list | stop <port>', file=sys.stderr)
 			return 0


### PR DESCRIPTION
Fixes #4626

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace deprecated asyncio.get_event_loop/run_until_complete with asyncio.run() in the CLI to restore Python 3.14 compatibility. Fixes #4626 and prevents runtime errors in the `doctor` and `tunnel` commands.

<sup>Written for commit 99a8674214ec66a784cd368e3d6e3116779d4162. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

