### PR TITLE
fix: handle BrokenPipeError gracefully when MCP client disconnects

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -1227,18 +1227,21 @@ class BrowserUseServer:
 			raise RuntimeError('MCP stdio transport requires stdin, but this process was launched without one.')
 
 		async with mcp.server.stdio.stdio_server() as (read_stream, write_stream):
-			await self.server.run(
-				read_stream,
-				write_stream,
-				InitializationOptions(
-					server_name='browser-use',
-					server_version='0.1.0',
-					capabilities=self.server.get_capabilities(
-						notification_options=NotificationOptions(),
-						experimental_capabilities={},
+			try:
+				await self.server.run(
+					read_stream,
+					write_stream,
+					InitializationOptions(
+						server_name='browser-use',
+						server_version='0.1.0',
+						capabilities=self.server.get_capabilities(
+							notification_options=NotificationOptions(),
+							experimental_capabilities={},
+						),
 					),
-				),
-			)
+				)
+			except BrokenPipeError:
+				logger.warning('MCP client disconnected while writing to stdio; shutting down server cleanly.')
 
 
 async def main(session_timeout_minutes: int = 10):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Gracefully handle MCP stdio disconnections by catching BrokenPipeError, preventing crashes and shutting down the server cleanly.

- **Bug Fixes**
  - Wrap `server.run` in a `try/except BrokenPipeError`.
  - Log a warning and exit cleanly when the MCP client disconnects.

<sup>Written for commit df4e2f9f151803decbb1555b5278e31a558814b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

