### PR TITLE
close alias for BrowserSession stop

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -721,6 +721,10 @@ class BrowserSession(BaseModel):
 		# Create fresh event bus
 		self.event_bus = EventBus()
 
+	async def close(self) -> None:
+		"""Alias for stop()."""
+		await self.stop()
+
 	@observe_debug(ignore_input=True, ignore_output=True, name='browser_start_event_handler')
 	async def on_BrowserStartEvent(self, event: BrowserStartEvent) -> dict[str, str]:
 		"""Handle browser start request.


### PR DESCRIPTION
thousands of users have attempted to use close, so why not add it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `close()` to `BrowserSession` as an alias for `stop()`, so `session.close()` cleanly stops the session and matches common APIs.

<sup>Written for commit 76604913ad0ca43cc4797da338a395a3e5ea9bb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

