### PR TITLE
fix(tools): auto-attach browser downloads in default done action

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1908,7 +1908,7 @@ Validated Code (after quote fixing):
 				'Complete task. Only report actions you performed and data you extracted in this session.',
 				param_model=DoneAction,
 			)
-			async def done(params: DoneAction, file_system: FileSystem):
+			async def done(params: DoneAction, file_system: FileSystem, browser_session: BrowserSession):
 				user_message = params.text
 
 				len_text = len(params.text)
@@ -1938,6 +1938,15 @@ Validated Code (after quote fixing):
 								attachments.append(file_name)
 
 				attachments = [str(file_system.get_dir() / file_name) for file_name in attachments]
+
+				# Auto-attach actual session downloads (CDP-tracked browser downloads)
+				# but NOT user-supplied whitelist paths from available_file_paths
+				session_downloads = browser_session.downloaded_files
+				if session_downloads:
+					existing = set(attachments)
+					for file_path in session_downloads:
+						if file_path not in existing:
+							attachments.append(file_path)
 
 				return ActionResult(
 					is_done=True,

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -666,3 +666,87 @@ class TestStructuredOutputDoneWithFiles:
 		assert 'files_to_display' not in top_level_props
 		# data should still be present
 		assert 'data' in top_level_props
+
+
+class TestDefaultDoneWithDownloads:
+	"""Tests for browser download auto-attachment in the default (non-structured) done action."""
+
+	async def test_default_done_auto_attaches_downloads(self, browser_session, base_url):
+		"""Session downloads are auto-attached in the default done action (no output_model)."""
+		tools = Tools()
+
+		with tempfile.TemporaryDirectory() as temp_dir:
+			file_system = FileSystem(temp_dir)
+
+			# Simulate a CDP-tracked browser download
+			fake_download = os.path.join(temp_dir, 'report.pdf')
+			await anyio.Path(fake_download).write_bytes(b'%PDF-1.4 fake pdf content')
+
+			saved_downloads = browser_session._downloaded_files.copy()
+			browser_session._downloaded_files.append(fake_download)
+			try:
+				result = await tools.done(
+					text='Downloaded the report',
+					success=True,
+					browser_session=browser_session,
+					file_system=file_system,
+				)
+
+				assert isinstance(result, ActionResult)
+				assert result.is_done is True
+				assert result.success is True
+				# The download should be auto-attached
+				assert result.attachments is not None
+				assert len(result.attachments) == 1
+				assert result.attachments[0] == fake_download
+			finally:
+				browser_session._downloaded_files = saved_downloads
+
+	async def test_default_done_without_downloads(self, browser_session, base_url):
+		"""Default done action works normally when there are no downloads."""
+		tools = Tools()
+
+		with tempfile.TemporaryDirectory() as temp_dir:
+			file_system = FileSystem(temp_dir)
+
+			result = await tools.done(
+				text='Task completed successfully',
+				success=True,
+				browser_session=browser_session,
+				file_system=file_system,
+			)
+
+			assert isinstance(result, ActionResult)
+			assert result.is_done is True
+			assert result.success is True
+			assert result.attachments == []
+
+	async def test_default_done_deduplicates_downloads_and_files_to_display(self, browser_session):
+		"""Downloads already covered by files_to_display are not duplicated in default done."""
+		tools = Tools()
+
+		with tempfile.TemporaryDirectory() as temp_dir:
+			file_system = FileSystem(temp_dir)
+			await file_system.write_file('data.csv', 'col1,col2\n1,2\n')
+
+			# The same file appears in both files_to_display and session downloads
+			fs_path = str(file_system.get_dir() / 'data.csv')
+
+			saved_downloads = browser_session._downloaded_files.copy()
+			browser_session._downloaded_files.append(fs_path)
+			try:
+				result = await tools.done(
+					text='Exported the data',
+					success=True,
+					files_to_display=['data.csv'],
+					browser_session=browser_session,
+					file_system=file_system,
+				)
+
+				assert isinstance(result, ActionResult)
+				# Should have exactly 1 attachment, not 2
+				assert result.attachments is not None
+				assert len(result.attachments) == 1
+				assert result.attachments[0] == fs_path
+			finally:
+				browser_session._downloaded_files = saved_downloads


### PR DESCRIPTION
## Problem

The structured-output `done` handler (used when `output_model` is set) correctly auto-attaches `browser_session.downloaded_files` to `ActionResult.attachments`. However, the default (non-structured) `done` handler — which is the code path for **the majority of users** — was missing this logic entirely.

This meant that any files downloaded by the browser during a session would silently **not appear** in `ActionResult.attachments` for default agent usage.

**Affected code:** `browser_use/tools/service.py`, line ~1911

```python
# Structured done (correct) — accepts browser_session, attaches downloads
async def done(params: StructuredOutputAction, file_system: FileSystem, browser_session: BrowserSession):
    ...
    session_downloads = browser_session.downloaded_files  # ✅ attached
    ...

# Default done (broken) — missing browser_session entirely
async def done(params: DoneAction, file_system: FileSystem):  # ❌ no browser_session
    ...
    # downloads silently lost
```

Fixes #4482

## Solution

1. Add `browser_session: BrowserSession` parameter to the default done handler (the registry's dependency injection already provides this via `special_context`)
2. Mirror the same download auto-attachment logic from the structured path, placed after `files_to_display` resolution
3. Include deduplication so downloads already covered by `files_to_display` are not duplicated

## Changes

| File | Change |
|------|--------|
| `browser_use/tools/service.py` | Add `browser_session` param + download attachment logic to default done handler (+10 lines) |
| `tests/ci/test_tools.py` | 3 new tests: auto-attach, no-download baseline, deduplication (+84 lines) |

## Testing

All 19 tests in `tests/ci/test_tools.py` pass (16 existing + 3 new):

```
tests/ci/test_tools.py::TestDefaultDoneWithDownloads::test_default_done_auto_attaches_downloads PASSED
tests/ci/test_tools.py::TestDefaultDoneWithDownloads::test_default_done_without_downloads PASSED
tests/ci/test_tools.py::TestDefaultDoneWithDownloads::test_default_done_deduplicates_downloads_and_files_to_display PASSED
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-attaches browser session downloads in the default `done` action so downloaded files show up in `ActionResult.attachments` for non-structured runs. Aligns default behavior with structured output and avoids duplicate attachments. Fixes #4482.

- **Bug Fixes**
  - Default `done` now accepts `browser_session` and attaches `browser_session.downloaded_files` after resolving `files_to_display`, with deduplication.
  - Updated `browser_use/tools/service.py` to add the new param and attachment logic.
  - Added tests in `tests/ci/test_tools.py` for auto-attach, no-download baseline, and deduplication.

<sup>Written for commit e30353e1a8531b16469e471d6889ae9e90735b18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

