### PR TITLE
fix: add 10s timeout wrapper for CDP Runtime.evaluate

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -689,6 +690,8 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	@classmethod
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
+		# Use deep copy to avoid mutating the caller's input
+		data = copy.deepcopy(data)
 		# loop through history and validate output_model actions to enrich with custom actions
 		for h in data['history']:
 			if h['model_output']:

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -692,14 +692,19 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
 		# Use deep copy to avoid mutating the caller's input
 		data = copy.deepcopy(data)
+		# Filter out malformed history items (non-dict entries) before processing
+		data['history'] = [h for h in data['history'] if isinstance(h, dict)]
 		# loop through history and validate output_model actions to enrich with custom actions
 		for h in data['history']:
-			if h['model_output']:
+			if 'model_output' in h and h['model_output']:
 				if isinstance(h['model_output'], dict):
-					h['model_output'] = output_model.model_validate(h['model_output'])
+					try:
+						h['model_output'] = output_model.model_validate(h['model_output'])
+					except (ValidationError, TypeError, AttributeError):
+						h['model_output'] = None
 				else:
 					h['model_output'] = None
-			if 'interacted_element' not in h['state']:
+			if 'state' in h and 'interacted_element' not in h['state']:
 				h['state']['interacted_element'] = None
 
 		history = cls.model_validate(data)


### PR DESCRIPTION
## Bug
CDP `Runtime.evaluate` calls in `_get_pending_network_requests` had no per-call timeout, causing indefinite hangs with remote browsers.

## Fix
Wrap in `asyncio.wait_for(timeout=10.0)` with explicit `asyncio.TimeoutError` handling. On timeout, log a clear warning with 10.0s timeout value and return empty list.

Closes #4589

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 10s timeout around CDP `Runtime.evaluate` when detecting pending network requests to avoid hangs with remote browsers. Also harden agent history loading to avoid mutating inputs and to safely skip malformed items. Fixes #4589.

- **Bug Fixes**
  - `_get_pending_network_requests`: wrap CDP `Runtime.evaluate` in `asyncio.wait_for(10s)`; on timeout, log a clear warning and return an empty list. Simplify error handling by flattening the try/except around the timeout and result parsing. Also cap the pre-wait check in `on_BrowserStateRequestEvent` with a 2s timeout.
  - `AgentHistoryList.load_from_dict`: deep copy input `data`, drop non-dict `history` entries, guard `model_output` validation (set to `None` on errors), and handle missing `state` while defaulting `interacted_element` to `None`.

<sup>Written for commit d16dbffe04e395f6bd3015f105c7cc412070f3dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

