### PR TITLE
feat: Add Astraflow (UCloud ModelVerse) LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,8 @@ BROWSER_USE_API_KEY=your_bu_api_key_here
 # DEEPSEEK_API_KEY=
 # GROK_API_KEY=
 # NOVITA_API_KEY=
+# ASTRAFLOW_API_KEY=
+# ASTRAFLOW_CN_API_KEY=
 
 # AWS Bedrock Configuration (for AWS Bedrock models)
 # Requires: pip install browser-use[aws]

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -26,6 +26,7 @@ from browser_use.llm.messages import (
 
 # Type stubs for lazy imports
 if TYPE_CHECKING:
+	from browser_use.llm.astraflow.chat import ChatAstraflow, ChatAstraflowCN
 	from browser_use.llm.anthropic.chat import ChatAnthropic
 	from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
 	from browser_use.llm.aws.chat_bedrock import ChatAWSBedrock
@@ -94,6 +95,8 @@ _LAZY_IMPORTS = {
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
 	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
+	'ChatAstraflow': ('browser_use.llm.astraflow.chat', 'ChatAstraflow'),
+	'ChatAstraflowCN': ('browser_use.llm.astraflow.chat', 'ChatAstraflowCN'),
 }
 
 # Cache for model instances - only created when accessed
@@ -158,4 +161,6 @@ __all__ = [
 	'ChatOpenRouter',
 	'ChatVercel',
 	'ChatCerebras',
+	'ChatAstraflow',
+	'ChatAstraflowCN',
 ]

--- a/browser_use/llm/astraflow/__init__.py
+++ b/browser_use/llm/astraflow/__init__.py
@@ -1,0 +1,3 @@
+from browser_use.llm.astraflow.chat import ChatAstraflow, ChatAstraflowCN
+
+__all__ = ['ChatAstraflow', 'ChatAstraflowCN']

--- a/browser_use/llm/astraflow/chat.py
+++ b/browser_use/llm/astraflow/chat.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from browser_use.llm.openai.chat import ChatOpenAI
+
+
+@dataclass
+class ChatAstraflow(ChatOpenAI):
+	"""
+	Astraflow (UCloud ModelVerse) global endpoint wrapper.
+
+	Uses the OpenAI-compatible API at https://api-us-ca.umodelverse.ai/v1.
+	Set the ASTRAFLOW_API_KEY environment variable with your API key.
+
+	Supported models include:
+	  - deepseek-r1
+	  - deepseek-v3
+	  - llama-3.3-70b-instruct
+	"""
+
+	model: str = 'deepseek-v3'
+	base_url: str | httpx.URL | None = 'https://api-us-ca.umodelverse.ai/v1'
+
+	# Astraflow does not advertise support for frequency_penalty;
+	# set to None to avoid potential 422 errors on the provider side.
+	frequency_penalty: float | None = None
+
+	@property
+	def provider(self) -> str:
+		return 'astraflow'
+
+
+@dataclass
+class ChatAstraflowCN(ChatOpenAI):
+	"""
+	Astraflow (UCloud ModelVerse) China endpoint wrapper.
+
+	Uses the OpenAI-compatible API at https://api.umodelverse.ai/v1.
+	Set the ASTRAFLOW_CN_API_KEY environment variable with your API key.
+
+	Supported models include:
+	  - deepseek-r1
+	  - deepseek-v3
+	  - llama-3.3-70b-instruct
+	"""
+
+	model: str = 'deepseek-v3'
+	base_url: str | httpx.URL | None = 'https://api.umodelverse.ai/v1'
+
+	frequency_penalty: float | None = None
+
+	@property
+	def provider(self) -> str:
+		return 'astraflow-cn'

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -19,6 +19,7 @@ from browser_use.llm.browser_use.chat import ChatBrowserUse
 from browser_use.llm.cerebras.chat import ChatCerebras
 from browser_use.llm.google.chat import ChatGoogle
 from browser_use.llm.mistral.chat import ChatMistral
+from browser_use.llm.astraflow.chat import ChatAstraflow, ChatAstraflowCN
 from browser_use.llm.openai.chat import ChatOpenAI
 
 # Optional OCI import
@@ -161,8 +162,20 @@ def get_llm_by_name(model_name: str):
 	else:
 		model = model_part.replace('_', '-')
 
+	# Astraflow / ModelVerse Models (global)
+	# Primary key: 'astraflow'; aliases: 'astra-flow', 'astra_flow', 'modelverse'
+	if provider in ('astraflow', 'astra-flow', 'astra_flow', 'modelverse'):
+		api_key = os.getenv('ASTRAFLOW_API_KEY')
+		return ChatAstraflow(model=model, api_key=api_key)
+
+	# Astraflow / ModelVerse Models (China)
+	# Primary key: 'astraflow-cn'; aliases: 'astraflow-china', 'astraflow_cn'
+	elif provider in ('astraflow-cn', 'astraflow-china', 'astraflow_cn'):
+		api_key = os.getenv('ASTRAFLOW_CN_API_KEY')
+		return ChatAstraflowCN(model=model, api_key=api_key)
+
 	# OpenAI Models
-	if provider == 'openai':
+	elif provider == 'openai':
 		api_key = os.getenv('OPENAI_API_KEY')
 		return ChatOpenAI(model=model, api_key=api_key)
 
@@ -211,7 +224,7 @@ def get_llm_by_name(model_name: str):
 		return ChatBrowserUse(model=model, api_key=api_key)
 
 	else:
-		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu']
+		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu', 'astraflow', 'astraflow-cn']
 
 		raise ValueError(f"Unknown provider: '{provider}'. Available providers: {', '.join(available_providers)}")
 
@@ -254,6 +267,8 @@ __all__ = [
 	'ChatMistral',
 	'ChatCerebras',
 	'ChatBrowserUse',
+	'ChatAstraflow',
+	'ChatAstraflowCN',
 ]
 
 if OCI_AVAILABLE:


### PR DESCRIPTION
## Summary

Adds **Astraflow** (UCloud ModelVerse) as a first-class LLM provider, supporting both the global endpoint and the China-region endpoint.

## Changes

### New files
- `browser_use/llm/astraflow/__init__.py` — package init, exports `ChatAstraflow` and `ChatAstraflowCN`
- `browser_use/llm/astraflow/chat.py` — two dataclass wrappers that extend `ChatOpenAI` with Astraflow-specific defaults

### Modified files
| File | Change |
|---|---|
| `browser_use/llm/__init__.py` | Lazy-import entries + TYPE_CHECKING stubs + `__all__` entries for both classes |
| `browser_use/llm/models.py` | Import classes; add `astraflow` / `astraflow-cn` branches (with aliases) to `get_llm_by_name`; update `__all__` |
| `.env.example` | Document `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` under Model Configuration |

## Provider Details

| | Global | China |
|---|---|---|
| Class | `ChatAstraflow` | `ChatAstraflowCN` |
| Primary key | `astraflow` | `astraflow-cn` |
| Aliases | `astra-flow`, `astra_flow`, `modelverse` | `astraflow-china`, `astraflow_cn` |
| Base URL | `https://api-us-ca.umodelverse.ai/v1` | `https://api.umodelverse.ai/v1` |
| Env var | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |

Supported models (non-exhaustive): `deepseek-r1`, `deepseek-v3`, `llama-3.3-70b-instruct`

## Usage Example

```python
import os
from browser_use.llm import ChatAstraflow, ChatAstraflowCN

# Global endpoint
llm = ChatAstraflow(model="deepseek-v3", api_key=os.getenv("ASTRAFLOW_API_KEY"))

# China endpoint
llm_cn = ChatAstraflowCN(model="deepseek-v3", api_key=os.getenv("ASTRAFLOW_CN_API_KEY"))

# Or via get_llm_by_name (aliases also work)
from browser_use.llm.models import get_llm_by_name
llm = get_llm_by_name("astraflow_deepseek-v3")
llm = get_llm_by_name("modelverse_deepseek-v3")   # alias
llm_cn = get_llm_by_name("astraflow-cn_deepseek-v3")
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Astraflow (UCloud ModelVerse) as a first-class LLM provider with global and China endpoints. You can now use Astraflow via `ChatAstraflow` / `ChatAstraflowCN` or `get_llm_by_name` with provider keys and aliases.

- **New Features**
  - New classes `ChatAstraflow` (global) and `ChatAstraflowCN` (China) extending `ChatOpenAI`, with default base URLs and `frequency_penalty=None`.
  - `get_llm_by_name` supports `astraflow` and `astraflow-cn` plus aliases (`astra-flow`, `astra_flow`, `modelverse`, `astraflow-china`, `astraflow_cn`).
  - Updated lazy exports and `__all__`; `.env.example` now documents `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY`.

- **Migration**
  - Set `ASTRAFLOW_API_KEY` and/or `ASTRAFLOW_CN_API_KEY`.
  - Use `ChatAstraflow(model="...")`, `ChatAstraflowCN(model="...")`, or `get_llm_by_name("astraflow_<model>")` / `get_llm_by_name("astraflow-cn_<model>")`.

<sup>Written for commit 1b82de615b37cc923ac00170a9b2ba5fe3ee8ca8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

