### PR TITLE
improve connect failure UX: fix chrome://inspect link and add fallbac…

### DIFF
--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -246,7 +246,7 @@ def discover_chrome_cdp_url() -> str:
 
 	raise RuntimeError(
 		'Could not discover a running Chrome instance with remote debugging enabled.\n'
-		'Enable remote debugging in Chrome (chrome://inspect, or launch with --remote-debugging-port=9222) and try again.'
+		'Enable remote debugging in Chrome (chrome://inspect/#remote-debugging, or launch with --remote-debugging-port=9222) and try again.'
 	)
 
 

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -30,6 +30,20 @@ To use the user's existing Chrome (preserves logins/cookies): run `browser-use c
 To use a cloud browser instead: run `browser-use cloud connect` first.
 After either, commands work the same way.
 
+### If `browser-use connect` fails
+
+When `browser-use connect` cannot find a running Chrome with remote debugging, prompt the user with two options:
+
+1. **Use their real Chrome browser** — they need to enable remote debugging first:
+   - Open `chrome://inspect/#remote-debugging` in Chrome, or relaunch Chrome with `--remote-debugging-port=9222`
+   - Then retry `browser-use connect`
+2. **Use managed Chromium with their Chrome profile** — no Chrome setup needed:
+   - Run `browser-use profile list` to show available profiles
+   - Ask which profile they want, then use `browser-use --profile "ProfileName" open <url>`
+   - This launches a separate Chromium instance with their profile data (cookies, logins, extensions)
+
+Let the user choose — don't assume one path over the other.
+
 ## Browser Modes
 
 ```bash


### PR DESCRIPTION
…k guidance

When `browser-use connect` fails to discover a running Chrome, the error now points to the correct `chrome://inspect/#remote-debugging` URL. The SKILL.md also guides agents to prompt users with two options: enable remote debugging or use managed Chromium with a Chrome profile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the connect failure UX by pointing to the correct Chrome remote debugging page and adding clear fallback steps. The error now links to `chrome://inspect/#remote-debugging`, and SKILL.md guides users to either enable remote debugging or use managed Chromium with their Chrome profile.

<sup>Written for commit d0fbf4c5807a2904e19ac2c1468d2639189a8f26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

