### PR TITLE
security: sandbox PythonSession namespace, block dangerous modules an…

### DIFF
--- a/browser_use/skill_cli/python_session.py
+++ b/browser_use/skill_cli/python_session.py
@@ -10,15 +10,48 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 
+def _make_safe_builtin_class() -> Any:
+	"""Build the ``_SafeBuiltin`` callable class in an isolated namespace.
+
+	A normal closure wrapper leaks this module's globals via ``wrapper.__globals__``
+	(e.g. ``print.__globals__['io']`` or ``print.__globals__['Path']``). A callable
+	class instance has no ``__globals__`` attribute at all, and by compiling the
+	class inside an isolated ``exec`` namespace its methods' ``__globals__`` point
+	to that isolated dict rather than this module — closing the escape.
+	"""
+	isolated: dict[str, Any] = {
+		'__name__': '_safe_builtin_ns',
+		'__builtins__': {
+			'__build_class__': __build_class__,
+			'object': object,
+			'AttributeError': AttributeError,
+		},
+	}
+	source = (
+		'class _SafeBuiltin:\n'
+		'    """Callable wrapper that hides __self__, __globals__, and the underlying fn."""\n'
+		'    __slots__ = ("_fn",)\n'
+		'    def __init__(self, fn):\n'
+		'        object.__setattr__(self, "_fn", fn)\n'
+		'    def __call__(self, *args, **kwargs):\n'
+		'        return object.__getattribute__(self, "_fn")(*args, **kwargs)\n'
+		'    def __getattribute__(self, name):\n'
+		'        # Only __call__ is reachable from sandboxed code — no __self__,\n'
+		'        # no __globals__, no _fn, no __class__-chain introspection.\n'
+		'        if name == "__call__":\n'
+		'            return object.__getattribute__(self, "__call__")\n'
+		'        raise AttributeError(name)\n'
+	)
+	exec(source, isolated)
+	return isolated['_SafeBuiltin']
+
+
+_SafeBuiltin = _make_safe_builtin_class()
+
+
 def _wrap_builtin(fn: Any) -> Any:
-	"""Wrap a builtin function to prevent ``__self__`` leaking the builtins module."""
-
-	def wrapper(*args: Any, **kwargs: Any) -> Any:
-		return fn(*args, **kwargs)
-
-	wrapper.__name__ = getattr(fn, '__name__', str(fn))
-	wrapper.__doc__ = getattr(fn, '__doc__', None)
-	return wrapper
+	"""Wrap a builtin function/type so ``__self__`` and ``__globals__`` don't leak."""
+	return _SafeBuiltin(fn)
 
 
 if TYPE_CHECKING:
@@ -68,6 +101,8 @@ class PythonSession:
 			'signal',
 			'tempfile',
 			'builtins',
+			'pathlib',
+			'asyncio',
 		}
 	)
 

--- a/browser_use/skill_cli/python_session.py
+++ b/browser_use/skill_cli/python_session.py
@@ -115,20 +115,23 @@ class PythonSession:
 		browser wrapper already provides.
 		"""
 
+		# Resolve the real import callable once so the guard doesn't depend on
+		# this function's __globals__ (which would leak via __import__.__globals__).
+		_real_import = __builtins__['__import__'] if isinstance(__builtins__, dict) else __import__
+		_blocked = PythonSession._BLOCKED_MODULES
+
 		def _safe_import(name: str, *args: Any, **kwargs: Any) -> Any:
 			"""Import guard that blocks dangerous modules."""
 			top_level = name.split('.')[0]
-			if top_level in PythonSession._BLOCKED_MODULES:
+			if top_level in _blocked:
 				raise ImportError(f"import of '{name}' is not allowed in this environment")
-			return (
-				__builtins__['__import__'](name, *args, **kwargs)
-				if isinstance(__builtins__, dict)
-				else __import__(name, *args, **kwargs)
-			)
+			return _real_import(name, *args, **kwargs)
 
 		safe_builtins: dict[str, Any] = {
 			'__build_class__': __build_class__,
-			'__import__': _safe_import,
+			# Wrap _safe_import in _SafeBuiltin so its __globals__ doesn't leak
+			# this module's real __builtins__ (which would defeat the sandbox).
+			'__import__': _SafeBuiltin(_safe_import),
 			'print': print,
 			'range': range,
 			'len': len,

--- a/browser_use/skill_cli/python_session.py
+++ b/browser_use/skill_cli/python_session.py
@@ -34,15 +34,141 @@ class PythonSession:
 	execution_count: int = 0
 	history: list[tuple[str, ExecutionResult]] = field(default_factory=list)
 
+	# Modules that must never be available in the execution namespace.
+	_BLOCKED_MODULES = frozenset(
+		{
+			'os',
+			'subprocess',
+			'shutil',
+			'sys',
+			'importlib',
+			'ctypes',
+			'socket',
+			'http',
+			'ftplib',
+			'smtplib',
+			'webbrowser',
+			'code',
+			'codeop',
+			'compileall',
+			'multiprocessing',
+			'signal',
+			'tempfile',
+			'builtins',
+		}
+	)
+
 	def __post_init__(self) -> None:
-		"""Initialize namespace with useful imports."""
+		"""Initialize namespace with useful imports.
+
+		Only safe, non-system-access modules are exposed. The ``os`` module and
+		other modules that provide file-system, process, or network access are
+		deliberately excluded to prevent arbitrary code execution beyond what the
+		browser wrapper already provides.
+		"""
+
+		def _safe_import(name: str, *args: Any, **kwargs: Any) -> Any:
+			"""Import guard that blocks dangerous modules."""
+			top_level = name.split('.')[0]
+			if top_level in PythonSession._BLOCKED_MODULES:
+				raise ImportError(f"import of '{name}' is not allowed in this environment")
+			return (
+				__builtins__['__import__'](name, *args, **kwargs)
+				if isinstance(__builtins__, dict)
+				else __import__(name, *args, **kwargs)
+			)
+
 		self.namespace.update(
 			{
 				'__name__': '__main__',
 				'__doc__': None,
+				'__builtins__': {
+					# Expose safe builtins only — no open(), exec(), eval(), compile(), __import__()
+					'__build_class__': __build_class__,
+					'__import__': _safe_import,
+					'print': print,
+					'range': range,
+					'len': len,
+					'int': int,
+					'float': float,
+					'str': str,
+					'bool': bool,
+					'list': list,
+					'dict': dict,
+					'tuple': tuple,
+					'set': set,
+					'frozenset': frozenset,
+					'bytes': bytes,
+					'bytearray': bytearray,
+					'type': type,
+					'isinstance': isinstance,
+					'issubclass': issubclass,
+					'hasattr': hasattr,
+					'getattr': getattr,
+					'setattr': setattr,
+					'delattr': delattr,
+					'callable': callable,
+					'iter': iter,
+					'next': next,
+					'enumerate': enumerate,
+					'zip': zip,
+					'map': map,
+					'filter': filter,
+					'sorted': sorted,
+					'reversed': reversed,
+					'min': min,
+					'max': max,
+					'sum': sum,
+					'abs': abs,
+					'round': round,
+					'pow': pow,
+					'divmod': divmod,
+					'hash': hash,
+					'id': id,
+					'repr': repr,
+					'ascii': ascii,
+					'chr': chr,
+					'ord': ord,
+					'hex': hex,
+					'oct': oct,
+					'bin': bin,
+					'format': format,
+					'any': any,
+					'all': all,
+					'dir': dir,
+					'vars': vars,
+					'property': property,
+					'staticmethod': staticmethod,
+					'classmethod': classmethod,
+					'super': super,
+					'object': object,
+					'Exception': Exception,
+					'BaseException': BaseException,
+					'TypeError': TypeError,
+					'ValueError': ValueError,
+					'KeyError': KeyError,
+					'IndexError': IndexError,
+					'AttributeError': AttributeError,
+					'RuntimeError': RuntimeError,
+					'StopIteration': StopIteration,
+					'GeneratorExit': GeneratorExit,
+					'NotImplementedError': NotImplementedError,
+					'ImportError': ImportError,
+					'FileNotFoundError': FileNotFoundError,
+					'OSError': OSError,
+					'IOError': IOError,
+					'ArithmeticError': ArithmeticError,
+					'ZeroDivisionError': ZeroDivisionError,
+					'OverflowError': OverflowError,
+					'LookupError': LookupError,
+					'NameError': NameError,
+					'SyntaxError': SyntaxError,
+					'True': True,
+					'False': False,
+					'None': None,
+				},
 				'json': __import__('json'),
 				're': __import__('re'),
-				'os': __import__('os'),
 				'Path': Path,
 				'asyncio': asyncio,
 			}
@@ -110,7 +236,7 @@ class PythonSession:
 
 	def get_variables(self) -> dict[str, str]:
 		"""Get user-defined variables and their types."""
-		skip = {'__name__', '__doc__', 'json', 're', 'os', 'Path', 'asyncio', 'browser'}
+		skip = {'__name__', '__doc__', '__builtins__', 'json', 're', 'Path', 'asyncio', 'browser'}
 		return {k: type(v).__name__ for k, v in self.namespace.items() if not k.startswith('_') and k not in skip}
 
 

--- a/browser_use/skill_cli/python_session.py
+++ b/browser_use/skill_cli/python_session.py
@@ -3,10 +3,23 @@
 import asyncio
 import io
 import traceback
+import types
 from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
+
+
+def _wrap_builtin(fn: Any) -> Any:
+	"""Wrap a builtin function to prevent ``__self__`` leaking the builtins module."""
+
+	def wrapper(*args: Any, **kwargs: Any) -> Any:
+		return fn(*args, **kwargs)
+
+	wrapper.__name__ = getattr(fn, '__name__', str(fn))
+	wrapper.__doc__ = getattr(fn, '__doc__', None)
+	return wrapper
+
 
 if TYPE_CHECKING:
 	from browser_use.browser.session import BrowserSession
@@ -78,99 +91,103 @@ class PythonSession:
 				else __import__(name, *args, **kwargs)
 			)
 
+		safe_builtins: dict[str, Any] = {
+			'__build_class__': __build_class__,
+			'__import__': _safe_import,
+			'print': print,
+			'range': range,
+			'len': len,
+			'int': int,
+			'float': float,
+			'str': str,
+			'bool': bool,
+			'list': list,
+			'dict': dict,
+			'tuple': tuple,
+			'set': set,
+			'frozenset': frozenset,
+			'bytes': bytes,
+			'bytearray': bytearray,
+			'type': type,
+			'isinstance': isinstance,
+			'issubclass': issubclass,
+			'hasattr': hasattr,
+			'getattr': getattr,
+			'setattr': setattr,
+			'delattr': delattr,
+			'callable': callable,
+			'iter': iter,
+			'next': next,
+			'enumerate': enumerate,
+			'zip': zip,
+			'map': map,
+			'filter': filter,
+			'sorted': sorted,
+			'reversed': reversed,
+			'min': min,
+			'max': max,
+			'sum': sum,
+			'abs': abs,
+			'round': round,
+			'pow': pow,
+			'divmod': divmod,
+			'hash': hash,
+			'id': id,
+			'repr': repr,
+			'ascii': ascii,
+			'chr': chr,
+			'ord': ord,
+			'hex': hex,
+			'oct': oct,
+			'bin': bin,
+			'format': format,
+			'any': any,
+			'all': all,
+			'dir': dir,
+			'vars': vars,
+			'property': property,
+			'staticmethod': staticmethod,
+			'classmethod': classmethod,
+			'super': super,
+			'object': object,
+			'Exception': Exception,
+			'BaseException': BaseException,
+			'TypeError': TypeError,
+			'ValueError': ValueError,
+			'KeyError': KeyError,
+			'IndexError': IndexError,
+			'AttributeError': AttributeError,
+			'RuntimeError': RuntimeError,
+			'StopIteration': StopIteration,
+			'GeneratorExit': GeneratorExit,
+			'NotImplementedError': NotImplementedError,
+			'ImportError': ImportError,
+			'FileNotFoundError': FileNotFoundError,
+			'OSError': OSError,
+			'IOError': IOError,
+			'ArithmeticError': ArithmeticError,
+			'ZeroDivisionError': ZeroDivisionError,
+			'OverflowError': OverflowError,
+			'LookupError': LookupError,
+			'NameError': NameError,
+			'SyntaxError': SyntaxError,
+			'True': True,
+			'False': False,
+			'None': None,
+		}
+
+		# Wrap builtin functions so __self__ doesn't leak the builtins module
+		for key, val in safe_builtins.items():
+			if isinstance(val, types.BuiltinFunctionType):
+				safe_builtins[key] = _wrap_builtin(val)
+
 		self.namespace.update(
 			{
 				'__name__': '__main__',
 				'__doc__': None,
-				'__builtins__': {
-					# Expose safe builtins only — no open(), exec(), eval(), compile(), __import__()
-					'__build_class__': __build_class__,
-					'__import__': _safe_import,
-					'print': print,
-					'range': range,
-					'len': len,
-					'int': int,
-					'float': float,
-					'str': str,
-					'bool': bool,
-					'list': list,
-					'dict': dict,
-					'tuple': tuple,
-					'set': set,
-					'frozenset': frozenset,
-					'bytes': bytes,
-					'bytearray': bytearray,
-					'type': type,
-					'isinstance': isinstance,
-					'issubclass': issubclass,
-					'hasattr': hasattr,
-					'getattr': getattr,
-					'setattr': setattr,
-					'delattr': delattr,
-					'callable': callable,
-					'iter': iter,
-					'next': next,
-					'enumerate': enumerate,
-					'zip': zip,
-					'map': map,
-					'filter': filter,
-					'sorted': sorted,
-					'reversed': reversed,
-					'min': min,
-					'max': max,
-					'sum': sum,
-					'abs': abs,
-					'round': round,
-					'pow': pow,
-					'divmod': divmod,
-					'hash': hash,
-					'id': id,
-					'repr': repr,
-					'ascii': ascii,
-					'chr': chr,
-					'ord': ord,
-					'hex': hex,
-					'oct': oct,
-					'bin': bin,
-					'format': format,
-					'any': any,
-					'all': all,
-					'dir': dir,
-					'vars': vars,
-					'property': property,
-					'staticmethod': staticmethod,
-					'classmethod': classmethod,
-					'super': super,
-					'object': object,
-					'Exception': Exception,
-					'BaseException': BaseException,
-					'TypeError': TypeError,
-					'ValueError': ValueError,
-					'KeyError': KeyError,
-					'IndexError': IndexError,
-					'AttributeError': AttributeError,
-					'RuntimeError': RuntimeError,
-					'StopIteration': StopIteration,
-					'GeneratorExit': GeneratorExit,
-					'NotImplementedError': NotImplementedError,
-					'ImportError': ImportError,
-					'FileNotFoundError': FileNotFoundError,
-					'OSError': OSError,
-					'IOError': IOError,
-					'ArithmeticError': ArithmeticError,
-					'ZeroDivisionError': ZeroDivisionError,
-					'OverflowError': OverflowError,
-					'LookupError': LookupError,
-					'NameError': NameError,
-					'SyntaxError': SyntaxError,
-					'True': True,
-					'False': False,
-					'None': None,
-				},
+				'__builtins__': safe_builtins,
 				'json': __import__('json'),
 				're': __import__('re'),
-				'Path': Path,
-				'asyncio': asyncio,
 			}
 		)
 
@@ -236,7 +253,7 @@ class PythonSession:
 
 	def get_variables(self) -> dict[str, str]:
 		"""Get user-defined variables and their types."""
-		skip = {'__name__', '__doc__', '__builtins__', 'json', 're', 'Path', 'asyncio', 'browser'}
+		skip = {'__name__', '__doc__', '__builtins__', 'json', 're', 'browser'}
 		return {k: type(v).__name__ for k, v in self.namespace.items() if not k.startswith('_') and k not in skip}
 
 

--- a/tests/ci/test_python_session_security.py
+++ b/tests/ci/test_python_session_security.py
@@ -40,6 +40,8 @@ def browser_session():
 		'multiprocessing',
 		'signal',
 		'tempfile',
+		'pathlib',
+		'asyncio',
 	],
 )
 def test_blocked_module_not_in_namespace(session, module):
@@ -63,6 +65,10 @@ def test_blocked_module_not_in_namespace(session, module):
 		'import builtins',
 		"import builtins; builtins.open('/etc/passwd')",
 		"import builtins; builtins.__import__('os')",
+		'import pathlib',
+		'from pathlib import Path',
+		'import asyncio',
+		'from asyncio import subprocess',
 	],
 )
 def test_blocked_module_import_fails(session, browser_session, code):
@@ -117,23 +123,6 @@ def test_re_available(session, browser_session):
 	assert '123' in result.output
 
 
-def test_path_importable(session, browser_session):
-	"""Path is not pre-loaded but can be imported from pathlib."""
-	assert 'Path' not in session.namespace
-	session.execute('from pathlib import Path', browser_session)
-	result = session.execute("str(Path('.'))", browser_session)
-	assert result.success
-	assert '.' in result.output
-
-
-def test_asyncio_importable(session, browser_session):
-	"""asyncio is not pre-loaded but can be imported."""
-	assert 'asyncio' not in session.namespace
-	session.execute('import asyncio', browser_session)
-	result = session.execute('asyncio.get_event_loop_policy()', browser_session)
-	assert result.success
-
-
 def test_safe_import_allowed(session, browser_session):
 	"""Non-blocked modules like math should be importable."""
 	result = session.execute('import math; math.sqrt(4)', browser_session)
@@ -170,13 +159,43 @@ def test_get_variables_excludes_builtins(session):
 def test_builtin_self_bypass_blocked(session, browser_session):
 	"""print.__self__ must not leak the real builtins module."""
 	result = session.execute('print.__self__', browser_session)
-	assert not result.success or 'builtins' not in result.output
+	assert not result.success
 
 
 def test_builtin_self_import_bypass_blocked(session, browser_session):
 	"""Cannot recover __import__ via print.__self__."""
 	result = session.execute("print.__self__.__import__('os')", browser_session)
 	assert not result.success
+
+
+@pytest.mark.parametrize(
+	'code',
+	[
+		"print.__globals__['io']",
+		"print.__globals__['Path']",
+		"print.__globals__['__builtins__']",
+		'print.__globals__',
+	],
+)
+def test_builtin_globals_bypass_blocked(session, browser_session, code):
+	"""print.__globals__ must not leak this module's imports (io, Path, real __builtins__)."""
+	result = session.execute(code, browser_session)
+	assert not result.success
+
+
+@pytest.mark.parametrize(
+	'code',
+	[
+		"type(print).__call__.__func__.__globals__.get('io')",
+		"type(print).__call__.__func__.__globals__.get('Path')",
+		"type(print).__call__.__func__.__globals__.get('asyncio')",
+	],
+)
+def test_deep_globals_bypass_clean(session, browser_session, code):
+	"""Even via type(print).__call__.__func__.__globals__, no dangerous imports leak."""
+	result = session.execute(code, browser_session)
+	# Either blocked outright, or returns None (not found in isolated namespace)
+	assert not result.success or 'module' not in result.output
 
 
 def test_path_globals_not_in_namespace(session):

--- a/tests/ci/test_python_session_security.py
+++ b/tests/ci/test_python_session_security.py
@@ -117,10 +117,21 @@ def test_re_available(session, browser_session):
 	assert '123' in result.output
 
 
-def test_path_available(session, browser_session):
+def test_path_importable(session, browser_session):
+	"""Path is not pre-loaded but can be imported from pathlib."""
+	assert 'Path' not in session.namespace
+	session.execute('from pathlib import Path', browser_session)
 	result = session.execute("str(Path('.'))", browser_session)
 	assert result.success
 	assert '.' in result.output
+
+
+def test_asyncio_importable(session, browser_session):
+	"""asyncio is not pre-loaded but can be imported."""
+	assert 'asyncio' not in session.namespace
+	session.execute('import asyncio', browser_session)
+	result = session.execute('asyncio.get_event_loop_policy()', browser_session)
+	assert result.success
 
 
 def test_safe_import_allowed(session, browser_session):
@@ -154,6 +165,28 @@ def test_get_variables_excludes_builtins(session):
 	"""__builtins__ must not appear in user-visible variables."""
 	variables = session.get_variables()
 	assert '__builtins__' not in variables
+
+
+def test_builtin_self_bypass_blocked(session, browser_session):
+	"""print.__self__ must not leak the real builtins module."""
+	result = session.execute('print.__self__', browser_session)
+	assert not result.success or 'builtins' not in result.output
+
+
+def test_builtin_self_import_bypass_blocked(session, browser_session):
+	"""Cannot recover __import__ via print.__self__."""
+	result = session.execute("print.__self__.__import__('os')", browser_session)
+	assert not result.success
+
+
+def test_path_globals_not_in_namespace(session):
+	"""Path must not be pre-loaded (prevents Path.cwd.__globals__['os'] bypass)."""
+	assert 'Path' not in session.namespace
+
+
+def test_asyncio_not_in_namespace(session):
+	"""asyncio must not be pre-loaded (prevents asyncio.sys.modules bypass)."""
+	assert 'asyncio' not in session.namespace
 
 
 def test_reset_restores_sandbox(session, browser_session):

--- a/tests/ci/test_python_session_security.py
+++ b/tests/ci/test_python_session_security.py
@@ -183,6 +183,18 @@ def test_builtin_globals_bypass_blocked(session, browser_session, code):
 	assert not result.success
 
 
+def test_safe_import_globals_bypass_blocked(session, browser_session):
+	"""__import__.__globals__ must not leak this module's real __builtins__."""
+	result = session.execute('__import__.__globals__', browser_session)
+	assert not result.success
+
+
+def test_safe_import_deep_bypass_blocked(session, browser_session):
+	"""Cannot recover real __import__ via __import__.__globals__['__builtins__']['__import__']."""
+	result = session.execute("__import__.__globals__['__builtins__']['__import__']('os')", browser_session)
+	assert not result.success
+
+
 @pytest.mark.parametrize(
 	'code',
 	[

--- a/tests/ci/test_python_session_security.py
+++ b/tests/ci/test_python_session_security.py
@@ -1,0 +1,163 @@
+"""Security tests for PythonSession sandbox.
+
+Verifies that dangerous modules and builtins are blocked from user code
+executed via eval/exec in the PythonSession namespace.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from browser_use.skill_cli.python_session import PythonSession
+
+
+@pytest.fixture
+def session():
+	return PythonSession()
+
+
+@pytest.fixture
+def browser_session():
+	return MagicMock()
+
+
+# ---------------------------------------------------------------------------
+# Blocked modules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+	'module',
+	[
+		'os',
+		'subprocess',
+		'shutil',
+		'sys',
+		'importlib',
+		'ctypes',
+		'socket',
+		'http',
+		'multiprocessing',
+		'signal',
+		'tempfile',
+	],
+)
+def test_blocked_module_not_in_namespace(session, module):
+	"""Dangerous modules must not be pre-loaded in the namespace."""
+	assert module not in session.namespace
+
+
+@pytest.mark.parametrize(
+	'code',
+	[
+		'import os',
+		'import subprocess',
+		'import shutil',
+		'import sys',
+		'import ctypes',
+		'import socket',
+		'from os import path',
+		'from subprocess import run',
+		"__import__('os')",
+		"__import__('subprocess')",
+		'import builtins',
+		"import builtins; builtins.open('/etc/passwd')",
+		"import builtins; builtins.__import__('os')",
+	],
+)
+def test_blocked_module_import_fails(session, browser_session, code):
+	"""Importing blocked modules via user code must fail."""
+	result = session.execute(code, browser_session)
+	assert not result.success
+	assert result.error is not None
+	assert 'not allowed' in result.error or 'ImportError' in result.error
+
+
+# ---------------------------------------------------------------------------
+# Blocked builtins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+	'code',
+	[
+		"open('/etc/passwd')",
+		"exec('1+1')",
+		"eval('1+1')",
+		"compile('1', '<x>', 'exec')",
+	],
+)
+def test_dangerous_builtins_blocked(session, browser_session, code):
+	"""open(), exec(), eval(), compile() must not be available in user code."""
+	result = session.execute(code, browser_session)
+	assert not result.success
+	assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
+# Safe operations still work
+# ---------------------------------------------------------------------------
+
+
+def test_basic_arithmetic(session, browser_session):
+	result = session.execute('2 + 3', browser_session)
+	assert result.success
+	assert '5' in result.output
+
+
+def test_json_available(session, browser_session):
+	result = session.execute("json.dumps({'a': 1})", browser_session)
+	assert result.success
+	assert '"a"' in result.output
+
+
+def test_re_available(session, browser_session):
+	result = session.execute("re.match(r'\\d+', '123').group()", browser_session)
+	assert result.success
+	assert '123' in result.output
+
+
+def test_path_available(session, browser_session):
+	result = session.execute("str(Path('.'))", browser_session)
+	assert result.success
+	assert '.' in result.output
+
+
+def test_safe_import_allowed(session, browser_session):
+	"""Non-blocked modules like math should be importable."""
+	result = session.execute('import math; math.sqrt(4)', browser_session)
+	assert result.success
+
+
+def test_class_definition(session, browser_session):
+	"""Class definitions must work (__build_class__ is available)."""
+	session.execute('class Foo:\n\tx = 42', browser_session)
+	result = session.execute('Foo.x', browser_session)
+	assert result.success
+	assert '42' in result.output
+
+
+def test_list_comprehension(session, browser_session):
+	result = session.execute('[x**2 for x in range(5)]', browser_session)
+	assert result.success
+	assert '[0, 1, 4, 9, 16]' in result.output
+
+
+def test_variable_persistence(session, browser_session):
+	session.execute('x = 42', browser_session)
+	result = session.execute('x', browser_session)
+	assert result.success
+	assert '42' in result.output
+
+
+def test_get_variables_excludes_builtins(session):
+	"""__builtins__ must not appear in user-visible variables."""
+	variables = session.get_variables()
+	assert '__builtins__' not in variables
+
+
+def test_reset_restores_sandbox(session, browser_session):
+	"""After reset, blocked modules must still be blocked."""
+	session.reset()
+	result = session.execute('import os', browser_session)
+	assert not result.success


### PR DESCRIPTION
…d builtins

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sandboxed `PythonSession` by restricting `__builtins__`, guarding imports, and removing `os`, `Path`, and `asyncio` from the default namespace. Also wrapped `__import__` to block `__import__.__globals__` escape paths.

- **New Features**
  - Safe `__builtins__` with `__build_class__`; no `open`/`exec`/`eval`/`compile`; hidden from `get_variables`.
  - Import guard blocks `os`, `sys`, `subprocess`, `shutil`, `socket`, `ctypes`, `multiprocessing`, `signal`, `tempfile`, `importlib`, `builtins`, `pathlib`, `asyncio`, and `http`/`ftplib`/`smtplib`/`webbrowser`/`code*` modules.
  - Removed preloaded `os`, `Path`, `asyncio`; kept `json`, `re`; safe imports like `math` still allowed.
  - Hardened builtins and `__import__` using `_SafeBuiltin` (built in an isolated exec namespace) to prevent `print.__self__`, `print.__globals__`, and `__import__.__globals__` leaks; tests cover blocked imports/builtins, safe ops, bypass attempts, and `reset()` persistence.

<sup>Written for commit 0d596156889cd00bbbec229a590d44a9dff16cb3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

