### PR TITLE
Find more recent versions of Playwright-installed Chromium for Mac/ARM users

### DIFF
--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -251,7 +251,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				playwright_path = '~/Library/Caches/ms-playwright'
 			all_patterns = [
 				('chrome', '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'),
-				('chromium', f'{playwright_path}/chromium-*/chrome-mac/Chromium.app/Contents/MacOS/Chromium'),
+				('chromium', f'{playwright_path}/chromium-*/chrome-mac*/Chromium.app/Contents/MacOS/Chromium'),
 				('chromium', '/Applications/Chromium.app/Contents/MacOS/Chromium'),
 				('chrome-canary', '/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary'),
 				('brave', '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser'),


### PR DESCRIPTION
Users who have Mac devices with ARM chips may have more recent versions of Chromium installed in `~/Library/Caches/ms-playwright/chromium-*/chrome-mac-arm64/`, but the current code only searches in `~/Library/Caches/ms-playwright/chromium-*/chrome-mac/`. As a result, Browser Use will use a significantly out-of-date browser when a newer version is available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Chromium detection on macOS by searching both `chrome-mac` and `chrome-mac-arm64` in the Playwright cache. Mac/ARM users now run the latest Playwright-installed Chromium instead of an outdated build.

- **Bug Fixes**
  - Expanded search to `~/Library/Caches/ms-playwright/chromium-*/chrome-mac*/Chromium.app/Contents/MacOS/Chromium` to include `chrome-mac-arm64`.

<sup>Written for commit 98a86bead7c7bef4c4fb6af4a7d615b16cddf816. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

