### PR TITLE
fix(browser): intercept native file-chooser dialogs on every page target

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -864,6 +864,51 @@ class SessionManager:
 			# Enable network monitoring for networkIdle detection
 			await cdp_session.cdp_client.send.Network.enable(session_id=cdp_session.session_id)
 
+			# Suppress native OS file-chooser dialogs on this target.
+			# Without this, any code path that triggers an <input type=file> (a direct
+			# click, a JS-triggered .click(), or user Python that bypasses the
+			# is_file_input guard in default_action_watchdog.on_ClickElementEvent)
+			# will pop a modal GTK/Aqua/Windows file picker that wedges the renderer —
+			# subsequent Page.captureScreenshot calls return { code: -32603, message:
+			# 'Internal error' } until the dialog is dismissed, and on a Linux/Xvfb
+			# headful setup there is no one to dismiss it. With interception enabled
+			# Chromium emits Page.fileChooserOpened instead and the renderer stays
+			# responsive; the registered default handler below cancels the dialog so
+			# sessions recover even if the agent never calls Page.handleFileChooser.
+			try:
+				await cdp_session.cdp_client.send.Page.setInterceptFileChooserDialog(
+					params={'enabled': True}, session_id=cdp_session.session_id
+				)
+
+				async def _default_file_chooser_handler(event: dict, session_id: str | None = None) -> None:
+					# Only act on the session this handler was registered for.
+					if session_id != cdp_session.session_id:
+						return
+					# UploadFileEvent drives uploads via DOM.setFileInputFiles, so any
+					# fileChooserOpened event that reaches us here is either unhandled
+					# user code or an accidental click. Cancel rather than leave the
+					# dialog modal and wedge future CDP commands.
+					try:
+						await cdp_session.cdp_client.send.Page.handleFileChooser(
+							params={'action': 'cancel'}, session_id=cdp_session.session_id
+						)
+					except Exception as cancel_exc:
+						self.logger.debug(
+							f'[SessionManager] handleFileChooser(cancel) failed on session '
+							f'{cdp_session.session_id}: {cancel_exc}'
+						)
+
+				cdp_session.cdp_client.register.Page.fileChooserOpened(
+					_default_file_chooser_handler
+				)
+			except Exception as intercept_exc:
+				# Older Chromium builds or non-Page targets may not support this.
+				# Log and continue — pre-existing heuristic guards still apply.
+				self.logger.debug(
+					f'[SessionManager] Page.setInterceptFileChooserDialog not enabled on '
+					f'session {cdp_session.session_id}: {intercept_exc}'
+				)
+
 			# Initialize lifecycle event storage for this session (thread-safe)
 			from collections import deque
 

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -872,34 +872,13 @@ class SessionManager:
 			# subsequent Page.captureScreenshot calls return { code: -32603, message:
 			# 'Internal error' } until the dialog is dismissed, and on a Linux/Xvfb
 			# headful setup there is no one to dismiss it. With interception enabled
-			# Chromium emits Page.fileChooserOpened instead and the renderer stays
-			# responsive; the registered default handler below cancels the dialog so
-			# sessions recover even if the agent never calls Page.handleFileChooser.
+			# Chromium never shows the native dialog (per CDP spec: "native file chooser
+			# dialog is not shown") — it emits Page.fileChooserOpened instead, the page
+			# sees no files selected, and the renderer stays responsive. UploadFileEvent
+			# drives uploads via DOM.setFileInputFiles which is independent of this flag.
 			try:
 				await cdp_session.cdp_client.send.Page.setInterceptFileChooserDialog(
 					params={'enabled': True}, session_id=cdp_session.session_id
-				)
-
-				async def _default_file_chooser_handler(event: dict, session_id: str | None = None) -> None:
-					# Only act on the session this handler was registered for.
-					if session_id != cdp_session.session_id:
-						return
-					# UploadFileEvent drives uploads via DOM.setFileInputFiles, so any
-					# fileChooserOpened event that reaches us here is either unhandled
-					# user code or an accidental click. Cancel rather than leave the
-					# dialog modal and wedge future CDP commands.
-					try:
-						await cdp_session.cdp_client.send.Page.handleFileChooser(
-							params={'action': 'cancel'}, session_id=cdp_session.session_id
-						)
-					except Exception as cancel_exc:
-						self.logger.debug(
-							f'[SessionManager] handleFileChooser(cancel) failed on session '
-							f'{cdp_session.session_id}: {cancel_exc}'
-						)
-
-				cdp_session.cdp_client.register.Page.fileChooserOpened(
-					_default_file_chooser_handler
 				)
 			except Exception as intercept_exc:
 				# Older Chromium builds or non-Page targets may not support this.


### PR DESCRIPTION
## What this fixes

Any code path that activates an `<input type=file>` without going through `UploadFileEvent` (JS-triggered `input.click()`, `ClickCoordinateEvent` on a button whose element-at-point isn't itself the file input, or user Python that dispatches CDP input directly) **currently opens a native OS file picker**. On a headful Linux/Xvfb setup (our default on cloud runners) the GTK file-chooser is modal to the tab and has nobody to dismiss it.

Once that modal is up, the renderer wedges. Concretely:

- `Page.captureScreenshot` starts returning `{ code: -32603, message: 'Internal error' }`
- `DOMWatchdog.on_BrowserStateRequestEvent` runs out the 30 s `bubus` ceiling
- Only `BrowserSession.reset()` recovers (that kills the tab, which tears down the dialog)

We debugged one session where this stalled the agent for 6 minutes before reset fired.

## Fix

Enable `Page.setInterceptFileChooserDialog(enabled=true)` inside `_enable_page_monitoring` — the function in `session_manager.py` that already runs exactly once per attached page target (right alongside `Page.enable` + `Page.setLifecycleEventsEnabled` + `Network.enable`). Also register a default `Page.fileChooserOpened` handler that calls `Page.handleFileChooser({action: 'cancel'})` so any dialog that reaches this layer leaves the renderer responsive instead of modal-locked.

`UploadFileEvent` continues to use `DOM.setFileInputFiles` and is unaffected — that path never causes Chromium to emit `fileChooserOpened` in the first place, so the default handler doesn't run for legitimate uploads.

Wrapped in try/except so Chromium builds that don't support the command fall back cleanly to today's behaviour; the existing `is_file_input` heuristic guards in `default_action_watchdog` still apply.

## Why the existing guards weren't enough

- `on_ClickElementEvent` and `on_ClickCoordinateEvent` both refuse clicks on file-input elements (`is_file_input` in `default_action_watchdog.py:351,417`). That's DOM-heuristic — it breaks when the visible button isn't the file input itself (`<button onclick=\"document.getElementById('file').click()\">`).
- `_click_on_coordinate` wraps the mouse dispatches in 3 s / 5 s `asyncio.wait_for` explicitly because a dialog can lock the input event (`default_action_watchdog.py:1095,1114`). That prevents the click from hanging, but it doesn't stop the dialog from opening, and subsequent screenshot/DOM calls still fail.

`Page.setInterceptFileChooserDialog` is a protocol-level flag that Chromium honours regardless of how the `<input type=file>` is activated — protection that's complementary to the DOM heuristics, not redundant.

## Test plan

- [ ] Manual: load a page where a button calls `document.getElementById('file').click()` (the TikTok upload page is a real-world repro); confirm no GTK file-chooser appears on the Xvfb display, and `Page.captureScreenshot` continues to succeed.
- [ ] Existing upload flow via `UploadFileEvent` continues to work (`DOM.setFileInputFiles` path is unchanged).
- [ ] Unit coverage for `_enable_page_monitoring` — we only add new CDP calls inside the existing try block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent native OS file pickers from blocking the renderer by intercepting file-chooser dialogs on every page target. Keeps screenshots and DOM calls working when <input type="file"> is triggered outside `UploadFileEvent`.

- **Bug Fixes**
  - Enable `Page.setInterceptFileChooserDialog({ enabled: true })` in `_enable_page_monitoring` for each attached page.
  - Drop the `Page.fileChooserOpened` handler and `Page.handleFileChooser` call; interception alone suppresses the native dialog.
  - Guard with try/except to fall back on older Chromium; existing `is_file_input` checks remain.
  - `UploadFileEvent` still uses `DOM.setFileInputFiles`; legitimate uploads don’t open a dialog.

<sup>Written for commit 4573b5222f12ab057dda9797abc7d9de60728d79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

