### PR TITLE
chore: dedupe __all__, fix TODO wording, single type ignore

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -152,7 +152,6 @@ __all__ = [
 	'ChatOllama',
 	'ChatVercel',
 	'Tools',
-	'Controller',
 	# LLM models module
 	'models',
 	# Sandbox execution

--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -1015,7 +1015,7 @@ class Element:
 			)
 
 			if bounds_result.get('result', {}).get('value'):
-				bounds = bounds_result['result']['value']  # type: ignore  # type: ignore
+				bounds = bounds_result['result']['value']  # type: ignore
 				center_x = bounds['x'] + bounds['width'] / 2
 				center_y = bounds['y'] + bounds['height'] / 2
 

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -566,7 +566,7 @@ class EnhancedDOMTreeNode:
 				return
 
 			# Skip this branch if we hit a highlighted element (except for the current node)
-			# TODO: think whether if makese sense to add text until the next clickable element or everything from children
+			# TODO: think whether it makes sense to add text until the next clickable element or everything from children
 			# if node.node_type == NodeType.ELEMENT_NODE
 			# if isinstance(node, DOMElementNode) and node != self and node.highlight_index is not None:
 			# 	return


### PR DESCRIPTION
- Remove duplicate Controller from browser_use __all__
- Clarify TODO comment in dom/views
- Collapse duplicate type: ignore in actor/element


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed duplicate `Controller` from `browser_use.__all__` to prevent redundant export and keep the public API clean. Clarified a TODO in `dom/views.py` and collapsed a duplicated `# type: ignore` in `actor/element.py`.

<sup>Written for commit 13327f7de39eaf5cbbc4c61c7b6cf2b62388acfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

