### PR TITLE
Add explicit clear_input action

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -122,7 +122,7 @@ def _normalize_action_for_hash(action_name: str, params: dict[str, Any]) -> str:
 		engine = params.get('engine', 'google')
 		return f'search|{engine}|{"|".join(tokens)}'
 
-	if action_name in ('click', 'input'):
+	if action_name in ('click', 'input', 'clear_input'):
 		# For element-interaction actions, we only use the index (element identity).
 		# Two clicks on the same element index are the same action.
 		index = params.get('index')
@@ -130,6 +130,8 @@ def _normalize_action_for_hash(action_name: str, params: dict[str, Any]) -> str:
 			text = str(params.get('text', ''))
 			# Normalize input text: lowercase, strip whitespace
 			return f'input|{index}|{text.strip().lower()}'
+		if action_name == 'clear_input':
+			return f'clear_input|{index}'
 		return f'click|{index}'
 
 	if action_name == 'navigate':

--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -156,6 +156,14 @@ class TypeTextEvent(ElementSelectedEvent[dict | None]):
 	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_TypeTextEvent', 60.0))  # seconds
 
 
+class ClearInputEvent(ElementSelectedEvent[None]):
+	"""Request to clear an input element's content."""
+
+	node: 'EnhancedDOMTreeNode'
+
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ClearInputEvent', 10.0))  # seconds
+
+
 class ScrollEvent(ElementSelectedEvent[None]):
 	"""Scroll the page or element."""
 

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -8,6 +8,7 @@ from cdp_use.cdp.input.commands import DispatchKeyEventParameters
 
 from browser_use.actor.utils import get_key_info
 from browser_use.browser.events import (
+	ClearInputEvent,
 	ClickCoordinateEvent,
 	ClickElementEvent,
 	GetDropdownOptionsEvent,
@@ -21,7 +22,6 @@ from browser_use.browser.events import (
 	TypeTextEvent,
 	UploadFileEvent,
 	WaitEvent,
-	ClearInputEvent,
 )
 from browser_use.browser.views import BrowserError, URLNotAllowedError
 from browser_use.browser.watchdog_base import BaseWatchdog

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -519,8 +519,9 @@ class DefaultActionWatchdog(BaseWatchdog):
 			index_for_logging = element_node.backend_node_id or 'unknown'
 
 			if not element_node.backend_node_id or element_node.backend_node_id == 0:
-				self.logger.warning('Cannot clear input: no specific element targeted')
-				return None
+				msg = 'Cannot clear input: no specific element targeted'
+				self.logger.warning(msg)
+				raise BrowserError(msg)
 
 			cdp_session = await self.browser_session.cdp_client_for_node(element_node)
 
@@ -530,8 +531,9 @@ class DefaultActionWatchdog(BaseWatchdog):
 			)
 
 			if 'object' not in result or 'objectId' not in result['object']:
-				self.logger.warning(f'Could not resolve element {index_for_logging} for clearing')
-				return None
+				msg = f'Could not resolve element {index_for_logging} for clearing'
+				self.logger.warning(msg)
+				raise BrowserError(msg)
 
 			object_id = result['object']['objectId']
 
@@ -548,8 +550,11 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			if success:
 				self.logger.info(f'🧹 Cleared input field with index {index_for_logging}')
+				return True
 			else:
-				self.logger.warning(f'❌ Failed to clear input field with index {index_for_logging}')
+				msg = f'Failed to clear input field with index {index_for_logging} after trying all strategies'
+				self.logger.warning(f'❌ {msg}')
+				raise BrowserError(msg)
 
 		except Exception:
 			raise
@@ -1446,14 +1451,11 @@ class DefaultActionWatchdog(BaseWatchdog):
 					return True
 				else:
 					self.logger.debug(f'⚠️ JavaScript clear partially failed, field still contains: "{final_text}"')
-					return False
 			else:
 				self.logger.debug(f'❌ JavaScript clear failed: {clear_info.get("error", "Unknown error")}')
-				return False
 
 		except Exception as e:
 			self.logger.debug(f'JavaScript clear failed with exception: {e}')
-			return False
 
 		# Strategy 2: Triple-click + Delete (fallback for stubborn fields)
 		try:
@@ -1550,7 +1552,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 				session_id=cdp_session.session_id,
 			)
 
-			# Delete selected text (Backspace)
+			# Backspace
 			await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
 				params={
 					'type': 'keyDown',
@@ -1568,12 +1570,13 @@ class DefaultActionWatchdog(BaseWatchdog):
 				session_id=cdp_session.session_id,
 			)
 
-			self.logger.debug('✅ Text field cleared using keyboard shortcuts')
+			self.logger.debug(f'✅ Text field cleared using {modifier_name}+A + Backspace')
 			return True
 
 		except Exception as e:
-			self.logger.debug(f'All clearing strategies failed: {e}')
-			return False
+			self.logger.debug(f'Keyboard shortcut clear failed: {e}')
+
+		return False
 
 	async def _focus_element_simple(
 		self, backend_node_id: int, object_id: str, cdp_session, input_coordinates: dict | None = None

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -21,6 +21,7 @@ from browser_use.browser.events import (
 	TypeTextEvent,
 	UploadFileEvent,
 	WaitEvent,
+	ClearInputEvent,
 )
 from browser_use.browser.views import BrowserError, URLNotAllowedError
 from browser_use.browser.watchdog_base import BaseWatchdog
@@ -36,6 +37,7 @@ SelectDropdownOptionEvent.model_rebuild()
 TypeTextEvent.model_rebuild()
 ScrollEvent.model_rebuild()
 UploadFileEvent.model_rebuild()
+ClearInputEvent.model_rebuild()
 
 
 class DefaultActionWatchdog(BaseWatchdog):
@@ -507,7 +509,49 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# Note: We don't clear cached state here - let multi_act handle DOM change detection
 			# by explicitly rebuilding and comparing when needed
-		except Exception as e:
+		except Exception:
+			raise
+
+	async def on_ClearInputEvent(self, event: ClearInputEvent) -> None:
+		"""Handle clear input request with CDP."""
+		try:
+			element_node = event.node
+			index_for_logging = element_node.backend_node_id or 'unknown'
+
+			if not element_node.backend_node_id or element_node.backend_node_id == 0:
+				self.logger.warning('Cannot clear input: no specific element targeted')
+				return None
+
+			cdp_session = await self.browser_session.cdp_client_for_node(element_node)
+
+			# Resolve node to get object_id
+			result = await cdp_session.cdp_client.send.DOM.resolveNode(
+				params={'backendNodeId': element_node.backend_node_id}, session_id=cdp_session.session_id
+			)
+
+			if 'object' not in result or 'objectId' not in result['object']:
+				self.logger.warning(f'Could not resolve element {index_for_logging} for clearing')
+				return None
+
+			object_id = result['object']['objectId']
+
+			# Scroll into view if possible
+			try:
+				await cdp_session.cdp_client.send.DOM.scrollIntoViewIfNeeded(
+					params={'backendNodeId': element_node.backend_node_id}, session_id=cdp_session.session_id
+				)
+			except Exception:
+				pass
+
+			# Clear the field
+			success = await self._clear_text_field(object_id=object_id, cdp_session=cdp_session)
+
+			if success:
+				self.logger.info(f'🧹 Cleared input field with index {index_for_logging}')
+			else:
+				self.logger.warning(f'❌ Failed to clear input field with index {index_for_logging}')
+
+		except Exception:
 			raise
 
 	async def on_ScrollEvent(self, event: ScrollEvent) -> None:

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -512,7 +512,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 		except Exception:
 			raise
 
-	async def on_ClearInputEvent(self, event: ClearInputEvent) -> None:
+	async def on_ClearInputEvent(self, event: ClearInputEvent) -> bool:
 		"""Handle clear input request with CDP."""
 		try:
 			element_node = event.node

--- a/browser_use/skill_cli/__init__.py
+++ b/browser_use/skill_cli/__init__.py
@@ -10,6 +10,7 @@ Usage:
     browser-use python "print(browser.url)"
     browser-use close
 """
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/browser_use/skill_cli/__init__.py
+++ b/browser_use/skill_cli/__init__.py
@@ -10,6 +10,10 @@ Usage:
     browser-use python "print(browser.url)"
     browser-use close
 """
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from browser_use.skill_cli.main import main
 
 __all__ = ['main']
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from browser_use.agent.views import ActionModel, ActionResult
 from browser_use.browser import BrowserSession
 from browser_use.browser.events import (
+	ClearInputEvent,
 	ClickCoordinateEvent,
 	ClickElementEvent,
 	CloseTabEvent,
@@ -27,7 +28,6 @@ from browser_use.browser.events import (
 	SwitchTabEvent,
 	TypeTextEvent,
 	UploadFileEvent,
-	ClearInputEvent,
 )
 from browser_use.browser.views import BrowserError
 from browser_use.dom.service import EnhancedDOMTreeNode
@@ -38,6 +38,7 @@ from browser_use.observability import observe_debug
 from browser_use.tools.registry.service import Registry
 from browser_use.tools.utils import get_click_description
 from browser_use.tools.views import (
+	ClearInputAction,
 	ClickElementAction,
 	ClickElementActionIndexOnly,
 	CloseTabAction,
@@ -58,7 +59,6 @@ from browser_use.tools.views import (
 	StructuredOutputAction,
 	SwitchTabAction,
 	UploadFileAction,
-	ClearInputAction,
 )
 from browser_use.utils import create_task_with_error_handling, sanitize_surrogates, time_execution_sync
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -788,7 +788,7 @@ class Tools(Generic[Context]):
 			try:
 				event = browser_session.event_bus.dispatch(ClearInputEvent(node=node))
 				await event
-				await event.event_result(raise_if_any=True, raise_if_none=False)
+				await event.event_result(raise_if_any=True, raise_if_none=True)
 
 				msg = f'Cleared input field at index {params.index}'
 				logger.debug(msg)

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -27,6 +27,7 @@ from browser_use.browser.events import (
 	SwitchTabEvent,
 	TypeTextEvent,
 	UploadFileEvent,
+	ClearInputEvent,
 )
 from browser_use.browser.views import BrowserError
 from browser_use.dom.service import EnhancedDOMTreeNode
@@ -57,6 +58,7 @@ from browser_use.tools.views import (
 	StructuredOutputAction,
 	SwitchTabAction,
 	UploadFileAction,
+	ClearInputAction,
 )
 from browser_use.utils import create_task_with_error_handling, sanitize_surrogates, time_execution_sync
 
@@ -68,6 +70,7 @@ ClickElementEvent.model_rebuild()
 TypeTextEvent.model_rebuild()
 ScrollEvent.model_rebuild()
 UploadFileEvent.model_rebuild()
+ClearInputEvent.model_rebuild()
 
 Context = TypeVar('Context')
 
@@ -762,6 +765,40 @@ class Tools(Generic[Context]):
 				# Log the full error for debugging
 				logger.error(f'Failed to dispatch TypeTextEvent: {type(e).__name__}: {e}')
 				error_msg = f'Failed to type text into element {params.index}: {e}'
+				return ActionResult(error=error_msg)
+
+		@self.registry.action(
+			'Clear text input element by index.',
+			param_model=ClearInputAction,
+		)
+		async def clear_input(params: ClearInputAction, browser_session: BrowserSession):
+			# Look up the node from the selector map
+			node = await browser_session.get_element_by_index(params.index)
+			if node is None:
+				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+				logger.warning(f'⚠️ {msg}')
+				return ActionResult(extracted_content=msg)
+
+			# Highlight the element being cleared (truly non-blocking)
+			create_task_with_error_handling(
+				browser_session.highlight_interaction_element(node), name='highlight_clear_element', suppress_exceptions=True
+			)
+
+			# Dispatch clear input event with node
+			try:
+				event = browser_session.event_bus.dispatch(ClearInputEvent(node=node))
+				await event
+				await event.event_result(raise_if_any=True, raise_if_none=False)
+
+				msg = f'Cleared input field at index {params.index}'
+				logger.debug(msg)
+
+				return ActionResult(extracted_content=msg, long_term_memory=msg)
+			except BrowserError as e:
+				return handle_browser_error(e)
+			except Exception as e:
+				logger.error(f'Failed to dispatch ClearInputEvent: {type(e).__name__}: {e}')
+				error_msg = f'Failed to clear input field at index {params.index}: {e}'
 				return ActionResult(error=error_msg)
 
 		@self.registry.action(

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -86,6 +86,10 @@ class InputTextAction(BaseModel):
 	clear: bool = Field(default=True, description='1=clear, 0=append')
 
 
+class ClearInputAction(BaseModel):
+	index: int = Field(ge=0, description='Element index from browser_state')
+
+
 class DoneAction(BaseModel):
 	text: str = Field(
 		description=(


### PR DESCRIPTION
Introduces a first-class clear_input action, providing a dedicated, high-level tool for clearing input fields. This is more efficient than the workaround of using input_text with an empty string.

- Add ClearInputAction model in tools/views.py
- Register clear_input action in tools/service.py
- Add ClearInputEvent in browser/events.py
- Implement handler in default_action_watchdog.py using _clear_text_field
- Add loop detection in agent/views.py for repeated clearing
#4683 