### PR TITLE
fix input clear fallbacks and clarify clear-then-type behavior

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1402,10 +1402,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 					return True
 				else:
 					self.logger.debug(f'⚠️ JavaScript clear partially failed, field still contains: "{final_text}"')
-					return False
 			else:
 				self.logger.debug(f'❌ JavaScript clear failed: {clear_info.get("error", "Unknown error")}')
-				return False
 
 		except Exception as e:
 			self.logger.debug(f'JavaScript clear failed with exception: {e}')

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -258,7 +258,7 @@ class BrowserUseServer:
 				),
 				types.Tool(
 					name='browser_type',
-					description='Type text into an input field',
+					description='Type text into an input field. Clears existing text by default; pass text="" to clear only.',
 					inputSchema={
 						'type': 'object',
 						'properties': {
@@ -266,7 +266,10 @@ class BrowserUseServer:
 								'type': 'integer',
 								'description': 'The index of the input element (from browser_get_state)',
 							},
-							'text': {'type': 'string', 'description': 'The text to type'},
+							'text': {
+								'type': 'string',
+								'description': 'The text to type. Pass an empty string ("") to clear the field without typing.',
+							},
 						},
 						'required': ['index', 'text'],
 					},

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -713,7 +713,7 @@ Setup:
 	p.add_argument('text', help='Text to type')
 
 	# input <index> <text>
-	p = subparsers.add_parser('input', help='Type text into specific element')
+	p = subparsers.add_parser('input', help='Clear-then-type into specific element; pass "" to clear only')
 	p.add_argument('index', type=int, help='Element index')
 	p.add_argument('text', help='Text to type')
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -679,7 +679,7 @@ class Tools(Generic[Context]):
 		self._register_click_action()
 
 		@self.registry.action(
-			'Input text into element by index.',
+			'Input text into element by index. Clears existing text by default; pass text="" to clear only, or clear=False to append.',
 			param_model=InputTextAction,
 		)
 		async def input(

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -82,8 +82,8 @@ class ClickElementActionIndexOnly(BaseModel):
 
 class InputTextAction(BaseModel):
 	index: int = Field(ge=0, description='from browser_state')
-	text: str
-	clear: bool = Field(default=True, description='1=clear, 0=append')
+	text: str = Field(description='Text to enter. With clear=True, text="" clears the field without typing.')
+	clear: bool = Field(default=True, description='Clear existing text before typing. Set to False to append instead.')
 
 
 class DoneAction(BaseModel):

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -77,7 +77,8 @@ browser-use screenshot [path.png]         # Screenshot (base64 if no path, --ful
 browser-use click <index>                 # Click element by index
 browser-use click <x> <y>                 # Click at pixel coordinates
 browser-use type "text"                   # Type into focused element
-browser-use input <index> "text"          # Click element, then type
+browser-use input <index> "text"          # Click element, clear existing text, then type
+browser-use input <index> ""              # Clear a field without typing new text
 browser-use keys "Enter"                  # Send keyboard keys (also "Control+a", etc.)
 browser-use select <index> "option"       # Select dropdown option
 browser-use upload <index> <path>         # Upload file to file input


### PR DESCRIPTION
Resolves #4683

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes input clearing so we don’t stop on JS clear failures, and clarifies “clear-then-type” as the default. Adds a clear-only option via text="" and a way to append via clear=False. Resolves #4683.

- **Bug Fixes**
  - Removed premature returns in JS clear to enable fallback strategies.
  - Aligned docs and help to the default behavior: clear-then-type; `text=""` clears only; `clear=False` appends (`browser_type` tool, `InputTextAction` schema, CLI `input`, SKILL.md).

<sup>Written for commit 4476f6e16e557d1cf10cc40989a5479e17438d51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

