### PR TITLE
ci: add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,30 @@
+name: actionlint
+
+# Cancel in-progress runs when a new commit is pushed to the same branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+      - stable
+      - 'releases/**'
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: validate GitHub Actions workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@v1


### PR DESCRIPTION
## Summary
- add a dedicated actionlint workflow for GitHub Actions files
- run it only when `.github/workflows/**` changes or when manually dispatched
- keep permissions read-only and reuse the repo concurrency pattern

## Validation
- parsed `.github/workflows/actionlint.yml` as YAML locally
- inspected existing workflow conventions for trigger paths, permissions, and concurrency

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an `actionlint` CI workflow to lint GitHub Actions files and prevent broken workflows from merging. It runs on changes to `.github/workflows/**` (push/PR) and `workflow_dispatch`, uses `actions/checkout@v4` + `reviewdog/action-actionlint@v1`, keeps permissions read-only, and cancels stale runs with concurrency.

<sup>Written for commit b20b1c2980c5f8866c60a1da7c27fde3bb76f5cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

