### PR TITLE
fix(recording): use CDP timestamps to preserve real-time video playback speed

### DIFF
--- a/browser_use/browser/video_recorder.py
+++ b/browser_use/browser/video_recorder.py
@@ -36,7 +36,14 @@ class VideoRecorderService:
 	This service captures individual frames from the CDP screencast, decodes them,
 	and appends them to a video file using a pip-installable ffmpeg backend.
 	It automatically resizes frames to match the target video dimensions.
+
+	Timestamps from CDP screencast metadata are used to insert duplicate frames during
+	pauses, preserving real-time playback speed. Without this, videos play back much
+	faster than real time because CDP only delivers frames on visual change.
 	"""
+
+	# Max seconds of silence to fill with duplicate frames. Caps file size during long idle periods.
+	MAX_FILL_SECONDS = 10.0
 
 	def __init__(self, output_path: Path, size: ViewportSize, framerate: int):
 		"""
@@ -53,6 +60,8 @@ class VideoRecorderService:
 		self._writer: Optional['Format.Writer'] = None
 		self._is_active = False
 		self.padded_size = _get_padded_size(self.size)
+		self._last_timestamp: float | None = None
+		self._last_frame: 'np.ndarray | None' = None
 
 	def start(self) -> None:
 		"""
@@ -84,13 +93,19 @@ class VideoRecorderService:
 			logger.error(f'Failed to initialize video writer: {e}')
 			self._is_active = False
 
-	def add_frame(self, frame_data_b64: str) -> None:
+	def add_frame(self, frame_data_b64: str, timestamp: float | None = None) -> None:
 		"""
 		Decodes a base64-encoded PNG frame, resizes it, pads it to be codec-compatible,
 		and appends it to the video.
 
+		When a CDP timestamp is provided, duplicate frames are inserted to fill time gaps
+		so the video plays back at real-time speed. Without this, automated sessions appear
+		sped up because CDP only delivers frames on visual change.
+
 		Args:
 		    frame_data_b64: A base64-encoded string of the PNG frame data.
+		    timestamp: CDP screencast frame timestamp in seconds since epoch. When provided,
+		               filler frames are inserted to maintain real-time playback speed.
 		"""
 		if not self._is_active or not self._writer:
 			return
@@ -118,7 +133,22 @@ class VideoRecorderService:
 				# 3. Convert to numpy array for imageio
 				img_array = np.array(img)
 
+			# Insert filler frames to preserve real-time playback speed.
+			# CDP screencast fires on visual change only, so long pauses produce no frames.
+			# Duplicating the previous frame for the elapsed wall-clock time keeps the video
+			# in sync with actual session duration.
+			if timestamp is not None and self._last_timestamp is not None and self._last_frame is not None:
+				gap_seconds = min(timestamp - self._last_timestamp, self.MAX_FILL_SECONDS)
+				if gap_seconds > 0:
+					# -1 because we're about to append the current frame as well
+					filler_count = max(0, int(gap_seconds * self.framerate) - 1)
+					for _ in range(filler_count):
+						self._writer.append_data(self._last_frame)
+
 			self._writer.append_data(img_array)
+			self._last_frame = img_array
+			if timestamp is not None:
+				self._last_timestamp = timestamp
 		except Exception as e:
 			logger.warning(f'Could not process and add video frame: {e}')
 

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import mimetypes
 import os
 
 from cdp_use.cdp.input.commands import DispatchKeyEventParameters
@@ -2659,6 +2660,31 @@ class DefaultActionWatchdog(BaseWatchdog):
 					msg = f'Upload failed - file {event.file_path} is empty (0 bytes).'
 					raise BrowserError(message=msg, long_term_memory=msg)
 				self.logger.debug(f'📎 File {event.file_path} validated ({file_size} bytes)')
+
+				# Validate file type against the input's accept attribute
+				accept_attr = (element_node.attributes or {}).get('accept', '').strip()
+				if accept_attr:
+					file_ext = os.path.splitext(event.file_path)[1].lower()
+					file_mime = mimetypes.guess_type(event.file_path)[0] or ''
+					accepted_types = [t.strip().lower() for t in accept_attr.split(',') if t.strip()]
+					accepted = False
+					for accept_type in accepted_types:
+						if accept_type.startswith('.'):
+							if file_ext == accept_type:
+								accepted = True
+								break
+						elif accept_type.endswith('/*'):
+							mime_family = accept_type[:-2]
+							if file_mime.startswith(mime_family + '/'):
+								accepted = True
+								break
+						else:
+							if file_mime == accept_type:
+								accepted = True
+								break
+					if not accepted:
+						msg = f'Upload failed - file type "{file_ext or file_mime or event.file_path}" is not accepted by this input. Accepted types: {accept_attr}'
+						raise BrowserError(message=msg, long_term_memory=msg)
 
 			# Set file(s) to upload
 			backend_node_id = element_node.backend_node_id

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2668,23 +2668,34 @@ class DefaultActionWatchdog(BaseWatchdog):
 					file_mime = mimetypes.guess_type(event.file_path)[0] or ''
 					accepted_types = [t.strip().lower() for t in accept_attr.split(',') if t.strip()]
 					accepted = False
+					mime_required = False  # whether any rule required a MIME match
 					for accept_type in accepted_types:
 						if accept_type.startswith('.'):
 							if file_ext == accept_type:
 								accepted = True
 								break
 						elif accept_type.endswith('/*'):
+							mime_required = True
 							mime_family = accept_type[:-2]
-							if file_mime.startswith(mime_family + '/'):
+							if file_mime and file_mime.startswith(mime_family + '/'):
 								accepted = True
 								break
 						else:
-							if file_mime == accept_type:
+							mime_required = True
+							if file_mime and file_mime == accept_type:
 								accepted = True
 								break
 					if not accepted:
-						msg = f'Upload failed - file type "{file_ext or file_mime or event.file_path}" is not accepted by this input. Accepted types: {accept_attr}'
-						raise BrowserError(message=msg, long_term_memory=msg)
+						# When MIME inference fails, fall back to letting the browser decide
+						# (mimetypes.guess_type is OS-dependent and may return None for valid files).
+						if mime_required and not file_mime:
+							self.logger.warning(
+								f'📎 Could not infer MIME type for {event.file_path}; '
+								f'skipping client-side accept="{accept_attr}" check and deferring to browser.'
+							)
+						else:
+							msg = f'Upload failed - file type "{file_ext or file_mime or event.file_path}" is not accepted by this input. Accepted types: {accept_attr}'
+							raise BrowserError(message=msg, long_term_memory=msg)
 
 			# Set file(s) to upload
 			backend_node_id = element_node.backend_node_id

--- a/browser_use/browser/watchdogs/recording_watchdog.py
+++ b/browser_use/browser/watchdogs/recording_watchdog.py
@@ -75,6 +75,10 @@ class RecordingWatchdog(BaseWatchdog):
 		"""
 		if self._recorder:
 			self.logger.debug(f'Agent focus changed to {event.target_id}, switching screencast...')
+			# Reset timestamp tracking so the first frame from the new tab doesn't
+			# trigger spurious filler frames spanning the tab-switch gap.
+			self._recorder._last_timestamp = None
+			self._recorder._last_frame = None
 			await self._start_screencast()
 
 	async def _start_screencast(self) -> None:
@@ -142,7 +146,15 @@ class RecordingWatchdog(BaseWatchdog):
 
 		if not self._recorder:
 			return
-		self._recorder.add_frame(event['data'])
+
+		# Pass the CDP-provided timestamp so the recorder can insert filler frames during
+		# pauses, keeping the video in sync with real wall-clock time.
+		timestamp: float | None = None
+		metadata = event.get('metadata') if isinstance(event, dict) else getattr(event, 'metadata', None)
+		if metadata is not None:
+			timestamp = metadata.get('timestamp') if isinstance(metadata, dict) else getattr(metadata, 'timestamp', None)
+
+		self._recorder.add_frame(event['data'], timestamp=timestamp)
 		create_task_with_error_handling(
 			self._ack_screencast_frame(event, session_id),
 			name='ack_screencast_frame',

--- a/browser_use/browser/watchdogs/screenshot_watchdog.py
+++ b/browser_use/browser/watchdogs/screenshot_watchdog.py
@@ -1,5 +1,6 @@
 """Screenshot watchdog for handling screenshot requests using CDP."""
 
+import asyncio
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from bubus import BaseEvent
@@ -12,6 +13,9 @@ from browser_use.observability import observe_debug
 
 if TYPE_CHECKING:
 	pass
+
+_SCREENSHOT_MAX_RETRIES = 3
+_SCREENSHOT_RETRY_DELAY = 0.5
 
 
 class ScreenshotWatchdog(BaseWatchdog):
@@ -73,16 +77,29 @@ class ScreenshotWatchdog(BaseWatchdog):
 				}
 			params = CaptureScreenshotParameters(**params_dict)
 
-			# Take screenshot using CDP
-			self.logger.debug(f'[ScreenshotWatchdog] Taking screenshot with params: {params}')
-			result = await cdp_session.cdp_client.send.Page.captureScreenshot(params=params, session_id=cdp_session.session_id)
+			# Take screenshot using CDP, retrying on transient timeouts
+			last_error: Exception | None = None
+			for attempt in range(_SCREENSHOT_MAX_RETRIES):
+				try:
+					self.logger.debug(f'[ScreenshotWatchdog] Taking screenshot with params: {params} (attempt {attempt + 1}/{_SCREENSHOT_MAX_RETRIES})')
+					result = await cdp_session.cdp_client.send.Page.captureScreenshot(params=params, session_id=cdp_session.session_id)
 
-			# Return base64-encoded screenshot data
-			if result and 'data' in result:
-				self.logger.debug('[ScreenshotWatchdog] Screenshot captured successfully')
-				return result['data']
+					# Return base64-encoded screenshot data
+					if result and 'data' in result:
+						self.logger.debug('[ScreenshotWatchdog] Screenshot captured successfully')
+						return result['data']
 
-			raise BrowserError('[ScreenshotWatchdog] Screenshot result missing data')
+					raise BrowserError('[ScreenshotWatchdog] Screenshot result missing data')
+				except RuntimeError as e:
+					if 'timed out' in str(e) and attempt < _SCREENSHOT_MAX_RETRIES - 1:
+						last_error = e
+						self.logger.warning(f'[ScreenshotWatchdog] Screenshot timed out (attempt {attempt + 1}/{_SCREENSHOT_MAX_RETRIES}), retrying in {_SCREENSHOT_RETRY_DELAY}s...')
+						await asyncio.sleep(_SCREENSHOT_RETRY_DELAY)
+						continue
+					raise
+
+			# Should not be reached, but satisfies type checker
+			raise last_error or BrowserError('[ScreenshotWatchdog] Screenshot failed after retries')
 		except Exception as e:
 			self.logger.error(f'[ScreenshotWatchdog] Screenshot failed: {e}')
 			raise

--- a/browser_use/browser/watchdogs/screenshot_watchdog.py
+++ b/browser_use/browser/watchdogs/screenshot_watchdog.py
@@ -81,8 +81,12 @@ class ScreenshotWatchdog(BaseWatchdog):
 			last_error: Exception | None = None
 			for attempt in range(_SCREENSHOT_MAX_RETRIES):
 				try:
-					self.logger.debug(f'[ScreenshotWatchdog] Taking screenshot with params: {params} (attempt {attempt + 1}/{_SCREENSHOT_MAX_RETRIES})')
-					result = await cdp_session.cdp_client.send.Page.captureScreenshot(params=params, session_id=cdp_session.session_id)
+					self.logger.debug(
+						f'[ScreenshotWatchdog] Taking screenshot with params: {params} (attempt {attempt + 1}/{_SCREENSHOT_MAX_RETRIES})'
+					)
+					result = await cdp_session.cdp_client.send.Page.captureScreenshot(
+						params=params, session_id=cdp_session.session_id
+					)
 
 					# Return base64-encoded screenshot data
 					if result and 'data' in result:
@@ -93,7 +97,9 @@ class ScreenshotWatchdog(BaseWatchdog):
 				except RuntimeError as e:
 					if 'timed out' in str(e) and attempt < _SCREENSHOT_MAX_RETRIES - 1:
 						last_error = e
-						self.logger.warning(f'[ScreenshotWatchdog] Screenshot timed out (attempt {attempt + 1}/{_SCREENSHOT_MAX_RETRIES}), retrying in {_SCREENSHOT_RETRY_DELAY}s...')
+						self.logger.warning(
+							f'[ScreenshotWatchdog] Screenshot timed out (attempt {attempt + 1}/{_SCREENSHOT_MAX_RETRIES}), retrying in {_SCREENSHOT_RETRY_DELAY}s...'
+						)
 						await asyncio.sleep(_SCREENSHOT_RETRY_DELAY)
 						continue
 					raise

--- a/browser_use/skill_cli/commands/browser.py
+++ b/browser_use/skill_cli/commands/browser.py
@@ -280,7 +280,10 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 				hint = ' No file input found on the page.'
 			return {'error': f'Element {index} is not a file input.{hint}'}
 
-		await actions.upload_file(file_input_node, file_path)
+		try:
+			await actions.upload_file(file_input_node, file_path)
+		except Exception as e:
+			return {'error': str(e)}
 		return {'uploaded': file_path, 'element': index}
 
 	elif action == 'eval':

--- a/tests/ci/test_cli_upload.py
+++ b/tests/ci/test_cli_upload.py
@@ -139,6 +139,110 @@ class TestUploadCommandHandler:
 		finally:
 			await session.kill()
 
+	async def test_upload_rejected_by_accept_attribute(self, httpserver):
+		"""Uploading a file whose type is not in the accept attribute raises an error."""
+		from browser_use.browser.events import NavigateToUrlEvent
+		from browser_use.browser.session import BrowserSession
+		from browser_use.skill_cli.actions import ActionHandler
+		from browser_use.skill_cli.commands.browser import handle
+		from browser_use.skill_cli.sessions import SessionInfo
+
+		# File input that only accepts images
+		httpserver.expect_request('/').respond_with_data(
+			'<html><body><input type="file" id="upload" accept="image/*" /></body></html>',
+			content_type='text/html',
+		)
+
+		session = BrowserSession(headless=True)
+		await session.start()
+		try:
+			await session.event_bus.dispatch(NavigateToUrlEvent(url=httpserver.url_for('/')))
+
+			session_info = SessionInfo(
+				name='test',
+				headed=False,
+				profile=None,
+				cdp_url=None,
+				browser_session=session,
+				actions=ActionHandler(session),
+			)
+
+			await session.get_browser_state_summary()
+
+			selector_map = await session.get_selector_map()
+			file_input_index = None
+			for idx, el in selector_map.items():
+				if session.is_file_input(el):
+					file_input_index = idx
+					break
+			assert file_input_index is not None, 'File input not found in selector map'
+
+			# Attempt to upload a PDF (not accepted by image/*)
+			with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as f:
+				f.write(b'%PDF-1.4 fake content')
+				pdf_file = f.name
+
+			try:
+				result = await handle('upload', session_info, {'index': file_input_index, 'path': pdf_file})
+				assert 'error' in result
+				assert 'not accepted' in result['error'].lower()
+			finally:
+				Path(pdf_file).unlink(missing_ok=True)
+		finally:
+			await session.kill()
+
+	async def test_upload_accepted_by_extension(self, httpserver):
+		"""Uploading a file that matches the accept extension succeeds."""
+		from browser_use.browser.events import NavigateToUrlEvent
+		from browser_use.browser.session import BrowserSession
+		from browser_use.skill_cli.actions import ActionHandler
+		from browser_use.skill_cli.commands.browser import handle
+		from browser_use.skill_cli.sessions import SessionInfo
+
+		# File input that accepts only .pdf files
+		httpserver.expect_request('/').respond_with_data(
+			'<html><body><input type="file" id="upload" accept=".pdf" /></body></html>',
+			content_type='text/html',
+		)
+
+		session = BrowserSession(headless=True)
+		await session.start()
+		try:
+			await session.event_bus.dispatch(NavigateToUrlEvent(url=httpserver.url_for('/')))
+
+			session_info = SessionInfo(
+				name='test',
+				headed=False,
+				profile=None,
+				cdp_url=None,
+				browser_session=session,
+				actions=ActionHandler(session),
+			)
+
+			await session.get_browser_state_summary()
+
+			selector_map = await session.get_selector_map()
+			file_input_index = None
+			for idx, el in selector_map.items():
+				if session.is_file_input(el):
+					file_input_index = idx
+					break
+			assert file_input_index is not None, 'File input not found in selector map'
+
+			# Upload a PDF — should be accepted
+			with tempfile.NamedTemporaryFile(suffix='.pdf', delete=False) as f:
+				f.write(b'%PDF-1.4 fake content')
+				pdf_file = f.name
+
+			try:
+				result = await handle('upload', session_info, {'index': file_input_index, 'path': pdf_file})
+				assert 'uploaded' in result
+			finally:
+				Path(pdf_file).unlink(missing_ok=True)
+		finally:
+			await session.kill()
+
+
 	async def test_upload_happy_path(self, httpserver):
 		"""Upload to a file input element succeeds."""
 		from browser_use.browser.events import NavigateToUrlEvent

--- a/tests/ci/test_cli_upload.py
+++ b/tests/ci/test_cli_upload.py
@@ -242,7 +242,6 @@ class TestUploadCommandHandler:
 		finally:
 			await session.kill()
 
-
 	async def test_upload_happy_path(self, httpserver):
 		"""Upload to a file input element succeeds."""
 		from browser_use.browser.events import NavigateToUrlEvent


### PR DESCRIPTION
Fixes #4696

## Problem

When using `record_video_dir`, the recorded video plays back much faster than real time. CDP screencast delivers frames only on visual change — during network waits or idle periods between agent steps, zero frames are produced. All captured frames are then written to the video at the configured framerate (30 fps default), so a 5-second page load appears to be instant in the video.

## Solution

`ScreencastFrameMetadata` includes a `timestamp` field (Unix seconds). This PR threads that timestamp from the CDP event through to `VideoRecorderService.add_frame()`. When a new frame arrives, the recorder computes the wall-clock gap since the last frame and inserts duplicate filler frames to fill the silence — matching the video duration to actual session time.

Key details:
- Filler frame count: `int(gap_seconds * framerate) - 1` (the current frame accounts for the last slot)
- Idle gaps longer than `MAX_FILL_SECONDS` (10 s) are capped to keep file sizes reasonable
- Tab switches reset the timestamp so no spurious filler spans different targets
- Fully backward-compatible: if no timestamp is available, `add_frame()` behaves as before

## Testing

The change can be verified by recording a session that includes a few-second network wait and comparing the video duration to the actual elapsed time. Before this fix the video would be significantly shorter than wall-clock time; after the fix the durations match.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses CDP screencast timestamps to keep recorded video playback in real time. Also validates uploads against `accept` rules, retries flaky screenshot timeouts, and returns CLI upload errors as error dicts.

- **Bug Fixes**
  - Recording: Use `ScreencastFrameMetadata.timestamp` to detect pauses and insert duplicate frames so duration matches wall clock; cap fills at 10s; reset on tab switch; fallback if missing.
  - Screenshots: Retry `Page.captureScreenshot` up to 3 times (0.5s delay) on transient "timed out" errors.
  - Uploads: Validate `<input accept>` for `.ext`, `type/*`, and exact MIME; if MIME is unknown and rules are MIME-only, warn and defer to the browser; otherwise raise `BrowserError`. CLI `upload` now catches this and returns `{'error': ...}`. Adds tests for accept/reject paths.

- **Refactors**
  - Formatting: Apply ruff format to satisfy CI.

<sup>Written for commit 0f4fe1a0e1a90deb0fe85bdab294deb31fa1ef9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

