### PR TITLE
fix(agent): correct step_interval calculation

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1355,7 +1355,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				if last_history_item.metadata:
 					previous_end_time = last_history_item.metadata.step_end_time
 					previous_start_time = last_history_item.metadata.step_start_time
-					step_interval = max(0, previous_end_time - previous_start_time)
+					step_interval = max(0, self.step_start_time - previous_end_time)
 			metadata = StepMetadata(
 				step_number=self.state.n_steps,
 				step_start_time=self.step_start_time,


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #4484

### Problem
The step_interval in StepMetadata was incorrectly computing the duration of the previous step instead of the idle time gap between steps.

### Changes
- Fixed calculation in browser_use/agent/service.py (line 1358)
- Changed from: max(0, previous_end_time - previous_start_time)
- Changed to: max(0, self.step_start_time - previous_end_time)

### Impact
Any monitoring or telemetry relying on step_interval now receives correct idle time data between steps.

Thanks to @warren618 for the clear bug report! 🙏

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected step_interval to measure idle time between steps instead of the previous step’s duration for accurate telemetry of step gaps. `StepMetadata.step_interval` now uses `max(0, self.step_start_time - previous_end_time)` to report the true idle time.

<sup>Written for commit 15d95c22036ad0738824cc3cd08c8da23f5589e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

