### PR TITLE
fix(mcp): honor BROWSER_USE_CDP_URL so MCP server connects to existing Chrome

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -597,11 +597,22 @@ class BrowserUseServer:
 		for key, value in kwargs.items():
 			profile_data[key] = value
 
-		# Create browser profile
-		profile = BrowserProfile(**profile_data)
+		# Connect to an existing Chrome via CDP when BROWSER_USE_CDP_URL
+		# is set. We must pass cdp_url as a top-level BrowserSession
+		# kwarg: nesting it inside browser_profile triggers the
+		# is_local=True fallback in BrowserSession.__init__ and the
+		# local launcher runs instead of connecting, which hangs forever
+		# on BrowserStartEvent. The CLI path (skill_cli/sessions.py)
+		# already passes cdp_url as a top-level kwarg.
+		cdp_url_env = os.environ.get('BROWSER_USE_CDP_URL')
+		if cdp_url_env:
+			self.browser_session = BrowserSession(cdp_url=cdp_url_env)
+		else:
+			# Create browser profile
+			profile = BrowserProfile(**profile_data)
 
-		# Create browser session
-		self.browser_session = BrowserSession(browser_profile=profile)
+			# Create browser session
+			self.browser_session = BrowserSession(browser_profile=profile)
 		await self.browser_session.start()
 
 		# Track the session for management


### PR DESCRIPTION
## Problem

When the browser-use MCP server is launched and given an existing
Chrome via CDP (`--cdp-url` on the CLI, or `BROWSER_USE_CDP_URL` in
the env), every tool call hangs for 30 seconds with
`Event handler BrowserSession.on_BrowserStartEvent timed out`.
Subsequent calls then fail with `Root CDP client not initialized`
or `Expected at least one handler to return a non-None result`
on `BrowserStateRequestEvent`.

## Root cause

`BrowserUseServer._init_browser_session` currently creates the
session via `BrowserSession(browser_profile=profile)` with `cdp_url`
nested inside the profile. But `BrowserSession.__init__`
(`browser/session.py`, around the
`if not cdp_url and not use_cloud: profile_kwargs['is_local'] = True`
check) only inspects its **top-level** `cdp_url` kwarg. When the
value lives on the profile, the top-level kwarg is `None` →
`is_local` is forced to `True` → the local launcher fires → hang
on `BrowserStartEvent`.

The CLI path
(`skill_cli/sessions.py::create_browser_session`) already does the
right thing by passing `cdp_url` as a top-level kwarg. The MCP
server should match.

## Fix

Read `BROWSER_USE_CDP_URL` from the environment and, when set,
create the `BrowserSession` with `cdp_url` as a top-level kwarg.
Otherwise fall back to the existing profile-based construction so
nothing else changes.

## Reproduce

```bash
google-chrome --headless=new --remote-debugging-port=9222 &
BROWSER_USE_CDP_URL=http://127.0.0.1:9222 \
  uvx --from "browser-use[cli]" browser-use --mcp
# every tool call hangs ~30s on BrowserStartEvent
```

After the patch, `browser_navigate`, `browser_get_state`,
`browser_screenshot`, `browser_list_sessions` all succeed
immediately against the existing Chrome.

## Testing

Manually verified against a real `chrome --remote-debugging-port=9222`
on headless Linux (Chrome 146):

- `browser_navigate` ✅
- `browser_get_state` ✅
- `browser_screenshot` ✅
- `browser_list_sessions` ✅

Happy to add a regression test if a maintainer points me at the
existing MCP test scaffolding.

## Alternative (bigger, cleaner)

A more invasive fix would be in `BrowserSession.__init__` itself:
extract `cdp_url` from `browser_profile` before the `is_local` check
so any caller gets consistent behavior. That touches more code
paths; happy to follow up if this MCP-only patch looks like the
wrong layer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `BROWSER_USE_CDP_URL` in the MCP server to connect to an existing Chrome via CDP using a top-level `cdp_url`. This removes the 30s hang and init errors so browser tools respond immediately.

- **Bug Fixes**
  - When `BROWSER_USE_CDP_URL` is set, create `BrowserSession(cdp_url=...)` instead of nesting it in `BrowserProfile`; otherwise keep the existing profile-based path.
  - Fixes 30s hangs on `BrowserStartEvent` and "Root CDP client not initialized"; `browser_navigate`, `browser_get_state`, `browser_screenshot`, and `browser_list_sessions` work against an existing Chrome.

<sup>Written for commit 7b7d7032d7cd5afe64e822ef4d65fff19ec41cc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

