### PR TITLE
Harden cloud CDP reconnect handling for BrowserSession

### DIFF
--- a/browser_use/browser/cloud/cloud.py
+++ b/browser_use/browser/cloud/cloud.py
@@ -24,24 +24,12 @@ class CloudBrowserClient:
 		self.client = httpx.AsyncClient(timeout=30.0)
 		self.current_session_id: str | None = None
 
-	async def create_browser(
-		self, request: CreateBrowserRequest, extra_headers: dict[str, str] | None = None
-	) -> CloudBrowserResponse:
-		"""Create a new cloud browser instance. For full docs refer to https://docs.cloud.browser-use.com/api-reference/v-2-api-current/browsers/create-browser-session-browsers-post
-
-		Args:
-			request: CreateBrowserRequest object containing browser creation parameters
-
-		Returns:
-			CloudBrowserResponse: Contains CDP URL and other browser info
-		"""
-		url = f'{self.api_base_url}/api/v2/browsers'
-
-		# Try to get API key from environment variable first, then auth config
+	@staticmethod
+	def _get_api_token() -> str:
+		"""Resolve the Browser Use Cloud API token from env or auth config."""
 		api_token = os.getenv('BROWSER_USE_API_KEY')
 
 		if not api_token:
-			# Fallback to auth config file
 			try:
 				auth_config = CloudAuthConfig.load_from_file()
 				api_token = auth_config.api_token
@@ -54,7 +42,29 @@ class CloudBrowserClient:
 				'https://cloud.browser-use.com/new-api-key?utm_source=oss&utm_medium=use_cloud'
 			)
 
-		headers = {'X-Browser-Use-API-Key': api_token, 'Content-Type': 'application/json', **(extra_headers or {})}
+		return api_token
+
+	def _build_headers(self, extra_headers: dict[str, str] | None = None) -> dict[str, str]:
+		"""Build authenticated headers for cloud browser API requests."""
+		return {
+			'X-Browser-Use-API-Key': self._get_api_token(),
+			'Content-Type': 'application/json',
+			**(extra_headers or {}),
+		}
+
+	async def create_browser(
+		self, request: CreateBrowserRequest, extra_headers: dict[str, str] | None = None
+	) -> CloudBrowserResponse:
+		"""Create a new cloud browser instance. For full docs refer to https://docs.cloud.browser-use.com/api-reference/v-2-api-current/browsers/create-browser-session-browsers-post
+
+		Args:
+			request: CreateBrowserRequest object containing browser creation parameters
+
+		Returns:
+			CloudBrowserResponse: Contains CDP URL and other browser info
+		"""
+		url = f'{self.api_base_url}/api/v2/browsers'
+		headers = self._build_headers(extra_headers)
 
 		# Convert request to dictionary and exclude unset fields
 		request_body = request.model_dump(exclude_unset=True)
@@ -103,6 +113,49 @@ class CloudBrowserClient:
 				raise
 			raise CloudBrowserError(f'Unexpected error creating cloud browser: {e}')
 
+	async def get_browser(
+		self, session_id: str | None = None, extra_headers: dict[str, str] | None = None
+	) -> CloudBrowserResponse:
+		"""Get current details for a cloud browser session."""
+		if session_id is None:
+			session_id = self.current_session_id
+
+		if not session_id:
+			raise CloudBrowserError('No session ID provided and no current session available')
+
+		url = f'{self.api_base_url}/api/v2/browsers/{session_id}'
+		headers = self._build_headers(extra_headers)
+
+		try:
+			response = await self.client.get(url, headers=headers)
+
+			if response.status_code == 401:
+				raise CloudBrowserAuthError(
+					'Authentication failed. Please make sure you have set the BROWSER_USE_API_KEY environment variable to authenticate with the cloud service.'
+				)
+			elif response.status_code == 404:
+				raise CloudBrowserError(f'Cloud browser session {session_id} not found')
+			elif not response.is_success:
+				error_msg = f'Failed to fetch cloud browser: HTTP {response.status_code}'
+				try:
+					error_data = response.json()
+					if 'detail' in error_data:
+						error_msg += f' - {error_data["detail"]}'
+				except Exception:
+					pass
+				raise CloudBrowserError(error_msg)
+
+			return CloudBrowserResponse(**response.json())
+
+		except httpx.TimeoutException:
+			raise CloudBrowserError('Timeout while fetching cloud browser. Please try again.')
+		except httpx.ConnectError:
+			raise CloudBrowserError('Failed to connect to cloud browser service. Please check your internet connection.')
+		except Exception as e:
+			if isinstance(e, (CloudBrowserError, CloudBrowserAuthError)):
+				raise
+			raise CloudBrowserError(f'Unexpected error fetching cloud browser: {e}')
+
 	async def stop_browser(
 		self, session_id: str | None = None, extra_headers: dict[str, str] | None = None
 	) -> CloudBrowserResponse:
@@ -125,25 +178,7 @@ class CloudBrowserClient:
 			raise CloudBrowserError('No session ID provided and no current session available')
 
 		url = f'{self.api_base_url}/api/v2/browsers/{session_id}'
-
-		# Try to get API key from environment variable first, then auth config
-		api_token = os.getenv('BROWSER_USE_API_KEY')
-
-		if not api_token:
-			# Fallback to auth config file
-			try:
-				auth_config = CloudAuthConfig.load_from_file()
-				api_token = auth_config.api_token
-			except Exception:
-				pass
-
-		if not api_token:
-			raise CloudBrowserAuthError(
-				'BROWSER_USE_API_KEY is not set. To use cloud browsers, get a key at:\n'
-				'https://cloud.browser-use.com/new-api-key?utm_source=oss&utm_medium=use_cloud'
-			)
-
-		headers = {'X-Browser-Use-API-Key': api_token, 'Content-Type': 'application/json', **(extra_headers or {})}
+		headers = self._build_headers(extra_headers)
 
 		request_body = {'action': 'stop'}
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -4,9 +4,10 @@ import asyncio
 import logging
 import re
 import time
+from collections.abc import Awaitable, Callable
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Self, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Literal, Self, TypeVar, Union, cast, overload
 from urllib.parse import urlparse, urlunparse
 from uuid import UUID
 
@@ -62,6 +63,7 @@ DEFAULT_BROWSER_PROFILE = BrowserProfile()
 _LOGGED_UNIQUE_SESSION_IDS = set()  # track unique session IDs that have been logged to make sure we always assign a unique enough id to new sessions and avoid ambiguity in logs
 red = '\033[91m'
 reset = '\033[0m'
+T = TypeVar('T')
 
 
 class Target(BaseModel):
@@ -1197,6 +1199,87 @@ class BrowserSession(BaseModel):
 			else:
 				self.logger.debug(f'File already tracked: {event.path}')
 
+	def _is_connection_like_error(self, error: Exception) -> bool:
+		"""Check if an error looks like a transient CDP/WebSocket failure."""
+		error_str = str(error).lower()
+		return (
+			isinstance(error, ConnectionError)
+			or 'websocket connection closed' in error_str
+			or 'connection closed' in error_str
+			or 'keepalive ping timeout' in error_str
+			or 'client is stopping' in error_str
+			or 'cdp client not initialized' in error_str
+			or 'sessionmanager not initialized' in error_str
+			or 'browser may not be connected yet' in error_str
+		)
+
+	async def _wait_for_reconnect(self, operation_name: str) -> None:
+		"""Wait for an in-flight reconnect to finish and validate the result."""
+		wait_timeout = self.RECONNECT_WAIT_TIMEOUT
+		self.logger.warning(f'🔄 {operation_name}: waiting up to {wait_timeout}s for CDP reconnect...')
+		try:
+			await asyncio.wait_for(self._reconnect_event.wait(), timeout=wait_timeout)
+		except TimeoutError as e:
+			raise ConnectionError(f'{operation_name}: reconnect wait timed out after {wait_timeout}s') from e
+
+		if not self.is_cdp_connected:
+			raise ConnectionError(f'{operation_name}: reconnect finished but CDP is still unavailable')
+
+	async def _refresh_cloud_cdp_url_for_reconnect(self) -> None:
+		"""Refresh cloud browser metadata before reconnecting, if this is a cloud session."""
+		cloud_session_id = self._cloud_browser_client.current_session_id or self._cloud_session_id_from_cdp_url()
+		if not cloud_session_id:
+			return
+
+		try:
+			browser_response = await self._cloud_browser_client.get_browser(cloud_session_id)
+		except Exception as e:
+			self.logger.warning(f'🔄 Failed to refresh cloud browser session {cloud_session_id} before reconnect: {e}')
+			return
+
+		if browser_response.status != 'active' or not browser_response.cdpUrl:
+			raise ConnectionError(
+				f'Cloud browser session {cloud_session_id} is {browser_response.status} and cannot accept a CDP reconnect'
+			)
+
+		if browser_response.cdpUrl != self.cdp_url:
+			self.logger.info(f'🔄 Cloud browser CDP URL refreshed for session {cloud_session_id}')
+		self.browser_profile.cdp_url = browser_response.cdpUrl
+
+	async def _recover_cdp_connection(self, operation_name: str) -> None:
+		"""Ensure the CDP connection is usable before a direct BrowserSession CDP call."""
+		if self._intentional_stop or not self.cdp_url:
+			raise ConnectionError(f'{operation_name}: CDP connection is not available')
+
+		if self.is_cdp_connected:
+			return
+
+		if self.is_reconnecting:
+			await self._wait_for_reconnect(operation_name)
+			return
+
+		self.logger.warning(f'🔄 {operation_name}: CDP socket is down, forcing a reconnect...')
+		await self._auto_reconnect(max_attempts=1)
+
+		if not self.is_cdp_connected:
+			raise ConnectionError(f'{operation_name}: forced reconnect did not restore the CDP connection')
+
+	async def _run_cdp_command_with_reconnect(self, operation_name: str, command_factory: Callable[[], Awaitable[T]]) -> T:
+		"""Run a direct CDP operation with one reconnect-aware retry for transient socket failures."""
+		await self._recover_cdp_connection(operation_name)
+
+		for attempt in range(2):
+			try:
+				return await command_factory()
+			except Exception as e:
+				if attempt == 1 or not self._is_connection_like_error(e):
+					raise
+
+				self.logger.warning(f'🔄 {operation_name} failed due to a transient CDP error, retrying once: {e}')
+				await self._recover_cdp_connection(f'{operation_name} retry')
+
+		raise RuntimeError(f'{operation_name}: unreachable retry state')
+
 	def _cloud_session_id_from_cdp_url(self) -> str | None:
 		"""Derive cloud browser session ID from a Browser Use CDP URL."""
 		if not self.cdp_url:
@@ -2043,6 +2126,10 @@ class BrowserSession(BaseModel):
 		assert self.cdp_url, 'Cannot reconnect without a CDP URL'
 
 		old_focus_target_id = self.agent_focus_target_id
+
+		# Refresh the cloud session details first because cloud infrastructure may rotate the
+		# CDP URL after a transport drop even while the browser session itself remains alive.
+		await self._refresh_cloud_cdp_url_for_reconnect()
 
 		# 1. Stop old CDPClient (WS is already dead, this just cleans internal state)
 		if self._cdp_client_root:
@@ -3327,28 +3414,39 @@ class BrowserSession(BaseModel):
 
 	async def _cdp_get_cookies(self) -> list[Cookie]:
 		"""Get cookies using CDP Network.getCookies."""
-		cdp_session = await self.get_or_create_cdp_session(target_id=None)
-		result = await asyncio.wait_for(
-			cdp_session.cdp_client.send.Storage.getCookies(session_id=cdp_session.session_id), timeout=8.0
-		)
-		return result.get('cookies', [])
+
+		async def _get_cookies() -> list[Cookie]:
+			cdp_session = await self.get_or_create_cdp_session(target_id=None)
+			result = await asyncio.wait_for(
+				cdp_session.cdp_client.send.Storage.getCookies(session_id=cdp_session.session_id), timeout=8.0
+			)
+			return result.get('cookies', [])
+
+		return await self._run_cdp_command_with_reconnect('Get browser cookies', _get_cookies)
 
 	async def _cdp_set_cookies(self, cookies: list[Cookie]) -> None:
 		"""Set cookies using CDP Storage.setCookies."""
 		if not self.agent_focus_target_id or not cookies:
 			return
 
-		cdp_session = await self.get_or_create_cdp_session(target_id=None)
-		# Storage.setCookies expects params dict with 'cookies' key
-		await cdp_session.cdp_client.send.Storage.setCookies(
-			params={'cookies': cookies},  # type: ignore[arg-type]
-			session_id=cdp_session.session_id,
-		)
+		async def _set_cookies() -> None:
+			cdp_session = await self.get_or_create_cdp_session(target_id=None)
+			# Storage.setCookies expects params dict with 'cookies' key
+			await cdp_session.cdp_client.send.Storage.setCookies(
+				params={'cookies': cookies},  # type: ignore[arg-type]
+				session_id=cdp_session.session_id,
+			)
+
+		await self._run_cdp_command_with_reconnect('Set browser cookies', _set_cookies)
 
 	async def _cdp_clear_cookies(self) -> None:
 		"""Clear all cookies using CDP Network.clearBrowserCookies."""
-		cdp_session = await self.get_or_create_cdp_session()
-		await cdp_session.cdp_client.send.Storage.clearCookies(session_id=cdp_session.session_id)
+
+		async def _clear_cookies() -> None:
+			cdp_session = await self.get_or_create_cdp_session()
+			await cdp_session.cdp_client.send.Storage.clearCookies(session_id=cdp_session.session_id)
+
+		await self._run_cdp_command_with_reconnect('Clear browser cookies', _clear_cookies)
 
 	async def _cdp_grant_permissions(self, permissions: list[str], origin: str | None = None) -> None:
 		"""Grant permissions using CDP Browser.grantPermissions."""
@@ -3419,13 +3517,13 @@ class BrowserSession(BaseModel):
 
 	async def _cdp_get_origins(self) -> list[dict[str, Any]]:
 		"""Get origins with localStorage and sessionStorage using CDP."""
-		origins = []
-		cdp_session = await self.get_or_create_cdp_session(target_id=None)
 
-		try:
+		async def _get_origins() -> list[dict[str, Any]]:
+			origins: list[dict[str, Any]] = []
+			cdp_session = await self.get_or_create_cdp_session(target_id=None)
+
 			# Enable DOMStorage domain to track storage
 			await cdp_session.cdp_client.send.DOMStorage.enable(session_id=cdp_session.session_id)
-
 			try:
 				# Get all frames to find unique origins
 				frames_result = await cdp_session.cdp_client.send.Page.getFrameTree(session_id=cdp_session.session_id)
@@ -3485,12 +3583,18 @@ class BrowserSession(BaseModel):
 
 			finally:
 				# Always disable DOMStorage tracking when done
-				await cdp_session.cdp_client.send.DOMStorage.disable(session_id=cdp_session.session_id)
+				try:
+					await cdp_session.cdp_client.send.DOMStorage.disable(session_id=cdp_session.session_id)
+				except Exception as e:
+					self.logger.debug(f'Failed to disable DOMStorage tracking cleanly: {e}')
 
+			return origins
+
+		try:
+			return await self._run_cdp_command_with_reconnect('Get storage origins', _get_origins)
 		except Exception as e:
 			self.logger.warning(f'Failed to get origins: {e}')
-
-		return origins
+			return []
 
 	async def _cdp_get_storage_state(self) -> dict:
 		"""Get storage state (cookies, localStorage, sessionStorage) using CDP."""

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1248,11 +1248,14 @@ class BrowserSession(BaseModel):
 
 	async def _recover_cdp_connection(self, operation_name: str) -> None:
 		"""Ensure the CDP connection is usable before a direct BrowserSession CDP call."""
-		if self._intentional_stop or not self.cdp_url:
+		if not self.cdp_url:
 			raise ConnectionError(f'{operation_name}: CDP connection is not available')
 
 		if self.is_cdp_connected:
 			return
+
+		if self._intentional_stop:
+			raise ConnectionError(f'{operation_name}: CDP connection is down and session is shutting down')
 
 		if self.is_reconnecting:
 			await self._wait_for_reconnect(operation_name)

--- a/tests/ci/browser/test_cloud_browser.py
+++ b/tests/ci/browser/test_cloud_browser.py
@@ -2,7 +2,7 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -11,7 +11,7 @@ from browser_use.browser.cloud.cloud import (
 	CloudBrowserClient,
 	CloudBrowserError,
 )
-from browser_use.browser.cloud.views import CreateBrowserRequest
+from browser_use.browser.cloud.views import CloudBrowserResponse, CreateBrowserRequest
 from browser_use.browser.profile import BrowserProfile
 from browser_use.browser.session import BrowserSession
 from browser_use.sync.auth import CloudAuthConfig
@@ -229,6 +229,45 @@ class TestCloudBrowserClient:
 
 			assert 'not found' in str(exc_info.value)
 
+	async def test_get_browser_success(self, mock_auth_config, monkeypatch):
+		"""Test fetching cloud browser details."""
+
+		monkeypatch.delenv('BROWSER_USE_API_KEY', raising=False)
+
+		mock_response_data = {
+			'id': 'test-browser-id',
+			'status': 'active',
+			'liveUrl': 'https://live.browser-use.com?wss=test',
+			'cdpUrl': 'wss://fresh.proxy.browser-use.com/devtools/browser/test',
+			'timeoutAt': '2025-09-17T04:35:36.049892',
+			'startedAt': '2025-09-17T03:35:36.049974',
+			'finishedAt': None,
+		}
+
+		with patch('httpx.AsyncClient') as mock_client_class:
+			mock_response = AsyncMock()
+			mock_response.status_code = 200
+			mock_response.is_success = True
+			mock_response.json = lambda: mock_response_data
+
+			mock_client = AsyncMock()
+			mock_client.get.return_value = mock_response
+			mock_client_class.return_value = mock_client
+
+			client = CloudBrowserClient()
+			client.client = mock_client
+			client.current_session_id = 'test-browser-id'
+
+			result = await client.get_browser()
+
+			assert result.id == 'test-browser-id'
+			assert result.cdpUrl == 'wss://fresh.proxy.browser-use.com/devtools/browser/test'
+
+			mock_client.get.assert_called_once()
+			call_args = mock_client.get.call_args
+			assert 'X-Browser-Use-API-Key' in call_args.kwargs['headers']
+			assert call_args.kwargs['headers']['X-Browser-Use-API-Key'] == 'test-token'
+
 
 class TestBrowserSessionCloudIntegration:
 	"""Test BrowserSession integration with cloud browsers."""
@@ -257,3 +296,65 @@ class TestBrowserSessionCloudIntegration:
 		# Provide CDP URL to avoid actual connection attempts
 		session = BrowserSession(browser_profile=profile, cdp_url='ws://mock-url')
 		assert session.cloud_browser is True
+
+	async def test_reconnect_refreshes_cloud_cdp_url(self, mock_auth_config, monkeypatch):
+		"""Reconnect should refresh cloud cdp_url before rebuilding the CDP client."""
+
+		monkeypatch.delenv('BROWSER_USE_API_KEY', raising=False)
+
+		cloud_session_id = '7166c636-8500-4bb7-afd9-31bc025dc630'
+		old_cdp_url = f'wss://{cloud_session_id}.cdp1.browser-use.com/devtools/browser/old'
+		fresh_cdp_url = f'wss://{cloud_session_id}.cdp2.browser-use.com/devtools/browser/fresh'
+
+		session = BrowserSession(browser_profile=BrowserProfile(use_cloud=True), cdp_url=old_cdp_url)
+		session.browser_profile.is_local = False
+		session._cloud_browser_client.current_session_id = cloud_session_id
+		session.agent_focus_target_id = 'target-123'
+		session._cloud_browser_client.get_browser = AsyncMock(
+			return_value=CloudBrowserResponse(
+				id=cloud_session_id,
+				status='active',
+				liveUrl='https://live.browser-use.com?wss=test',
+				cdpUrl=fresh_cdp_url,
+				timeoutAt='2025-09-17T04:35:36.049892',
+				startedAt='2025-09-17T03:35:36.049974',
+				finishedAt=None,
+			)
+		)
+
+		old_root_client = Mock()
+		old_root_client.stop = AsyncMock()
+		session._cdp_client_root = old_root_client
+
+		old_session_manager = Mock()
+		old_session_manager.clear = AsyncMock()
+		session.session_manager = old_session_manager
+
+		new_root_client = Mock()
+		new_root_client.start = AsyncMock()
+		new_root_client.send = Mock()
+		new_root_client.send.Target = Mock()
+		new_root_client.send.Target.setAutoAttach = AsyncMock()
+
+		new_session_manager = Mock()
+		new_session_manager.start_monitoring = AsyncMock()
+		new_session_manager.get_all_page_targets.return_value = [Mock(target_id='target-123')]
+
+		with (
+			patch('browser_use.browser.session.CDPClient', return_value=new_root_client) as mock_cdp_client,
+			patch('browser_use.browser.session_manager.SessionManager', return_value=new_session_manager),
+			patch.object(BrowserSession, 'get_or_create_cdp_session', AsyncMock()) as mock_get_or_create,
+			patch.object(BrowserSession, '_setup_proxy_auth', AsyncMock()),
+			patch.object(BrowserSession, '_attach_ws_drop_callback'),
+		):
+			await session.reconnect()
+
+		session._cloud_browser_client.get_browser.assert_awaited_once_with(cloud_session_id)
+		assert session.cdp_url == fresh_cdp_url
+		assert mock_cdp_client.call_args.args[0] == fresh_cdp_url
+		old_root_client.stop.assert_awaited_once()
+		old_session_manager.clear.assert_awaited_once()
+		new_session_manager.start_monitoring.assert_awaited_once()
+		new_root_client.start.assert_awaited_once()
+		new_root_client.send.Target.setAutoAttach.assert_awaited_once()
+		mock_get_or_create.assert_awaited_once_with('target-123', focus=True)

--- a/tests/ci/browser/test_session_start.py
+++ b/tests/ci/browser/test_session_start.py
@@ -11,8 +11,10 @@ Tests cover:
 
 import asyncio
 import logging
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
+from websockets.protocol import State
 
 from browser_use.browser.profile import (
 	BROWSERUSE_DEFAULT_CHANNEL,
@@ -344,6 +346,33 @@ class TestBrowserSessionEventSystem:
 		# Check that no exceptions were raised
 		for result in results:
 			assert not isinstance(result, Exception), f'Event failed with: {result}'
+
+	async def test_cdp_get_cookies_retries_after_connection_drop(self):
+		"""Direct BrowserSession cookie export should retry once across a transient CDP drop."""
+
+		session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=False))
+		session._cdp_client_root = Mock(ws=Mock(state=State.OPEN))
+
+		mock_cdp_session = Mock()
+		mock_cdp_session.session_id = 'session-123'
+		mock_cdp_session.cdp_client = Mock()
+		mock_cdp_session.cdp_client.send = Mock()
+		mock_cdp_session.cdp_client.send.Storage = Mock()
+		mock_cdp_session.cdp_client.send.Storage.getCookies = AsyncMock(
+			side_effect=[ConnectionError('WebSocket connection closed'), {'cookies': [{'name': 'sid', 'value': 'abc'}]}]
+		)
+
+		with (
+			patch.object(
+				BrowserSession, 'get_or_create_cdp_session', AsyncMock(return_value=mock_cdp_session)
+			) as mock_get_session,
+			patch.object(BrowserSession, '_recover_cdp_connection', AsyncMock()) as mock_recover,
+		):
+			cookies = await session._cdp_get_cookies()
+
+		assert cookies == [{'name': 'sid', 'value': 'abc'}]
+		assert mock_get_session.await_count == 2
+		assert mock_recover.await_args_list == [call('Get browser cookies'), call('Get browser cookies retry')]
 
 	# async def test_many_parallel_browser_sessions(self):
 	# 	"""Test spawning 12 parallel browser_sessions with different settings and ensure they all work"""

--- a/tests/ci/browser/test_session_start.py
+++ b/tests/ci/browser/test_session_start.py
@@ -374,6 +374,31 @@ class TestBrowserSessionEventSystem:
 		assert mock_get_session.await_count == 2
 		assert mock_recover.await_args_list == [call('Get browser cookies'), call('Get browser cookies retry')]
 
+	async def test_cdp_get_cookies_allows_live_reads_during_intentional_shutdown(self):
+		"""Intentional shutdown should still allow cookie reads on an already-live CDP socket."""
+
+		session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=False))
+		session._cdp_client_root = Mock(ws=Mock(state=State.OPEN))
+		session.browser_profile.cdp_url = 'wss://example.com/devtools/browser/test'
+		session._intentional_stop = True
+
+		mock_cdp_session = Mock()
+		mock_cdp_session.session_id = 'session-123'
+		mock_cdp_session.cdp_client = Mock()
+		mock_cdp_session.cdp_client.send = Mock()
+		mock_cdp_session.cdp_client.send.Storage = Mock()
+		mock_cdp_session.cdp_client.send.Storage.getCookies = AsyncMock(
+			return_value={'cookies': [{'name': 'sid', 'value': 'abc'}]}
+		)
+
+		with patch.object(
+			BrowserSession, 'get_or_create_cdp_session', AsyncMock(return_value=mock_cdp_session)
+		) as mock_get_session:
+			cookies = await session._cdp_get_cookies()
+
+		assert cookies == [{'name': 'sid', 'value': 'abc'}]
+		mock_get_session.assert_awaited_once_with(target_id=None)
+
 	# async def test_many_parallel_browser_sessions(self):
 	# 	"""Test spawning 12 parallel browser_sessions with different settings and ensure they all work"""
 	# 	from browser_use import BrowserSession


### PR DESCRIPTION
## Summary
Addresses #4688 by hardening `BrowserSession` against transient cloud CDP drops.

This change:
- refreshes the cloud browser session before reconnecting so reconnect can pick up a rotated `cdpUrl`
- adds reconnect-aware retry handling for direct `BrowserSession` storage-related CDP calls
- adds regression coverage for both the cloud reconnect path and direct cookie export retry behavior

## Testing
- `uv run pytest tests/ci/browser/test_cloud_browser.py -k 'get_browser_success or reconnect_refreshes_cloud_cdp_url'`
- `uv run pytest tests/ci/browser/test_session_start.py -k test_cdp_get_cookies_retries_after_connection_drop`
- `uv run pre-commit run --files browser_use/browser/cloud/cloud.py browser_use/browser/session.py tests/ci/browser/test_cloud_browser.py tests/ci/browser/test_session_start.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened cloud CDP reconnects in `BrowserSession` to recover from transient drops and rotated `cdpUrl`s, with reconnect-aware retries for cookie/storage CDP calls; addresses #4688. Also allows storage reads during intentional shutdown when the CDP socket is still live.

- **Bug Fixes**
  - Refresh cloud browser via `get_browser` before reconnect; update `cdp_url` if rotated.
  - Retry direct storage CDP calls once (get/set/clear cookies, storage origins) on transient socket errors; wait for in-flight reconnects or force a reconnect.
  - Allow storage reads during shutdown when the CDP socket is already connected.
  - Added `CloudBrowserClient.get_browser` and token/header helpers with clearer error handling.

<sup>Written for commit 3f589515b3f89e73a3180425eef61a1c758e0a44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

