### PR TITLE
docs: fix malformed HTML attributes in README picture/img tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <picture>
-  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/2ccdb752-22fb-41c7-8948-857fc1ad7e24"">
+  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/2ccdb752-22fb-41c7-8948-857fc1ad7e24">
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/774a46d5-27a0-490c-b7d0-e65fcbbfa358">
   <img alt="Shows a black Browser Use Logo in light color mode and a white one in dark color mode." src="https://github.com/user-attachments/assets/2ccdb752-22fb-41c7-8948-857fc1ad7e24"  width="full">
 </picture>
 
 <div align="center">
     <picture>
-    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/9955dda9-ede3-4971-8ee0-91cbc3850125"">
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/9955dda9-ede3-4971-8ee0-91cbc3850125">
     <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/6797d09b-8ac3-4cb9-ba07-b289e080765a">
     <img alt="The AI browser agent." src="https://github.com/user-attachments/assets/9955dda9-ede3-4971-8ee0-91cbc3850125"  width="400">
     </picture>
@@ -30,7 +30,7 @@
 <a href="https://github.com/browser-use/browser-use"><img src="https://media.browser-use.tools/badges/github" alt="Github Stars"></a>
 <img width="4" height="1" alt="">
 <a href="https://x.com/intent/user?screen_name=browser_use"><img src="https://media.browser-use.tools/badges/twitter" alt="Twitter"></a>
-<img width="4 height="1" alt="">
+<img width="4" height="1" alt="">
 <a href="https://link.browser-use.com/discord"><img src="https://media.browser-use.tools/badges/discord" alt="Discord"></a>
 <img width="4" height="1" alt="">
 <a href="https://cloud.browser-use.com?utm_source=github&utm_medium=readme-badge-cloud"><img src="https://media.browser-use.tools/badges/cloud" height="48" alt="Browser-Use Cloud"></a>


### PR DESCRIPTION
## Summary

Three HTML attribute-quoting typos in `README.md`:

- Line 2 — trailing `""` on the light-mode `<source srcset=...>` in the top logo `<picture>`.
- Line 9 — same trailing `""` on the light-mode `<source srcset=...>` for the hero image.
- Line 33 — missing closing `"` on `<img width="4 height="1" alt="">` between the Twitter and Discord badges (was: `width="4 height="1"`, now: `width="4" height="1"`).

Diff is 3 insertions / 3 deletions, one file, no code paths touched.

### Why

GitHub's markdown renderer tolerates these today, but:

- Strict HTML parsers / README mirrors (pypi page, docs sites, some RSS/embed previews) can choke on the stray quotes or run attributes together.
- `width="4 height="1"` is parsed as `width="4 height="` with a stray `1"` token — the `height` attribute is effectively silently dropped.
- Costs nothing to have the raw source be valid HTML.

Pure docs fix, no behavior change, no new deps.

### Test plan

- [x] `git diff --stat` → 1 file, 3/3.
- [x] Visual inspection of rendered README on fork still looks identical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix three malformed HTML attributes in `README.md` to make the HTML valid across strict renderers and mirrors. Removed trailing quotes from two light‑mode `<source srcset>` tags and fixed a missing quote in an `<img>` tag’s `width`/`height` attributes; no behavior change.

<sup>Written for commit eb12fb9df66247cff615686f7afb296b45530327. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

---
_Part of open-source blockchain work from [kcolbchain.com](https://kcolbchain.com) — maintained by [Abhishek Krishna](https://abhishekkrishna.com). PR opened via [kcolbchain contrib-bot](https://github.com/kcolbchain/kcolbchain.github.io/blob/master/deploy/contrib-bot/README.md)._