### PR TITLE
Bump pillow to 12.2.0 (CVE-2026-40192)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "reportlab==4.4.9",
     "cdp-use==1.4.5",
     "pyotp==2.9.0",
-    "pillow==12.1.1",
+    "pillow==12.2.0",
     "cloudpickle==3.1.2",
     "markdownify==1.2.2",
     "python-docx==1.2.0",


### PR DESCRIPTION
## Summary
- Bumps pinned `pillow` from `12.1.1` to `12.2.0` to patch [CVE-2026-40192](https://github.com/python-pillow/Pillow/security/advisories/GHSA-whj4-6x5x-4v2j) (FITS GZIP decompression bomb).
- Pillow 10.3.0-12.1.1 did not bound GZIP-compressed reads when decoding FITS images, enabling a memory-exhaustion DoS via a crafted FITS file. Fixed upstream in 12.2.0.
- Practical exposure in this repo is minimal — all `Image.open` call sites operate on PNG screenshot bytes from CDP or bundled static assets, no FITS input path — but the pinned version was flagged by Dependabot and the bump is a safe patch-level upgrade.

## Test plan
- [x] `uv sync --frozen` resolves cleanly
- [x] `uv run python -c "import PIL; from PIL import Image, ImageDraw, ImageFont"` succeeds on 12.2.0
- [ ] CI (`tests/ci`) green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `pillow` from 12.1.1 to 12.2.0 to patch CVE-2026-40192 (FITS GZIP decompression bomb) and clear the security alert. No functional changes; the app does not process FITS images.

<sup>Written for commit e7b0caac9f4130f20ac24d0b1c76acde5e674ff6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

