### PR TITLE
Bump pypdf to 6.10.2 (CVE-2026-40260)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "google-auth==2.48.0",
     "google-auth-oauthlib==1.2.4",
     "mcp==1.26.0",
-    "pypdf==6.9.1",
+    "pypdf==6.10.2",
     "reportlab==4.4.9",
     "cdp-use==1.4.5",
     "pyotp==2.9.0",


### PR DESCRIPTION
## Summary
- Bumps pinned `pypdf` from `6.9.1` to `6.10.2` to patch [CVE-2026-40260](https://github.com/py-pdf/pypdf/security/advisories) (XMP metadata XML entity expansion / billion-laughs RAM exhaustion).
- pypdf < 6.10.0 did not restrict recursive entity declarations in XMP metadata DTDs, so a small crafted PDF could allocate gigabytes of memory when opened.
- Call site: `browser_use/filesystem/file_system.py:549` uses `pypdf.PdfReader` on PDFs the agent has downloaded — i.e. reachable from attacker-controlled content, which makes this more than cosmetic.

## Test plan
- [x] `uv sync --frozen` resolves cleanly
- [x] `uv run python -c "import pypdf; pypdf.PdfReader"` on 6.10.2
- [x] `tests/ci/test_file_system_*.py` (24 passed)
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `pypdf` to 6.10.2 to fix CVE-2026-40260 (XMP XML entity expansion “billion laughs” DoS). This secures our `PdfReader` usage in `browser_use/filesystem/file_system.py` when opening agent-downloaded PDFs.

- **Dependencies**
  - Bump `pypdf` from `6.9.1` to `6.10.2`.

<sup>Written for commit 74ccf0ebd63e08396616973d4ec8d79e2b170368. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

