### PR TITLE
Bump aiohttp to 3.13.4 (CVE-2026-34515)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "aiohttp==3.13.3",
+    "aiohttp==3.13.4",
     "anyio==4.12.1",
     "bubus==1.5.6",
     "click==8.3.1",


### PR DESCRIPTION
## Summary
- Bumps pinned `aiohttp` from `3.13.3` to `3.13.4` to patch [CVE-2026-34515](https://github.com/aio-libs/aiohttp/security/advisories/GHSA-p998-jp59-783m) (NTLMv2 credential leak via aiohttp's Windows static resource handler).
- **Not exploitable in this codebase.** aiohttp is used only as a client (CDP polling in `browser_use/browser/watchdogs/local_browser_watchdog.py:410`, plus two examples). There is no `aiohttp.web` server, no `add_static`, no Windows-only server code — none of the vulnerable surface is reached.
- Bumping purely to clear Dependabot alert #29. Safe patch-level upgrade.

## Test plan
- [x] `uv sync --frozen` resolves cleanly
- [x] `uv run python -c "import aiohttp; import aiohttp.web"` on 3.13.4
- [ ] CI green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `aiohttp` from 3.13.3 to 3.13.4 to patch CVE-2026-34515 in the Windows static resource handler. We only use `aiohttp` as a client, so the vuln isn’t reachable; this is a safe patch to clear the security alert.

<sup>Written for commit 8e9c3488de3329cec920e48f24f1d8639b69442a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

