### PR TITLE
feat: Add Astraflow LLM provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,12 @@ BROWSER_USE_API_KEY=your_bu_api_key_here
 # DEEPSEEK_API_KEY=
 # GROK_API_KEY=
 # NOVITA_API_KEY=
+# Astraflow Configuration (UCloud / 优刻得 — 200+ models, OpenAI-compatible)
+# Sign up at: https://astraflow.ucloud.cn/
+# Global endpoint (https://api-us-ca.umodelverse.ai/v1)
+# ASTRAFLOW_API_KEY=
+# China endpoint  (https://api.modelverse.cn/v1)
+# ASTRAFLOW_CN_API_KEY=
 
 # AWS Bedrock Configuration (for AWS Bedrock models)
 # Requires: pip install browser-use[aws]

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -153,6 +153,13 @@ class OldConfig:
 	@property
 	def NOVITA_API_KEY(self) -> str:
 		return os.getenv('NOVITA_API_KEY', '')
+	@property
+	def ASTRAFLOW_API_KEY(self) -> str:
+		return os.getenv('ASTRAFLOW_API_KEY', '')
+
+	@property
+	def ASTRAFLOW_CN_API_KEY(self) -> str:
+		return os.getenv('ASTRAFLOW_CN_API_KEY', '')
 
 	@property
 	def AZURE_OPENAI_ENDPOINT(self) -> str:
@@ -217,6 +224,8 @@ class FlatEnvConfig(BaseSettings):
 	GROK_API_KEY: str = Field(default='')
 	NOVITA_API_KEY: str = Field(default='')
 	AZURE_OPENAI_ENDPOINT: str = Field(default='')
+	ASTRAFLOW_API_KEY: str = Field(default='')
+	ASTRAFLOW_CN_API_KEY: str = Field(default='')
 	AZURE_OPENAI_KEY: str = Field(default='')
 	SKIP_LLM_API_KEY_VERIFICATION: bool = Field(default=False)
 	DEFAULT_LLM: str = Field(default='')

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -26,6 +26,8 @@ from browser_use.llm.messages import (
 
 # Type stubs for lazy imports
 if TYPE_CHECKING:
+	from browser_use.llm.astraflow.chat import ChatAstraflow
+if TYPE_CHECKING:
 	from browser_use.llm.anthropic.chat import ChatAnthropic
 	from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
 	from browser_use.llm.aws.chat_bedrock import ChatAWSBedrock
@@ -92,6 +94,7 @@ _LAZY_IMPORTS = {
 	'ChatOCIRaw': ('browser_use.llm.oci_raw.chat', 'ChatOCIRaw'),
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
+	'ChatAstraflow': ('browser_use.llm.astraflow.chat', 'ChatAstraflow'),
 	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
 }
@@ -155,6 +158,7 @@ __all__ = [
 	'ChatAzureOpenAI',
 	'ChatOCIRaw',
 	'ChatOllama',
+	'ChatAstraflow',
 	'ChatOpenRouter',
 	'ChatVercel',
 	'ChatCerebras',

--- a/browser_use/llm/astraflow/chat.py
+++ b/browser_use/llm/astraflow/chat.py
@@ -1,0 +1,201 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, TypeVar, overload
+
+import httpx
+from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
+from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.shared_params.response_format_json_schema import (
+	JSONSchema,
+	ResponseFormatJSONSchema,
+)
+from pydantic import BaseModel
+
+from browser_use.llm.astraflow.serializer import AstraflowMessageSerializer
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
+
+T = TypeVar('T', bound=BaseModel)
+
+
+@dataclass
+class ChatAstraflow(BaseChatModel):
+	"""
+	A wrapper around Astraflow's chat API (by UCloud / 优刻得), which provides
+	access to 200+ models through a unified OpenAI-compatible interface.
+
+	Global endpoint (default): https://api-us-ca.umodelverse.ai/v1
+	  -> set via env var ASTRAFLOW_API_KEY
+	China endpoint:            https://api.modelverse.cn/v1
+	  -> set via env var ASTRAFLOW_CN_API_KEY
+
+	API key sign-up: https://astraflow.ucloud.cn/
+	"""
+
+	# Model configuration
+	model: str
+
+	# Model params
+	temperature: float | None = None
+	top_p: float | None = None
+	seed: int | None = None
+
+	# Client initialization parameters
+	api_key: str | None = None
+	base_url: str | httpx.URL = 'https://api-us-ca.umodelverse.ai/v1'
+	timeout: float | httpx.Timeout | None = None
+	max_retries: int = 10
+	default_headers: Mapping[str, str] | None = None
+	default_query: Mapping[str, object] | None = None
+	http_client: httpx.AsyncClient | None = None
+	_strict_response_validation: bool = False
+	extra_body: dict[str, Any] | None = None
+
+	@property
+	def provider(self) -> str:
+		return 'astraflow'
+
+	def _get_client_params(self) -> dict[str, Any]:
+		"""Prepare client parameters dictionary."""
+		base_params = {
+			'api_key': self.api_key,
+			'base_url': self.base_url,
+			'timeout': self.timeout,
+			'max_retries': self.max_retries,
+			'default_headers': self.default_headers,
+			'default_query': self.default_query,
+			'_strict_response_validation': self._strict_response_validation,
+		}
+		client_params = {k: v for k, v in base_params.items() if v is not None}
+		if self.http_client is not None:
+			client_params['http_client'] = self.http_client
+		return client_params
+
+	def get_client(self) -> AsyncOpenAI:
+		"""
+		Returns an AsyncOpenAI client configured for Astraflow.
+
+		Returns:
+		    AsyncOpenAI: An instance of the AsyncOpenAI client with the Astraflow base URL.
+		"""
+		if not hasattr(self, '_client'):
+			client_params = self._get_client_params()
+			self._client = AsyncOpenAI(**client_params)
+		return self._client
+
+	@property
+	def name(self) -> str:
+		return str(self.model)
+
+	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
+		"""Extract usage information from the Astraflow response."""
+		if response.usage is None:
+			return None
+
+		prompt_details = getattr(response.usage, 'prompt_tokens_details', None)
+		cached_tokens = prompt_details.cached_tokens if prompt_details else None
+
+		return ChatInvokeUsage(
+			prompt_tokens=response.usage.prompt_tokens,
+			prompt_cached_tokens=cached_tokens,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+			# Completion
+			completion_tokens=response.usage.completion_tokens,
+			total_tokens=response.usage.total_tokens,
+		)
+
+	@overload
+	async def ainvoke(
+		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[str]: ...
+
+	@overload
+	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T], **kwargs: Any) -> ChatInvokeCompletion[T]: ...
+
+	async def ainvoke(
+		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		"""
+		Invoke the model with the given messages through Astraflow.
+
+		Args:
+		    messages: List of chat messages
+		    output_format: Optional Pydantic model class for structured output
+
+		Returns:
+		    Either a string response or an instance of output_format
+		"""
+		astraflow_messages = AstraflowMessageSerializer.serialize_messages(messages)
+
+		try:
+			if output_format is None:
+				# Return string response
+				response = await self.get_client().chat.completions.create(
+					model=self.model,
+					messages=astraflow_messages,
+					temperature=self.temperature,
+					top_p=self.top_p,
+					seed=self.seed,
+					**(self.extra_body or {}),
+				)
+
+				usage = self._get_usage(response)
+				return ChatInvokeCompletion(
+					completion=response.choices[0].message.content or '',
+					usage=usage,
+				)
+
+			else:
+				# Create a JSON schema for structured output
+				schema = SchemaOptimizer.create_optimized_json_schema(output_format)
+
+				response_format_schema: JSONSchema = {
+					'name': 'agent_output',
+					'strict': True,
+					'schema': schema,
+				}
+
+				# Return structured response
+				response = await self.get_client().chat.completions.create(
+					model=self.model,
+					messages=astraflow_messages,
+					temperature=self.temperature,
+					top_p=self.top_p,
+					seed=self.seed,
+					response_format=ResponseFormatJSONSchema(
+						json_schema=response_format_schema,
+						type='json_schema',
+					),
+					**(self.extra_body or {}),
+				)
+
+				if response.choices[0].message.content is None:
+					raise ModelProviderError(
+						message='Failed to parse structured output from model response',
+						status_code=500,
+						model=self.name,
+					)
+				usage = self._get_usage(response)
+
+				parsed = output_format.model_validate_json(response.choices[0].message.content)
+
+				return ChatInvokeCompletion(
+					completion=parsed,
+					usage=usage,
+				)
+
+		except RateLimitError as e:
+			raise ModelRateLimitError(message=e.message, model=self.name) from e
+
+		except APIConnectionError as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e
+
+		except APIStatusError as e:
+			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
+
+		except Exception as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/astraflow/serializer.py
+++ b/browser_use/llm/astraflow/serializer.py
@@ -1,0 +1,26 @@
+from openai.types.chat import ChatCompletionMessageParam
+
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.openai.serializer import OpenAIMessageSerializer
+
+
+class AstraflowMessageSerializer:
+	"""
+	Serializer for converting between custom message types and Astraflow message formats.
+
+	Astraflow uses the OpenAI-compatible API, so we can reuse the OpenAI serializer.
+	"""
+
+	@staticmethod
+	def serialize_messages(messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
+		"""
+		Serialize a list of browser_use messages to Astraflow-compatible messages.
+
+		Args:
+		    messages: List of browser_use messages
+
+		Returns:
+		    List of Astraflow-compatible messages (identical to OpenAI format)
+		"""
+		# Astraflow uses the same message format as OpenAI
+		return OpenAIMessageSerializer.serialize_messages(messages)

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -14,6 +14,7 @@ Usage:
 import os
 from typing import TYPE_CHECKING
 
+from browser_use.llm.astraflow.chat import ChatAstraflow
 from browser_use.llm.azure.chat import ChatAzureOpenAI
 from browser_use.llm.browser_use.chat import ChatBrowserUse
 from browser_use.llm.cerebras.chat import ChatCerebras
@@ -84,6 +85,19 @@ cerebras_qwen_3_coder_480b: 'BaseChatModel'
 bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
 bu_2_0: 'BaseChatModel'
+astraflow_gpt_4o: 'BaseChatModel'
+astraflow_gpt_4o_mini: 'BaseChatModel'
+astraflow_gpt_4_1_mini: 'BaseChatModel'
+astraflow_claude_3_5_sonnet: 'BaseChatModel'
+astraflow_claude_3_7_sonnet: 'BaseChatModel'
+astraflow_deepseek_v3: 'BaseChatModel'
+astraflow_deepseek_r1: 'BaseChatModel'
+astraflow_gemini_2_5_pro: 'BaseChatModel'
+astraflow_gemini_2_5_flash: 'BaseChatModel'
+astraflow_cn_gpt_4o: 'BaseChatModel'
+astraflow_cn_gpt_4o_mini: 'BaseChatModel'
+astraflow_cn_deepseek_v3: 'BaseChatModel'
+astraflow_cn_deepseek_r1: 'BaseChatModel'
 
 
 def get_llm_by_name(model_name: str):
@@ -203,6 +217,18 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('CEREBRAS_API_KEY')
 		return ChatCerebras(model=model, api_key=api_key)
 
+	# Astraflow Models (global endpoint)
+	elif provider == 'astraflow':
+		api_key = os.getenv('ASTRAFLOW_API_KEY')
+		base_url = os.getenv('ASTRAFLOW_BASE_URL', 'https://api-us-ca.umodelverse.ai/v1')
+		return ChatAstraflow(model=model, api_key=api_key, base_url=base_url)
+
+	# Astraflow Models (China endpoint)
+	elif provider == 'astraflow_cn':
+		api_key = os.getenv('ASTRAFLOW_CN_API_KEY')
+		base_url = os.getenv('ASTRAFLOW_CN_BASE_URL', 'https://api.modelverse.cn/v1')
+		return ChatAstraflow(model=model, api_key=api_key, base_url=base_url)
+
 	# Browser Use Models
 	elif provider == 'bu':
 		# Handle bu_latest -> bu-latest conversion (need to prepend 'bu-' back)
@@ -211,7 +237,7 @@ def get_llm_by_name(model_name: str):
 		return ChatBrowserUse(model=model, api_key=api_key)
 
 	else:
-		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu']
+		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu', 'astraflow', 'astraflow_cn']
 
 		raise ValueError(f"Unknown provider: '{provider}'. Available providers: {', '.join(available_providers)}")
 
@@ -238,6 +264,8 @@ def __getattr__(name: str) -> 'BaseChatModel':
 		return ChatCerebras  # type: ignore
 	elif name == 'ChatBrowserUse':
 		return ChatBrowserUse  # type: ignore
+	elif name == 'ChatAstraflow':
+		return ChatAstraflow  # type: ignore
 
 	# Handle model instances - these are the main use case
 	try:
@@ -313,6 +341,23 @@ __all__ += [
 	'bu_latest',
 	'bu_1_0',
 	'bu_2_0',
+]
+# Astraflow instances - created on demand
+__all__ += [
+	'ChatAstraflow',
+	'astraflow_gpt_4o',
+	'astraflow_gpt_4o_mini',
+	'astraflow_gpt_4_1_mini',
+	'astraflow_claude_3_5_sonnet',
+	'astraflow_claude_3_7_sonnet',
+	'astraflow_deepseek_v3',
+	'astraflow_deepseek_r1',
+	'astraflow_gemini_2_5_pro',
+	'astraflow_gemini_2_5_flash',
+	'astraflow_cn_gpt_4o',
+	'astraflow_cn_gpt_4o_mini',
+	'astraflow_cn_deepseek_v3',
+	'astraflow_cn_deepseek_r1',
 ]
 
 # NOTE: OCI backend is optional. The try/except ImportError and conditional __all__ are required


### PR DESCRIPTION
## Add Astraflow LLM provider support

This PR integrates **Astraflow** (by UCloud / 优刻得) as a first-class LLM provider in browser-use, following the exact same patterns used by OpenRouter, DeepSeek, Groq, and the other providers.

### About Astraflow
- OpenAI-compatible AI model aggregation platform supporting **200+ models**
- API key sign-up: https://astraflow.ucloud.cn/
- **Global endpoint:** `https://api-us-ca.umodelverse.ai/v1` → env var `ASTRAFLOW_API_KEY`
- **China endpoint:** `https://api.modelverse.cn/v1` → env var `ASTRAFLOW_CN_API_KEY`

### Changes

| File | What changed |
|------|-------------|
| `browser_use/llm/astraflow/chat.py` | New `ChatAstraflow` dataclass — OpenAI-compatible client, mirrors `ChatOpenRouter` |
| `browser_use/llm/astraflow/serializer.py` | Thin adapter that delegates to the shared `OpenAIMessageSerializer` |
| `browser_use/llm/__init__.py` | Lazy-import entry + `TYPE_CHECKING` stub + `__all__` export |
| `browser_use/llm/models.py` | Type stubs, `get_llm_by_name` provider branch, `__getattr__` class handler, `__all__` entries |
| `browser_use/config.py` | `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY` env-var properties in both `OldConfig` and `FlatEnvConfig` |
| `.env.example` | Documents both API key variables with a comment pointing to the sign-up page |

### Usage examples

```python
from browser_use.llm.astraflow.chat import ChatAstraflow

# Global endpoint (default)
llm = ChatAstraflow(model="gpt-4o", api_key="sk-...")

# China endpoint
llm = ChatAstraflow(
    model="gpt-4o",
    api_key="sk-...",
    base_url="https://api.modelverse.cn/v1",
)

# Via convenience accessor (reads ASTRAFLOW_API_KEY from env)
import browser_use.llm as llm
model = llm.astraflow_gpt_4o
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Astraflow as an OpenAI‑compatible LLM provider so you can use 200+ models via global and China endpoints. Exposes `ChatAstraflow`, env vars, and model bindings with both text and structured output support.

- **New Features**
  - New `browser_use.llm.astraflow.chat.ChatAstraflow` (OpenAI-compatible via `AsyncOpenAI`), including JSON‑schema structured output and usage mapping.
  - `AstraflowMessageSerializer` reuses the OpenAI serializer for message formatting.
  - Provider wiring: lazy import/export in `browser_use.llm.__init__`, `get_llm_by_name` adds `astraflow` and `astraflow_cn`, on-demand instances like `astraflow_gpt_4o`.
  - Config/env: `ASTRAFLOW_API_KEY` and `ASTRAFLOW_CN_API_KEY`; optional `ASTRAFLOW_BASE_URL` and `ASTRAFLOW_CN_BASE_URL` (defaults to global/China endpoints).
  - `.env.example` documents keys, endpoints, and signup link.

<sup>Written for commit 545f3d4c2e9b237a40160660d5bc1e5769672e83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

