### PR TITLE
fix: video recording speed by implementing frame duplication (#4696)

### DIFF
--- a/browser_use/browser/video_recorder.py
+++ b/browser_use/browser/video_recorder.py
@@ -53,6 +53,8 @@ class VideoRecorderService:
 		self._writer: Optional['Format.Writer'] = None
 		self._is_active = False
 		self.padded_size = _get_padded_size(self.size)
+		self.last_frame_time: Optional[float] = None
+		self._last_img_array: Optional[np.ndarray] = None
 
 	def start(self) -> None:
 		"""
@@ -84,13 +86,14 @@ class VideoRecorderService:
 			logger.error(f'Failed to initialize video writer: {e}')
 			self._is_active = False
 
-	def add_frame(self, frame_data_b64: str) -> None:
+	def add_frame(self, frame_data_b64: str, timestamp: Optional[float] = None) -> None:
 		"""
 		Decodes a base64-encoded PNG frame, resizes it, pads it to be codec-compatible,
 		and appends it to the video.
 
 		Args:
 		    frame_data_b64: A base64-encoded string of the PNG frame data.
+		    timestamp: The timestamp of the frame.
 		"""
 		if not self._is_active or not self._writer:
 			return
@@ -118,7 +121,17 @@ class VideoRecorderService:
 				# 3. Convert to numpy array for imageio
 				img_array = np.array(img)
 
+			if timestamp is not None and self.last_frame_time is not None:
+				dt = timestamp - self.last_frame_time
+				if dt > 1.0 / self.framerate:
+					num_fill_frames = int(dt * self.framerate) - 1
+					if num_fill_frames > 0 and self._last_img_array is not None:
+						for _ in range(num_fill_frames):
+							self._writer.append_data(self._last_img_array)
+
 			self._writer.append_data(img_array)
+			self._last_img_array = img_array
+			self.last_frame_time = timestamp
 		except Exception as e:
 			logger.warning(f'Could not process and add video frame: {e}')
 

--- a/browser_use/browser/video_recorder.py
+++ b/browser_use/browser/video_recorder.py
@@ -53,7 +53,7 @@ class VideoRecorderService:
 		self._writer: Optional['Format.Writer'] = None
 		self._is_active = False
 		self.padded_size = _get_padded_size(self.size)
-		self.last_frame_time: Optional[float] = None
+		self.last_frame_time: float | None = None
 		self._last_img_array: Optional[np.ndarray] = None
 
 	def start(self) -> None:
@@ -86,7 +86,7 @@ class VideoRecorderService:
 			logger.error(f'Failed to initialize video writer: {e}')
 			self._is_active = False
 
-	def add_frame(self, frame_data_b64: str, timestamp: Optional[float] = None) -> None:
+	def add_frame(self, frame_data_b64: str, timestamp: float | None = None) -> None:
 		"""
 		Decodes a base64-encoded PNG frame, resizes it, pads it to be codec-compatible,
 		and appends it to the video.

--- a/browser_use/browser/video_recorder.py
+++ b/browser_use/browser/video_recorder.py
@@ -43,9 +43,9 @@ class VideoRecorderService:
 		Initializes the video recorder.
 
 		Args:
-		    output_path: The full path where the video will be saved.
-		    size: A ViewportSize object specifying the width and height of the video.
-		    framerate: The desired framerate for the output video.
+			output_path: The full path where the video will be saved.
+			size: A ViewportSize object specifying the width and height of the video.
+			framerate: The desired framerate for the output video.
 		"""
 		self.output_path = output_path
 		self.size = size
@@ -54,7 +54,7 @@ class VideoRecorderService:
 		self._is_active = False
 		self.padded_size = _get_padded_size(self.size)
 		self.last_frame_time: float | None = None
-		self._last_img_array: Optional[np.ndarray] = None
+		self._last_img_array: np.ndarray | None = None
 
 	def start(self) -> None:
 		"""
@@ -92,8 +92,8 @@ class VideoRecorderService:
 		and appends it to the video.
 
 		Args:
-		    frame_data_b64: A base64-encoded string of the PNG frame data.
-		    timestamp: The timestamp of the frame.
+			frame_data_b64: A base64-encoded string of the PNG frame data.
+			timestamp: The timestamp of the frame.
 		"""
 		if not self._is_active or not self._writer:
 			return

--- a/browser_use/browser/video_recorder.py
+++ b/browser_use/browser/video_recorder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Video Recording Service for Browser Use Sessions."""
 
 import base64
@@ -5,9 +7,12 @@ import io
 import logging
 import math
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from browser_use.browser.profile import ViewportSize
+
+if TYPE_CHECKING:
+	from imageio.core.format import Format
 
 try:
 	import imageio.v2 as iio  # type: ignore[import-not-found]
@@ -50,7 +55,7 @@ class VideoRecorderService:
 		self.output_path = output_path
 		self.size = size
 		self.framerate = framerate
-		self._writer: Optional['Format.Writer'] = None
+		self._writer: Format.Writer | None = None
 		self._is_active = False
 		self.padded_size = _get_padded_size(self.size)
 		self.last_frame_time: float | None = None

--- a/browser_use/browser/watchdogs/recording_watchdog.py
+++ b/browser_use/browser/watchdogs/recording_watchdog.py
@@ -195,7 +195,9 @@ class RecordingWatchdog(BaseWatchdog):
 
 		if not self._recorder:
 			return
-		self._recorder.add_frame(event['data'])
+
+		timestamp = event.get('metadata', {}).get('timestamp')
+		self._recorder.add_frame(event['data'], timestamp=timestamp)
 		create_task_with_error_handling(
 			self._ack_screencast_frame(event, session_id),
 			name='ack_screencast_frame',


### PR DESCRIPTION
**Description:**
This PR fixes the issue where browser session recordings appear accelerated (Issue #4696). The root cause was the `VideoRecorderService` ignoring the real-time intervals between CDP screencast frames. It now implements a frame duplication strategy:
- Extracted `timestamp` from `ScreencastFrameEvent` metadata.
- Automatically injects duplicate frames in the video stream to fill gaps in browser activity (e.g., waiting for page loads or LLM thinking).
- Ensures video playback speed matches real-world execution speed without significantly increasing file size.

**Verification:**
Tested locally by running an agent with a deliberate 15-second pause. Verified the output `.mp4` duration with `ffprobe`, confirming it correctly reflects the real-time wait.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes accelerated playback in session recordings by pacing frames using CDP timestamps and duplicating the last frame to fill gaps. Keeps video duration aligned with real-time execution.

- **Bug Fixes**
  - `VideoRecorderService.add_frame(data, timestamp=None)`: accepts an optional `timestamp`, keeps `last_frame_time` and `_last_img_array`, and inserts `int(dt * framerate) - 1` duplicate frames when `dt > 1/framerate` before writing the current frame.
  - `RecordingWatchdog.on_screencastFrame`: reads `metadata.timestamp` with `get` and forwards it to the recorder.

- **Refactors**
  - Added `from __future__ import annotations`, `TYPE_CHECKING`, and precise types (e.g., `Format.Writer | None`); fixed indentation/linting for CI with no behavior change.

<sup>Written for commit 0112e6f2d91cce8bb0f14676e3ea61acf788650f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

