### PR TITLE
refactor(schema): remove unreachable type branch entry

### DIFF
--- a/browser_use/llm/schema.py
+++ b/browser_use/llm/schema.py
@@ -89,7 +89,6 @@ class SchemaOptimizer:
 
 					# Keep essential validation fields
 					elif key in [
-						'type',
 						'required',
 						'minimum',
 						'maximum',


### PR DESCRIPTION
Summary:
- remove the unreachable type entry from the later validation-key branch in SchemaOptimizer.optimize_schema()
- keep the dedicated key == type handling as the only code path for that key
- make the branching intent clearer for future maintenance

Testing:
- python3 -m pytest /tmp/browser-use-user/tests/ci/models/test_llm_schema_optimizer.py
- This failed in this environment because tests/ci/conftest.py imports pytest_httpserver, which is not installed here

Closes #4703

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unreachable `type` case from the validation-keys branch in `optimize_schema`, keeping the dedicated `key == "type"` path as the sole handler. This simplifies branching and clarifies the intent for future maintenance.

<sup>Written for commit 538a02372cef947cc14c23d25dcc00ce48976101. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

