### PR TITLE
Guard direct CDP helpers during reconnect

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1354,6 +1354,23 @@ class BrowserSession(BaseModel):
 		"""Clear all cookies."""
 		await self.cdp_client.send.Network.clearBrowserCookies()
 
+
+	async def _ensure_cdp_ready_for_command(self, operation_name: str) -> None:
+		"""Wait for in-flight reconnection or fail fast before direct CDP helper commands."""
+		if self.is_cdp_connected:
+			return
+		if self.is_reconnecting:
+			wait_timeout = self.RECONNECT_WAIT_TIMEOUT
+			self.logger.debug(f'⏳ Waiting for CDP reconnection before {operation_name} ({wait_timeout}s)...')
+			try:
+				await asyncio.wait_for(self._reconnect_event.wait(), timeout=wait_timeout)
+			except TimeoutError as exc:
+				raise ConnectionError(f'{operation_name}: reconnection wait timed out after {wait_timeout}s') from exc
+			if self.is_cdp_connected:
+				return
+			raise ConnectionError(f'{operation_name}: reconnection finished but CDP is still not connected')
+		raise ConnectionError(f'{operation_name}: CDP is not connected')
+
 	async def export_storage_state(self, output_path: str | Path | None = None) -> dict[str, Any]:
 		"""Export all browser cookies and storage to storage_state format.
 
@@ -1367,6 +1384,8 @@ class BrowserSession(BaseModel):
 
 		"""
 		from pathlib import Path
+
+		await self._ensure_cdp_ready_for_command('export_storage_state')
 
 		# Get all cookies using Storage.getCookies (returns decrypted cookies from all domains)
 		cookies = await self._cdp_get_cookies()
@@ -3328,6 +3347,7 @@ class BrowserSession(BaseModel):
 
 	async def _cdp_get_cookies(self) -> list[Cookie]:
 		"""Get cookies using CDP Network.getCookies."""
+		await self._ensure_cdp_ready_for_command('_cdp_get_cookies')
 		cdp_session = await self.get_or_create_cdp_session(target_id=None)
 		result = await asyncio.wait_for(
 			cdp_session.cdp_client.send.Storage.getCookies(session_id=cdp_session.session_id), timeout=8.0
@@ -3339,6 +3359,8 @@ class BrowserSession(BaseModel):
 		if not self.agent_focus_target_id or not cookies:
 			return
 
+		await self._ensure_cdp_ready_for_command('_cdp_set_cookies')
+
 		cdp_session = await self.get_or_create_cdp_session(target_id=None)
 		# Storage.setCookies expects params dict with 'cookies' key
 		await cdp_session.cdp_client.send.Storage.setCookies(
@@ -3348,6 +3370,7 @@ class BrowserSession(BaseModel):
 
 	async def _cdp_clear_cookies(self) -> None:
 		"""Clear all cookies using CDP Network.clearBrowserCookies."""
+		await self._ensure_cdp_ready_for_command('_cdp_clear_cookies')
 		cdp_session = await self.get_or_create_cdp_session()
 		await cdp_session.cdp_client.send.Storage.clearCookies(session_id=cdp_session.session_id)
 

--- a/tests/ci/browser/test_session_start.py
+++ b/tests/ci/browser/test_session_start.py
@@ -11,6 +11,7 @@ Tests cover:
 
 import asyncio
 import logging
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 
@@ -434,3 +435,69 @@ class TestBrowserSessionEventSystem:
 	# 	for i, result in enumerate(results):
 	# 		if isinstance(result, Exception):
 	# 			print(f'Warning: Browser session kill raised exception: {type(result).__name__}: {result}')
+
+
+async def test_cdp_command_waits_for_reconnect_success():
+	"""Direct CDP helpers should wait for an in-flight reconnect before continuing."""
+	browser_session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=False))
+	browser_session.RECONNECT_WAIT_TIMEOUT = 0.2
+	browser_session._reconnecting = True
+	browser_session._reconnect_event.clear()
+
+	async def release_reconnect():
+		await asyncio.sleep(0.01)
+		browser_session._reconnect_event.set()
+
+	release_task = asyncio.create_task(release_reconnect())
+	try:
+		with patch.object(BrowserSession, 'is_cdp_connected', new_callable=PropertyMock) as connected:
+			connected.side_effect = [False, True]
+			await browser_session._ensure_cdp_ready_for_command('_cdp_get_cookies')
+	finally:
+		await release_task
+
+
+async def test_cdp_command_timeout_when_reconnect_stalls():
+	"""Direct CDP helpers should fail with a clear timeout when reconnect never finishes."""
+	browser_session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=False))
+	browser_session.RECONNECT_WAIT_TIMEOUT = 0.01
+	browser_session._reconnecting = True
+	browser_session._reconnect_event.clear()
+	with patch.object(BrowserSession, 'is_cdp_connected', new_callable=PropertyMock) as connected:
+		connected.return_value = False
+		with pytest.raises(ConnectionError, match='reconnection wait timed out'):
+			await browser_session._ensure_cdp_ready_for_command('_cdp_get_cookies')
+
+
+async def test_cdp_command_fails_fast_when_disconnected_and_not_reconnecting():
+	"""Direct CDP helpers should fail fast when CDP is simply disconnected."""
+	browser_session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=False))
+	browser_session._reconnecting = False
+	with patch.object(BrowserSession, 'is_cdp_connected', new_callable=PropertyMock) as connected:
+		connected.return_value = False
+		with pytest.raises(ConnectionError, match='CDP is not connected'):
+			await browser_session._ensure_cdp_ready_for_command('export_storage_state')
+
+
+async def test_export_storage_state_waits_for_reconnect_before_fetching_cookies():
+	"""Export should reuse the reconnect guard before hitting direct CDP cookie helpers."""
+	browser_session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=False))
+	browser_session.RECONNECT_WAIT_TIMEOUT = 0.2
+	browser_session._reconnecting = True
+	browser_session._reconnect_event.clear()
+	browser_session._cdp_get_cookies = AsyncMock(return_value=[{'name': 'sid', 'value': '1', 'domain': 'example.com', 'path': '/'}])
+
+	async def release_reconnect():
+		await asyncio.sleep(0.01)
+		browser_session._reconnect_event.set()
+
+	release_task = asyncio.create_task(release_reconnect())
+	try:
+		with patch.object(BrowserSession, 'is_cdp_connected', new_callable=PropertyMock) as connected:
+			connected.side_effect = [False, True]
+			state = await browser_session.export_storage_state()
+	finally:
+		await release_task
+
+	assert state['cookies'][0]['name'] == 'sid'
+	browser_session._cdp_get_cookies.assert_awaited_once()


### PR DESCRIPTION
## Summary
- wait for in-flight CDP reconnects before direct storage/cookie helper commands run
- fail fast with a clear ConnectionError when CDP is still unavailable
- add focused regression tests for reconnect success, timeout, and export_storage_state behavior

## Testing
- python -m pytest tests/ci/browser/test_session_start.py -k "cdp_command or export_storage_state_waits_for_reconnect"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded direct CDP cookie/storage helpers to wait for in‑flight reconnects and fail fast when CDP is unavailable. This prevents race conditions during reconnect and surfaces clear errors.

- **Bug Fixes**
  - Added `_ensure_cdp_ready_for_command` and applied it to `export_storage_state`, `_cdp_get_cookies`, `_cdp_set_cookies`, and `_cdp_clear_cookies` with timeout and clear `ConnectionError` messages.
  - Added focused tests for reconnect success, timeout, fast‑fail when disconnected, and `export_storage_state` waiting before fetching cookies.

<sup>Written for commit 4fa600a38783d92213c8e98ec12785d75a7d12af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

