### PR TITLE
fix: implement retry logic for captureScreenshot to avoid timeouts (#…

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3923,17 +3923,32 @@ class BrowserSession(BaseModel):
 
 		params = CaptureScreenshotParameters(**params)
 
-		result = await cdp_session.cdp_client.send.Page.captureScreenshot(params=params, session_id=cdp_session.session_id)
+		max_retries = 3
+		last_exception = None
 
-		if not result or 'data' not in result:
-			raise Exception('Screenshot failed - no data returned')
+		for attempt in range(max_retries):
+			try:
+				result = await cdp_session.cdp_client.send.Page.captureScreenshot(
+					params=params, session_id=cdp_session.session_id
+				)
 
-		screenshot_data = base64.b64decode(result['data'])
+				if not result or 'data' not in result:
+					raise Exception('No data returned from captureScreenshot')
 
-		if path:
-			Path(path).write_bytes(screenshot_data)
+				screenshot_data = base64.b64decode(result['data'])
 
-		return screenshot_data
+				if path:
+					Path(path).write_bytes(screenshot_data)
+
+				return screenshot_data
+
+			except Exception as e:
+				last_exception = e
+				self.logger.warning(f'Screenshot attempt {attempt + 1}/{max_retries} failed: {e}')
+				if attempt < max_retries - 1:
+					await asyncio.sleep(1.0 * (attempt + 1))
+
+		raise Exception(f'Screenshot failed after {max_retries} attempts. Last error: {last_exception}')
 
 	async def screenshot_element(
 		self,


### PR DESCRIPTION
…4651)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds retry logic to screenshot capture to reduce transient timeouts and flakiness. Improves reliability by retrying the CDP call and only saving on success.

- **Bug Fixes**
  - Tries up to 3 times with incremental backoff (1s, 2s), logging each failure.
  - Validates response contains `data` before decoding; only writes the file on success.
  - Fails with a clear error after the final attempt, including the last exception.

<sup>Written for commit 33e0662369050615fe621845b9990724d27fdd1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

