### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,10 @@ BROWSER_USE_API_KEY=your_bu_api_key_here
 # DEEPSEEK_API_KEY=
 # GROK_API_KEY=
 # NOVITA_API_KEY=
+# Astraflow (UCloud) - OpenAI-compatible, 200+ models
+# Sign up: https://astraflow.ucloud.cn/
+# ASTRAFLOW_API_KEY=        # Global endpoint (US/CA): https://api-us-ca.umodelverse.ai/v1
+# ASTRAFLOW_CN_API_KEY=     # China endpoint: https://api.modelverse.cn/v1
 
 # AWS Bedrock Configuration (for AWS Bedrock models)
 # Requires: pip install browser-use[aws]

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -155,6 +155,14 @@ class OldConfig:
 		return os.getenv('NOVITA_API_KEY', '')
 
 	@property
+	def ASTRAFLOW_API_KEY(self) -> str:
+		return os.getenv('ASTRAFLOW_API_KEY', '')
+
+	@property
+	def ASTRAFLOW_CN_API_KEY(self) -> str:
+		return os.getenv('ASTRAFLOW_CN_API_KEY', '')
+
+	@property
 	def AZURE_OPENAI_ENDPOINT(self) -> str:
 		return os.getenv('AZURE_OPENAI_ENDPOINT', '')
 
@@ -216,6 +224,8 @@ class FlatEnvConfig(BaseSettings):
 	DEEPSEEK_API_KEY: str = Field(default='')
 	GROK_API_KEY: str = Field(default='')
 	NOVITA_API_KEY: str = Field(default='')
+	ASTRAFLOW_API_KEY: str = Field(default='')
+	ASTRAFLOW_CN_API_KEY: str = Field(default='')
 	AZURE_OPENAI_ENDPOINT: str = Field(default='')
 	AZURE_OPENAI_KEY: str = Field(default='')
 	SKIP_LLM_API_KEY_VERIFICATION: bool = Field(default=False)

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -27,6 +27,7 @@ from browser_use.llm.messages import (
 # Type stubs for lazy imports
 if TYPE_CHECKING:
 	from browser_use.llm.anthropic.chat import ChatAnthropic
+	from browser_use.llm.astraflow.chat import ChatAstraflow
 	from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
 	from browser_use.llm.aws.chat_bedrock import ChatAWSBedrock
 	from browser_use.llm.azure.chat import ChatAzureOpenAI
@@ -80,6 +81,7 @@ if TYPE_CHECKING:
 # Lazy imports mapping for heavy chat models
 _LAZY_IMPORTS = {
 	'ChatAnthropic': ('browser_use.llm.anthropic.chat', 'ChatAnthropic'),
+	'ChatAstraflow': ('browser_use.llm.astraflow.chat', 'ChatAstraflow'),
 	'ChatAnthropicBedrock': ('browser_use.llm.aws.chat_anthropic', 'ChatAnthropicBedrock'),
 	'ChatAWSBedrock': ('browser_use.llm.aws.chat_bedrock', 'ChatAWSBedrock'),
 	'ChatAzureOpenAI': ('browser_use.llm.azure.chat', 'ChatAzureOpenAI'),
@@ -158,4 +160,5 @@ __all__ = [
 	'ChatOpenRouter',
 	'ChatVercel',
 	'ChatCerebras',
+	'ChatAstraflow',
 ]

--- a/browser_use/llm/astraflow/chat.py
+++ b/browser_use/llm/astraflow/chat.py
@@ -1,0 +1,204 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, TypeVar, overload
+
+import httpx
+from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
+from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.shared_params.response_format_json_schema import (
+	JSONSchema,
+	ResponseFormatJSONSchema,
+)
+from pydantic import BaseModel
+
+from browser_use.llm.astraflow.serializer import AstraflowMessageSerializer
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
+
+T = TypeVar('T', bound=BaseModel)
+
+
+@dataclass
+class ChatAstraflow(BaseChatModel):
+	"""
+	A wrapper around Astraflow's chat API (by UCloud / 优刻得).
+
+	Astraflow is an OpenAI-compatible AI model aggregation platform that
+	provides access to 200+ models through a unified interface.
+
+	Global endpoint : https://api-us-ca.umodelverse.ai/v1  (ASTRAFLOW_API_KEY)
+	China endpoint  : https://api.modelverse.cn/v1         (ASTRAFLOW_CN_API_KEY)
+	Sign up         : https://astraflow.ucloud.cn/
+	"""
+
+	# Model configuration
+	model: str
+
+	# Generation parameters
+	temperature: float | None = None
+	top_p: float | None = None
+	seed: int | None = None
+
+	# Client initialisation parameters
+	api_key: str | None = None
+	base_url: str | httpx.URL = 'https://api-us-ca.umodelverse.ai/v1'
+	timeout: float | httpx.Timeout | None = None
+	max_retries: int = 10
+	default_headers: Mapping[str, str] | None = None
+	default_query: Mapping[str, object] | None = None
+	http_client: httpx.AsyncClient | None = None
+	_strict_response_validation: bool = False
+	extra_body: dict[str, Any] | None = None
+
+	@property
+	def provider(self) -> str:
+		return 'astraflow'
+
+	def _get_client_params(self) -> dict[str, Any]:
+		"""Prepare client parameters dictionary."""
+		base_params = {
+			'api_key': self.api_key,
+			'base_url': self.base_url,
+			'timeout': self.timeout,
+			'max_retries': self.max_retries,
+			'default_headers': self.default_headers,
+			'default_query': self.default_query,
+			'_strict_response_validation': self._strict_response_validation,
+		}
+
+		# Only include non-None values
+		client_params = {k: v for k, v in base_params.items() if v is not None}
+
+		if self.http_client is not None:
+			client_params['http_client'] = self.http_client
+
+		return client_params
+
+	def get_client(self) -> AsyncOpenAI:
+		"""
+		Returns an AsyncOpenAI client configured for Astraflow.
+
+		Returns:
+		    AsyncOpenAI: An instance of the AsyncOpenAI client pointed at the
+		                 Astraflow base URL.
+		"""
+		if not hasattr(self, '_client'):
+			client_params = self._get_client_params()
+			self._client = AsyncOpenAI(**client_params)
+		return self._client
+
+	@property
+	def name(self) -> str:
+		return str(self.model)
+
+	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
+		"""Extract usage information from the Astraflow response."""
+		if response.usage is None:
+			return None
+
+		prompt_details = getattr(response.usage, 'prompt_tokens_details', None)
+		cached_tokens = prompt_details.cached_tokens if prompt_details else None
+
+		return ChatInvokeUsage(
+			prompt_tokens=response.usage.prompt_tokens,
+			prompt_cached_tokens=cached_tokens,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+			# Completion
+			completion_tokens=response.usage.completion_tokens,
+			total_tokens=response.usage.total_tokens,
+		)
+
+	@overload
+	async def ainvoke(
+		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[str]: ...
+
+	@overload
+	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T], **kwargs: Any) -> ChatInvokeCompletion[T]: ...
+
+	async def ainvoke(
+		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		"""
+		Invoke the model with the given messages through Astraflow.
+
+		Args:
+		    messages: List of chat messages
+		    output_format: Optional Pydantic model class for structured output
+
+		Returns:
+		    Either a string response or an instance of output_format
+		"""
+		astraflow_messages = AstraflowMessageSerializer.serialize_messages(messages)
+
+		try:
+			if output_format is None:
+				# Return plain-text response
+				response = await self.get_client().chat.completions.create(
+					model=self.model,
+					messages=astraflow_messages,
+					temperature=self.temperature,
+					top_p=self.top_p,
+					seed=self.seed,
+					**(self.extra_body or {}),
+				)
+
+				usage = self._get_usage(response)
+				return ChatInvokeCompletion(
+					completion=response.choices[0].message.content or '',
+					usage=usage,
+				)
+
+			else:
+				# Return structured (JSON-schema) response
+				schema = SchemaOptimizer.create_optimized_json_schema(output_format)
+
+				response_format_schema: JSONSchema = {
+					'name': 'agent_output',
+					'strict': True,
+					'schema': schema,
+				}
+
+				response = await self.get_client().chat.completions.create(
+					model=self.model,
+					messages=astraflow_messages,
+					temperature=self.temperature,
+					top_p=self.top_p,
+					seed=self.seed,
+					response_format=ResponseFormatJSONSchema(
+						json_schema=response_format_schema,
+						type='json_schema',
+					),
+					**(self.extra_body or {}),
+				)
+
+				if response.choices[0].message.content is None:
+					raise ModelProviderError(
+						message='Failed to parse structured output from model response',
+						status_code=500,
+						model=self.name,
+					)
+
+				usage = self._get_usage(response)
+				parsed = output_format.model_validate_json(response.choices[0].message.content)
+
+				return ChatInvokeCompletion(
+					completion=parsed,
+					usage=usage,
+				)
+
+		except RateLimitError as e:
+			raise ModelRateLimitError(message=e.message, model=self.name) from e
+
+		except APIConnectionError as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e
+
+		except APIStatusError as e:
+			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
+
+		except Exception as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/astraflow/serializer.py
+++ b/browser_use/llm/astraflow/serializer.py
@@ -1,0 +1,27 @@
+from openai.types.chat import ChatCompletionMessageParam
+
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.openai.serializer import OpenAIMessageSerializer
+
+
+class AstraflowMessageSerializer:
+	"""
+	Serializer for converting between custom message types and Astraflow message
+	formats.
+
+	Astraflow uses the OpenAI-compatible API, so we can reuse the OpenAI serializer.
+	"""
+
+	@staticmethod
+	def serialize_messages(messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
+		"""
+		Serialize a list of browser_use messages to Astraflow-compatible messages.
+
+		Args:
+		    messages: List of browser_use messages
+
+		Returns:
+		    List of Astraflow-compatible messages (identical to OpenAI format)
+		"""
+		# Astraflow uses the same message format as OpenAI
+		return OpenAIMessageSerializer.serialize_messages(messages)

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -14,6 +14,7 @@ Usage:
 import os
 from typing import TYPE_CHECKING
 
+from browser_use.llm.astraflow.chat import ChatAstraflow
 from browser_use.llm.azure.chat import ChatAzureOpenAI
 from browser_use.llm.browser_use.chat import ChatBrowserUse
 from browser_use.llm.cerebras.chat import ChatCerebras
@@ -84,6 +85,11 @@ cerebras_qwen_3_coder_480b: 'BaseChatModel'
 bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
 bu_2_0: 'BaseChatModel'
+
+astraflow_deepseek_v3: 'BaseChatModel'
+astraflow_deepseek_r1: 'BaseChatModel'
+astraflow_cn_deepseek_v3: 'BaseChatModel'
+astraflow_cn_deepseek_r1: 'BaseChatModel'
 
 
 def get_llm_by_name(model_name: str):
@@ -203,6 +209,16 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('CEREBRAS_API_KEY')
 		return ChatCerebras(model=model, api_key=api_key)
 
+	# Astraflow Models (global endpoint)
+	elif provider == 'astraflow':
+		api_key = os.getenv('ASTRAFLOW_API_KEY')
+		return ChatAstraflow(model=model_part.replace('_', '/'), api_key=api_key)
+
+	# Astraflow Models (China endpoint)
+	elif provider == 'astraflow_cn':
+		api_key = os.getenv('ASTRAFLOW_CN_API_KEY')
+		return ChatAstraflow(model=model_part.replace('_', '/'), api_key=api_key, base_url='https://api.modelverse.cn/v1')
+
 	# Browser Use Models
 	elif provider == 'bu':
 		# Handle bu_latest -> bu-latest conversion (need to prepend 'bu-' back)
@@ -211,7 +227,7 @@ def get_llm_by_name(model_name: str):
 		return ChatBrowserUse(model=model, api_key=api_key)
 
 	else:
-		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu']
+		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu', 'astraflow', 'astraflow_cn']
 
 		raise ValueError(f"Unknown provider: '{provider}'. Available providers: {', '.join(available_providers)}")
 
@@ -239,6 +255,9 @@ def __getattr__(name: str) -> 'BaseChatModel':
 	elif name == 'ChatBrowserUse':
 		return ChatBrowserUse  # type: ignore
 
+	elif name == 'ChatAstraflow':
+		return ChatAstraflow  # type: ignore
+
 	# Handle model instances - these are the main use case
 	try:
 		return get_llm_by_name(name)
@@ -254,6 +273,7 @@ __all__ = [
 	'ChatMistral',
 	'ChatCerebras',
 	'ChatBrowserUse',
+	'ChatAstraflow',
 ]
 
 if OCI_AVAILABLE:
@@ -313,6 +333,11 @@ __all__ += [
 	'bu_latest',
 	'bu_1_0',
 	'bu_2_0',
+	# Astraflow instances - created on demand
+	'astraflow_deepseek_v3',
+	'astraflow_deepseek_r1',
+	'astraflow_cn_deepseek_v3',
+	'astraflow_cn_deepseek_r1',
 ]
 
 # NOTE: OCI backend is optional. The try/except ImportError and conditional __all__ are required


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a first-class LLM provider in browser-use.

Astraflow is an OpenAI-compatible AI model aggregation platform that provides access to 200+ models through a unified API. This PR follows the exact same patterns used by the existing `openrouter` and `deepseek` providers.

### What's added

| File | Change |
|------|--------|
| `browser_use/llm/astraflow/chat.py` | New `ChatAstraflow` dataclass — OpenAI-compatible chat client supporting both plain-text and structured output |
| `browser_use/llm/astraflow/serializer.py` | `AstraflowMessageSerializer` — delegates to the OpenAI serializer (Astraflow is fully OpenAI-compatible) |
| `browser_use/llm/__init__.py` | TYPE_CHECKING import, lazy-import registry entry, `__all__` entry |
| `browser_use/llm/models.py` | Top-level type stub, `get_llm_by_name` provider branches (`astraflow` + `astraflow_cn`), `__getattr__` handler, `__all__` entries |
| `browser_use/config.py` | `ASTRAFLOW_API_KEY` + `ASTRAFLOW_CN_API_KEY` in both `OldConfig` and `FlatEnvConfig` |
| `.env.example` | Documents both Astraflow env vars with sign-up link |

### Endpoints

| Region | Base URL | Env var |
|--------|----------|---------|
| Global (US/CA) | `https://api-us-ca.umodelverse.ai/v1` | `ASTRAFLOW_API_KEY` |
| China | `https://api.modelverse.cn/v1` | `ASTRAFLOW_CN_API_KEY` |

### Usage

**Direct instantiation:**
```python
import os
from browser_use.llm.astraflow.chat import ChatAstraflow

# Global endpoint (default)
llm = ChatAstraflow(
    model="deepseek-ai/DeepSeek-V3",
    api_key=os.getenv("ASTRAFLOW_API_KEY"),
)

# China endpoint
llm_cn = ChatAstraflow(
    model="deepseek-ai/DeepSeek-V3",
    api_key=os.getenv("ASTRAFLOW_CN_API_KEY"),
    base_url="https://api.modelverse.cn/v1",
)
```

**Via the lazy `llm` module:**
```python
from browser_use import llm

model = llm.astraflow_deepseek_v3     # global endpoint, ASTRAFLOW_API_KEY
model = llm.astraflow_cn_deepseek_v3  # China endpoint, ASTRAFLOW_CN_API_KEY
```

**Via `get_llm_by_name`:**
```python
from browser_use.llm.models import get_llm_by_name

model = get_llm_by_name("astraflow_deepseek_v3")
model = get_llm_by_name("astraflow_cn_deepseek_r1")
```

### References
- Sign up: https://astraflow.ucloud.cn/
- Global API docs: https://api-us-ca.umodelverse.ai/v1
- China API docs: https://api.modelverse.cn/v1


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Astraflow` as a new provider with chat completions and optional JSON-schema output. Supports both global and China endpoints with simple env-based configuration.

- **New Features**
  - New `ChatAstraflow` client with text and structured outputs.
  - Message serializer delegates to the existing OpenAI-format serializer.
  - `get_llm_by_name` supports `astraflow_*` and `astraflow_cn_*` (e.g., `astraflow_deepseek_v3`).
  - Config adds `ASTRAFLOW_API_KEY` (global) and `ASTRAFLOW_CN_API_KEY` (China); endpoints are `https://api-us-ca.umodelverse.ai/v1` and `https://api.modelverse.cn/v1`.

- **Migration**
  - Set `ASTRAFLOW_API_KEY` or `ASTRAFLOW_CN_API_KEY` as needed.
  - No breaking changes; existing providers are unaffected.

<sup>Written for commit 1a6a5e459f1c5b5ac1ee8bc7b3d0efd0f5132102. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

