### PR TITLE
fix(browser): replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -982,7 +982,7 @@ class BrowserSession(BaseModel):
 			)
 			timeout = 3.0 if same_domain else 8.0
 
-		nav_start_time = asyncio.get_event_loop().time()
+		nav_start_time = asyncio.get_running_loop().time()
 
 		# Wrap Page.navigate() with timeout — heavy sites can block here for 10s+
 		# Use nav_timeout parameter if provided, otherwise default to 20.0
@@ -997,19 +997,19 @@ class BrowserSession(BaseModel):
 				timeout=nav_timeout,
 			)
 		except TimeoutError:
-			duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
+			duration_ms = (asyncio.get_running_loop().time() - nav_start_time) * 1000
 			raise RuntimeError(f'Page.navigate() timed out after {nav_timeout}s ({duration_ms:.0f}ms) for {url}')
 
 		if nav_result.get('errorText'):
 			raise RuntimeError(f'Navigation failed: {nav_result["errorText"]}')
 
 		if wait_until == 'commit':
-			duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
+			duration_ms = (asyncio.get_running_loop().time() - nav_start_time) * 1000
 			self.logger.debug(f'✅ Page ready for {url} (commit, {duration_ms:.0f}ms)')
 			return
 
 		navigation_id = nav_result.get('loaderId')
-		start_time = asyncio.get_event_loop().time()
+		start_time = asyncio.get_running_loop().time()
 		seen_events = []
 
 		if not hasattr(cdp_session, '_lifecycle_events'):
@@ -1027,7 +1027,7 @@ class BrowserSession(BaseModel):
 			acceptable_events.add('DOMContentLoaded')
 
 		poll_interval = 0.05
-		while (asyncio.get_event_loop().time() - start_time) < timeout:
+		while (asyncio.get_running_loop().time() - start_time) < timeout:
 			try:
 				for event_data in list(cdp_session._lifecycle_events):
 					event_name = event_data.get('name')
@@ -1041,7 +1041,7 @@ class BrowserSession(BaseModel):
 						continue
 
 					if event_name in acceptable_events:
-						duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
+						duration_ms = (asyncio.get_running_loop().time() - nav_start_time) * 1000
 						self.logger.debug(f'✅ Page ready for {url} ({event_name}, {duration_ms:.0f}ms)')
 						return
 
@@ -1050,7 +1050,7 @@ class BrowserSession(BaseModel):
 
 			await asyncio.sleep(poll_interval)
 
-		duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
+		duration_ms = (asyncio.get_running_loop().time() - nav_start_time) * 1000
 		if not seen_events:
 			self.logger.error(
 				f'❌ No lifecycle events received for {url} after {duration_ms:.0f}ms! '

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -337,9 +337,9 @@ class SessionManager:
 		# Wait for recovery complete event (event-driven, not polling!)
 		if self._recovery_complete_event:
 			try:
-				start_time = asyncio.get_event_loop().time()
+				start_time = asyncio.get_running_loop().time()
 				await asyncio.wait_for(self._recovery_complete_event.wait(), timeout=timeout)
-				elapsed = asyncio.get_event_loop().time() - start_time
+				elapsed = asyncio.get_running_loop().time() - start_time
 
 				# Verify recovery succeeded - simple existence check
 				focus_id = self.browser_session.agent_focus_target_id
@@ -886,7 +886,7 @@ class SessionManager:
 					event_data = {
 						'name': event_name,
 						'loaderId': event_loader_id,
-						'timestamp': asyncio.get_event_loop().time(),
+						'timestamp': asyncio.get_running_loop().time(),
 					}
 					# Append is atomic in CPython
 					try:

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -881,9 +881,9 @@ class DownloadsWatchdog(BaseWatchdog):
 
 		# Poll for new files
 		max_wait = 20  # seconds
-		start_time = asyncio.get_event_loop().time()
+		start_time = asyncio.get_running_loop().time()
 
-		while asyncio.get_event_loop().time() - start_time < max_wait:  # noqa: ASYNC110
+		while asyncio.get_running_loop().time() - start_time < max_wait:  # noqa: ASYNC110
 			await asyncio.sleep(5.0)  # Check every 5 seconds
 
 			if Path(downloads_dir).exists():

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -409,9 +409,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		"""Wait for the browser to start and return the CDP URL."""
 		import aiohttp
 
-		start_time = asyncio.get_event_loop().time()
+		start_time = asyncio.get_running_loop().time()
 
-		while asyncio.get_event_loop().time() - start_time < timeout:
+		while asyncio.get_running_loop().time() - start_time < timeout:
 			try:
 				async with aiohttp.ClientSession() as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:

--- a/browser_use/browser/watchdogs/recording_watchdog.py
+++ b/browser_use/browser/watchdogs/recording_watchdog.py
@@ -113,7 +113,7 @@ class RecordingWatchdog(BaseWatchdog):
 				self.logger.debug(f'Failed to stop CDP screencast on {session_id}: {e}')
 
 		output_path = recorder.output_path
-		loop = asyncio.get_event_loop()
+		loop = asyncio.get_running_loop()
 		await loop.run_in_executor(None, recorder.stop_and_save)
 		return output_path
 


### PR DESCRIPTION
## Summary

Replaces 15 deprecated `asyncio.get_event_loop()` calls with `asyncio.get_running_loop()` across the `browser/` module:

- `browser/session.py` (7 calls, all in `_navigate_and_wait`)
- `browser/session_manager.py` (3 calls)
- `browser/watchdogs/local_browser_watchdog.py` (2 calls)
- `browser/watchdogs/downloads_watchdog.py` (2 calls)
- `browser/watchdogs/recording_watchdog.py` (1 call)

## Why

`asyncio.get_event_loop()` is deprecated when there is no running loop and emits `DeprecationWarning` in Python 3.12+; it is slated to change behavior further in 3.14. All touched call sites are inside `async def` methods, so `asyncio.get_running_loop()` is a direct, semantics-preserving swap (same `loop.time()` / `loop.run_in_executor` methods).

This follows the same pattern merged in #4659 (which fixed the CLI for Python 3.14 compat). Other modules with remaining `get_event_loop()` calls (`filesystem/`, `agent/`, `llm/oci_raw/`, `utils.py`) can be addressed in follow-up PRs, scoped separately for easier review.

## Testing

- `uv run ruff check` on all changed files → passes
- Import smoke test on the 5 modified modules → passes
- No behavior change; `get_running_loop()` returns the same loop object `get_event_loop()` does when called from within a running coroutine

## Diff stats

```
 5 files changed, 15 insertions(+), 15 deletions(-)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()` across the `browser/` module to remove Python 3.12+ warnings and prepare for Python 3.14. Behavior is unchanged.

- **Bug Fixes**
  - Updated 15 call sites across 5 files (all in async functions), preserving `loop.time()` and `run_in_executor` usage.

<sup>Written for commit 423b13eb73bc38de9c597f0c6ea2a117fa7ec65f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

