### PR TITLE
feat(cli): add --proxy-url flag for local Chromium sessions

### DIFF
--- a/browser_use/skill_cli/daemon.py
+++ b/browser_use/skill_cli/daemon.py
@@ -303,6 +303,12 @@ class Daemon:
 						'cdp_url': live_cdp_url,
 						'use_cloud': self.use_cloud,
 						'proxy_url': self.proxy_url,
+						'proxy_bypass': self.proxy_bypass,
+						'proxy_username': self.proxy_username,
+						# Do not return proxy_password — still include its presence
+						# so the config-mismatch check can detect changes without
+						# leaking the secret over the socket.
+						'proxy_password_set': bool(self.proxy_password),
 					},
 				}
 

--- a/browser_use/skill_cli/daemon.py
+++ b/browser_use/skill_cli/daemon.py
@@ -288,7 +288,8 @@ class Daemon:
 
 			# Handle ping — returns daemon config for mismatch detection
 			if action == 'ping':
-				# Return live CDP URL (may differ from constructor arg for cloud sessions)
+				# Keep configured CDP URL stable for config-mismatch checks, but
+				# also expose the live browser CDP URL for status/sessions output.
 				live_cdp_url = self.cdp_url
 				if self._session and self._session.browser_session.cdp_url:
 					live_cdp_url = self._session.browser_session.cdp_url
@@ -300,7 +301,8 @@ class Daemon:
 						'pid': os.getpid(),
 						'headed': self.headed,
 						'profile': self.profile,
-						'cdp_url': live_cdp_url,
+						'cdp_url': self.cdp_url,
+						'live_cdp_url': live_cdp_url,
 						'use_cloud': self.use_cloud,
 						'proxy_url': self.proxy_url,
 						'proxy_bypass': self.proxy_bypass,

--- a/browser_use/skill_cli/daemon.py
+++ b/browser_use/skill_cli/daemon.py
@@ -41,6 +41,10 @@ class Daemon:
 		cloud_proxy_country_code: str | None = None,
 		cloud_timeout: int | None = None,
 		session: str = 'default',
+		proxy_url: str | None = None,
+		proxy_bypass: str | None = None,
+		proxy_username: str | None = None,
+		proxy_password: str | None = None,
 	) -> None:
 		from browser_use.skill_cli.utils import validate_session_name
 
@@ -53,6 +57,10 @@ class Daemon:
 		self.cloud_profile_id = cloud_profile_id
 		self.cloud_proxy_country_code = cloud_proxy_country_code
 		self.cloud_timeout = cloud_timeout
+		self.proxy_url = proxy_url
+		self.proxy_bypass = proxy_bypass
+		self.proxy_username = proxy_username
+		self.proxy_password = proxy_password
 		self.running = True
 		self._server: asyncio.Server | None = None
 		self._shutdown_event = asyncio.Event()
@@ -127,6 +135,10 @@ class Daemon:
 				cloud_profile_id=self.cloud_profile_id,
 				cloud_proxy_country_code=self.cloud_proxy_country_code,
 				cloud_timeout=self.cloud_timeout,
+				proxy_url=self.proxy_url,
+				proxy_bypass=self.proxy_bypass,
+				proxy_username=self.proxy_username,
+				proxy_password=self.proxy_password,
 			)
 
 			try:
@@ -290,6 +302,7 @@ class Daemon:
 						'profile': self.profile,
 						'cdp_url': live_cdp_url,
 						'use_cloud': self.use_cloud,
+						'proxy_url': self.proxy_url,
 					},
 				}
 
@@ -510,10 +523,17 @@ def main() -> None:
 	parser.add_argument('--cloud-profile-id', help='Cloud browser profile ID')
 	parser.add_argument('--cloud-proxy-country', help='Cloud browser proxy country code')
 	parser.add_argument('--cloud-timeout', type=int, help='Cloud browser timeout in minutes')
+	parser.add_argument(
+		'--proxy-url',
+		help='Proxy server for local Chromium (e.g. http://host:8080 or socks5://host:1080)',
+	)
+	parser.add_argument('--proxy-bypass', help='Comma-separated hosts to bypass proxy')
+	parser.add_argument('--proxy-username', help='Proxy auth username')
+	parser.add_argument('--proxy-password', help='Proxy auth password')
 	args = parser.parse_args()
 
 	logger.info(
-		f'Starting daemon: session={args.session}, headed={args.headed}, profile={args.profile}, cdp_url={args.cdp_url}, use_cloud={args.use_cloud}'
+		f'Starting daemon: session={args.session}, headed={args.headed}, profile={args.profile}, cdp_url={args.cdp_url}, use_cloud={args.use_cloud}, proxy={bool(args.proxy_url)}'
 	)
 
 	daemon = Daemon(
@@ -525,6 +545,10 @@ def main() -> None:
 		cloud_proxy_country_code=args.cloud_proxy_country,
 		cloud_timeout=args.cloud_timeout,
 		session=args.session,
+		proxy_url=args.proxy_url,
+		proxy_bypass=args.proxy_bypass,
+		proxy_username=args.proxy_username,
+		proxy_password=args.proxy_password,
 	)
 
 	exit_code = 0

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -450,6 +450,9 @@ def ensure_daemon(
 					and data.get('cdp_url') == cdp_url
 					and data.get('use_cloud') == use_cloud
 					and data.get('proxy_url') == proxy_url
+					and data.get('proxy_bypass') == proxy_bypass
+					and data.get('proxy_username') == proxy_username
+					and data.get('proxy_password_set', False) == bool(proxy_password)
 				):
 					return  # Already running with correct config
 

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -1057,12 +1057,14 @@ def _handle_sessions(args: argparse.Namespace) -> int:
 				if resp.get('success'):
 					data = resp.get('data', {})
 					config_parts = []
+					live_cdp_url = data.get('live_cdp_url') or data.get('cdp_url')
 					if data.get('headed'):
 						config_parts.append('headed')
 					if data.get('profile'):
 						config_parts.append(f'profile={data["profile"]}')
+					if live_cdp_url:
+						entry['cdp_url'] = live_cdp_url
 					if data.get('cdp_url'):
-						entry['cdp_url'] = data['cdp_url']
 						if not data.get('use_cloud'):
 							config_parts.append('cdp')
 					if data.get('use_cloud'):

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -426,6 +426,10 @@ def ensure_daemon(
 	cloud_profile_id: str | None = None,
 	cloud_proxy_country_code: str | None = None,
 	cloud_timeout: int | None = None,
+	proxy_url: str | None = None,
+	proxy_bypass: str | None = None,
+	proxy_username: str | None = None,
+	proxy_password: str | None = None,
 ) -> None:
 	"""Start daemon if not running. Uses state file for phase-aware decisions."""
 	probe = _probe_session(session)
@@ -445,6 +449,7 @@ def ensure_daemon(
 					and data.get('profile') == profile
 					and data.get('cdp_url') == cdp_url
 					and data.get('use_cloud') == use_cloud
+					and data.get('proxy_url') == proxy_url
 				):
 					return  # Already running with correct config
 
@@ -518,6 +523,14 @@ def ensure_daemon(
 		cmd.extend(['--cloud-proxy-country', cloud_proxy_country_code])
 	if cloud_timeout is not None:
 		cmd.extend(['--cloud-timeout', str(cloud_timeout)])
+	if proxy_url is not None:
+		cmd.extend(['--proxy-url', proxy_url])
+	if proxy_bypass is not None:
+		cmd.extend(['--proxy-bypass', proxy_bypass])
+	if proxy_username is not None:
+		cmd.extend(['--proxy-username', proxy_username])
+	if proxy_password is not None:
+		cmd.extend(['--proxy-password', proxy_password])
 
 	# Set up environment
 	env = os.environ.copy()
@@ -655,6 +668,18 @@ Setup:
 	parser.add_argument('--json', action='store_true', help='Output as JSON')
 	parser.add_argument('--mcp', action='store_true', help='Run as MCP server (JSON-RPC via stdin/stdout)')
 	parser.add_argument('--template', help='Generate template file (use with --output for custom path)')
+	parser.add_argument(
+		'--proxy-url',
+		default=None,
+		help='Proxy server for local Chromium (e.g. http://host:8080 or socks5://host:1080)',
+	)
+	parser.add_argument(
+		'--proxy-bypass',
+		default=None,
+		help='Comma-separated hosts to bypass proxy (e.g. localhost,127.0.0.1,*.internal)',
+	)
+	parser.add_argument('--proxy-username', default=None, help='Proxy auth username')
+	parser.add_argument('--proxy-password', default=None, help='Proxy auth password')
 
 	subparsers = parser.add_subparsers(dest='command', help='Command to execute')
 
@@ -1451,8 +1476,29 @@ def main() -> int:
 	_migrate_legacy_files()
 
 	# Ensure daemon is running
-	explicit_config = any(flag in sys.argv for flag in ('--headed', '--profile', '--cdp-url'))
-	ensure_daemon(args.headed, args.profile, args.cdp_url, session=session, explicit_config=explicit_config)
+	explicit_config = any(
+		flag in sys.argv
+		for flag in (
+			'--headed',
+			'--profile',
+			'--cdp-url',
+			'--proxy-url',
+			'--proxy-bypass',
+			'--proxy-username',
+			'--proxy-password',
+		)
+	)
+	ensure_daemon(
+		args.headed,
+		args.profile,
+		args.cdp_url,
+		session=session,
+		explicit_config=explicit_config,
+		proxy_url=args.proxy_url,
+		proxy_bypass=args.proxy_bypass,
+		proxy_username=args.proxy_username,
+		proxy_password=args.proxy_password,
+	)
 
 	# Build params from args
 	params = {}

--- a/browser_use/skill_cli/sessions.py
+++ b/browser_use/skill_cli/sessions.py
@@ -30,6 +30,25 @@ class SessionInfo:
 	use_cloud: bool = False
 
 
+def _build_local_proxy(
+	proxy_url: str | None,
+	proxy_bypass: str | None,
+	proxy_username: str | None,
+	proxy_password: str | None,
+) -> dict | None:
+	"""Build a ProxySettings-compatible dict for BrowserProfile, or None if no proxy."""
+	if not proxy_url:
+		return None
+	proxy: dict = {'server': proxy_url}
+	if proxy_bypass:
+		proxy['bypass'] = proxy_bypass
+	if proxy_username:
+		proxy['username'] = proxy_username
+	if proxy_password:
+		proxy['password'] = proxy_password
+	return proxy
+
+
 async def create_browser_session(
 	headed: bool,
 	profile: str | None,
@@ -38,6 +57,10 @@ async def create_browser_session(
 	cloud_profile_id: str | None = None,
 	cloud_proxy_country_code: str | None = None,
 	cloud_timeout: int | None = None,
+	proxy_url: str | None = None,
+	proxy_bypass: str | None = None,
+	proxy_username: str | None = None,
+	proxy_password: str | None = None,
 ) -> CLIBrowserSession:
 	"""Create BrowserSession based on connection mode.
 
@@ -45,6 +68,10 @@ async def create_browser_session(
 	- Cloud: Provision a cloud browser via BrowserSession(use_cloud=True)
 	- With profile: User's real Chrome with the specified profile
 	- No profile: Playwright-managed Chromium (default)
+
+	When proxy_url is set and the session is local (no cdp_url, not cloud),
+	the proxy is forwarded to Chromium via BrowserProfile.proxy, which
+	translates to --proxy-server=<url> on launch.
 	"""
 	if cdp_url is not None:
 		return CLIBrowserSession(cdp_url=cdp_url)  # type: ignore[call-arg]
@@ -59,8 +86,13 @@ async def create_browser_session(
 			kwargs['cloud_timeout'] = cloud_timeout
 		return CLIBrowserSession(**kwargs)  # type: ignore[call-arg]
 
+	local_proxy = _build_local_proxy(proxy_url, proxy_bypass, proxy_username, proxy_password)
+
 	if profile is None:
-		return CLIBrowserSession(headless=not headed)  # type: ignore[call-arg]
+		local_kwargs: dict = {'headless': not headed}
+		if local_proxy is not None:
+			local_kwargs['proxy'] = local_proxy
+		return CLIBrowserSession(**local_kwargs)  # type: ignore[call-arg]
 
 	from browser_use.skill_cli.utils import find_chrome_executable, get_chrome_profile_path, list_chrome_profiles
 
@@ -100,9 +132,12 @@ async def create_browser_session(
 				lines.append(f'  "{p["name"]}" ({p["directory"]})')
 			raise RuntimeError('\n'.join(lines))
 
-	return CLIBrowserSession(
-		executable_path=chrome_path,  # type: ignore[call-arg]
-		user_data_dir=user_data_dir,  # type: ignore[call-arg]
-		profile_directory=profile_directory,  # type: ignore[call-arg]
-		headless=not headed,  # type: ignore[call-arg]
-	)
+	real_chrome_kwargs: dict = {
+		'executable_path': chrome_path,
+		'user_data_dir': user_data_dir,
+		'profile_directory': profile_directory,
+		'headless': not headed,
+	}
+	if local_proxy is not None:
+		real_chrome_kwargs['proxy'] = local_proxy
+	return CLIBrowserSession(**real_chrome_kwargs)  # type: ignore[call-arg]

--- a/tests/ci/test_cli_lifecycle.py
+++ b/tests/ci/test_cli_lifecycle.py
@@ -5,6 +5,8 @@ Daemons bind sockets and write state/PID files without launching browsers
 (lazy session creation means the daemon is ready after socket bind).
 """
 
+import argparse
+import asyncio
 import json
 import os
 import signal
@@ -13,6 +15,8 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -253,6 +257,91 @@ def test_probe_session_corrupt_state_file(home_dir):
 			os.environ.pop('BROWSER_USE_HOME', None)
 		else:
 			os.environ['BROWSER_USE_HOME'] = old_env
+
+
+def test_ensure_daemon_reuses_local_session_after_live_cdp_url_appears(monkeypatch):
+	"""Live browser CDP URLs must not trip config-mismatch for local sessions."""
+	from browser_use.skill_cli.daemon import Daemon
+	from browser_use.skill_cli.main import _SessionProbe, ensure_daemon
+
+	daemon = Daemon(
+		headed=True,
+		profile=None,
+		session='default',
+		proxy_url='http://proxy.local:3128',
+	)
+	daemon._session = cast(
+		Any,
+		SimpleNamespace(browser_session=SimpleNamespace(cdp_url='ws://127.0.0.1/devtools/browser/live')),
+	)
+
+	monkeypatch.setattr(
+		'browser_use.skill_cli.main._probe_session',
+		lambda _session: _SessionProbe(
+			name='default',
+			pid=123,
+			pid_alive=True,
+			socket_reachable=True,
+		),
+	)
+	monkeypatch.setattr(
+		'browser_use.skill_cli.main.send_command',
+		lambda action, params, session='default': asyncio.run(daemon.dispatch({'action': action, 'id': 'test-ping'})),
+	)
+
+	ensure_daemon(
+		True,
+		None,
+		session='default',
+		explicit_config=True,
+		proxy_url='http://proxy.local:3128',
+	)
+
+
+def test_handle_sessions_json_prefers_live_cdp_url(monkeypatch, home_dir, capsys):
+	"""Sessions output should still show the live browser CDP URL when present."""
+	from browser_use.skill_cli.main import _handle_sessions, _SessionProbe
+
+	(home_dir / 'default.pid').write_text('123')
+	monkeypatch.setenv('BROWSER_USE_HOME', str(home_dir))
+	monkeypatch.setattr(
+		'browser_use.skill_cli.main._probe_session',
+		lambda _session: _SessionProbe(
+			name='default',
+			phase='running',
+			pid=123,
+			pid_alive=True,
+			socket_reachable=True,
+		),
+	)
+	monkeypatch.setattr(
+		'browser_use.skill_cli.main.send_command',
+		lambda action, params, session='default': {
+			'success': True,
+			'data': {
+				'headed': True,
+				'profile': None,
+				'cdp_url': None,
+				'live_cdp_url': 'ws://127.0.0.1/devtools/browser/live',
+				'use_cloud': False,
+			},
+		},
+	)
+
+	assert _handle_sessions(argparse.Namespace(json=True)) == 0
+
+	payload = json.loads(capsys.readouterr().out)
+	assert payload == {
+		'sessions': [
+			{
+				'name': 'default',
+				'pid': 123,
+				'phase': 'running',
+				'cdp_url': 'ws://127.0.0.1/devtools/browser/live',
+				'config': 'headed',
+			}
+		]
+	}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The `browser-use` CLI already supports `--cloud-proxy-country` for cloud sessions, but there is no way to configure a proxy for **local/managed Chromium** sessions. Any agent whose outbound traffic must go through an HTTP/SOCKS5 proxy — corporate egress gateways, geo-located research (per-country tinyproxy exit nodes), CI runners behind a firewall — ends up routing through the host's native IP instead, regardless of env vars (Chromium does not honor `HTTP_PROXY` natively).

We hit this running geo-scoped webshop audits through 22 per-country GCE tinyproxy exits. The CLI happily reported "using proxy" in logs, but `ipinfo.io/ip` returned the VM's native IP on every call. Surprising and hard to diagnose.

## What

Four new top-level CLI flags that apply to local Chromium sessions:

- `--proxy-url` — e.g. `http://host:8080` or `socks5://host:1080`
- `--proxy-bypass` — comma-separated bypass hosts, same shape as Chrome's `--proxy-bypass-list`
- `--proxy-username` / `--proxy-password` — for authenticated proxies

Example:

```
browser-use --proxy-url http://10.0.0.5:3128 --session x open https://ipinfo.io/ip
```

## How

Minimal plumbing change — `BrowserProfile.proxy` already translates to `--proxy-server=<url>` on Chromium launch, so nothing needed to change in the browser layer:

- **`skill_cli/main.py`** — register the four flags on the top-level parser, forward them through `ensure_daemon()` to the spawned daemon process, include them in the \`explicit_config\` fingerprint so a mismatched proxy fails loudly rather than silently reusing a non-proxied daemon.
- **`skill_cli/daemon.py`** — accept the same four args, thread them to `create_browser_session()`, include `proxy_url` in the \`ping\` response so the main CLI's config-mismatch check works.
- **`skill_cli/sessions.py`** — a small `_build_local_proxy()` helper assembles a dict compatible with `ProxySettings` and passes it as `proxy=` to `CLIBrowserSession` for both the Playwright-Chromium and real-Chrome branches. Cloud and CDP paths are untouched.

## Validation

Run against an unreachable proxy — confirms the flag actually reaches Chromium:

```
$ browser-use --session test open https://example.com
url: https://example.com          # ✓ loads normally

$ browser-use --session test2 --proxy-url http://127.0.0.1:9 open https://example.com
Error: Navigation failed: net::ERR_PROXY_CONNECTION_FAILED   # ✓ proxy applied
```

The `ERR_PROXY_CONNECTION_FAILED` is the definitive signal: Chromium tried to route through the (unreachable) proxy, so `--proxy-server=http://127.0.0.1:9` made it to the browser launch.

## Non-goals

- No change to cloud sessions (`--cloud-proxy-country` stays the way to pick a cloud proxy).
- No change to CDP-URL mode (proxy is the client's responsibility when connecting to an existing browser).
- No env-var reading — Chromium doesn't honor `HTTP_PROXY` natively, so quietly picking it up would re-introduce the exact silent-failure mode this PR is trying to fix. Users who want env-var semantics can pipe through their shell: `--proxy-url "\$HTTPS_PROXY"`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--proxy-url` with optional `--proxy-bypass`, `--proxy-username`, and `--proxy-password` to route local Chromium sessions through HTTP/SOCKS5 proxies, and prevents false config mismatches after local launch when a live CDP URL appears.

- New Features
  - Local-only; cloud (`--cloud-proxy-country`) and CDP are unchanged.
  - Flags are forwarded via the daemon to `create_browser_session()` and applied as Chromium `--proxy-server` through `BrowserProfile.proxy`.
  - Daemon ping includes `proxy_url`, `proxy_bypass`, `proxy_username`, and `proxy_password_set`; the CLI compares all four to detect config mismatches without exposing the password.

- Bug Fixes
  - Avoid false mismatch when a live CDP URL appears for local sessions: ping returns both `cdp_url` (configured) and `live_cdp_url`; the config check compares only the configured URL.
  - `sessions` output prefers `live_cdp_url` for display when available.

<sup>Written for commit e084aae3a8ff30ea3d5482428bcb396f0abdcb88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

