### PR TITLE
fix: remove dead code in optimize_schema()

### DIFF
--- a/browser_use/llm/schema.py
+++ b/browser_use/llm/schema.py
@@ -57,10 +57,6 @@ class SchemaOptimizer:
 						if value:  # Only include non-empty descriptions
 							optimized[key] = value
 
-					# Handle type field - must recursively process in case value contains $ref
-					elif key == 'type':
-						optimized[key] = value if not isinstance(value, (dict, list)) else optimize_schema(value, defs_lookup)
-
 					# FLATTEN: Resolve $ref by inlining the actual definition
 					elif key == '$ref' and defs_lookup:
 						ref_path = value.split('/')[-1]  # Get the definition name from "#/$defs/SomeName"


### PR DESCRIPTION
Removes unreachable dead code in SchemaOptimizer.optimize_schema(). The 'elif key == type' branch was dead code because 'type' is already handled in the later essential validation fields branch. Fixes #4703

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unreachable code in `optimize_schema()` by deleting the early `'type'` branch, which duplicated logic handled later for essential validation fields. No behavior change; improves readability and fixes #4703.

<sup>Written for commit 4d44aafe3a663b9d5705c139d1316ddb1a2080a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

