### PR TITLE
fix(schema): remove unreachable 'type' key from validation fields list

### DIFF
--- a/browser_use/llm/schema.py
+++ b/browser_use/llm/schema.py
@@ -89,7 +89,6 @@ class SchemaOptimizer:
 
 					# Keep essential validation fields
 					elif key in [
-						'type',
 						'required',
 						'minimum',
 						'maximum',


### PR DESCRIPTION
## Summary
- Remove unreachable `'type'` key from the validation fields list in `optimize_schema()`
- The `'type'` key is already handled by an earlier `elif key == 'type':` branch (line ~61), so its presence in the later `elif key in [...]` block (line ~91) is dead code

## Fix
In `browser_use/llm/schema.py`, removed `'type'` from the `elif key in [...]` block since it's already caught by the earlier `elif key == 'type':` branch.

## Test plan
- [x] pyright type check passes (0 errors)
- [ ] Add test if needed

Fixes #4703

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unreachable 'type' key from the validation fields list in optimize_schema(), since 'type' is already handled earlier. This removes dead code and clarifies the validation logic.

<sup>Written for commit c4f712b90b73cee6c493273e3d34946cbfbacc8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

