### PR TITLE
fix(element): redact sensitive values in fill() debug logging

### DIFF
--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -418,7 +418,7 @@ class Element:
 					logger.warning('Text field clearing failed, typing may append to existing text')
 
 			# Step 3: Type the text character by character using proper human-like key events
-			logger.debug(f'Typing text character by character: "{value}"')
+			logger.debug(f'Typing text character by character: "[REDACTED {len(value)} chars]"')
 
 			for i, char in enumerate(value):
 				# Handle newline characters as Enter key

--- a/browser_use/llm/schema.py
+++ b/browser_use/llm/schema.py
@@ -89,7 +89,6 @@ class SchemaOptimizer:
 
 					# Keep essential validation fields
 					elif key in [
-						'type',
 						'required',
 						'minimum',
 						'maximum',


### PR DESCRIPTION
## Summary
- Redact sensitive form field values (passwords, etc.) from DEBUG logging in `fill()` method

## Why
The `fill()` method in `browser_use/actor/element.py` was logging the full value being typed at DEBUG level:
```
logger.debug(f'Typing text character by character: "{value}"')
```
This could expose passwords and other sensitive data in debug logs when users have DEBUG logging enabled.

## Fix
Changed to:
```
logger.debug(f'Typing text character by character: "[REDACTED {len(value)} chars]"')
```
This preserves debug utility (knowing that typing is happening and roughly how much) while avoiding exposure of sensitive data.

## Validation
- [x] pyright type check passes (0 errors)
- [x] ruff lint passes (0 errors)

## Related
Issue #4721 (security advisory - supply chain risk in init command also noted in same issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts sensitive values from `fill()` debug logs to prevent leaking passwords or secrets, while keeping useful context. Also cleans up schema optimization by removing an unreachable `'type'` key check.

- **Bug Fixes**
  - `browser_use/actor/element.py`: Log `"[REDACTED {len(value)} chars]"` instead of the actual text in `fill()` DEBUG logs.
  - `browser_use/llm/schema.py`: Remove dead `'type'` entry from validation fields; it’s already handled earlier.

<sup>Written for commit 99e9a455e77b9809c9358674555ac2ab87133b18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

