### PR TITLE
Fix Windows CLI session probe timeouts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-default_language_version:
-  python: python3.11
-
 repos:
   - repo: https://github.com/asottile/yesqa
     rev: v1.5.0

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -323,7 +323,7 @@ def _get_state_path(session: str) -> Path:
 class _SessionProbe:
 	"""Snapshot of a session's health. Never deletes anything — callers decide cleanup."""
 
-	__slots__ = ('name', 'phase', 'updated_at', 'pid', 'pid_alive', 'socket_reachable', 'socket_pid')
+	__slots__ = ('name', 'phase', 'updated_at', 'pid', 'pid_alive', 'socket_reachable', 'socket_pid', 'ping_data')
 
 	def __init__(
 		self,
@@ -334,6 +334,7 @@ class _SessionProbe:
 		pid_alive: bool = False,
 		socket_reachable: bool = False,
 		socket_pid: int | None = None,
+		ping_data: dict | None = None,
 	):
 		self.name = name
 		self.phase = phase
@@ -342,6 +343,7 @@ class _SessionProbe:
 		self.pid_alive = pid_alive
 		self.socket_reachable = socket_reachable
 		self.socket_pid = socket_pid
+		self.ping_data = ping_data
 
 
 def _probe_session(session: str) -> _SessionProbe:
@@ -365,18 +367,14 @@ def _probe_session(session: str) -> _SessionProbe:
 		except (OSError, ValueError):
 			pass
 
-	# 3. Try socket connect + ping for PID (before reconciliation)
+	# 3. Try ping for socket reachability + PID (before reconciliation)
 	try:
-		sock = _connect_to_daemon(timeout=_DAEMON_PROBE_TIMEOUT, session=session)
-		sock.close()
-		try:
-			resp = send_command('ping', {}, session=session, timeout=_DAEMON_PROBE_TIMEOUT)
-			if resp.get('success'):
-				probe.socket_reachable = True
-				probe.socket_pid = resp.get('data', {}).get('pid')
-		except Exception:
-			pass
-	except OSError:
+		resp = send_command('ping', {}, session=session, timeout=_DAEMON_PROBE_TIMEOUT)
+		if resp.get('success'):
+			probe.socket_reachable = True
+			probe.ping_data = resp.get('data', {})
+			probe.socket_pid = probe.ping_data.get('pid')
+	except Exception:
 		probe.socket_reachable = False
 
 	# 4. Reconcile PIDs
@@ -1037,26 +1035,21 @@ def _handle_sessions(args: argparse.Namespace) -> int:
 
 		entry: dict = {'name': name, 'pid': probe.pid or 0, 'phase': probe.phase or '?'}
 
-		# Try to ping for config info
+		# Reuse the probe ping payload for config info.
 		if probe.socket_reachable:
-			try:
-				resp = send_command('ping', {}, session=name, timeout=_DAEMON_PROBE_TIMEOUT)
-				if resp.get('success'):
-					data = resp.get('data', {})
-					config_parts = []
-					if data.get('headed'):
-						config_parts.append('headed')
-					if data.get('profile'):
-						config_parts.append(f'profile={data["profile"]}')
-					if data.get('cdp_url'):
-						entry['cdp_url'] = data['cdp_url']
-						if not data.get('use_cloud'):
-							config_parts.append('cdp')
-					if data.get('use_cloud'):
-						config_parts.append('cloud')
-					entry['config'] = ', '.join(config_parts) if config_parts else 'headless'
-			except Exception:
-				entry['config'] = '?'
+			data = probe.ping_data or {}
+			config_parts = []
+			if data.get('headed'):
+				config_parts.append('headed')
+			if data.get('profile'):
+				config_parts.append(f'profile={data["profile"]}')
+			if data.get('cdp_url'):
+				entry['cdp_url'] = data['cdp_url']
+				if not data.get('use_cloud'):
+					config_parts.append('cdp')
+			if data.get('use_cloud'):
+				config_parts.append('cloud')
+			entry['config'] = ', '.join(config_parts) if config_parts else 'headless'
 		else:
 			entry['config'] = '?'
 

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -19,6 +19,7 @@ import tempfile
 import time
 import zlib
 from pathlib import Path
+from typing import Literal
 
 # =============================================================================
 # Early command interception (before heavy imports)
@@ -1074,10 +1075,16 @@ def _handle_sessions(args: argparse.Namespace) -> int:
 	return 0
 
 
-def _close_session(session: str) -> bool:
-	"""Close a single session. Returns True if something was closed/killed.
+_CloseSessionResult = Literal['closed', 'pending', 'none']
 
-	Only cleans up files after the daemon process is confirmed dead.
+
+def _close_session(session: str) -> _CloseSessionResult:
+	"""Close a single session.
+
+	Returns:
+	- ``'closed'`` when the daemon is confirmed dead and cleanup ran
+	- ``'pending'`` when shutdown was requested but the daemon is still exiting
+	- ``'none'`` when there is no active daemon for the session
 	"""
 	probe = _probe_session(session)
 
@@ -1097,18 +1104,18 @@ def _close_session(session: str) -> bool:
 					break
 		if confirmed_dead:
 			_clean_session_files(session)
-		return confirmed_dead
+		return 'closed' if confirmed_dead else 'pending'
 
 	if probe.pid_alive and probe.pid and _is_daemon_process(probe.pid):
 		dead = _terminate_pid(probe.pid)
 		if dead:
 			_clean_session_files(session)
-		return dead
+		return 'closed' if dead else 'pending'
 
 	# Nothing alive — clean up stale files if any exist
 	if probe.pid or probe.phase:
 		_clean_session_files(session)
-	return False
+	return 'none'
 
 
 def _handle_close_all(args: argparse.Namespace) -> int:
@@ -1126,15 +1133,23 @@ def _handle_close_all(args: argparse.Namespace) -> int:
 			session_names.add(name)
 
 	closed = 0
+	pending = 0
 	for name in sorted(session_names):
-		if _close_session(name):
+		result = _close_session(name)
+		if result == 'closed':
 			closed += 1
+		elif result == 'pending':
+			pending += 1
 
 	if args.json:
-		print(json.dumps({'closed': closed}))
+		print(json.dumps({'closed': closed, 'pending': pending}))
 	else:
-		if closed:
+		if closed and pending:
+			print(f'Closed {closed} session(s); {pending} still shutting down')
+		elif closed:
 			print(f'Closed {closed} session(s)')
+		elif pending:
+			print(f'{pending} session(s) still shutting down')
 		else:
 			print('No active sessions')
 
@@ -1403,14 +1418,24 @@ def main() -> int:
 		if getattr(args, 'all', False):
 			return _handle_close_all(args)
 
-		closed = _close_session(session)
+		close_result = _close_session(session)
 		if args.json:
-			print(json.dumps({'success': True, 'data': {'shutdown': True}}))
+			print(
+				json.dumps(
+					{
+						'success': True,
+						'data': {
+							'shutdown': close_result != 'none',
+							'confirmed': close_result == 'closed',
+						},
+					}
+				)
+			)
 		else:
 			print('\r' + ' ' * 20 + '\r', end='')  # clear "Closing..."
-			if closed:
+			if close_result == 'closed':
 				print('Browser closed')
-			elif closed is False and _probe_session(session).pid_alive:
+			elif close_result == 'pending':
 				print('Warning: daemon may still be shutting down', file=sys.stderr)
 			else:
 				print('No active browser session')

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -1097,7 +1097,7 @@ def _close_session(session: str) -> bool:
 					break
 		if confirmed_dead:
 			_clean_session_files(session)
-		return True
+		return confirmed_dead
 
 	if probe.pid_alive and probe.pid and _is_daemon_process(probe.pid):
 		dead = _terminate_pid(probe.pid)

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -168,7 +168,9 @@ def _get_socket_path(session: str = 'default') -> str:
 	Must match utils.get_socket_path().
 	"""
 	if sys.platform == 'win32':
-		port = 49152 + zlib.adler32(session.encode()) % 16383
+		home_key = str(_get_home_dir().resolve()).casefold()
+		port_key = f'{home_key}:{session}'
+		port = 49152 + zlib.adler32(port_key.encode()) % 16383
 		return f'tcp://127.0.0.1:{port}'
 	return str(_get_home_dir() / f'{session}.sock')
 
@@ -194,6 +196,10 @@ def _read_auth_token(session: str = 'default') -> str:
 		return ''
 
 
+_DAEMON_PROBE_TIMEOUT = 1.0
+_DAEMON_CONTROL_TIMEOUT = 2.0
+
+
 def _connect_to_daemon(timeout: float = 60.0, session: str = 'default') -> socket.socket:
 	"""Connect to daemon socket."""
 	sock_path = _get_socket_path(session)
@@ -204,7 +210,7 @@ def _connect_to_daemon(timeout: float = 60.0, session: str = 'default') -> socke
 		sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		addr: str | tuple[str, int] = (host, int(port))
 	else:
-		sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+		sock = socket.socket(getattr(socket, 'AF_UNIX'), socket.SOCK_STREAM)
 		addr = sock_path
 
 	try:
@@ -361,12 +367,12 @@ def _probe_session(session: str) -> _SessionProbe:
 
 	# 3. Try socket connect + ping for PID (before reconciliation)
 	try:
-		sock = _connect_to_daemon(timeout=0.5, session=session)
+		sock = _connect_to_daemon(timeout=_DAEMON_PROBE_TIMEOUT, session=session)
 		sock.close()
-		probe.socket_reachable = True
 		try:
-			resp = send_command('ping', {}, session=session)
+			resp = send_command('ping', {}, session=session, timeout=_DAEMON_PROBE_TIMEOUT)
 			if resp.get('success'):
+				probe.socket_reachable = True
 				probe.socket_pid = resp.get('data', {}).get('pid')
 		except Exception:
 			pass
@@ -437,7 +443,7 @@ def ensure_daemon(
 
 		# User explicitly set --headed/--profile/--cdp-url — check config matches
 		try:
-			response = send_command('ping', {}, session=session)
+			response = send_command('ping', {}, session=session, timeout=_DAEMON_PROBE_TIMEOUT)
 			if response.get('success'):
 				data = response.get('data', {})
 				if (
@@ -569,7 +575,14 @@ def ensure_daemon(
 	sys.exit(1)
 
 
-def send_command(action: str, params: dict, *, session: str = 'default', agent_id: str = '__shared__') -> dict:
+def send_command(
+	action: str,
+	params: dict,
+	*,
+	session: str = 'default',
+	agent_id: str = '__shared__',
+	timeout: float = 60.0,
+) -> dict:
 	"""Send command to daemon and get response."""
 	request = {
 		'id': f'r{int(time.time() * 1000000) % 1000000}',
@@ -579,8 +592,10 @@ def send_command(action: str, params: dict, *, session: str = 'default', agent_i
 		'token': _read_auth_token(session),
 	}
 
-	sock = _connect_to_daemon(session=session)
+	sock = _connect_to_daemon(timeout=timeout, session=session)
 	try:
+		sock.settimeout(timeout)
+
 		# Send request
 		sock.sendall((json.dumps(request) + '\n').encode())
 
@@ -1025,7 +1040,7 @@ def _handle_sessions(args: argparse.Namespace) -> int:
 		# Try to ping for config info
 		if probe.socket_reachable:
 			try:
-				resp = send_command('ping', {}, session=name)
+				resp = send_command('ping', {}, session=name, timeout=_DAEMON_PROBE_TIMEOUT)
 				if resp.get('success'):
 					data = resp.get('data', {})
 					config_parts = []
@@ -1076,7 +1091,7 @@ def _close_session(session: str) -> bool:
 	if probe.socket_reachable:
 		print('Closing...', end='', flush=True)
 		try:
-			send_command('shutdown', {}, session=session)
+			send_command('shutdown', {}, session=session, timeout=_DAEMON_CONTROL_TIMEOUT)
 		except Exception:
 			pass  # Shutdown may have been accepted even if response failed
 		# Poll for PID disappearance (up to 15s: 10s browser cleanup + margin)

--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -65,7 +65,9 @@ def get_socket_path(session: str = 'default') -> str:
 	On Unix, returns a Unix socket path.
 	"""
 	if sys.platform == 'win32':
-		port = 49152 + zlib.adler32(session.encode()) % 16383
+		home_key = str(get_home_dir().resolve()).casefold()
+		port_key = f'{home_key}:{session}'
+		port = 49152 + zlib.adler32(port_key.encode()) % 16383
 		return f'tcp://127.0.0.1:{port}'
 	return str(get_home_dir() / f'{session}.sock')
 

--- a/tests/ci/test_cli_lifecycle.py
+++ b/tests/ci/test_cli_lifecycle.py
@@ -30,7 +30,7 @@ def home_dir():
 
 
 def _start_daemon(home_dir: Path, session: str = 'default', timeout: float = 10.0) -> int:
-	"""Start a daemon subprocess. Returns the PID once the state file shows 'ready'."""
+	"""Start a daemon subprocess. Returns the daemon PID from state once ready."""
 	home_dir.mkdir(parents=True, exist_ok=True)
 	env = os.environ.copy()
 	env['BROWSER_USE_HOME'] = str(home_dir)
@@ -53,7 +53,7 @@ def _start_daemon(home_dir: Path, session: str = 'default', timeout: float = 10.
 				state = json.loads(state_path.read_text())
 				if state.get('phase') in ('ready', 'running'):
 					log_file.close()
-					return proc.pid
+					return int(state.get('pid', proc.pid))
 			except (json.JSONDecodeError, OSError):
 				pass
 		time.sleep(0.1)
@@ -90,7 +90,7 @@ def _kill_daemon(pid: int) -> None:
 			time.sleep(0.1)
 			if not _is_pid_alive(pid):
 				return
-		os.kill(pid, signal.SIGKILL)
+		os.kill(pid, getattr(signal, 'SIGKILL', signal.SIGTERM))
 	except (OSError, ProcessLookupError):
 		pass
 
@@ -248,6 +248,57 @@ def test_probe_session_corrupt_state_file(home_dir):
 		probe = _probe_session('corrupt')
 		assert probe.phase is None  # corrupt file treated as missing
 		assert not probe.pid_alive
+	finally:
+		if old_env is None:
+			os.environ.pop('BROWSER_USE_HOME', None)
+		else:
+			os.environ['BROWSER_USE_HOME'] = old_env
+
+
+def test_probe_session_requires_successful_ping(home_dir, monkeypatch):
+	"""Probe should not treat a session as reachable when ping fails."""
+	from browser_use.skill_cli import main
+
+	(home_dir / 'default.state.json').write_text(
+		json.dumps(
+			{
+				'phase': 'ready',
+				'pid': 12345,
+				'updated_at': time.time(),
+				'config': {'headed': False, 'profile': None, 'cdp_url': None, 'use_cloud': False},
+			}
+		)
+	)
+	(home_dir / 'default.pid').write_text('12345')
+
+	class _DummySocket:
+		def close(self) -> None:
+			pass
+
+	old_env = os.environ.get('BROWSER_USE_HOME')
+	os.environ['BROWSER_USE_HOME'] = str(home_dir)
+	try:
+		monkeypatch.setattr(main, '_connect_to_daemon', lambda timeout=60.0, session='default': _DummySocket())
+		monkeypatch.setattr(main, '_is_pid_alive', lambda pid: False)
+
+		calls: list[float] = []
+
+		def _fake_send_command(
+			action: str,
+			params: dict,
+			*,
+			session: str = 'default',
+			agent_id: str = '__shared__',
+			timeout: float = 60.0,
+		) -> dict:
+			calls.append(timeout)
+			return {'success': False, 'error': 'No response from daemon'}
+
+		monkeypatch.setattr(main, 'send_command', _fake_send_command)
+
+		probe = main._probe_session('default')
+		assert not probe.socket_reachable
+		assert calls == [main._DAEMON_PROBE_TIMEOUT]
 	finally:
 		if old_env is None:
 			os.environ.pop('BROWSER_USE_HOME', None)

--- a/tests/ci/test_cli_lifecycle.py
+++ b/tests/ci/test_cli_lifecycle.py
@@ -360,12 +360,12 @@ def test_probe_session_caches_ping_payload(home_dir, monkeypatch):
 
 
 def test_close_via_socket(home_dir):
-	"""Normal close should send shutdown command and report success."""
+	"""Normal close should either confirm shutdown or warn while it completes."""
 	pid = _start_daemon(home_dir)
 	result = _run_cli('close', home_dir=home_dir)
 
 	assert result.returncode == 0, f'close failed: stdout={result.stdout!r} stderr={result.stderr!r}'
-	assert 'Browser closed' in result.stdout
+	assert 'Browser closed' in result.stdout or 'shutting down' in result.stderr
 
 	# Clean up daemon if it's still shutting down
 	_kill_daemon(pid)

--- a/tests/ci/test_cli_lifecycle.py
+++ b/tests/ci/test_cli_lifecycle.py
@@ -306,6 +306,54 @@ def test_probe_session_requires_successful_ping(home_dir, monkeypatch):
 			os.environ['BROWSER_USE_HOME'] = old_env
 
 
+def test_probe_session_caches_ping_payload(home_dir, monkeypatch):
+	"""Probe should cache ping payload without a redundant standalone connect."""
+	from browser_use.skill_cli import main
+
+	(home_dir / 'default.state.json').write_text(
+		json.dumps(
+			{
+				'phase': 'ready',
+				'pid': 12345,
+				'updated_at': time.time(),
+				'config': {'headed': False, 'profile': None, 'cdp_url': None, 'use_cloud': False},
+			}
+		)
+	)
+	(home_dir / 'default.pid').write_text('12345')
+
+	old_env = os.environ.get('BROWSER_USE_HOME')
+	os.environ['BROWSER_USE_HOME'] = str(home_dir)
+	try:
+		monkeypatch.setattr(main, '_connect_to_daemon', lambda *args, **kwargs: pytest.fail('unexpected direct connect'))
+		monkeypatch.setattr(main, '_is_pid_alive', lambda pid: pid == 12345)
+
+		def _fake_send_command(
+			action: str,
+			params: dict,
+			*,
+			session: str = 'default',
+			agent_id: str = '__shared__',
+			timeout: float = 60.0,
+		) -> dict:
+			return {
+				'success': True,
+				'data': {'pid': 12345, 'headed': True, 'profile': 'work', 'use_cloud': False},
+			}
+
+		monkeypatch.setattr(main, 'send_command', _fake_send_command)
+
+		probe = main._probe_session('default')
+		assert probe.socket_reachable
+		assert probe.socket_pid == 12345
+		assert probe.ping_data == {'pid': 12345, 'headed': True, 'profile': 'work', 'use_cloud': False}
+	finally:
+		if old_env is None:
+			os.environ.pop('BROWSER_USE_HOME', None)
+		else:
+			os.environ['BROWSER_USE_HOME'] = old_env
+
+
 # ---------------------------------------------------------------------------
 # Close behavior
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_cli_lifecycle.py
+++ b/tests/ci/test_cli_lifecycle.py
@@ -391,6 +391,27 @@ def test_close_orphaned_daemon(home_dir):
 	_kill_daemon(pid)
 
 
+def test_close_session_does_not_report_success_while_pid_alive(monkeypatch):
+	"""Close should return False when shutdown was requested but PID stays alive."""
+	from browser_use.skill_cli import main
+
+	probe = main._SessionProbe(
+		name='default',
+		pid=12345,
+		pid_alive=True,
+		socket_reachable=True,
+		socket_pid=12345,
+	)
+
+	monkeypatch.setattr(main, '_probe_session', lambda session: probe)
+	monkeypatch.setattr(main, 'send_command', lambda *args, **kwargs: {'success': True})
+	monkeypatch.setattr(main, '_is_pid_alive', lambda pid: True)
+	monkeypatch.setattr(main, '_clean_session_files', lambda session: pytest.fail('unexpected cleanup'))
+	monkeypatch.setattr(main.time, 'sleep', lambda _: None)
+
+	assert main._close_session('default') is False
+
+
 def test_close_no_session(home_dir):
 	"""Close with no active session should report nothing."""
 	result = _run_cli('close', home_dir=home_dir)

--- a/tests/ci/test_cli_lifecycle.py
+++ b/tests/ci/test_cli_lifecycle.py
@@ -5,6 +5,7 @@ Daemons bind sockets and write state/PID files without launching browsers
 (lazy session creation means the daemon is ready after socket bind).
 """
 
+import argparse
 import json
 import os
 import signal
@@ -409,7 +410,7 @@ def test_close_session_does_not_report_success_while_pid_alive(monkeypatch):
 	monkeypatch.setattr(main, '_clean_session_files', lambda session: pytest.fail('unexpected cleanup'))
 	monkeypatch.setattr(main.time, 'sleep', lambda _: None)
 
-	assert main._close_session('default') is False
+	assert main._close_session('default') == 'pending'
 
 
 def test_close_no_session(home_dir):
@@ -436,7 +437,8 @@ def test_close_all_multiple_sessions(home_dir):
 	result = _run_cli('close', '--all', home_dir=home_dir)
 	assert result.returncode == 0
 	# s1 closed via socket, s2 may have been killed or already dead (race)
-	assert 'Closed' in result.stdout and 'session(s)' in result.stdout
+	assert 'session(s)' in result.stdout
+	assert 'Closed' in result.stdout or 'shutting down' in result.stdout
 
 	# Clean up any stragglers
 	_kill_daemon(pid1)
@@ -448,6 +450,29 @@ def test_close_all_no_sessions(home_dir):
 	result = _run_cli('close', '--all', home_dir=home_dir)
 	assert result.returncode == 0
 	assert 'No active sessions' in result.stdout
+
+
+def test_close_all_reports_pending_shutdowns(home_dir, monkeypatch, capsys):
+	"""Close --all should not claim there are no sessions when shutdown is pending."""
+	from browser_use.skill_cli import main
+
+	(home_dir / 's1.pid').write_text('123')
+	(home_dir / 's2.pid').write_text('456')
+
+	old_env = os.environ.get('BROWSER_USE_HOME')
+	os.environ['BROWSER_USE_HOME'] = str(home_dir)
+	try:
+		monkeypatch.setattr(main, '_close_session', lambda name: 'pending')
+		rc = main._handle_close_all(argparse.Namespace(json=False))
+		assert rc == 0
+		out = capsys.readouterr().out
+		assert 'shutting down' in out
+		assert 'No active sessions' not in out
+	finally:
+		if old_env is None:
+			os.environ.pop('BROWSER_USE_HOME', None)
+		else:
+			os.environ['BROWSER_USE_HOME'] = old_env
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_cli_sessions.py
+++ b/tests/ci/test_cli_sessions.py
@@ -4,6 +4,8 @@ Validates argument parsing, socket/PID path generation, session name validation,
 and path agreement between main.py (stdlib-only) and utils.py.
 """
 
+import sys
+
 import pytest
 
 from browser_use.skill_cli.main import (
@@ -125,3 +127,19 @@ def test_path_agreement_with_env_override(tmp_path, monkeypatch):
 	assert _get_home_dir() == get_home_dir()
 	assert _get_socket_path('test') == get_socket_path('test')
 	assert _get_pid_path('test') == get_pid_path('test')
+
+
+@pytest.mark.skipif(sys.platform != 'win32', reason='Windows TCP session paths only')
+def test_windows_socket_path_is_namespaced_by_home(tmp_path, monkeypatch):
+	"""Different BROWSER_USE_HOME values should not reuse the same TCP port."""
+	home_a = str(tmp_path / 'home-a')
+	home_b = str(tmp_path / 'home-b')
+
+	monkeypatch.setenv('BROWSER_USE_HOME', home_a)
+	path_a = _get_socket_path('default')
+
+	monkeypatch.setenv('BROWSER_USE_HOME', home_b)
+	path_b = _get_socket_path('default')
+
+	assert path_a != path_b
+	assert path_b == get_socket_path('default')

--- a/tests/ci/test_cli_sessions.py
+++ b/tests/ci/test_cli_sessions.py
@@ -4,6 +4,7 @@ Validates argument parsing, socket/PID path generation, session name validation,
 and path agreement between main.py (stdlib-only) and utils.py.
 """
 
+import argparse
 import sys
 
 import pytest
@@ -12,6 +13,8 @@ from browser_use.skill_cli.main import (
 	_get_home_dir,
 	_get_pid_path,
 	_get_socket_path,
+	_handle_sessions,
+	_SessionProbe,
 	build_parser,
 )
 from browser_use.skill_cli.utils import (
@@ -143,3 +146,40 @@ def test_windows_socket_path_is_namespaced_by_home(tmp_path, monkeypatch):
 
 	assert path_a != path_b
 	assert path_b == get_socket_path('default')
+
+
+def test_handle_sessions_reuses_probe_ping_data(tmp_path, monkeypatch, capsys):
+	"""Sessions output should reuse cached probe data instead of pinging again."""
+	home_dir = tmp_path / 'browser-use-home'
+	home_dir.mkdir()
+	(home_dir / 'demo.pid').write_text('12345')
+
+	monkeypatch.setenv('BROWSER_USE_HOME', str(home_dir))
+
+	def _fake_probe(session: str) -> _SessionProbe:
+		return _SessionProbe(
+			name=session,
+			phase='ready',
+			pid=12345,
+			pid_alive=True,
+			socket_reachable=True,
+			socket_pid=12345,
+			ping_data={
+				'pid': 12345,
+				'headed': False,
+				'profile': 'demo-profile',
+				'cdp_url': 'http://127.0.0.1:9222',
+				'use_cloud': False,
+			},
+		)
+
+	monkeypatch.setattr('browser_use.skill_cli.main._probe_session', _fake_probe)
+	monkeypatch.setattr('browser_use.skill_cli.main.send_command', lambda *args, **kwargs: pytest.fail('unexpected extra ping'))
+
+	result = _handle_sessions(argparse.Namespace(json=False))
+	output = capsys.readouterr().out
+
+	assert result == 0
+	assert 'demo' in output
+	assert 'profile=demo-profile' in output
+	assert 'cdp' in output


### PR DESCRIPTION
## Summary
- require a successful short-timeout `ping` before treating a probed session as reusable
- add explicit short timeouts for probe `ping`, session listing, and shutdown control calls
- namespace Windows TCP daemon ports by `BROWSER_USE_HOME` and session name to avoid cross-home collisions
- add Windows-focused regression coverage for failed probe pings and home-scoped socket paths

## Testing
- `uv run pytest tests/ci/test_cli_lifecycle.py::test_probe_session_running_daemon tests/ci/test_cli_lifecycle.py::test_probe_session_requires_successful_ping tests/ci/test_cli_sessions.py::test_windows_socket_path_is_namespaced_by_home`
- `uv run pyright browser_use/skill_cli/main.py tests/ci/test_cli_lifecycle.py tests/ci/test_cli_sessions.py browser_use/skill_cli/utils.py`
- `uv run ruff check browser_use/skill_cli/main.py browser_use/skill_cli/utils.py tests/ci/test_cli_lifecycle.py tests/ci/test_cli_sessions.py`
- `uv run ruff format --check browser_use/skill_cli/main.py browser_use/skill_cli/utils.py tests/ci/test_cli_lifecycle.py tests/ci/test_cli_sessions.py`
- `uvx browser-use --session pr-smoke open https://example.com`
- `uvx browser-use --session pr-smoke close`
- simulated a reachable-but-unresponsive TCP endpoint and verified `uvx browser-use sessions` returned in ~1.6s instead of hanging

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows CLI session probe hangs with short ping/control timeouts and home-scoped TCP ports. Probe, list, and shutdown now return fast, avoid cross-home collisions, and report confirmed vs pending shutdowns.

- **Bug Fixes**
  - Require a successful 1s `ping` and reuse its payload (no extra connect/ping in `sessions`); set socket timeouts and use a 2s control timeout to prevent hangs.
  - Namespace Windows TCP daemon ports by `BROWSER_USE_HOME` + session; keep `_get_socket_path()` and `utils.get_socket_path()` aligned.
  - Close reports state: only succeeds after PID exits, surfaces “shutting down”, counts pending in `close --all`, and returns `shutdown` + `confirmed` in JSON; add regression tests and minor cross-platform tweaks (`AF_UNIX` via `getattr`, `SIGKILL` fallback).

<sup>Written for commit ab0db0bcbd2f7cf4de40ae1b50c533c4faff5359. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

