### PR TITLE
docs: add Codex skill install snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ curl -o ~/.claude/skills/browser-use/SKILL.md \
   https://raw.githubusercontent.com/browser-use/browser-use/main/skills/browser-use/SKILL.md
 ```
 
+For Codex, install the same skill under the Codex skills directory:
+
+```bash
+mkdir -p ~/.codex/skills/browser-use
+curl -o ~/.codex/skills/browser-use/SKILL.md \
+  https://raw.githubusercontent.com/browser-use/browser-use/main/skills/browser-use/SKILL.md
+```
+
 <br/>
 
 ## Integrations, hosting, custom tools, MCP, and more on our [Docs ↗](https://docs.browser-use.com)


### PR DESCRIPTION
Adds a Codex install snippet for the existing browser-use skill, alongside the Claude Code skill install instructions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Codex install instructions for the `browser-use` skill to the README. This mirrors the Claude Code steps and shows how to install under ~/.codex/skills using curl.

<sup>Written for commit 63f27df93e9b0be1fbc3107c8303aaa35559bfea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

