### PR TITLE
fix(anthropic-serializer): type tool_calls + raise on malformed data URL

### DIFF
--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -18,6 +18,7 @@ from browser_use.llm.messages import (
 	ContentPartTextParam,
 	SupportedImageMediaType,
 	SystemMessage,
+	ToolCall,
 	UserMessage,
 )
 
@@ -39,7 +40,13 @@ class AnthropicMessageSerializer:
 		if not url.startswith('data:'):
 			raise ValueError(f'Invalid base64 URL: {url}')
 
-		header, data = url.split(',', 1)
+		# Guard against malformed data URLs (no comma separator).
+		# Without this guard, the unpacking below raised a confusing
+		# ValueError("not enough values to unpack") that hid the real cause.
+		parts = url.split(',', 1)
+		if len(parts) != 2:
+			raise ValueError(f'Invalid base64 data URL — missing comma separator after header: {url[:80]}...')
+		header, data = parts
 		media_type = header.split(';')[0].replace('data:', '')
 
 		# Ensure it's a supported media type
@@ -132,7 +139,7 @@ class AnthropicMessageSerializer:
 		return serialized_blocks
 
 	@staticmethod
-	def _serialize_tool_calls_to_content(tool_calls, use_cache: bool = False) -> list[ToolUseBlockParam]:
+	def _serialize_tool_calls_to_content(tool_calls: list[ToolCall], use_cache: bool = False) -> list[ToolUseBlockParam]:
 		"""Convert tool calls to Anthropic's ToolUseBlockParam format."""
 		blocks: list[ToolUseBlockParam] = []
 		for i, tool_call in enumerate(tool_calls):

--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -144,7 +144,10 @@ class AnthropicMessageSerializer:
 		blocks: list[ToolUseBlockParam] = []
 		for i, tool_call in enumerate(tool_calls):
 			# Parse the arguments JSON string to object
-
+			# Annotated as dict[str, object] (the type ToolUseBlockParam.input
+			# expects) so the json fallback's dict[str, str] is widened
+			# correctly under dict invariance.
+			input_obj: dict[str, object]
 			try:
 				input_obj = json.loads(tool_call.function.arguments)
 			except json.JSONDecodeError:


### PR DESCRIPTION
## Summary
Two small, orthogonal hardening fixes in `browser_use/llm/anthropic/serializer.py`:

### 1. Add `ToolCall` annotation on `_serialize_tool_calls_to_content`

The function had no type on its `tool_calls` parameter, leaving it implicitly `Any`. Callers always pass `list[ToolCall]` (per `AssistantMessage.tool_calls` in `browser_use/llm/messages.py:208`), so the annotation makes the contract explicit and lets static checkers verify the `.function.arguments` / `.function.name` / `.id` attribute accesses inside.

### 2. Raise a clear error on malformed base64 data URLs

`_parse_base64_url` did:
```python
header, data = url.split(',', 1)
```
without checking that the split actually produced two pieces. A user passing a header-only data URL like `data:image/jpeg;base64` (no comma + payload) would hit the unpacking and see the unhelpful

```
ValueError: not enough values to unpack (expected 2, got 1)
```

Now the function checks the split length first and raises a self-explaining `ValueError` that names the real cause and includes a prefix of the offending URL.

## Backward compatibility
Both changes are non-breaking — happy paths (well-formed URLs, callers already passing `list[ToolCall]`) behave identically. Only the error message + path on bad input changes.

## Verification
`python3 -c "import ast; ast.parse(open('browser_use/llm/anthropic/serializer.py').read())"` → exit 0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Anthropic serializer with stricter typing and clearer error handling.
Types tool_calls as list[ToolCall] in _serialize_tool_calls_to_content, types the tool input object as dict[str, object] to match ToolUseBlockParam, and makes _parse_base64_url raise a clear ValueError when a base64 data URL is missing the comma separator.

<sup>Written for commit 3b4a88185fb74c828668b2b1448ed470c8447ca1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

