### PR TITLE
fix(mcp): avoid inline screenshot blobs in tool results

### DIFF
--- a/browser_use/mcp/client.py
+++ b/browser_use/mcp/client.py
@@ -47,6 +47,16 @@ MCP_AVAILABLE = True
 class MCPClient:
 	"""Client for connecting to MCP servers and exposing their tools as browser-use actions."""
 
+	@staticmethod
+	def _image_extension_for_mime_type(mime_type: str) -> str:
+		"""Map an image MIME type to a file extension."""
+		return {
+			'image/png': 'png',
+			'image/jpeg': 'jpg',
+			'image/gif': 'gif',
+			'image/webp': 'webp',
+		}.get(mime_type, 'png')
+
 	def __init__(
 		self,
 		server_name: str,
@@ -324,10 +334,11 @@ class MCPClient:
 					result = await self.session.call_tool(tool.name, tool_params)
 
 					# Convert MCP result to ActionResult
-					extracted_content = self._format_mcp_result(result)
+					extracted_content, images = self._extract_mcp_result_payload(result)
 
 					return ActionResult(
 						extracted_content=extracted_content,
+						images=images or None,
 						long_term_memory=f"Used MCP tool '{tool.name}' from {self.server_name}",
 						include_extracted_content_only_once=True,
 					)
@@ -368,10 +379,11 @@ class MCPClient:
 					result = await self.session.call_tool(tool.name, {})
 
 					# Convert MCP result to ActionResult
-					extracted_content = self._format_mcp_result(result)
+					extracted_content, images = self._extract_mcp_result_payload(result)
 
 					return ActionResult(
 						extracted_content=extracted_content,
+						images=images or None,
 						long_term_memory=f"Used MCP tool '{tool.name}' from {self.server_name}",
 						include_extracted_content_only_once=True,
 					)
@@ -408,43 +420,53 @@ class MCPClient:
 
 		logger.debug(f"✅ Registered MCP tool '{tool.name}' as action '{action_name}'")
 
-	def _format_mcp_result(self, result: Any) -> str:
-		"""Format MCP tool result into a string for ActionResult.
+	def _extract_mcp_result_payload(self, result: Any) -> tuple[str | None, list[dict[str, str]]]:
+		"""Extract text and image payloads from an MCP tool result.
 
 		Args:
 			result: Raw result from MCP tool call
 
 		Returns:
-			Formatted string representation of the result
+			Tuple of (text_content, image_payloads)
 		"""
+		image_payloads: list[dict[str, str]] = []
+
 		# Handle different MCP result formats
 		if hasattr(result, 'content'):
 			# Structured content response
 			if isinstance(result.content, list):
 				# Multiple content items
 				parts = []
-				for item in result.content:
+				for idx, item in enumerate(result.content, start=1):
 					if hasattr(item, 'text'):
 						parts.append(item.text)
+					elif hasattr(item, 'type') and item.type == 'image' and hasattr(item, 'data'):
+						mime_type = getattr(item, 'mimeType', 'image/png') or 'image/png'
+						extension = self._image_extension_for_mime_type(mime_type)
+						image_payloads.append({'name': f'mcp-image-{idx}.{extension}', 'data': item.data})
 					elif hasattr(item, 'type') and item.type == 'text':
 						parts.append(str(item))
 					else:
 						parts.append(str(item))
-				return '\n'.join(parts)
+				return ('\n'.join(parts) or None), image_payloads
 			else:
-				return str(result.content)
+				return str(result.content), image_payloads
 		elif isinstance(result, list):
 			# List of content items
 			parts = []
-			for item in result:
+			for idx, item in enumerate(result, start=1):
 				if hasattr(item, 'text'):
 					parts.append(item.text)
+				elif hasattr(item, 'type') and item.type == 'image' and hasattr(item, 'data'):
+					mime_type = getattr(item, 'mimeType', 'image/png') or 'image/png'
+					extension = self._image_extension_for_mime_type(mime_type)
+					image_payloads.append({'name': f'mcp-image-{idx}.{extension}', 'data': item.data})
 				else:
 					parts.append(str(item))
-			return '\n'.join(parts)
+			return ('\n'.join(parts) or None), image_payloads
 		else:
 			# Direct result or unknown format
-			return str(result)
+			return str(result), image_payloads
 
 	def _json_schema_to_python_type(self, schema: dict, model_name: str = 'NestedModel') -> Any:
 		"""Convert JSON Schema type to Python type.

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -1168,7 +1168,6 @@ class BrowserUseServer:
 
 		session_data = self.active_sessions[session_id]
 		session = session_data['session']
-		cleanup_error = self._cleanup_mcp_screenshots(session_data)
 
 		try:
 			# Close the session
@@ -1179,6 +1178,8 @@ class BrowserUseServer:
 
 			# Remove from tracking
 			del self.active_sessions[session_id]
+
+			cleanup_error = self._cleanup_mcp_screenshots(session_data)
 
 			# If this was the current session, clear it
 			if self.browser_session and self.browser_session.id == session_id:

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -31,8 +31,10 @@ os.environ['BROWSER_USE_LOGGING_LEVEL'] = 'critical'
 os.environ['BROWSER_USE_SETUP_LOGGING'] = 'false'
 
 import asyncio
+import base64
 import json
 import logging
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -200,6 +202,8 @@ class BrowserUseServer:
 		self.file_system: FileSystem | None = None
 		self._telemetry = ProductTelemetry()
 		self._start_time = time.time()
+		self._mcp_screenshot_dir = Path(tempfile.gettempdir()) / 'browser-use-mcp-screenshots'
+		self._mcp_screenshot_dir.mkdir(parents=True, exist_ok=True)
 
 		# Session management
 		self.active_sessions: dict[str, dict[str, Any]] = {}  # session_id -> session info
@@ -282,7 +286,7 @@ class BrowserUseServer:
 						'properties': {
 							'include_screenshot': {
 								'type': 'boolean',
-								'description': 'Whether to include a screenshot of the current page',
+								'description': 'Whether to capture a screenshot reference for the current page. The tool returns a local PNG path in the JSON response instead of inlining base64 image data.',
 								'default': False,
 							}
 						},
@@ -319,7 +323,7 @@ class BrowserUseServer:
 				),
 				types.Tool(
 					name='browser_screenshot',
-					description='Take a screenshot of the current page. Returns viewport metadata as text and the screenshot as an image.',
+					description='Take a screenshot of the current page. Returns viewport metadata plus a local PNG file path in the JSON response.',
 					inputSchema={
 						'type': 'object',
 						'properties': {
@@ -525,21 +529,15 @@ class BrowserUseServer:
 				return await self._type_text(arguments['index'], arguments['text'])
 
 			elif tool_name == 'browser_get_state':
-				state_json, screenshot_b64 = await self._get_browser_state(arguments.get('include_screenshot', False))
-				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=state_json)]
-				if screenshot_b64:
-					content.append(types.ImageContent(type='image', data=screenshot_b64, mimeType='image/png'))
-				return content
+				state_json, _ = await self._get_browser_state(arguments.get('include_screenshot', False))
+				return [types.TextContent(type='text', text=state_json)]
 
 			elif tool_name == 'browser_get_html':
 				return await self._get_html(arguments.get('selector'))
 
 			elif tool_name == 'browser_screenshot':
-				meta_json, screenshot_b64 = await self._screenshot(arguments.get('full_page', False))
-				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=meta_json)]
-				if screenshot_b64:
-					content.append(types.ImageContent(type='image', data=screenshot_b64, mimeType='image/png'))
-				return content
+				meta_json, _ = await self._screenshot(arguments.get('full_page', False))
+				return [types.TextContent(type='text', text=meta_json)]
 
 			elif tool_name == 'browser_extract_content':
 				return await self._extract_content(arguments['query'], arguments.get('extract_links', False))
@@ -909,10 +907,10 @@ class BrowserUseServer:
 				elem_info['href'] = element.attributes['href']
 			result['interactive_elements'].append(elem_info)
 
-		# Return screenshot separately as ImageContent instead of embedding base64 in JSON
 		screenshot_b64 = None
 		if include_screenshot and state.screenshot:
-			screenshot_b64 = state.screenshot
+			screenshot_b64 = None
+			result['screenshot_path'] = self._store_mcp_screenshot(base64.b64decode(state.screenshot), prefix='state')
 			# Include viewport dimensions in JSON so LLM can map pixels to coordinates
 			if state.page_info:
 				result['screenshot_dimensions'] = {
@@ -954,24 +952,29 @@ class BrowserUseServer:
 		if not self.browser_session:
 			return 'Error: No browser session active', None
 
-		import base64
-
 		self._update_session_activity(self.browser_session.id)
 
 		data = await self.browser_session.take_screenshot(full_page=full_page)
-		b64 = base64.b64encode(data).decode()
 
-		# Return screenshot separately as ImageContent instead of embedding base64 in JSON
 		state = await self.browser_session.get_browser_state_summary()
 		result: dict[str, Any] = {
 			'size_bytes': len(data),
+			'screenshot_path': self._store_mcp_screenshot(data, prefix='screenshot'),
 		}
 		if state.page_info:
 			result['viewport'] = {
 				'width': state.page_info.viewport_width,
 				'height': state.page_info.viewport_height,
 			}
-		return json.dumps(result), b64
+		return json.dumps(result), None
+
+	def _store_mcp_screenshot(self, data: bytes, prefix: str) -> str:
+		"""Persist screenshot bytes to a temp PNG file and return its path."""
+		with tempfile.NamedTemporaryFile(
+			mode='wb', suffix='.png', prefix=f'browser-use-{prefix}-', dir=self._mcp_screenshot_dir, delete=False
+		) as tmp_file:
+			tmp_file.write(data)
+			return tmp_file.name
 
 	async def _extract_content(self, query: str, extract_links: bool = False) -> str:
 		"""Extract content from current page."""

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -974,7 +974,31 @@ class BrowserUseServer:
 			mode='wb', suffix='.png', prefix=f'browser-use-{prefix}-', dir=self._mcp_screenshot_dir, delete=False
 		) as tmp_file:
 			tmp_file.write(data)
-			return tmp_file.name
+			path = tmp_file.name
+
+		browser_session_id = getattr(self.browser_session, 'id', None)
+		if browser_session_id and browser_session_id in self.active_sessions:
+			session_data = self.active_sessions[browser_session_id]
+			session_data.setdefault('screenshot_paths', []).append(path)
+
+		return path
+
+	def _cleanup_mcp_screenshots(self, session_data: dict[str, Any]) -> str | None:
+		"""Delete any persisted screenshots associated with a session."""
+		screenshot_paths = session_data.pop('screenshot_paths', [])
+		if not screenshot_paths:
+			return None
+
+		errors: list[str] = []
+		for screenshot_path in screenshot_paths:
+			try:
+				Path(screenshot_path).unlink(missing_ok=True)
+			except OSError as e:
+				errors.append(f'{screenshot_path}: {e}')
+
+		if errors:
+			return f'Warning: failed to remove {len(errors)} screenshot file(s): {"; ".join(errors)}'
+		return None
 
 	async def _extract_content(self, query: str, extract_links: bool = False) -> str:
 		"""Extract content from current page."""
@@ -1102,6 +1126,7 @@ class BrowserUseServer:
 			'created_at': time.time(),
 			'last_activity': time.time(),
 			'url': getattr(session, 'current_url', None),
+			'screenshot_paths': [],
 		}
 
 	def _update_session_activity(self, session_id: str) -> None:
@@ -1143,6 +1168,7 @@ class BrowserUseServer:
 
 		session_data = self.active_sessions[session_id]
 		session = session_data['session']
+		cleanup_error = self._cleanup_mcp_screenshots(session_data)
 
 		try:
 			# Close the session
@@ -1159,7 +1185,10 @@ class BrowserUseServer:
 				self.browser_session = None
 				self.tools = None
 
-			return f'Successfully closed session {session_id}'
+			result = f'Successfully closed session {session_id}'
+			if cleanup_error:
+				result += f'. {cleanup_error}'
+			return result
 		except Exception as e:
 			return f'Error closing session {session_id}: {str(e)}'
 

--- a/tests/ci/test_mcp_screenshot_results.py
+++ b/tests/ci/test_mcp_screenshot_results.py
@@ -48,7 +48,7 @@ async def test_get_browser_state_writes_screenshot_to_file(tmp_path: Path):
 
 	assert screenshot_b64_result is None
 	assert payload['screenshot_path'].endswith('.png')
-	assert 'png-bytes' not in state_json
+	assert screenshot_b64 not in state_json
 	assert Path(payload['screenshot_path']).read_bytes() == b'png-bytes'
 
 
@@ -65,12 +65,35 @@ async def test_screenshot_writes_file_reference_instead_of_inline_base64(tmp_pat
 
 	meta_json, screenshot_b64_result = await server._screenshot(full_page=False)
 	payload = json.loads(meta_json)
+	screenshot_b64 = base64.b64encode(b'fresh-png').decode()
 
 	assert screenshot_b64_result is None
 	assert payload['screenshot_path'].endswith('.png')
 	assert payload['size_bytes'] == len(b'fresh-png')
-	assert 'fresh-png' not in meta_json
+	assert screenshot_b64 not in meta_json
 	assert Path(payload['screenshot_path']).read_bytes() == b'fresh-png'
+
+
+@pytest.mark.asyncio
+async def test_close_session_removes_persisted_screenshots(tmp_path: Path):
+	server = BrowserUseServer()
+	screenshot_path = tmp_path / 'browser-use-screenshot-test.png'
+	screenshot_path.write_bytes(b'png-bytes')
+	session = SimpleNamespace(close=AsyncMock())
+	server.active_sessions['session-1'] = {
+		'session': session,
+		'created_at': 0,
+		'last_activity': 0,
+		'url': 'https://example.com',
+		'screenshot_paths': [str(screenshot_path)],
+	}
+	server.browser_session = SimpleNamespace(id='session-1')
+
+	result = await server._close_session('session-1')
+
+	assert result == 'Successfully closed session session-1'
+	assert not screenshot_path.exists()
+	assert 'session-1' not in server.active_sessions
 
 
 def test_mcp_client_extracts_images_without_inlining_base64():

--- a/tests/ci/test_mcp_screenshot_results.py
+++ b/tests/ci/test_mcp_screenshot_results.py
@@ -96,6 +96,28 @@ async def test_close_session_removes_persisted_screenshots(tmp_path: Path):
 	assert 'session-1' not in server.active_sessions
 
 
+@pytest.mark.asyncio
+async def test_failed_close_keeps_screenshot_cleanup_state(tmp_path: Path):
+	server = BrowserUseServer()
+	screenshot_path = tmp_path / 'browser-use-screenshot-test.png'
+	screenshot_path.write_bytes(b'png-bytes')
+	session = SimpleNamespace(close=AsyncMock(side_effect=RuntimeError('boom')))
+	server.active_sessions['session-1'] = {
+		'session': session,
+		'created_at': 0,
+		'last_activity': 0,
+		'url': 'https://example.com',
+		'screenshot_paths': [str(screenshot_path)],
+	}
+	server.browser_session = SimpleNamespace(id='session-1')
+
+	result = await server._close_session('session-1')
+
+	assert result == 'Error closing session session-1: boom'
+	assert screenshot_path.exists()
+	assert server.active_sessions['session-1']['screenshot_paths'] == [str(screenshot_path)]
+
+
 def test_mcp_client_extracts_images_without_inlining_base64():
 	client = MCPClient(server_name='test', command='echo')
 	result = SimpleNamespace(

--- a/tests/ci/test_mcp_screenshot_results.py
+++ b/tests/ci/test_mcp_screenshot_results.py
@@ -1,0 +1,88 @@
+import base64
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from mcp import types
+
+from browser_use.mcp.client import MCPClient
+from browser_use.mcp.server import BrowserUseServer
+
+
+class _FakePageInfo:
+	viewport_width = 1280
+	viewport_height = 720
+	page_width = 1280
+	page_height = 2000
+	scroll_x = 0
+	scroll_y = 120
+
+
+class _FakeDOMState:
+	selector_map = {}
+
+
+class _FakeState:
+	url = 'https://example.com'
+	title = 'Example'
+	tabs = [SimpleNamespace(url='https://example.com', title='Example')]
+	dom_state = _FakeDOMState()
+	page_info = _FakePageInfo()
+
+	def __init__(self, screenshot: str | None):
+		self.screenshot = screenshot
+
+
+@pytest.mark.asyncio
+async def test_get_browser_state_writes_screenshot_to_file(tmp_path: Path):
+	server = BrowserUseServer()
+	server._mcp_screenshot_dir = tmp_path
+
+	screenshot_b64 = base64.b64encode(b'png-bytes').decode()
+	server.browser_session = SimpleNamespace(get_browser_state_summary=AsyncMock(return_value=_FakeState(screenshot_b64)))
+
+	state_json, screenshot_b64_result = await server._get_browser_state(include_screenshot=True)
+	payload = json.loads(state_json)
+
+	assert screenshot_b64_result is None
+	assert payload['screenshot_path'].endswith('.png')
+	assert 'png-bytes' not in state_json
+	assert Path(payload['screenshot_path']).read_bytes() == b'png-bytes'
+
+
+@pytest.mark.asyncio
+async def test_screenshot_writes_file_reference_instead_of_inline_base64(tmp_path: Path):
+	server = BrowserUseServer()
+	server._mcp_screenshot_dir = tmp_path
+	server._update_session_activity = lambda *_args, **_kwargs: None
+	server.browser_session = SimpleNamespace(
+		id='session-1',
+		take_screenshot=AsyncMock(return_value=b'fresh-png'),
+		get_browser_state_summary=AsyncMock(return_value=_FakeState(None)),
+	)
+
+	meta_json, screenshot_b64_result = await server._screenshot(full_page=False)
+	payload = json.loads(meta_json)
+
+	assert screenshot_b64_result is None
+	assert payload['screenshot_path'].endswith('.png')
+	assert payload['size_bytes'] == len(b'fresh-png')
+	assert 'fresh-png' not in meta_json
+	assert Path(payload['screenshot_path']).read_bytes() == b'fresh-png'
+
+
+def test_mcp_client_extracts_images_without_inlining_base64():
+	client = MCPClient(server_name='test', command='echo')
+	result = SimpleNamespace(
+		content=[
+			types.TextContent(type='text', text='Viewport metadata'),
+			types.ImageContent(type='image', data='abc123', mimeType='image/png'),
+		]
+	)
+
+	text, images = client._extract_mcp_result_payload(result)
+
+	assert text == 'Viewport metadata'
+	assert images == [{'name': 'mcp-image-2.png', 'data': 'abc123'}]


### PR DESCRIPTION
`browser_get_state` and `browser_screenshot` were returning inline PNG blobs in MCP tool results. Clients that replay tool history back through Anthropic can trip `Could not process image` on every later turn once that screenshot payload lands in the conversation.

This stores MCP screenshots as temporary PNG files and returns the local path in the JSON payload instead of inlining base64 image data. I also taught the in-repo MCP client to lift image blocks into `ActionResult.images` so MCP image results still flow through the browser-use message pipeline without getting stringified into prompt text.

Tests:
- `pytest tests/ci/test_mcp_screenshot_results.py -q`
- `pytest tests/ci/test_file_system_llm_integration.py -q -k "image_stored_in_message_manager or agent_message_prompt_includes_images or image_end_to_end"`

Fixes #4742

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop inlining screenshot base64 in MCP tool results. Screenshots are saved to temp files, returned as local paths, and cleaned up on successful session close to avoid Anthropic “Could not process image” errors when replaying tool history. Fixes #4742.

- **Bug Fixes**
  - `browser_get_state` and `browser_screenshot` write PNGs to a temp dir and return `screenshot_path` in JSON; no base64 inlined.
  - Server stores screenshots in a dedicated temp dir, deletes them on successful close (warns if a file can’t be removed), and preserves files/state if close fails for retry.
  - Updated tool descriptions to reflect path-based screenshot results.
  - MCP client lifts `types.ImageContent` into `ActionResult.images` (with correct extensions) and keeps text in `extracted_content`.
  - Added tests for file-backed screenshots, cleanup on close, preservation on close failure, and client image extraction.

<sup>Written for commit f094a5bdad05c861249133c1ddabb9aaf82af253. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4743?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

