### PR TITLE
docs: document context controls for long-running agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,40 @@ For CAPTCHA handling, you need better browser fingerprinting and proxies. Use [B
 </details>
 
 <details>
+<summary><b>How do I keep long-running agents from overloading the LLM context?</b></summary>
+
+Browser Use includes several context controls for long-running or multi-step runs:
+
+- `message_compaction=True` is enabled by default and summarizes older step history into a compact memory block.
+- Use `MessageCompactionSettings(...)` when you want explicit thresholds such as `trigger_token_count`, `compact_every_n_steps`, `keep_last_items`, and `summary_max_chars`.
+- Use `max_history_items` to cap how many raw step history items are kept in the prompt.
+- Tune `max_clickable_elements_length` if large pages are dominating the browser state message.
+- Set `calculate_cost=True` when you want token and cost telemetry for a run.
+
+```python
+from browser_use import Agent, ChatBrowserUse
+from browser_use.agent.views import MessageCompactionSettings
+
+agent = Agent(
+    task="Research several pages and keep a concise running memory.",
+    llm=ChatBrowserUse(),
+    max_history_items=20,
+    max_clickable_elements_length=20_000,
+    message_compaction=MessageCompactionSettings(
+        trigger_token_count=8_000,
+        compact_every_n_steps=4,
+        keep_last_items=8,
+        summary_max_chars=3_000,
+    ),
+    calculate_cost=True,
+)
+```
+
+For file-heavy tasks, prefer Browser Use's filesystem-backed extraction flow instead of pasting full documents into the prompt. Large PDF reads stay within a character budget and mark skipped pages so the agent can ask for more targeted reads when needed.
+
+</details>
+
+<details>
 <summary><b>How do I go into production?</b></summary>
 
 Chrome can consume a lot of memory, and running many agents in parallel can be tricky to manage.


### PR DESCRIPTION
## Summary

This follows up on #4739, especially the agreed audit signal around context memory / paging policy in https://github.com/browser-use/browser-use/issues/4739#issuecomment-4322153373.

The runtime already has useful controls here, but they were hard to discover from the README. This PR documents the practical knobs users can apply before long-running agents start ballooning their prompt context:

- `message_compaction=True` and `MessageCompactionSettings(...)`
- `max_history_items`
- `max_clickable_elements_length`
- `calculate_cost=True`
- file-heavy task guidance for filesystem-backed extraction instead of pasting entire documents into the prompt

## Why

The agchk audit called out "context memory lacks paging policy", and a maintainer/community comment noted that memory and context growth become real operational pain quickly. This README addition turns that audit point into a concrete user-facing runbook without changing runtime behavior.

## Validation

- `git diff --check`
- `python3 - <<'PY' ...` README marker check for the new documented options
- `uv run python - <<'PY' ...` instantiated `MessageCompactionSettings` with the README-style values and verified the derived char threshold


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document practical context controls for long-running agents to prevent prompt bloat and manage cost. Adds a README FAQ with a code sample for `message_compaction`/`MessageCompactionSettings`, `max_history_items`, `max_clickable_elements_length`, `calculate_cost`, plus guidance to use filesystem-backed extraction for large files.

<sup>Written for commit 862cd1cf6841aea5852132982262210d964418dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

