### PR TITLE
docs: update issue template setup and docs links

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: What version of browser-use are you currently using?
       description: |
-        Run `pip show browser-use` or `git log -n 1` and share the exact number or git hash. DO NOT JUST ENTER `latest release` OR `main`.  
+        Run `uv pip show browser-use` or `git log -n 1` and share the exact number or git hash. DO NOT JUST ENTER `latest release` OR `main`.
         We need to know what version of the browser-use library you're running in order to contextualize your feature request.  
         Sometimes features are already available and just need to be enabled with config on certain versions.
       placeholder: "e.g. 0.1.48 or 62760baaefd"

--- a/.github/ISSUE_TEMPLATE/4_docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/4_docs_issue.yml
@@ -27,7 +27,7 @@ body:
     attributes:
       label: Documentation Page
       description: Which page or section of the documentation is this about?
-      placeholder: "e.g. https://docs.browser-use.com/customize/browser-settings > Context Configuration > headless"
+      placeholder: "e.g. https://docs.browser-use.com/open-source/customize/browser/all-parameters > Display & Appearance > headless"
     validations:
       required: true
 


### PR DESCRIPTION
## Summary

Updates two GitHub issue template fields for consistency with the current project docs and setup guidance.

## Changes

- Update the feature request template to use `uv pip show browser-use` instead of `pip show browser-use`
- Refresh the docs issue template placeholder URL to the current Browser all-parameters page:
  `https://docs.browser-use.com/open-source/customize/browser/all-parameters`

## Validation

- Ran `git diff --check`
- Parsed both edited YAML files successfully


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update GitHub issue templates for accuracy. Feature requests now use `uv pip show browser-use` for version checks, and the docs issue placeholder links to the current all-parameters page.

<sup>Written for commit 88d61e8b623f0f9a316ffb82743843fb832abe60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

