### PR TITLE
fix(element): redact field content in clear failure debug log

### DIFF
--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -995,7 +995,7 @@ class Element:
 				logger.debug('Text field cleared successfully using JavaScript')
 				return True
 			else:
-				logger.debug(f'JavaScript clear partially failed, field still contains: "{current_value}"')
+				logger.debug(f'JavaScript clear partially failed, field still contains: [{len(current_value)} chars]')
 
 		except Exception as e:
 			logger.debug(f'JavaScript clear failed: {e}')


### PR DESCRIPTION
Fixes #4721

## Problem

When the JavaScript field-clearing strategy partially fails, the debug log outputs the raw remaining field content:

```python
logger.debug(f'JavaScript clear partially failed, field still contains: "{current_value}"')
```

This can expose sensitive user input (passwords, credit card numbers, etc.) in debug logs — the same class of issue that was fixed for the `fill()` typing log in a prior commit (`99e9a455`).

## Solution

Replace the raw value with its character count, preserving debug utility without leaking sensitive data:

```python
logger.debug(f'JavaScript clear partially failed, field still contains: [{len(current_value)} chars]')
```

This is consistent with the fix already applied to the typing log on line 421.

## Testing

- The change is a one-line logging adjustment with no behavioral impact
- Verified the pattern matches the existing redaction style used in line 421

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts remaining field content in the JavaScript clear-failure debug log by logging only the character count, preventing sensitive input from appearing in logs. Aligns with existing typing redaction and fixes #4721.

<sup>Written for commit eff81ac8455c34961255a847e55be61e0126bda6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

