### PR TITLE
fix(browser): extend startup timeouts

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -295,7 +295,7 @@ class BrowserStartEvent(BaseEvent):
 	cdp_url: str | None = None
 	launch_options: dict[str, Any] = Field(default_factory=dict)
 
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStartEvent', 30.0))  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserStartEvent', 60.0))  # seconds
 
 
 class BrowserStopEvent(BaseEvent):
@@ -318,7 +318,7 @@ class BrowserLaunchEvent(BaseEvent[BrowserLaunchResult]):
 
 	# TODO: add executable_path, proxy settings, preferences, extra launch args, etc.
 
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserLaunchEvent', 30.0))  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_BrowserLaunchEvent', 60.0))  # seconds
 
 
 class BrowserKillEvent(BaseEvent):

--- a/tests/ci/browser/test_session_start.py
+++ b/tests/ci/browser/test_session_start.py
@@ -345,6 +345,13 @@ class TestBrowserSessionEventSystem:
 		for result in results:
 			assert not isinstance(result, Exception), f'Event failed with: {result}'
 
+	def test_browser_start_and_launch_timeout_defaults_allow_slow_local_startup(self):
+		"""Browser start and launch should allow enough headroom for slower Linux setups."""
+		from browser_use.browser.events import BrowserLaunchEvent, BrowserStartEvent
+
+		assert BrowserStartEvent().event_timeout == 60.0
+		assert BrowserLaunchEvent().event_timeout == 60.0
+
 	# async def test_many_parallel_browser_sessions(self):
 	# 	"""Test spawning 12 parallel browser_sessions with different settings and ensure they all work"""
 	# 	from browser_use import BrowserSession


### PR DESCRIPTION
Browser startup on slower Linux hosts can exceed the current 30s budget, so the daemon aborts while opening a page.

Bumped BrowserStartEvent and BrowserLaunchEvent defaults to 60s so local launch and startup have enough headroom before timing out. Added a regression test for the new defaults.

Fixes #4752

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extended default timeouts for `BrowserStartEvent` and `BrowserLaunchEvent` from 30s to 60s to prevent aborting on slower Linux hosts. Added a regression test to lock the new defaults.

<sup>Written for commit 364861ec1eb3931cf54e3518a1c0b7d39770249d. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4753?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

