### PR TITLE
docs(models): fix invalid import examples

### DIFF
--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -131,12 +131,13 @@ llm = ChatAzureOpenAI(
 ## AWS Bedrock
 
 ```python
-from browser_use import Agent, ChatAWSBedrock
+from browser_use import Agent
+from browser_use.llm import ChatAWSBedrock
 
 llm = ChatAWSBedrock(model="us.anthropic.claude-sonnet-4-20250514-v1:0", region="us-east-1")
 
 # Or via Anthropic wrapper
-from browser_use import ChatAnthropicBedrock
+from browser_use.llm import ChatAnthropicBedrock
 llm = ChatAnthropicBedrock(model="us.anthropic.claude-sonnet-4-20250514-v1:0", aws_region="us-east-1")
 ```
 
@@ -147,7 +148,8 @@ Supports profiles, IAM roles, SSO via standard AWS credential chain. Install wit
 ## DeepSeek
 
 ```python
-from browser_use import Agent, ChatDeepSeek
+from browser_use import Agent
+from browser_use.llm import ChatDeepSeek
 
 llm = ChatDeepSeek(model="deepseek-chat")
 ```
@@ -177,7 +179,8 @@ llm = ChatGroq(model="meta-llama/llama-4-maverick-17b-128e-instruct")
 ## Cerebras
 
 ```python
-from browser_use import Agent, ChatCerebras
+from browser_use import Agent
+from browser_use.llm import ChatCerebras
 
 llm = ChatCerebras(model="llama3.3-70b")
 ```
@@ -199,7 +202,8 @@ llm = ChatOllama(model="llama3", num_ctx=32000)
 Access 300+ models from any provider through a single API.
 
 ```python
-from browser_use import Agent, ChatOpenRouter
+from browser_use import Agent
+from browser_use.llm import ChatOpenRouter
 
 llm = ChatOpenRouter(model="anthropic/claude-sonnet-4-6")
 ```


### PR DESCRIPTION
Corrects unsupported import examples in the supported models docs by using the package paths that actually export the classes.\n\nUpdated examples for AWS Bedrock, Anthropic Bedrock, DeepSeek, Cerebras, and OpenRouter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid import examples in the Supported Models docs by pointing to the correct `browser_use.llm` exports. Prevents copy-paste import errors for several providers.

- Bug Fixes
  - Switched imports for `ChatAWSBedrock`, `ChatAnthropicBedrock`, `ChatDeepSeek`, `ChatCerebras`, and `ChatOpenRouter` to `browser_use.llm`; `Agent` stays imported from `browser_use`.

<sup>Written for commit 24464b2a523f6b0d7ba2e5ebd2c6d2a7338a6016. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4756?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

