### PR TITLE
feat(cli): add new tab detection after click and enter actions

### DIFF
--- a/browser_use/skill_cli/commands/browser.py
+++ b/browser_use/skill_cli/commands/browser.py
@@ -100,19 +100,42 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 
 	elif action == 'click':
 		args = params.get('args', [])
+		pre_target_ids = set()
+		response = None
 		if len(args) == 2:
 			x, y = args
+			pre_target_ids = set(bs.session_manager._targets.keys())
 			await actions.click_coordinate(x, y)
-			return {'clicked_coordinate': {'x': x, 'y': y}}
+			response = {'clicked_coordinate': {'x': x, 'y': y}}
 		elif len(args) == 1:
 			index = args[0]
 			node = await bs.get_element_by_index(index)
 			if node is None:
 				return {'error': f'Element index {index} not found - page may have changed'}
+			pre_target_ids = set(bs.session_manager._targets.keys())
 			await actions.click_element(node)
-			return {'clicked': index}
+			response = {'clicked': index}
 		else:
 			return {'error': 'Usage: click <index> or click <x> <y>'}
+
+		if bs.session_manager:
+			new_tab_index = None
+			max_retries = 5
+			for _ in range(max_retries):
+				await asyncio.sleep(0.1)
+				current_targets = bs.session_manager._targets
+				new_ids = set(current_targets.keys()) - pre_target_ids
+				if new_ids:
+					new_target_id = list(new_ids)[0]
+					all_page_ids = [
+						tid for tid, t in current_targets.items()
+						if getattr(t, 'target_type', '') == 'page'
+					]
+					if new_target_id in all_page_ids:
+						new_tab_index = all_page_ids.index(new_target_id)
+						response['new_tab_index'] = new_tab_index
+						break
+		return response
 
 	elif action == 'type':
 		text = params['text']
@@ -242,8 +265,31 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 
 	elif action == 'keys':
 		keys = params['keys']
+		is_enter = keys.lower() in ['enter', 'return']
+		pre_target_ids = set()
+		if is_enter and bs.session_manager:
+			pre_target_ids = set(bs.session_manager._targets.keys())
 		await actions.send_keys(keys)
-		return {'sent': keys}
+		response = {'sent': keys}
+
+		if is_enter and bs.session_manager:
+			new_tab_index = None
+			max_retries = 5
+			for _ in range(max_retries):
+				await asyncio.sleep(0.1)
+				current_targets = bs.session_manager._targets
+				new_ids = set(current_targets.keys()) - pre_target_ids
+				if new_ids:
+					new_target_id = list(new_ids)[0]
+					all_page_ids = [
+						tid for tid, t in current_targets.items()
+						if getattr(t, 'target_type', '') == 'page'
+					]
+					if new_target_id in all_page_ids:
+						new_tab_index = all_page_ids.index(new_target_id)
+						response['new_tab_index'] = new_tab_index
+						break
+		return response
 
 	elif action == 'select':
 		index = params['index']

--- a/browser_use/skill_cli/commands/browser.py
+++ b/browser_use/skill_cli/commands/browser.py
@@ -104,7 +104,8 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 		response = None
 		if len(args) == 2:
 			x, y = args
-			pre_target_ids = set(bs.session_manager._targets.keys())
+			if bs and hasattr(bs, 'session_manager') and bs.session_manager:
+				pre_target_ids = set(bs.session_manager._targets.keys())
 			await actions.click_coordinate(x, y)
 			response = {'clicked_coordinate': {'x': x, 'y': y}}
 		elif len(args) == 1:
@@ -112,7 +113,8 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 			node = await bs.get_element_by_index(index)
 			if node is None:
 				return {'error': f'Element index {index} not found - page may have changed'}
-			pre_target_ids = set(bs.session_manager._targets.keys())
+			if bs and hasattr(bs, 'session_manager') and bs.session_manager:
+				pre_target_ids = set(bs.session_manager._targets.keys())
 			await actions.click_element(node)
 			response = {'clicked': index}
 		else:
@@ -126,14 +128,11 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 				current_targets = bs.session_manager._targets
 				new_ids = set(current_targets.keys()) - pre_target_ids
 				if new_ids:
-					new_target_id = list(new_ids)[0]
-					all_page_ids = [
-						tid for tid, t in current_targets.items()
-						if getattr(t, 'target_type', '') == 'page'
-					]
-					if new_target_id in all_page_ids:
-						new_tab_index = all_page_ids.index(new_target_id)
-						response['new_tab_index'] = new_tab_index
+					all_page_ids = [tid for tid, t in current_targets.items() if getattr(t, 'target_type', '') == 'page']
+					actual_new_page_id = next((tid for tid in new_ids if tid in all_page_ids), None)
+					if actual_new_page_id:
+						new_tab_index = all_page_ids.index(actual_new_page_id)
+						response['navigation'] = {'new_tab_index': new_tab_index}
 						break
 		return response
 
@@ -280,14 +279,11 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 				current_targets = bs.session_manager._targets
 				new_ids = set(current_targets.keys()) - pre_target_ids
 				if new_ids:
-					new_target_id = list(new_ids)[0]
-					all_page_ids = [
-						tid for tid, t in current_targets.items()
-						if getattr(t, 'target_type', '') == 'page'
-					]
-					if new_target_id in all_page_ids:
-						new_tab_index = all_page_ids.index(new_target_id)
-						response['new_tab_index'] = new_tab_index
+					all_page_ids = [tid for tid, t in current_targets.items() if getattr(t, 'target_type', '') == 'page']
+					actual_new_page_id = next((tid for tid in new_ids if tid in all_page_ids), None)
+					if actual_new_page_id:
+						new_tab_index = all_page_ids.index(actual_new_page_id)
+						response['navigation'] = {'new_tab_index': new_tab_index}
 						break
 		return response
 


### PR DESCRIPTION
Summary:
- Implement pre-action and post-action tab state comparison.
- Enable the CLI to notify the LLM when a new page is opened via `click` or `Enter`.
- Fix the issue where external LLMs lose context due to undetected navigation.

This allows external models to decide whether to invoke `switch_tab` based on the execution feedback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects new tab openings after `click` and Enter in the CLI and adds the new tab index to the action response under `navigation.new_tab_index`. This lets external models switch tabs reliably and prevents context loss after navigation.

- **New Features**
  - Compare tab targets before and after `click` and `keys` (Enter/Return).
  - Poll up to 5 times (100ms delay) to detect a new `page` target.
  - Return `navigation.new_tab_index` when a new tab opens.

- **Bug Fixes**
  - Fix undetected navigation after clicks or Enter and add safety checks around session/target state to avoid errors and false positives.

<sup>Written for commit 753723925c77ac1b679e5cf85da87243284066f9. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4759?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

