### PR TITLE
fix: export documented llm classes from top level

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -55,8 +55,12 @@ if TYPE_CHECKING:
 	from browser_use.dom.service import DomService
 	from browser_use.llm import models
 	from browser_use.llm.anthropic.chat import ChatAnthropic
+	from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
+	from browser_use.llm.aws.chat_bedrock import ChatAWSBedrock
 	from browser_use.llm.azure.chat import ChatAzureOpenAI
 	from browser_use.llm.browser_use.chat import ChatBrowserUse
+	from browser_use.llm.cerebras.chat import ChatCerebras
+	from browser_use.llm.deepseek.chat import ChatDeepSeek
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
 	from browser_use.llm.litellm.chat import ChatLiteLLM
@@ -64,6 +68,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.oci_raw.chat import ChatOCIRaw
 	from browser_use.llm.ollama.chat import ChatOllama
 	from browser_use.llm.openai.chat import ChatOpenAI
+	from browser_use.llm.openrouter.chat import ChatOpenRouter
 	from browser_use.llm.vercel.chat import ChatVercel
 	from browser_use.sandbox import sandbox
 	from browser_use.tools.service import Controller, Tools
@@ -91,13 +96,18 @@ _LAZY_IMPORTS = {
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
 	'ChatGoogle': ('browser_use.llm.google.chat', 'ChatGoogle'),
 	'ChatAnthropic': ('browser_use.llm.anthropic.chat', 'ChatAnthropic'),
+	'ChatAnthropicBedrock': ('browser_use.llm.aws.chat_anthropic', 'ChatAnthropicBedrock'),
+	'ChatAWSBedrock': ('browser_use.llm.aws.chat_bedrock', 'ChatAWSBedrock'),
 	'ChatBrowserUse': ('browser_use.llm.browser_use.chat', 'ChatBrowserUse'),
+	'ChatCerebras': ('browser_use.llm.cerebras.chat', 'ChatCerebras'),
+	'ChatDeepSeek': ('browser_use.llm.deepseek.chat', 'ChatDeepSeek'),
 	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
 	'ChatLiteLLM': ('browser_use.llm.litellm.chat', 'ChatLiteLLM'),
 	'ChatMistral': ('browser_use.llm.mistral.chat', 'ChatMistral'),
 	'ChatAzureOpenAI': ('browser_use.llm.azure.chat', 'ChatAzureOpenAI'),
 	'ChatOCIRaw': ('browser_use.llm.oci_raw.chat', 'ChatOCIRaw'),
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
+	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
 	# LLM models module
 	'models': ('browser_use.llm.models', None),
@@ -143,13 +153,18 @@ __all__ = [
 	'ChatOpenAI',
 	'ChatGoogle',
 	'ChatAnthropic',
+	'ChatAnthropicBedrock',
+	'ChatAWSBedrock',
 	'ChatBrowserUse',
+	'ChatCerebras',
+	'ChatDeepSeek',
 	'ChatGroq',
 	'ChatLiteLLM',
 	'ChatMistral',
 	'ChatAzureOpenAI',
 	'ChatOCIRaw',
 	'ChatOllama',
+	'ChatOpenRouter',
 	'ChatVercel',
 	'Tools',
 	'Controller',

--- a/tests/ci/models/test_top_level_llm_exports.py
+++ b/tests/ci/models/test_top_level_llm_exports.py
@@ -1,0 +1,12 @@
+import browser_use
+
+
+def test_documented_llm_classes_are_exported_from_top_level() -> None:
+	"""Keep top-level imports in sync with the supported-models docs."""
+	for name in (
+		'ChatCerebras',
+		'ChatDeepSeek',
+		'ChatOpenRouter',
+	):
+		assert name in browser_use.__all__
+		assert getattr(browser_use, name).__name__ == name


### PR DESCRIPTION
## Summary

- Export documented LLM classes from the top-level `browser_use` package
- Keep lazy imports and `__all__` in sync with `browser_use.llm`
- Add a regression test for the documented top-level model imports

## Testing

- `python3 -m pytest tests/ci/models/test_top_level_llm_exports.py`
- `python3 -m ruff check browser_use/__init__.py tests/ci/models/test_top_level_llm_exports.py`
- `python3 -m ruff format --check browser_use/__init__.py tests/ci/models/test_top_level_llm_exports.py`

Fixes #4755

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export the documented LLM chat classes from the top-level `browser_use` package so direct imports work as described: ChatCerebras, ChatDeepSeek, ChatOpenRouter, ChatAnthropicBedrock, and ChatAWSBedrock. Update the lazy import map and `__all__` to include these names and add a regression test to keep top-level exports in sync with `browser_use.llm`.

<sup>Written for commit 2ec64023748ce6d75dedf021fb8bc91d05ba04fd. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4760?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

