### PR TITLE
fix(security): block data URLs under domain policies

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -179,8 +179,7 @@ class SecurityWatchdog(BaseWatchdog):
 			return False
 
 		has_domain_policy = bool(
-			self.browser_session.browser_profile.allowed_domains
-			or self.browser_session.browser_profile.prohibited_domains
+			self.browser_session.browser_profile.allowed_domains or self.browser_session.browser_profile.prohibited_domains
 		)
 
 		# data: and blob: URLs do not have hostnames to validate against domain policies.

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -178,9 +178,14 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
+		has_domain_policy = bool(
+			self.browser_session.browser_profile.allowed_domains
+			or self.browser_session.browser_profile.prohibited_domains
+		)
+
+		# data: and blob: URLs do not have hostnames to validate against domain policies.
 		if parsed.scheme in ['data', 'blob']:
-			return True
+			return not has_domain_policy
 
 		# Get the actual host (domain)
 		host = parsed.hostname
@@ -193,10 +198,7 @@ class SecurityWatchdog(BaseWatchdog):
 				return False
 
 		# If no allowed_domains specified, allow all URLs
-		if (
-			not self.browser_session.browser_profile.allowed_domains
-			and not self.browser_session.browser_profile.prohibited_domains
-		):
+		if not has_domain_policy:
 			return True
 
 		# Check allowed domains (fast path for sets, slow path for lists with patterns)

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -26,6 +26,33 @@ class TestUrlAllowlistSecurity:
 		# Make sure legitimate auth credentials still work
 		assert watchdog._is_url_allowed('https://user:password@example.com') is True
 
+	def test_data_and_blob_urls_do_not_bypass_domain_policy(self):
+		"""data: and blob: URLs have no host to validate against allowed/prohibited domains."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		restricted_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		restricted_session = BrowserSession(browser_profile=restricted_profile)
+		restricted_watchdog = SecurityWatchdog(browser_session=restricted_session, event_bus=EventBus())
+
+		assert restricted_watchdog._is_url_allowed('data:text/html,<h1>blocked</h1>') is False
+		assert restricted_watchdog._is_url_allowed('blob:https://example.com/1234') is False
+
+		prohibited_profile = BrowserProfile(prohibited_domains=['evil.com'], headless=True, user_data_dir=None)
+		prohibited_session = BrowserSession(browser_profile=prohibited_profile)
+		prohibited_watchdog = SecurityWatchdog(browser_session=prohibited_session, event_bus=EventBus())
+
+		assert prohibited_watchdog._is_url_allowed('data:text/html,<h1>blocked</h1>') is False
+		assert prohibited_watchdog._is_url_allowed('blob:https://example.com/1234') is False
+
+		open_profile = BrowserProfile(headless=True, user_data_dir=None)
+		open_session = BrowserSession(browser_profile=open_profile)
+		open_watchdog = SecurityWatchdog(browser_session=open_session, event_bus=EventBus())
+
+		assert open_watchdog._is_url_allowed('data:text/html,<h1>allowed</h1>') is True
+		assert open_watchdog._is_url_allowed('blob:https://example.com/1234') is True
+
 	def test_glob_pattern_matching(self):
 		"""Test that glob patterns in allowed_domains work correctly."""
 		from bubus import EventBus


### PR DESCRIPTION
## Summary

- Prevent `data:` and `blob:` URLs from bypassing configured domain policies.
- Keep existing behavior when no `allowed_domains` or `prohibited_domains` policy is configured.
- Add regression coverage for allowlist, prohibitlist, and unrestricted profiles.

Closes #4763.

## Testing

- `uv run --with pytest --with pytest-asyncio python -m pytest tests/ci/security/test_domain_filtering.py -q`
- `uv run --with ruff ruff check browser_use/browser/watchdogs/security_watchdog.py tests/ci/security/test_domain_filtering.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block `data:` and `blob:` URLs from bypassing domain allow/prohibit policies, while keeping behavior unchanged when no policy is set (closes #4763).

- **Bug Fixes**
  - Deny `data:`/`blob:` when `allowed_domains` or `prohibited_domains` are configured, using a single `has_domain_policy` check.
  - Add regression tests for allowlist, prohibitlist, and unrestricted profiles; minor formatting in `security_watchdog.py`.

<sup>Written for commit da9daeec64ef40d13b5d75ee25be80b940ebaa3d. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4766?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

