### PR TITLE
fix(agent): restore message history debug logging

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 from typing import Literal
 
 from browser_use.agent.message_manager.views import (
@@ -51,6 +52,11 @@ def _log_get_message_emoji(message: BaseMessage) -> str:
 	return emoji_map.get(message.__class__.__name__, '🎮')
 
 
+def _log_estimate_tokens(content: str) -> int:
+	"""Estimate tokens for debug display only; billing uses TokenCost service."""
+	return max(1, len(content) // 4) if content else 0
+
+
 def _log_format_message_line(message: BaseMessage, content: str, is_last_message: bool, terminal_width: int) -> list[str]:
 	"""Format a single message for logging display"""
 	try:
@@ -58,9 +64,7 @@ def _log_format_message_line(message: BaseMessage, content: str, is_last_message
 
 		# Get emoji and token info
 		emoji = _log_get_message_emoji(message)
-		# token_str = str(message.metadata.tokens).rjust(4)
-		# TODO: fix the token count
-		token_str = '??? (TODO)'
+		token_str = f'~{_log_estimate_tokens(content)}'.rjust(5)
 		prefix = f'{emoji}[{token_str}]: '
 
 		# Calculate available width (emoji=2 visual cols + [token]: =8 chars)
@@ -506,40 +510,28 @@ class MessageManager:
 
 	def _log_history_lines(self) -> str:
 		"""Generate a formatted log string of message history for debugging / printing to terminal"""
-		# TODO: fix logging
+		try:
+			messages = self.state.history.get_messages()
+			total_input_tokens = 0
+			message_lines = []
+			terminal_width = shutil.get_terminal_size((80, 20)).columns
 
-		# try:
-		# 	total_input_tokens = 0
-		# 	message_lines = []
-		# 	terminal_width = shutil.get_terminal_size((80, 20)).columns
+			for i, message in enumerate(messages):
+				try:
+					content = message.text
+					total_input_tokens += _log_estimate_tokens(content)
+					is_last_message = i == len(messages) - 1
+					message_lines.extend(_log_format_message_line(message, content, is_last_message, terminal_width))
+				except Exception as e:
+					logger.warning(f'Failed to format message {i} for logging: {e}')
+					message_lines.append('❓[   ?]: [Error formatting this message]')
 
-		# 	for i, m in enumerate(self.state.history.messages):
-		# 		try:
-		# 			total_input_tokens += m.metadata.tokens
-		# 			is_last_message = i == len(self.state.history.messages) - 1
-
-		# 			# Extract content for logging
-		# 			content = _log_extract_message_content(m.message, is_last_message, m.metadata)
-
-		# 			# Format the message line(s)
-		# 			lines = _log_format_message_line(m, content, is_last_message, terminal_width)
-		# 			message_lines.extend(lines)
-		# 		except Exception as e:
-		# 			logger.warning(f'Failed to format message {i} for logging: {e}')
-		# 			# Add a fallback line for this message
-		# 			message_lines.append('❓[   ?]: [Error formatting this message]')
-
-		# 	# Build final log message
-		# 	return (
-		# 		f'📜 LLM Message history ({len(self.state.history.messages)} messages, {total_input_tokens} tokens):\n'
-		# 		+ '\n'.join(message_lines)
-		# 	)
-		# except Exception as e:
-		# 	logger.warning(f'Failed to generate history log: {e}')
-		# 	# Return a minimal fallback message
-		# 	return f'📜 LLM Message history (error generating log: {e})'
-
-		return ''
+			return f'📜 LLM Message history ({len(messages)} messages, ~{total_input_tokens} tokens):\n' + '\n'.join(
+				message_lines
+			)
+		except Exception as e:
+			logger.warning(f'Failed to generate history log: {e}')
+			return f'📜 LLM Message history (error generating log: {e})'
 
 	@time_execution_sync('--get_messages')
 	def get_messages(self) -> list[BaseMessage]:

--- a/tests/ci/test_message_manager_logging.py
+++ b/tests/ci/test_message_manager_logging.py
@@ -1,0 +1,42 @@
+from browser_use.agent.message_manager.service import MessageManager, _log_format_message_line
+from browser_use.agent.message_manager.views import MessageHistory, MessageManagerState
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.llm.messages import SystemMessage, UserMessage
+
+
+def test_log_format_message_line_uses_estimated_tokens():
+	lines = _log_format_message_line(
+		UserMessage(content='hello world'),
+		'hello world',
+		is_last_message=False,
+		terminal_width=80,
+	)
+
+	assert len(lines) == 1
+	assert '??? (TODO)' not in lines[0]
+	assert '💬[   ~2]:' in lines[0]
+
+
+def test_log_history_lines_includes_message_history(tmp_path):
+	system_message = SystemMessage(content='system prompt')
+	state = MessageManagerState(
+		history=MessageHistory(
+			system_message=system_message,
+			state_message=UserMessage(content='current page state'),
+			context_messages=[UserMessage(content='previous action result')],
+		)
+	)
+	manager = MessageManager(
+		task='test task',
+		system_message=system_message,
+		file_system=FileSystem(tmp_path),
+		state=state,
+	)
+
+	log_output = manager._log_history_lines()
+
+	assert 'LLM Message history (3 messages, ~' in log_output
+	assert 'system prompt' in log_output
+	assert 'current page state' in log_output
+	assert 'previous action result' in log_output
+	assert '??? (TODO)' not in log_output


### PR DESCRIPTION
## Summary
- restore `_log_history_lines()` so debug logging emits the current LLM message history again
- replace the hard-coded `??? (TODO)` marker with an explicit approximate token estimate (`~N`) based on message text
- add focused regression coverage for the formatting helper and the message history log output

Fixes #4150

## Notes
This keeps billing/usage accounting unchanged; exact token accounting still comes from the existing `TokenCost` service after model responses. The `~` prefix marks these debug-log counts as estimates.

## Testing
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/ci/test_message_manager_logging.py -q`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/ci/test_message_manager_logging.py tests/ci/test_file_system_llm_integration.py -q`
- `uv run --with ruff ruff check browser_use/agent/message_manager/service.py tests/ci/test_message_manager_logging.py`
- `uv run --with ruff ruff format --check browser_use/agent/message_manager/service.py tests/ci/test_message_manager_logging.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the message history debug log and replaces the placeholder token marker with a simple estimated count. Adds focused tests; billing and token accounting remain unchanged.

- **Bug Fixes**
  - Re-enabled message history logging and formatting via _log_history_lines(), including totals.
  - Replaced '??? (TODO)' with '~N' estimated tokens based on content length (debug-only; billing still uses TokenCost).
  - Added regression tests for message line formatting and history log output.

<sup>Written for commit d0c9df545ba95f07e0861a2456aacabf41ce674b. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4767?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

