### PR TITLE
fix(tools): report new tabs after send keys

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1441,10 +1441,12 @@ You will be given a query and the markdown of a webpage that has been filtered t
 		async def send_keys(params: SendKeysAction, browser_session: BrowserSession):
 			# Dispatch send keys event
 			try:
+				tabs_before = {t.target_id for t in await browser_session.get_tabs()}
 				event = browser_session.event_bus.dispatch(SendKeysEvent(keys=params.keys))
 				await event
 				await event.event_result(raise_if_any=True, raise_if_none=False)
 				memory = f'Sent keys: {params.keys}'
+				memory += await _detect_new_tab_opened(browser_session, tabs_before)
 				msg = f'⌨️  {memory}'
 				logger.info(msg)
 				return ActionResult(extracted_content=memory, long_term_memory=memory)

--- a/tests/ci/test_send_keys_new_tab_detection.py
+++ b/tests/ci/test_send_keys_new_tab_detection.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from browser_use.tools.service import Tools
+
+
+class AwaitableEvent:
+	def __init__(self, result=None):
+		self._result = result
+
+	def __await__(self):
+		async def _wait():
+			return self
+
+		return _wait().__await__()
+
+	async def event_result(self, *args, **kwargs):
+		return self._result
+
+
+@pytest.mark.asyncio
+async def test_send_keys_reports_new_tab():
+	tools = Tools()
+	browser_session = MagicMock()
+	browser_session.get_current_page_url = AsyncMock(return_value='https://example.com')
+	browser_session.cdp_client = None
+	browser_session.get_tabs = AsyncMock(
+		side_effect=[
+			[SimpleNamespace(target_id='tab-before')],
+			[SimpleNamespace(target_id='tab-before'), SimpleNamespace(target_id='tab-after')],
+		]
+	)
+	browser_session.event_bus.dispatch.return_value = AwaitableEvent()
+
+	result = await tools.registry.execute_action(
+		action_name='send_keys',
+		params={'keys': 'Enter'},
+		browser_session=browser_session,
+	)
+
+	assert result.extracted_content == 'Sent keys: Enter. Automatically switched to new tab (tab_id: fter).'
+	assert result.long_term_memory == result.extracted_content


### PR DESCRIPTION
## What changed

- Capture tab ids before `send_keys` and reuse the existing new-tab detection after the key event finishes.
- This gives `send_keys(keys="Enter")` the same new-tab feedback/auto-switch behavior that click actions already have.
- Add a regression test for an Enter key action that opens a new tab.

Fixes #4758 for the Enter-key path. The click path already uses this helper on current `main`.

## Testing

- `uv run --with pytest --with pytest-asyncio python -m pytest tests/ci/test_send_keys_new_tab_detection.py -q`
- `uv run --with ruff ruff check browser_use/tools/service.py tests/ci/test_send_keys_new_tab_detection.py`
- `uv run --with ruff ruff format --check browser_use/tools/service.py tests/ci/test_send_keys_new_tab_detection.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report and auto-switch to new tabs opened by `send_keys` (e.g., Enter) to match click behavior. We capture tabs before the key event and reuse the existing new-tab detection.

- **Bug Fixes**
  - `send_keys` now reports and switches to a new tab when Enter opens one, consistent with click actions.
  - Added a regression test for the Enter-key path.

<sup>Written for commit 9a4cbf270df3f4fe47b5a7a6804995cba628b467. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4768?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

