### PR TITLE
fix: preserve partial action results when mid-batch action fails

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2807,15 +2807,17 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					self.logger.info(f'Page changed after "{action_name}" — skipping {total_actions - i - 1} remaining action(s)')
 					break
 
-			except Exception as e:
-				# Handle any exceptions during action execution
-				self.logger.error(f'❌ Executing action {i + 1} failed -> {type(e).__name__}: {e}')
-				await self._demo_mode_log(
-					f'Action "{action_name}" raised {type(e).__name__}: {e}',
-					'error',
-					{'action': action_name, 'step': self.state.n_steps},
-				)
-				raise e
+		except Exception as e:
+			# Handle any exceptions during action execution
+			self.logger.error(f'❌ Executing action {i + 1} failed -> {type(e).__name__}: {e}')
+			await self._demo_mode_log(
+				f'Action "{action_name}" raised {type(e).__name__}: {e}',
+				'error',
+				{'action': action_name, 'step': self.state.n_steps},
+			)
+			# Preserve partial results so the agent knows which actions succeeded before the failure
+			results.append(ActionResult(error=str(e)))
+			return results
 
 		return results
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2808,6 +2808,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					break
 
 		except Exception as e:
+			# Re-raise control-flow exceptions to preserve stop/pause/interrupt behavior
+			if isinstance(e, (InterruptedError, asyncio.CancelledError)):
+				raise
 			# Handle any exceptions during action execution
 			self.logger.error(f'❌ Executing action {i + 1} failed -> {type(e).__name__}: {e}')
 			await self._demo_mode_log(

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2807,20 +2807,23 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					self.logger.info(f'Page changed after "{action_name}" — skipping {total_actions - i - 1} remaining action(s)')
 					break
 
-		except Exception as e:
-			# Re-raise control-flow exceptions to preserve stop/pause/interrupt behavior
-			if isinstance(e, (InterruptedError, asyncio.CancelledError)):
-				raise
-			# Handle any exceptions during action execution
-			self.logger.error(f'❌ Executing action {i + 1} failed -> {type(e).__name__}: {e}')
-			await self._demo_mode_log(
-				f'Action "{action_name}" raised {type(e).__name__}: {e}',
-				'error',
-				{'action': action_name, 'step': self.state.n_steps},
-			)
-			# Preserve partial results so the agent knows which actions succeeded before the failure
-			results.append(ActionResult(error=str(e)))
-			return results
+			except Exception as e:
+				# Re-raise InterruptedError so _check_stop_or_pause's stop/pause signal still propagates
+				if isinstance(e, InterruptedError):
+					raise
+				# Re-raise browser/connection errors so _handle_step_error can handle reconnect/shutdown
+				if self._is_connection_like_error(e):
+					raise
+				# Handle any exceptions during action execution
+				self.logger.error(f'❌ Executing action {i + 1} failed -> {type(e).__name__}: {e}')
+				await self._demo_mode_log(
+					f'Action "{action_name}" raised {type(e).__name__}: {e}',
+					'error',
+					{'action': action_name, 'step': self.state.n_steps},
+				)
+				# Preserve partial results so the agent knows which actions succeeded before the failure
+				results.append(ActionResult(error=f'{type(e).__name__}: {e}'))
+				return results
 
 		return results
 


### PR DESCRIPTION
## Problem
When `multi_act()` executes a batch of N actions and action K (where 0 < K < N) raises an exception, the partial results from successfully executed actions 1..K-1 are silently lost. The exception propagates through `_execute_actions()` → `_handle_step_error()`, which creates a single generic `ActionResult(error=error_msg)` that overwrites any trace of the earlier successes.

The LLM receives only the generic error and loses visibility into which specific actions completed before the failure — even though those actions had real side effects (clicks, form fills, navigation).

## Fix
Instead of re-raising the exception, append an error `ActionResult` to the accumulated `results` list and return it. This path is already supported downstream:

- `_execute_actions()` (line 1205): `self.state.last_result` is set from the return value
- `_post_process()` (lines 1221-1222): explicitly handles multi-action errors via loop detection and replan nudges
- `_finalize()`: saves all results to history for the LLM to see

**Change**: `raise e` → `results.append(ActionResult(error=str(e))); return results`

## Impact
- The agent now sees exactly which actions succeeded and which failed
- No change to the success path
- Error handling remains correct: single-action errors still increment `consecutive_failures`, multi-action errors are handled by loop detection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves partial results in `multi_act()` when a mid-batch action fails by returning accumulated successes plus a trailing error `ActionResult`. Keeps stop/pause and reconnect/shutdown behavior by re-raising `InterruptedError` and connection-like errors.

- **Bug Fixes**
  - For non-control-flow and non-connection exceptions, log, append `ActionResult(error="<Exception>: <msg>")`, and return accumulated results.
  - Re-raise `InterruptedError`; `asyncio.CancelledError` doesn’t reach this handler; re-raise connection-like errors so `_handle_step_error` can run reconnect/shutdown.
  - Fixed `except` block indentation to match the inner `try` (prevented a SyntaxError).

<sup>Written for commit 54322e6a8b121df61828a44750de7b62aff96017. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

