### PR TITLE
fix: disable chromium sandbox for root on linux

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -93,6 +93,10 @@ CHROME_DOCKER_ARGS = [
 	'--disable-site-isolation-trials',  # lowers RAM use by 10-16% in docker, but could lead to easier bot blocking if pages can detect it?
 ]
 
+CHROME_NO_SANDBOX_ARGS = [
+	'--no-sandbox',
+]
+
 
 CHROME_DISABLE_SECURITY_ARGS = [
 	'--disable-site-isolation-trials',
@@ -862,7 +866,8 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			*self.args,
 			f'--user-data-dir={self.user_data_dir}',
 			f'--profile-directory={self.profile_directory}',
-			*(CHROME_DOCKER_ARGS if (CONFIG.IN_DOCKER or not self.chromium_sandbox) else []),
+			*(CHROME_DOCKER_ARGS if CONFIG.IN_DOCKER else []),
+			*(CHROME_NO_SANDBOX_ARGS if not CONFIG.IN_DOCKER and not self.chromium_sandbox else []),
 			*(CHROME_HEADLESS_ARGS if self.headless else []),
 			*(CHROME_DISABLE_SECURITY_ARGS if self.disable_security else []),
 			*(CHROME_DETERMINISTIC_RENDERING_ARGS if self.deterministic_rendering else []),

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -797,6 +797,9 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	def model_post_init(self, __context: Any) -> None:
 		"""Called after model initialization to set up display configuration."""
 		self.detect_display_configuration()
+		if sys.platform.startswith('linux') and hasattr(os, 'geteuid') and os.geteuid() == 0 and self.chromium_sandbox:
+			logger.warning('⚠️ Running as root on Linux; disabling Chromium sandbox so local browser startup works.')
+			self.chromium_sandbox = False
 		self._copy_profile()
 
 	def _copy_profile(self) -> None:

--- a/tests/ci/test_browser_profile_root_sandbox.py
+++ b/tests/ci/test_browser_profile_root_sandbox.py
@@ -1,21 +1,43 @@
 import os
 import sys
 
+import browser_use.config as browser_use_config
 from browser_use.browser import BrowserProfile
 
 
 def test_browser_profile_disables_sandbox_for_root_on_linux(monkeypatch):
 	monkeypatch.setattr(sys, 'platform', 'linux')
 	monkeypatch.setattr(os, 'geteuid', lambda: 0)
+	monkeypatch.setenv('IN_DOCKER', 'false')
+	monkeypatch.setattr(browser_use_config, 'is_running_in_docker', lambda: False)
 
 	profile = BrowserProfile(headless=True, chromium_sandbox=True)
 
 	assert profile.chromium_sandbox is False
 
 
+def test_browser_profile_only_adds_no_sandbox_for_root_outside_docker(monkeypatch, tmp_path):
+	monkeypatch.setattr(sys, 'platform', 'linux')
+	monkeypatch.setattr(os, 'geteuid', lambda: 0)
+	monkeypatch.setenv('IN_DOCKER', 'false')
+	monkeypatch.setattr(browser_use_config, 'is_running_in_docker', lambda: False)
+
+	profile = BrowserProfile(headless=True, chromium_sandbox=True, user_data_dir=tmp_path, enable_default_extensions=False)
+	args = profile.get_args()
+
+	assert '--no-sandbox' in args
+	assert '--disable-gpu-sandbox' not in args
+	assert '--disable-setuid-sandbox' not in args
+	assert '--no-xshm' not in args
+	assert '--no-zygote' not in args
+	assert '--disable-site-isolation-trials' not in args
+
+
 def test_browser_profile_keeps_sandbox_for_non_root(monkeypatch):
 	monkeypatch.setattr(sys, 'platform', 'linux')
 	monkeypatch.setattr(os, 'geteuid', lambda: 1000)
+	monkeypatch.setenv('IN_DOCKER', 'false')
+	monkeypatch.setattr(browser_use_config, 'is_running_in_docker', lambda: False)
 
 	profile = BrowserProfile(headless=True, chromium_sandbox=True)
 

--- a/tests/ci/test_browser_profile_root_sandbox.py
+++ b/tests/ci/test_browser_profile_root_sandbox.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+from browser_use.browser import BrowserProfile
+
+
+def test_browser_profile_disables_sandbox_for_root_on_linux(monkeypatch):
+	monkeypatch.setattr(sys, 'platform', 'linux')
+	monkeypatch.setattr(os, 'geteuid', lambda: 0)
+
+	profile = BrowserProfile(headless=True, chromium_sandbox=True)
+
+	assert profile.chromium_sandbox is False
+
+
+def test_browser_profile_keeps_sandbox_for_non_root(monkeypatch):
+	monkeypatch.setattr(sys, 'platform', 'linux')
+	monkeypatch.setattr(os, 'geteuid', lambda: 1000)
+
+	profile = BrowserProfile(headless=True, chromium_sandbox=True)
+
+	assert profile.chromium_sandbox is True


### PR DESCRIPTION
## Summary
- disable Chromium sandbox automatically when browser-use runs as root on Linux
- keep existing behavior unchanged for non-root users
- add regression tests for root vs non-root sandbox behavior

## Why
Running browser-use as root on Linux currently launches Chromium without `--no-sandbox`, which causes local browser startup to fail immediately with Chromium's root/sandbox restriction.

## Testing
- `uv run pytest tests/ci/test_browser_profile_root_sandbox.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically disable the Chromium sandbox when `browser-use` runs as root on Linux so local browser startup doesn’t fail. Outside Docker we now only add `--no-sandbox`; non-root behavior is unchanged and Docker runs keep full flags.

- **Bug Fixes**
  - In `BrowserProfile`, detect Linux root during init, log a warning, and set `chromium_sandbox=False`; use Docker flags only when `IN_DOCKER` is true, otherwise add only `--no-sandbox`.
  - Added tests to confirm sandbox is disabled for root, preserved for non-root, and that only `--no-sandbox` is added outside Docker.

<sup>Written for commit 91e8baf11113a63afbd9cc3bef911cceeb2bb666. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

