### PR TITLE
fix(install): add Arch Linux support with system Chromium fallback

### DIFF
--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -161,6 +161,45 @@ detect_platform() {
 	log_info "Detected platform: $PLATFORM ($arch)"
 }
 
+# Detect Linux distribution for package manager selection
+detect_linux_distro() {
+	if [ "$PLATFORM" != "linux" ]; then
+		LINUX_DISTRO=""
+		return 0
+	fi
+
+	if command -v pacman &> /dev/null; then
+		LINUX_DISTRO="arch"
+	elif command -v apt-get &> /dev/null; then
+		LINUX_DISTRO="debian"
+	elif command -v dnf &> /dev/null; then
+		LINUX_DISTRO="fedora"
+	elif command -v yum &> /dev/null; then
+		LINUX_DISTRO="rhel"
+	else
+		LINUX_DISTRO="unknown"
+	fi
+}
+
+# Find existing Chromium system binary
+find_system_chromium() {
+	local candidates=(
+		/usr/bin/chromium
+		/usr/bin/chromium-browser
+		/usr/local/bin/chromium
+		/usr/local/bin/chromium-browser
+		snap/bin/chromium
+	)
+
+	for candidate in "${candidates[@]}"; do
+		if [ -x "$candidate" ]; then
+			echo "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
 # =============================================================================
 # Virtual environment helpers
 # =============================================================================
@@ -256,15 +295,27 @@ install_python() {
 			fi
 			;;
 		linux)
-			if command -v apt-get &> /dev/null; then
-				$SUDO apt-get update
-				$SUDO apt-get install -y python3.11 python3.11-venv python3-pip
-			elif command -v yum &> /dev/null; then
-				$SUDO yum install -y python311 python311-pip
-			else
-				log_error "Unsupported package manager. Install Python 3.11+ manually."
-				exit 1
-			fi
+			detect_linux_distro
+			case "$LINUX_DISTRO" in
+				debian)
+					$SUDO apt-get update
+					$SUDO apt-get install -y python3.11 python3.11-venv python3-pip
+					;;
+				fedora|rhel)
+					$SUDO dnf install -y python3.11 python3.11-pip || $SUDO yum install -y python311 python311-pip
+					;;
+				arch)
+					log_info "Arch Linux detected. Checking for Python 3.11+..."
+					if ! python3 --version 2>&1 | grep -qE 'Python 3\.(1[1-9]|[2-9][0-9])'; then
+						$SUDO pacman -Syy
+						$SUDO pacman -S --noconfirm python
+					fi
+					;;
+				*)
+					log_error "Unsupported package manager. Install Python 3.11+ manually."
+					exit 1
+					;;
+			esac
 			;;
 		windows)
 			log_error "Please install Python 3.11+ from: https://www.python.org/downloads/"
@@ -346,7 +397,38 @@ install_chromium() {
 
 	activate_venv
 
-	# Build command - only use --with-deps on Linux (it fails on Windows/macOS)
+	if [ "$PLATFORM" = "linux" ]; then
+		detect_linux_distro
+	fi
+
+	# On Arch Linux, use system Chromium as fallback
+	if [ "$PLATFORM" = "linux" ] && [ "$LINUX_DISTRO" = "arch" ]; then
+		log_info "Arch Linux detected. Looking for system Chromium..."
+		local chromium_path
+		if chromium_path=$(find_system_chromium); then
+			log_success "Found system Chromium at $chromium_path — skipping Playwright install"
+			return 0
+		fi
+
+		if [ -t 0 ]; then
+			read -p "Chromium not found. Install via pacman? [y/N] " -n 1 -r < /dev/tty
+			echo
+			if [[ $REPLY =~ ^[Yy]$ ]]; then
+				SUDO=""
+				if [ "$(id -u)" -ne 0 ] && command -v sudo &> /dev/null; then
+					SUDO="sudo"
+				fi
+				$SUDO pacman -S --noconfirm chromium
+			else
+				log_warn "Chromium not installed. You can use --profile or --connect later."
+				return 0
+			fi
+		else
+			log_warn "Chromium not found and non-interactive mode. Install chromium manually."
+			return 0
+		fi
+	fi
+
 	local cmd="uvx playwright install chromium"
 	if [ "$PLATFORM" = "linux" ]; then
 		cmd="$cmd --with-deps"

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -188,7 +188,7 @@ find_system_chromium() {
 		/usr/bin/chromium-browser
 		/usr/local/bin/chromium
 		/usr/local/bin/chromium-browser
-		snap/bin/chromium
+		/snap/bin/chromium
 	)
 
 	for candidate in "${candidates[@]}"; do
@@ -419,6 +419,7 @@ install_chromium() {
 					SUDO="sudo"
 				fi
 				$SUDO pacman -S --noconfirm chromium
+				return 0
 			else
 				log_warn "Chromium not installed. You can use --profile or --connect later."
 				return 0


### PR DESCRIPTION
## Problem
On Arch Linux (and other pacman-based distributions), the `install.sh` bootstrap script fails at the Chromium installation step because it unconditionally calls `uvx playwright install chromium --with-deps`, which internally tries to run `apt-get` on Linux. Since Arch does not have `apt-get`, the script aborts with:

```
sh: line 1: apt-get: command not found
Failed to install browsers
Error: Installation process exited with code: 127
```

This prevents the installer from completing PATH setup and validation, leaving users without a working `browser-use` CLI.

## Solution
This PR introduces distro-aware detection and a system-Chromium fallback for Arch Linux:

1. **`detect_linux_distro()`**  
   Detects the Linux distribution by checking for available package managers (`pacman`, `apt-get`, `dnf`, `yum`).

2. **`find_system_chromium()`**  
   Searches common paths for an already-installed Chromium binary (e.g. `/usr/bin/chromium`).

3. **`install_python()` — refactored**  
   Uses a `case` block based on `LINUX_DISTRO`. On Arch, it verifies that Python 3.11+ is present (Arch typically ships it by default) and installs via `pacman` only if needed.

4. **`install_chromium()` — refactored**  
   - On Arch Linux, skips the Playwright-managed Chromium install entirely.
   - If a system Chromium is found, prints a success message and returns cleanly.
   - If no system Chromium is found, prompts the user interactively to install via `pacman -S --noconfirm chromium`.
   - In non-interactive mode (CI), logs a warning and continues instead of aborting.

## Why not install Playwright Chromium on Arch?
Playwright's `--with-deps` flag is hard-coded to Debian/Ubuntu-style dependencies. Supporting Arch natively through Playwright would require maintaining a separate dependency list, which is brittle. Using the system Chromium is simpler, faster, and aligns with how Arch users already manage browsers.

## Validation

Tested on a fresh Arch Linux machine with the following log:

```bash
# Log from: bash browser_use/skill_cli/install.sh
```bash
 󱞩 bash browser_use/skill_cli/install.sh

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Browser-Use Installer
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

ℹ Detected platform: linux (x86_64)
ℹ Checking Python installation...
✓ Python 3.14.4 found (python3)
ℹ Installing uv package manager...
✓ uv already installed
ℹ Installing browser-use...
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
Using CPython 3.13.5
Creating virtual environment at: /home/gabriel/.browser-use-env
Activate with: source /home/gabriel/.browser-use-env/bin/activate
ℹ Installing from GitHub: browser-use/browser-use@main
Cloning into '/tmp/tmp.8Zgi0EDwEe'...
remote: Enumerating objects: 571, done.
remote: Counting objects: 100% (571/571), done.
remote: Compressing objects: 100% (550/550), done.
remote: Total 571 (delta 18), reused 269 (delta 7), pack-reused 0 (from 0)
Receiving objects: 100% (571/571), 4.31 MiB | 24.24 MiB/s, done.
Resolving deltas: 100% (18/18), done.
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
Using Python 3.13.5 environment at: /home/gabriel/.browser-use-env
Resolved 98 packages in 324ms
      Built browser-use @ file:///tmp/tmp.8Zgi0EDwEe
Prepared 45 packages in 996ms
Installed 98 packages in 386ms
 + aiofiles==25.1.0
 + aiohappyeyeballs==2.6.1
 + aiohttp==3.13.4
 + aiosignal==1.4.0
 + annotated-types==0.7.0
 + anthropic==0.76.0
 + anyio==4.12.1
 + attrs==26.1.0
 + backoff==2.2.1
 + beautifulsoup4==4.14.3
 + browser-use==0.12.6 (from file:///tmp/tmp.8Zgi0EDwEe)
 + browser-use-sdk==3.4.2
 + bubus==1.5.6
 + cdp-use==1.4.5
 + certifi==2026.4.22
 + cffi==2.0.0
 + charset-normalizer==3.4.7
 + click==8.3.1
 + cloudpickle==3.1.2
 + cryptography==47.0.0
 + distro==1.9.0
 + docstring-parser==0.18.0
 + frozenlist==1.8.0
 + google-api-core==2.29.0
 + google-api-python-client==2.188.0
 + google-auth==2.48.0
 + google-auth-httplib2==0.3.1
 + google-auth-oauthlib==1.2.4
 + google-genai==1.65.0
 + googleapis-common-protos==1.74.0
 + groq==1.0.0
 + h11==0.16.0
 + httpcore==1.0.9
 + httplib2==0.31.2
 + httpx==0.28.1
 + httpx-sse==0.4.3
 + idna==3.13
 + inquirerpy==0.3.4
 + jiter==0.14.0
 + jsonschema==4.26.0
 + jsonschema-specifications==2025.9.1
 + lxml==6.1.0
 + markdown-it-py==4.0.0
 + markdownify==1.2.2
 + mcp==1.26.0
 + mdurl==0.1.2
 + multidict==6.7.1
 + oauthlib==3.3.1
 + ollama==0.6.1
 + openai==2.16.0
 + pfzy==0.3.4
 + pillow==12.2.0
 + portalocker==3.2.0
 + posthog==7.7.0
 + prompt-toolkit==3.0.52
 + propcache==0.4.1
 + proto-plus==1.27.2
 + protobuf==6.33.6
 + psutil==7.2.2
 + pyasn1==0.6.3
 + pyasn1-modules==0.4.2
 + pycparser==3.0
 + pydantic==2.12.5
 + pydantic-core==2.41.5
 + pydantic-settings==2.14.0
 + pygments==2.20.0
 + pyjwt==2.12.1
 + pyotp==2.9.0
 + pyparsing==3.3.2
 + pypdf==6.10.2
 + python-dateutil==2.9.0.post0
 + python-docx==1.2.0
 + python-dotenv==1.2.1
 + python-multipart==0.0.27
 + referencing==0.37.0
 + reportlab==4.4.9
 + requests==2.33.0
 + requests-oauthlib==2.0.0
 + rich==14.3.1
 + rpds-py==0.30.0
 + rsa==4.9.1
 + screeninfo==0.8.1
 + six==1.17.0
 + sniffio==1.3.1
 + soupsieve==2.8.3
 + sse-starlette==3.4.1
 + starlette==1.0.0
 + tenacity==9.1.4
 + tqdm==4.67.3
 + typing-extensions==4.15.0
 + typing-inspection==0.4.2
 + uritemplate==4.2.0
 + urllib3==2.6.3
 + uuid7==0.1.0
 + uvicorn==0.46.0
 + wcwidth==0.6.0
 + websockets==16.0
 + yarl==1.23.0
✓ browser-use installed
ℹ Installing Chromium browser...
ℹ Arch Linux detected. Looking for system Chromium...
✓ Found system Chromium at /usr/bin/chromium — skipping Playwright install
ℹ Installing profile-use...
Downloading profile-use v1.0.2...

✓ Installed profile-use v1.0.2 to /home/gabriel/.browser-use/bin/profile-use

Note: /home/gabriel/.browser-use/bin is not in your PATH.
Add it by running:

  export PATH="/home/gabriel/.browser-use/bin:$PATH"

Or add that line to your ~/.bashrc, ~/.zshrc, or equivalent.

Start here:
  profile-use                      # interactive wizard — prompts for API key, picks profile, picks domains, syncs

Other commands:
  profile-use auth                               save the API key separately
  profile-use list                               detected local browsers and profiles
  profile-use inspect --profile <name>           preview cookie domains before you sync
  profile-use sync --profile <name>              non-interactive sync
    --cloud-profile-id <uuid>                    refresh an existing cloud profile instead of creating new
    --domain <d>  / --exclude-domain <d>         scope by cookie domain (repeatable, subdomain-aware)

  profile-use --help                             everything else
✓ profile-use installed
✓ Added to PATH in /home/gabriel/.zshrc
ℹ Validating installation...

Diagnostics:

  ✓ package: browser-use unknown
  ✓ browser: Browser profile available
  ✓ network: Network connectivity OK
  ○ cloudflared: cloudflared not installed (needed for browser-use tunnel)
      Fix: Install cloudflared: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/
  ✓ profile_use: profile-use installed (/home/gabriel/.browser-use/bin/profile-use)

⚠ 4/5 checks passed, 1 missing

Config (/home/gabriel/.browser-use/config.json):

  ○ api_key: not set
  ○ cloud_connect_profile_id: not set
  ○ cloud_connect_proxy: us (default)
  ○ cloud_connect_timeout: not set
  ○ cloud_connect_recording: True (default)
  Docs: https://docs.browser-use.com/open-source/browser-use-cli
✓ Installation validated successfully!

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

✓ Browser-Use installed successfully!

Next steps:
  1. Restart your shell or run: source ~/.zshrc
  2. Try: browser-use open https://example.com

Documentation: https://docs.browser-use.com
``` 
```

```
## Key highlights from the log
- **Platform detected:** `linux (x86_64)` — Arch Linux.
- **Chromium step:** correctly identified Arch, found `/usr/bin/chromium`, skipped Playwright install.
- **Validation:** `browser-use doctor` passed (4/5 checks; missing `cloudflared` is unrelated).

## Checklist
- [x] Code follows the existing shell style.
- [x] Syntax checked with `bash -n`.
- [x] Manually tested on Arch Linux.
- [x] No changes to non-installer code.
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).