### PR TITLE
fix: enforce domain restrictions for data and blob URLs

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -178,9 +178,17 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
+		has_domain_restrictions = bool(
+			self.browser_session.browser_profile.allowed_domains or self.browser_session.browser_profile.prohibited_domains
+		)
+
+		# Allow data: and blob: URLs only when there are no domain restrictions.
 		if parsed.scheme in ['data', 'blob']:
-			return True
+			if not has_domain_restrictions:
+				return True
+			if parsed.scheme == 'data':
+				return False
+			return self._is_url_allowed(url.removeprefix('blob:'))
 
 		# Get the actual host (domain)
 		host = parsed.hostname
@@ -193,10 +201,7 @@ class SecurityWatchdog(BaseWatchdog):
 				return False
 
 		# If no allowed_domains specified, allow all URLs
-		if (
-			not self.browser_session.browser_profile.allowed_domains
-			and not self.browser_session.browser_profile.prohibited_domains
-		):
+		if not has_domain_restrictions:
 			return True
 
 		# Check allowed domains (fast path for sets, slow path for lists with patterns)

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -26,6 +26,36 @@ class TestUrlAllowlistSecurity:
 		# Make sure legitimate auth credentials still work
 		assert watchdog._is_url_allowed('https://user:password@example.com') is True
 
+	def test_data_and_blob_urls_follow_domain_restrictions(self):
+		"""Test that hostless URLs cannot bypass configured domain restrictions."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('data:text/html,<script>location="https://evil.com"</script>') is False
+		assert watchdog._is_url_allowed('blob:https://example.com/2f1e4d13-8ac4-4ca3-8b2c-6207b063fc9f') is True
+		assert watchdog._is_url_allowed('blob:https://evil.com/2f1e4d13-8ac4-4ca3-8b2c-6207b063fc9f') is False
+		assert watchdog._is_url_allowed('blob:null/2f1e4d13-8ac4-4ca3-8b2c-6207b063fc9f') is False
+
+	def test_data_and_blob_urls_allowed_without_domain_restrictions(self):
+		"""Test backwards-compatible handling when no allowlist or blocklist is configured."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('data:text/html,<h1>local</h1>') is True
+		assert watchdog._is_url_allowed('blob:https://example.com/2f1e4d13-8ac4-4ca3-8b2c-6207b063fc9f') is True
+
 	def test_glob_pattern_matching(self):
 		"""Test that glob patterns in allowed_domains work correctly."""
 		from bubus import EventBus


### PR DESCRIPTION
Closes #4763

## Summary
- block `data:` URLs whenever `allowed_domains` or `prohibited_domains` is configured
- validate `blob:` URLs against the encoded origin instead of allowing them unconditionally
- keep existing behavior for `data:`/`blob:` URLs when no domain restrictions are configured

## Tests
- `uv run ruff check browser_use/browser/watchdogs/security_watchdog.py tests/ci/security/test_domain_filtering.py`
- `uv run pytest tests/ci/security/test_domain_filtering.py -q`
- `uv run pytest tests/ci/security -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce domain restrictions for data: and blob: URLs to prevent bypassing allow/block rules, while keeping previous behavior when no restrictions are set.

- **Bug Fixes**
  - Block `data:` URLs when `allowed_domains` or `prohibited_domains` is configured.
  - Validate `blob:` URLs against their encoded origin; reject cross-origin, `blob:null`, and non-allowed hosts.
  - Preserve old behavior for `data:`/`blob:` when no domain lists are set.
  - Add tests for restricted and unrestricted data/blob cases.

<sup>Written for commit 634463ba1c41feb2024bad3404a31c738a6af2a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

