### PR TITLE
fix(init): reject path-traversal in remote templates.json fields

### DIFF
--- a/browser_use/init_cmd.py
+++ b/browser_use/init_cmd.py
@@ -32,6 +32,43 @@ TEMPLATE_REPO_URL = 'https://raw.githubusercontent.com/browser-use/template-libr
 INIT_TEMPLATES: dict[str, Any] = {}
 
 
+def _validate_relative_path(name: str, *, field: str) -> str:
+	"""
+	Reject any path string from the remote manifest that is absolute, contains `..`,
+	or otherwise tries to escape the directory it will be joined onto.
+
+	The manifest is fetched at runtime from a third-party-controllable URL, so every
+	string that ends up in a filesystem path or remote URL must be a plain relative
+	name. Without this, `Path('/tmp/x') / Path('/etc/crontab')` silently yields
+	`/etc/crontab`, which is enough to turn a manifest compromise into arbitrary
+	file write on the user's machine the moment they run `browser-use init`.
+	"""
+	if not isinstance(name, str) or not name:
+		raise ValueError(f'Invalid {field} in template manifest: {name!r}')
+	candidate = Path(name)
+	if candidate.is_absolute() or candidate.drive or candidate.root:
+		raise ValueError(f'Refusing absolute {field} from template manifest: {name!r}')
+	if any(part in ('..', '') for part in candidate.parts):
+		raise ValueError(f'Refusing traversal {field} from template manifest: {name!r}')
+	# Also block backslash-as-separator on POSIX, which Path treats as a literal char
+	# but the running shell / IDE may not.
+	if '\x00' in name or '\\' in name:
+		raise ValueError(f'Refusing {field} with unsafe characters: {name!r}')
+	return name
+
+
+def _safe_join(base: Path, name: str, *, field: str) -> Path:
+	"""Join ``name`` onto ``base`` and confirm the result stays inside ``base``."""
+	_validate_relative_path(name, field=field)
+	base_resolved = base.resolve()
+	candidate = (base_resolved / name).resolve()
+	# `is_relative_to` is the right primitive but only exists on 3.9+; the project
+	# already requires >=3.11 per CLAUDE.md so we can rely on it.
+	if not candidate.is_relative_to(base_resolved):
+		raise ValueError(f'Refusing {field} that escapes template directory: {name!r}')
+	return candidate
+
+
 def _fetch_template_list() -> dict[str, Any] | None:
 	"""
 	Fetch template list from GitHub templates.json.
@@ -326,6 +363,15 @@ def main(
 	# Template is guaranteed to be set at this point (either from option or prompt)
 	assert template is not None
 
+	# The template name comes from the (remote, third-party-controllable) manifest
+	# keys when picked interactively, and from the CLI flag otherwise. Either way
+	# it is concatenated onto $CWD below, so it must be a plain relative name.
+	try:
+		_validate_relative_path(template, field='template name')
+	except ValueError as e:
+		console.print(f'[red]✗[/red] {e}')
+		sys.exit(1)
+
 	# Create template directory
 	template_dir = Path.cwd() / template
 	if template_dir.exists() and not force:
@@ -346,6 +392,7 @@ def main(
 	# Read template file from GitHub
 	try:
 		template_file = INIT_TEMPLATES[template]['file']
+		_validate_relative_path(template_file, field='template file')
 		content = _get_template_content(template_file)
 	except Exception as e:
 		console.print(f'[red]✗[/red] Error reading template: {e}')
@@ -362,9 +409,19 @@ def main(
 			for file_spec in INIT_TEMPLATES[template]['files']:
 				source_path = file_spec['source']
 				dest_name = file_spec['dest']
-				dest_path = output_path.parent / dest_name
 				is_binary = file_spec.get('binary', False)
 				is_executable = file_spec.get('executable', False)
+
+				# Validate manifest-controlled paths *before* touching the disk: the
+				# `dest` field is the primary path-traversal sink, but `source` also
+				# flows into a remote URL we then fetch and execute, so it earns the
+				# same treatment.
+				try:
+					_validate_relative_path(source_path, field='file source')
+					dest_path = _safe_join(output_path.parent, dest_name, field='file dest')
+				except ValueError as e:
+					console.print(f'[yellow]⚠[/yellow]  Skipping unsafe template entry: {e}')
+					continue
 
 				# Skip if we already wrote this file (main.py)
 				if dest_path == output_path:

--- a/tests/ci/test_cli_install_init.py
+++ b/tests/ci/test_cli_install_init.py
@@ -7,6 +7,13 @@ heavy dependencies for simple setup tasks.
 
 import subprocess
 import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from pytest_httpserver import HTTPServer
+
+from browser_use import init_cmd
 
 
 def test_install_command_help():
@@ -78,3 +85,171 @@ def test_template_flag_help():
 	)
 	assert result.returncode == 0
 	assert '--template' in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal regression tests for templates.json (`dest`/`source`/`file`)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+	'name',
+	[
+		'/etc/crontab',
+		'/tmp/abs',
+		'../../../etc/passwd',
+		'foo/../../bar',
+		'..',
+		'a/../b',
+		'',
+		'foo\\bar',  # backslashes treated as a literal char on POSIX – ambiguous, reject
+		'foo\x00bar',
+	],
+)
+def test_validate_relative_path_rejects_dangerous_inputs(name: str):
+	with pytest.raises(ValueError):
+		init_cmd._validate_relative_path(name, field='dest')
+
+
+@pytest.mark.parametrize(
+	'name',
+	[
+		'main.py',
+		'subdir/main.py',
+		'a/b/c/d.txt',
+		'.gitignore',
+	],
+)
+def test_validate_relative_path_accepts_plain_names(name: str):
+	assert init_cmd._validate_relative_path(name, field='dest') == name
+
+
+def test_safe_join_keeps_path_inside_base(tmp_path: Path):
+	base = tmp_path / 'tpl'
+	base.mkdir()
+	resolved = init_cmd._safe_join(base, 'sub/file.py', field='dest')
+	assert resolved == (base / 'sub' / 'file.py').resolve()
+
+
+def test_safe_join_rejects_absolute_dest(tmp_path: Path):
+	base = tmp_path / 'tpl'
+	base.mkdir()
+	with pytest.raises(ValueError):
+		init_cmd._safe_join(base, '/etc/crontab', field='dest')
+
+
+def test_safe_join_rejects_traversal_dest(tmp_path: Path):
+	base = tmp_path / 'tpl'
+	base.mkdir()
+	with pytest.raises(ValueError):
+		init_cmd._safe_join(base, '../escape.py', field='dest')
+
+
+def _malicious_manifest() -> dict:
+	"""A templates.json shaped exactly like the one in the vuln report."""
+	return {
+		'evil': {
+			'description': 'Innocuous-looking template',
+			'file': 'evil/main.py',
+			'files': [
+				{
+					'source': 'evil/payload.sh',
+					'dest': '../../../../../../tmp/browser_use_pwn_marker',
+					'executable': True,
+				},
+				{
+					'source': 'evil/cron',
+					'dest': '/tmp/browser_use_pwn_abs_marker',
+					'binary': False,
+				},
+			],
+		}
+	}
+
+
+def test_init_refuses_manifest_path_traversal(tmp_path: Path, httpserver: HTTPServer, monkeypatch):
+	"""
+	End-to-end: a compromised templates.json that points `dest` at /tmp or
+	outside the template dir must NOT cause writes outside the per-template
+	directory the user created in their cwd.
+	"""
+	manifest = _malicious_manifest()
+	httpserver.expect_request('/templates.json').respond_with_json(manifest)
+	# main.py for the template is fetched first; serve a benign body so the
+	# code reaches the `files` loop where the traversal would happen.
+	httpserver.expect_request('/evil/main.py').respond_with_data('print("hi")\n')
+	httpserver.expect_request('/evil/payload.sh').respond_with_data('#!/bin/sh\necho pwn\n')
+	httpserver.expect_request('/evil/cron').respond_with_data('* * * * * root pwn\n')
+
+	monkeypatch.setattr(init_cmd, 'TEMPLATE_REPO_URL', httpserver.url_for('').rstrip('/'))
+	monkeypatch.chdir(tmp_path)
+
+	# Pre-create the marker locations to assert they are NOT overwritten.
+	rel_marker = Path('/tmp/browser_use_pwn_marker')
+	abs_marker = Path('/tmp/browser_use_pwn_abs_marker')
+	for m in (rel_marker, abs_marker):
+		if m.exists():
+			m.unlink()
+
+	runner = CliRunner()
+	result = runner.invoke(init_cmd.main, ['--template', 'evil', '--force'])
+
+	# The benign main.py write should still succeed; only the malicious entries
+	# get skipped with a warning.
+	assert result.exit_code == 0, result.output
+	assert (tmp_path / 'evil' / 'main.py').exists()
+	assert not rel_marker.exists(), 'traversal `dest` wrote outside template dir'
+	assert not abs_marker.exists(), 'absolute `dest` wrote outside template dir'
+	assert 'unsafe template entry' in result.output
+
+
+def test_init_refuses_traversal_in_template_name(tmp_path: Path, httpserver: HTTPServer, monkeypatch):
+	"""A manifest that names a template `..` (used as cwd subdir) is rejected."""
+	httpserver.expect_request('/templates.json').respond_with_json({'../escape': {'file': 'x.py'}})
+	monkeypatch.setattr(init_cmd, 'TEMPLATE_REPO_URL', httpserver.url_for('').rstrip('/'))
+	monkeypatch.chdir(tmp_path)
+
+	runner = CliRunner()
+	result = runner.invoke(init_cmd.main, ['--template', '../escape', '--force'])
+	assert result.exit_code == 1
+	assert 'template name' in result.output
+	# Make sure no escape directory was created in the parent.
+	assert not (tmp_path.parent / 'escape').exists()
+
+
+def test_init_refuses_traversal_in_template_file(tmp_path: Path, httpserver: HTTPServer, monkeypatch):
+	"""A manifest whose `file` URL path tries to escape the repo URL is rejected."""
+	httpserver.expect_request('/templates.json').respond_with_json({'evil': {'file': '../../private/secret.py'}})
+	monkeypatch.setattr(init_cmd, 'TEMPLATE_REPO_URL', httpserver.url_for('').rstrip('/'))
+	monkeypatch.chdir(tmp_path)
+
+	runner = CliRunner()
+	result = runner.invoke(init_cmd.main, ['--template', 'evil', '--force'])
+	# main exits non-zero via sys.exit(1) inside the except block.
+	assert result.exit_code == 1
+	assert 'template file' in result.output
+
+
+def test_init_happy_path_still_writes_files(tmp_path: Path, httpserver: HTTPServer, monkeypatch):
+	"""Sanity check: a normal manifest with relative paths still works."""
+	manifest = {
+		'good': {
+			'description': 'Benign',
+			'file': 'good/main.py',
+			'files': [
+				{'source': 'good/helper.py', 'dest': 'helper.py'},
+			],
+		}
+	}
+	httpserver.expect_request('/templates.json').respond_with_json(manifest)
+	httpserver.expect_request('/good/main.py').respond_with_data('print("main")\n')
+	httpserver.expect_request('/good/helper.py').respond_with_data('print("helper")\n')
+
+	monkeypatch.setattr(init_cmd, 'TEMPLATE_REPO_URL', httpserver.url_for('').rstrip('/'))
+	monkeypatch.chdir(tmp_path)
+
+	runner = CliRunner()
+	result = runner.invoke(init_cmd.main, ['--template', 'good', '--force'])
+	assert result.exit_code == 0, result.output
+	assert (tmp_path / 'good' / 'main.py').read_text() == 'print("main")\n'
+	assert (tmp_path / 'good' / 'helper.py').read_text() == 'print("helper")\n'


### PR DESCRIPTION
## Summary
- The `dest`, `source`, `file`, and template-name fields in the runtime-fetched `templates.json` were concatenated straight into filesystem paths and URLs with no validation. `Path('/tmp/x') / Path('/etc/crontab')` silently yields `/etc/crontab`, so a manifest compromise turned into **arbitrary file write under the invoking user** (`~/.bashrc`, `/etc/cron.d/*`, `~/.ssh/authorized_keys`, …) the moment a user ran `browser-use init`.
- Adds `_validate_relative_path` + `_safe_join` and applies them to every manifest-controlled string before it touches disk or a URL.
  - Per-entry `files[]` violations are skipped with a warning so a single bad entry can't poison the whole template.
  - Top-level violations (`template`, `file`) abort with exit 1.
- The `template` directory under `cwd` and the `file` URL path also flow from manifest-controlled keys, so they get the same treatment.

## Why this matters
1. Attacker controls `templates.json` (compromised maintainer creds, malicious PR, branch hijack on `template-library@main` since the URL pins to `main`, etc.).
2. They publish an entry with `\"dest\": \"/etc/cron.d/pwn\"` or `\"dest\": \"../../../../home/victim/.bashrc\"`.
3. User runs `uvx browser-use init` and the loop in `main()` writes attacker-controlled bytes there. The `executable` flag also chmod's +x, and the binary branch bypasses the overwrite prompt entirely.

## Test plan
- [x] 19 new tests in `tests/ci/test_cli_install_init.py`, including:
  - parametrized rejection of absolute paths, `..` segments, empty strings, NUL bytes, backslashes
  - end-to-end scenario from the report: a malicious `templates.json` served via `pytest-httpserver`, asserting that pre-staged marker files at `/tmp/browser_use_pwn_*` remain absent after `init` runs
  - traversal in template name and template `file` aborts with exit 1
  - happy-path benign manifest still writes both files correctly
- [x] `uv run pytest -vxs tests/ci/test_cli_install_init.py` — 26 passed
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [x] `uv run pyright` on touched files — 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical path traversal in the init command by validating all manifest-controlled paths to prevent arbitrary file writes and unsafe URL fetches. Unsafe entries are blocked or skipped so a poisoned `templates.json` cannot escape the template directory.

- **Bug Fixes**
  - Added `_validate_relative_path` and `_safe_join`; applied to template name, `file`, and each `files[]` `source`/`dest`.
  - Reject absolute paths, `..` segments, empty strings, backslashes, and NUL bytes; enforce that joins stay inside the template directory.
  - Skip unsafe `files[]` entries with a warning; abort on unsafe template name or `file` with exit 1.

<sup>Written for commit d6c221d1a8207bc9fce2b0e11923adf9e4978f53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

