### PR TITLE
fix: use return_exceptions in asyncio.gather for AX tree collection

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -363,12 +363,17 @@ class DomService:
 			)
 			ax_tree_requests.append(ax_tree_request)
 
-		# Wait for all requests to complete
-		ax_trees = await asyncio.gather(*ax_tree_requests)
+		# Wait for all requests to complete — use return_exceptions=True so that
+		# a single detached iframe (common with ads/analytics) doesn't discard
+		# successful results from every other frame.
+		ax_trees = await asyncio.gather(*ax_tree_requests, return_exceptions=True)
 
-		# Merge all AX nodes into a single array
+		# Merge all AX nodes into a single array, skipping failed frames
 		merged_nodes: list[AXNode] = []
-		for ax_tree in ax_trees:
+		for i, ax_tree in enumerate(ax_trees):
+			if isinstance(ax_tree, BaseException):
+				self.logger.debug(f'Failed to get AX tree for frame {all_frame_ids[i]}: {ax_tree}')
+				continue
 			merged_nodes.extend(ax_tree['nodes'])
 
 		return {'nodes': merged_nodes}


### PR DESCRIPTION
## Problem

`_get_ax_tree_for_all_frames` fires parallel `Accessibility.getFullAXTree` CDP calls for every frame, but uses `asyncio.gather()` without `return_exceptions=True`. When any single iframe detaches between `getFrameTree` and `getFullAXTree` (a common TOCTOU race with ad/analytics iframes), the entire gather raises and all successful AX results are lost.

The agent ends up with an empty DOM tree (`SerializedDOMState(_root=None, selector_map={})`) and loses all ability to interact with the page.

## Fix

Pass `return_exceptions=True` so failed frames are skipped gracefully while all surviving frames (including the main document) are preserved. Failed frames are logged at DEBUG level.

Fixes #4778

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `asyncio.gather(..., return_exceptions=True)` for AX tree collection so one detached iframe doesn’t drop all results. Preserves AX nodes from surviving frames and prevents an empty DOM state. Fixes #4778.

- **Bug Fixes**
  - Continue merging the AX tree even if some frames fail.
  - Log failed frame fetches at DEBUG with the frame ID for easier diagnosis.

<sup>Written for commit 9f0b0e2e58c89433574d20112ccbb65ca5b85ad4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

