### PR TITLE
docs: clarify ChatOpenRouter availability and import path

### DIFF
--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -206,6 +206,10 @@ llm = ChatOpenRouter(model="anthropic/claude-sonnet-4-6")
 
 **Env:** `OPENROUTER_API_KEY` | [Available models](https://openrouter.ai/models)
 
+<Note>
+`ChatOpenRouter` is available directly from `browser_use` when installed from source or PyPI ≥ v0.12.0. If you encounter an import error, upgrade with `uv pip install -U browser-use`.
+</Note>
+
 ## Vercel AI Gateway
 
 Proxy to multiple providers with automatic fallback:


### PR DESCRIPTION
## Summary
The documentation for OpenRouter shows `from browser_use import Agent, ChatOpenRouter`, but some users report that `ChatOpenRouter` does not exist in their installation.

## Changes
- Added a `<Note>` block under the OpenRouter section explaining that `ChatOpenRouter` is available directly from `browser_use` when installed from source or PyPI ≥ v0.12.0.
- Included an upgrade command (`uv pip install -U browser-use`) for users hitting import errors.

Fixes #4755

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified the `ChatOpenRouter` import in the OpenRouter docs to prevent confusion about availability.
Added a note that it’s available directly from `browser_use` in PyPI ≥ v0.12.0 (or source installs) and included an upgrade command (`uv pip install -U browser-use`) for import errors.

<sup>Written for commit 6eef7ad58e74c0c095cbd1872eb5e9fd2e4e5c96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

