### PR TITLE
fix(BrowserError): drop trailing 'during: None' when no event is attached

### DIFF
--- a/browser_use/browser/views.py
+++ b/browser_use/browser/views.py
@@ -188,12 +188,12 @@ class BrowserError(Exception):
 		super().__init__(message)
 
 	def __str__(self) -> str:
+		parts = [self.message]
 		if self.details:
-			return f'{self.message} ({self.details}) during: {self.while_handling_event}'
-		elif self.while_handling_event:
-			return f'{self.message} (while handling: {self.while_handling_event})'
-		else:
-			return self.message
+			parts.append(f'({self.details})')
+		if self.while_handling_event:
+			parts.append(f'during: {self.while_handling_event}')
+		return ' '.join(parts)
 
 
 class URLNotAllowedError(BrowserError):


### PR DESCRIPTION
## Problem

`BrowserError.__str__` unconditionally appends `during: <while_handling_event>`, so any error with `details` set but no `event` attached renders as:

```
Text not found: "IMI" ({'text': 'IMI'}) during: None
```

The `during: None` tail is logging noise. The biggest offender is `default_action_watchdog.on_ScrollToTextEvent` (`raise BrowserError(f'Text not found: ...', details={'text': event.text})` — no event passed), but every other call site that passes `details=` without `event=` hits the same path.

**Production volume (last 24h, Datadog us5):**
- 1,600 occurrences matching `status:error env:production "'}) during: None"` ([log query](https://us5.datadoghq.com/logs?from_ts=1777910480700&live=false&query=status%3Aerror+env%3Aproduction+%22%27%7D%29+during%3A+None%22&stream_sort=desc&to_ts=1777996880700))
- Sample line:
  ```
  🚌 [DefaultActionWatchdog.on_ScrollToTextEvent(#64b7)] ❌ Failed (0.08s): BrowserError: Text not found: "IMI" ({'text': 'IMI'}) during: None
  ```

## Fix

Build the string from whichever parts are actually populated, instead of two mutually-exclusive branches that always print one of them. Behavior matrix:

| details | while_handling_event | Before | After |
| --- | --- | --- | --- |
| set | None | \`msg ({...}) during: None\` | \`msg ({...})\` |
| set | set | \`msg ({...}) during: <event>\` | \`msg ({...}) during: <event>\` |
| None | set | \`msg (while handling: <event>)\` | \`msg during: <event>\` |
| None | None | \`msg\` | \`msg\` |

The only behavior change for clean cases is a small wording tweak in the \`details=None, event=set\` row (\`while handling:\` → \`during:\`) — keeping the prefix consistent across all permutations.

## Test plan

- [ ] No new test added (string-only change); existing tests should still pass
- [ ] Manual: run an agent task that triggers \`ScrollToText\` against a page that doesn't contain the text; verify no \`during: None\` in logs
- [ ] After merge + deploy, the same Datadog query should drop to ~0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the noisy "during: None" suffix from `BrowserError` messages when no event is attached, making logs cleaner and easier to scan.

- **Bug Fixes**
  - Build the error message from only the populated parts; omit "during" when no event is present.
  - Standardize the label to "during:" when an event exists (was "while handling:"); expected to eliminate ~1.6k noisy log lines/day.

<sup>Written for commit c16bd93d12925f23f64df2f69e4c04c83d6bb2b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

