### PR TITLE
fix(dom): handle frame detach race in _get_ax_tree_for_all_frames

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -364,7 +364,9 @@ class DomService:
 			ax_tree_requests.append(ax_tree_request)
 
 		# Wait for all requests to complete
-		ax_trees = await asyncio.gather(*ax_tree_requests)
+		ax_trees = await asyncio.gather(*ax_tree_requests, return_exceptions=True)
+        # Filter out failed frame requests (e.g., frame detached during request)
+        ax_trees = [t for t in ax_trees if not isinstance(t, Exception)]
 
 		# Merge all AX nodes into a single array
 		merged_nodes: list[AXNode] = []


### PR DESCRIPTION
## Summary

Fixes #4778

## Bug

In `_get_ax_tree_for_all_frames` (line 367), `asyncio.gather()` is called without `return_exceptions=True`. When any single frame's AX tree request fails (common TOCTOU race with ad iframes, analytics, chat widgets), the entire gather raises and all AX data from all frames is lost.

This leaves the agent with an empty DOM tree and no ability to interact with the page.

## Fix

Add `return_exceptions=True` and filter out exception results:

```python
ax_trees = await asyncio.gather(*ax_tree_requests, return_exceptions=True)
# Filter out failed frame requests (e.g., frame detached during request)
ax_trees = [t for t in ax_trees if not isinstance(t, Exception)]
```

## Impact

- Single frame failures no longer kill the entire DOM extraction
- Agent retains AX data from all successful frames
- Graceful degradation: partial DOM is better than empty DOM


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent AX tree collection from failing when a single frame errors in `_get_ax_tree_for_all_frames`. We now gather with `return_exceptions=True` and ignore failed frame requests, preserving AX data from remaining frames and avoiding empty DOM on iframe detach races.

<sup>Written for commit 198e7c9a85e8b5c0be97a95417889112cceed5dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

