### PR TITLE
fix(skill-cli): fall back to single file input upload

### DIFF
--- a/browser_use/skill_cli/commands/browser.py
+++ b/browser_use/skill_cli/commands/browser.py
@@ -274,12 +274,16 @@ async def handle(action: str, session: SessionInfo, params: dict[str, Any]) -> A
 
 		if file_input_node is None:
 			selector_map = await bs.get_selector_map()
-			file_input_indices = [idx for idx, el in selector_map.items() if bs.is_file_input(el)]
-			if file_input_indices:
+			file_input_matches = [(idx, el) for idx, el in selector_map.items() if bs.is_file_input(el)]
+			if len(file_input_matches) == 1:
+				file_input_node = file_input_matches[0][1]
+			elif file_input_matches:
+				file_input_indices = [idx for idx, _ in file_input_matches]
 				hint = f' File input(s) found at index: {", ".join(map(str, file_input_indices))}'
+				return {'error': f'Element {index} is not a file input.{hint}'}
 			else:
 				hint = ' No file input found on the page.'
-			return {'error': f'Element {index} is not a file input.{hint}'}
+				return {'error': f'Element {index} is not a file input.{hint}'}
 
 		await actions.upload_file(file_input_node, file_path)
 		return {'uploaded': file_path, 'element': index}

--- a/tests/ci/test_cli_upload.py
+++ b/tests/ci/test_cli_upload.py
@@ -99,6 +99,63 @@ class TestUploadCommandHandler:
 		finally:
 			Path(empty_path).unlink(missing_ok=True)
 
+	async def test_upload_uses_single_file_input_fallback_without_browser(self):
+		"""A single page-level file input is used when near-element lookup fails."""
+		from browser_use.skill_cli.commands.browser import handle
+		from browser_use.skill_cli.sessions import SessionInfo
+
+		class FakeElement:
+			def __init__(self, node_name: str) -> None:
+				self.node_name = node_name
+
+		class FakeBrowserSession:
+			def __init__(self) -> None:
+				self.button = FakeElement('BUTTON')
+				self.file_input = FakeElement('INPUT')
+
+			async def get_element_by_index(self, index):
+				if index == 1:
+					return self.button
+				return None
+
+			def find_file_input_near_element(self, node):
+				return None
+
+			async def get_selector_map(self):
+				return {1: self.button, 2: self.file_input}
+
+			def is_file_input(self, element):
+				return element is self.file_input
+
+		class FakeActions:
+			def __init__(self) -> None:
+				self.uploaded = None
+
+			async def upload_file(self, node, file_path):
+				self.uploaded = (node, file_path)
+
+		browser_session = FakeBrowserSession()
+		actions = FakeActions()
+		session_info = SessionInfo(
+			name='test',
+			headed=False,
+			profile=None,
+			cdp_url=None,
+			browser_session=browser_session,
+			actions=actions,
+		)
+
+		with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as f:
+			f.write(b'test content')
+			test_file = f.name
+
+		try:
+			result = await handle('upload', session_info, {'index': 1, 'path': test_file})
+			assert result == {'uploaded': test_file, 'element': 1}
+			assert actions.uploaded == (browser_session.file_input, test_file)
+		finally:
+			Path(test_file).unlink(missing_ok=True)
+
 	async def test_upload_element_not_found(self, httpserver):
 		"""Invalid element index returns error."""
 		from browser_use.browser.events import NavigateToUrlEvent
@@ -204,6 +261,7 @@ class TestUploadCommandHandler:
 			"""<html><body>
 				<div><div><div><div><div><button id="btn">Click me</button></div></div></div></div></div>
 				<div><div><div><div><div><input type="file" id="upload" /></div></div></div></div></div>
+				<div><div><div><div><div><input type="file" id="backup-upload" /></div></div></div></div></div>
 			</body></html>""",
 			content_type='text/html',
 		)


### PR DESCRIPTION
## Summary
- let `browser-use upload` fall back to the only file input on the page when the selected element is not near a file input
- preserve the existing ambiguity error when multiple file inputs are present
- add focused CLI handler coverage for the single-input fallback without launching a browser

## Tests
- `git diff --check`
- `uv run pytest tests/ci/test_cli_upload.py::TestUploadCommandHandler::test_upload_uses_single_file_input_fallback_without_browser tests/ci/test_cli_upload.py::TestUploadCommandHandler::test_upload_file_not_found tests/ci/test_cli_upload.py::TestUploadCommandHandler::test_upload_empty_file -q`

Note: I also tried the full `uv run pytest tests/ci/test_cli_upload.py -q`; the browser-launch tests hit the existing local Chrome extension/browser startup timeout before reaching this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `browser-use upload` fall back to the page’s only file input when the selected element isn’t near one, so uploads work on simple forms. Preserve the ambiguity error when multiple file inputs exist, and add focused handler tests that run without launching a browser.

<sup>Written for commit af4c45cfd5dc185b717737b22862c86c1c8a4927. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

