### PR TITLE
fix(browser): retry cookie export after cdp timeout

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3339,7 +3339,7 @@ class BrowserSession(BaseModel):
 			except Exception as e:
 				last_error = e
 				is_reconnect_error = self._is_storage_state_cdp_reconnect_error(e)
-				if attempt == 0 and self.cdp_url and is_reconnect_error:
+				if attempt == 0 and self.cdp_url and is_reconnect_error and not self._intentional_stop:
 					self.logger.warning(
 						'Storage state cookie export lost the CDP connection (%s: %s); reconnecting once and retrying',
 						type(e).__name__,

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -48,7 +48,7 @@ from browser_use.browser.events import (
 	TabCreatedEvent,
 )
 from browser_use.browser.profile import BrowserProfile, ProxySettings
-from browser_use.browser.views import BrowserStateSummary, TabInfo
+from browser_use.browser.views import BrowserError, BrowserStateSummary, TabInfo
 from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, TargetInfo
 from browser_use.observability import observe_debug
 from browser_use.utils import _log_pretty_url, create_task_with_error_handling, is_new_tab_page
@@ -3328,11 +3328,54 @@ class BrowserSession(BaseModel):
 
 	async def _cdp_get_cookies(self) -> list[Cookie]:
 		"""Get cookies using CDP Network.getCookies."""
-		cdp_session = await self.get_or_create_cdp_session(target_id=None)
-		result = await asyncio.wait_for(
-			cdp_session.cdp_client.send.Storage.getCookies(session_id=cdp_session.session_id), timeout=8.0
+		last_error: Exception | None = None
+		for attempt in range(2):
+			try:
+				cdp_session = await self.get_or_create_cdp_session(target_id=None)
+				result = await asyncio.wait_for(
+					cdp_session.cdp_client.send.Storage.getCookies(session_id=cdp_session.session_id), timeout=8.0
+				)
+				return result.get('cookies', [])
+			except Exception as e:
+				last_error = e
+				is_reconnect_error = self._is_storage_state_cdp_reconnect_error(e)
+				if attempt == 0 and self.cdp_url and is_reconnect_error:
+					self.logger.warning(
+						'Storage state cookie export lost the CDP connection (%s: %s); reconnecting once and retrying',
+						type(e).__name__,
+						e,
+					)
+					await self.reconnect()
+					continue
+				if attempt == 0 and not is_reconnect_error:
+					raise
+				break
+
+		assert last_error is not None
+		raise BrowserError(
+			'Failed to export storage state cookies after CDP connection loss/timeout. '
+			'The browser CDP WebSocket may have dropped and the one-shot reconnect retry did not recover.',
+			short_term_memory='Storage state export failed because the CDP connection was lost or timed out.',
+			details={'error_type': type(last_error).__name__, 'error': str(last_error)},
+		) from last_error
+
+	@staticmethod
+	def _is_storage_state_cdp_reconnect_error(error: Exception) -> bool:
+		"""Return whether a cookie export error is likely a transient CDP/WebSocket drop."""
+		if isinstance(error, TimeoutError):
+			return True
+		error_text = f'{type(error).__name__}: {error}'.lower()
+		return any(
+			phrase in error_text
+			for phrase in (
+				'websocket',
+				'connection closed',
+				'connectionclose',
+				'closed connection',
+				'not connected',
+				'silent websocket',
+			)
 		)
-		return result.get('cookies', [])
 
 	async def _cdp_set_cookies(self, cookies: list[Cookie]) -> None:
 		"""Set cookies using CDP Storage.setCookies."""

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3339,13 +3339,20 @@ class BrowserSession(BaseModel):
 			except Exception as e:
 				last_error = e
 				is_reconnect_error = self._is_storage_state_cdp_reconnect_error(e)
-				if attempt == 0 and self.cdp_url and is_reconnect_error and not self._intentional_stop:
-					self.logger.warning(
-						'Storage state cookie export lost the CDP connection (%s: %s); reconnecting once and retrying',
-						type(e).__name__,
-						e,
-					)
-					await self.reconnect()
+				if attempt == 0 and self.cdp_url and is_reconnect_error:
+					if self._intentional_stop:
+						self.logger.warning(
+							'Storage state cookie export hit a transient CDP error during shutdown (%s: %s); retrying once without reconnecting',
+							type(e).__name__,
+							e,
+						)
+					else:
+						self.logger.warning(
+							'Storage state cookie export lost the CDP connection (%s: %s); reconnecting once and retrying',
+							type(e).__name__,
+							e,
+						)
+						await self.reconnect()
 					continue
 				if attempt == 0 and not is_reconnect_error:
 					raise

--- a/tests/ci/browser/test_storage_state_cdp_retry.py
+++ b/tests/ci/browser/test_storage_state_cdp_retry.py
@@ -81,11 +81,11 @@ async def test_cdp_get_cookies_raises_actionable_error_after_retry(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_cdp_get_cookies_does_not_reconnect_during_intentional_stop(monkeypatch):
+async def test_cdp_get_cookies_retries_without_reconnect_during_intentional_stop(monkeypatch):
 	session = BrowserSession(headless=True)
 	session.browser_profile.cdp_url = 'ws://example.test/devtools/browser/1'
 	session._intentional_stop = True
-	storage = FakeStorage(failures_before_success=2)
+	storage = FakeStorage(failures_before_success=1)
 	reconnect_calls = 0
 
 	async def fake_get_or_create_cdp_session(self, target_id=None, focus=True):
@@ -98,8 +98,8 @@ async def test_cdp_get_cookies_does_not_reconnect_during_intentional_stop(monkey
 	monkeypatch.setattr(BrowserSession, 'get_or_create_cdp_session', fake_get_or_create_cdp_session)
 	monkeypatch.setattr(BrowserSession, 'reconnect', fake_reconnect)
 
-	with pytest.raises(BrowserError):
-		await session._cdp_get_cookies()
+	cookies = await session._cdp_get_cookies()
 
-	assert storage.calls == 1
+	assert cookies == [{'name': 'session', 'value': 'ok'}]
+	assert storage.calls == 2
 	assert reconnect_calls == 0

--- a/tests/ci/browser/test_storage_state_cdp_retry.py
+++ b/tests/ci/browser/test_storage_state_cdp_retry.py
@@ -78,3 +78,28 @@ async def test_cdp_get_cookies_raises_actionable_error_after_retry(monkeypatch):
 	assert 'storage state' in message.lower()
 	assert 'cdp connection' in message.lower()
 	assert storage.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cdp_get_cookies_does_not_reconnect_during_intentional_stop(monkeypatch):
+	session = BrowserSession(headless=True)
+	session.browser_profile.cdp_url = 'ws://example.test/devtools/browser/1'
+	session._intentional_stop = True
+	storage = FakeStorage(failures_before_success=2)
+	reconnect_calls = 0
+
+	async def fake_get_or_create_cdp_session(self, target_id=None, focus=True):
+		return FakeCdpSession(storage)
+
+	async def fake_reconnect(self):
+		nonlocal reconnect_calls
+		reconnect_calls += 1
+
+	monkeypatch.setattr(BrowserSession, 'get_or_create_cdp_session', fake_get_or_create_cdp_session)
+	monkeypatch.setattr(BrowserSession, 'reconnect', fake_reconnect)
+
+	with pytest.raises(BrowserError):
+		await session._cdp_get_cookies()
+
+	assert storage.calls == 1
+	assert reconnect_calls == 0

--- a/tests/ci/browser/test_storage_state_cdp_retry.py
+++ b/tests/ci/browser/test_storage_state_cdp_retry.py
@@ -1,0 +1,80 @@
+import pytest
+
+from browser_use.browser.session import BrowserSession
+from browser_use.browser.views import BrowserError
+
+
+class FakeStorage:
+	def __init__(self, failures_before_success=1):
+		self.calls = 0
+		self.failures_before_success = failures_before_success
+
+	async def getCookies(self, session_id):
+		self.calls += 1
+		if self.calls <= self.failures_before_success:
+			raise TimeoutError('silent WebSocket during Storage.getCookies')
+		return {'cookies': [{'name': 'session', 'value': 'ok'}]}
+
+
+class FakeSend:
+	def __init__(self, storage):
+		self.Storage = storage
+
+
+class FakeCdpClient:
+	def __init__(self, storage):
+		self.send = FakeSend(storage)
+
+
+class FakeCdpSession:
+	def __init__(self, storage):
+		self.cdp_client = FakeCdpClient(storage)
+		self.session_id = 'session-1'
+
+
+@pytest.mark.asyncio
+async def test_cdp_get_cookies_retries_once_after_timeout(monkeypatch):
+	session = BrowserSession(headless=True)
+	session.browser_profile.cdp_url = 'ws://example.test/devtools/browser/1'
+	storage = FakeStorage(failures_before_success=1)
+	reconnect_calls = 0
+
+	async def fake_get_or_create_cdp_session(self, target_id=None, focus=True):
+		return FakeCdpSession(storage)
+
+	async def fake_reconnect(self):
+		nonlocal reconnect_calls
+		reconnect_calls += 1
+
+	monkeypatch.setattr(BrowserSession, 'get_or_create_cdp_session', fake_get_or_create_cdp_session)
+	monkeypatch.setattr(BrowserSession, 'reconnect', fake_reconnect)
+
+	cookies = await session._cdp_get_cookies()
+
+	assert cookies == [{'name': 'session', 'value': 'ok'}]
+	assert storage.calls == 2
+	assert reconnect_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_cdp_get_cookies_raises_actionable_error_after_retry(monkeypatch):
+	session = BrowserSession(headless=True)
+	session.browser_profile.cdp_url = 'ws://example.test/devtools/browser/1'
+	storage = FakeStorage(failures_before_success=2)
+
+	async def fake_get_or_create_cdp_session(self, target_id=None, focus=True):
+		return FakeCdpSession(storage)
+
+	async def fake_reconnect(self):
+		return None
+
+	monkeypatch.setattr(BrowserSession, 'get_or_create_cdp_session', fake_get_or_create_cdp_session)
+	monkeypatch.setattr(BrowserSession, 'reconnect', fake_reconnect)
+
+	with pytest.raises(BrowserError) as exc_info:
+		await session._cdp_get_cookies()
+
+	message = str(exc_info.value)
+	assert 'storage state' in message.lower()
+	assert 'cdp connection' in message.lower()
+	assert storage.calls == 2


### PR DESCRIPTION
## Summary
- retry `Storage.getCookies` once after a transient CDP/WebSocket timeout during storage-state export
- reconnect before the retry so cloud sessions can recover from a dropped CDP socket
- raise an actionable `BrowserError` if the retry still cannot export cookies
- add focused fake-CDP regression coverage for retry success and retry failure

Fixes #4688

## Tests
- `git diff --check`
- `uv run pytest tests/ci/browser/test_storage_state_cdp_retry.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a one-shot retry for `Storage.getCookies` during storage-state export to handle transient CDP/WebSocket timeouts. During intentional shutdown, retry once without reconnect; on failure, raise a clear `BrowserError` (fixes #4688).

- **Bug Fixes**
  - Retry once on transient CDP/WebSocket drop or timeout; reconnect before retry unless shutting down.
  - During shutdown, retry without reconnect; non-transient errors bubble up immediately.
  - Raise an actionable `BrowserError` on failure; add fake-CDP tests for retry success, failure, and shutdown no-reconnect.

<sup>Written for commit 25c26e97507fc5e67018e13208da8dc79992326b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

