### PR TITLE
fix(agent): create parent dirs for GIF output

### DIFF
--- a/browser_use/agent/gif.py
+++ b/browser_use/agent/gif.py
@@ -5,6 +5,7 @@ import io
 import logging
 import os
 import platform
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from browser_use.agent.views import AgentHistoryList
@@ -193,6 +194,7 @@ def create_history_gif(
 
 	if images:
 		# Save the GIF
+		Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 		images[0].save(
 			output_path,
 			save_all=True,

--- a/tests/ci/test_agent_gif.py
+++ b/tests/ci/test_agent_gif.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from PIL import Image
+
+from browser_use.agent.gif import create_history_gif
+from browser_use.agent.views import AgentHistory, AgentHistoryList
+from browser_use.browser.views import BrowserStateHistory
+
+
+def test_create_history_gif_creates_parent_directories(tmp_path):
+	"""Nested custom GIF output paths should behave like other saved artifacts."""
+	screenshot_path = tmp_path / 'screenshot.png'
+	Image.new('RGB', (8, 8), color='white').save(screenshot_path)
+
+	history = AgentHistoryList(
+		history=[
+			AgentHistory(
+				model_output=None,
+				result=[],
+				state=BrowserStateHistory(
+					url='https://example.com',
+					title='Example',
+					tabs=[],
+					interacted_element=[],
+					screenshot_path=str(screenshot_path),
+				),
+			)
+		]
+	)
+
+	output_path = tmp_path / 'nested' / 'gif' / 'agent_history.gif'
+
+	create_history_gif(
+		task='test task',
+		history=history,
+		output_path=str(output_path),
+		show_task=False,
+		show_goals=False,
+	)
+
+	assert output_path.exists()


### PR DESCRIPTION
## Summary
- create parent directories before saving generated agent GIFs
- add a regression test for nested custom GIF output paths

## Tests
- `uv run pytest -q tests/ci/test_agent_gif.py`
- `uv run ruff check browser_use/agent/gif.py tests/ci/test_agent_gif.py`
- `uv run ruff format --check browser_use/agent/gif.py tests/ci/test_agent_gif.py`
- `uv run pyright browser_use/agent/gif.py tests/ci/test_agent_gif.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix saving agent GIFs to nested output paths by creating parent directories before writing the file, so saving no longer fails. Adds a regression test to verify nested custom GIF paths are created and the GIF is saved.

<sup>Written for commit 2dcf4d873e529d1f5d145846b9c9eb0c4a1a12ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

