### PR TITLE
fix: clarify upload guidance for local html files

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -354,7 +354,12 @@ Available tabs:
 		agent_state += f'<step_info>{step_info_description}</step_info>\n'
 		if self.available_file_paths:
 			available_file_paths_text = '\n'.join(self.available_file_paths)
-			agent_state += f'<available_file_paths>{available_file_paths_text}\nUse with absolute paths</available_file_paths>\n'
+			agent_state += (
+				f'<available_file_paths>{available_file_paths_text}\n'
+				'These are local file paths, not URLs. Do not navigate to them, even if they end in .html. '
+				'Use upload_file to upload them to file inputs, or read_file to inspect supported file contents.'
+				'</available_file_paths>\n'
+			)
 		return agent_state
 
 	def _resize_screenshot(self, screenshot_b64: str) -> str:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -833,7 +833,7 @@ class Tools(Generic[Context]):
 				return ActionResult(error=error_msg)
 
 		@self.registry.action(
-			'',
+			'Upload a local file from available_file_paths to a file input element. Use for user-provided files, including .html files; do not navigate to the file path.',
 			param_model=UploadFileAction,
 		)
 		async def upload_file(

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -138,8 +138,10 @@ class SendKeysAction(BaseModel):
 
 
 class UploadFileAction(BaseModel):
-	index: int
-	path: str
+	index: int = Field(description='Element index of the file input or nearby upload control from browser_state')
+	path: str = Field(
+		description='Absolute local file path from available_file_paths. Pass the path exactly, including .html files; do not navigate to this path.'
+	)
 
 
 class NoParamsAction(BaseModel):

--- a/tests/ci/test_upload_file_guidance.py
+++ b/tests/ci/test_upload_file_guidance.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from browser_use.agent.prompts import AgentMessagePrompt
+from browser_use.browser.views import BrowserStateSummary, TabInfo
+from browser_use.dom.views import SerializedDOMState
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.tools.views import UploadFileAction
+
+
+def test_available_html_file_paths_are_described_as_local_files(tmp_path: Path):
+	browser_state = BrowserStateSummary(
+		url='https://example.com',
+		title='Test',
+		tabs=[TabInfo(target_id='test-0', url='https://example.com', title='Test')],
+		screenshot=None,
+		dom_state=SerializedDOMState(_root=None, selector_map={}),
+	)
+	prompt = AgentMessagePrompt(
+		browser_state_summary=browser_state,
+		file_system=FileSystem(tmp_path),
+		available_file_paths=['/app/something_capabilities.html'],
+	)
+
+	user_message = prompt.get_user_message(use_vision=False)
+
+	assert isinstance(user_message.content, str)
+	assert '/app/something_capabilities.html' in user_message.content
+	assert 'These are local file paths, not URLs' in user_message.content
+	assert 'Do not navigate to them, even if they end in .html' in user_message.content
+	assert 'Use upload_file to upload them to file inputs' in user_message.content
+
+
+def test_upload_file_action_schema_describes_available_file_paths():
+	schema = UploadFileAction.model_json_schema()
+
+	assert 'file input' in schema['properties']['index']['description']
+	assert 'available_file_paths' in schema['properties']['path']['description']
+	assert '.html files' in schema['properties']['path']['description']
+	assert 'do not navigate' in schema['properties']['path']['description']


### PR DESCRIPTION
## Summary

Fixes #4794 by clarifying that `available_file_paths` entries are local files, not URLs, and that `.html` files should be uploaded with `upload_file` rather than navigated to.

This updates:
- the `upload_file` action description
- the `UploadFileAction` schema field descriptions
- the agent state guidance shown with `<available_file_paths>`
- regression coverage for `.html` file path guidance

## Why

When a user asks the agent to upload a local file like `/app/something_capabilities.html`, the model can confuse the `.html` suffix with a website and choose `navigate` instead of `upload_file`. The upload action previously had no action description and its schema fields had no guidance, so the model had little tool metadata to disambiguate local file paths from URLs.

## Testing

- `uv run pytest tests/ci/test_upload_file_guidance.py`
- `uv run ruff format browser_use/agent/prompts.py browser_use/tools/service.py browser_use/tools/views.py tests/ci/test_upload_file_guidance.py`
- `uv run ruff check browser_use/agent/prompts.py browser_use/tools/service.py browser_use/tools/views.py tests/ci/test_upload_file_guidance.py`
- `uv run pyright browser_use/agent/prompts.py browser_use/tools/service.py browser_use/tools/views.py tests/ci/test_upload_file_guidance.py`

No screenshot/gif is included because this is a prompt/tool-schema clarification with unit coverage rather than a UI change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that entries in `available_file_paths` are local files and that `.html` files must be uploaded with `upload_file`, not opened via navigation. Reduces wrong tool selection when users provide local `.html` paths.

- **Bug Fixes**
  - Updated agent prompt to state that `available_file_paths` are local (not URLs) and to avoid navigating to `.html` files; use `upload_file` (or `read_file` when inspecting supported content).
  - Added explicit guidance to the `upload_file` action and `UploadFileAction` schema (clear `index`/`path` descriptions, `.html` allowed, do not navigate).
  - Added regression tests covering prompt content and schema descriptions.

<sup>Written for commit 78ba3d24f39d089beb26ee2a51e8a9a208202981. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

