### PR TITLE
fix(browser): lazy-create cloud browser client

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -532,7 +532,7 @@ class BrowserSession(BaseModel):
 	_captcha_watchdog: Any | None = PrivateAttr(default=None)
 	_watchdogs_attached: bool = PrivateAttr(default=False)
 
-	_cloud_browser_client: CloudBrowserClient = PrivateAttr(default_factory=lambda: CloudBrowserClient())
+	_cloud_browser_client: CloudBrowserClient | None = PrivateAttr(default=None)
 	_demo_mode: 'DemoMode | None' = PrivateAttr(default=None)
 
 	# WebSocket reconnection state
@@ -544,6 +544,12 @@ class BrowserSession(BaseModel):
 	_reconnect_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
 	_reconnect_task: asyncio.Task | None = PrivateAttr(default=None)
 	_intentional_stop: bool = PrivateAttr(default=False)
+
+	def _get_cloud_browser_client(self) -> CloudBrowserClient:
+		"""Lazily create the cloud browser client only when cloud mode is used."""
+		if self._cloud_browser_client is None:
+			self._cloud_browser_client = CloudBrowserClient()
+		return self._cloud_browser_client
 
 	_logger: Any = PrivateAttr(default=None)
 
@@ -749,7 +755,7 @@ class BrowserSession(BaseModel):
 					try:
 						# Use cloud_browser_params if provided, otherwise create empty request
 						cloud_params = self.browser_profile.cloud_browser_params or CreateBrowserRequest()
-						cloud_browser_response = await self._cloud_browser_client.create_browser(cloud_params)
+						cloud_browser_response = await self._get_cloud_browser_client().create_browser(cloud_params)
 						self.browser_profile.cdp_url = cloud_browser_response.cdpUrl
 						self.browser_profile.is_local = False
 						self.logger.info('🌤️ Successfully connected to cloud browser service')
@@ -1218,17 +1224,21 @@ class BrowserSession(BaseModel):
 			# Clean up cloud browser session for both:
 			# 1) native use_cloud sessions (current_session_id set by create_browser)
 			# 2) reconnected cdp_url sessions (derive UUID from host)
-			cloud_session_id = self._cloud_browser_client.current_session_id or self._cloud_session_id_from_cdp_url()
+			cloud_browser_client = self._cloud_browser_client
+			cloud_session_id = (
+				cloud_browser_client.current_session_id if cloud_browser_client else None
+			) or self._cloud_session_id_from_cdp_url()
 			if cloud_session_id:
+				cloud_browser_client = self._get_cloud_browser_client()
 				try:
-					await self._cloud_browser_client.stop_browser(cloud_session_id)
+					await cloud_browser_client.stop_browser(cloud_session_id)
 					self.logger.info(f'🌤️ Cloud browser session cleaned up: {cloud_session_id}')
 				except Exception as e:
 					self.logger.debug(f'Failed to cleanup cloud browser session {cloud_session_id}: {e}')
 				finally:
 					# Always close the httpx client to free connection pool memory
 					try:
-						await self._cloud_browser_client.close()
+						await cloud_browser_client.close()
 					except Exception:
 						pass
 

--- a/tests/ci/browser/test_cloud_browser.py
+++ b/tests/ci/browser/test_cloud_browser.py
@@ -233,6 +233,17 @@ class TestCloudBrowserClient:
 class TestBrowserSessionCloudIntegration:
 	"""Test BrowserSession integration with cloud browsers."""
 
+	def test_local_browser_session_does_not_create_cloud_client_under_socks_proxy(self, monkeypatch):
+		"""Local sessions should not instantiate httpx cloud clients during construction."""
+		for env_name in ('ALL_PROXY', 'all_proxy', 'HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy'):
+			monkeypatch.delenv(env_name, raising=False)
+		monkeypatch.setenv('ALL_PROXY', 'socks5://127.0.0.1:9')
+
+		session = BrowserSession()
+
+		assert session.cloud_browser is False
+		assert session._cloud_browser_client is None
+
 	async def test_cloud_browser_profile_property(self):
 		"""Test that cloud_browser property works correctly."""
 


### PR DESCRIPTION
## Summary
- lazy-create `CloudBrowserClient` only when a cloud browser path actually needs it
- keep local `BrowserSession()` construction independent of cloud httpx client setup
- add regression coverage for local session construction when `ALL_PROXY` points at a SOCKS proxy without `socksio` installed

## Why
`CloudBrowserClient` owns an `httpx.AsyncClient`. With `ALL_PROXY`/`HTTP_PROXY` set to a `socks5://` URL and `socksio` absent, httpx raises during client construction. Because `BrowserSession` eagerly created the cloud client as a private attribute, even a normal local session could fail before cloud browser functionality was used.

## Tests
- `python -m pytest tests/ci/browser/test_cloud_browser.py -q`
- `python -m ruff check browser_use/browser/session.py tests/ci/browser/test_cloud_browser.py`
- `python -m ruff format --check browser_use/browser/session.py tests/ci/browser/test_cloud_browser.py`
- `python -m pre_commit run --files browser_use/browser/session.py tests/ci/browser/test_cloud_browser.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazily create the cloud browser client so local sessions don’t crash when a SOCKS proxy is set and `socksio` isn’t installed. The client is now created only when cloud mode is used.

- **Bug Fixes**
  - Defer `CloudBrowserClient` creation behind a `_get_cloud_browser_client()` helper and use it in start/stop paths.
  - Decouple local `BrowserSession()` from cloud `httpx.AsyncClient` setup and proxy envs (`ALL_PROXY`, `HTTP_PROXY`, `HTTPS_PROXY`).
  - Add regression test to ensure local sessions don’t instantiate the client under `socks5://` proxies without `socksio`.

<sup>Written for commit b1288f2902fa4f0eee6a5a1194a0e032ec610081. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

