### PR TITLE
docs: clarify ChatOpenRouter import path and availability

### DIFF
--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -159,3 +159,6 @@ __all__ = [
 	'ChatVercel',
 	'ChatCerebras',
 ]
+
+# Re-export ChatOpenRouter for backward compatibility with docs that reference it
+from browser_use.llm.openrouter.chat import ChatOpenRouter as ChatOpenRouter

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -206,6 +206,8 @@ llm = ChatOpenRouter(model="anthropic/claude-sonnet-4-6")
 
 **Env:** `OPENROUTER_API_KEY` | [Available models](https://openrouter.ai/models)
 
+**Note:** `ChatOpenRouter` is available directly from `browser_use` (via `from browser_use import ChatOpenRouter`) as well as from `browser_use.llm.openrouter.chat`.
+
 ## Vercel AI Gateway
 
 Proxy to multiple providers with automatic fallback:


### PR DESCRIPTION
## Summary

Some model examples include imports that don't exist or are unclear, which can be confusing for new users (see #4755).

## Changes
- Add explicit re-export of `ChatOpenRouter` in `browser_use.llm.__init__` so it can be imported directly from `browser_use`
- Add note in `models.md` documenting both import paths (`browser_use` and `browser_use.llm.openrouter.chat`)

Fixes #4755

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exported `ChatOpenRouter` in `browser_use.llm.__init__` so it can be imported with `from browser_use import ChatOpenRouter`, preserving backward compatibility and fixing #4755. Updated `models.md` to document both import paths (`browser_use` and `browser_use.llm.openrouter.chat`).

<sup>Written for commit daa597ba9904167070753d4a06f5e9ace2240f1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

