### PR TITLE
fix(skill_cli): restrict daemon socket and ~/.browser-use to owner (0o600/0o700)

### DIFF
--- a/browser_use/skill_cli/daemon.py
+++ b/browser_use/skill_cli/daemon.py
@@ -396,12 +396,26 @@ class Daemon:
 			)
 			logger.info(f'Listening on TCP {host}:{port}')
 		else:
-			# Unix: socket server
+			# Unix: socket server.
+			# Bind under a tight umask so the socket inode is created with
+			# mode 0o600 (no group/world access), and chmod afterwards as
+			# belt-and-braces on platforms where umask is bypassed (e.g.
+			# some macOS sandboxes). Connecting requires write access to
+			# the socket inode, so this restricts dispatch to the owner
+			# even if the auth token file were ever leaked.
 			Path(sock_path).unlink(missing_ok=True)
-			self._server = await asyncio.start_unix_server(
-				self.handle_connection,
-				sock_path,
-			)
+			old_umask = os.umask(0o077)
+			try:
+				self._server = await asyncio.start_unix_server(
+					self.handle_connection,
+					sock_path,
+				)
+			finally:
+				os.umask(old_umask)
+			try:
+				os.chmod(sock_path, 0o600)
+			except OSError as e:
+				logger.warning(f'Failed to chmod socket {sock_path}: {e}')
 			logger.info(f'Listening on Unix socket {sock_path}')
 
 		# Write PID file after server is bound

--- a/browser_use/skill_cli/utils.py
+++ b/browser_use/skill_cli/utils.py
@@ -4,6 +4,7 @@ import json as _json
 import os
 import platform
 import re
+import stat
 import subprocess
 import sys
 import urllib.request
@@ -48,6 +49,10 @@ def get_home_dir() -> Path:
 
 	All CLI-managed files live here: config, sockets, PIDs, binaries, tunnels.
 	Override with BROWSER_USE_HOME env var.
+
+	The directory is restricted to the owner (mode 0o700) on POSIX, since it
+	holds the daemon auth token and Unix socket. On Windows this is a no-op
+	(POSIX mode bits are not enforced).
 	"""
 	env = os.environ.get('BROWSER_USE_HOME')
 	if env:
@@ -55,6 +60,15 @@ def get_home_dir() -> Path:
 	else:
 		d = Path.home() / '.browser-use'
 	d.mkdir(parents=True, exist_ok=True)
+	# Tighten permissions defensively even if the directory pre-existed with
+	# a more permissive mode (e.g. created before this hardening landed).
+	if sys.platform != 'win32':
+		try:
+			current = stat.S_IMODE(os.stat(d).st_mode)
+			if current & 0o077:
+				os.chmod(d, 0o700)
+		except OSError:
+			pass
 	return d
 
 


### PR DESCRIPTION
## Summary

Hardens the `skill_cli` daemon against same-host local users by tightening filesystem permissions on the per-user state directory (`~/.browser-use`) and the per-session Unix socket. This is a small, defense-in-depth follow-up to the auth-token work in `a05a053d`.

## The issue (CWE-276 / CWE-732 — Incorrect Default Permissions)

When the daemon starts on a POSIX host:

- `get_home_dir()` in `browser_use/skill_cli/utils.py` calls `Path.mkdir(parents=True, exist_ok=True)` with no `mode=`, so the directory is created using the process umask. Under the typical default umask `0o022` this yields mode `0o755` — readable and traversable by any local user.
- `Daemon.run()` in `browser_use/skill_cli/daemon.py` calls `asyncio.start_unix_server(..., sock_path)` without adjusting umask or chmod-ing the resulting inode. The socket inode is therefore created `0o755` as well, so any local user can `connect(2)` to it.

Concrete consequences on a shared/multi-user host:

1. **Auth-token leakage path.** `a05a053d` writes the auth token via `os.open(..., O_CREAT|O_WRONLY|O_TRUNC, 0o600)` so the token file itself is mode `0o600`. However, **sibling files** in the same directory (`config.json`, PID files, session state, log files written by other code paths) are created with the default `0o644`. With the parent dir at `0o755` they're world-readable, exposing session metadata, PIDs, and configuration to other local accounts.
2. **Socket reachable by other users.** Even though the daemon enforces an HMAC-checked token before dispatching commands, any local user can `connect()` to the socket and probe / spam it. That's an unnecessary attack surface and a cheap local DoS vector.
3. **Belt-and-braces if the token ever leaks** (e.g. via a swap file, backup, or accidental log capture) — without socket-level permissions, leaking the token would immediately equal command execution as the owner.

## The fix

Two minimal changes:

**`browser_use/skill_cli/utils.py` — `get_home_dir()`**

After ensuring the directory exists, on POSIX, `stat()` it and `chmod` to `0o700` if any group/other bits are set. This handles both fresh installs and pre-existing directories created before this hardening landed. Windows is a no-op since POSIX mode bits aren't enforced there.

**`browser_use/skill_cli/daemon.py` — `Daemon.run()` (Unix branch only)**

Wrap `asyncio.start_unix_server(...)` in a `umask(0o077)` block so the socket inode is created `0o600` from the outset, then `os.chmod(sock_path, 0o600)` immediately after as a backstop for platforms where the umask path is bypassed (some macOS sandboxes do this). The TCP/Windows branch is unchanged — it already binds to `127.0.0.1` and relies on the auth token.

Diff is 33 lines added across 2 files, no behavior change for the owner.

## Testing

- `python -c "from browser_use.skill_cli.utils import get_home_dir; import os; print(oct(os.stat(get_home_dir()).st_mode & 0o777))"` → `0o700` after the change (was `0o755`).
- Started the daemon, then `stat -c '%a' ~/.browser-use/*.sock` → `600` (was `755`). Owner connect/dispatch still works end-to-end; another local user attempting `socat - UNIX-CONNECT:...sock` fails with `Permission denied` at connect time.
- Pre-existing `~/.browser-use` at `0o755` is silently tightened to `0o700` on next daemon/CLI invocation — verified by manually `chmod 755`-ing the dir, importing, and re-checking.
- Windows path unchanged: `sys.platform == 'win32'` short-circuits the chmod, and the Unix-socket branch isn't taken.

## Adversarial review

Before submitting we tried to disprove this. The original auth-token mechanism (`a05a053d`) does prevent unauthorized command dispatch — so on its own this isn't an RCE. We considered whether the existing `0o600` mode on the token file alone was sufficient, but other files written into the same directory by the CLI inherit the default `0o644`, so the parent-dir `0o755` still leaks session metadata to other local users on shared hosts. We also considered whether umask alone was enough on the socket — it isn't reliable across all POSIX platforms, hence the explicit `chmod` backstop. Net effect is bounded but real: this closes a local information-disclosure channel and shrinks the attack surface of the daemon socket on multi-user hosts.

cc @lewiswigmore


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down POSIX permissions for `skill_cli` by setting `~/.browser-use` to 0o700 and the Unix socket to 0o600. This prevents other local users from reading state files or connecting to the daemon; Windows behavior is unchanged.

- **Bug Fixes**
  - `get_home_dir()` now clamps the state directory to 0o700 on POSIX, including existing directories; no-op on Windows.
  - Unix socket is created under `umask(0o077)` and then `chmod`-ed to 0o600 as a backstop; TCP/Windows path remains the same.

<sup>Written for commit 0b7f668ce891b51ab71c2cee85b3cb578cc4ce9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

