### PR TITLE
fix(cli): mask sensitive config set output

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -1289,6 +1289,7 @@ def main() -> int:
 	if args.command == 'config':
 		from browser_use.skill_cli.config import (
 			CLI_DOCS_URL,
+			CONFIG_KEYS,
 			get_config_display,
 			get_config_value,
 			set_config_value,
@@ -1300,7 +1301,8 @@ def main() -> int:
 		if config_cmd == 'set':
 			try:
 				set_config_value(args.key, args.value)
-				print(f'{args.key} = {args.value}')
+				display_value = 'set' if CONFIG_KEYS.get(args.key, {}).get('sensitive') else args.value
+				print(f'{args.key} = {display_value}')
 			except ValueError as e:
 				print(f'Error: {e}', file=sys.stderr)
 				return 1

--- a/tests/ci/test_cli_config.py
+++ b/tests/ci/test_cli_config.py
@@ -1,0 +1,41 @@
+"""Tests for browser-use CLI config commands."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_cli(*args: str, browser_use_home: Path) -> subprocess.CompletedProcess:
+	"""Run the CLI with an isolated browser-use home directory."""
+	env = os.environ.copy()
+	env['BROWSER_USE_HOME'] = str(browser_use_home)
+	env.pop('BROWSER_USE_API_KEY', None)
+
+	return subprocess.run(
+		[sys.executable, '-m', 'browser_use.skill_cli.main', *args],
+		capture_output=True,
+		text=True,
+		env=env,
+		timeout=15,
+	)
+
+
+def test_config_set_masks_sensitive_api_key(tmp_path):
+	"""config set should not echo the raw API key back to stdout."""
+	secret = 'sk-browser-use-test-secret'
+
+	result = run_cli('config', 'set', 'api_key', secret, browser_use_home=tmp_path)
+
+	assert result.returncode == 0
+	assert 'api_key = set' in result.stdout
+	assert secret not in result.stdout
+	assert secret not in result.stderr
+
+
+def test_config_set_keeps_non_sensitive_values_visible(tmp_path):
+	"""Non-sensitive config values should keep the existing explicit output."""
+	result = run_cli('config', 'set', 'cloud_connect_proxy', 'us', browser_use_home=tmp_path)
+
+	assert result.returncode == 0
+	assert 'cloud_connect_proxy = us' in result.stdout


### PR DESCRIPTION
## Summary
- mask sensitive config values in `browser-use config set` output instead of echoing raw secrets
- keep non-sensitive config values visible so existing CLI feedback is unchanged
- add subprocess CLI coverage with isolated `BROWSER_USE_HOME`

## Why
`CONFIG_KEYS` already marks `api_key` as sensitive, and `doctor` / `config list` display it as `set`. The `config set` path still printed the raw value immediately after writing it, which can leave API keys in terminal scrollback or captured logs. This makes the write confirmation consistent with the existing sensitive display behavior.

## Tests
- `uv run pytest tests/ci/test_cli_config.py -q`
- `uv run ruff check browser_use/skill_cli/main.py tests/ci/test_cli_config.py`
- `uv run ruff format --check browser_use/skill_cli/main.py tests/ci/test_cli_config.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mask sensitive values in `browser-use config set` output to prevent secrets from appearing in stdout or logs. `api_key` now prints as 'set' while non-sensitive keys still show their values, and CLI tests cover this behavior with isolated `BROWSER_USE_HOME`.

<sup>Written for commit d61c5e48e71e6364586bb389c27f97b6d9c92475. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

