### PR TITLE
fix: handle locked Chrome profile copies

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 from collections.abc import Iterable
 from enum import Enum
+from fnmatch import fnmatch
 from functools import cache
 from pathlib import Path
 from typing import Annotated, Any, Literal, Self
@@ -26,6 +27,13 @@ def _get_enable_default_extensions_default() -> bool:
 
 CHROME_DEBUG_PORT = 9242  # use a non-default port to avoid conflicts with other tools / devs using 9222
 DOMAIN_OPTIMIZATION_THRESHOLD = 100  # Convert domain lists to sets for O(1) lookup when >= this size
+CHROME_PROFILE_TRANSIENT_FILE_PATTERNS = (
+	'Singleton*',
+	'*.lock',
+	'*-journal',
+	'LOCK',
+	'LOCKFILE',
+)
 CHROME_DISABLED_COMPONENTS = [
 	# Playwright defaults: https://github.com/microsoft/playwright/blob/41008eeddd020e2dee1c540f7c0cdfa337e99637/packages/playwright-core/src/server/chromium/chromiumSwitches.ts#L76
 	# AcceptCHFrame,AutoExpandDetailsElement,AvoidUnnecessaryBeforeUnloadCheckSync,CertificateTransparencyComponentUpdater,DeferRendererTasksAfterInput,DestroyProfileOnBrowserClose,DialMediaRouteProvider,ExtensionManifestV2Disabled,GlobalMediaControls,HttpsUpgrades,ImprovedCookieControls,LazyFrameLoading,LensOverlay,MediaRouter,PaintHolding,ThirdPartyStoragePartitioning,Translate
@@ -76,6 +84,34 @@ CHROME_DISABLED_COMPONENTS = [
 	'ExtensionDisableUnsupportedDeveloper',
 	'ExtensionManifestV2Unsupported',
 ]
+
+
+def _ignore_chrome_profile_transient_files(_src: str, names: list[str]) -> set[str]:
+	"""Skip Chrome lock/journal files that should not be copied into a temp profile."""
+	return {name for name in names if any(fnmatch(name, pattern) for pattern in CHROME_PROFILE_TRANSIENT_FILE_PATTERNS)}
+
+
+def _is_chrome_profile_lock_error(error: BaseException) -> bool:
+	"""Detect Windows sharing violations or permission errors raised while copying a Chrome profile."""
+	if isinstance(error, PermissionError):
+		return True
+
+	if getattr(error, 'winerror', None) == 32:
+		return True
+
+	# shutil.Error stores copy failures as (src, dst, message/exception) triples.
+	for arg in getattr(error, 'args', ()):
+		if isinstance(arg, (list, tuple)):
+			for item in arg:
+				if isinstance(item, (list, tuple)) and item:
+					detail = item[-1]
+					if isinstance(detail, BaseException) and _is_chrome_profile_lock_error(detail):
+						return True
+					if 'WinError 32' in str(detail) or 'being used by another process' in str(detail):
+						return True
+
+	return False
+
 
 CHROME_HEADLESS_ARGS = [
 	'--headless=new',
@@ -827,7 +863,22 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		if path_original_profile.exists():
 			import shutil
 
-			shutil.copytree(path_original_profile, path_temp_profile)
+			try:
+				shutil.copytree(
+					path_original_profile,
+					path_temp_profile,
+					ignore=_ignore_chrome_profile_transient_files,
+				)
+			except (OSError, shutil.Error) as error:
+				if not _is_chrome_profile_lock_error(error):
+					raise
+
+				shutil.rmtree(temp_dir, ignore_errors=True)
+				raise RuntimeError(
+					f'Unable to copy Chrome profile "{self.profile_directory}" because one or more files are locked. '
+					'Close any Chrome windows using this profile, or start browser-use with --cdp-url to connect to '
+					'an already-running browser instead of copying the profile.'
+				) from error
 			local_state_src = path_original_user_data / 'Local State'
 			local_state_dst = Path(temp_dir) / 'Local State'
 			if local_state_src.exists():

--- a/tests/ci/browser/test_profile_copy.py
+++ b/tests/ci/browser/test_profile_copy.py
@@ -28,6 +28,7 @@ def test_chrome_profile_copy_skips_transient_lock_files(tmp_path: Path) -> None:
 		headless=True,
 	)
 
+	assert browser_profile.user_data_dir is not None
 	temp_user_data_dir = Path(browser_profile.user_data_dir)
 	try:
 		assert (temp_user_data_dir / 'Default' / 'Preferences').read_text() == '{"profile": "default"}'

--- a/tests/ci/browser/test_profile_copy.py
+++ b/tests/ci/browser/test_profile_copy.py
@@ -1,0 +1,62 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from browser_use.browser import profile as profile_module
+from browser_use.browser.profile import BrowserChannel, BrowserProfile
+
+
+def _create_chrome_user_data_dir(tmp_path: Path) -> Path:
+	user_data_dir = tmp_path / 'Chrome User Data'
+	default_profile = user_data_dir / 'Default'
+	default_profile.mkdir(parents=True)
+	(default_profile / 'Preferences').write_text('{"profile": "default"}')
+	(user_data_dir / 'Local State').write_text('{"browser": "chrome"}')
+	return user_data_dir
+
+
+def test_chrome_profile_copy_skips_transient_lock_files(tmp_path: Path) -> None:
+	user_data_dir = _create_chrome_user_data_dir(tmp_path)
+	default_profile = user_data_dir / 'Default'
+	(default_profile / 'SingletonLock').write_text('locked')
+	(default_profile / 'Cookies-journal').write_text('journal')
+
+	browser_profile = BrowserProfile(
+		user_data_dir=user_data_dir,
+		channel=BrowserChannel.CHROME,
+		headless=True,
+	)
+
+	temp_user_data_dir = Path(browser_profile.user_data_dir)
+	try:
+		assert (temp_user_data_dir / 'Default' / 'Preferences').read_text() == '{"profile": "default"}'
+		assert (temp_user_data_dir / 'Local State').read_text() == '{"browser": "chrome"}'
+		assert not (temp_user_data_dir / 'Default' / 'SingletonLock').exists()
+		assert not (temp_user_data_dir / 'Default' / 'Cookies-journal').exists()
+	finally:
+		shutil.rmtree(temp_user_data_dir, ignore_errors=True)
+
+
+def test_chrome_profile_copy_lock_error_is_actionable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+	user_data_dir = _create_chrome_user_data_dir(tmp_path)
+	temp_user_data_dir = tmp_path / 'browser-use-user-data-dir-test'
+
+	def fake_mkdtemp(prefix: str) -> str:
+		temp_user_data_dir.mkdir()
+		return str(temp_user_data_dir)
+
+	def fake_copytree(*_args: object, **_kwargs: object) -> None:
+		raise PermissionError(13, 'The process cannot access the file because it is being used by another process')
+
+	monkeypatch.setattr(profile_module.tempfile, 'mkdtemp', fake_mkdtemp)
+	monkeypatch.setattr(shutil, 'copytree', fake_copytree)
+
+	with pytest.raises(RuntimeError, match='Close any Chrome windows using this profile.*--cdp-url'):
+		BrowserProfile(
+			user_data_dir=user_data_dir,
+			channel=BrowserChannel.CHROME,
+			headless=True,
+		)
+
+	assert not temp_user_data_dir.exists()


### PR DESCRIPTION
## Summary
- skip transient Chrome profile lock/journal files when cloning a Chrome profile into the browser-use temp user-data directory
- turn Windows/profile-copy sharing violations into an actionable error that tells users to close Chrome or connect to the running browser with `--cdp-url`
- add focused regression coverage for the ignored transient files and the locked-profile error path

Fixes #4546.

## Tests
- `uv run ruff check browser_use/browser/profile.py tests/ci/browser/test_profile_copy.py`
- `uv run ruff format --check browser_use/browser/profile.py tests/ci/browser/test_profile_copy.py`
- `uv run pytest tests/ci/browser/test_profile_copy.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles locked Chrome profile copies on Windows by skipping transient lock/journal files and surfacing a clear, actionable error. Prevents failed launches and keeps temp profiles clean.

- **Bug Fixes**
  - Ignore transient files during profile copy: `Singleton*`, `*.lock`, `*-journal`, `LOCK`, `LOCKFILE`.
  - Detect sharing violations (`PermissionError`/WinError 32), clean up temp dir, and raise an actionable error prompting users to close Chrome or connect with `--cdp-url`.
  - Regression tests for skipped files and locked-profile error path; tests now pass `pyright`.

<sup>Written for commit ae52ce8dcdb1a3887b2ce51ce4b74ab10c44a14e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

