### PR TITLE
fix(config): document proxy URL env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ BROWSER_USE_API_KEY=your_bu_api_key_here
 # BROWSER_USE_USER_DATA_DIR=./browser_data
 
 # Proxy Configuration (optional)
-# BROWSER_USE_PROXY_SERVER=http://proxy.example.com:8080
+# BROWSER_USE_PROXY_URL=http://proxy.example.com:8080
 # BROWSER_USE_NO_PROXY=localhost,127.0.0.1,*.internal
 # BROWSER_USE_PROXY_USERNAME=username
 # BROWSER_USE_PROXY_PASSWORD=password

--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -118,3 +118,30 @@ class TestLazyConfig:
 				os.environ['BROWSER_USE_CLOUD_SYNC'] = sync_original
 			else:
 				os.environ.pop('BROWSER_USE_CLOUD_SYNC', None)
+
+	def test_proxy_env_vars_populate_browser_profile_proxy(self):
+		"""Test proxy env vars are mapped into browser profile proxy config."""
+		proxy_env_vars = {
+			'BROWSER_USE_PROXY_URL': 'http://proxy.example.com:8080',
+			'BROWSER_USE_NO_PROXY': 'localhost, 127.0.0.1, *.internal',
+			'BROWSER_USE_PROXY_USERNAME': 'username',
+			'BROWSER_USE_PROXY_PASSWORD': 'password',
+		}
+		original_values = {key: os.environ.get(key) for key in proxy_env_vars}
+		try:
+			os.environ.update(proxy_env_vars)
+
+			config = CONFIG.load_config()
+
+			assert config['browser_profile']['proxy'] == {
+				'server': 'http://proxy.example.com:8080',
+				'bypass': 'localhost,127.0.0.1,*.internal',
+				'username': 'username',
+				'password': 'password',
+			}
+		finally:
+			for key, original_value in original_values.items():
+				if original_value is None:
+					os.environ.pop(key, None)
+				else:
+					os.environ[key] = original_value


### PR DESCRIPTION
## Summary
- update `.env.example` to document `BROWSER_USE_PROXY_URL`, which is the proxy server env var read by the config loader
- add config regression coverage for proxy URL, bypass domains, username, and password env vars

## Tests
- `uv run pytest tests/ci/infrastructure/test_config.py -q`
- `uv run ruff check tests/ci/infrastructure/test_config.py browser_use/config.py`
- `uv run ruff format --check tests/ci/infrastructure/test_config.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix proxy env var docs by updating `.env.example` to use `BROWSER_USE_PROXY_URL` (was `BROWSER_USE_PROXY_SERVER`). Add regression tests ensuring proxy URL, bypass list (whitespace normalized), username, and password map to `browser_profile.proxy`.

<sup>Written for commit 7991374e1444882c21bcae6657be4bd1983e1e0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

