### PR TITLE
fix(upload): fall back to file inputs without coordinates

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -3,6 +3,7 @@ import json
 import logging
 import math
 import os
+from collections.abc import Callable
 from typing import Generic, TypeVar
 
 import anyio
@@ -94,6 +95,46 @@ _DEFAULT_PDF_FOOTER_TEMPLATE = (
 	'<span class="url" style="min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;"></span>'
 	'<span style="flex-shrink:0; padding-left:8px;"><span class="pageNumber"></span> / <span class="totalPages"></span></span></div>'
 )
+
+
+def _find_fallback_file_input_for_upload(
+	selector_map: dict[int, EnhancedDOMTreeNode],
+	current_scroll_y: float,
+	is_file_input: Callable[[EnhancedDOMTreeNode], bool],
+) -> tuple[EnhancedDOMTreeNode | None, float | None, bool]:
+	"""Pick a fallback file input for upload_file.
+
+	Prefer the file input closest to the current scroll position when DOM
+	coordinates are available. If the serializer omitted coordinates for every
+	file input, still return the first file input so upload_file can use the
+	backend node id instead of failing with "No file upload element found".
+	"""
+	closest_file_input = None
+	first_file_input = None
+	min_distance = float('inf')
+
+	for element in selector_map.values():
+		if not is_file_input(element):
+			continue
+
+		if first_file_input is None:
+			first_file_input = element
+
+		absolute_position = getattr(element, 'absolute_position', None)
+		if absolute_position:
+			element_y = absolute_position.y
+			distance = abs(element_y - current_scroll_y)
+			if distance < min_distance:
+				min_distance = distance
+				closest_file_input = element
+
+	if closest_file_input is not None:
+		return closest_file_input, min_distance, False
+
+	if first_file_input is not None:
+		return first_file_input, None, True
+
+	return None, None, False
 
 
 # Global per-action timeout: last-resort guard against hung event handlers.
@@ -950,23 +991,19 @@ class Tools(Generic[Context]):
 				except Exception:
 					current_scroll_y = 0
 
-				# Find all file inputs in the selector map and pick the closest one to scroll position
-				closest_file_input = None
-				min_distance = float('inf')
+				# Find file inputs in the selector map. Prefer the one closest to the current scroll
+				# position, but still use the first file input if coordinates are missing from the
+				# serialized DOM node; UploadFileEvent only needs the backend node id.
+				fallback_file_input, min_distance, used_coordinate_less_fallback = _find_fallback_file_input_for_upload(
+					selector_map, current_scroll_y, browser_session.is_file_input
+				)
 
-				for idx, element in selector_map.items():
-					if browser_session.is_file_input(element):
-						# Get element's Y position
-						if element.absolute_position:
-							element_y = element.absolute_position.y
-							distance = abs(element_y - current_scroll_y)
-							if distance < min_distance:
-								min_distance = distance
-								closest_file_input = element
-
-				if closest_file_input:
-					file_input_node = closest_file_input
-					logger.info(f'Found file input closest to scroll position (distance: {min_distance}px)')
+				if fallback_file_input:
+					file_input_node = fallback_file_input
+					if used_coordinate_less_fallback:
+						logger.info('Found file input without coordinates as final upload fallback')
+					else:
+						logger.info(f'Found file input closest to scroll position (distance: {min_distance}px)')
 
 					# Highlight the fallback file input element (truly non-blocking)
 					create_task_with_error_handling(
@@ -978,7 +1015,6 @@ class Tools(Generic[Context]):
 					msg = 'No file upload element found on the page'
 					logger.error(msg)
 					raise BrowserError(msg)
-					# TODO: figure out why this fails sometimes + add fallback hail mary, just look for any file input on page
 
 			# Dispatch upload file event with the file input node
 			try:

--- a/tests/ci/test_upload_file_fallback.py
+++ b/tests/ci/test_upload_file_fallback.py
@@ -1,0 +1,73 @@
+from browser_use.dom.service import EnhancedDOMTreeNode
+from browser_use.dom.views import DOMRect, NodeType
+from browser_use.tools.service import _find_fallback_file_input_for_upload
+
+
+def _node(*, is_file_input: bool = True, y: int | None = None) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='INPUT' if is_file_input else 'BUTTON',
+		node_value='',
+		attributes={'type': 'file'} if is_file_input else {},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=DOMRect(x=0, y=y, width=10, height=10) if y is not None else None,
+		target_id='target',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=None,
+		snapshot_node=None,
+	)
+
+
+def _is_file_input(node: EnhancedDOMTreeNode) -> bool:
+	return node.attributes.get('type') == 'file'
+
+
+def test_upload_file_fallback_prefers_closest_positioned_input():
+	far_file_input = _node(y=20)
+	near_file_input = _node(y=115)
+	selector_map = {
+		1: _node(is_file_input=False, y=100),
+		2: far_file_input,
+		3: near_file_input,
+	}
+
+	selected, distance, used_coordinate_less_fallback = _find_fallback_file_input_for_upload(selector_map, 100, _is_file_input)
+
+	assert selected is near_file_input
+	assert distance == 15
+	assert used_coordinate_less_fallback is False
+
+
+def test_upload_file_fallback_uses_first_file_input_without_coordinates():
+	first_file_input = _node()
+	second_file_input = _node()
+	selector_map = {
+		1: _node(is_file_input=False),
+		2: first_file_input,
+		3: second_file_input,
+	}
+
+	selected, distance, used_coordinate_less_fallback = _find_fallback_file_input_for_upload(selector_map, 100, _is_file_input)
+
+	assert selected is first_file_input
+	assert distance is None
+	assert used_coordinate_less_fallback is True
+
+
+def test_upload_file_fallback_returns_none_when_page_has_no_file_input():
+	selected, distance, used_coordinate_less_fallback = _find_fallback_file_input_for_upload(
+		{1: _node(is_file_input=False, y=100)}, 100, _is_file_input
+	)
+
+	assert selected is None
+	assert distance is None
+	assert used_coordinate_less_fallback is False


### PR DESCRIPTION
## Summary
- add a final `upload_file` fallback that uses the first file input when DOM coordinates are missing
- preserve the existing closest-to-scroll-position behavior when coordinates are available
- add focused regression coverage for positioned inputs, coordinate-less inputs, and pages with no file input

## Tests
- `uv run --dev pytest tests/ci/test_upload_file_fallback.py -q`
- `uv run --dev pytest tests/ci/test_upload_file_fallback.py tests/ci/test_cli_upload.py -q`
- `uv run --dev ruff check browser_use/tools/service.py tests/ci/test_upload_file_fallback.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes upload failures when file inputs lack DOM coordinates by falling back to the first `input[type="file"]` via backend node id. Still prefers the input closest to the current scroll when positions exist, and errors if no file input is present.

- **Bug Fixes**
  - Added `_find_fallback_file_input_for_upload(selector_map, current_scroll_y, is_file_input)` to pick the closest positioned input, or the first input if none have coordinates.
  - Integrated into `upload_file` with non-blocking highlight, clearer logs (notes when coordinate-less fallback is used), and tests for positioned, coordinate-less, and no-input pages.

<sup>Written for commit 80d00d382f69045ea45142c1b9cacdf119493e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

