### PR TITLE
feat: add OpenCode Go as a first-class LLM provider

### DIFF
--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.ollama.chat import ChatOllama
 	from browser_use.llm.openai.chat import ChatOpenAI
 	from browser_use.llm.openrouter.chat import ChatOpenRouter
+	from browser_use.llm.opencode.chat import ChatOpenCode
 	from browser_use.llm.vercel.chat import ChatVercel
 
 	# Type stubs for model instances - enables IDE autocomplete
@@ -75,6 +76,21 @@ if TYPE_CHECKING:
 	google_gemini_2_5_flash: ChatGoogle
 	google_gemini_2_5_flash_lite: ChatGoogle
 
+	opencode_kimi_k2_6: ChatOpenCode
+	opencode_kimi_k2_5: ChatOpenCode
+	opencode_deepseek_v4_pro: ChatOpenCode
+	opencode_deepseek_v4_flash: ChatOpenCode
+	opencode_glm_5_1: ChatOpenCode
+	opencode_glm_5: ChatOpenCode
+	opencode_qwen3_6_plus: ChatOpenCode
+	opencode_qwen3_5_plus: ChatOpenCode
+	opencode_minimax_m2_7: ChatOpenCode
+	opencode_minimax_m2_5: ChatOpenCode
+	opencode_mimo_v2_pro: ChatOpenCode
+	opencode_mimo_v2_omni: ChatOpenCode
+	opencode_mimo_v2_5_pro: ChatOpenCode
+	opencode_mimo_v2_5: ChatOpenCode
+
 # Models are imported on-demand via __getattr__
 
 # Lazy imports mapping for heavy chat models
@@ -93,6 +109,7 @@ _LAZY_IMPORTS = {
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
 	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
+	'ChatOpenCode': ('browser_use.llm.opencode.chat', 'ChatOpenCode'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
 }
 
@@ -156,6 +173,7 @@ __all__ = [
 	'ChatOCIRaw',
 	'ChatOllama',
 	'ChatOpenRouter',
+	'ChatOpenCode',
 	'ChatVercel',
 	'ChatCerebras',
 ]

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -20,6 +20,7 @@ from browser_use.llm.cerebras.chat import ChatCerebras
 from browser_use.llm.google.chat import ChatGoogle
 from browser_use.llm.mistral.chat import ChatMistral
 from browser_use.llm.openai.chat import ChatOpenAI
+from browser_use.llm.opencode.chat import ChatOpenCode, OPENCODE_BASE_URL
 
 # Optional OCI import
 try:
@@ -85,6 +86,22 @@ bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
 bu_2_0: 'BaseChatModel'
 
+
+
+opencode_kimi_k2_6: 'BaseChatModel'
+opencode_kimi_k2_5: 'BaseChatModel'
+opencode_deepseek_v4_pro: 'BaseChatModel'
+opencode_deepseek_v4_flash: 'BaseChatModel'
+opencode_glm_5_1: 'BaseChatModel'
+opencode_glm_5: 'BaseChatModel'
+opencode_qwen3_6_plus: 'BaseChatModel'
+opencode_qwen3_5_plus: 'BaseChatModel'
+opencode_minimax_m2_7: 'BaseChatModel'
+opencode_minimax_m2_5: 'BaseChatModel'
+opencode_mimo_v2_pro: 'BaseChatModel'
+opencode_mimo_v2_omni: 'BaseChatModel'
+opencode_mimo_v2_5_pro: 'BaseChatModel'
+opencode_mimo_v2_5: 'BaseChatModel'
 
 def get_llm_by_name(model_name: str):
 	"""
@@ -210,8 +227,33 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('BROWSER_USE_API_KEY')
 		return ChatBrowserUse(model=model, api_key=api_key)
 
+
+	# OpenCode Models
+	elif provider == 'opencode':
+		api_key = os.getenv('OPENCODE_API_KEY')
+		base_url = os.getenv('OPENCODE_BASE_URL', OPENCODE_BASE_URL)
+		# Map from attribute-style underscored names to real model names (with dots/dashes)
+		_opencode_attr_map = {
+			'kimi_k2_6': 'kimi-k2.6',
+			'kimi_k2_5': 'kimi-k2.5',
+			'deepseek_v4_pro': 'deepseek-v4-pro',
+			'deepseek_v4_flash': 'deepseek-v4-flash',
+			'glm_5_1': 'glm-5.1',
+			'glm_5': 'glm-5',
+			'qwen3_6_plus': 'qwen3.6-plus',
+			'qwen3_5_plus': 'qwen3.5-plus',
+			'minimax_m2_7': 'minimax-m2.7',
+			'minimax_m2_5': 'minimax-m2.5',
+			'mimo_v2_pro': 'mimo-v2-pro',
+			'mimo_v2_omni': 'mimo-v2-omni',
+			'mimo_v2_5_pro': 'mimo-v2.5-pro',
+			'mimo_v2_5': 'mimo-v2.5',
+		}
+		resolved = _opencode_attr_map.get(model_part, model_part)
+		return ChatOpenCode(model=resolved, api_key=api_key, base_url=base_url)
+
 	else:
-		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu']
+		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu', 'opencode']
 
 		raise ValueError(f"Unknown provider: '{provider}'. Available providers: {', '.join(available_providers)}")
 
@@ -238,6 +280,8 @@ def __getattr__(name: str) -> 'BaseChatModel':
 		return ChatCerebras  # type: ignore
 	elif name == 'ChatBrowserUse':
 		return ChatBrowserUse  # type: ignore
+	elif name == 'ChatOpenCode':
+		return ChatOpenCode  # type: ignore
 
 	# Handle model instances - these are the main use case
 	try:
@@ -254,6 +298,7 @@ __all__ = [
 	'ChatMistral',
 	'ChatCerebras',
 	'ChatBrowserUse',
+	'ChatOpenCode',
 ]
 
 if OCI_AVAILABLE:
@@ -309,6 +354,22 @@ __all__ += [
 	'cerebras_qwen_3_235b_a22b_instruct_2507',
 	'cerebras_qwen_3_235b_a22b_thinking_2507',
 	'cerebras_qwen_3_coder_480b',
+
+	# OpenCode Go instances - created on demand
+	'opencode_kimi_k2_6',
+	'opencode_kimi_k2_5',
+	'opencode_deepseek_v4_pro',
+	'opencode_deepseek_v4_flash',
+	'opencode_glm_5_1',
+	'opencode_glm_5',
+	'opencode_qwen3_6_plus',
+	'opencode_qwen3_5_plus',
+	'opencode_minimax_m2_7',
+	'opencode_minimax_m2_5',
+	'opencode_mimo_v2_pro',
+	'opencode_mimo_v2_omni',
+	'opencode_mimo_v2_5_pro',
+	'opencode_mimo_v2_5',
 	# Browser Use instances - created on demand
 	'bu_latest',
 	'bu_1_0',

--- a/browser_use/llm/opencode/__init__.py
+++ b/browser_use/llm/opencode/__init__.py
@@ -1,0 +1,3 @@
+from browser_use.llm.opencode.chat import OPENCODE_MODELS, ChatOpenCode
+
+__all__ = ['ChatOpenCode', 'OPENCODE_MODELS']

--- a/browser_use/llm/opencode/chat.py
+++ b/browser_use/llm/opencode/chat.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass, field
+
+from browser_use.llm.openai.chat import ChatOpenAI
+
+OPENCODE_MODELS = [
+	'kimi-k2.6',
+	'kimi-k2.5',
+	'deepseek-v4-pro',
+	'deepseek-v4-flash',
+	'glm-5.1',
+	'glm-5',
+	'qwen3.6-plus',
+	'qwen3.5-plus',
+	'minimax-m2.7',
+	'minimax-m2.5',
+	'mimo-v2-pro',
+	'mimo-v2-omni',
+	'mimo-v2.5-pro',
+	'mimo-v2.5',
+]
+
+OPENCODE_BASE_URL = 'https://opencode.ai/zen/go/v1'
+
+
+@dataclass
+class ChatOpenCode(ChatOpenAI):
+	"""
+	A wrapper around OpenCode Go's chat API.
+
+	OpenCode Go exposes an OpenAI-compatible REST interface, so this class
+	simply overrides the default base_url and provider name while inheriting
+	all serialization and invocation logic from ChatOpenAI.
+
+	Supported models:
+	    kimi-k2.6, kimi-k2.5, deepseek-v4-pro, deepseek-v4-flash,
+	    glm-5.1, glm-5, qwen3.6-plus, qwen3.5-plus, minimax-m2.7,
+	    minimax-m2.5, mimo-v2-pro, mimo-v2-omni, mimo-v2.5-pro, mimo-v2.5
+
+	Usage::
+
+	    from browser_use.llm.opencode.chat import ChatOpenCode
+
+	    llm = ChatOpenCode(
+	        model='kimi-k2.6',
+	        api_key='oc-...',  # or set OPENCODE_API_KEY env var
+	    )
+
+	Environment variables:
+	    OPENCODE_API_KEY: API key for OpenCode Go
+	    OPENCODE_BASE_URL: Override the default base URL (optional)
+	"""
+
+	model: str = 'kimi-k2.6'
+	base_url: str = field(default=OPENCODE_BASE_URL)
+
+	@property
+	def provider(self) -> str:
+		return 'opencode'

--- a/browser_use/llm/tests/test_opencode.py
+++ b/browser_use/llm/tests/test_opencode.py
@@ -1,0 +1,106 @@
+"""
+Tests for ChatOpenCode — OpenCode Go provider.
+
+Live tests require the OPENCODE_API_KEY environment variable.
+Unit tests run without any API key.
+"""
+
+import os
+
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.opencode.chat import OPENCODE_MODELS, ChatOpenCode, OPENCODE_BASE_URL
+from browser_use.llm.messages import UserMessage, SystemMessage
+from browser_use.llm.messages import ContentPartTextParam
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (no API key required)
+# ---------------------------------------------------------------------------
+
+class TestChatOpenCodeUnit:
+	"""Unit tests that do not require network access or an API key."""
+
+	def test_provider_property(self):
+		llm = ChatOpenCode(model='kimi-k2.6', api_key='dummy')
+		assert llm.provider == 'opencode'
+
+	def test_default_base_url(self):
+		llm = ChatOpenCode(model='kimi-k2.6', api_key='dummy')
+		assert str(llm.base_url) == OPENCODE_BASE_URL
+
+	def test_custom_base_url(self):
+		custom_url = 'https://custom.opencode.example/v1'
+		llm = ChatOpenCode(model='kimi-k2.6', api_key='dummy', base_url=custom_url)
+		assert str(llm.base_url) == custom_url
+
+	def test_supported_models_list(self):
+		assert 'kimi-k2.6' in OPENCODE_MODELS
+		assert 'deepseek-v4-pro' in OPENCODE_MODELS
+		assert 'mimo-v2.5-pro' in OPENCODE_MODELS
+		assert len(OPENCODE_MODELS) == 14
+
+	def test_name_property(self):
+		llm = ChatOpenCode(model='glm-5.1', api_key='dummy')
+		assert llm.name == 'glm-5.1'
+
+	def test_lazy_import_via_llm_module(self):
+		from browser_use import llm
+		assert llm.ChatOpenCode is ChatOpenCode
+
+	def test_get_llm_by_name_opencode(self):
+		from browser_use.llm.models import get_llm_by_name
+		# Supply a dummy key so ChatOpenCode is instantiated without env var
+		os.environ.setdefault('OPENCODE_API_KEY', 'dummy')
+		instance = get_llm_by_name('opencode_kimi_k2_6')
+		assert isinstance(instance, ChatOpenCode)
+		assert instance.provider == 'opencode'
+
+
+# ---------------------------------------------------------------------------
+# Live integration tests (require OPENCODE_API_KEY)
+# ---------------------------------------------------------------------------
+
+class CapitalResponse(BaseModel):
+	country: str
+	capital: str
+
+
+class TestChatOpenCodeLive:
+	"""Live tests that call the real OpenCode Go API."""
+
+	SYSTEM_MSG = SystemMessage(content=[ContentPartTextParam(text='You are a helpful assistant.', type='text')])
+	QUESTION = UserMessage(content='What is the capital of France? Answer in one word.')
+
+	@pytest.fixture
+	def llm(self):
+		api_key = os.getenv('OPENCODE_API_KEY')
+		if not api_key:
+			pytest.skip('OPENCODE_API_KEY not set')
+		return ChatOpenCode(model='kimi-k2.6', api_key=api_key, temperature=0)
+
+	@pytest.mark.asyncio
+	async def test_ainvoke_normal(self, llm):
+		"""Test plain text response."""
+		response = await llm.ainvoke([self.SYSTEM_MSG, self.QUESTION])
+		assert isinstance(response.completion, str)
+		assert 'paris' in response.completion.lower()
+
+	@pytest.mark.asyncio
+	async def test_ainvoke_structured(self, llm):
+		"""Test structured JSON output."""
+		response = await llm.ainvoke(
+			[UserMessage(content='What is the capital of France?')],
+			output_format=CapitalResponse,
+		)
+		assert isinstance(response.completion, CapitalResponse)
+		assert response.completion.capital.lower() == 'paris'
+
+	@pytest.mark.asyncio
+	async def test_ainvoke_usage(self, llm):
+		"""Verify usage metadata is returned."""
+		response = await llm.ainvoke([self.QUESTION])
+		if response.usage is not None:
+			assert response.usage.prompt_tokens > 0
+			assert response.usage.completion_tokens > 0


### PR DESCRIPTION
## Summary

This PR adds **OpenCode Go** ([opencode.ai](https://opencode.ai)) as a first-class LLM provider in browser-use.

OpenCode Go exposes an OpenAI-compatible REST API at `https://opencode.ai/zen/go/v1` that gives access to a curated selection of frontier models — Kimi, DeepSeek, GLM, Qwen, MiniMax and Mimo — without requiring individual vendor API keys.

---

## Changes

### New files

| File | Purpose |
|------|---------|
| `browser_use/llm/opencode/chat.py` | `ChatOpenCode` dataclass — inherits `ChatOpenAI`, overrides `base_url` and `provider` |
| `browser_use/llm/opencode/__init__.py` | Public re-exports |
| `browser_use/llm/tests/test_opencode.py` | Unit tests (no API key) + live tests gated on `OPENCODE_API_KEY` |

### Modified files

- **`browser_use/llm/__init__.py`** — lazy import for `ChatOpenCode`, type stubs for 14 convenience model instances
- **`browser_use/llm/models.py`** — `ChatOpenCode` import, 14 convenience instances (`opencode_kimi_k2_6`, etc.), `get_llm_by_name` support for `opencode_*` names, `__all__` additions

### Supported models

```
kimi-k2.6, kimi-k2.5
deepseek-v4-pro, deepseek-v4-flash
glm-5.1, glm-5
qwen3.6-plus, qwen3.5-plus
minimax-m2.7, minimax-m2.5
mimo-v2-pro, mimo-v2-omni, mimo-v2.5-pro, mimo-v2.5
```

---

## Usage

```python
from browser_use.llm.opencode.chat import ChatOpenCode

llm = ChatOpenCode(
    model='kimi-k2.6',
    api_key='oc-...',   # or set OPENCODE_API_KEY env var
)

# Convenience instances (API key read from OPENCODE_API_KEY)
from browser_use import llm
model = llm.opencode_kimi_k2_6
model = llm.opencode_deepseek_v4_pro

# get_llm_by_name
from browser_use.llm.models import get_llm_by_name
model = get_llm_by_name('opencode_kimi_k2_6')
```

---

## Related context: ChatOpenRouter base_url gap

`ChatOpenRouter` already accepts a `base_url` parameter in its dataclass, but the MCP server's `get_llm_by_name()` helper in `models.py` never forwards a `base_url` override when creating an OpenRouter instance. This means users who need to point OpenRouter at a custom endpoint (e.g. a proxy) cannot do so through the string-name API today. Leaving that fix as a follow-up to keep this PR focused.

---

## Testing

Unit tests can be run without any API key:

```bash
pytest browser_use/llm/tests/test_opencode.py -k 'Unit'
```

Live integration tests require `OPENCODE_API_KEY`:

```bash
OPENCODE_API_KEY=oc-... pytest browser_use/llm/tests/test_opencode.py -k 'Live'
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenCode Go as a first-class LLM provider to access frontier models via an OpenAI-compatible endpoint without individual vendor keys. Introduces `ChatOpenCode` with `opencode_*` convenience models and name-based lookups.

- **New Features**
  - Added `ChatOpenCode` (extends `ChatOpenAI`) with default `base_url` `https://opencode.ai/zen/go/v1` and `provider='opencode'`.
  - Enabled `get_llm_by_name('opencode_*')` with mapping to real model IDs.
  - Exported 14 convenience instances from `browser_use.llm` (e.g., `opencode_kimi_k2_6`) covering Kimi, DeepSeek, GLM, Qwen, MiniMax, and Mimo.
  - Supports `OPENCODE_API_KEY` for auth; `OPENCODE_BASE_URL` optional override.

<sup>Written for commit c14f344584901e8954b717e49dce1a2f278e00b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

