### PR TITLE
Reject boolean input_text indexes

### DIFF
--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -1,6 +1,6 @@
 from typing import Generic, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from pydantic.json_schema import SkipJsonSchema
 
 
@@ -81,7 +81,7 @@ class ClickElementActionIndexOnly(BaseModel):
 
 
 class InputTextAction(BaseModel):
-	index: int = Field(ge=0, description='from browser_state')
+	index: StrictInt = Field(ge=0, description='from browser_state')
 	text: str = Field(description='Text to enter. With clear=True, text="" clears the field without typing.')
 	clear: bool = Field(default=True, description='Clear existing text before typing. Set to False to append instead.')
 

--- a/tests/ci/test_action_validation.py
+++ b/tests/ci/test_action_validation.py
@@ -1,0 +1,18 @@
+import pytest
+from pydantic import ValidationError
+
+from browser_use.tools.views import InputTextAction
+
+
+def test_input_text_index_rejects_boolean_values():
+	"""Boolean indexes should not be coerced to element indexes."""
+	with pytest.raises(ValidationError):
+		InputTextAction.model_validate({'index': True, 'text': 'hello'})
+
+	with pytest.raises(ValidationError):
+		InputTextAction.model_validate({'index': False, 'text': 'hello'})
+
+
+def test_input_text_index_accepts_integers():
+	assert InputTextAction.model_validate({'index': 0, 'text': 'hello'}).index == 0
+	assert InputTextAction.model_validate({'index': 3, 'text': 'hello'}).index == 3


### PR DESCRIPTION
Fixes #4796.

## Summary
- Tighten `InputTextAction.index` to a strict integer so booleans are not coerced into element indexes.
- Add regression coverage for `true`/`false` indexes while preserving normal integer indexes.

## Validation
- `python3 -m py_compile browser_use/tools/views.py tests/ci/test_action_validation.py`
- `git diff --check`
- `.venv-test/bin/python -m pytest tests/ci/test_action_validation.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject boolean indexes in `InputTextAction` by switching `index` to `StrictInt` so `True`/`False` are not coerced to 1/0. Add tests that fail on boolean indexes and pass for valid integer indexes.

<sup>Written for commit f901236074c85fb96532b6936242efa605b2fa9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4815?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

