### PR TITLE
fix(llm/google): demote JSON parse failures to WARNING (retry wrapper handles them)

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -368,7 +368,7 @@ class ChatGoogle(BaseChatModel):
 										stop_reason=self._get_stop_reason(response),
 									)
 								except (json.JSONDecodeError, ValueError) as e:
-									self.logger.error(f'❌ Failed to parse JSON response: {str(e)}')
+									self.logger.warning(f'⚠️ Failed to parse JSON response: {str(e)}')
 									self.logger.debug(f'Raw response text: {response.text[:200]}...')
 									raise ModelProviderError(
 										message=f'Failed to parse or validate response {response}: {str(e)}',
@@ -449,7 +449,7 @@ class ChatGoogle(BaseChatModel):
 									stop_reason=self._get_stop_reason(response),
 								)
 							except (json.JSONDecodeError, ValueError) as e:
-								self.logger.error(f'❌ Failed to parse fallback JSON: {str(e)}')
+								self.logger.warning(f'⚠️ Failed to parse fallback JSON: {str(e)}')
 								self.logger.debug(f'Raw response text: {response.text[:200]}...')
 								raise ModelProviderError(
 									message=f'Model does not support JSON mode and failed to parse JSON from text response: {str(e)}',


### PR DESCRIPTION
## Pattern (24h, prod)

```
status:error env:production service:browser-use-production-agent-worker
"Failed to parse JSON response: Unterminated string"
```

**147** ERROR-level log entries in 24h matching `❌ Failed to parse JSON response: Unterminated string starting at: line N column M (char K)`. Same `trace_id` repeats 3-5 times for one upstream request — these are retry attempts on the same failed parse.

Sample:
```
[ERROR] 2026-05-10T16:00:42.492Z [dd.trace_id=6a00aa570000000058a8746b1203a7b1] ❌ Failed to parse JSON response: Unterminated string starting at: line 2 column 15 (char 16)
[ERROR] 2026-05-10T15:58:47.55Z  [dd.trace_id=6a00aa570000000058a8746b1203a7b1] ❌ Failed to parse JSON response: Unterminated string starting at: line 2 column 15 (char 16)
[ERROR] 2026-05-10T15:58:21.799Z [dd.trace_id=6a00aa570000000058a8746b1203a7b1] ❌ Failed to parse JSON response: Unterminated string starting at: line 2 column 15 (char 16)
```

## Root cause

`ChatGoogle._make_api_call()` in `browser_use/llm/google/chat.py` has two JSON-parse paths (structured output at line 370, fallback at line 451). Both:

1. Log `logger.error('❌ Failed to parse JSON response/fallback JSON: ...')`
2. Immediately raise `ModelProviderError(status_code=500)`

The retry wrapper at line 475 treats 500 as retryable (default `retryable_status_codes = [429, 500, 502, 503, 504]`, `max_retries = 5`) and silently retries with exponential backoff. So a single upstream call produces up to 5 ERROR log lines for one recoverable failure.

The Vercel chat path (`browser_use/llm/vercel/chat.py:621-626`) handles the equivalent case by raising directly without a redundant `logger.error`, which is the consistent pattern this PR aligns Google to.

## Change

Demote both `logger.error` calls to `logger.warning`. No behavior change:

- Exception is still raised with the same message and status code
- Retry wrapper still retries (and logs its own WARNING on each retry attempt)
- Final failure (after all retries exhausted) still propagates to the caller, which logs at its own level

## Why this matters

These 147 ERROR lines/day drown out genuinely actionable errors in log dashboards and inflate alert volume for self-healing failures. Same family of fix as #4276, #4277, #4286, #4304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Demoted JSON parse failures in the Google chat path to warnings to reduce noisy ERROR logs from recoverable retries. Behavior is unchanged; retries still happen and final failures still surface.

- **Bug Fixes**
  - Switched `logger.error` to `logger.warning` for JSON parse failures in both structured-output and fallback paths in `browser_use/llm/google/chat.py`.
  - Still raises `ModelProviderError(500)`, so the retry wrapper handles retries; only the log level changes. Aligns with `browser_use/llm/vercel/chat.py`.

<sup>Written for commit f63c563667f91296fded74fa139965dd384718a6. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4817?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

