### PR TITLE
fix: handle multi-character upper/lower in CDP typing

### DIFF
--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -865,13 +865,20 @@ class Element:
 			base_key, vk_code = shift_chars[char]
 			return (8, vk_code, base_key)  # Shift=8
 
+		# Some Unicode characters' upper()/lower() expand to multiple code points
+		# (e.g. 'ß'.upper() == 'SS', 'ﬃ'.upper() == 'FFI'). ord() rejects those,
+		# so fall back to the original char's code point for the VK code.
+		def _vk_from(c: str) -> int:
+			up = c.upper()
+			return ord(up) if len(up) == 1 else ord(c)
+
 		# Uppercase letters require Shift
 		if char.isupper():
-			return (8, ord(char), char.lower())  # Shift=8
+			return (8, ord(char), char.lower()[:1] or char)  # Shift=8
 
 		# Lowercase letters
 		if char.islower():
-			return (0, ord(char.upper()), char)
+			return (0, _vk_from(char), char)
 
 		# Numbers
 		if char.isdigit():
@@ -897,7 +904,7 @@ class Element:
 			return (0, no_shift_chars[char], char)
 
 		# Fallback
-		return (0, ord(char.upper()) if char.isalpha() else ord(char), char)
+		return (0, _vk_from(char) if char.isalpha() else ord(char), char)
 
 	def _get_key_code_for_char(self, char: str) -> str:
 		"""Get the proper key code for a character (like Playwright does)."""

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1247,13 +1247,20 @@ class DefaultActionWatchdog(BaseWatchdog):
 			base_key, vk_code = shift_chars[char]
 			return (8, vk_code, base_key)  # Shift=8
 
+		# Some Unicode characters' upper()/lower() expand to multiple code points
+		# (e.g. 'ß'.upper() == 'SS', 'ﬃ'.upper() == 'FFI'). ord() rejects those,
+		# so fall back to the original char's code point for the VK code.
+		def _vk_from(c: str) -> int:
+			up = c.upper()
+			return ord(up) if len(up) == 1 else ord(c)
+
 		# Uppercase letters require Shift
 		if char.isupper():
-			return (8, ord(char), char.lower())  # Shift=8
+			return (8, ord(char), char.lower()[:1] or char)  # Shift=8
 
 		# Lowercase letters
 		if char.islower():
-			return (0, ord(char.upper()), char)
+			return (0, _vk_from(char), char)
 
 		# Numbers
 		if char.isdigit():
@@ -1279,7 +1286,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 			return (0, no_shift_chars[char], char)
 
 		# Fallback
-		return (0, ord(char.upper()) if char.isalpha() else ord(char), char)
+		return (0, _vk_from(char) if char.isalpha() else ord(char), char)
 
 	def _get_key_code_for_char(self, char: str) -> str:
 		"""Get the proper key code for a character (like Playwright does)."""


### PR DESCRIPTION
## Problem

`Failed to input text via CDP: TypeError: ord() expected a character, but string of length 2 found` — a burst of ~30 occurrences appeared in production within the last hour (across 5 distinct sessions), all in the agent-worker Lambda.

## Root cause

`browser_use/browser/watchdogs/default_action_watchdog.py` and `browser_use/actor/element.py` call \`ord(char.upper())\` / \`ord(char.lower())\` to derive a Windows virtual-key code for each typed character.

A handful of Unicode characters expand on case conversion, so \`char.upper()\` returns more than one code point and \`ord()\` raises:

| char | .upper() | len |
|---|---|---|
| \`ß\` | \`SS\` | 2 |
| \`ﬃ\` | \`FFI\` | 3 |
| \`ŉ\` | \`ʼN\` | 2 |
| \`ﬀ\` | \`FF\` | 2 |
| \`ﬁ\` | \`FI\` | 2 |

Any task that types German \"ß\" or one of the Latin ligatures aborts the action.

## Fix

Wrap the conversion in a helper that falls back to the original code point when \`upper()\` expands:

\`\`\`python
def _vk_from(c: str) -> int:
    up = c.upper()
    return ord(up) if len(up) == 1 else ord(c)
\`\`\`

The Windows VK code is only approximate (CDP uses the \`text\` field for the actual character anyway), so this preserves the existing behavior for ASCII while keeping typing alive for the rest of Unicode. The lowercase fallback (\`char.lower()[:1] or char\`) prevents the same edge case in the uppercase branch's returned \`base_key\`.

## Test plan

- [ ] Existing typing tests still pass
- [ ] Typing \"Straße\", \"ﬃ\", etc. into a text input no longer raises TypeError
- [ ] Production: error pattern \`TypeError: ord() expected a character\` should drop to 0 after deploy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a CDP typing crash caused by Unicode characters whose upper/lower case expands (e.g., ß → SS, ﬃ → FFI), which made ord() raise and aborted actions. We now derive a safe VK code that falls back to the original character so typing continues normally.

- Bug Fixes
  - Added `\_vk_from` to use `ord(upper)` only when it’s a single code point; otherwise fall back to `ord(char)`.
  - Applied in both typing paths and adjusted uppercase handling (`char.lower()[:1]`) to avoid multi-character expansions.

<sup>Written for commit 02dd650a197dadfc18d7a3694b68d3128825d8d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

