### PR TITLE
fix: restore token count display in verbose logs with safe fallback (#4150)

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -58,9 +58,16 @@ def _log_format_message_line(message: BaseMessage, content: str, is_last_message
 
 		# Get emoji and token info
 		emoji = _log_get_message_emoji(message)
-		# token_str = str(message.metadata.tokens).rjust(4)
-		# TODO: fix the token count
-		token_str = '??? (TODO)'
+		# Safely get the token count from message metadata (if available)
+		token_str = '   ?'
+		try:
+			metadata = getattr(message, 'metadata', None)
+			if metadata is not None:
+				tokens = getattr(metadata, 'tokens', None)
+				if tokens is not None:
+					token_str = str(tokens).rjust(4)
+		except Exception:
+			pass
 		prefix = f'{emoji}[{token_str}]: '
 
 		# Calculate available width (emoji=2 visual cols + [token]: =8 chars)


### PR DESCRIPTION
## Summary

Fixes #4150 — restores per-message token count in verbose debug logs with a safe fallback when token metadata is unavailable.

### Changes
- Replaced `??? (TODO)` placeholder with actual token count from `message.metadata.tokens`
- Added nested `getattr` guards for graceful handling when metadata/tokens are absent
- Falls back to `"   ?"` when tokens are not available
- Preserves original 4-char right-justified formatting

### Testing
Token display now works for messages with metadata. No crashes for messages without tokens.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores per-message token count in verbose debug logs with a safe fallback when token metadata is missing. Keeps the 4-char right-justified display and prevents errors by defaulting to "   ?".

<sup>Written for commit 8d3b7ae96c83fc552c8727c2252dd6d9d08df2a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

