### PR TITLE
feat(rerun): add HTML debug report and richer replay diagnostics

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3132,6 +3132,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			history_file_path=str(source_history_path) if source_history_path else None,
 			started_at=time.time(),
 		)
+		capture_debug_screenshots = bool(debug_trace_path or debug_report_path)
 
 		# Track previous step for redundant retry detection
 		previous_item: AgentHistory | None = None
@@ -3240,13 +3241,21 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 						trace_step.status = 'success'
 						trace_step.retry_count = retry_count
 						attempt.status = 'succeeded'
-						await self._update_rerun_trace_step_browser_state(trace_step, attempt=attempt)
+						await self._update_rerun_trace_step_browser_state(
+							trace_step,
+							attempt=attempt,
+							capture_screenshot=capture_debug_screenshots,
+						)
 						break
 
 					except Exception as e:
 						error_str = str(e)
 						attempt.error = error_str
-						await self._update_rerun_trace_step_browser_state(trace_step, attempt=attempt)
+						await self._update_rerun_trace_step_browser_state(
+							trace_step,
+							attempt=attempt,
+							capture_screenshot=capture_debug_screenshots,
+						)
 						retry_count += 1
 						trace_step.retry_count = retry_count
 
@@ -3362,10 +3371,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self,
 		trace_step: RerunTraceStep,
 		attempt: RerunTraceAttempt | None = None,
+		capture_screenshot: bool = False,
 	) -> None:
 		"""Best-effort capture of the current browser state for rerun trace diagnostics."""
 		try:
-			state = await self.browser_session.get_browser_state_summary(include_screenshot=False)
+			state = await self.browser_session.get_browser_state_summary(include_screenshot=capture_screenshot)
 		except Exception:
 			return
 
@@ -3378,6 +3388,35 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if attempt is not None:
 			attempt.replay_url = state.url
 			attempt.replay_title = state.title
+			if capture_screenshot and state.screenshot:
+				screenshot_path = await self._store_rerun_trace_screenshot(
+					state.screenshot,
+					trace_step.original_step_number,
+					attempt.attempt_number,
+				)
+				attempt.replay_screenshot_path = screenshot_path
+				trace_step.replay_screenshot_path = screenshot_path
+
+	def _get_rerun_trace_screenshot_filename(self, original_step_number: int, attempt_number: int) -> str:
+		"""Build a stable screenshot filename for rerun trace artifacts."""
+		return f'rerun_trace_step_{original_step_number}_attempt_{attempt_number}.png'
+
+	async def _store_rerun_trace_screenshot(
+		self,
+		screenshot_b64: str,
+		original_step_number: int,
+		attempt_number: int,
+	) -> str | None:
+		"""Persist a rerun-trace screenshot using the existing screenshot service."""
+		if not screenshot_b64:
+			return None
+
+		filename = self._get_rerun_trace_screenshot_filename(original_step_number, attempt_number)
+		try:
+			return await self.screenshot_service.store_named_screenshot(screenshot_b64, filename)
+		except Exception as e:
+			self.logger.warning(f'Failed to store rerun trace screenshot {filename}: {e}')
+			return None
 
 	def _compute_rerun_trace_final_status(self, trace: RerunTrace) -> Literal['running', 'success', 'partial', 'failed']:
 		"""Summarize overall rerun outcome from recorded step statuses."""

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1,5 +1,6 @@
 import asyncio
 import gc
+import hashlib
 import inspect
 import json
 import logging
@@ -3396,10 +3397,53 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				)
 				attempt.replay_screenshot_path = screenshot_path
 				trace_step.replay_screenshot_path = screenshot_path
+				self._update_rerun_trace_screenshot_comparison(trace_step)
 
 	def _get_rerun_trace_screenshot_filename(self, original_step_number: int, attempt_number: int) -> str:
 		"""Build a stable screenshot filename for rerun trace artifacts."""
 		return f'rerun_trace_step_{original_step_number}_attempt_{attempt_number}.png'
+
+	def _update_rerun_trace_screenshot_comparison(self, trace_step: RerunTraceStep) -> None:
+		"""Compare original and replay screenshots using file hashes and annotate the step."""
+		original_path = trace_step.original_screenshot_path
+		replay_path = trace_step.replay_screenshot_path
+
+		if not original_path and not replay_path:
+			trace_step.screenshot_comparison_status = 'unavailable'
+			trace_step.screenshot_comparison_note = 'Neither original nor replay screenshot is available.'
+			return
+		if not original_path:
+			trace_step.screenshot_comparison_status = 'missing_original'
+			trace_step.screenshot_comparison_note = 'Replay screenshot exists, but no original screenshot was recorded.'
+			return
+		if not replay_path:
+			trace_step.screenshot_comparison_status = 'missing_replay'
+			trace_step.screenshot_comparison_note = 'Original screenshot exists, but no replay screenshot was captured.'
+			return
+
+		try:
+			original_file = Path(original_path)
+			replay_file = Path(replay_path)
+			if not original_file.exists():
+				trace_step.screenshot_comparison_status = 'missing_original'
+				trace_step.screenshot_comparison_note = f'Original screenshot file is missing: {original_path}'
+				return
+			if not replay_file.exists():
+				trace_step.screenshot_comparison_status = 'missing_replay'
+				trace_step.screenshot_comparison_note = f'Replay screenshot file is missing: {replay_path}'
+				return
+
+			original_hash = hashlib.sha256(original_file.read_bytes()).hexdigest()
+			replay_hash = hashlib.sha256(replay_file.read_bytes()).hexdigest()
+			if original_hash == replay_hash:
+				trace_step.screenshot_comparison_status = 'identical'
+				trace_step.screenshot_comparison_note = 'Original and replay screenshots have identical file hashes.'
+			else:
+				trace_step.screenshot_comparison_status = 'changed'
+				trace_step.screenshot_comparison_note = 'Original and replay screenshots differ by file hash.'
+		except Exception as e:
+			trace_step.screenshot_comparison_status = 'unavailable'
+			trace_step.screenshot_comparison_note = f'Could not compare screenshots: {e}'
 
 	async def _store_rerun_trace_screenshot(
 		self,

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3228,7 +3228,13 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					)
 					trace_step.attempts.append(attempt)
 					try:
-						result = await self._execute_history_step(history_item, step_delay, ai_step_llm, wait_for_elements)
+						result = await self._execute_history_step(
+							history_item,
+							step_delay,
+							ai_step_llm,
+							wait_for_elements,
+							trace_attempt=attempt,
+						)
 						results.extend(result)
 						step_succeeded = True
 						trace_step.status = 'success'
@@ -3509,6 +3515,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		delay: float,
 		ai_step_llm: BaseChatModel | None = None,
 		wait_for_elements: bool = False,
+		trace_attempt: RerunTraceAttempt | None = None,
 	) -> list[ActionResult]:
 		"""Execute a single step from history with element validation.
 
@@ -3587,11 +3594,16 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			else:
 				# For non-extract actions, update indices and collect for batch execution
 				historical_elem = history_item.state.interacted_element[i]
-				updated_action = await self._update_action_indices(
+				updated_action, match_detail = await self._update_action_indices(
 					historical_elem,
 					action,
 					state,
 				)
+				if trace_attempt is not None and match_detail is not None:
+					trace_attempt.action_match_details.append(match_detail)
+					if trace_attempt.matched_element is None and match_detail.get('matched_element') is not None:
+						trace_attempt.matched_element = match_detail['matched_element']
+						trace_attempt.match_level = match_detail.get('match_level')
 				if updated_action is None:
 					# Build informative error message with diagnostic info
 					elem_info = self._format_element_for_error(historical_elem)
@@ -3618,6 +3630,18 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 						diagnostic = (
 							f'\n  Found {same_node_count} <{hist_node.upper()}> elements (none with matching identifiers)'
 						)
+					if trace_attempt is not None:
+						trace_attempt.action_match_details.append(
+							{
+								'action_index': i,
+								'action': action_data,
+								'match_level': None,
+								'matched_element': None,
+								'historical_element': historical_elem.to_dict() if historical_elem else None,
+								'selector_count': selector_count,
+								'diagnostic': diagnostic.strip() or None,
+							}
+						)
 
 					raise ValueError(
 						f'Could not find matching element for action {i} in current page.\n'
@@ -3639,7 +3663,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		historical_element: DOMInteractedElement | None,
 		action: ActionModel,  # Type this properly based on your action model
 		browser_state_summary: BrowserStateSummary,
-	) -> ActionModel | None:
+	) -> tuple[ActionModel | None, dict[str, Any] | None]:
 		"""
 		Update action indices based on current page state.
 		Returns updated action or None if element cannot be found.
@@ -3651,8 +3675,15 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		4. AX_NAME: Accessible name match from accessibility tree (robust for dynamic menus)
 		5. ATTRIBUTE: Unique attribute match (name, id, aria-label) for old history files
 		"""
+		action_dump = action.model_dump(exclude_none=True, mode='json')
 		if not historical_element or not browser_state_summary.dom_state.selector_map:
-			return action
+			return action, {
+				'action': action_dump,
+				'match_level': None,
+				'matched_element': None,
+				'historical_element': historical_element.to_dict() if historical_element else None,
+				'note': 'No historical element or selector map available; action replayed without index remapping.',
+			}
 
 		selector_map = browser_state_summary.dom_state.selector_map
 		highlight_index: int | None = None
@@ -3775,7 +3806,13 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				)
 
 		if highlight_index is None:
-			return None
+			return None, {
+				'action': action_dump,
+				'match_level': None,
+				'matched_element': None,
+				'historical_element': historical_element.to_dict() if historical_element else None,
+				'selector_count': len(selector_map),
+			}
 
 		old_index = action.get_index()
 		if old_index != highlight_index:
@@ -3783,7 +3820,42 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			level_name = match_level.name if match_level else 'UNKNOWN'
 			self.logger.info(f'Element index updated {old_index} → {highlight_index} (matched at {level_name} level)')
 
-		return action
+		matched_dom_element = selector_map.get(highlight_index)
+		return action, {
+			'action': action_dump,
+			'match_level': match_level.name if match_level else None,
+			'matched_element': self._serialize_matched_dom_element(matched_dom_element, highlight_index),
+			'historical_element': historical_element.to_dict(),
+			'original_index': old_index,
+			'resolved_index': highlight_index,
+		}
+
+	def _serialize_matched_dom_element(self, element: Any, highlight_index: int | None) -> dict[str, Any] | None:
+		"""Build a compact, trace-friendly snapshot of the matched live DOM element."""
+		if element is None:
+			return None
+
+		ax_name = None
+		if getattr(element, 'ax_node', None) and getattr(element.ax_node, 'name', None):
+			ax_name = element.ax_node.name
+
+		bounds = None
+		if getattr(element, 'bounds', None):
+			try:
+				bounds = element.bounds.to_dict()
+			except Exception:
+				bounds = None
+
+		return {
+			'index': highlight_index,
+			'node_name': getattr(element, 'node_name', None),
+			'attributes': getattr(element, 'attributes', None),
+			'x_path': getattr(element, 'xpath', None),
+			'element_hash': getattr(element, 'element_hash', None),
+			'stable_hash': element.compute_stable_hash() if hasattr(element, 'compute_stable_hash') else None,
+			'ax_name': ax_name,
+			'bounds': bounds,
+		}
 
 	def _format_element_for_error(self, elem: DOMInteractedElement | None) -> str:
 		"""Format element info for error messages during history rerun."""

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3511,9 +3511,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			trace_step.divergence_note = 'The replay could not find a matching element for the historical action.'
 			return
 		if used_fallback_match:
+			fallback_match_levels = sorted({level for level in attempt_match_levels if level is not None})
 			trace_step.divergence_category = 'matched_via_fallback'
 			trace_step.divergence_note = (
-				f'The replay matched at least one element via a fallback strategy: {", ".join(sorted(set(attempt_match_levels)))}.'
+				f'The replay matched at least one element via a fallback strategy: {", ".join(fallback_match_levels)}.'
 			)
 			return
 		if trace_step.retry_count > 0:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -4209,6 +4209,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				- max_step_interval: Cap on saved step_interval (default: 45.0s)
 				- summary_llm: Custom LLM for final summary
 				- ai_step_llm: Custom LLM for extract re-evaluation
+				- debug_trace_path: Optional JSON artifact path for rerun diagnostics
+				- debug_report_path: Optional HTML report path for rerun diagnostics
 		"""
 		if not history_file:
 			history_file = 'AgentHistory.json'

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3094,6 +3094,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		ai_step_llm: BaseChatModel | None = None,
 		wait_for_elements: bool = False,
 		debug_trace_path: str | Path | None = None,
+		debug_report_path: str | Path | None = None,
 		source_history_path: str | Path | None = None,
 	) -> list[ActionResult]:
 		"""
@@ -3113,6 +3114,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		                               matching. Useful for SPA pages where shadow DOM content loads dynamically.
 		                               Default is False.
 		                debug_trace_path: Optional path to save a structured rerun debug trace as JSON
+		                debug_report_path: Optional path to save a rendered HTML rerun debug report
 		                source_history_path: Optional path to the source history file used to start the rerun
 
 		Returns:
@@ -3321,6 +3323,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					debug_trace.save_to_file(debug_trace_path)
 				except Exception as e:
 					self.logger.warning(f'Failed to save rerun debug trace to {debug_trace_path}: {e}')
+			if debug_report_path:
+				try:
+					debug_trace.save_html_report(debug_report_path)
+				except Exception as e:
+					self.logger.warning(f'Failed to save rerun debug report to {debug_report_path}: {e}')
 			# Always close resources, even on failure
 			await self.close()
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -59,6 +59,9 @@ from browser_use.agent.views import (
 	JudgementResult,
 	MessageCompactionSettings,
 	PlanItem,
+	RerunTrace,
+	RerunTraceAttempt,
+	RerunTraceStep,
 	StepMetadata,
 )
 from browser_use.browser.events import _get_timeout
@@ -3090,6 +3093,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		summary_llm: BaseChatModel | None = None,
 		ai_step_llm: BaseChatModel | None = None,
 		wait_for_elements: bool = False,
+		debug_trace_path: str | Path | None = None,
+		source_history_path: str | Path | None = None,
 	) -> list[ActionResult]:
 		"""
 		Rerun a saved history of actions with error handling and retry logic.
@@ -3107,6 +3112,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		                wait_for_elements: If True, wait for minimum number of elements before attempting element
 		                               matching. Useful for SPA pages where shadow DOM content loads dynamically.
 		                               Default is False.
+		                debug_trace_path: Optional path to save a structured rerun debug trace as JSON
+		                source_history_path: Optional path to the source history file used to start the rerun
 
 		Returns:
 		                List of action results (including AI summary as the final result)
@@ -3118,6 +3125,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		await self.browser_session.start()
 
 		results = []
+		debug_trace = RerunTrace(
+			task=self.task,
+			history_file_path=str(source_history_path) if source_history_path else None,
+			started_at=time.time(),
+		)
 
 		# Track previous step for redundant retry detection
 		previous_item: AgentHistory | None = None
@@ -3128,6 +3140,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				goal = history_item.model_output.current_state.next_goal if history_item.model_output else ''
 				step_num = history_item.metadata.step_number if history_item.metadata else i
 				step_name = 'Initial actions' if step_num == 0 else f'Step {step_num}'
+				trace_step = self._build_rerun_trace_step(history_item, replay_step_index=i)
+				trace_step.status = 'running'
+				debug_trace.steps.append(trace_step)
 
 				# Determine step delay
 				if history_item.metadata and history_item.metadata.step_interval is not None:
@@ -3158,6 +3173,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					or history_item.model_output.action == [None]
 				):
 					self.logger.warning(f'{step_name}: No action to replay, skipping')
+					trace_step.status = 'skipped'
+					trace_step.skip_reason = 'No action to replay'
 					results.append(ActionResult(error='No action to replay'))
 					continue
 
@@ -3167,6 +3184,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					error_msgs = [r.error for r in history_item.result if r.error]
 					self.logger.warning(
 						f'{step_name}: Original step had error(s), skipping (skip_failures=True): {error_msgs[0][:100] if error_msgs else "unknown"}'
+					)
+					trace_step.status = 'skipped'
+					trace_step.skip_reason = (
+						f'Original step had error and skip_failures=True: {error_msgs[0][:200] if error_msgs else "unknown"}'
 					)
 					results.append(
 						ActionResult(
@@ -3180,6 +3201,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				# due to slow page response, but during replay the first click already worked
 				if self._is_redundant_retry_step(history_item, previous_item, previous_step_succeeded):
 					self.logger.info(f'{step_name}: Skipping redundant retry (previous step already succeeded with same element)')
+					trace_step.status = 'skipped'
+					trace_step.skip_reason = 'Skipped redundant retry because the previous step already succeeded'
 					results.append(
 						ActionResult(
 							extracted_content='Skipped - redundant retry of previous step',
@@ -3196,15 +3219,28 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				base_retry_delay = 5.0
 				max_retry_delay = 30.0
 				while retry_count < max_retries:
+					attempt = RerunTraceAttempt(
+						attempt_number=retry_count + 1,
+						status='started',
+						note=f'{step_name} replay attempt {retry_count + 1}',
+					)
+					trace_step.attempts.append(attempt)
 					try:
 						result = await self._execute_history_step(history_item, step_delay, ai_step_llm, wait_for_elements)
 						results.extend(result)
 						step_succeeded = True
+						trace_step.status = 'success'
+						trace_step.retry_count = retry_count
+						attempt.status = 'succeeded'
+						await self._update_rerun_trace_step_browser_state(trace_step, attempt=attempt)
 						break
 
 					except Exception as e:
 						error_str = str(e)
+						attempt.error = error_str
+						await self._update_rerun_trace_step_browser_state(trace_step, attempt=attempt)
 						retry_count += 1
+						trace_step.retry_count = retry_count
 
 						# Check if this is a "Could not find matching element" error for a menu item
 						# If so, try to re-open the dropdown from the previous step before retrying
@@ -3227,6 +3263,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 									# Don't increment retry_count for the menu reopen attempt
 									# Retry immediately with minimal delay
 									retry_count -= 1
+									trace_step.retry_count = retry_count
+									attempt.status = 'retried'
+									attempt.note = 'Re-opened dropdown/menu and retried immediately'
 									step_delay = 0.5  # Use short delay after reopening
 									self.logger.info('🔄 Dropdown re-opened, retrying element match...')
 									continue
@@ -3234,6 +3273,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 						if retry_count == max_retries:
 							error_msg = f'{step_name} failed after {max_retries} attempts: {error_str}'
 							self.logger.error(error_msg)
+							trace_step.status = 'failed'
+							trace_step.failure_reason = error_msg
+							attempt.status = 'failed'
+							attempt.note = 'Retry budget exhausted'
 							# Always record the error in results so AI summary counts it correctly
 							results.append(ActionResult(error=error_msg))
 							if not skip_failures:
@@ -3242,10 +3285,18 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 						else:
 							# Exponential backoff: 5s, 10s, 20s, ... capped at 30s
 							retry_delay = min(base_retry_delay * (2 ** (retry_count - 1)), max_retry_delay)
+							attempt.status = 'retried'
+							attempt.retry_delay_seconds = retry_delay
+							attempt.note = f'Retrying after failure with exponential backoff ({retry_delay}s)'
 							self.logger.warning(
 								f'{step_name} failed (attempt {retry_count}/{max_retries}), retrying in {retry_delay}s...'
 							)
 							await asyncio.sleep(retry_delay)
+
+				if trace_step.status == 'running':
+					trace_step.status = 'success' if step_succeeded else 'failed'
+				if trace_step.status != 'success' and trace_step.failure_reason is None and trace_step.skip_reason is None:
+					trace_step.failure_reason = f'{step_name} did not complete successfully during rerun'
 
 				# Update tracking for redundant retry detection
 				previous_item = history_item
@@ -3255,11 +3306,81 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			self.logger.info('🤖 Generating AI summary of rerun completion...')
 			summary_result = await self._generate_rerun_summary(self.task, results, summary_llm)
 			results.append(summary_result)
+			debug_trace.summary = summary_result.extracted_content
 
 			return results
+		except Exception as e:
+			if debug_trace.summary is None:
+				debug_trace.summary = f'Rerun aborted: {e}'
+			raise
 		finally:
+			debug_trace.completed_at = time.time()
+			debug_trace.final_status = self._compute_rerun_trace_final_status(debug_trace)
+			if debug_trace_path:
+				try:
+					debug_trace.save_to_file(debug_trace_path)
+				except Exception as e:
+					self.logger.warning(f'Failed to save rerun debug trace to {debug_trace_path}: {e}')
 			# Always close resources, even on failure
 			await self.close()
+
+	def _build_rerun_trace_step(self, history_item: AgentHistory, replay_step_index: int) -> RerunTraceStep:
+		"""Create a normalized debug step record from a saved history item."""
+		original_actions: list[dict[str, Any]] = []
+		if history_item.model_output:
+			original_actions = [action.model_dump(exclude_none=True, mode='json') for action in history_item.model_output.action]
+
+		original_elements: list[dict[str, Any] | None] = []
+		for element in history_item.state.interacted_element or []:
+			original_elements.append(element.to_dict() if element else None)
+
+		return RerunTraceStep(
+			replay_step_index=replay_step_index,
+			original_step_number=history_item.metadata.step_number if history_item.metadata else replay_step_index,
+			goal=history_item.model_output.current_state.next_goal if history_item.model_output else None,
+			original_actions=original_actions,
+			original_interacted_elements=original_elements,
+			original_url=history_item.state.url,
+			original_title=history_item.state.title,
+			original_screenshot_path=history_item.state.screenshot_path,
+		)
+
+	async def _update_rerun_trace_step_browser_state(
+		self,
+		trace_step: RerunTraceStep,
+		attempt: RerunTraceAttempt | None = None,
+	) -> None:
+		"""Best-effort capture of the current browser state for rerun trace diagnostics."""
+		try:
+			state = await self.browser_session.get_browser_state_summary(include_screenshot=False)
+		except Exception:
+			return
+
+		if not state:
+			return
+
+		trace_step.replay_url = state.url
+		trace_step.replay_title = state.title
+
+		if attempt is not None:
+			attempt.replay_url = state.url
+			attempt.replay_title = state.title
+
+	def _compute_rerun_trace_final_status(self, trace: RerunTrace) -> Literal['running', 'success', 'partial', 'failed']:
+		"""Summarize overall rerun outcome from recorded step statuses."""
+		if not trace.steps:
+			return 'failed'
+
+		statuses = [step.status for step in trace.steps]
+		if all(status == 'success' for status in statuses):
+			return 'success'
+		if all(status == 'failed' for status in statuses):
+			return 'failed'
+		if any(status == 'success' for status in statuses):
+			return 'partial'
+		if any(status == 'skipped' for status in statuses):
+			return 'partial'
+		return 'failed'
 
 	async def _execute_initial_actions(self) -> None:
 		# Execute initial actions if provided
@@ -3877,7 +3998,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if variables:
 			history = self._substitute_variables_in_history(history, variables)
 
-		return await self.rerun_history(history, **kwargs)
+		return await self.rerun_history(history, source_history_path=history_file, **kwargs)
 
 	def save_history(self, file_path: str | Path | None = None) -> None:
 		"""Save the history to a file with sensitive data filtering"""

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3315,6 +3315,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					trace_step.status = 'success' if step_succeeded else 'failed'
 				if trace_step.status != 'success' and trace_step.failure_reason is None and trace_step.skip_reason is None:
 					trace_step.failure_reason = f'{step_name} did not complete successfully during rerun'
+				self._classify_rerun_trace_step(trace_step)
 
 				# Update tracking for redundant retry detection
 				previous_item = history_item
@@ -3477,6 +3478,63 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if any(status == 'skipped' for status in statuses):
 			return 'partial'
 		return 'failed'
+
+	def _classify_rerun_trace_step(self, trace_step: RerunTraceStep) -> None:
+		"""Assign a high-level divergence category to a replay step."""
+		attempt_match_levels = [
+			detail.get('match_level')
+			for attempt in trace_step.attempts
+			for detail in attempt.action_match_details
+			if isinstance(detail, dict) and detail.get('match_level')
+		]
+		used_fallback_match = any(level in {'STABLE', 'XPATH', 'AX_NAME', 'ATTRIBUTE'} for level in attempt_match_levels)
+		page_changed = bool(
+			trace_step.original_url and trace_step.replay_url and trace_step.original_url != trace_step.replay_url
+		)
+		failure_text = (trace_step.failure_reason or '').lower()
+		skip_text = (trace_step.skip_reason or '').lower()
+
+		if 'redundant retry' in skip_text:
+			trace_step.divergence_category = 'skipped_redundant_retry'
+			trace_step.divergence_note = 'The replay skipped this step because a prior equivalent step already succeeded.'
+			return
+		if 'original step had error' in skip_text:
+			trace_step.divergence_category = 'skipped_original_error'
+			trace_step.divergence_note = 'The replay skipped this step because the original trace had an error and skip_failures was enabled.'
+			return
+		if 'could not find matching element' in failure_text:
+			if page_changed:
+				trace_step.divergence_category = 'page_changed_before_match'
+				trace_step.divergence_note = 'The replay page URL changed before the historical element could be matched.'
+				return
+			trace_step.divergence_category = 'missing_element'
+			trace_step.divergence_note = 'The replay could not find a matching element for the historical action.'
+			return
+		if used_fallback_match:
+			trace_step.divergence_category = 'matched_via_fallback'
+			trace_step.divergence_note = (
+				f'The replay matched at least one element via a fallback strategy: {", ".join(sorted(set(attempt_match_levels)))}.'
+			)
+			return
+		if trace_step.retry_count > 0:
+			trace_step.divergence_category = 'retried_before_success'
+			trace_step.divergence_note = 'The replay required one or more retries before completing this step.'
+			return
+		if trace_step.screenshot_comparison_status == 'changed':
+			trace_step.divergence_category = 'visual_change_detected'
+			trace_step.divergence_note = 'The replay screenshot differs visually from the original screenshot.'
+			return
+		if trace_step.status == 'success':
+			trace_step.divergence_category = 'none'
+			trace_step.divergence_note = 'The replay step completed without an obvious divergence signal.'
+			return
+		if trace_step.status == 'failed':
+			trace_step.divergence_category = 'failed_without_specific_classifier'
+			trace_step.divergence_note = 'The replay step failed, but no more specific divergence classifier matched.'
+			return
+		if trace_step.status == 'skipped':
+			trace_step.divergence_category = 'skipped_without_specific_classifier'
+			trace_step.divergence_note = 'The replay step was skipped, but no more specific divergence classifier matched.'
 
 	async def _execute_initial_actions(self) -> None:
 		# Execute initial actions if provided

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -425,6 +425,14 @@ class RerunTraceStep(BaseModel):
 		default=None,
 		description='Human-readable explanation of the screenshot comparison result',
 	)
+	divergence_category: str | None = Field(
+		default=None,
+		description='High-level diagnosis for why this replay step diverged or required fallback behavior',
+	)
+	divergence_note: str | None = Field(
+		default=None,
+		description='Human-readable explanation of the divergence category',
+	)
 	retry_count: int = Field(default=0, description='How many retry attempts were needed for this step')
 	skip_reason: str | None = Field(default=None, description='Structured explanation when the step is skipped')
 	failure_reason: str | None = Field(default=None, description='Structured explanation when the step fails')
@@ -493,6 +501,34 @@ class RerunTrace(BaseModel):
 				f'</div>'
 			)
 
+		divergence_counts: dict[str, int] = {}
+		for step in self.steps:
+			key = step.divergence_category or 'uncategorized'
+			divergence_counts[key] = divergence_counts.get(key, 0) + 1
+
+		divergence_summary_html = ''.join(
+			f'<li class="summary-list-item"><code>{_esc(category)}</code><strong>{count}</strong></li>'
+			for category, count in sorted(divergence_counts.items(), key=lambda item: (-item[1], item[0]))
+		)
+
+		important_steps = [
+			step
+			for step in self.steps
+			if step.status in {'failed', 'skipped'} or (step.divergence_category not in {None, 'none'})
+		]
+		important_steps_html = ''.join(
+			f"""
+			<li class="summary-list-item">
+				<div>
+					<strong>Step {step.original_step_number}</strong>
+					<p>{_esc(step.divergence_category or step.status)}</p>
+				</div>
+				<code>{_esc(step.divergence_note or step.failure_reason or step.skip_reason or step.goal or '-')}</code>
+			</li>
+			"""
+			for step in important_steps[:6]
+		)
+
 		step_cards: list[str] = []
 		for step in self.steps:
 			attempts_html = ''.join(
@@ -547,6 +583,8 @@ class RerunTrace(BaseModel):
 							<div class="kv"><span>Screenshot</span>{_image_html(step.replay_screenshot_path, f'Replay step {step.original_step_number} screenshot')}</div>
 							<div class="kv"><span>Visual Change</span><code>{_esc(step.screenshot_comparison_status or '-')}</code></div>
 							<div class="kv"><span>Comparison Note</span><code>{_esc(step.screenshot_comparison_note or '-')}</code></div>
+							<div class="kv"><span>Divergence</span><code>{_esc(step.divergence_category or '-')}</code></div>
+							<div class="kv"><span>Divergence Note</span><code>{_esc(step.divergence_note or '-')}</code></div>
 							<div class="kv"><span>Retries</span><code>{step.retry_count}</code></div>
 						</div>
 					</div>
@@ -650,6 +688,28 @@ class RerunTrace(BaseModel):
 			border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 		}}
 		.kv span {{ color: var(--muted); font-size: 13px; }}
+		.summary-list {{
+			list-style: none;
+			padding: 0;
+			margin: 0;
+			display: grid;
+			gap: 10px;
+		}}
+		.summary-list-item {{
+			display: grid;
+			grid-template-columns: minmax(0, 1fr) auto;
+			gap: 12px;
+			align-items: start;
+			padding: 12px;
+			border-radius: 12px;
+			background: rgba(15, 17, 21, 0.72);
+			border: 1px solid rgba(255, 255, 255, 0.06);
+		}}
+		.summary-list-item p {{
+			margin: 4px 0 0;
+			color: var(--muted);
+			font-size: 13px;
+		}}
 		code, pre {{
 			font-family: "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, monospace;
 			font-size: 12px;
@@ -722,6 +782,18 @@ class RerunTrace(BaseModel):
 				<div class="panel">
 					<h3>Summary</h3>
 					<pre>{_esc(self.summary or 'No summary recorded')}</pre>
+				</div>
+				<div class="panel">
+					<h3>Divergence Categories</h3>
+					<ul class="summary-list">
+						{divergence_summary_html or '<li class="summary-list-item"><code>No divergence data</code><strong>0</strong></li>'}
+					</ul>
+				</div>
+				<div class="panel">
+					<h3>Priority Steps</h3>
+					<ul class="summary-list">
+						{important_steps_html or '<li class="summary-list-item"><code>No priority steps</code><strong>OK</strong></li>'}
+					</ul>
 				</div>
 			</div>
 		</section>

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -371,6 +371,13 @@ class RerunTraceAttempt(BaseModel):
 	matched_element: dict[str, Any] | None = Field(
 		default=None, description='Matched rerun element metadata when available'
 	)
+	match_level: str | None = Field(
+		default=None, description='Element match strategy used for the primary matched element'
+	)
+	action_match_details: list[dict[str, Any]] = Field(
+		default_factory=list,
+		description='Per-action match metadata captured during this attempt',
+	)
 	replay_url: str | None = Field(default=None, description='URL observed during this attempt')
 	replay_title: str | None = Field(default=None, description='Page title observed during this attempt')
 	retry_delay_seconds: float | None = Field(
@@ -474,11 +481,17 @@ class RerunTrace(BaseModel):
 						<strong>Attempt {attempt.attempt_number}</strong>
 						<span class="status-pill {_status_class(attempt.status)}">{_esc(attempt.status)}</span>
 					</div>
+					<div class="kv"><span>Match Level</span><code>{_esc(attempt.match_level or '-')}</code></div>
+					<div class="kv"><span>Matched Element</span><pre>{_esc(attempt.matched_element or '-')}</pre></div>
 					<div class="kv"><span>Replay URL</span><code>{_esc(attempt.replay_url or step.replay_url or '-')}</code></div>
 					<div class="kv"><span>Replay Title</span><code>{_esc(attempt.replay_title or step.replay_title or '-')}</code></div>
 					<div class="kv"><span>Error</span><code>{_esc(attempt.error or '-')}</code></div>
 					<div class="kv"><span>Retry Delay</span><code>{_esc(attempt.retry_delay_seconds if attempt.retry_delay_seconds is not None else '-')}</code></div>
 					<div class="kv"><span>Note</span><code>{_esc(attempt.note or '-')}</code></div>
+					<div class="panel">
+						<h4>Action Match Details</h4>
+						<pre>{_esc(attempt.action_match_details or '-')}</pre>
+					</div>
 				</li>
 				"""
 				for attempt in step.attempts

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -623,42 +623,43 @@ class RerunTrace(BaseModel):
 	<title>Browser Use Rerun Trace Report</title>
 	<style>
 		:root {{
-			--bg: #0f1115;
-			--panel: #171a21;
-			--panel-2: #1f2430;
-			--text: #edf2f7;
-			--muted: #98a2b3;
-			--border: #2d3748;
-			--success: #1f9d55;
-			--warning: #d69e2e;
-			--failed: #e53e3e;
-			--neutral: #718096;
-			--accent: #5ea0ff;
+			--bg: #f6f7f9;
+			--panel: #ffffff;
+			--panel-2: #fafbfc;
+			--text: #1f2328;
+			--muted: #57606a;
+			--border: #d0d7de;
+			--success: #1a7f37;
+			--warning: #9a6700;
+			--failed: #cf222e;
+			--neutral: #57606a;
+			--accent: #0969da;
 		}}
 		* {{ box-sizing: border-box; }}
 		body {{
 			margin: 0;
-			font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-			background: linear-gradient(180deg, #0b0d12 0%, #121722 100%);
+			font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+			background: var(--bg);
 			color: var(--text);
-			padding: 32px;
+			padding: 24px;
+			line-height: 1.45;
 		}}
-		main {{ max-width: 1280px; margin: 0 auto; }}
+		main {{ max-width: 1360px; margin: 0 auto; }}
 		h1, h2, h3, p {{ margin-top: 0; }}
 		.hero, .step-card, .panel {{
-			background: rgba(23, 26, 33, 0.94);
+			background: var(--panel);
 			border: 1px solid var(--border);
-			border-radius: 16px;
-			box-shadow: 0 18px 50px rgba(0, 0, 0, 0.28);
+			border-radius: 6px;
+			box-shadow: none;
 		}}
-		.hero {{ padding: 24px; margin-bottom: 24px; }}
+		.hero {{ padding: 20px; margin-bottom: 16px; }}
 		.hero-grid, .grid {{
 			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-			gap: 16px;
+			grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+			gap: 12px;
 		}}
-		.step-card {{ padding: 20px; margin-bottom: 20px; }}
-		.panel {{ padding: 16px; background: rgba(31, 36, 48, 0.7); }}
+		.step-card {{ padding: 16px; margin-bottom: 16px; }}
+		.panel {{ padding: 14px; background: var(--panel-2); }}
 		.step-header, .attempt-header {{
 			display: flex;
 			align-items: start;
@@ -669,41 +670,40 @@ class RerunTrace(BaseModel):
 			display: inline-flex;
 			align-items: center;
 			border-radius: 999px;
-			padding: 6px 10px;
+			padding: 3px 8px;
 			font-size: 12px;
-			font-weight: 700;
-			text-transform: uppercase;
-			letter-spacing: 0.06em;
+			font-weight: 600;
 			border: 1px solid currentColor;
+			background: var(--panel);
 		}}
-		.status-pill.success {{ color: #7ee7a8; }}
-		.status-pill.warning {{ color: #f6d06f; }}
-		.status-pill.failed {{ color: #ff8b8b; }}
-		.status-pill.neutral {{ color: #c4ccd9; }}
+		.status-pill.success {{ color: var(--success); }}
+		.status-pill.warning {{ color: var(--warning); }}
+		.status-pill.failed {{ color: var(--failed); }}
+		.status-pill.neutral {{ color: var(--neutral); }}
 		.kv {{
 			display: grid;
 			grid-template-columns: 120px 1fr;
 			gap: 10px;
-			padding: 8px 0;
-			border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+			padding: 6px 0;
+			border-bottom: 1px solid var(--border);
 		}}
-		.kv span {{ color: var(--muted); font-size: 13px; }}
+		.kv span {{ color: var(--muted); font-size: 13px; font-weight: 500; }}
 		.summary-list {{
 			list-style: none;
 			padding: 0;
 			margin: 0;
 			display: grid;
-			gap: 10px;
+			gap: 8px;
 		}}
 		.summary-list-item {{
 			display: grid;
 			grid-template-columns: minmax(0, 1fr) auto;
 			gap: 12px;
 			align-items: start;
-			padding: 12px;
-			border-radius: 12px;
-			background: rgba(15, 17, 21, 0.72);
-			border: 1px solid rgba(255, 255, 255, 0.06);
+			padding: 10px 12px;
+			border-radius: 4px;
+			background: var(--panel);
+			border: 1px solid var(--border);
 		}}
 		.summary-list-item p {{
 			margin: 4px 0 0;
@@ -711,32 +711,53 @@ class RerunTrace(BaseModel):
 			font-size: 13px;
 		}}
 		code, pre {{
-			font-family: "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, monospace;
+			font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 			font-size: 12px;
 			white-space: pre-wrap;
 			word-break: break-word;
 		}}
+		code {{
+			background: #f3f4f6;
+			padding: 1px 4px;
+			border-radius: 4px;
+		}}
 		pre {{
 			margin: 0;
-			padding: 12px;
-			border-radius: 12px;
-			background: rgba(15, 17, 21, 0.85);
-			border: 1px solid rgba(255, 255, 255, 0.06);
+			padding: 10px 12px;
+			border-radius: 4px;
+			background: #f6f8fa;
+			border: 1px solid var(--border);
 			max-height: 340px;
 			overflow: auto;
 		}}
+		h1 {{ font-size: 28px; margin-bottom: 6px; }}
+		h2 {{ font-size: 20px; margin-bottom: 6px; }}
+		h3 {{ font-size: 15px; margin-bottom: 10px; }}
+		h4 {{ font-size: 13px; margin: 0 0 8px; color: var(--muted); }}
 		.attempt-list {{
 			list-style: none;
 			padding: 0;
 			margin: 0;
 			display: grid;
-			gap: 12px;
+			gap: 10px;
 		}}
 		.attempt-card {{
 			padding: 12px;
-			border-radius: 12px;
-			border: 1px solid rgba(255, 255, 255, 0.08);
-			background: rgba(15, 17, 21, 0.72);
+			border-radius: 4px;
+			border: 1px solid var(--border);
+			background: var(--panel);
+		}}
+		.attempt-card.success,
+		.step-card.success {{
+			border-left: 4px solid var(--success);
+		}}
+		.attempt-card.warning,
+		.step-card.warning {{
+			border-left: 4px solid var(--warning);
+		}}
+		.attempt-card.failed,
+		.step-card.failed {{
+			border-left: 4px solid var(--failed);
 		}}
 		.image-block {{
 			display: grid;
@@ -746,14 +767,19 @@ class RerunTrace(BaseModel):
 			width: 100%;
 			max-height: 260px;
 			object-fit: contain;
-			border-radius: 12px;
-			border: 1px solid rgba(255, 255, 255, 0.08);
-			background: rgba(11, 13, 18, 0.9);
+			border-radius: 4px;
+			border: 1px solid var(--border);
+			background: #ffffff;
 		}}
-		.step-card.success {{ border-color: rgba(126, 231, 168, 0.35); }}
-		.step-card.warning {{ border-color: rgba(246, 208, 111, 0.35); }}
-		.step-card.failed {{ border-color: rgba(255, 139, 139, 0.35); }}
 		a {{ color: var(--accent); }}
+		@media (max-width: 720px) {{
+			body {{ padding: 12px; }}
+			.kv {{ grid-template-columns: 1fr; }}
+			.step-header, .attempt-header {{
+				flex-direction: column;
+				align-items: flex-start;
+			}}
+		}}
 	</style>
 </head>
 <body>
@@ -762,7 +788,7 @@ class RerunTrace(BaseModel):
 			<div class="step-header">
 				<div>
 					<h1>Browser Use Rerun Trace Report</h1>
-					<p>Static debug report generated from a saved rerun trace artifact.</p>
+					<p>Static diagnostic report generated from a saved rerun trace artifact.</p>
 				</div>
 				<span class="status-pill {_status_class(self.final_status)}">{_esc(self.final_status)}</span>
 			</div>

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -417,6 +417,14 @@ class RerunTraceStep(BaseModel):
 	replay_screenshot_path: str | None = Field(
 		default=None, description='Replay screenshot path captured for this step, when available'
 	)
+	screenshot_comparison_status: str | None = Field(
+		default=None,
+		description='Visual comparison label between original and replay screenshots',
+	)
+	screenshot_comparison_note: str | None = Field(
+		default=None,
+		description='Human-readable explanation of the screenshot comparison result',
+	)
 	retry_count: int = Field(default=0, description='How many retry attempts were needed for this step')
 	skip_reason: str | None = Field(default=None, description='Structured explanation when the step is skipped')
 	failure_reason: str | None = Field(default=None, description='Structured explanation when the step fails')
@@ -537,6 +545,8 @@ class RerunTrace(BaseModel):
 							<div class="kv"><span>URL</span><code>{_esc(step.replay_url or '-')}</code></div>
 							<div class="kv"><span>Title</span><code>{_esc(step.replay_title or '-')}</code></div>
 							<div class="kv"><span>Screenshot</span>{_image_html(step.replay_screenshot_path, f'Replay step {step.original_step_number} screenshot')}</div>
+							<div class="kv"><span>Visual Change</span><code>{_esc(step.screenshot_comparison_status or '-')}</code></div>
+							<div class="kv"><span>Comparison Note</span><code>{_esc(step.screenshot_comparison_note or '-')}</code></div>
 							<div class="kv"><span>Retries</span><code>{step.retry_count}</code></div>
 						</div>
 					</div>

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -380,6 +380,9 @@ class RerunTraceAttempt(BaseModel):
 	)
 	replay_url: str | None = Field(default=None, description='URL observed during this attempt')
 	replay_title: str | None = Field(default=None, description='Page title observed during this attempt')
+	replay_screenshot_path: str | None = Field(
+		default=None, description='Replay screenshot path captured for this attempt, when available'
+	)
 	retry_delay_seconds: float | None = Field(
 		default=None, description='Delay scheduled before the next retry, when applicable'
 	)
@@ -472,6 +475,16 @@ class RerunTrace(BaseModel):
 				return 'warning'
 			return 'neutral'
 
+		def _image_html(path: str | None, alt: str) -> str:
+			if not path:
+				return '<code>-</code>'
+			return (
+				f'<div class="image-block">'
+				f'<code>{_esc(path)}</code>'
+				f'<img src="{_esc(path)}" alt="{_esc(alt)}" loading="lazy">'
+				f'</div>'
+			)
+
 		step_cards: list[str] = []
 		for step in self.steps:
 			attempts_html = ''.join(
@@ -485,6 +498,7 @@ class RerunTrace(BaseModel):
 					<div class="kv"><span>Matched Element</span><pre>{_esc(attempt.matched_element or '-')}</pre></div>
 					<div class="kv"><span>Replay URL</span><code>{_esc(attempt.replay_url or step.replay_url or '-')}</code></div>
 					<div class="kv"><span>Replay Title</span><code>{_esc(attempt.replay_title or step.replay_title or '-')}</code></div>
+					<div class="kv"><span>Replay Screenshot</span>{_image_html(attempt.replay_screenshot_path, f'Attempt {attempt.attempt_number} screenshot')}</div>
 					<div class="kv"><span>Error</span><code>{_esc(attempt.error or '-')}</code></div>
 					<div class="kv"><span>Retry Delay</span><code>{_esc(attempt.retry_delay_seconds if attempt.retry_delay_seconds is not None else '-')}</code></div>
 					<div class="kv"><span>Note</span><code>{_esc(attempt.note or '-')}</code></div>
@@ -516,13 +530,13 @@ class RerunTrace(BaseModel):
 							<div class="kv"><span>Goal</span><code>{_esc(step.goal or '-')}</code></div>
 							<div class="kv"><span>URL</span><code>{_esc(step.original_url or '-')}</code></div>
 							<div class="kv"><span>Title</span><code>{_esc(step.original_title or '-')}</code></div>
-							<div class="kv"><span>Screenshot</span><code>{_esc(step.original_screenshot_path or '-')}</code></div>
+							<div class="kv"><span>Screenshot</span>{_image_html(step.original_screenshot_path, f'Original step {step.original_step_number} screenshot')}</div>
 						</div>
 						<div class="panel">
 							<h3>Replay</h3>
 							<div class="kv"><span>URL</span><code>{_esc(step.replay_url or '-')}</code></div>
 							<div class="kv"><span>Title</span><code>{_esc(step.replay_title or '-')}</code></div>
-							<div class="kv"><span>Screenshot</span><code>{_esc(step.replay_screenshot_path or '-')}</code></div>
+							<div class="kv"><span>Screenshot</span>{_image_html(step.replay_screenshot_path, f'Replay step {step.original_step_number} screenshot')}</div>
 							<div class="kv"><span>Retries</span><code>{step.retry_count}</code></div>
 						</div>
 					</div>
@@ -653,6 +667,18 @@ class RerunTrace(BaseModel):
 			border-radius: 12px;
 			border: 1px solid rgba(255, 255, 255, 0.08);
 			background: rgba(15, 17, 21, 0.72);
+		}}
+		.image-block {{
+			display: grid;
+			gap: 8px;
+		}}
+		.image-block img {{
+			width: 100%;
+			max-height: 260px;
+			object-fit: contain;
+			border-radius: 12px;
+			border: 1px solid rgba(255, 255, 255, 0.08);
+			background: rgba(11, 13, 18, 0.9);
 		}}
 		.step-card.success {{ border-color: rgba(126, 231, 168, 0.35); }}
 		.step-card.warning {{ border-color: rgba(246, 208, 111, 0.35); }}

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import html
 import json
 import logging
 import re
@@ -444,6 +445,248 @@ class RerunTrace(BaseModel):
 		path.parent.mkdir(parents=True, exist_ok=True)
 		with open(path, 'w', encoding='utf-8') as f:
 			json.dump(self.model_dump(mode='json'), f, indent=2, ensure_ascii=False)
+
+	def to_html_report(self) -> str:
+		"""Render a static HTML debug report for this rerun trace."""
+
+		def _esc(value: Any) -> str:
+			if value is None:
+				return ''
+			if isinstance(value, (dict, list)):
+				value = json.dumps(value, indent=2, ensure_ascii=False)
+			return html.escape(str(value))
+
+		def _status_class(status: str | None) -> str:
+			if status in ('success', 'succeeded'):
+				return 'success'
+			if status in ('failed',):
+				return 'failed'
+			if status in ('skipped', 'retried', 'partial'):
+				return 'warning'
+			return 'neutral'
+
+		step_cards: list[str] = []
+		for step in self.steps:
+			attempts_html = ''.join(
+				f"""
+				<li class="attempt-card {_status_class(attempt.status)}">
+					<div class="attempt-header">
+						<strong>Attempt {attempt.attempt_number}</strong>
+						<span class="status-pill {_status_class(attempt.status)}">{_esc(attempt.status)}</span>
+					</div>
+					<div class="kv"><span>Replay URL</span><code>{_esc(attempt.replay_url or step.replay_url or '-')}</code></div>
+					<div class="kv"><span>Replay Title</span><code>{_esc(attempt.replay_title or step.replay_title or '-')}</code></div>
+					<div class="kv"><span>Error</span><code>{_esc(attempt.error or '-')}</code></div>
+					<div class="kv"><span>Retry Delay</span><code>{_esc(attempt.retry_delay_seconds if attempt.retry_delay_seconds is not None else '-')}</code></div>
+					<div class="kv"><span>Note</span><code>{_esc(attempt.note or '-')}</code></div>
+				</li>
+				"""
+				for attempt in step.attempts
+			)
+
+			actions_block = _esc(step.original_actions)
+			elements_block = _esc(step.original_interacted_elements)
+
+			step_cards.append(
+				f"""
+				<section class="step-card {_status_class(step.status)}">
+					<div class="step-header">
+						<div>
+							<h2>Step {step.original_step_number}</h2>
+							<p>Replay Index: {step.replay_step_index}</p>
+						</div>
+						<span class="status-pill {_status_class(step.status)}">{_esc(step.status)}</span>
+					</div>
+					<div class="grid">
+						<div class="panel">
+							<h3>Original</h3>
+							<div class="kv"><span>Goal</span><code>{_esc(step.goal or '-')}</code></div>
+							<div class="kv"><span>URL</span><code>{_esc(step.original_url or '-')}</code></div>
+							<div class="kv"><span>Title</span><code>{_esc(step.original_title or '-')}</code></div>
+							<div class="kv"><span>Screenshot</span><code>{_esc(step.original_screenshot_path or '-')}</code></div>
+						</div>
+						<div class="panel">
+							<h3>Replay</h3>
+							<div class="kv"><span>URL</span><code>{_esc(step.replay_url or '-')}</code></div>
+							<div class="kv"><span>Title</span><code>{_esc(step.replay_title or '-')}</code></div>
+							<div class="kv"><span>Screenshot</span><code>{_esc(step.replay_screenshot_path or '-')}</code></div>
+							<div class="kv"><span>Retries</span><code>{step.retry_count}</code></div>
+						</div>
+					</div>
+					<div class="grid">
+						<div class="panel">
+							<h3>Original Actions</h3>
+							<pre>{actions_block}</pre>
+						</div>
+						<div class="panel">
+							<h3>Original Interacted Elements</h3>
+							<pre>{elements_block}</pre>
+						</div>
+					</div>
+					<div class="grid">
+						<div class="panel">
+							<h3>Outcome</h3>
+							<div class="kv"><span>Skip Reason</span><code>{_esc(step.skip_reason or '-')}</code></div>
+							<div class="kv"><span>Failure Reason</span><code>{_esc(step.failure_reason or '-')}</code></div>
+						</div>
+						<div class="panel">
+							<h3>Attempts</h3>
+							<ul class="attempt-list">
+								{attempts_html or '<li class="attempt-card neutral"><code>No attempts recorded</code></li>'}
+							</ul>
+						</div>
+					</div>
+				</section>
+				"""
+			)
+
+		return f"""<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Browser Use Rerun Trace Report</title>
+	<style>
+		:root {{
+			--bg: #0f1115;
+			--panel: #171a21;
+			--panel-2: #1f2430;
+			--text: #edf2f7;
+			--muted: #98a2b3;
+			--border: #2d3748;
+			--success: #1f9d55;
+			--warning: #d69e2e;
+			--failed: #e53e3e;
+			--neutral: #718096;
+			--accent: #5ea0ff;
+		}}
+		* {{ box-sizing: border-box; }}
+		body {{
+			margin: 0;
+			font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+			background: linear-gradient(180deg, #0b0d12 0%, #121722 100%);
+			color: var(--text);
+			padding: 32px;
+		}}
+		main {{ max-width: 1280px; margin: 0 auto; }}
+		h1, h2, h3, p {{ margin-top: 0; }}
+		.hero, .step-card, .panel {{
+			background: rgba(23, 26, 33, 0.94);
+			border: 1px solid var(--border);
+			border-radius: 16px;
+			box-shadow: 0 18px 50px rgba(0, 0, 0, 0.28);
+		}}
+		.hero {{ padding: 24px; margin-bottom: 24px; }}
+		.hero-grid, .grid {{
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+			gap: 16px;
+		}}
+		.step-card {{ padding: 20px; margin-bottom: 20px; }}
+		.panel {{ padding: 16px; background: rgba(31, 36, 48, 0.7); }}
+		.step-header, .attempt-header {{
+			display: flex;
+			align-items: start;
+			justify-content: space-between;
+			gap: 12px;
+		}}
+		.status-pill {{
+			display: inline-flex;
+			align-items: center;
+			border-radius: 999px;
+			padding: 6px 10px;
+			font-size: 12px;
+			font-weight: 700;
+			text-transform: uppercase;
+			letter-spacing: 0.06em;
+			border: 1px solid currentColor;
+		}}
+		.status-pill.success {{ color: #7ee7a8; }}
+		.status-pill.warning {{ color: #f6d06f; }}
+		.status-pill.failed {{ color: #ff8b8b; }}
+		.status-pill.neutral {{ color: #c4ccd9; }}
+		.kv {{
+			display: grid;
+			grid-template-columns: 120px 1fr;
+			gap: 10px;
+			padding: 8px 0;
+			border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+		}}
+		.kv span {{ color: var(--muted); font-size: 13px; }}
+		code, pre {{
+			font-family: "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, monospace;
+			font-size: 12px;
+			white-space: pre-wrap;
+			word-break: break-word;
+		}}
+		pre {{
+			margin: 0;
+			padding: 12px;
+			border-radius: 12px;
+			background: rgba(15, 17, 21, 0.85);
+			border: 1px solid rgba(255, 255, 255, 0.06);
+			max-height: 340px;
+			overflow: auto;
+		}}
+		.attempt-list {{
+			list-style: none;
+			padding: 0;
+			margin: 0;
+			display: grid;
+			gap: 12px;
+		}}
+		.attempt-card {{
+			padding: 12px;
+			border-radius: 12px;
+			border: 1px solid rgba(255, 255, 255, 0.08);
+			background: rgba(15, 17, 21, 0.72);
+		}}
+		.step-card.success {{ border-color: rgba(126, 231, 168, 0.35); }}
+		.step-card.warning {{ border-color: rgba(246, 208, 111, 0.35); }}
+		.step-card.failed {{ border-color: rgba(255, 139, 139, 0.35); }}
+		a {{ color: var(--accent); }}
+	</style>
+</head>
+<body>
+	<main>
+		<section class="hero">
+			<div class="step-header">
+				<div>
+					<h1>Browser Use Rerun Trace Report</h1>
+					<p>Static debug report generated from a saved rerun trace artifact.</p>
+				</div>
+				<span class="status-pill {_status_class(self.final_status)}">{_esc(self.final_status)}</span>
+			</div>
+			<div class="hero-grid">
+				<div class="panel">
+					<h3>Session</h3>
+					<div class="kv"><span>Task</span><code>{_esc(self.task or '-')}</code></div>
+					<div class="kv"><span>Trace Version</span><code>{_esc(self.version)}</code></div>
+					<div class="kv"><span>History File</span><code>{_esc(self.history_file_path or '-')}</code></div>
+				</div>
+				<div class="panel">
+					<h3>Timing</h3>
+					<div class="kv"><span>Started</span><code>{_esc(self.started_at or '-')}</code></div>
+					<div class="kv"><span>Completed</span><code>{_esc(self.completed_at or '-')}</code></div>
+					<div class="kv"><span>Steps</span><code>{len(self.steps)}</code></div>
+				</div>
+				<div class="panel">
+					<h3>Summary</h3>
+					<pre>{_esc(self.summary or 'No summary recorded')}</pre>
+				</div>
+			</div>
+		</section>
+		{''.join(step_cards) if step_cards else '<section class="step-card neutral"><p>No step data recorded.</p></section>'}
+	</main>
+</body>
+</html>
+"""
+
+	def save_html_report(self, filepath: str | Path) -> None:
+		"""Persist a rendered HTML rerun trace report to disk."""
+		path = Path(filepath)
+		path.parent.mkdir(parents=True, exist_ok=True)
+		path.write_text(self.to_html_report(), encoding='utf-8')
 
 	@classmethod
 	def load_from_file(cls, filepath: str | Path) -> 'RerunTrace':

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -359,6 +359,100 @@ class RerunSummaryAction(BaseModel):
 	)
 
 
+class RerunTraceAttempt(BaseModel):
+	"""Single replay attempt for a rerun step."""
+
+	attempt_number: int = Field(description='1-based replay attempt number for this step')
+	status: Literal['started', 'succeeded', 'failed', 'retried'] = Field(
+		description='Outcome of this attempt or transition into a retry'
+	)
+	error: str | None = Field(default=None, description='Error text captured for a failed attempt')
+	matched_element: dict[str, Any] | None = Field(
+		default=None, description='Matched rerun element metadata when available'
+	)
+	replay_url: str | None = Field(default=None, description='URL observed during this attempt')
+	replay_title: str | None = Field(default=None, description='Page title observed during this attempt')
+	retry_delay_seconds: float | None = Field(
+		default=None, description='Delay scheduled before the next retry, when applicable'
+	)
+	note: str | None = Field(default=None, description='Optional human-readable note about the attempt')
+
+
+class RerunTraceStep(BaseModel):
+	"""Normalized debug record for a single replayed history step."""
+
+	replay_step_index: int = Field(description='0-based index of the history item inside the rerun session')
+	original_step_number: int = Field(description='Original step number from the saved agent history')
+	status: Literal['pending', 'running', 'success', 'skipped', 'failed'] = Field(
+		default='pending',
+		description='Current or final status of this replayed step',
+	)
+	goal: str | None = Field(default=None, description='Original next_goal text for the step, if present')
+	original_actions: list[dict[str, Any]] = Field(
+		default_factory=list,
+		description='Serialized original actions for this step',
+	)
+	original_interacted_elements: list[dict[str, Any] | None] = Field(
+		default_factory=list,
+		description='Serialized original interacted elements aligned with original_actions',
+	)
+	original_url: str | None = Field(default=None, description='Original URL captured in history')
+	original_title: str | None = Field(default=None, description='Original page title captured in history')
+	original_screenshot_path: str | None = Field(
+		default=None, description='Original screenshot path captured in the saved history'
+	)
+	replay_url: str | None = Field(default=None, description='Latest URL observed during replay of this step')
+	replay_title: str | None = Field(default=None, description='Latest page title observed during replay of this step')
+	replay_screenshot_path: str | None = Field(
+		default=None, description='Replay screenshot path captured for this step, when available'
+	)
+	retry_count: int = Field(default=0, description='How many retry attempts were needed for this step')
+	skip_reason: str | None = Field(default=None, description='Structured explanation when the step is skipped')
+	failure_reason: str | None = Field(default=None, description='Structured explanation when the step fails')
+	attempts: list[RerunTraceAttempt] = Field(
+		default_factory=list,
+		description='Attempt-by-attempt replay details for this step',
+	)
+
+
+class RerunTrace(BaseModel):
+	"""Top-level debug artifact for a rerun session."""
+
+	version: Literal['1'] = Field(default='1', description='Schema version for rerun trace artifacts')
+	task: str | None = Field(default=None, description='Task text associated with the rerun session')
+	history_file_path: str | None = Field(
+		default=None, description='Optional source history file path used to start the rerun'
+	)
+	started_at: float | None = Field(default=None, description='Unix timestamp when rerun tracing began')
+	completed_at: float | None = Field(default=None, description='Unix timestamp when rerun tracing completed')
+	final_status: Literal['running', 'success', 'partial', 'failed'] = Field(
+		default='running',
+		description='Overall rerun outcome across all replayed steps',
+	)
+	summary: str | None = Field(
+		default=None,
+		description='Optional high-level explanation or post-run summary for the rerun session',
+	)
+	steps: list[RerunTraceStep] = Field(
+		default_factory=list,
+		description='Replay step records in execution order',
+	)
+
+	def save_to_file(self, filepath: str | Path) -> None:
+		"""Persist a rerun trace artifact to disk as JSON."""
+		path = Path(filepath)
+		path.parent.mkdir(parents=True, exist_ok=True)
+		with open(path, 'w', encoding='utf-8') as f:
+			json.dump(self.model_dump(mode='json'), f, indent=2, ensure_ascii=False)
+
+	@classmethod
+	def load_from_file(cls, filepath: str | Path) -> 'RerunTrace':
+		"""Load a rerun trace artifact from disk."""
+		with open(filepath, encoding='utf-8') as f:
+			data = json.load(f)
+		return cls.model_validate(data)
+
+
 class StepMetadata(BaseModel):
 	"""Metadata for a single step including timing and token information"""
 

--- a/browser_use/screenshots/service.py
+++ b/browser_use/screenshots/service.py
@@ -25,7 +25,12 @@ class ScreenshotService:
 	async def store_screenshot(self, screenshot_b64: str, step_number: int) -> str:
 		"""Store screenshot to disk and return the full path as string"""
 		screenshot_filename = f'step_{step_number}.png'
-		screenshot_path = self.screenshots_dir / screenshot_filename
+		return await self.store_named_screenshot(screenshot_b64, screenshot_filename)
+
+	@observe_debug(ignore_input=True, ignore_output=True, name='store_named_screenshot')
+	async def store_named_screenshot(self, screenshot_b64: str, filename: str) -> str:
+		"""Store screenshot to disk using an explicit filename and return the full path."""
+		screenshot_path = self.screenshots_dir / filename
 
 		# Decode base64 and save to disk
 		screenshot_data = base64.b64decode(screenshot_b64)

--- a/examples/features/rerun_history.py
+++ b/examples/features/rerun_history.py
@@ -5,7 +5,8 @@ This example shows how to:
 1. Run an agent and save its history (including initial URL navigation)
 2. Detect variables in the saved history (emails, names, dates, etc.)
 3. Rerun the history with substituted values (different data)
-4. Get AI-generated summary of rerun completion (with screenshot analysis)
+4. Save a structured debug trace and HTML replay report
+5. Get AI-generated summary of rerun completion (with screenshot analysis)
 
 Useful for:
 - Debugging agent behavior
@@ -13,6 +14,7 @@ Useful for:
 - Replaying successful workflows with different data
 - Understanding what values can be substituted in reruns
 - Getting automated verification of rerun success
+- Inspecting why a replay diverged, retried, or matched via fallback
 
 Note: Initial actions (like opening URLs from tasks) are now automatically
 saved to history and will be replayed during rerun, so you don't need to
@@ -46,6 +48,10 @@ The AI summary will be the last item in results and will have:
 	- extracted_content: The summary text
 	- success: Whether rerun was successful
 	- is_done: Always True for summary
+
+Debug Artifacts:
+	- `debug_trace_path`: Saves a JSON trace with per-step/per-attempt diagnostics
+	- `debug_report_path`: Saves a static HTML report for quick inspection
 """
 
 import asyncio
@@ -58,6 +64,8 @@ from browser_use.llm import ChatBrowserUse
 async def main():
 	# Example task to demonstrate history saving and rerunning
 	history_file = Path('agent_history.json')
+	debug_trace_file = Path('rerun_trace.json')
+	debug_report_file = Path('rerun_trace.html')
 	task = 'Go to https://browser-use.github.io/stress-tests/challenges/reference-number-form.html and fill the form with example data and submit and extract the refernence number.'
 	llm = ChatBrowserUse(model='bu-2-0')
 
@@ -122,6 +130,8 @@ async def main():
 			variables=new_values,
 			ai_step_llm=ai_step_llm,  # For extract action re-evaluation
 			summary_llm=summary_llm,  # For final summary
+			debug_trace_path=debug_trace_file,  # Structured JSON artifact
+			debug_report_path=debug_report_file,  # Static HTML report
 			max_step_interval=20,
 			delay_between_actions=1,
 		)
@@ -132,6 +142,8 @@ async def main():
 			print('\n📊 AI Summary:')
 			print(f'  Summary: {summary.extracted_content}')
 			print(f'  Success: {summary.success}')
+		print(f'  Debug trace: {debug_trace_file}')
+		print(f'  Debug report: {debug_report_file}')
 		print('✓ History rerun with substituted values complete')
 	else:
 		print('\n⚠️  No variables detected, skipping substitution rerun')

--- a/tests/ci/test_rerun_debug_trace.py
+++ b/tests/ci/test_rerun_debug_trace.py
@@ -123,6 +123,8 @@ def test_rerun_trace_html_report_renders_match_metadata():
 				replay_url='https://example.com/form',
 				replay_title='Form',
 				replay_screenshot_path='screenshots/replay-step-3.png',
+				screenshot_comparison_status='changed',
+				screenshot_comparison_note='Original and replay screenshots differ by file hash.',
 				retry_count=1,
 				failure_reason='Could not find matching element after retries.',
 				attempts=[
@@ -152,3 +154,5 @@ def test_rerun_trace_html_report_renders_match_metadata():
 	assert 'resolved_index' in report_html
 	assert 'fixtures/login-history.json' in report_html
 	assert 'screenshots/replay-step-3-attempt-1.png' in report_html
+	assert 'changed' in report_html
+	assert 'Original and replay screenshots differ by file hash.' in report_html

--- a/tests/ci/test_rerun_debug_trace.py
+++ b/tests/ci/test_rerun_debug_trace.py
@@ -125,6 +125,8 @@ def test_rerun_trace_html_report_renders_match_metadata():
 				replay_screenshot_path='screenshots/replay-step-3.png',
 				screenshot_comparison_status='changed',
 				screenshot_comparison_note='Original and replay screenshots differ by file hash.',
+				divergence_category='matched_via_fallback',
+				divergence_note='The replay matched at least one element via a fallback strategy: AX_NAME.',
 				retry_count=1,
 				failure_reason='Could not find matching element after retries.',
 				attempts=[
@@ -156,3 +158,8 @@ def test_rerun_trace_html_report_renders_match_metadata():
 	assert 'screenshots/replay-step-3-attempt-1.png' in report_html
 	assert 'changed' in report_html
 	assert 'Original and replay screenshots differ by file hash.' in report_html
+	assert 'matched_via_fallback' in report_html
+	assert 'fallback strategy: AX_NAME' in report_html
+	assert 'Divergence Categories' in report_html
+	assert 'Priority Steps' in report_html
+	assert 'Step 3' in report_html

--- a/tests/ci/test_rerun_debug_trace.py
+++ b/tests/ci/test_rerun_debug_trace.py
@@ -1,0 +1,91 @@
+"""Tests for rerun debug trace artifact generation."""
+
+import json
+from unittest.mock import AsyncMock
+
+from browser_use.agent.service import Agent
+from browser_use.agent.views import (
+	ActionResult,
+	AgentHistory,
+	AgentHistoryList,
+	RerunSummaryAction,
+	StepMetadata,
+)
+from browser_use.browser.views import BrowserStateHistory
+from tests.ci.conftest import create_mock_llm
+
+
+async def test_rerun_debug_trace_written_for_skipped_step(tmp_path):
+	"""rerun_history should persist a structured debug trace when requested."""
+
+	summary_action = RerunSummaryAction(
+		summary='Rerun completed with skipped steps',
+		success=True,
+		completion_status='partial',
+	)
+
+	async def custom_ainvoke(*args, **kwargs):
+		output_format = args[1] if len(args) > 1 else kwargs.get('output_format')
+		if output_format is RerunSummaryAction:
+			from browser_use.llm.views import ChatInvokeCompletion
+
+			return ChatInvokeCompletion(completion=summary_action, usage=None)
+		raise ValueError('Unexpected output_format')
+
+	mock_summary_llm = AsyncMock()
+	mock_summary_llm.ainvoke.side_effect = custom_ainvoke
+
+	llm = create_mock_llm(actions=None)
+	agent = Agent(task='Test task', llm=llm)
+	trace_path = tmp_path / 'rerun-trace.json'
+
+	mock_state = BrowserStateHistory(
+		url='https://example.com',
+		title='Test Page',
+		tabs=[],
+		interacted_element=[None],
+	)
+
+	AgentOutput = agent.AgentOutput
+	failed_step = AgentHistory(
+		model_output=AgentOutput(
+			evaluation_previous_goal=None,
+			memory='Trying to navigate',
+			next_goal='Open the destination page',
+			action=[{'navigate': {'url': 'https://example.com/page'}}],  # type: ignore[arg-type]
+		),
+		result=[ActionResult(error='Navigation failed - network error')],
+		state=mock_state,
+		metadata=StepMetadata(
+			step_start_time=0,
+			step_end_time=1,
+			step_number=1,
+			step_interval=1.0,
+		),
+	)
+
+	history = AgentHistoryList(history=[failed_step])
+
+	try:
+		results = await agent.rerun_history(
+			history,
+			skip_failures=True,
+			summary_llm=mock_summary_llm,
+			debug_trace_path=trace_path,
+			source_history_path='fixtures/test-history.json',
+		)
+
+		assert len(results) == 2
+		assert trace_path.exists()
+
+		trace = json.loads(trace_path.read_text(encoding='utf-8'))
+		assert trace['history_file_path'] == 'fixtures/test-history.json'
+		assert trace['final_status'] == 'partial'
+		assert trace['summary'] == 'Rerun completed with skipped steps'
+		assert len(trace['steps']) == 1
+		assert trace['steps'][0]['status'] == 'skipped'
+		assert 'skip_failures=True' in trace['steps'][0]['skip_reason']
+		assert trace['steps'][0]['original_url'] == 'https://example.com'
+		assert trace['steps'][0]['goal'] == 'Open the destination page'
+	finally:
+		await agent.close()

--- a/tests/ci/test_rerun_debug_trace.py
+++ b/tests/ci/test_rerun_debug_trace.py
@@ -8,6 +8,9 @@ from browser_use.agent.views import (
 	ActionResult,
 	AgentHistory,
 	AgentHistoryList,
+	RerunTrace,
+	RerunTraceAttempt,
+	RerunTraceStep,
 	RerunSummaryAction,
 	StepMetadata,
 )
@@ -96,3 +99,52 @@ async def test_rerun_debug_trace_written_for_skipped_step(tmp_path):
 		assert 'Rerun completed with skipped steps' in report_html
 	finally:
 		await agent.close()
+
+
+def test_rerun_trace_html_report_renders_match_metadata():
+	"""HTML report should expose match-level and action match details."""
+
+	trace = RerunTrace(
+		task='Replay login flow',
+		history_file_path='fixtures/login-history.json',
+		final_status='partial',
+		summary='Replay diverged on submit button matching.',
+		steps=[
+			RerunTraceStep(
+				replay_step_index=0,
+				original_step_number=3,
+				status='failed',
+				goal='Click submit',
+				original_actions=[{'click': {'index': 7}}],
+				original_interacted_elements=[{'node_name': 'button', 'attributes': {'aria-label': 'Submit'}}],
+				original_url='https://example.com/form',
+				original_title='Form',
+				replay_url='https://example.com/form',
+				replay_title='Form',
+				retry_count=1,
+				failure_reason='Could not find matching element after retries.',
+				attempts=[
+					RerunTraceAttempt(
+						attempt_number=1,
+						status='failed',
+						match_level='AX_NAME',
+						matched_element={'index': 11, 'node_name': 'button', 'ax_name': 'Submit'},
+						action_match_details=[
+							{
+								'action': {'click': {'index': 7}},
+								'match_level': 'AX_NAME',
+								'resolved_index': 11,
+							}
+						],
+						error='Could not find matching element after navigation changed the page.',
+					)
+				],
+			)
+		],
+	)
+
+	report_html = trace.to_html_report()
+	assert 'Browser Use Rerun Trace Report' in report_html
+	assert 'AX_NAME' in report_html
+	assert 'resolved_index' in report_html
+	assert 'fixtures/login-history.json' in report_html

--- a/tests/ci/test_rerun_debug_trace.py
+++ b/tests/ci/test_rerun_debug_trace.py
@@ -119,8 +119,10 @@ def test_rerun_trace_html_report_renders_match_metadata():
 				original_interacted_elements=[{'node_name': 'button', 'attributes': {'aria-label': 'Submit'}}],
 				original_url='https://example.com/form',
 				original_title='Form',
+				original_screenshot_path='screenshots/original-step-3.png',
 				replay_url='https://example.com/form',
 				replay_title='Form',
+				replay_screenshot_path='screenshots/replay-step-3.png',
 				retry_count=1,
 				failure_reason='Could not find matching element after retries.',
 				attempts=[
@@ -129,6 +131,7 @@ def test_rerun_trace_html_report_renders_match_metadata():
 						status='failed',
 						match_level='AX_NAME',
 						matched_element={'index': 11, 'node_name': 'button', 'ax_name': 'Submit'},
+						replay_screenshot_path='screenshots/replay-step-3-attempt-1.png',
 						action_match_details=[
 							{
 								'action': {'click': {'index': 7}},
@@ -148,3 +151,4 @@ def test_rerun_trace_html_report_renders_match_metadata():
 	assert 'AX_NAME' in report_html
 	assert 'resolved_index' in report_html
 	assert 'fixtures/login-history.json' in report_html
+	assert 'screenshots/replay-step-3-attempt-1.png' in report_html

--- a/tests/ci/test_rerun_debug_trace.py
+++ b/tests/ci/test_rerun_debug_trace.py
@@ -38,6 +38,7 @@ async def test_rerun_debug_trace_written_for_skipped_step(tmp_path):
 	llm = create_mock_llm(actions=None)
 	agent = Agent(task='Test task', llm=llm)
 	trace_path = tmp_path / 'rerun-trace.json'
+	report_path = tmp_path / 'rerun-trace.html'
 
 	mock_state = BrowserStateHistory(
 		url='https://example.com',
@@ -72,13 +73,16 @@ async def test_rerun_debug_trace_written_for_skipped_step(tmp_path):
 			skip_failures=True,
 			summary_llm=mock_summary_llm,
 			debug_trace_path=trace_path,
+			debug_report_path=report_path,
 			source_history_path='fixtures/test-history.json',
 		)
 
 		assert len(results) == 2
 		assert trace_path.exists()
+		assert report_path.exists()
 
 		trace = json.loads(trace_path.read_text(encoding='utf-8'))
+		report_html = report_path.read_text(encoding='utf-8')
 		assert trace['history_file_path'] == 'fixtures/test-history.json'
 		assert trace['final_status'] == 'partial'
 		assert trace['summary'] == 'Rerun completed with skipped steps'
@@ -87,5 +91,8 @@ async def test_rerun_debug_trace_written_for_skipped_step(tmp_path):
 		assert 'skip_failures=True' in trace['steps'][0]['skip_reason']
 		assert trace['steps'][0]['original_url'] == 'https://example.com'
 		assert trace['steps'][0]['goal'] == 'Open the destination page'
+		assert 'Browser Use Rerun Trace Report' in report_html
+		assert 'fixtures/test-history.json' in report_html
+		assert 'Rerun completed with skipped steps' in report_html
 	finally:
 		await agent.close()


### PR DESCRIPTION
 This PR improves the rerun_history() debugging workflow rather than the replay
  mechanism itself. Browser Use already had retrying, fallback matcher behavior,
  variable substitution, and rerun summaries, but when a rerun diverged from the
  original execution it was still hard to understand why from raw logs alone. This
  change adds a static HTML replay report plus structured per-step and per-attempt
  diagnostics so replay behavior is inspectable after the fact.

  In practice, the repo is better because rerun failures are now explainable. The new
  artifacts expose which matcher path succeeded or failed, what element metadata was
  matched, whether fallback strategies like AX_NAME or XPATH were used, how many
  attempts happened, what screenshots were produced during replay, and whether the
  replay visually diverged from the original run. It also introduces divergence
  categories such as missing_element, matched_via_fallback,
  page_changed_before_match, and retried_before_success, which makes debugging more
  systematic for both maintainers and users.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a structured rerun debug trace and a static HTML report to make `rerun_history` divergences explainable with clear per-step/per-attempt diagnostics, element match details, retries, and screenshots. This makes replay issues visible without digging through logs.

- **New Features**
  - `rerun_history` and `load_and_rerun` accept `debug_trace_path`, `debug_report_path`, and `source_history_path` (auto-populated by `load_and_rerun`).
  - Writes a JSON trace with step/attempt data: `status`, `skip_reason`/`failure_reason`, retry info, errors, URLs, titles.
  - Captures action-level match metadata: `match_level`, resolved index, and a compact matched-element snapshot (attributes, AX name, bounds, hashes); enhanced fallback match logging (e.g., `AX_NAME`, `XPATH`, `ATTRIBUTE`, `STABLE`).
  - Captures attempt screenshots; compares to originals via file hashes; deterministic filenames; stored via new `store_named_screenshot`.
  - Classifies divergences (`missing_element`, `matched_via_fallback`, `page_changed_before_match`, `retried_before_success`, `visual_change_detected`, `skipped_redundant_retry`, `skipped_original_error`).
  - Generates a static HTML report with session summary, divergence breakdown, priority steps, per-step cards, and detailed action match info.
  - Example updated in `examples/features/rerun_history.py`; CI tests added for trace/report generation and HTML rendering.

- **Migration**
  - No breaking changes; new args are optional.
  - To enable diagnostics, pass `debug_trace_path` and/or `debug_report_path` to `load_and_rerun(...)` or `rerun_history(...)`.
  - `store_screenshot` now delegates to `store_named_screenshot`; existing behavior is unchanged.

<sup>Written for commit f7f663fced168370c7e75f95c811583febd74ff3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

