### PR TITLE
fix(agent): label available file paths as local

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -343,7 +343,12 @@ Available tabs:
 
 		if self.available_file_paths:
 			available_file_paths_text = '\n'.join(self.available_file_paths)
-			agent_state += f'<available_file_paths>{available_file_paths_text}\nUse with absolute paths</available_file_paths>\n'
+			agent_state += (
+				f'<available_file_paths>{available_file_paths_text}\n'
+				'These are local file paths for read_file or upload actions. They are not URLs. '
+				'Do not navigate to a filename, file extension, or path fragment unless the user explicitly asks you to open it as a web page.\n'
+				'Use with absolute paths</available_file_paths>\n'
+			)
 		return agent_state
 
 	def _get_user_request_description(self) -> str:

--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -355,7 +355,12 @@ Available tabs:
 
 		if self.available_file_paths:
 			available_file_paths_text = '\n'.join(self.available_file_paths)
-			agent_state += f'<available_file_paths>{available_file_paths_text}\nUse with absolute paths</available_file_paths>\n'
+			agent_state += (
+				f'<available_file_paths>{available_file_paths_text}\n'
+				'These are local file paths for read_file or upload actions. They are not URLs. '
+				'Do not navigate to a filename, file extension, or path fragment unless the user explicitly asks you to open it as a web page.\n'
+				'Use with absolute paths</available_file_paths>\n'
+			)
 		return agent_state
 
 	def _get_user_request_description(self) -> str:

--- a/tests/ci/test_file_system_llm_integration.py
+++ b/tests/ci/test_file_system_llm_integration.py
@@ -141,6 +141,32 @@ class TestImageInLLMMessages:
 		assert 'data:image/' in img_part.image_url.url
 		assert 'base64,base64_image_data_here' in img_part.image_url.url
 
+	def test_available_file_paths_are_labeled_as_local_files(self, tmp_path: Path):
+		"""Test that uploaded HTML filenames are not presented as navigation targets."""
+		fs = FileSystem(tmp_path)
+		local_html = '/app/something_capabilities.html'
+
+		browser_state = BrowserStateSummary(
+			url='https://example.com',
+			title='Test',
+			tabs=[TabInfo(target_id='test-0', url='https://example.com', title='Test')],
+			screenshot=None,
+			dom_state=SerializedDOMState(_root=None, selector_map={}),
+		)
+
+		prompt = AgentMessagePrompt(
+			browser_state_summary=browser_state,
+			file_system=fs,
+			available_file_paths=[local_html],
+		)
+
+		user_message = prompt.get_user_message(use_vision=False)
+
+		assert isinstance(user_message.content, str)
+		assert local_html in user_message.content
+		assert 'These are local file paths for read_file or upload actions. They are not URLs.' in user_message.content
+		assert 'Do not navigate to a filename, file extension, or path fragment' in user_message.content
+
 	def test_agent_message_prompt_png_vs_jpg_media_type(self, tmp_path: Path):
 		"""Test that AgentMessagePrompt correctly detects PNG vs JPG media types."""
 		fs = FileSystem(tmp_path)


### PR DESCRIPTION
## Summary
- clarify that `available_file_paths` entries are local files for read/upload actions, not navigation targets
- warn the planner not to navigate to filenames, extensions, or path fragments unless explicitly requested
- add regression coverage for an uploaded `.html` filename so the warning stays near the file-path context

Fixes #4794.

## Tests
- `uv run pytest tests/ci/test_file_system_llm_integration.py::TestImageInLLMMessages::test_available_file_paths_are_labeled_as_local_files`
- `uv run pytest tests/ci/test_file_system_llm_integration.py`
- `uv run ruff format --check browser_use/agent/prompts.py tests/ci/test_file_system_llm_integration.py`
- `uv run ruff check browser_use/agent/prompts.py tests/ci/test_file_system_llm_integration.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `available_file_paths` are local files for read/upload, not navigation targets, and prevents the planner from treating filenames, extensions, or path fragments as URLs. Fixes #4794.

- **Bug Fixes**
  - Updated the prompt to label paths as local and "not URLs," and to avoid navigating to filenames, extensions, or path fragments unless the user asks.
  - Added a regression test ensuring an uploaded `.html` filename appears in the prompt with the new warnings.

<sup>Written for commit 280790751db675c51fde717d4b1a069b1d33478b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

