### PR TITLE
Add Browser Use Box self-hosted demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ We benchmark Browser Use across 100 real-world browser tasks. Full benchmark is 
 - You need [custom tools](https://docs.browser-use.com/customize/tools/basics) or deep code-level integration
 - We recommend pairing with our [cloud browsers](https://docs.browser-use.com/open-source/customize/browser/remote) for leading stealth, proxy rotation, and scaling
 - Or self-host the open-source agent fully on your own machines
+- Want a 24/7 Linux box agent with Telegram control and a persistent cloud browser? See [Browser Use Box](https://github.com/browser-use/bux) and [watch the demo](https://www.tiktok.com/@browser_use/video/7639824093721758989)
 
 **Use the [Fully-Hosted Cloud Agent](https://cloud.browser-use.com?utm_source=github&utm_medium=readme-hosted-agent) (recommended)**
 - Much more powerful agent for complex tasks (see plot above)


### PR DESCRIPTION
Adds a focused README link from the self-hosted open-source path to Browser Use Box and its short demo.

Official page: https://browser-use.com/bux
Project: https://github.com/browser-use/bux
Demo: https://www.tiktok.com/@browser_use/video/7639824093721758989

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a targeted README link in the self-hosted open-source section to Browser Use Box and its short demo. This helps self-hosting users discover the 24/7 Linux box agent with Telegram control and a persistent cloud browser.

<sup>Written for commit a786428885bb5ee3abdcec2d246883bb8c1a2ae5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->