### PR TITLE
fix(openai): report empty structured output

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -289,10 +289,23 @@ class ChatOpenAI(BaseChatModel):
 						model=self.name,
 					)
 
-				if choice.message.content is None:
+				if choice.message.content is None or not choice.message.content.strip():
+					details = []
+					response_id = getattr(response, 'id', None)
+					if response_id:
+						details.append(f'response_id={response_id}')
+					if choice.finish_reason:
+						details.append(f'finish_reason={choice.finish_reason}')
+					if self.base_url is not None:
+						details.append(f'base_url={self.base_url}')
+
+					details_text = f' ({", ".join(details)})' if details else ''
 					raise ModelProviderError(
-						message='Failed to parse structured output from model response',
-						status_code=500,
+						message=(
+							'OpenAI returned an empty structured output, so browser-use could not parse the'
+							f' requested JSON schema.{details_text}'
+						),
+						status_code=502,
 						model=self.name,
 					)
 

--- a/tests/ci/models/test_llm_openai_structured_output.py
+++ b/tests/ci/models/test_llm_openai_structured_output.py
@@ -1,0 +1,48 @@
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.messages import UserMessage
+from browser_use.llm.openai.chat import ChatOpenAI
+
+
+class StructuredAnswer(BaseModel):
+	answer: str
+
+
+class FakeChatOpenAI(ChatOpenAI):
+	def __init__(self, content: str | None) -> None:
+		super().__init__(model='gpt-4.1-mini', api_key='test')
+		self.content = content
+
+	def get_client(self):
+		async def create(**kwargs):
+			return SimpleNamespace(
+				id='chatcmpl-empty',
+				usage=None,
+				choices=[
+					SimpleNamespace(
+						finish_reason='stop',
+						message=SimpleNamespace(content=self.content),
+					)
+				],
+			)
+
+		return SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+
+
+@pytest.mark.parametrize('content', [None, '', '   \n\t'])
+async def test_openai_structured_output_empty_content_raises_provider_error(content):
+	llm = FakeChatOpenAI(content)
+
+	with pytest.raises(ModelProviderError) as exc_info:
+		await llm.ainvoke([UserMessage(content='Return JSON')], output_format=StructuredAnswer)
+
+	error = exc_info.value
+	assert error.status_code == 502
+	assert error.model == 'gpt-4.1-mini'
+	assert 'empty structured output' in error.message
+	assert 'response_id=chatcmpl-empty' in error.message
+	assert 'finish_reason=stop' in error.message


### PR DESCRIPTION
## Summary
- detect empty or whitespace-only OpenAI structured-output content before Pydantic JSON parsing
- raise a `ModelProviderError` with response diagnostics such as `response_id` and `finish_reason`
- add regression coverage for `None`, empty string, and whitespace-only content

## Why
When OpenAI chat completions return an empty structured-output message, browser-use currently surfaces a low-level Pydantic EOF error. That makes agent failures much harder to diagnose after long runs. This keeps the error at the provider boundary and preserves useful completion metadata.

Fixes #4786.

## Tests
- `uv run pytest tests/ci/models/test_llm_openai_structured_output.py`
- `uv run ruff format --check browser_use/llm/openai/chat.py tests/ci/models/test_llm_openai_structured_output.py`
- `uv run ruff check browser_use/llm/openai/chat.py tests/ci/models/test_llm_openai_structured_output.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects and reports empty OpenAI structured output before JSON parsing, returning a 502 `ModelProviderError` with diagnostics instead of a `pydantic` EOF. Fixes #4786.

- **Bug Fixes**
  - Detects `None`/empty/whitespace `message.content` and raises `ModelProviderError` (502) with `response_id`, `finish_reason`, and `base_url` when available.
  - Prevents low-level `pydantic` EOF errors from leaking past the provider boundary.
  - Adds regression tests for `None`, empty string, and whitespace-only content, asserting diagnostic details.

<sup>Written for commit dd1e3da45ce591e63507500f1e29a9bbf4e39720. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

