### PR TITLE
fix(browser): ignore extension page targets

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -188,7 +188,7 @@ class SessionManager:
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
+			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
 				page_targets.append(target)
 		return page_targets
 

--- a/tests/ci/browser/test_session_manager.py
+++ b/tests/ci/browser/test_session_manager.py
@@ -1,7 +1,11 @@
 import logging
+from typing import TYPE_CHECKING, cast
 
 from browser_use.browser.session import Target
 from browser_use.browser.session_manager import SessionManager
+
+if TYPE_CHECKING:
+	from browser_use.browser.session import BrowserSession
 
 
 class FakeBrowserSession:
@@ -9,7 +13,7 @@ class FakeBrowserSession:
 
 
 def test_get_all_page_targets_excludes_chrome_extension_pages():
-	session_manager = SessionManager(FakeBrowserSession())
+	session_manager = SessionManager(cast('BrowserSession', FakeBrowserSession()))
 	regular_page = Target(
 		target_id='page-target',
 		target_type='page',

--- a/tests/ci/browser/test_session_manager.py
+++ b/tests/ci/browser/test_session_manager.py
@@ -1,0 +1,46 @@
+import logging
+
+from browser_use.browser.session import Target
+from browser_use.browser.session_manager import SessionManager
+
+
+class FakeBrowserSession:
+	logger = logging.getLogger(__name__)
+
+
+def test_get_all_page_targets_excludes_chrome_extension_pages():
+	session_manager = SessionManager(FakeBrowserSession())
+	regular_page = Target(
+		target_id='page-target',
+		target_type='page',
+		url='https://example.com',
+		title='Example',
+	)
+	regular_tab = Target(
+		target_id='tab-target',
+		target_type='tab',
+		url='https://docs.example.com',
+		title='Docs',
+	)
+	extension_side_panel = Target(
+		target_id='extension-side-panel',
+		target_type='page',
+		url='chrome-extension://abcdefghijklmnop/side-panel.html',
+		title='Extension side panel',
+	)
+	iframe_target = Target(
+		target_id='iframe-target',
+		target_type='iframe',
+		url='https://example.com/frame',
+		title='Frame',
+	)
+	session_manager._targets = {
+		regular_page.target_id: regular_page,
+		extension_side_panel.target_id: extension_side_panel,
+		regular_tab.target_id: regular_tab,
+		iframe_target.target_id: iframe_target,
+	}
+
+	targets = session_manager.get_all_page_targets()
+
+	assert targets == [regular_page, regular_tab]


### PR DESCRIPTION
## Summary
- exclude `chrome-extension://` page/tab targets from `SessionManager.get_all_page_targets()`
- add a regression test that keeps normal page/tab targets while filtering extension side panels and iframe targets

## Why
Chrome extension side panels are exposed by CDP as `type: "page"`. Because `get_all_page_targets()` feeds focus recovery, tab listing, and initial target selection, those extension pages could be treated as normal browser tabs and steal agent focus.

Fixes #4133.

## Tests
- `uv run pytest tests/ci/browser/test_session_manager.py`
- `uv run ruff format --check browser_use/browser/session_manager.py tests/ci/browser/test_session_manager.py`
- `uv run ruff check browser_use/browser/session_manager.py tests/ci/browser/test_session_manager.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore `chrome-extension://` targets in `SessionManager.get_all_page_targets()` so extension side panels aren't treated as tabs and don't steal focus. Normal pages and tabs are unchanged. Fixes #4133.

- **Bug Fixes**
  - Skip `'page'`/`'tab'` targets with `chrome-extension://` URLs.
  - Add a regression test using a typed fake browser session to keep normal pages/tabs and exclude extension side panels (and iframes).

<sup>Written for commit a27e5ffd654b4b08ca1c5be745e6d61fbae3b7e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

