### PR TITLE
Fix icon-only control labels in DOM serialization

### DIFF
--- a/browser_use/dom/serializer/clickable_elements.py
+++ b/browser_use/dom/serializer/clickable_elements.py
@@ -235,7 +235,7 @@ class ClickableElementDetector:
 			# Check if this small element has interactive properties
 			if node.attributes:
 				# Small elements with these attributes are likely interactive icons
-				icon_attributes = {'class', 'role', 'onclick', 'data-action', 'aria-label'}
+				icon_attributes = {'class', 'role', 'onclick', 'data-action', 'aria-label', 'title'}
 				if any(attr in node.attributes for attr in icon_attributes):
 					return True
 

--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -1185,6 +1185,16 @@ class DOMTreeSerializer:
 		)
 
 		# Include accessibility properties
+		if node.ax_node:
+			if 'ax_name' in include_attributes and node.ax_node.name:
+				ax_name = str(node.ax_node.name).strip()
+				if ax_name:
+					attributes_to_include['ax_name'] = ax_name
+			if 'ax_description' in include_attributes and node.ax_node.description:
+				ax_description = str(node.ax_node.description).strip()
+				if ax_description:
+					attributes_to_include['ax_description'] = ax_description
+
 		if node.ax_node and node.ax_node.properties:
 			# Properties that carry field values - must be excluded for password fields
 			value_properties = {'value', 'valuetext'}
@@ -1235,7 +1245,7 @@ class DOMTreeSerializer:
 			seen_values = {}
 
 			# Attributes that should never be removed as duplicates (they serve distinct purposes)
-			protected_attrs = {'format', 'expected_format', 'placeholder', 'value', 'aria-label', 'title'}
+			protected_attrs = {'format', 'expected_format', 'placeholder', 'value', 'aria-label', 'title', 'ax_name'}
 
 			for key in ordered_keys:
 				value = attributes_to_include[key]
@@ -1270,7 +1280,7 @@ class DOMTreeSerializer:
 		if 'expanded' in attributes_to_include and 'aria-expanded' in attributes_to_include:
 			del attributes_to_include['aria-expanded']
 
-		attrs_to_remove_if_text_matches = ['aria-label', 'placeholder', 'title']
+		attrs_to_remove_if_text_matches = ['aria-label', 'placeholder', 'title', 'ax_name', 'ax_description']
 		for attr in attrs_to_remove_if_text_matches:
 			if attributes_to_include.get(attr) and attributes_to_include.get(attr, '').strip().lower() == text.strip().lower():
 				del attributes_to_include[attr]

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -79,6 +79,7 @@ DEFAULT_INCLUDE_ATTRIBUTES = [
 	'live',
 	# Accessibility name (contains text content for StaticText elements)
 	'ax_name',
+	'ax_description',
 ]
 
 STATIC_ATTRIBUTES = {

--- a/tests/ci/browser/test_clickable_elements.py
+++ b/tests/ci/browser/test_clickable_elements.py
@@ -1,0 +1,47 @@
+from browser_use.dom.serializer.clickable_elements import ClickableElementDetector
+from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, EnhancedSnapshotNode, NodeType
+
+
+def _element_with_bounds(attributes: dict[str, str], width: float, height: float) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='DIV',
+		node_value='',
+		attributes=attributes,
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=None,
+		snapshot_node=EnhancedSnapshotNode(
+			is_clickable=None,
+			cursor_style=None,
+			bounds=DOMRect(x=0, y=0, width=width, height=height),
+			clientRects=None,
+			scrollRects=None,
+			computed_styles=None,
+			paint_order=None,
+			stacking_contexts=None,
+		),
+	)
+
+
+def test_title_identifies_small_icon_control_as_interactive():
+	element = _element_with_bounds({'title': 'Create Test'}, width=24, height=24)
+
+	assert ClickableElementDetector.is_interactive(element)
+
+
+def test_title_alone_does_not_make_large_container_interactive():
+	element = _element_with_bounds({'title': 'Create Test'}, width=240, height=80)
+
+	assert not ClickableElementDetector.is_interactive(element)

--- a/tests/ci/browser/test_clickable_elements.py
+++ b/tests/ci/browser/test_clickable_elements.py
@@ -1,5 +1,6 @@
 from browser_use.dom.serializer.clickable_elements import ClickableElementDetector
-from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, EnhancedSnapshotNode, NodeType
+from browser_use.dom.serializer.serializer import DOMTreeSerializer
+from browser_use.dom.views import DOMRect, EnhancedAXNode, EnhancedDOMTreeNode, EnhancedSnapshotNode, NodeType
 
 
 def _element_with_bounds(attributes: dict[str, str], width: float, height: float) -> EnhancedDOMTreeNode:
@@ -45,3 +46,26 @@ def test_title_alone_does_not_make_large_container_interactive():
 	element = _element_with_bounds({'title': 'Create Test'}, width=240, height=80)
 
 	assert not ClickableElementDetector.is_interactive(element)
+
+
+def test_accessibility_name_is_serialized_for_icon_only_control():
+	element = _element_with_bounds({}, width=24, height=24)
+	element.node_name = 'BUTTON'
+	element.ax_node = EnhancedAXNode(
+		ax_node_id='1',
+		ignored=False,
+		role='button',
+		name='Create Test',
+		description='Opens the create test dialog',
+		properties=None,
+		child_ids=None,
+	)
+
+	attrs = DOMTreeSerializer._build_attributes_string(
+		element,
+		include_attributes=['ax_name', 'ax_description'],
+		text='',
+	)
+
+	assert 'ax_name=Create Test' in attrs
+	assert 'ax_description=Opens the create test dialog' in attrs


### PR DESCRIPTION
## Summary

Fixes browser-use/browser-use#4801 by making icon-only controls easier for the agent to identify when the target label lives in tooltip or accessibility metadata instead of visible text.

This PR:
- treats small elements with a `title` attribute as interactive candidates, covering toolbar icon buttons such as `title="Create Test"`
- serializes accessibility names and descriptions (`ax_name`, `ax_description`) into the LLM-visible DOM attributes when available
- adds focused regression coverage for titled icon controls and AX-named icon-only buttons

## Why

Icon-only toolbar buttons often have no text content. If the only useful label is a `title`, tooltip, or accessibility-tree name, the selector map can either omit the button or serialize it without the semantic label the model needs. Surfacing these labels gives the planner a stable way to map instructions like "Click Create Test" to the correct button.

## Validation

- `uv run pytest tests/ci/browser/test_clickable_elements.py -q`
- `uv run ruff check browser_use/dom/views.py browser_use/dom/serializer/serializer.py tests/ci/browser/test_clickable_elements.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make icon-only controls easier to detect and label by using `title` and accessibility metadata in DOM serialization. This helps the agent reliably click toolbar icons like "Create Test."

- **Bug Fixes**
  - Treat small elements with a `title` attribute as interactive; ignore large containers with only `title`.
  - Serialize `ax_name` and `ax_description` from AX nodes; keep `ax_name` when distinct and remove if it matches visible text.
  - Add tests for titled icons, AX-named icon-only buttons, and non-interactive large titled elements.

<sup>Written for commit 42380e418200f1b4b077faaac749af0cfed1d9fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

