### PR TITLE
fix(config): avoid docker detection false positives

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -20,16 +20,17 @@ logger = logging.getLogger(__name__)
 def is_running_in_docker() -> bool:
 	"""Detect if we are running in a docker container, for the purpose of optimizing chrome launch flags (dev shm usage, gpu settings, etc.)"""
 	try:
-		if Path('/.dockerenv').exists() or 'docker' in Path('/proc/1/cgroup').read_text().lower():
+		if Path('/.dockerenv').exists():
+			return True
+
+		cgroup = Path('/proc/1/cgroup').read_text().lower()
+		if any(marker in cgroup for marker in ('docker', 'containerd', 'kubepods')):
 			return True
 	except Exception:
 		pass
 
 	try:
-		# if init proc (PID 1) looks like uvicorn/python/uv/etc. then we're in Docker
-		# if init proc (PID 1) looks like bash/systemd/init/etc. then we're probably NOT in Docker
-		init_cmd = ' '.join(psutil.Process(1).cmdline())
-		if ('py' in init_cmd) or ('uv' in init_cmd) or ('app' in init_cmd):
+		if os.environ.get('container') or os.environ.get('DOCKER_CONTAINER'):
 			return True
 	except Exception:
 		pass

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -24,7 +24,7 @@ def is_running_in_docker() -> bool:
 			return True
 
 		cgroup = Path('/proc/1/cgroup').read_text().lower()
-		container_cgroup_markers = ('/docker/', 'docker-', '/kubepods', 'cri-containerd-')
+		container_cgroup_markers = ('/docker/', 'docker-', '/kubepods', 'cri-containerd-', ':cri-containerd:')
 		if any(marker in cgroup for marker in container_cgroup_markers):
 			return True
 	except Exception:

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -24,7 +24,8 @@ def is_running_in_docker() -> bool:
 			return True
 
 		cgroup = Path('/proc/1/cgroup').read_text().lower()
-		if any(marker in cgroup for marker in ('docker', 'containerd', 'kubepods')):
+		container_cgroup_markers = ('/docker/', 'docker-', '/kubepods', 'cri-containerd-')
+		if any(marker in cgroup for marker in container_cgroup_markers):
 			return True
 	except Exception:
 		pass

--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -1,7 +1,9 @@
 """Tests for lazy loading configuration system."""
 
 import os
+from pathlib import Path
 
+from browser_use import config
 from browser_use.config import CONFIG
 
 
@@ -118,3 +120,26 @@ class TestLazyConfig:
 				os.environ['BROWSER_USE_CLOUD_SYNC'] = sync_original
 			else:
 				os.environ.pop('BROWSER_USE_CLOUD_SYNC', None)
+
+	def test_docker_detection_ignores_pid1_command_substrings(self, monkeypatch):
+		"""PID 1 commands like python/app are common on VMs and should not imply Docker."""
+		config.is_running_in_docker.cache_clear()
+		monkeypatch.setattr(Path, 'exists', lambda _self: False)
+		monkeypatch.setattr(Path, 'read_text', lambda _self: '')
+		monkeypatch.setattr(config.psutil, 'pids', lambda: list(range(20)))
+		monkeypatch.delenv('container', raising=False)
+		monkeypatch.delenv('DOCKER_CONTAINER', raising=False)
+
+		assert config.is_running_in_docker() is False
+		config.is_running_in_docker.cache_clear()
+
+	def test_docker_detection_accepts_container_runtime_hints(self, monkeypatch):
+		config.is_running_in_docker.cache_clear()
+		monkeypatch.setattr(Path, 'exists', lambda _self: False)
+		monkeypatch.setattr(Path, 'read_text', lambda _self: '0::/system.slice/containerd.service')
+		monkeypatch.setattr(config.psutil, 'pids', lambda: list(range(20)))
+		monkeypatch.delenv('container', raising=False)
+		monkeypatch.delenv('DOCKER_CONTAINER', raising=False)
+
+		assert config.is_running_in_docker() is True
+		config.is_running_in_docker.cache_clear()

--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 from browser_use import config
 from browser_use.config import CONFIG
@@ -127,16 +128,36 @@ class TestLazyConfig:
 		monkeypatch.setattr(Path, 'exists', lambda _self: False)
 		monkeypatch.setattr(Path, 'read_text', lambda _self: '')
 		monkeypatch.setattr(config.psutil, 'pids', lambda: list(range(20)))
+		monkeypatch.setattr(
+			config.psutil,
+			'Process',
+			lambda pid: SimpleNamespace(cmdline=lambda: ['python', 'app.py']) if pid == 1 else None,
+		)
 		monkeypatch.delenv('container', raising=False)
 		monkeypatch.delenv('DOCKER_CONTAINER', raising=False)
 
 		assert config.is_running_in_docker() is False
 		config.is_running_in_docker.cache_clear()
 
-	def test_docker_detection_accepts_container_runtime_hints(self, monkeypatch):
+	def test_docker_detection_ignores_containerd_host_service(self, monkeypatch):
 		config.is_running_in_docker.cache_clear()
 		monkeypatch.setattr(Path, 'exists', lambda _self: False)
 		monkeypatch.setattr(Path, 'read_text', lambda _self: '0::/system.slice/containerd.service')
+		monkeypatch.setattr(config.psutil, 'pids', lambda: list(range(20)))
+		monkeypatch.delenv('container', raising=False)
+		monkeypatch.delenv('DOCKER_CONTAINER', raising=False)
+
+		assert config.is_running_in_docker() is False
+		config.is_running_in_docker.cache_clear()
+
+	def test_docker_detection_accepts_container_cgroup_path(self, monkeypatch):
+		config.is_running_in_docker.cache_clear()
+		monkeypatch.setattr(Path, 'exists', lambda _self: False)
+		monkeypatch.setattr(
+			Path,
+			'read_text',
+			lambda _self: '0::/kubepods.slice/kubepods-burstable.slice/cri-containerd-abc.scope',
+		)
 		monkeypatch.setattr(config.psutil, 'pids', lambda: list(range(20)))
 		monkeypatch.delenv('container', raising=False)
 		monkeypatch.delenv('DOCKER_CONTAINER', raising=False)

--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -164,3 +164,14 @@ class TestLazyConfig:
 
 		assert config.is_running_in_docker() is True
 		config.is_running_in_docker.cache_clear()
+
+	def test_docker_detection_accepts_colon_delimited_containerd_cgroup(self, monkeypatch):
+		config.is_running_in_docker.cache_clear()
+		monkeypatch.setattr(Path, 'exists', lambda _self: False)
+		monkeypatch.setattr(Path, 'read_text', lambda _self: '11:devices:/a.slice/b.slice:cri-containerd:abc')
+		monkeypatch.setattr(config.psutil, 'pids', lambda: list(range(20)))
+		monkeypatch.delenv('container', raising=False)
+		monkeypatch.delenv('DOCKER_CONTAINER', raising=False)
+
+		assert config.is_running_in_docker() is True
+		config.is_running_in_docker.cache_clear()


### PR DESCRIPTION
## Summary
- Remove broad PID 1 command substring matching from Docker detection
- Detect common container runtimes through `/.dockerenv`, cgroup markers, and explicit container env hints
- Add regression coverage so Python/app-style PID 1 commands on non-container hosts do not enable Docker-only launch assumptions

Fixes #4149

## Tests
- uv run pytest tests/ci/infrastructure/test_config.py
- uv run ruff format --check browser_use/config.py tests/ci/infrastructure/test_config.py
- uv run ruff check browser_use/config.py tests/ci/infrastructure/test_config.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Docker detection false positives by dropping PID 1 command checks and tightening cgroup matching (fixes #4149). Detects containers via `/.dockerenv`, cgroup markers (`/docker/`, `docker-`, `/kubepods`, `cri-containerd-`, `:cri-containerd:`), or `container`/`DOCKER_CONTAINER` env vars.

**Bug Fixes**
- Non-container hosts with python/app PID 1 commands no longer trigger Docker-only paths.
- Hosts running the `containerd` service are no longer mis-detected, while systemd `cri-containerd` cgroups are still recognized.
- Added regression tests for PID 1 commands, host `containerd` services, and container cgroup paths.

<sup>Written for commit b09b91540ab6412c5ee00dcafa0a0a2c8e9c3e33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

