### PR TITLE
fix: strip thinking tags before JSON parsing for MiniMax compatibility

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -281,7 +281,19 @@ class ChatOpenAI(BaseChatModel):
 
 				usage = self._get_usage(response)
 
-				parsed = output_format.model_validate_json(choice.message.content)
+				# Strip thinking tags and markdown code fences before parsing JSON
+				# This handles models (e.g., MiniMax, DeepSeek) that output thinking tags like
+				# <think>...</think> before the JSON content, which would cause JSON parsing to fail
+				content = choice.message.content
+				content = re.sub(r'```json\s*', '', content)
+				content = re.sub(r'```\s*', '', content)
+				THINK_TAGS = re.compile(r'<think>.*?</think>', re.DOTALL)
+				content = re.sub(THINK_TAGS, '', content)
+				STRAY_CLOSE_TAG = re.compile(r'.*?</think>', re.DOTALL)
+				content = re.sub(STRAY_CLOSE_TAG, '', content)
+				content = content.strip()
+
+				parsed = output_format.model_validate_json(content)
 
 				return ChatInvokeCompletion(
 					completion=parsed,


### PR DESCRIPTION
## Problem
Models like MiniMax output thinking tags (<think>...</think>) before the JSON content, causing `model_validate_json()` to fail with "Invalid JSON: expected value at line 1 column 1".

## Solution
Strip markdown code fences and thinking tags before parsing JSON in `ChatOpenAI.ainvoke()`. This enables compatibility with MiniMax and similar models that output thinking content.

## Changes
- `browser_use/llm/openai/chat.py`: Added regex to strip ```json fences and <think>...</think> tags before `model_validate_json()`

## Testing
Tested with MiniMax-M2.7-highspeed model - task "open Baidu, search browser-use, print titles" completed successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip `<think>` blocks and markdown code fences before JSON parsing to prevent “Invalid JSON” errors and enable compatibility with MiniMax/DeepSeek responses.

- **Bug Fixes**
  - Remove ```json/``` fences and `<think>...</think>` (including stray `</think>`) via regex before parsing.
  - Trim cleaned content and pass to `model_validate_json()` for reliable parsing.
  - Change localized to `browser_use/llm/openai/chat.py`.

<sup>Written for commit 4938dc814857f2aa31fdf24bd0180ffaef1a5565. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

