### PR TITLE
fix: relax OpenAI dependency pin

### DIFF
--- a/examples/custom-functions/cua.py
+++ b/examples/custom-functions/cua.py
@@ -261,6 +261,8 @@ async def openai_cua_fallback(params: OpenAICUAAction, browser_session: BrowserS
 			raise Exception('No computer calls found in CUA response')
 
 		action = computer_call.action
+		if action is None:
+			raise Exception('No action found in CUA computer call')
 		print(f'🎬 Executing CUA action: {action.type} - {action}')
 
 		action_result = await handle_model_action(browser_session, action)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "google-genai==1.65.0",
-    "openai==2.16.0",
+    "openai>=2.16.0,<3",
     "anthropic==0.76.0",
     "groq==1.0.0",
     "ollama==0.6.1",


### PR DESCRIPTION
Fixes #4285.

## Summary
- Relax the runtime OpenAI SDK dependency from an exact `2.16.0` pin to `>=2.16.0,<3`
- Keep the lower bound at the currently supported version while allowing downstream projects to use newer compatible OpenAI 2.x releases
- Unblocks resolver combinations such as browser-use with recent openai-agents versions

## Verification
- `uv lock --check`
- Resolver smoke test with local browser-use plus `openai-agents>=0.12.2`, which resolved `openai==2.36.0`
- `uv build --wheel`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed `openai` to `>=2.16.0,<3` and added a guard when a CUA computer call has no `action`; unblocks newer 2.x downstreams and resolves resolver conflicts (e.g., with `openai-agents` in `browser-use`).

<sup>Written for commit 555c833c3b64a80fa63e01418b44809fa44774d1. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4840?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

