### PR TITLE
Require explicit opt-in for real browser CLI access

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -181,6 +181,34 @@ def _get_pid_path(session: str = 'default') -> Path:
 	return _get_home_dir() / f'{session}.pid'
 
 
+def _env_truthy(name: str) -> bool:
+	"""Return True when an environment variable is set to a truthy value."""
+	return os.environ.get(name, '').strip().lower()[:1] in 'ty1'
+
+
+def _confirm_real_browser_access(action: str, data_scope: str) -> bool:
+	"""Require explicit confirmation before touching a real browser session/profile."""
+	if _env_truthy('BROWSER_USE_YES'):
+		return True
+
+	if not sys.stdin.isatty():
+		print(
+			f'Error: refusing to {action} non-interactively without --yes. '
+			f'This would expose {data_scope}.',
+			file=sys.stderr,
+		)
+		return False
+
+	print(f'Warning: this will {action}.', file=sys.stderr)
+	print(f'It can expose {data_scope}.', file=sys.stderr)
+	try:
+		reply = input('Continue? [y/N] ').strip().lower()
+	except (EOFError, KeyboardInterrupt):
+		print('', file=sys.stderr)
+		return False
+	return reply in {'y', 'yes'}
+
+
 def _read_auth_token(session: str = 'default') -> str:
 	"""Read per-session auth token written by the daemon.
 
@@ -652,6 +680,11 @@ Setup:
 		help='(Deprecated) Use "browser-use connect" instead',
 	)
 	parser.add_argument('--session', default=None, help='Session name (default: "default")')
+	parser.add_argument(
+		'--yes',
+		action='store_true',
+		help='Skip confirmation prompts for real browser/profile access',
+	)
 	parser.add_argument('--json', action='store_true', help='Output as JSON')
 	parser.add_argument('--mcp', action='store_true', help='Run as MCP server (JSON-RPC via stdin/stdout)')
 	parser.add_argument('--template', help='Generate template file (use with --output for custom path)')
@@ -1418,6 +1451,12 @@ def main() -> int:
 
 	# Handle connect command (discover local Chrome, start daemon)
 	if args.command == 'connect':
+		if not args.yes and not _confirm_real_browser_access(
+			'attach to a running Chrome instance',
+			'your open tabs, cookies, and logged-in sessions',
+		):
+			return 1
+
 		from browser_use.skill_cli.utils import discover_chrome_cdp_url
 
 		try:
@@ -1447,6 +1486,13 @@ def main() -> int:
 		print('Error: --cdp-url and --profile are mutually exclusive', file=sys.stderr)
 		return 1
 
+	if args.profile and not args.yes:
+		if not _confirm_real_browser_access(
+			f'launch Chrome with profile "{args.profile}"',
+			"that profile's cookies, saved logins, and browsing data",
+		):
+			return 1
+
 	# One-time legacy migration
 	_migrate_legacy_files()
 
@@ -1456,7 +1502,7 @@ def main() -> int:
 
 	# Build params from args
 	params = {}
-	skip_keys = {'command', 'headed', 'json', 'cdp_url', 'session', 'connect'}
+	skip_keys = {'command', 'headed', 'json', 'cdp_url', 'session', 'connect', 'yes'}
 
 	for key, value in vars(args).items():
 		if key not in skip_keys and value is not None:

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -194,8 +194,7 @@ def _confirm_real_browser_access(action: str, data_scope: str) -> bool:
 
 	if not sys.stdin.isatty():
 		print(
-			f'Error: refusing to {action} non-interactively without --yes. '
-			f'This would expose {data_scope}.',
+			f'Error: refusing to {action} non-interactively without --yes. This would expose {data_scope}.',
 			file=sys.stderr,
 		)
 		return False

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -183,7 +183,8 @@ def _get_pid_path(session: str = 'default') -> Path:
 
 def _env_truthy(name: str) -> bool:
 	"""Return True when an environment variable is set to a truthy value."""
-	return os.environ.get(name, '').strip().lower()[:1] in 'ty1'
+	val = os.environ.get(name, '').strip().lower()[:1]
+	return bool(val) and val in 'ty1'
 
 
 def _confirm_real_browser_access(action: str, data_scope: str) -> bool:

--- a/tests/ci/test_cli_cloud_connect.py
+++ b/tests/ci/test_cli_cloud_connect.py
@@ -46,3 +46,11 @@ def test_cloud_connect_help_shows_in_epilog():
 	"""Main --help epilog should mention cloud connect."""
 	result = run_cli('--help')
 	assert 'cloud connect' in result.stdout.lower()
+
+
+def test_profile_requires_yes_noninteractive():
+	"""Real Chrome profile access should require explicit opt-in in subprocess mode."""
+	result = run_cli('--profile', 'Default', 'open', 'https://example.com')
+	assert result.returncode == 1
+	assert 'without --yes' in result.stderr
+	assert 'saved logins' in result.stderr

--- a/tests/ci/test_cli_connect.py
+++ b/tests/ci/test_cli_connect.py
@@ -181,3 +181,11 @@ def test_connect_shows_in_help():
 	"""--help output should contain --connect."""
 	result = run_cli('--help')
 	assert '--connect' in result.stdout
+
+
+def test_connect_requires_yes_noninteractive():
+	"""connect should refuse non-interactive real-browser attachment without --yes."""
+	result = run_cli('connect')
+	assert result.returncode == 1
+	assert 'without --yes' in result.stderr
+	assert 'logged-in sessions' in result.stderr

--- a/tests/ci/test_cli_headed_flag.py
+++ b/tests/ci/test_cli_headed_flag.py
@@ -65,3 +65,12 @@ def test_no_profile_defaults_to_none():
 
 	args = parser.parse_args(['open', 'http://example.com'])
 	assert args.profile is None
+
+
+def test_yes_flag_parses_globally():
+	"""Test --yes can be used before subcommands that access real browser state."""
+	parser = build_parser()
+
+	args = parser.parse_args(['--yes', '--profile', 'Default', 'open', 'http://example.com'])
+	assert args.yes is True
+	assert args.profile == 'Default'


### PR DESCRIPTION
Summary
- add an explicit confirmation step before the CLI attaches to a running Chrome instance
- add the same opt-in gate before launching with a real Chrome profile
- add a global --yes escape hatch for automation and CI
- add focused CLI tests for the new behavior

Why
The CLI currently makes it easy to attach to a live Chrome session or launch against a real local Chrome profile without an explicit trust boundary. Those flows can expose open tabs, cookies, saved logins, and other local browsing state.

This PR keeps the change narrow. It does not block cloud flows or normal managed-browser usage. It only requires explicit opt-in when the CLI is about to access real local browser state.

Testing
- python3 -m py_compile browser_use/skill_cli/main.py tests/ci/test_cli_cloud_connect.py tests/ci/test_cli_connect.py tests/ci/test_cli_headed_flag.py
- python3 -m pytest tests/ci/test_cli_connect.py tests/ci/test_cli_cloud_connect.py tests/ci/test_cli_headed_flag.py -q (blocked locally: missing pytest_httpserver from tests/ci/conftest.py in this environment)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit opt-in before the CLI attaches to a running Chrome or launches with a real local profile to protect local browsing data. Adds a global `--yes` flag and a `BROWSER_USE_YES` env var (true/yes/1), improves the warning text, and fails non-interactive runs without opt-in; cloud and managed-browser flows are unchanged.

- **Migration**
  - For scripts/CI using connect or --profile, pass `--yes` or set `BROWSER_USE_YES=true/yes/1`.
  - Interactive runs show a prompt; answer y to continue.

<sup>Written for commit 9b4f2e57840044897728ff9a467648d6d1bf7488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

