### PR TITLE
Add a Qianfan example for OpenAI-compatible model setup

### DIFF
--- a/examples/models/qianfan.py
+++ b/examples/models/qianfan.py
@@ -20,6 +20,7 @@ if not api_key:
 # Browser Use agents rely on structured outputs through OpenAI-compatible response_format.
 # Qianfan structured-output smoke tests on 2026-05-16 succeeded with ernie-5.0.
 
+
 async def run_search():
 	agent = Agent(
 		task=('go to google, search for browser-use github'),

--- a/examples/models/qianfan.py
+++ b/examples/models/qianfan.py
@@ -1,0 +1,38 @@
+"""
+Simple try of the agent.
+
+@dev You need to add QIANFAN_API_KEY to your environment variables.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from browser_use import Agent, ChatOpenAI
+
+load_dotenv()
+
+api_key = os.getenv('QIANFAN_API_KEY', '')
+if not api_key:
+	raise ValueError('QIANFAN_API_KEY is not set')
+
+# Browser Use agents rely on structured outputs through OpenAI-compatible response_format.
+# Qianfan structured-output smoke tests on 2026-05-16 succeeded with ernie-5.0.
+
+async def run_search():
+	agent = Agent(
+		task=('go to google, search for browser-use github'),
+		llm=ChatOpenAI(
+			model='ernie-5.0',
+			base_url='https://qianfan.baidubce.com/v2',
+			api_key=api_key,
+		),
+		use_vision=False,
+	)
+
+	await agent.run()
+
+
+if __name__ == '__main__':
+	asyncio.run(run_search())


### PR DESCRIPTION
## Summary

This PR adds a first-party Qianfan example using Browser Use's existing `ChatOpenAI` compatibility path.

Changes:
- add `examples/models/qianfan.py`
- document the required `QIANFAN_API_KEY`
- use Qianfan's OpenAI-compatible base URL: `https://qianfan.baidubce.com/v2`

The example uses `ernie-5.0` by default because it worked reliably in local structured-output checks, which is important for Browser Use agents.

## Why

Browser Use already includes examples for several OpenAI-compatible providers.
Qianfan is a useful addition for developers building on Baidu's model platform, and it fits the existing example pattern without adding new runtime abstractions.

## Validation

I validated this change locally with:
- `uv run python -m py_compile examples/models/qianfan.py`
- `uv run ruff check examples/models/qianfan.py`

I also verified the Qianfan setup with a real API key:
- structured-output checks succeeded with `ernie-5.0`
- a local end-to-end Browser Use smoke test completed successfully against a simple test page

## Non-goals

This PR does not:
- add a new `ChatQianfan` provider class
- change Browser Use runtime behavior
- introduce provider-specific abstractions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Qianfan example that configures a Browser Use `Agent` with `ChatOpenAI` using Qianfan’s OpenAI-compatible API. Defaults to model `ernie-5.0`, sets `base_url` to `https://qianfan.baidubce.com/v2`, and requires `QIANFAN_API_KEY` (loaded via `dotenv`).

<sup>Written for commit a5188fd4a3bfa28b012873649ca43b219d326f3e. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4842?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

