### PR TITLE
fix(browser): dispatch tab event for window.open targets

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from cdp_use.cdp.target import AttachedToTargetEvent, DetachedFromTargetEvent, SessionID, TargetID
 
+from browser_use.browser.events import TabCreatedEvent
 from browser_use.utils import create_task_with_error_handling
 
 if TYPE_CHECKING:
@@ -403,6 +404,7 @@ class SessionManager:
 
 		from browser_use.browser.session import Target
 
+		target_url = target_info.get('url') or 'about:blank'
 		async with self._lock:
 			# Track this session for the target
 			if target_id not in self._target_sessions:
@@ -417,7 +419,7 @@ class SessionManager:
 				target = Target(
 					target_id=target_id,
 					target_type=target_type,
-					url=target_info.get('url', 'about:blank'),
+					url=target_url,
 					title=target_info.get('title', 'Unknown title'),
 				)
 				self._targets[target_id] = target
@@ -425,8 +427,9 @@ class SessionManager:
 			else:
 				# Update existing target info
 				existing_target = self._targets[target_id]
-				existing_target.url = target_info.get('url', existing_target.url)
+				existing_target.url = target_info.get('url') or existing_target.url or 'about:blank'
 				existing_target.title = target_info.get('title', existing_target.title)
+				target_url = existing_target.url
 
 		# Create CDPSession (communication channel)
 		from browser_use.browser.session import CDPSession
@@ -465,6 +468,8 @@ class SessionManager:
 		# Enable lifecycle events and network monitoring for page targets
 		if target_type in ('page', 'tab'):
 			await self._enable_page_monitoring(cdp_session)
+
+			self.browser_session.event_bus.dispatch(TabCreatedEvent(target_id=target_id, url=target_url))
 
 		# Resume execution if waiting for debugger
 		if waiting_for_debugger:

--- a/tests/ci/browser/test_tabs.py
+++ b/tests/ci/browser/test_tabs.py
@@ -19,13 +19,19 @@ Usage:
 
 import asyncio
 import time
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
+from cdp_use import CDPClient
+from cdp_use.cdp.target import AttachedToTargetEvent, TargetInfo
 from pytest_httpserver import HTTPServer
 
 from browser_use.agent.service import Agent
 from browser_use.browser import BrowserSession
+from browser_use.browser.events import TabCreatedEvent
 from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session_manager import SessionManager
 from tests.ci.conftest import create_mock_llm
 
 
@@ -103,6 +109,107 @@ async def browser_session():
 	await session.start()
 	yield session
 	await session.kill()
+
+
+class _RecordingEventBus:
+	def __init__(self):
+		self.events = []
+
+	def dispatch(self, event):
+		self.events.append(event)
+
+
+class _TargetCommands:
+	def __init__(self):
+		self.auto_attach_calls = []
+
+	async def setAutoAttach(self, params, session_id):
+		self.auto_attach_calls.append((params, session_id))
+
+
+def _build_session_manager_for_attach_test():
+	cdp_client_root = CDPClient('ws://unused')
+	cast(Any, cdp_client_root).send = SimpleNamespace(Target=_TargetCommands())
+	event_bus = _RecordingEventBus()
+	browser_session = SimpleNamespace(
+		_cdp_client_root=cdp_client_root,
+		browser_profile=SimpleNamespace(proxy=None),
+		event_bus=event_bus,
+		logger=SimpleNamespace(debug=lambda *args, **kwargs: None, warning=lambda *args, **kwargs: None),
+	)
+	manager = SessionManager(cast(BrowserSession, browser_session))
+	monitored_sessions = []
+
+	async def record_page_monitoring(cdp_session):
+		monitored_sessions.append(cdp_session)
+
+	manager._enable_page_monitoring = record_page_monitoring
+	return manager, event_bus, monitored_sessions
+
+
+def _target_attached_event(*, session_id: str, target_id: str, target_type: str, url: str, title: str) -> AttachedToTargetEvent:
+	target_info = cast(
+		TargetInfo,
+		{
+			'targetId': target_id,
+			'type': target_type,
+			'url': url,
+			'title': title,
+			'attached': True,
+			'canAccessOpener': False,
+		},
+	)
+	return cast(
+		AttachedToTargetEvent,
+		{
+			'sessionId': session_id,
+			'targetInfo': target_info,
+			'waitingForDebugger': False,
+		},
+	)
+
+
+async def test_window_open_target_attach_dispatches_tab_created_event_for_about_blank():
+	"""CDP page targets created by window.open() must initialize tab watchdogs."""
+	manager, event_bus, monitored_sessions = _build_session_manager_for_attach_test()
+
+	await manager._handle_target_attached(
+		_target_attached_event(
+			session_id='session-window-open',
+			target_id='target-window-open',
+			target_type='page',
+			url='',
+			title='',
+		)
+	)
+
+	assert len(monitored_sessions) == 1
+	assert len(event_bus.events) == 1
+	tab_created_event = event_bus.events[0]
+	assert isinstance(tab_created_event, TabCreatedEvent)
+	assert tab_created_event.target_id == 'target-window-open'
+	assert tab_created_event.url == 'about:blank'
+	target = manager.get_target('target-window-open')
+	assert target is not None
+	assert target.url == 'about:blank'
+
+
+async def test_non_page_target_attach_does_not_dispatch_tab_created_event():
+	"""Worker/iframe attaches should not be treated as browser tabs."""
+	manager, event_bus, monitored_sessions = _build_session_manager_for_attach_test()
+
+	await manager._handle_target_attached(
+		_target_attached_event(
+			session_id='session-worker',
+			target_id='target-worker',
+			target_type='worker',
+			url='https://example.com/worker.js',
+			title='',
+		)
+	)
+
+	assert monitored_sessions == []
+	assert event_bus.events == []
 
 
 class TestMultiTabOperations:


### PR DESCRIPTION
## Summary

Fixes #4208.

When Chrome attaches a `page`/`tab` target created by `window.open()`, the session manager enabled page monitoring but did not dispatch `TabCreatedEvent`. That left the tab lifecycle/watchdog path unaware of the new target, which can freeze interaction with the previous page and prevent normal navigation to the popup.

This change dispatches `TabCreatedEvent` from `_handle_target_attached()` for CDP page/tab targets and normalizes an empty CDP target URL to `about:blank`, matching the target state stored by `SessionManager`.

## Tests

Passed locally:

- `uv run ruff check browser_use/browser/session_manager.py tests/ci/browser/test_tabs.py`
- `uv run ruff format --check browser_use/browser/session_manager.py tests/ci/browser/test_tabs.py`
- `uv run pytest tests/ci/browser/test_tabs.py::test_window_open_target_attach_dispatches_tab_created_event_for_about_blank tests/ci/browser/test_tabs.py::test_non_page_target_attach_does_not_dispatch_tab_created_event -q`
- `uv run pyright browser_use/browser/session_manager.py tests/ci/browser/test_tabs.py`
- `uv run python -m py_compile browser_use/browser/session_manager.py tests/ci/browser/test_tabs.py`
- `uv run pre-commit run --files browser_use/browser/session_manager.py tests/ci/browser/test_tabs.py`
- `git diff --check`

Remote CI:

- Full lint/test matrix passed, including `browser/test_tabs`.
- CLA remains pending.

Blocked locally:

- `uv run pytest tests/ci/browser/test_tabs.py -q` timed out during browser startup (`BrowserStartEvent` / `LocalBrowserWatchdog.on_BrowserLaunchEvent`) before reaching the tab tests in this environment.

## Notes

Prior PR #4239 attempted the same root fix but was closed stale/unmerged. I did not find an open duplicate PR for #4208.
