### PR TITLE
fix(browser): load in-memory storage_state dictionaries

### DIFF
--- a/browser_use/browser/watchdogs/storage_state_watchdog.py
+++ b/browser_use/browser/watchdogs/storage_state_watchdog.py
@@ -68,7 +68,7 @@ class StorageStateWatchdog(BaseWatchdog):
 		if path is None:
 			# Use profile default path if available
 			if self.browser_session.browser_profile.storage_state:
-				path = str(self.browser_session.browser_profile.storage_state)
+				path = self.browser_session.browser_profile.storage_state
 			else:
 				path = None  # Skip saving if no path available
 		await self._save_storage_state(path)
@@ -80,7 +80,7 @@ class StorageStateWatchdog(BaseWatchdog):
 		if path is None:
 			# Use profile default path if available
 			if self.browser_session.browser_profile.storage_state:
-				path = str(self.browser_session.browser_profile.storage_state)
+				path = self.browser_session.browser_profile.storage_state
 			else:
 				path = None  # Skip loading if no path available
 		await self._load_storage_state(path)
@@ -164,7 +164,7 @@ class StorageStateWatchdog(BaseWatchdog):
 			self.logger.debug(f'[StorageStateWatchdog] Error comparing cookies: {e}')
 			return False
 
-	async def _save_storage_state(self, path: str | None = None) -> None:
+	async def _save_storage_state(self, path: str | Path | dict[str, Any] | None = None) -> None:
 		"""Save browser storage state to file."""
 		async with self._save_lock:
 			# Check if CDP client is available
@@ -230,22 +230,28 @@ class StorageStateWatchdog(BaseWatchdog):
 			except Exception as e:
 				self.logger.error(f'[StorageStateWatchdog] Failed to save storage state: {e}')
 
-	async def _load_storage_state(self, path: str | None = None) -> None:
+	async def _load_storage_state(self, path: str | Path | dict[str, Any] | None = None) -> None:
 		"""Load browser storage state from file."""
 		if not self.browser_session.cdp_client:
 			self.logger.warning('[StorageStateWatchdog] No CDP client available for loading')
 			return
 
 		load_path = path or self.browser_session.browser_profile.storage_state
-		if not load_path or not os.path.exists(str(load_path)):
+		if not load_path:
 			return
 
 		try:
-			# Read the storage state file asynchronously
-			import anyio
+			if isinstance(load_path, dict):
+				storage = load_path
+			else:
+				if not os.path.exists(str(load_path)):
+					return
 
-			content = await anyio.Path(str(load_path)).read_text()
-			storage = json.loads(content)
+				# Read the storage state file asynchronously
+				import anyio
+
+				content = await anyio.Path(str(load_path)).read_text()
+				storage = json.loads(content)
 
 			# Apply cookies if present
 			if 'cookies' in storage and storage['cookies']:
@@ -309,7 +315,7 @@ class StorageStateWatchdog(BaseWatchdog):
 
 			self.event_bus.dispatch(
 				StorageStateLoadedEvent(
-					path=str(load_path),
+					path='<memory>' if isinstance(load_path, dict) else str(load_path),
 					cookies_count=len(storage.get('cookies', [])),
 					origins_count=len(storage.get('origins', [])),
 				)

--- a/tests/ci/browser/test_storage_state_watchdog.py
+++ b/tests/ci/browser/test_storage_state_watchdog.py
@@ -31,9 +31,10 @@ def _storage_state() -> dict:
 	}
 
 
-def _watchdog_for_storage_state(storage_state: dict) -> tuple[StorageStateWatchdog, EventBus, list, list]:
+def _watchdog_for_storage_state(storage_state: dict) -> tuple[StorageStateWatchdog, EventBus, list, list, list]:
 	set_cookies_calls = []
 	init_scripts = []
+	get_storage_state_calls = []
 
 	class FakeBrowserSession:
 		browser_profile = BrowserProfile(storage_state=storage_state, headless=True, user_data_dir=None)
@@ -50,15 +51,16 @@ def _watchdog_for_storage_state(storage_state: dict) -> tuple[StorageStateWatchd
 			return object()
 
 		async def _cdp_get_storage_state(self):
+			get_storage_state_calls.append(True)
 			raise AssertionError('in-memory storage_state should not be saved as a file')
 
 	event_bus = EventBus()
 	watchdog = StorageStateWatchdog.model_construct(browser_session=FakeBrowserSession(), event_bus=event_bus)
-	return watchdog, event_bus, set_cookies_calls, init_scripts
+	return watchdog, event_bus, set_cookies_calls, init_scripts, get_storage_state_calls
 
 
 async def test_load_storage_state_accepts_in_memory_dict_from_profile():
-	watchdog, event_bus, set_cookies_calls, init_scripts = _watchdog_for_storage_state(_storage_state())
+	watchdog, event_bus, set_cookies_calls, init_scripts, _get_storage_state_calls = _watchdog_for_storage_state(_storage_state())
 
 	try:
 		await watchdog.on_LoadStorageStateEvent(LoadStorageStateEvent())
@@ -75,9 +77,12 @@ async def test_load_storage_state_accepts_in_memory_dict_from_profile():
 
 
 async def test_save_storage_state_skips_in_memory_dict_from_profile():
-	watchdog, event_bus, _set_cookies_calls, _init_scripts = _watchdog_for_storage_state(_storage_state())
+	watchdog, event_bus, _set_cookies_calls, _init_scripts, get_storage_state_calls = _watchdog_for_storage_state(
+		_storage_state()
+	)
 
 	try:
 		await watchdog.on_SaveStorageStateEvent(SaveStorageStateEvent())
+		assert get_storage_state_calls == []
 	finally:
 		await event_bus.stop(clear=True, timeout=5)

--- a/tests/ci/browser/test_storage_state_watchdog.py
+++ b/tests/ci/browser/test_storage_state_watchdog.py
@@ -1,0 +1,83 @@
+import logging
+
+from bubus import EventBus
+
+from browser_use.browser import BrowserProfile
+from browser_use.browser.events import LoadStorageStateEvent, SaveStorageStateEvent
+from browser_use.browser.watchdogs.storage_state_watchdog import StorageStateWatchdog
+
+
+def _storage_state() -> dict:
+	return {
+		'cookies': [
+			{
+				'name': 'sessionid',
+				'value': 'abc123',
+				'domain': 'example.com',
+				'path': '/',
+				'expires': -1,
+				'httpOnly': True,
+				'secure': False,
+				'sameSite': 'Lax',
+			}
+		],
+		'origins': [
+			{
+				'origin': 'https://example.com',
+				'localStorage': [{'name': 'token', 'value': 'local'}],
+				'sessionStorage': [{'name': 'step', 'value': '1'}],
+			}
+		],
+	}
+
+
+def _watchdog_for_storage_state(storage_state: dict) -> tuple[StorageStateWatchdog, EventBus, list, list]:
+	set_cookies_calls = []
+	init_scripts = []
+
+	class FakeBrowserSession:
+		browser_profile = BrowserProfile(storage_state=storage_state, headless=True, user_data_dir=None)
+		cdp_client = object()
+		logger = logging.getLogger('test_storage_state_watchdog')
+
+		async def _cdp_set_cookies(self, cookies):
+			set_cookies_calls.append(cookies)
+
+		async def _cdp_add_init_script(self, script: str):
+			init_scripts.append(script)
+
+		async def get_or_create_cdp_session(self, target_id=None, focus=None):
+			return object()
+
+		async def _cdp_get_storage_state(self):
+			raise AssertionError('in-memory storage_state should not be saved as a file')
+
+	event_bus = EventBus()
+	watchdog = StorageStateWatchdog.model_construct(browser_session=FakeBrowserSession(), event_bus=event_bus)
+	return watchdog, event_bus, set_cookies_calls, init_scripts
+
+
+async def test_load_storage_state_accepts_in_memory_dict_from_profile():
+	watchdog, event_bus, set_cookies_calls, init_scripts = _watchdog_for_storage_state(_storage_state())
+
+	try:
+		await watchdog.on_LoadStorageStateEvent(LoadStorageStateEvent())
+
+		assert len(set_cookies_calls) == 1
+		assert set_cookies_calls[0][0]['name'] == 'sessionid'
+		assert 'expires' not in set_cookies_calls[0][0]
+		assert len(init_scripts) == 2
+		assert 'localStorage.setItem("token", "local")' in init_scripts[0]
+		assert 'sessionStorage.setItem("step", "1")' in init_scripts[1]
+		assert watchdog._last_cookie_state == _storage_state()['cookies']
+	finally:
+		await event_bus.stop(clear=True, timeout=5)
+
+
+async def test_save_storage_state_skips_in_memory_dict_from_profile():
+	watchdog, event_bus, _set_cookies_calls, _init_scripts = _watchdog_for_storage_state(_storage_state())
+
+	try:
+		await watchdog.on_SaveStorageStateEvent(SaveStorageStateEvent())
+	finally:
+		await event_bus.stop(clear=True, timeout=5)


### PR DESCRIPTION
## Summary

Fixes #4257.

When `BrowserProfile.storage_state` is provided as an in-memory dictionary, `StorageStateWatchdog` currently converts it to a string before loading. That makes the loader treat the dictionary representation as a file path, so cookies and origin storage are never applied.

This change preserves dict storage state through the save/load event handlers, loads in-memory dictionaries directly, and keeps file-path loading unchanged. In-memory storage state still skips file persistence on save.

## Tests

- `uv run pytest tests/ci/browser/test_storage_state_watchdog.py -q`
- `uv run ruff check browser_use/browser/watchdogs/storage_state_watchdog.py tests/ci/browser/test_storage_state_watchdog.py`
- `uv run ruff format --check browser_use/browser/watchdogs/storage_state_watchdog.py tests/ci/browser/test_storage_state_watchdog.py`
- `uv run pyright browser_use/browser/watchdogs/storage_state_watchdog.py tests/ci/browser/test_storage_state_watchdog.py`
- `uv run python -m py_compile browser_use/browser/watchdogs/storage_state_watchdog.py tests/ci/browser/test_storage_state_watchdog.py`
- `uv run pre-commit run --files browser_use/browser/watchdogs/storage_state_watchdog.py tests/ci/browser/test_storage_state_watchdog.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loading of in-memory `storage_state` dicts so cookies and origin storage apply correctly. File-path behavior is unchanged; in-memory state is not written to disk.

- **Bug Fixes**
  - Keep dict `storage_state` through events (no str coercion); load dicts directly; update types to accept `dict | str | Path`.
  - For dict state: skip file writes; for paths: keep existing save/load and check existence before read.
  - Emit `StorageStateLoadedEvent` with `path: '<memory>'` for dict loads; add tests for in-memory load and save-skip.

<sup>Written for commit 87bd07703bb378cc5af695fcdc24c8560420691b. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4844?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

