### PR TITLE
fix(browser): preserve video recording timing

### DIFF
--- a/browser_use/browser/video_recorder.py
+++ b/browser_use/browser/video_recorder.py
@@ -4,8 +4,10 @@ import base64
 import io
 import logging
 import math
+import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from browser_use.browser.profile import ViewportSize
 
@@ -38,7 +40,7 @@ class VideoRecorderService:
 	It automatically resizes frames to match the target video dimensions.
 	"""
 
-	def __init__(self, output_path: Path, size: ViewportSize, framerate: int):
+	def __init__(self, output_path: Path, size: ViewportSize, framerate: int, time_func: Callable[[], float] | None = None):
 		"""
 		Initializes the video recorder.
 
@@ -50,9 +52,13 @@ class VideoRecorderService:
 		self.output_path = output_path
 		self.size = size
 		self.framerate = framerate
+		self._time_func = time_func or time.monotonic
 		self._writer: Optional['Format.Writer'] = None
 		self._is_active = False
 		self.padded_size = _get_padded_size(self.size)
+		self._last_frame_monotonic: float | None = None
+		self._frame_time_accumulator = 0.0
+		self._last_frame_array: Any | None = None
 
 	def start(self) -> None:
 		"""
@@ -118,9 +124,47 @@ class VideoRecorderService:
 				# 3. Convert to numpy array for imageio
 				img_array = np.array(img)
 
-			self._writer.append_data(img_array)
+			self._append_timed_frame(img_array)
 		except Exception as e:
 			logger.warning(f'Could not process and add video frame: {e}')
+
+	def _get_frame_write_plan(self, now: float) -> tuple[int, int]:
+		"""Return (previous frame repeats, current frame repeats) for fixed-FPS output."""
+		if self.framerate <= 0:
+			self._last_frame_monotonic = now
+			self._frame_time_accumulator = 0.0
+			return (0, 1)
+
+		if self._last_frame_monotonic is None:
+			self._last_frame_monotonic = now
+			return (0, 1)
+
+		elapsed = max(0.0, now - self._last_frame_monotonic)
+		self._last_frame_monotonic = now
+		self._frame_time_accumulator += elapsed
+
+		frame_interval = 1.0 / self.framerate
+		intervals_elapsed = int(self._frame_time_accumulator / frame_interval)
+		if intervals_elapsed <= 0:
+			return (0, 0)
+
+		self._frame_time_accumulator -= intervals_elapsed * frame_interval
+		return (max(0, intervals_elapsed - 1), 1)
+
+	def _append_timed_frame(self, frame_array: Any) -> None:
+		"""Append frames according to elapsed wall-clock time between screencast frames."""
+		if not self._writer:
+			return
+
+		previous_repeats, current_repeats = self._get_frame_write_plan(self._time_func())
+		if previous_repeats and self._last_frame_array is not None:
+			for _ in range(previous_repeats):
+				self._writer.append_data(self._last_frame_array)
+
+		for _ in range(current_repeats):
+			self._writer.append_data(frame_array)
+
+		self._last_frame_array = frame_array
 
 	def stop_and_save(self) -> None:
 		"""

--- a/browser_use/browser/video_recorder.py
+++ b/browser_use/browser/video_recorder.py
@@ -42,7 +42,14 @@ class VideoRecorderService:
 	It automatically resizes frames to match the target video dimensions.
 	"""
 
-	def __init__(self, output_path: Path, size: ViewportSize, framerate: int, time_func: Callable[[], float] | None = None):
+	def __init__(
+		self,
+		output_path: Path,
+		size: ViewportSize,
+		framerate: int,
+		time_func: Callable[[], float] | None = None,
+		max_frame_fill_seconds: float = 10.0,
+	):
 		"""
 		Initializes the video recorder.
 
@@ -54,12 +61,14 @@ class VideoRecorderService:
 		self.output_path = output_path
 		self.size = size
 		self.framerate = framerate
+		self.max_frame_fill_seconds = max_frame_fill_seconds
 		self._time_func = time_func or time.monotonic
 		self._writer: Optional['Format.Writer'] = None
 		self._is_active = False
 		self.padded_size = _get_padded_size(self.size)
 		self._last_frame_timestamp: float | None = None
 		self._last_frame_timestamp_source: TimestampSource | None = None
+		self._last_frame_local_timestamp: float | None = None
 		self._frame_time_accumulator = 0.0
 		self._last_frame_array: Any | None = None
 
@@ -136,6 +145,7 @@ class VideoRecorderService:
 		"""Reset frame timing state when the screencast source changes."""
 		self._last_frame_timestamp = None
 		self._last_frame_timestamp_source = None
+		self._last_frame_local_timestamp = None
 		self._frame_time_accumulator = 0.0
 		self._last_frame_array = None
 
@@ -153,7 +163,7 @@ class VideoRecorderService:
 			self._frame_time_accumulator = 0.0
 			return (0, 1)
 
-		elapsed = max(0.0, now - self._last_frame_timestamp)
+		elapsed = min(max(0.0, now - self._last_frame_timestamp), self.max_frame_fill_seconds)
 		self._last_frame_timestamp = now
 		self._frame_time_accumulator += elapsed
 
@@ -176,6 +186,7 @@ class VideoRecorderService:
 		else:
 			frame_timestamp = timestamp
 			timestamp_source = 'cdp'
+		local_timestamp = frame_timestamp if timestamp is None else self._time_func()
 
 		previous_repeats, current_repeats = self._get_frame_write_plan(frame_timestamp, timestamp_source)
 		if previous_repeats and self._last_frame_array is not None:
@@ -186,6 +197,24 @@ class VideoRecorderService:
 			self._writer.append_data(frame_array)
 
 		self._last_frame_array = frame_array
+		self._last_frame_local_timestamp = local_timestamp
+
+	def _flush_final_frame(self) -> None:
+		"""Extend the last frame to cover idle time before recording stops."""
+		if not self._writer or self.framerate <= 0 or self._last_frame_array is None or self._last_frame_local_timestamp is None:
+			return
+
+		elapsed = min(max(0.0, self._time_func() - self._last_frame_local_timestamp), self.max_frame_fill_seconds)
+		self._frame_time_accumulator += elapsed
+
+		frame_interval = 1.0 / self.framerate
+		intervals_elapsed = int(self._frame_time_accumulator / frame_interval)
+		if intervals_elapsed <= 0:
+			return
+
+		self._frame_time_accumulator -= intervals_elapsed * frame_interval
+		for _ in range(max(0, intervals_elapsed - 1)):
+			self._writer.append_data(self._last_frame_array)
 
 	def stop_and_save(self) -> None:
 		"""
@@ -197,6 +226,7 @@ class VideoRecorderService:
 			return
 
 		try:
+			self._flush_final_frame()
 			self._writer.close()
 			logger.info(f'📹 Video recording saved successfully to: {self.output_path}')
 		except Exception as e:

--- a/browser_use/browser/video_recorder.py
+++ b/browser_use/browser/video_recorder.py
@@ -7,7 +7,7 @@ import math
 import time
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from browser_use.browser.profile import ViewportSize
 
@@ -22,6 +22,8 @@ except ImportError:
 	IMAGEIO_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
+
+TimestampSource = Literal['cdp', 'local']
 
 
 def _get_padded_size(size: ViewportSize, macro_block_size: int = 16) -> ViewportSize:
@@ -56,7 +58,8 @@ class VideoRecorderService:
 		self._writer: Optional['Format.Writer'] = None
 		self._is_active = False
 		self.padded_size = _get_padded_size(self.size)
-		self._last_frame_monotonic: float | None = None
+		self._last_frame_timestamp: float | None = None
+		self._last_frame_timestamp_source: TimestampSource | None = None
 		self._frame_time_accumulator = 0.0
 		self._last_frame_array: Any | None = None
 
@@ -90,13 +93,14 @@ class VideoRecorderService:
 			logger.error(f'Failed to initialize video writer: {e}')
 			self._is_active = False
 
-	def add_frame(self, frame_data_b64: str) -> None:
+	def add_frame(self, frame_data_b64: str, timestamp: float | None = None) -> None:
 		"""
 		Decodes a base64-encoded PNG frame, resizes it, pads it to be codec-compatible,
 		and appends it to the video.
 
 		Args:
 		    frame_data_b64: A base64-encoded string of the PNG frame data.
+		    timestamp: Optional CDP screencast frame timestamp in seconds.
 		"""
 		if not self._is_active or not self._writer:
 			return
@@ -124,23 +128,33 @@ class VideoRecorderService:
 				# 3. Convert to numpy array for imageio
 				img_array = np.array(img)
 
-			self._append_timed_frame(img_array)
+			self._append_timed_frame(img_array, timestamp=timestamp)
 		except Exception as e:
 			logger.warning(f'Could not process and add video frame: {e}')
 
-	def _get_frame_write_plan(self, now: float) -> tuple[int, int]:
+	def reset_timing(self) -> None:
+		"""Reset frame timing state when the screencast source changes."""
+		self._last_frame_timestamp = None
+		self._last_frame_timestamp_source = None
+		self._frame_time_accumulator = 0.0
+		self._last_frame_array = None
+
+	def _get_frame_write_plan(self, now: float, timestamp_source: TimestampSource = 'cdp') -> tuple[int, int]:
 		"""Return (previous frame repeats, current frame repeats) for fixed-FPS output."""
 		if self.framerate <= 0:
-			self._last_frame_monotonic = now
+			self._last_frame_timestamp = now
+			self._last_frame_timestamp_source = timestamp_source
 			self._frame_time_accumulator = 0.0
 			return (0, 1)
 
-		if self._last_frame_monotonic is None:
-			self._last_frame_monotonic = now
+		if self._last_frame_timestamp is None or self._last_frame_timestamp_source != timestamp_source:
+			self._last_frame_timestamp = now
+			self._last_frame_timestamp_source = timestamp_source
+			self._frame_time_accumulator = 0.0
 			return (0, 1)
 
-		elapsed = max(0.0, now - self._last_frame_monotonic)
-		self._last_frame_monotonic = now
+		elapsed = max(0.0, now - self._last_frame_timestamp)
+		self._last_frame_timestamp = now
 		self._frame_time_accumulator += elapsed
 
 		frame_interval = 1.0 / self.framerate
@@ -151,12 +165,19 @@ class VideoRecorderService:
 		self._frame_time_accumulator -= intervals_elapsed * frame_interval
 		return (max(0, intervals_elapsed - 1), 1)
 
-	def _append_timed_frame(self, frame_array: Any) -> None:
+	def _append_timed_frame(self, frame_array: Any, timestamp: float | None = None) -> None:
 		"""Append frames according to elapsed wall-clock time between screencast frames."""
 		if not self._writer:
 			return
 
-		previous_repeats, current_repeats = self._get_frame_write_plan(self._time_func())
+		if timestamp is None:
+			frame_timestamp = self._time_func()
+			timestamp_source: TimestampSource = 'local'
+		else:
+			frame_timestamp = timestamp
+			timestamp_source = 'cdp'
+
+		previous_repeats, current_repeats = self._get_frame_write_plan(frame_timestamp, timestamp_source)
 		if previous_repeats and self._last_frame_array is not None:
 			for _ in range(previous_repeats):
 				self._writer.append_data(self._last_frame_array)

--- a/browser_use/browser/watchdogs/recording_watchdog.py
+++ b/browser_use/browser/watchdogs/recording_watchdog.py
@@ -16,6 +16,14 @@ from browser_use.browser.watchdog_base import BaseWatchdog
 from browser_use.utils import create_task_with_error_handling
 
 
+def _get_screencast_frame_timestamp(event: ScreencastFrameEvent) -> float | None:
+	"""Return the CDP frame timestamp when Chrome provides one."""
+	timestamp = event.get('metadata', {}).get('timestamp')
+	if timestamp is None:
+		return None
+	return float(timestamp)
+
+
 class RecordingWatchdog(BaseWatchdog):
 	"""
 	Manages video recording of a browser session using CDP screencasting.
@@ -128,6 +136,7 @@ class RecordingWatchdog(BaseWatchdog):
 		"""
 		if self._recorder:
 			self.logger.debug(f'Agent focus changed to {event.target_id}, switching screencast...')
+			self._recorder.reset_timing()
 			await self._start_screencast()
 
 	async def _start_screencast(self) -> None:
@@ -195,7 +204,7 @@ class RecordingWatchdog(BaseWatchdog):
 
 		if not self._recorder:
 			return
-		self._recorder.add_frame(event['data'])
+		self._recorder.add_frame(event['data'], timestamp=_get_screencast_frame_timestamp(event))
 		create_task_with_error_handling(
 			self._ack_screencast_frame(event, session_id),
 			name='ack_screencast_frame',

--- a/tests/ci/test_video_recorder.py
+++ b/tests/ci/test_video_recorder.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from browser_use.browser.profile import ViewportSize
+from browser_use.browser.video_recorder import VideoRecorderService
+
+
+class FakeWriter:
+	def __init__(self) -> None:
+		self.frames: list[str] = []
+
+	def append_data(self, frame: str) -> None:
+		self.frames.append(frame)
+
+
+def create_recorder(framerate: int = 10) -> VideoRecorderService:
+	return VideoRecorderService(
+		output_path=Path('test.mp4'),
+		size=ViewportSize(width=16, height=16),
+		framerate=framerate,
+	)
+
+
+def test_frame_write_plan_repeats_previous_frame_for_slow_screencast_frames():
+	recorder = create_recorder(framerate=10)
+
+	assert recorder._get_frame_write_plan(0.0) == (0, 1)
+
+	# A 500ms gap at 10fps covers 5 frame intervals. The already-written
+	# previous frame covers the first interval, then the current frame is written.
+	assert recorder._get_frame_write_plan(0.5) == (4, 1)
+
+
+def test_frame_write_plan_accumulates_fast_screencast_frames():
+	recorder = create_recorder(framerate=10)
+
+	assert recorder._get_frame_write_plan(0.0) == (0, 1)
+	assert recorder._get_frame_write_plan(0.04) == (0, 0)
+	assert recorder._get_frame_write_plan(0.1) == (0, 1)
+
+
+def test_append_timed_frame_writes_duplicate_frames_to_preserve_elapsed_time():
+	recorder = create_recorder(framerate=10)
+	writer = FakeWriter()
+	recorder._writer = writer  # type: ignore[assignment]
+
+	times = iter([0.0, 0.5])
+	recorder._time_func = lambda: next(times)
+
+	recorder._append_timed_frame('first')
+	recorder._append_timed_frame('second')
+
+	assert writer.frames == ['first', 'first', 'first', 'first', 'first', 'second']
+
+
+def test_append_timed_frame_skips_sub_frame_interval_updates():
+	recorder = create_recorder(framerate=10)
+	writer = FakeWriter()
+	recorder._writer = writer  # type: ignore[assignment]
+
+	times = iter([0.0, 0.04, 0.1])
+	recorder._time_func = lambda: next(times)
+
+	recorder._append_timed_frame('first')
+	recorder._append_timed_frame('too-fast')
+	recorder._append_timed_frame('next-frame')
+
+	assert writer.frames == ['first', 'next-frame']

--- a/tests/ci/test_video_recorder.py
+++ b/tests/ci/test_video_recorder.py
@@ -31,6 +31,13 @@ def test_frame_write_plan_repeats_previous_frame_for_slow_screencast_frames():
 	assert recorder._get_frame_write_plan(0.5) == (4, 1)
 
 
+def test_frame_write_plan_caps_long_idle_gaps():
+	recorder = create_recorder(framerate=10)
+
+	assert recorder._get_frame_write_plan(0.0) == (0, 1)
+	assert recorder._get_frame_write_plan(60.0) == (99, 1)
+
+
 def test_frame_write_plan_accumulates_fast_screencast_frames():
 	recorder = create_recorder(framerate=10)
 
@@ -60,11 +67,28 @@ def test_append_timed_frame_writes_duplicate_frames_to_preserve_elapsed_time():
 	assert writer.frames == ['first', 'first', 'first', 'first', 'first', 'second']
 
 
+def test_stop_and_save_flushes_final_idle_gap(monkeypatch):
+	recorder = create_recorder(framerate=10)
+	writer = FakeWriter()
+	writer.close = lambda: None  # type: ignore[attr-defined]
+	recorder._writer = writer  # type: ignore[assignment]
+	recorder._is_active = True
+
+	times = iter([0.0, 0.5])
+	recorder._time_func = lambda: next(times)
+
+	recorder._append_timed_frame('last')
+	recorder.stop_and_save()
+
+	assert writer.frames == ['last', 'last', 'last', 'last', 'last']
+
+
 def test_append_timed_frame_uses_cdp_timestamps_when_provided():
 	recorder = create_recorder(framerate=10)
 	writer = FakeWriter()
 	recorder._writer = writer  # type: ignore[assignment]
-	recorder._time_func = lambda: (_ for _ in ()).throw(AssertionError('local clock should not be used'))
+	times = iter([0.0, 0.0])
+	recorder._time_func = lambda: next(times)
 
 	recorder._append_timed_frame('first', timestamp=100.0)
 	recorder._append_timed_frame('second', timestamp=100.5)

--- a/tests/ci/test_video_recorder.py
+++ b/tests/ci/test_video_recorder.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from browser_use.browser.profile import ViewportSize
 from browser_use.browser.video_recorder import VideoRecorderService
+from browser_use.browser.watchdogs.recording_watchdog import _get_screencast_frame_timestamp
 
 
 class FakeWriter:
@@ -38,6 +39,13 @@ def test_frame_write_plan_accumulates_fast_screencast_frames():
 	assert recorder._get_frame_write_plan(0.1) == (0, 1)
 
 
+def test_frame_write_plan_resets_when_timestamp_source_changes():
+	recorder = create_recorder(framerate=10)
+
+	assert recorder._get_frame_write_plan(100.0, 'cdp') == (0, 1)
+	assert recorder._get_frame_write_plan(0.0, 'local') == (0, 1)
+
+
 def test_append_timed_frame_writes_duplicate_frames_to_preserve_elapsed_time():
 	recorder = create_recorder(framerate=10)
 	writer = FakeWriter()
@@ -48,6 +56,18 @@ def test_append_timed_frame_writes_duplicate_frames_to_preserve_elapsed_time():
 
 	recorder._append_timed_frame('first')
 	recorder._append_timed_frame('second')
+
+	assert writer.frames == ['first', 'first', 'first', 'first', 'first', 'second']
+
+
+def test_append_timed_frame_uses_cdp_timestamps_when_provided():
+	recorder = create_recorder(framerate=10)
+	writer = FakeWriter()
+	recorder._writer = writer  # type: ignore[assignment]
+	recorder._time_func = lambda: (_ for _ in ()).throw(AssertionError('local clock should not be used'))
+
+	recorder._append_timed_frame('first', timestamp=100.0)
+	recorder._append_timed_frame('second', timestamp=100.5)
 
 	assert writer.frames == ['first', 'first', 'first', 'first', 'first', 'second']
 
@@ -65,3 +85,24 @@ def test_append_timed_frame_skips_sub_frame_interval_updates():
 	recorder._append_timed_frame('next-frame')
 
 	assert writer.frames == ['first', 'next-frame']
+
+
+def test_screencast_frame_timestamp_is_read_from_metadata():
+	assert (
+		_get_screencast_frame_timestamp(
+			{
+				'data': 'frame',
+				'metadata': {
+					'offsetTop': 0.0,
+					'pageScaleFactor': 1.0,
+					'deviceWidth': 16.0,
+					'deviceHeight': 16.0,
+					'scrollOffsetX': 0.0,
+					'scrollOffsetY': 0.0,
+					'timestamp': 123.25,
+				},
+				'sessionId': 1,
+			}
+		)
+		== 123.25
+	)


### PR DESCRIPTION
## Summary

Fixes #4696.

CDP screencast frames can arrive much more slowly than the configured output framerate. The recorder previously appended one encoded frame per screencast frame while writing the MP4 at `record_video_framerate`, so sparse frame streams were compressed into a much shorter video and played too fast.

This change uses CDP `ScreencastFrameEvent.metadata.timestamp` values as the primary timing source, with a monotonic clock fallback for tests or callers that do not provide CDP metadata. The recorder writes duplicate frames for real elapsed gaps, skips sub-frame-interval bursts, caps very long idle fills, resets timing when the screencast source changes, and flushes the final bounded idle gap when recording stops.

## Tests

- `uv run pytest tests/ci/test_video_recorder.py -q`
- `uv run ruff check browser_use/browser/video_recorder.py browser_use/browser/watchdogs/recording_watchdog.py tests/ci/test_video_recorder.py`
- `uv run ruff format --check browser_use/browser/video_recorder.py browser_use/browser/watchdogs/recording_watchdog.py tests/ci/test_video_recorder.py`
- `uv run pyright browser_use/browser/video_recorder.py browser_use/browser/watchdogs/recording_watchdog.py tests/ci/test_video_recorder.py`
- `uv run python -m py_compile browser_use/browser/video_recorder.py browser_use/browser/watchdogs/recording_watchdog.py tests/ci/test_video_recorder.py`
- `uv run pre-commit run --files browser_use/browser/video_recorder.py browser_use/browser/watchdogs/recording_watchdog.py tests/ci/test_video_recorder.py`
- `git diff --check`
