### PR TITLE
fix(mcp): forward cdp-url to server mode

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -187,12 +187,14 @@ def get_parent_process_cmdline() -> str | None:
 class BrowserUseServer:
 	"""MCP Server for browser-use capabilities."""
 
-	def __init__(self, session_timeout_minutes: int = 10):
+	def __init__(self, session_timeout_minutes: int = 10, browser_profile_overrides: dict[str, Any] | None = None):
 		# Ensure all logging goes to stderr (in case new loggers were created)
 		_ensure_all_loggers_use_stderr()
 
 		self.server = Server('browser-use')
 		self.config = load_browser_use_config()
+		if browser_profile_overrides:
+			self.config.setdefault('browser_profile', {}).update(browser_profile_overrides)
 		self.agent: Agent | None = None
 		self.browser_session: BrowserSession | None = None
 		self.tools: Tools | None = None
@@ -601,11 +603,13 @@ class BrowserUseServer:
 		for key, value in kwargs.items():
 			profile_data[key] = value
 
-		# Create browser profile
+		# cdp_url must be passed as a top-level BrowserSession kwarg so CDP
+		# sessions follow the same path as the fast CLI daemon.
+		cdp_url = profile_data.pop('cdp_url', None)
 		profile = BrowserProfile(**profile_data)
 
 		# Create browser session
-		self.browser_session = BrowserSession(browser_profile=profile)
+		self.browser_session = BrowserSession(cdp_url=cdp_url, browser_profile=profile)
 		await self.browser_session.start()
 
 		# Track the session for management
@@ -1254,12 +1258,15 @@ class BrowserUseServer:
 				logger.warning('MCP client disconnected while writing to stdio; shutting down server cleanly.')
 
 
-async def main(session_timeout_minutes: int = 10):
+async def main(session_timeout_minutes: int = 10, browser_profile_overrides: dict[str, Any] | None = None):
 	if not MCP_AVAILABLE:
 		print('MCP SDK is required. Install with: pip install mcp', file=sys.stderr)
 		sys.exit(1)
 
-	server = BrowserUseServer(session_timeout_minutes=session_timeout_minutes)
+	server = BrowserUseServer(
+		session_timeout_minutes=session_timeout_minutes,
+		browser_profile_overrides=browser_profile_overrides,
+	)
 	server._telemetry.capture(
 		MCPServerTelemetryEvent(
 			version=get_browser_use_version(),

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -25,6 +25,29 @@ from pathlib import Path
 # These commands don't need the daemon infrastructure
 # =============================================================================
 
+
+def _get_early_option_value(argv: list[str], option: str) -> str | None:
+	"""Read an option value before the full argparse parser is initialized."""
+	for index, arg in enumerate(argv):
+		if arg == option and index + 1 < len(argv):
+			value = argv[index + 1]
+			if not value.startswith('-'):
+				return value
+		if arg.startswith(f'{option}='):
+			return arg.split('=', 1)[1]
+	return None
+
+
+def _get_early_mcp_browser_profile_overrides(argv: list[str]) -> dict[str, str] | None:
+	"""Extract browser profile overrides used by the early --mcp entrypoint."""
+	overrides: dict[str, str] = {}
+	cdp_url = _get_early_option_value(argv, '--cdp-url')
+	if cdp_url:
+		overrides['cdp_url'] = cdp_url
+
+	return overrides or None
+
+
 # Handle --mcp flag early to prevent logging initialization
 if '--mcp' in sys.argv:
 	import logging
@@ -37,7 +60,7 @@ if '--mcp' in sys.argv:
 
 	from browser_use.mcp.server import main as mcp_main
 
-	asyncio.run(mcp_main())
+	asyncio.run(mcp_main(browser_profile_overrides=_get_early_mcp_browser_profile_overrides(sys.argv[1:])))
 	sys.exit(0)
 
 

--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -28,14 +28,15 @@ from pathlib import Path
 
 def _get_early_option_value(argv: list[str], option: str) -> str | None:
 	"""Read an option value before the full argparse parser is initialized."""
+	value: str | None = None
 	for index, arg in enumerate(argv):
 		if arg == option and index + 1 < len(argv):
-			value = argv[index + 1]
-			if not value.startswith('-'):
-				return value
+			candidate = argv[index + 1]
+			if not candidate.startswith('-'):
+				value = candidate
 		if arg.startswith(f'{option}='):
-			return arg.split('=', 1)[1]
-	return None
+			value = arg.split('=', 1)[1]
+	return value
 
 
 def _get_early_mcp_browser_profile_overrides(argv: list[str]) -> dict[str, str] | None:

--- a/tests/ci/test_cli_install_init.py
+++ b/tests/ci/test_cli_install_init.py
@@ -5,8 +5,10 @@ These commands are handled early in the CLI before argparse, to avoid loading
 heavy dependencies for simple setup tasks.
 """
 
+import json
 import subprocess
 import sys
+import textwrap
 
 
 def test_install_command_help():
@@ -67,6 +69,55 @@ def test_mcp_flag_help():
 	assert result.returncode == 0
 	assert '--mcp' in result.stdout
 	assert 'MCP server' in result.stdout
+
+
+def test_mcp_mode_forwards_cdp_url_to_server(tmp_path):
+	"""Test that --cdp-url is still honored by the early --mcp entrypoint."""
+	output_path = tmp_path / 'mcp_args.json'
+	code = textwrap.dedent(
+		"""
+		import json
+		import runpy
+		import sys
+		import types
+		from pathlib import Path
+
+		output_path = Path(sys.argv[1])
+		fake_server = types.ModuleType('browser_use.mcp.server')
+
+		async def main(session_timeout_minutes=10, browser_profile_overrides=None):
+			output_path.write_text(
+				json.dumps(
+					{
+						'session_timeout_minutes': session_timeout_minutes,
+						'browser_profile_overrides': browser_profile_overrides,
+					}
+				),
+				encoding='utf-8',
+			)
+
+		fake_server.main = main
+		sys.modules['browser_use.mcp.server'] = fake_server
+		sys.argv = ['browser-use', '--cdp-url', 'http://127.0.0.1:9223', '--mcp']
+
+		try:
+			runpy.run_module('browser_use.skill_cli.main', run_name='__main__')
+		except SystemExit as exc:
+			if exc.code not in (0, None):
+				raise
+		"""
+	)
+
+	result = subprocess.run(
+		[sys.executable, '-c', code, str(output_path)],
+		capture_output=True,
+		text=True,
+	)
+
+	assert result.returncode == 0, result.stderr
+	assert json.loads(output_path.read_text(encoding='utf-8'))['browser_profile_overrides'] == {
+		'cdp_url': 'http://127.0.0.1:9223'
+	}
 
 
 def test_template_flag_help():

--- a/tests/ci/test_cli_install_init.py
+++ b/tests/ci/test_cli_install_init.py
@@ -120,6 +120,57 @@ def test_mcp_mode_forwards_cdp_url_to_server(tmp_path):
 	}
 
 
+def test_mcp_mode_uses_last_repeated_cdp_url(tmp_path):
+	"""Test early --mcp parsing matches argparse's last repeated option behavior."""
+	output_path = tmp_path / 'mcp_args.json'
+	code = textwrap.dedent(
+		"""
+		import json
+		import runpy
+		import sys
+		import types
+		from pathlib import Path
+
+		output_path = Path(sys.argv[1])
+		fake_server = types.ModuleType('browser_use.mcp.server')
+
+		async def main(session_timeout_minutes=10, browser_profile_overrides=None):
+			output_path.write_text(
+				json.dumps({'browser_profile_overrides': browser_profile_overrides}),
+				encoding='utf-8',
+			)
+
+		fake_server.main = main
+		sys.modules['browser_use.mcp.server'] = fake_server
+		sys.argv = [
+			'browser-use',
+			'--cdp-url',
+			'http://127.0.0.1:9222',
+			'--cdp-url',
+			'http://127.0.0.1:9223',
+			'--mcp',
+		]
+
+		try:
+			runpy.run_module('browser_use.skill_cli.main', run_name='__main__')
+		except SystemExit as exc:
+			if exc.code not in (0, None):
+				raise
+		"""
+	)
+
+	result = subprocess.run(
+		[sys.executable, '-c', code, str(output_path)],
+		capture_output=True,
+		text=True,
+	)
+
+	assert result.returncode == 0, result.stderr
+	assert json.loads(output_path.read_text(encoding='utf-8'))['browser_profile_overrides'] == {
+		'cdp_url': 'http://127.0.0.1:9223'
+	}
+
+
 def test_template_flag_help():
 	"""Test that the --template flag is documented in help."""
 	result = subprocess.run(

--- a/tests/ci/test_mcp_server.py
+++ b/tests/ci/test_mcp_server.py
@@ -1,0 +1,59 @@
+from browser_use.mcp import server as mcp_server
+
+
+def test_mcp_server_applies_browser_profile_overrides(monkeypatch):
+	"""Browser-use CLI overrides should reach the MCP browser profile."""
+	monkeypatch.setattr(
+		mcp_server,
+		'load_browser_use_config',
+		lambda: {
+			'browser_profile': {
+				'headless': True,
+			},
+			'llm': {},
+			'agent': {},
+		},
+	)
+
+	server = mcp_server.BrowserUseServer(browser_profile_overrides={'cdp_url': 'http://127.0.0.1:9223'})
+
+	assert server.config['browser_profile']['headless'] is True
+	assert server.config['browser_profile']['cdp_url'] == 'http://127.0.0.1:9223'
+
+
+async def test_mcp_browser_session_receives_cdp_url_as_top_level_kwarg(monkeypatch):
+	"""CDP URLs must use BrowserSession's top-level cdp_url path."""
+	captured_kwargs = {}
+
+	class FakeBrowserSession:
+		id = 'fake-session'
+		current_url = None
+
+		def __init__(self, **kwargs):
+			captured_kwargs.update(kwargs)
+			self.id = 'fake-session'
+			self.current_url = None
+
+		async def start(self):
+			return None
+
+	monkeypatch.setattr(mcp_server, 'BrowserSession', FakeBrowserSession)
+	monkeypatch.setattr(
+		mcp_server,
+		'load_browser_use_config',
+		lambda: {
+			'browser_profile': {
+				'cdp_url': 'http://127.0.0.1:9223',
+				'headless': True,
+				'user_data_dir': None,
+			},
+			'llm': {},
+			'agent': {},
+		},
+	)
+
+	server = mcp_server.BrowserUseServer()
+	await server._init_browser_session()
+
+	assert captured_kwargs['cdp_url'] == 'http://127.0.0.1:9223'
+	assert captured_kwargs['browser_profile'].cdp_url is None


### PR DESCRIPTION
Fixes #4846

## Summary
- Forward `browser-use --cdp-url ... --mcp` into MCP server mode before the fast CLI exits through its early `--mcp` path.
- Let `BrowserUseServer` accept browser profile overrides and merge them into its loaded config.
- Pass MCP `cdp_url` into `BrowserSession` as a top-level kwarg, matching the fast CLI daemon path.
- Add regression coverage for the early CLI path and MCP server CDP session construction.

## Root Cause
The fast CLI handles `--mcp` before building the normal argparse command state, so options that appear before `--mcp` were not passed to `browser_use.mcp.server.main()`. In the reported command:

```bash
browser-use --cdp-url http://127.0.0.1:9223 --mcp
```

MCP mode started without the requested CDP endpoint. This can leave MCP connected to the wrong browser/session path even though the direct CLI daemon path honors `--cdp-url`.

## Related Work
#4700 covers the `BROWSER_USE_CDP_URL` environment-variable path. This PR focuses on the `--cdp-url ... --mcp` command used in #4846 and adds regression tests for that early CLI forwarding path.

## Validation
- `uv run pytest -vxs tests/ci/test_cli_install_init.py tests/ci/test_mcp_server.py`
- `uv run ruff check browser_use/skill_cli/main.py browser_use/mcp/server.py tests/ci/test_cli_install_init.py tests/ci/test_mcp_server.py`
- `uv run ruff format --check browser_use/skill_cli/main.py browser_use/mcp/server.py tests/ci/test_cli_install_init.py tests/ci/test_mcp_server.py`
- `uv run pyright browser_use/mcp/server.py tests/ci/test_cli_install_init.py tests/ci/test_mcp_server.py`
- Manual smoke test: started a real headless `BrowserSession`, connected MCP server to its CDP URL through `browser_profile_overrides`, then verified `browser_navigate`, `browser_list_tabs`, `browser_get_state(include_screenshot=True)`, and `browser_screenshot` all succeed against a local HTTP page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP server mode not receiving `--cdp-url` when launched with `browser-use --cdp-url ... --mcp`, ensuring MCP connects to the intended CDP session.

- **Bug Fixes**
  - Parse `--cdp-url` in the early `--mcp` path and forward to `browser_use.mcp.server.main` via `browser_profile_overrides`; supports `--cdp-url=<url>` and prefers the last repeated flag.
  - `BrowserUseServer` merges `browser_profile_overrides` into the loaded config.
  - Pass `cdp_url` to `BrowserSession` as a top-level arg (not inside `BrowserProfile`).
  - Added tests for early CLI forwarding, repeated-flag behavior, and MCP server CDP session construction.

<sup>Written for commit 27975a169f90a9ca5c26016e33c8c0c751453ce4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

