### PR TITLE
fix(browser): launch local browser without asyncio subprocess support

### DIFF
--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
@@ -143,18 +144,10 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				self.logger.debug(
 					f'[LocalBrowserWatchdog] 📂 user_data_dir={profile.user_data_dir}, profile_directory={profile.profile_directory}'
 				)
-				subprocess = await asyncio.create_subprocess_exec(
-					browser_path,
-					*launch_args,
-					stdout=asyncio.subprocess.PIPE,
-					stderr=asyncio.subprocess.PIPE,
-				)
+				browser_process = await self._start_browser_process(browser_path, launch_args)
 				self.logger.debug(
-					f'[LocalBrowserWatchdog] 🎭 Browser running with browser_pid= {subprocess.pid} 🔗 listening on CDP port :{debug_port}'
+					f'[LocalBrowserWatchdog] 🎭 Browser running with browser_pid= {browser_process.pid} 🔗 listening on CDP port :{debug_port}'
 				)
-
-				# Convert to psutil.Process
-				process = psutil.Process(subprocess.pid)
 
 				# Wait for CDP to be ready and get the URL
 				cdp_url = await self._wait_for_cdp_url(debug_port)
@@ -175,7 +168,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				else:
 					self._temp_dirs_to_cleanup = []
 
-				return process, cdp_url
+				return browser_process, cdp_url
 
 			except Exception as e:
 				error_str = str(e).lower()
@@ -357,6 +350,66 @@ class LocalBrowserWatchdog(BaseWatchdog):
 
 		return None
 
+	@staticmethod
+	async def _start_browser_process(browser_path: str | Path, launch_args: list[str]) -> psutil.Process:
+		"""Start a browser process even when the active asyncio loop has no subprocess support."""
+		command = [str(browser_path), *launch_args]
+		try:
+			process = await asyncio.create_subprocess_exec(
+				*command,
+				stdout=asyncio.subprocess.DEVNULL,
+				stderr=asyncio.subprocess.DEVNULL,
+			)
+			return psutil.Process(process.pid)
+		except NotImplementedError:
+			# Some Windows event loops, notably selector loops used by embedding
+			# frameworks, cannot create asyncio subprocess transports.
+			process = await asyncio.to_thread(
+				subprocess.Popen,
+				command,
+				stdout=subprocess.DEVNULL,
+				stderr=subprocess.DEVNULL,
+			)
+			return psutil.Process(process.pid)
+
+	@staticmethod
+	async def _run_subprocess(cmd: list[str], timeout: float) -> tuple[bytes, bytes]:
+		"""Run a short-lived command with output capture across asyncio loop implementations."""
+		try:
+			process = await asyncio.create_subprocess_exec(
+				*cmd,
+				stdout=asyncio.subprocess.PIPE,
+				stderr=asyncio.subprocess.PIPE,
+			)
+		except NotImplementedError:
+			return await asyncio.to_thread(LocalBrowserWatchdog._run_subprocess_blocking, cmd, timeout)
+
+		try:
+			return await asyncio.wait_for(process.communicate(), timeout=timeout)
+		except TimeoutError:
+			process.kill()
+			await process.wait()
+			raise
+		except Exception:
+			if process.returncode is None:
+				process.kill()
+				await process.wait()
+			raise
+
+	@staticmethod
+	def _run_subprocess_blocking(cmd: list[str], timeout: float) -> tuple[bytes, bytes]:
+		try:
+			result = subprocess.run(
+				cmd,
+				capture_output=True,
+				timeout=timeout,
+				check=False,
+			)
+		except subprocess.TimeoutExpired as exc:
+			raise TimeoutError(f'Subprocess timed out after {timeout}s: {cmd}') from exc
+
+		return result.stdout, result.stderr
+
 	async def _install_browser_with_playwright(self) -> str:
 		"""Get browser executable path from playwright in a subprocess to avoid thread issues."""
 		import platform
@@ -366,15 +419,8 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		if platform.system() == 'Linux':
 			cmd.append('--with-deps')
 
-		# Run in subprocess with timeout
-		process = await asyncio.create_subprocess_exec(
-			*cmd,
-			stdout=asyncio.subprocess.PIPE,
-			stderr=asyncio.subprocess.PIPE,
-		)
-
 		try:
-			stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=60.0)
+			stdout, stderr = await self._run_subprocess(cmd, timeout=60.0)
 			self.logger.debug(f'[LocalBrowserWatchdog] 📦 Playwright install output: {stdout}')
 			browser_path = self._find_installed_browser_path()
 			if browser_path:
@@ -382,15 +428,8 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			self.logger.error(f'[LocalBrowserWatchdog] ❌ Playwright local browser installation error: \n{stdout}\n{stderr}')
 			raise RuntimeError('No local browser path found after: uvx playwright install chromium')
 		except TimeoutError:
-			# Kill the subprocess if it times out
-			process.kill()
-			await process.wait()
 			raise RuntimeError('Timeout getting browser path from playwright')
 		except Exception as e:
-			# Make sure subprocess is terminated
-			if process.returncode is None:
-				process.kill()
-				await process.wait()
 			raise RuntimeError(f'Error getting browser path: {e}')
 
 	@staticmethod

--- a/tests/ci/browser/test_local_browser_watchdog.py
+++ b/tests/ci/browser/test_local_browser_watchdog.py
@@ -1,0 +1,65 @@
+import asyncio
+import subprocess
+
+import psutil
+
+from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+
+async def _raise_subprocess_not_implemented(*args, **kwargs):
+	raise NotImplementedError
+
+
+async def test_start_browser_process_falls_back_to_popen(monkeypatch):
+	calls = {}
+
+	class FakePopen:
+		pid = 12345
+
+	class FakePsutilProcess:
+		def __init__(self, pid):
+			self.pid = pid
+
+	def fake_popen(command, **kwargs):
+		calls['command'] = command
+		calls['stdout'] = kwargs['stdout']
+		calls['stderr'] = kwargs['stderr']
+		return FakePopen()
+
+	monkeypatch.setattr(asyncio, 'create_subprocess_exec', _raise_subprocess_not_implemented)
+	monkeypatch.setattr(subprocess, 'Popen', fake_popen)
+	monkeypatch.setattr(psutil, 'Process', FakePsutilProcess)
+
+	process = await LocalBrowserWatchdog._start_browser_process('chrome', ['--remote-debugging-port=9222'])
+
+	assert process.pid == 12345
+	assert calls == {
+		'command': ['chrome', '--remote-debugging-port=9222'],
+		'stdout': subprocess.DEVNULL,
+		'stderr': subprocess.DEVNULL,
+	}
+
+
+async def test_run_subprocess_falls_back_to_blocking_run(monkeypatch):
+	calls = {}
+
+	def fake_run(command, **kwargs):
+		calls['command'] = command
+		calls['capture_output'] = kwargs['capture_output']
+		calls['timeout'] = kwargs['timeout']
+		calls['check'] = kwargs['check']
+		return subprocess.CompletedProcess(command, 0, stdout=b'installed', stderr=b'')
+
+	monkeypatch.setattr(asyncio, 'create_subprocess_exec', _raise_subprocess_not_implemented)
+	monkeypatch.setattr(subprocess, 'run', fake_run)
+
+	stdout, stderr = await LocalBrowserWatchdog._run_subprocess(['uvx', 'playwright', 'install', 'chromium'], timeout=60.0)
+
+	assert stdout == b'installed'
+	assert stderr == b''
+	assert calls == {
+		'command': ['uvx', 'playwright', 'install', 'chromium'],
+		'capture_output': True,
+		'timeout': 60.0,
+		'check': False,
+	}


### PR DESCRIPTION
## Summary

- fall back to `subprocess.Popen` when the active event loop cannot create asyncio subprocess transports
- apply the same fallback to the short-lived Playwright install subprocess path
- avoid piping long-running browser stdout/stderr that is never consumed
- add focused unit coverage for both fallback paths

Addresses the Windows `asyncio.create_subprocess_exec(...)` `NotImplementedError` traceback noted in #4709.

## Context

Some Windows embedding/server configurations use an event loop that does not support subprocess transports. In that environment, launching the local browser fails before Browser Use can connect to CDP.

The fallback runs the blocking subprocess call in `asyncio.to_thread()`, preserving async behavior for callers while avoiding the event-loop subprocess limitation.

## Validation

- `uv run pytest tests/ci/browser/test_local_browser_watchdog.py` -> 2 passed
- `uv run ruff format browser_use/browser/watchdogs/local_browser_watchdog.py tests/ci/browser/test_local_browser_watchdog.py` -> passed
- `uv run ruff check browser_use/browser/watchdogs/local_browser_watchdog.py tests/ci/browser/test_local_browser_watchdog.py` -> passed
- `uv run pre-commit run --files browser_use/browser/watchdogs/local_browser_watchdog.py tests/ci/browser/test_local_browser_watchdog.py` -> passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make local browser launch reliable on Windows loops without asyncio subprocess support by falling back to a threaded subprocess.Popen. Apply the same fallback to the `playwright` install step and discard unused browser output.

- **Bug Fixes**
  - Add `_start_browser_process`: try `asyncio.create_subprocess_exec`, fall back to `asyncio.to_thread(subprocess.Popen)` on `NotImplementedError`, with stdout/stderr to `DEVNULL`.
  - Add `_run_subprocess` for `playwright` install with output capture, timeout, and a blocking fallback via `subprocess.run`.
  - Add unit tests covering both fallbacks.

<sup>Written for commit 3b9001d5dca8b2547fdcb13dd764433921138076. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4848?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

