### PR TITLE
fix(mcp): respect state screenshot flag

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -871,7 +871,7 @@ class BrowserUseServer:
 		if not self.browser_session:
 			return 'Error: No browser session active', None
 
-		state = await self.browser_session.get_browser_state_summary()
+		state = await self.browser_session.get_browser_state_summary(include_screenshot=include_screenshot)
 
 		result: dict[str, Any] = {
 			'url': state.url,

--- a/tests/ci/test_mcp_server_state.py
+++ b/tests/ci/test_mcp_server_state.py
@@ -1,0 +1,81 @@
+import json
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from browser_use.mcp.server import BrowserUseServer
+
+
+class _FakeElement:
+	tag_name = 'button'
+	attributes = {'placeholder': 'Search', 'href': '/next'}
+
+	def get_all_children_text(self, max_depth: int) -> str:
+		return f'Click me depth={max_depth}'
+
+
+class _FakeDOMState:
+	selector_map = {7: _FakeElement()}
+
+
+class _FakePageInfo:
+	viewport_width = 1280
+	viewport_height = 720
+	page_width = 1280
+	page_height = 2000
+	scroll_x = 0
+	scroll_y = 120
+
+
+class _FakeState:
+	url = 'https://example.com'
+	title = 'Example'
+	tabs = [SimpleNamespace(url='https://example.com', title='Example')]
+	dom_state = _FakeDOMState()
+	page_info = _FakePageInfo()
+
+	def __init__(self, screenshot: str | None):
+		self.screenshot = screenshot
+
+
+def _server_with_session(session: SimpleNamespace) -> BrowserUseServer:
+	server = object.__new__(BrowserUseServer)
+	cast(Any, server).browser_session = session
+	return server
+
+
+@pytest.mark.asyncio
+async def test_get_browser_state_does_not_capture_screenshot_by_default():
+	session = SimpleNamespace(get_browser_state_summary=AsyncMock(return_value=_FakeState('ignored-image-data')))
+	server = _server_with_session(session)
+
+	state_json, screenshot = await server._get_browser_state()
+	payload = json.loads(state_json)
+
+	session.get_browser_state_summary.assert_awaited_once_with(include_screenshot=False)
+	assert screenshot is None
+	assert 'screenshot_dimensions' not in payload
+	assert payload['interactive_elements'] == [
+		{
+			'index': 7,
+			'tag': 'button',
+			'text': 'Click me depth=2',
+			'placeholder': 'Search',
+			'href': '/next',
+		}
+	]
+
+
+@pytest.mark.asyncio
+async def test_get_browser_state_captures_screenshot_when_requested():
+	session = SimpleNamespace(get_browser_state_summary=AsyncMock(return_value=_FakeState('image-data')))
+	server = _server_with_session(session)
+
+	state_json, screenshot = await server._get_browser_state(include_screenshot=True)
+	payload = json.loads(state_json)
+
+	session.get_browser_state_summary.assert_awaited_once_with(include_screenshot=True)
+	assert screenshot == 'image-data'
+	assert payload['screenshot_dimensions'] == {'width': 1280, 'height': 720}


### PR DESCRIPTION
## Summary
- Respect the MCP `browser_get_state` `include_screenshot` flag when fetching browser state.
- Avoid screenshot capture by default, matching the tool schema and caller behavior.
- Add focused tests for default and requested screenshot paths.

## Test plan
- `uv run pytest tests/ci/test_mcp_server_state.py -q`
- `uv run ruff check browser_use/mcp/server.py tests/ci/test_mcp_server_state.py`
- `uv run ruff format --check browser_use/mcp/server.py tests/ci/test_mcp_server_state.py`
- `uv run pyright browser_use/mcp/server.py tests/ci/test_mcp_server_state.py`
- `uv run pre-commit run --files browser_use/mcp/server.py tests/ci/test_mcp_server_state.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect the MCP `browser_get_state` `include_screenshot` flag so screenshots are captured only when requested. Default is no screenshot, matching the tool schema and reducing overhead.

- **Bug Fixes**
  - Passed `include_screenshot` to `browser_session.get_browser_state_summary`.
  - If `False`: skip screenshot and omit `screenshot_dimensions`. If `True`: return screenshot and include dimensions.
  - Added tests for both paths, verifying call args and payload (interactive elements and dimensions).

<sup>Written for commit 46590c90059df3ada72ce6056b248e0f4464d135. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4849?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

