### PR TITLE
fix(security): block special-scheme domain bypasses

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -178,9 +178,26 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
-		if parsed.scheme in ['data', 'blob']:
-			return True
+		scheme = parsed.scheme.lower()
+		allowed_domains = self.browser_session.browser_profile.allowed_domains
+		prohibited_domains = self.browser_session.browser_profile.prohibited_domains
+		has_domain_restrictions = bool(allowed_domains or prohibited_domains)
+
+		# data: and blob: URLs do not expose a normal hostname. Keep them available
+		# for unrestricted sessions, but do not let them bypass configured URL policy.
+		if scheme in ['data', 'blob']:
+			if not has_domain_restrictions:
+				return True
+			if scheme == 'data':
+				return False
+
+			blob_origin_url = url.split(':', 1)[1]
+			if not blob_origin_url or blob_origin_url.lower().startswith(('blob:', 'data:')):
+				return False
+			blob_origin = urlparse(blob_origin_url)
+			if not blob_origin.scheme or not blob_origin.hostname:
+				return False
+			return self._is_url_allowed(blob_origin_url)
 
 		# Get the actual host (domain)
 		host = parsed.hostname
@@ -192,17 +209,12 @@ class SecurityWatchdog(BaseWatchdog):
 			if self._is_ip_address(host):
 				return False
 
-		# If no allowed_domains specified, allow all URLs
-		if (
-			not self.browser_session.browser_profile.allowed_domains
-			and not self.browser_session.browser_profile.prohibited_domains
-		):
+		# If no URL policy is specified, allow all URLs
+		if not has_domain_restrictions:
 			return True
 
 		# Check allowed domains (fast path for sets, slow path for lists with patterns)
-		if self.browser_session.browser_profile.allowed_domains:
-			allowed_domains = self.browser_session.browser_profile.allowed_domains
-
+		if allowed_domains:
 			if isinstance(allowed_domains, set):
 				# Fast path: O(1) exact hostname match - check both www and non-www variants
 				host_variant, host_alt = self._get_domain_variants(host)
@@ -210,14 +222,12 @@ class SecurityWatchdog(BaseWatchdog):
 			else:
 				# Slow path: O(n) pattern matching for lists
 				for pattern in allowed_domains:
-					if self._is_url_match(url, host, parsed.scheme, pattern):
+					if self._is_url_match(url, host, scheme, pattern):
 						return True
 				return False
 
 		# Check prohibited domains (fast path for sets, slow path for lists with patterns)
-		if self.browser_session.browser_profile.prohibited_domains:
-			prohibited_domains = self.browser_session.browser_profile.prohibited_domains
-
+		if prohibited_domains:
 			if isinstance(prohibited_domains, set):
 				# Fast path: O(1) exact hostname match - check both www and non-www variants
 				host_variant, host_alt = self._get_domain_variants(host)
@@ -225,7 +235,7 @@ class SecurityWatchdog(BaseWatchdog):
 			else:
 				# Slow path: O(n) pattern matching for lists
 				for pattern in prohibited_domains:
-					if self._is_url_match(url, host, parsed.scheme, pattern):
+					if self._is_url_match(url, host, scheme, pattern):
 						return False
 				return True
 

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -26,6 +26,40 @@ class TestUrlAllowlistSecurity:
 		# Make sure legitimate auth credentials still work
 		assert watchdog._is_url_allowed('https://user:password@example.com') is True
 
+	def test_special_scheme_urls_do_not_bypass_allowlist(self):
+		"""Test that data/blob URLs cannot bypass configured allowed_domains."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('data:text/html,<script>location="https://evil.com"</script>') is False
+		assert watchdog._is_url_allowed('data:image/png;base64,AAAA') is False
+
+		assert watchdog._is_url_allowed('blob:https://example.com/1234-5678') is True
+		assert watchdog._is_url_allowed('blob:https://www.example.com/1234-5678') is True
+		assert watchdog._is_url_allowed('blob:https://evil.com/1234-5678') is False
+		assert watchdog._is_url_allowed('blob:about:blank') is False
+		assert watchdog._is_url_allowed('blob:null/1234-5678') is False
+
+	def test_special_scheme_urls_allowed_without_domain_restrictions(self):
+		"""Test that data/blob URLs remain allowed when no URL policy is configured."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('data:text/html,<h1>local</h1>') is True
+		assert watchdog._is_url_allowed('blob:https://example.com/1234-5678') is True
+
 	def test_glob_pattern_matching(self):
 		"""Test that glob patterns in allowed_domains work correctly."""
 		from bubus import EventBus
@@ -315,6 +349,23 @@ class TestUrlProhibitlistSecurity:
 
 		# Allow unrelated domains
 		assert watchdog._is_url_allowed('https://notexample.com') is True
+
+	def test_special_scheme_urls_respect_prohibited_domains(self):
+		"""Test that data/blob URLs cannot bypass configured prohibited_domains."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(prohibited_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('data:text/html,<h1>local</h1>') is False
+		assert watchdog._is_url_allowed('blob:https://example.com/1234-5678') is False
+		assert watchdog._is_url_allowed('blob:https://other.com/1234-5678') is True
+		assert watchdog._is_url_allowed('blob:about:blank') is False
+		assert watchdog._is_url_allowed('blob:null/1234-5678') is False
 
 	def test_glob_pattern_prohibited(self):
 		"""Wildcard patterns block subdomains and main domain for http/https only."""


### PR DESCRIPTION
## Summary
- Block data: URLs when allowed_domains or prohibited_domains are configured so they cannot bypass Browser Use URL policy.
- Treat blob: URLs as inheriting their embedded origin under URL policy, allowing only origins that pass the existing domain checks.
- Add focused regression coverage for allowlist, prohibitlist, unrestricted sessions, and opaque/internal blob origins.

Fixes #4763.

## Validation
- uv run pytest tests/ci/security/test_domain_filtering.py -q
- uv run pytest tests/ci/security -q
- uv run ruff format --check browser_use/browser/watchdogs/security_watchdog.py tests/ci/security/test_domain_filtering.py
- uv run ruff check browser_use/browser/watchdogs/security_watchdog.py tests/ci/security/test_domain_filtering.py
- uv run pyright browser_use/browser/watchdogs/security_watchdog.py tests/ci/security/test_domain_filtering.py
- uv run pre-commit run --files browser_use/browser/watchdogs/security_watchdog.py tests/ci/security/test_domain_filtering.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks special-scheme URL bypasses by enforcing domain rules for `data:` and making `blob:` inherit and validate its embedded origin. Fixes #4763.

- **Bug Fixes**
  - Deny `data:` URLs when `allowed_domains` or `prohibited_domains` is set; still allowed with no policy.
  - Allow `blob:` only if its embedded origin passes existing checks; reject opaque/internal and nested origins (e.g., `blob:about:blank`, `blob:null`, `blob:data:`).
  - Unrestricted sessions unchanged; http/https logic unchanged.
  - Added regression tests for allowlist, prohibitlist, unrestricted sessions, and special/opaque `blob:` cases.

<sup>Written for commit b9edb4bc2a1b0096d88abc58a0368d132b5e7204. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4850?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

