### PR TITLE
Add emem geospatial custom tool example

### DIFF
--- a/examples/custom-functions/emem_geospatial_tool.py
+++ b/examples/custom-functions/emem_geospatial_tool.py
@@ -35,43 +35,43 @@ EMEM_BASE_URL = 'https://emem.dev'
 
 
 class EmemQuery(BaseModel):
-    lat: float
-    lon: float
-    query: str
+	lat: float
+	lon: float
+	query: str
 
 
 @tools.action(
-    'Get geospatial facts from emem for a given location. Use this when you need real-world evidence about a place (elevation, flood risk, land cover, etc).',
-    param_model=EmemQuery,
+	'Get geospatial facts from emem for a given location. Use this when you need real-world evidence about a place (elevation, flood risk, land cover, etc).',
+	param_model=EmemQuery,
 )
 def get_geospatial_facts(params: EmemQuery):
-    """Call emem to get signed geospatial facts for a lat/lon."""
-    response = httpx.post(
-        f'{EMEM_BASE_URL}/ask',
-        json={
-            'lat': params.lat,
-            'lon': params.lon,
-            'query': params.query,
-        },
-        timeout=30,
-    )
-    response.raise_for_status()
-    return response.json()
+	"""Call emem to get signed geospatial facts for a lat/lon."""
+	response = httpx.post(
+		f'{EMEM_BASE_URL}/ask',
+		json={
+			'lat': params.lat,
+			'lon': params.lon,
+			'query': params.query,
+		},
+		timeout=30,
+	)
+	response.raise_for_status()
+	return response.json()
 
 
 async def main():
-    task = (
-        'Research Helsinki Airport, Finland. '
-        'Find its coordinates from the web, then use the emem geospatial tool '
-        'to get signed facts about whether the location is low-lying or flood-prone. '
-        'Summarize what you find.'
-    )
+	task = (
+		'Research Helsinki Airport, Finland. '
+		'Find its coordinates from the web, then use the emem geospatial tool '
+		'to get signed facts about whether the location is low-lying or flood-prone. '
+		'Summarize what you find.'
+	)
 
-    model = ChatOpenAI(model='gpt-4.1-mini')
-    agent = Agent(task=task, llm=model, tools=tools)
+	model = ChatOpenAI(model='gpt-4.1-mini')
+	agent = Agent(task=task, llm=model, tools=tools)
 
-    await agent.run()
+	await agent.run()
 
 
 if __name__ == '__main__':
-    asyncio.run(main())
+	asyncio.run(main())

--- a/examples/custom-functions/emem_geospatial_tool.py
+++ b/examples/custom-functions/emem_geospatial_tool.py
@@ -31,7 +31,7 @@ from browser_use.tools.service import Tools
 
 tools = Tools()
 
-EMEM_BASE_URL = "https://emem.dev"
+EMEM_BASE_URL = 'https://emem.dev'
 
 
 class EmemQuery(BaseModel):
@@ -41,17 +41,17 @@ class EmemQuery(BaseModel):
 
 
 @tools.action(
-    "Get geospatial facts from emem for a given location. Use this when you need real-world evidence about a place (elevation, flood risk, land cover, etc).",
+    'Get geospatial facts from emem for a given location. Use this when you need real-world evidence about a place (elevation, flood risk, land cover, etc).',
     param_model=EmemQuery,
 )
 def get_geospatial_facts(params: EmemQuery):
     """Call emem to get signed geospatial facts for a lat/lon."""
     response = httpx.post(
-        f"{EMEM_BASE_URL}/ask",
+        f'{EMEM_BASE_URL}/ask',
         json={
-            "lat": params.lat,
-            "lon": params.lon,
-            "query": params.query,
+            'lat': params.lat,
+            'lon': params.lon,
+            'query': params.query,
         },
         timeout=30,
     )
@@ -61,17 +61,17 @@ def get_geospatial_facts(params: EmemQuery):
 
 async def main():
     task = (
-        "Research Helsinki Airport, Finland. "
-        "Find its coordinates from the web, then use the emem geospatial tool "
-        "to get signed facts about whether the location is low-lying or flood-prone. "
-        "Summarize what you find."
+        'Research Helsinki Airport, Finland. '
+        'Find its coordinates from the web, then use the emem geospatial tool '
+        'to get signed facts about whether the location is low-lying or flood-prone. '
+        'Summarize what you find.'
     )
 
-    model = ChatOpenAI(model="gpt-4.1-mini")
+    model = ChatOpenAI(model='gpt-4.1-mini')
     agent = Agent(task=task, llm=model, tools=tools)
 
     await agent.run()
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     asyncio.run(main())

--- a/examples/custom-functions/emem_geospatial_tool.py
+++ b/examples/custom-functions/emem_geospatial_tool.py
@@ -1,0 +1,77 @@
+"""
+Example: browser-use agent with emem geospatial custom tool.
+
+The agent browses the web normally, but when a task needs factual geospatial
+evidence about a real-world location, it calls emem instead of guessing from
+web pages.
+
+emem is a public HTTP/MCP server for signed geospatial facts.
+- https://emem.dev
+- https://github.com/Vortx-AI/emem
+- MCP endpoint: https://emem.dev/mcp
+"""
+
+import asyncio
+import os
+import sys
+
+import httpx
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from pydantic import BaseModel
+
+from browser_use import ChatOpenAI
+from browser_use.agent.service import Agent
+from browser_use.tools.service import Tools
+
+tools = Tools()
+
+EMEM_BASE_URL = "https://emem.dev"
+
+
+class EmemQuery(BaseModel):
+    lat: float
+    lon: float
+    query: str
+
+
+@tools.action(
+    "Get geospatial facts from emem for a given location. Use this when you need real-world evidence about a place (elevation, flood risk, land cover, etc).",
+    param_model=EmemQuery,
+)
+def get_geospatial_facts(params: EmemQuery):
+    """Call emem to get signed geospatial facts for a lat/lon."""
+    response = httpx.post(
+        f"{EMEM_BASE_URL}/ask",
+        json={
+            "lat": params.lat,
+            "lon": params.lon,
+            "query": params.query,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def main():
+    task = (
+        "Research Helsinki Airport, Finland. "
+        "Find its coordinates from the web, then use the emem geospatial tool "
+        "to get signed facts about whether the location is low-lying or flood-prone. "
+        "Summarize what you find."
+    )
+
+    model = ChatOpenAI(model="gpt-4.1-mini")
+    agent = Agent(task=task, llm=model, tools=tools)
+
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Adds an example showing how to use browser-use with emem, a public MCP/HTTP server for signed geospatial facts.

The example gives a browser-use agent a custom tool that calls emem for place-based evidence, e.g. when a task asks whether a location is low-lying or flood-prone.

The agent browses the web normally for general info, but when it needs real-world geospatial evidence it calls emem instead of relying only on web pages.

Links:
- emem: https://emem.dev
- GitHub: https://github.com/Vortx-AI/emem
- MCP endpoint: https://emem.dev/mcp

This keeps browser-use focused on web automation while showing how custom tools can add external evidence sources.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an example that gives a `browser_use` agent a custom geospatial tool powered by emem to fetch signed facts for real locations. The agent browses normally, then calls emem for precise evidence (elevation, flood risk, etc.).

- **New Features**
  - New example: `examples/custom-functions/emem_geospatial_tool.py` with a `pydantic` model (`EmemQuery`) and a `tools.action` that POSTs to `https://emem.dev/ask` via `httpx` and returns JSON.
  - Demo task: research Helsinki Airport, find its coordinates on the web, then use the tool for signed geospatial facts and summarize.
  - References: https://emem.dev, https://github.com/Vortx-AI/emem, MCP endpoint https://emem.dev/mcp

- **Refactors**
  - Conformed indentation and quoting to repo style (tabs, single quotes) and applied Ruff formatting; no functional changes.

<sup>Written for commit 18ee8f8b9f334482d75960eee25820f028eab127. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4852?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

