### PR TITLE
fix: allow future Browser Use model names

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -58,8 +58,7 @@ class ChatBrowserUse(BaseChatModel):
 
 		Args:
 			model: Model name to use. Options:
-				- 'bu-latest' or 'bu-1-0': Default model
-				- 'bu-2-0': Latest premium model
+				- Any hosted 'bu-*' model, e.g. 'bu-latest', 'bu-1-0', or 'bu-2-0'
 				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
 			api_key: API key for browser-use cloud. Defaults to BROWSER_USE_API_KEY env var.
 			base_url: Base URL for the API. Defaults to BROWSER_USE_LLM_URL env var or production URL.
@@ -69,16 +68,11 @@ class ChatBrowserUse(BaseChatModel):
 			retry_max_delay: Maximum delay in seconds between retries (default: 60.0).
 		"""
 		# Validate model name - allow bu-* and browser-use/* patterns
-		valid_models = ['bu-latest', 'bu-1-0', 'bu-2-0']
-		is_valid = model in valid_models or model.startswith('browser-use/')
+		is_valid = model.startswith('bu-') or model.startswith('browser-use/')
 		if not is_valid:
-			raise ValueError(f"Invalid model: '{model}'. Must be one of {valid_models} or start with 'browser-use/'")
+			raise ValueError(f"Invalid model: '{model}'. Must start with 'bu-' or 'browser-use/'")
 
-		# Normalize bu-latest to bu-1-0 for default models
-		if model == 'bu-latest':
-			self.model = 'bu-1-0'
-		else:
-			self.model = model
+		self.model = model
 
 		self.fast = False
 		self.api_key = api_key or os.getenv('BROWSER_USE_API_KEY')

--- a/tests/ci/test_llm_retries.py
+++ b/tests/ci/test_llm_retries.py
@@ -17,6 +17,26 @@ class TestChatBrowserUseRetries:
 		"""Set up environment for ChatBrowserUse."""
 		monkeypatch.setenv('BROWSER_USE_API_KEY', 'test-api-key')
 
+	@pytest.mark.parametrize(
+		'model_name',
+		[
+			'bu-latest',
+			'bu-1-0',
+			'bu-2-0',
+			'bu-3-0',
+			'bu-ultra',
+			'bu-30b-a3b-preview',
+			'browser-use/bu-30b-a3b-preview',
+		],
+	)
+	def test_accepts_and_preserves_browser_use_model_names(self, mock_env, model_name):
+		"""ChatBrowserUse should allow current and future Browser Use model names."""
+		from browser_use.llm.browser_use.chat import ChatBrowserUse
+
+		client = ChatBrowserUse(model=model_name)
+
+		assert client.model == model_name
+
 	@pytest.mark.asyncio
 	async def test_retries_on_503_with_exponential_backoff(self, mock_env):
 		"""Test that 503 errors trigger retries with exponential backoff."""


### PR DESCRIPTION
## Summary
- allow ChatBrowserUse to accept any hosted `bu-*` model name instead of a hardcoded list
- preserve the caller-provided model string, including `bu-latest`, instead of normalizing it client-side
- add a regression test for current, future, and `browser-use/*` model names

## Tests
- `uv run pytest -q tests/ci/test_llm_retries.py`
- `uv run ruff check browser_use/llm/browser_use/chat.py tests/ci/test_llm_retries.py`
- `uv run pre-commit run --all-files`

Relates to #4729 and the previous stale PR #3851.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make ChatBrowserUse forward-compatible by accepting any hosted 'bu-*' model and preserving the exact model name you pass (including 'bu-latest'), instead of using a hardcoded list or normalizing it. Adds a regression test covering current, future, and 'browser-use/*' model names.

<sup>Written for commit 56f78c32c7ea9244001c228b29d08db9b7b2ca40. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4853?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

