### PR TITLE
fix(cli): use BROWSER_USE_API_KEY for cloud commands

### DIFF
--- a/browser_use/skill_cli/browser.py
+++ b/browser_use/skill_cli/browser.py
@@ -122,15 +122,21 @@ class CLIBrowserSession(BrowserSession):
 		if cloud_base:
 			self._cloud_browser_client.api_base_url = cloud_base.rstrip('/')
 
-		# Ensure CLI has an API key from config.json before proceeding.
-		from browser_use.skill_cli.config import get_config_value
+		# Ensure CLI has an API key before proceeding. The cloud client reads
+		# BROWSER_USE_API_KEY directly, so keep the daemon env in sync with the
+		# CLI's config/env lookup order.
+		from browser_use.skill_cli.commands.cloud import _get_api_key_or_none
 
-		if not get_config_value('api_key'):
+		api_key = _get_api_key_or_none()
+
+		if not api_key:
 			from browser_use.browser.cloud.views import CloudBrowserAuthError
 
 			raise CloudBrowserAuthError(
-				'No API key configured. Run `browser-use cloud login <key>` or `browser-use cloud signup`.'
+				'No API key configured. Run `browser-use cloud login <key>`, '
+				'`browser-use cloud signup`, or set BROWSER_USE_API_KEY.'
 			)
+		os.environ['BROWSER_USE_API_KEY'] = api_key
 
 		cloud_params = self.browser_profile.cloud_browser_params or CreateBrowserRequest()
 		# Set recording from CLI config (defaults to True)
@@ -146,7 +152,7 @@ class CLIBrowserSession(BrowserSession):
 				logger.info('Cloud profile invalid, creating new one and retrying')
 				from browser_use.skill_cli.commands.cloud import _create_cloud_profile_inner
 
-				api_key = get_config_value('api_key')
+				api_key = _get_api_key_or_none()
 				if not api_key:
 					raise
 				new_profile_id = _create_cloud_profile_inner(str(api_key))

--- a/browser_use/skill_cli/commands/cloud.py
+++ b/browser_use/skill_cli/commands/cloud.py
@@ -72,11 +72,14 @@ def _write_config(data: dict) -> None:
 
 
 def _get_api_key_or_none() -> str | None:
-	"""Return API key from CLI config file, or None if not found."""
+	"""Return API key from CLI config file or BROWSER_USE_API_KEY."""
 	from browser_use.skill_cli.config import get_config_value
 
 	val = get_config_value('api_key')
-	return str(val) if val is not None else None
+	if val is not None:
+		return str(val)
+
+	return os.environ.get('BROWSER_USE_API_KEY') or None
 
 
 def _get_api_key() -> str:
@@ -86,17 +89,14 @@ def _get_api_key() -> str:
 		return key
 
 	print('Error: No API key found.', file=sys.stderr)
-	if os.environ.get('BROWSER_USE_API_KEY'):
-		print('  Note: BROWSER_USE_API_KEY env var is set but not used by the CLI.', file=sys.stderr)
-		print('  Run: browser-use config set api_key "$BROWSER_USE_API_KEY"', file=sys.stderr)
-	else:
-		print(
-			'Already have an account? Get a key at: https://cloud.browser-use.com/settings?tab=api-keys&new=1&utm_source=oss&utm_medium=cli',
-			file=sys.stderr,
-		)
-		print('  Then run: browser-use cloud login <key>', file=sys.stderr)
-		print('No account? Run: browser-use cloud signup', file=sys.stderr)
-		print('  This creates an agent account you can claim later with: browser-use cloud signup --claim', file=sys.stderr)
+	print(
+		'Already have an account? Get a key at: https://cloud.browser-use.com/settings?tab=api-keys&new=1&utm_source=oss&utm_medium=cli',
+		file=sys.stderr,
+	)
+	print('  Then run: browser-use cloud login <key>', file=sys.stderr)
+	print('  Or set BROWSER_USE_API_KEY in your environment.', file=sys.stderr)
+	print('No account? Run: browser-use cloud signup', file=sys.stderr)
+	print('  This creates an agent account you can claim later with: browser-use cloud signup --claim', file=sys.stderr)
 	sys.exit(1)
 
 

--- a/tests/ci/test_cli_cloud.py
+++ b/tests/ci/test_cli_cloud.py
@@ -17,7 +17,7 @@ def run_cli(*args: str, env_override: dict | None = None, api_key: str | None = 
 	"""Run the CLI as a subprocess, returning the result.
 
 	If api_key is provided, writes it to a temp config.json via BROWSER_USE_HOME
-	(the CLI reads API keys from config.json only, not env vars).
+	so tests do not rely on the developer's environment.
 	"""
 	import os
 	import tempfile
@@ -170,6 +170,26 @@ def test_cloud_rest_sends_auth_header(httpserver: HTTPServer):
 			'BROWSER_USE_CLOUD_BASE_URL_V2': httpserver.url_for('/api/v2'),
 		},
 		api_key='sk-secret-key',
+	)
+	assert result.returncode == 0
+
+
+def test_cloud_rest_uses_browser_use_api_key_env(httpserver: HTTPServer, tmp_path: Path):
+	def handler(request: Request) -> Response:
+		assert request.headers.get('X-Browser-Use-API-Key') == 'sk-env-key'
+		return Response(json.dumps({'ok': True}), content_type='application/json')
+
+	httpserver.expect_request('/api/v2/test', method='GET').respond_with_handler(handler)
+
+	result = run_cli(
+		'v2',
+		'GET',
+		'/test',
+		env_override={
+			'BROWSER_USE_HOME': str(tmp_path),
+			'BROWSER_USE_API_KEY': 'sk-env-key',
+			'BROWSER_USE_CLOUD_BASE_URL_V2': httpserver.url_for('/api/v2'),
+		},
 	)
 	assert result.returncode == 0
 

--- a/tests/ci/test_cli_cloud_connect.py
+++ b/tests/ci/test_cli_cloud_connect.py
@@ -2,6 +2,10 @@
 
 import subprocess
 import sys
+from unittest.mock import AsyncMock
+
+from browser_use.browser.cloud.views import CloudBrowserResponse
+from browser_use.skill_cli.sessions import create_browser_session
 
 
 def run_cli(*args: str, env_override: dict | None = None) -> subprocess.CompletedProcess:
@@ -46,3 +50,67 @@ def test_cloud_connect_help_shows_in_epilog():
 	"""Main --help epilog should mention cloud connect."""
 	result = run_cli('--help')
 	assert 'cloud connect' in result.stdout.lower()
+
+
+def _cloud_browser_response() -> CloudBrowserResponse:
+	return CloudBrowserResponse(
+		id='browser-test',
+		status='active',
+		liveUrl='https://live.browser-use.com/session',
+		cdpUrl='wss://browser-use.test/cdp',
+		timeoutAt='2026-01-01T00:15:00Z',
+		startedAt='2026-01-01T00:00:00Z',
+		finishedAt=None,
+	)
+
+
+async def test_cloud_connect_browser_uses_env_api_key_without_saved_login(tmp_path, monkeypatch):
+	"""Cloud connect daemon should accept BROWSER_USE_API_KEY without saved login config."""
+	monkeypatch.setenv('BROWSER_USE_HOME', str(tmp_path))
+	monkeypatch.setenv('BROWSER_USE_API_KEY', 'sk-env-key')
+
+	browser_session = await create_browser_session(
+		headed=False,
+		profile=None,
+		use_cloud=True,
+		cloud_profile_id='profile-existing',
+	)
+	browser_session._cloud_browser_client.create_browser = AsyncMock(return_value=_cloud_browser_response())
+
+	await browser_session._provision_cloud_browser()
+
+	browser_session._cloud_browser_client.create_browser.assert_awaited_once()
+	assert browser_session.browser_profile.cdp_url == 'wss://browser-use.test/cdp'
+	assert browser_session.browser_profile.is_local is False
+
+
+async def test_cloud_connect_recreates_invalid_profile_with_env_api_key(tmp_path, monkeypatch):
+	"""Cloud connect profile recovery should use BROWSER_USE_API_KEY when config has no api_key."""
+	monkeypatch.setenv('BROWSER_USE_HOME', str(tmp_path))
+	monkeypatch.setenv('BROWSER_USE_API_KEY', 'sk-env-key')
+
+	created_with_keys: list[str] = []
+
+	def create_profile(api_key: str) -> str:
+		created_with_keys.append(api_key)
+		return 'profile-recreated'
+
+	monkeypatch.setattr('browser_use.skill_cli.commands.cloud._create_cloud_profile_inner', create_profile)
+
+	browser_session = await create_browser_session(
+		headed=False,
+		profile=None,
+		use_cloud=True,
+		cloud_profile_id='profile-stale',
+	)
+	browser_session._cloud_browser_client.create_browser = AsyncMock(
+		side_effect=[RuntimeError('profile invalid: 422'), _cloud_browser_response()]
+	)
+
+	await browser_session._provision_cloud_browser()
+
+	assert created_with_keys == ['sk-env-key']
+	assert browser_session._cloud_browser_client.create_browser.await_count == 2
+	retry_request = browser_session._cloud_browser_client.create_browser.await_args_list[1].args[0]
+	assert retry_request.profile_id == 'profile-recreated'
+	assert browser_session.browser_profile.cdp_url == 'wss://browser-use.test/cdp'


### PR DESCRIPTION
Summary:
- let cloud CLI commands use BROWSER_USE_API_KEY when no saved CLI api_key is configured
- keep saved CLI config keys as the first lookup source
- carry the resolved key into cloud connect daemon provisioning so env-only users are not rejected later
- add regression tests for REST calls, cloud connect provisioning, and stale-profile recovery with env-only auth

Tests:
- uv run pytest -q tests/ci/test_cli_cloud.py::test_cloud_rest_uses_browser_use_api_key_env
- uv run pytest -q tests/ci/test_cli_cloud.py
- uv run pytest -q tests/ci/test_cli_cloud_connect.py
- uv run pytest -q tests/ci/test_cli_cloud.py tests/ci/test_cli_cloud_connect.py
- uv run ruff format browser_use/skill_cli/commands/cloud.py browser_use/skill_cli/browser.py tests/ci/test_cli_cloud.py tests/ci/test_cli_cloud_connect.py --check
- uv run ruff check browser_use/skill_cli/commands/cloud.py browser_use/skill_cli/browser.py tests/ci/test_cli_cloud.py tests/ci/test_cli_cloud_connect.py
- uv run pre-commit run --all-files
