### PR TITLE
fix: index ARIA dropdown containers

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -600,6 +600,24 @@ class DOMTreeSerializer:
 
 		return False
 
+	def _is_dropdown_container_node(self, node: EnhancedDOMTreeNode) -> bool:
+		"""Return True when a node is a targetable dropdown/menu container."""
+		attrs = node.attributes or {}
+		role = attrs.get('role', '').lower()
+		tag_name = (node.tag_name or '').lower()
+		class_attr = attrs.get('class', '').lower()
+		class_list = class_attr.split() if class_attr else []
+
+		is_dropdown_by_role = role in ('listbox', 'menu', 'combobox', 'menubar', 'tree', 'grid')
+		is_dropdown_by_tag = tag_name == 'select'
+		is_dropdown_by_class = (
+			'dropdown' in class_list
+			or 'dropdown-menu' in class_list
+			or 'select-menu' in class_list
+			or ('ui' in class_list and 'dropdown' in class_attr)
+		)
+		return is_dropdown_by_role or is_dropdown_by_tag or is_dropdown_by_class
+
 	def _is_inside_shadow_dom(self, node: SimplifiedNode) -> bool:
 		"""Check if a node is inside a shadow DOM by walking up the parent chain.
 
@@ -672,35 +690,17 @@ class DOMTreeSerializer:
 			# Check if scrollable container should be made interactive
 			# For scrollable elements, ONLY make them interactive if they have no interactive descendants
 			should_make_interactive = False
-			if is_scrollable:
-				# Check if this is a dropdown container that needs to be indexed regardless of descendants
-				attrs = node.original_node.attributes or {}
-				role = attrs.get('role', '').lower()
-				tag_name = (node.original_node.tag_name or '').lower()
-				class_attr = attrs.get('class', '').lower()
-				class_list = class_attr.split() if class_attr else []
-
-				# Detect dropdown containers by role, tag, or class
-				is_dropdown_by_role = role in ('listbox', 'menu', 'combobox', 'menubar', 'tree', 'grid')
-				is_dropdown_by_tag = tag_name == 'select'
-				# Match common dropdown class patterns
-				is_dropdown_by_class = (
-					'dropdown' in class_list
-					or 'dropdown-menu' in class_list
-					or 'select-menu' in class_list
-					or ('ui' in class_list and 'dropdown' in class_attr)  # Semantic UI
-				)
-				is_dropdown_container = is_dropdown_by_role or is_dropdown_by_tag or is_dropdown_by_class
-
-				if is_dropdown_container:
-					# Always index dropdown containers - need to be targetable for select_dropdown
+			is_dropdown_container = self._is_dropdown_container_node(node.original_node)
+			if is_dropdown_container and is_visible:
+				# Always index visible dropdown containers - they need to be targetable for
+				# dropdown_options/select_dropdown even when their children are also interactive.
+				should_make_interactive = True
+			elif is_scrollable:
+				# For other scrollable elements, check if they have interactive children
+				has_interactive_desc = self._has_interactive_descendants(node)
+				# Only make scrollable container interactive if it has no interactive descendants
+				if not has_interactive_desc:
 					should_make_interactive = True
-				else:
-					# For other scrollable elements, check if they have interactive children
-					has_interactive_desc = self._has_interactive_descendants(node)
-					# Only make scrollable container interactive if it has no interactive descendants
-					if not has_interactive_desc:
-						should_make_interactive = True
 			elif is_interactive_assign and (is_visible or is_file_input or is_shadow_dom_element):
 				# Non-scrollable interactive elements: make interactive if visible (or file input or shadow DOM form element)
 				should_make_interactive = True
@@ -833,6 +833,10 @@ class DOMTreeSerializer:
 			role = node.original_node.attributes.get('role')
 			if role in ['button', 'link', 'checkbox', 'radio', 'tab', 'menuitem', 'option']:
 				return False
+
+		# 6. Keep dropdown containers so dropdown_options/select_dropdown can target them.
+		if self._is_dropdown_container_node(node.original_node):
+			return False
 
 		# Default: exclude this child
 		return True

--- a/tests/ci/interactions/test_dropdown_aria_menus.py
+++ b/tests/ci/interactions/test_dropdown_aria_menus.py
@@ -111,6 +111,7 @@ def http_server():
 		""",
 		content_type='text/html',
 	)
+	server.expect_request('/favicon.ico').respond_with_data('', status=204)
 
 	yield server
 	server.stop()
@@ -147,16 +148,10 @@ def tools():
 class TestARIAMenuDropdown:
 	"""Test ARIA menu support for get_dropdown_options and select_dropdown_option."""
 
-	@pytest.mark.skip(reason='TODO: fix')
 	async def test_get_dropdown_options_with_aria_menu(self, tools, browser_session: BrowserSession, base_url):
 		"""Test that get_dropdown_options can retrieve options from ARIA menus."""
 		# Navigate to the ARIA menu test page
 		await tools.navigate(url=f'{base_url}/aria-menu', new_tab=False, browser_session=browser_session)
-
-		# Wait for the page to load
-		from browser_use.browser.events import NavigationCompleteEvent
-
-		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state to populate the selector map
 		await browser_session.get_browser_state_summary()
@@ -181,18 +176,13 @@ class TestARIAMenuDropdown:
 			assert option in result.extracted_content, f"Option '{option}' not found in result content"
 
 		# Verify the instruction for using the text in select_dropdown is included
-		assert 'Use the exact text string in select_dropdown' in result.extracted_content
+		assert 'Use the exact text or value string' in result.extracted_content
+		assert 'select_dropdown' in result.extracted_content
 
-	@pytest.mark.skip(reason='TODO: fix')
 	async def test_select_dropdown_option_with_aria_menu(self, tools, browser_session: BrowserSession, base_url):
 		"""Test that select_dropdown_option can select an option from ARIA menus."""
 		# Navigate to the ARIA menu test page
 		await tools.navigate(url=f'{base_url}/aria-menu', new_tab=False, browser_session=browser_session)
-
-		# Wait for the page to load
-		from browser_use.browser.events import NavigationCompleteEvent
-
-		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state to populate the selector map
 		await browser_session.get_browser_state_summary()
@@ -210,7 +200,7 @@ class TestARIAMenuDropdown:
 
 		# Core logic validation: Verify selection was successful
 		assert result.extracted_content is not None
-		assert 'selected option' in result.extracted_content.lower() or 'clicked' in result.extracted_content.lower()
+		assert 'selected' in result.extracted_content.lower()
 		assert 'Filter' in result.extracted_content
 
 		# Verify the click actually had an effect on the page using CDP
@@ -222,16 +212,10 @@ class TestARIAMenuDropdown:
 		result_text = result.get('result', {}).get('value', '')
 		assert 'Filter' in result_text, f"Expected 'Filter' in result text, got '{result_text}'"
 
-	@pytest.mark.skip(reason='TODO: fix')
 	async def test_get_dropdown_options_with_nested_aria_menu(self, tools, browser_session: BrowserSession, base_url):
 		"""Test that get_dropdown_options can handle nested ARIA menus (like Sort submenu)."""
 		# Navigate to the ARIA menu test page
 		await tools.navigate(url=f'{base_url}/aria-menu', new_tab=False, browser_session=browser_session)
-
-		# Wait for the page to load
-		from browser_use.browser.events import NavigationCompleteEvent
-
-		await browser_session.event_bus.expect(NavigationCompleteEvent, timeout=10.0)
 
 		# Initialize the DOM state to populate the selector map
 		await browser_session.get_browser_state_summary()
@@ -272,4 +256,5 @@ class TestARIAMenuDropdown:
 		assert result.extracted_content is not None
 
 		# The action should return some menu options
-		assert 'Use the exact text string in select_dropdown' in result.extracted_content
+		assert 'Use the exact text or value string' in result.extracted_content
+		assert 'select_dropdown' in result.extracted_content


### PR DESCRIPTION
## Summary
- index visible ARIA/custom dropdown containers even when they are not scrollable
- keep dropdown containers through bounding-box filtering so dropdown_options/select_dropdown can target them
- re-enable the ARIA menu dropdown tests and update stale assertions to match the current action output

## Tests
- `uv run pytest -q tests/ci/interactions/test_dropdown_aria_menus.py`
- `uv run pytest -q tests/ci/interactions/test_dropdown_aria_menus.py tests/ci/interactions/test_dropdown_native.py`
- `uv run ruff format browser_use/dom/serializer/serializer.py tests/ci/interactions/test_dropdown_aria_menus.py --check`
- `uv run ruff check browser_use/dom/serializer/serializer.py tests/ci/interactions/test_dropdown_aria_menus.py`
- `uv run pre-commit run --all-files`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indexes visible ARIA and custom dropdown containers so `dropdown_options` and `select_dropdown` can target them, even when not scrollable or when they have interactive children. Re-enables ARIA menu tests and updates expectations.

- Bug Fixes
  - Always index visible dropdown/menu containers (roles: listbox/menu/combobox/menubar/tree/grid, tag: select, common class names).
  - Preserve dropdown containers during bounding-box filtering to keep them targetable.
  - Re-enabled ARIA menu tests; updated assertions and stubbed `/favicon.ico`.

- Refactors
  - Added `_is_dropdown_container_node` and used it in both indexing and filtering.

<sup>Written for commit 8a25236449c45eb04ab30c9bc10180980128fbea. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4855?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

