### PR TITLE
docs: clarify integration example placement

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,3 +5,4 @@ We love contributions! Please read through these links to get started:
  - 🔢 [Contribution Guidelines](https://docs.browser-use.com/development/contribution-guide)
  - 👾 [Local Development Setup Guide](https://docs.browser-use.com/development/local-setup)
  - 🏷️ [Issues Tagged: `#help-wanted`](https://github.com/browser-use/browser-use/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)
+ - 🔌 [Integration Example Guidelines](../examples/integrations/README.md)

--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -1,0 +1,30 @@
+# Integration examples
+
+This directory is for examples that show Browser Use working with external products, APIs, and services.
+
+## Where to put integration contributions
+
+- Use `examples/integrations/<provider>/` for small, runnable examples that demonstrate Browser Use with a specific third-party service.
+- Use `examples/custom-functions/` for provider-agnostic custom tool patterns.
+- Use `browser_use/integrations/<provider>/` only when the integration is shipped as part of the Browser Use package and has tests.
+- Keep product-specific workflows, full applications, or large third-party projects in their own repositories.
+- Add third-party projects to the community list below instead of vendoring their code into this repository.
+
+## Example checklist
+
+- Use `uv` in setup instructions.
+- Keep the example focused on the Browser Use integration point.
+- Document required environment variables, OAuth scopes, and local services.
+- Do not commit secrets, tokens, generated credentials, or private account data.
+- Prefer `ChatBrowserUse()` unless the example is specifically about another model.
+- Include the command that runs the example from the repository root.
+
+## Community integrations
+
+External projects listed here are maintained outside this repository. A listing is a pointer for users, not a support guarantee from Browser Use maintainers.
+
+Add entries in this format:
+
+```markdown
+- [Project name](https://github.com/org/project) - One sentence about what it integrates with. Maintained by @github-handle.
+```


### PR DESCRIPTION
## Summary
- add `examples/integrations/README.md` with placement rules for integration examples, package integrations, custom-function examples, and external community projects
- add a link from `.github/CONTRIBUTING.md` so contributors can find the guidance before opening integration PRs
- avoid adding any third-party example code directly; this only defines the contribution boundary

Resolves #4744.

## Tests
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `examples/integrations/README.md` with placement rules, an example checklist, and a community listing format, and links it from `.github/CONTRIBUTING.md`. No third-party code added; this only sets the contribution boundary. Resolves #4744.

<sup>Written for commit 7a33d8d251ee9cd475a14529007965942a94a636. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4856?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

