### PR TITLE
feat(cli): add extension diagnostics to doctor

### DIFF
--- a/browser_use/skill_cli/commands/doctor.py
+++ b/browser_use/skill_cli/commands/doctor.py
@@ -86,11 +86,27 @@ def _check_extensions() -> dict[str, Any]:
 
 	extensions_enabled = _get_enable_default_extensions_default()
 	env_value = os.getenv('BROWSER_USE_DISABLE_EXTENSIONS')
-	extensions_dir = CONFIG.BROWSER_USE_EXTENSIONS_DIR
-	extensions_dir.mkdir(parents=True, exist_ok=True)
-
-	manifest_dirs = sorted(path for path in extensions_dir.iterdir() if path.is_dir() and (path / 'manifest.json').exists())
-	crx_files = sorted(extensions_dir.glob('*.crx'))
+	extensions_dir_str: str | None = None
+	try:
+		extensions_dir = CONFIG.BROWSER_USE_EXTENSIONS_DIR
+		extensions_dir_str = str(extensions_dir)
+		extensions_dir.mkdir(parents=True, exist_ok=True)
+		manifest_dirs = sorted(path for path in extensions_dir.iterdir() if path.is_dir() and (path / 'manifest.json').exists())
+		crx_files = sorted(extensions_dir.glob('*.crx'))
+	except Exception as e:
+		note = f'BROWSER_USE_DISABLE_EXTENSIONS={env_value or "unset"}'
+		return {
+			'status': 'error',
+			'message': 'Unable to access extension cache directory',
+			'note': note,
+			'details': {
+				'enabled': extensions_enabled,
+				'env': env_value,
+				'cache_dir': extensions_dir_str,
+				'error': str(e),
+			},
+			'fix': 'Ensure BROWSER_USE_CONFIG_DIR is writable and not a file, then rerun doctor.',
+		}
 
 	details = {
 		'enabled': extensions_enabled,

--- a/browser_use/skill_cli/commands/doctor.py
+++ b/browser_use/skill_cli/commands/doctor.py
@@ -5,6 +5,7 @@ are available. Provides helpful diagnostic information and fixes.
 """
 
 import logging
+import os
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -23,10 +24,13 @@ async def handle() -> dict[str, Any]:
 	# 3. Network connectivity (basic check)
 	checks['network'] = await _check_network()
 
-	# 4. Optional: cloudflared (for browser-use tunnel)
+	# 4. Default Chrome extension cache/configuration
+	checks['extensions'] = _check_extensions()
+
+	# 5. Optional: cloudflared (for browser-use tunnel)
 	checks['cloudflared'] = _check_cloudflared()
 
-	# 5. Optional: profile-use (for browser-use profile)
+	# 6. Optional: profile-use (for browser-use profile)
 	checks['profile_use'] = _check_profile_use()
 
 	# Determine overall status
@@ -73,6 +77,69 @@ def _check_browser() -> dict[str, Any]:
 			'message': f'Browser may not be available: {e}',
 			'note': 'Will be installed on first use',
 		}
+
+
+def _check_extensions() -> dict[str, Any]:
+	"""Check default extension settings and cached unpacked extension manifests."""
+	from browser_use.browser.profile import BrowserProfile, _get_enable_default_extensions_default
+	from browser_use.config import CONFIG
+
+	extensions_enabled = _get_enable_default_extensions_default()
+	env_value = os.getenv('BROWSER_USE_DISABLE_EXTENSIONS')
+	extensions_dir = CONFIG.BROWSER_USE_EXTENSIONS_DIR
+	extensions_dir.mkdir(parents=True, exist_ok=True)
+
+	manifest_dirs = sorted(path for path in extensions_dir.iterdir() if path.is_dir() and (path / 'manifest.json').exists())
+	crx_files = sorted(extensions_dir.glob('*.crx'))
+
+	details = {
+		'enabled': extensions_enabled,
+		'env': env_value,
+		'cache_dir': str(extensions_dir),
+		'unpacked_count': len(manifest_dirs),
+		'crx_count': len(crx_files),
+		'unpacked_extension_ids': [path.name for path in manifest_dirs],
+	}
+	note = f'Cache: {extensions_dir}; BROWSER_USE_DISABLE_EXTENSIONS={env_value or "unset"}'
+
+	if not extensions_enabled:
+		return {
+			'status': 'warning',
+			'message': 'Default extensions are disabled by BROWSER_USE_DISABLE_EXTENSIONS',
+			'note': note,
+			'details': details,
+			'fix': 'Unset BROWSER_USE_DISABLE_EXTENSIONS or set it to 0/false to enable default extensions.',
+		}
+
+	invalid_manifests = [
+		path.name for path in manifest_dirs if not BrowserProfile._check_extension_manifest_version(path, path.name)
+	]
+	details['invalid_manifest_ids'] = invalid_manifests
+
+	if invalid_manifests:
+		return {
+			'status': 'warning',
+			'message': f'Found {len(invalid_manifests)} cached extension(s) with invalid or unsupported manifests',
+			'note': note,
+			'details': details,
+			'fix': f'Remove the affected directories from {extensions_dir} so Browser Use can download fresh copies.',
+		}
+
+	if manifest_dirs:
+		return {
+			'status': 'ok',
+			'message': f'Default extensions enabled; found {len(manifest_dirs)} unpacked extension(s)',
+			'note': note,
+			'details': details,
+		}
+
+	return {
+		'status': 'warning',
+		'message': f'Default extensions enabled but no unpacked extensions were found in {extensions_dir}',
+		'note': note,
+		'details': details,
+		'fix': 'Start a Browser with enable_default_extensions=True, then rerun doctor if Chrome still does not show them.',
+	}
 
 
 async def _check_network() -> dict[str, Any]:

--- a/tests/ci/test_doctor_command.py
+++ b/tests/ci/test_doctor_command.py
@@ -14,7 +14,7 @@ async def test_doctor_handle_returns_valid_structure():
 	assert 'summary' in result
 
 	# Verify all expected checks are present
-	expected_checks = ['package', 'browser', 'network', 'cloudflared', 'profile_use']
+	expected_checks = ['package', 'browser', 'network', 'extensions', 'cloudflared', 'profile_use']
 	for check in expected_checks:
 		assert check in result['checks']
 		assert 'status' in result['checks'][check]
@@ -35,6 +35,53 @@ def test_check_browser_returns_valid_structure():
 	assert 'status' in result
 	assert result['status'] in ('ok', 'warning')
 	assert 'message' in result
+
+
+def test_check_extensions_returns_valid_structure(tmp_path, monkeypatch):
+	"""Test _check_extensions returns diagnostic details."""
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(tmp_path / 'browseruse'))
+	monkeypatch.delenv('BROWSER_USE_DISABLE_EXTENSIONS', raising=False)
+
+	result = doctor._check_extensions()
+
+	assert result['status'] in ('ok', 'warning')
+	assert 'message' in result
+	assert 'details' in result
+	assert result['details']['enabled'] is True
+	assert result['details']['cache_dir'].endswith('extensions')
+	assert 'unpacked_count' in result['details']
+	assert 'BROWSER_USE_DISABLE_EXTENSIONS=unset' in result['note']
+
+
+def test_check_extensions_reports_disabled_env_var(tmp_path, monkeypatch):
+	"""Test _check_extensions reports when default extensions are disabled by env."""
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(tmp_path / 'browseruse'))
+	monkeypatch.setenv('BROWSER_USE_DISABLE_EXTENSIONS', '1')
+
+	result = doctor._check_extensions()
+
+	assert result['status'] == 'warning'
+	assert result['details']['enabled'] is False
+	assert result['details']['env'] == '1'
+	assert 'BROWSER_USE_DISABLE_EXTENSIONS' in result['message']
+	assert 'BROWSER_USE_DISABLE_EXTENSIONS=1' in result['note']
+
+
+def test_check_extensions_reports_cached_manifest(tmp_path, monkeypatch):
+	"""Test _check_extensions reports cached unpacked MV3 extensions."""
+	config_dir = tmp_path / 'browseruse'
+	extension_dir = config_dir / 'extensions' / 'extension-id'
+	extension_dir.mkdir(parents=True)
+	(extension_dir / 'manifest.json').write_text('{"manifest_version": 3}', encoding='utf-8')
+
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(config_dir))
+	monkeypatch.delenv('BROWSER_USE_DISABLE_EXTENSIONS', raising=False)
+
+	result = doctor._check_extensions()
+
+	assert result['status'] == 'ok'
+	assert result['details']['unpacked_count'] == 1
+	assert result['details']['unpacked_extension_ids'] == ['extension-id']
 
 
 async def test_check_network_returns_valid_structure():


### PR DESCRIPTION
## Summary
- add an `extensions` check to `browser-use doctor`
- report whether default extensions are enabled, the extension cache directory, cached CRX count, unpacked extension IDs, and invalid manifests
- surface the same data in `--json` output so users debugging Chrome extension loading can distinguish config/cache issues from browser-version issues

This does not change Chrome launch behavior. It adds diagnostics for reports like #4803.

## Tests
- `uv run pytest -q tests/ci/test_doctor_command.py tests/ci/test_extension_config.py`
- `uv run browser-use --json doctor`
- `uv run ruff format browser_use/skill_cli/commands/doctor.py tests/ci/test_doctor_command.py --check`
- `uv run ruff check browser_use/skill_cli/commands/doctor.py tests/ci/test_doctor_command.py`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds extension diagnostics to the `browser-use doctor` command to troubleshoot default Chrome extensions and cache state. Now safely handles missing or unwritable cache directories and surfaces clear errors; no changes to Chrome launch behavior.

- **New Features**
  - Adds an `extensions` check to `browser-use doctor`.
  - Reports enablement (respects BROWSER_USE_DISABLE_EXTENSIONS), cache path, unpacked/CRX counts, unpacked IDs, and invalid manifests; same data in `--json`.

- **Bug Fixes**
  - Guards the extensions check to avoid crashes when the cache dir is missing or unwritable; creates it when possible and returns a clear error with hints if BROWSER_USE_CONFIG_DIR is invalid.

<sup>Written for commit 887356afb9feb8f5c1e9e82436220383164a71b4. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4857?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

