### PR TITLE
fix(session): detect CDP reconnect flapping (#4471 Part 2)

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import re
 import time
+from collections import deque
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, Union, cast, overload
@@ -96,6 +97,65 @@ class CDPSession(BaseModel):
 	# Lifecycle monitoring (populated by SessionManager)
 	_lifecycle_events: Any = PrivateAttr(default=None)
 	_lifecycle_lock: Any = PrivateAttr(default=None)
+
+
+class ReconnectFlapDetector:
+	"""Sliding-window detector for CDP reconnect flapping.
+
+	The per-cycle attempt cap inside BrowserSession._auto_reconnect only fires if
+	every attempt within one cycle fails. When each reconnect *succeeds* at the
+	WS layer but the new socket dies immediately, cycles keep restarting and the
+	loop never terminates. This detector tracks reconnect successes in a sliding
+	time window and reports a one-way give-up signal once the count crosses a
+	configured threshold.
+
+	Uses time.monotonic() because the policy is about elapsed intervals, which
+	must be immune to wall-clock corrections (NTP, manual clock change). Eviction
+	is lazy: stale entries are pruned on read, keeping writes O(1) amortised.
+	Not thread-safe — call from a single event loop.
+	"""
+
+	__slots__ = ('window_seconds', 'max_events', '_timestamps', '_given_up')
+
+	def __init__(self, window_seconds: float, max_events: int) -> None:
+		assert window_seconds > 0, 'window_seconds must be > 0'
+		assert max_events >= 1, 'max_events must be >= 1'
+		self.window_seconds = window_seconds
+		self.max_events = max_events
+		self._timestamps: deque[float] = deque()
+		self._given_up = False
+
+	def record_success(self) -> None:
+		"""Record a successful reconnect at the current monotonic time."""
+		self._timestamps.append(time.monotonic())
+		self._evict()
+
+	def should_give_up(self) -> bool:
+		"""Whether the recent reconnect rate exceeds the threshold (latching)."""
+		if self._given_up:
+			return True
+		self._evict()
+		if len(self._timestamps) >= self.max_events:
+			self._given_up = True
+			return True
+		return False
+
+	def reset(self) -> None:
+		"""Clear history and the give-up latch (e.g. on manual session reset)."""
+		self._timestamps.clear()
+		self._given_up = False
+
+	@property
+	def recent_count(self) -> int:
+		"""Number of successes currently inside the sliding window."""
+		self._evict()
+		return len(self._timestamps)
+
+	def _evict(self) -> None:
+		cutoff = time.monotonic() - self.window_seconds
+		ts = self._timestamps
+		while ts and ts[0] < cutoff:
+			ts.popleft()
 
 
 class BrowserSession(BaseModel):
@@ -539,10 +599,20 @@ class BrowserSession(BaseModel):
 	# Max wait = attempts * timeout_per_attempt + sum(delays) + small buffer
 	# Default: 3 * 15s + (1+2+4)s + 2s = 54s
 	RECONNECT_WAIT_TIMEOUT: float = 54.0
+	# Cross-cycle flap detection. The per-cycle max_attempts cap inside
+	# _auto_reconnect only fires if every attempt within one cycle fails. If each
+	# reconnect succeeds at the WS layer but the new socket dies immediately
+	# (e.g. Chrome rejecting the post-connect setup), cycles keep restarting and
+	# the loop never terminates. Track successful reconnects in a sliding window
+	# and give up if we cross the threshold.
+	RECONNECT_FLAP_WINDOW_SECONDS: float = 60.0
+	RECONNECT_FLAP_MAX_SUCCESSES: int = 5
 	_reconnecting: bool = PrivateAttr(default=False)
 	_reconnect_event: asyncio.Event = PrivateAttr(default_factory=asyncio.Event)
 	_reconnect_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
 	_reconnect_task: asyncio.Task | None = PrivateAttr(default=None)
+	_reconnect_flap_detector: 'ReconnectFlapDetector | None' = PrivateAttr(default=None)
+	_reconnect_flap_dispatched: bool = PrivateAttr(default=False)
 	_intentional_stop: bool = PrivateAttr(default=False)
 
 	_logger: Any = PrivateAttr(default=None)
@@ -589,6 +659,10 @@ class BrowserSession(BaseModel):
 			self._reconnect_task = None
 		self._reconnecting = False
 		self._reconnect_event.set()  # unblock any waiters
+		# Clear flap state so post-reset reconnects start with a fresh budget
+		if self._reconnect_flap_detector is not None:
+			self._reconnect_flap_detector.reset()
+		self._reconnect_flap_dispatched = False
 
 		cdp_status = 'connected' if self._cdp_client_root else 'not connected'
 		session_mgr_status = 'exists' if self.session_manager else 'None'
@@ -2148,6 +2222,7 @@ class BrowserSession(BaseModel):
 					await asyncio.wait_for(self.reconnect(), timeout=15.0)
 					# Success
 					downtime = time.time() - start_time
+					self._reconnect_flap().record_success()
 					self.event_bus.dispatch(
 						BrowserReconnectedEvent(
 							cdp_url=self.cdp_url or '',
@@ -2176,6 +2251,15 @@ class BrowserSession(BaseModel):
 			self._reconnecting = False
 			self._reconnect_event.set()  # wake up all waiters regardless of outcome
 
+	def _reconnect_flap(self) -> ReconnectFlapDetector:
+		"""Lazy-init the flap detector so test-time config overrides take effect."""
+		if self._reconnect_flap_detector is None:
+			self._reconnect_flap_detector = ReconnectFlapDetector(
+				window_seconds=self.RECONNECT_FLAP_WINDOW_SECONDS,
+				max_events=self.RECONNECT_FLAP_MAX_SUCCESSES,
+			)
+		return self._reconnect_flap_detector
+
 	def _attach_ws_drop_callback(self) -> None:
 		"""Attach a done callback to the CDPClient's message handler task to detect WS drops."""
 		if not self._cdp_client_root or not hasattr(self._cdp_client_root, '_message_handler_task'):
@@ -2186,26 +2270,64 @@ class BrowserSession(BaseModel):
 			return
 
 		def _on_message_handler_done(fut: asyncio.Future) -> None:
-			# Guard: skip if intentionally stopped, already reconnecting, or no cdp_url
-			if self._intentional_stop or self._reconnecting or not self.cdp_url:
-				return
-
-			# The message handler task exiting means the WS connection dropped
 			exc = fut.exception() if not fut.cancelled() else None
-			self.logger.warning(
-				f'🔌 CDP WebSocket message handler exited unexpectedly'
-				f'{f": {type(exc).__name__}: {exc}" if exc else " (connection closed)"}'
-			)
-
-			# Fire auto-reconnect as an asyncio task
-			try:
-				loop = asyncio.get_running_loop()
-				self._reconnect_task = loop.create_task(self._auto_reconnect())
-			except RuntimeError:
-				# No running event loop — can't reconnect
-				self.logger.error('🔌 No event loop available for auto-reconnect')
+			self._handle_ws_drop(exc)
 
 		task.add_done_callback(_on_message_handler_done)
+
+	def _handle_ws_drop(self, exc: BaseException | None) -> None:
+		"""Decide what to do when the CDP WebSocket message handler exits.
+
+		Called from the message-handler done-callback (and from tests directly).
+		Either spawns an _auto_reconnect task, or — if the cross-cycle flap
+		threshold has been crossed — dispatches a terminal BrowserErrorEvent and
+		stays silent.
+		"""
+		# Guard: skip if intentionally stopped, already reconnecting, or no cdp_url
+		if self._intentional_stop or self._reconnecting or not self.cdp_url:
+			return
+
+		self.logger.warning(
+			f'🔌 CDP WebSocket message handler exited unexpectedly'
+			f'{f": {type(exc).__name__}: {exc}" if exc else " (connection closed)"}'
+		)
+
+		# Flap guard: if reconnects are succeeding but the new socket dies
+		# immediately, restarting the cycle just loops. Surface a terminal
+		# error so callers (Agent, MCP server) can react instead of hanging.
+		flap = self._reconnect_flap()
+		if flap.should_give_up():
+			if not self._reconnect_flap_dispatched:
+				self._reconnect_flap_dispatched = True
+				self._dispatch_flap_giveup(flap)
+			return
+
+		try:
+			loop = asyncio.get_running_loop()
+			self._reconnect_task = loop.create_task(self._auto_reconnect())
+		except RuntimeError:
+			# No running event loop — can't reconnect
+			self.logger.error('🔌 No event loop available for auto-reconnect')
+
+	def _dispatch_flap_giveup(self, flap: ReconnectFlapDetector) -> None:
+		"""Log + dispatch the terminal flap-giveup event exactly once per latch."""
+		count = flap.recent_count
+		self.logger.error(
+			f'🔌 CDP reconnect flapping — {count} reconnects within {flap.window_seconds:.0f}s. '
+			f'Giving up to avoid an infinite loop.'
+		)
+		self.event_bus.dispatch(
+			BrowserErrorEvent(
+				error_type='ReconnectionFlapping',
+				message=(f'CDP WebSocket reconnect flapping: {count} reconnects in {flap.window_seconds:.0f}s'),
+				details={
+					'cdp_url': self.cdp_url or '',
+					'window_seconds': flap.window_seconds,
+					'max_events': flap.max_events,
+					'recent_count': count,
+				},
+			)
+		)
 
 	async def get_tabs(self) -> list[TabInfo]:
 		"""Get information about all open tabs using cached target data."""

--- a/tests/ci/test_session_reconnect_flap.py
+++ b/tests/ci/test_session_reconnect_flap.py
@@ -1,0 +1,181 @@
+"""Tests for CDP reconnect flap detection.
+
+Covers issue #4471 (Part 2): when reconnects succeed at the WS layer but the
+new socket dies immediately, _auto_reconnect's per-cycle attempt cap doesn't
+trigger and the loop runs forever. ReconnectFlapDetector caps cross-cycle
+reconnect successes in a sliding window; BrowserSession surfaces a terminal
+BrowserErrorEvent the first time the threshold is crossed and refuses to spawn
+new reconnect tasks while the latch is set.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from browser_use.browser.events import BrowserErrorEvent
+from browser_use.browser.session import BrowserSession, ReconnectFlapDetector
+
+# ---------------------------------------------------------------------------
+# Detector — pure unit tests, no browser
+# ---------------------------------------------------------------------------
+
+
+def test_detector_starts_clean():
+	d = ReconnectFlapDetector(window_seconds=60.0, max_events=5)
+	assert d.recent_count == 0
+	assert d.should_give_up() is False
+
+
+def test_detector_under_threshold_does_not_trigger():
+	d = ReconnectFlapDetector(window_seconds=60.0, max_events=5)
+	for _ in range(4):
+		d.record_success()
+	assert d.recent_count == 4
+	assert d.should_give_up() is False
+
+
+def test_detector_at_threshold_latches():
+	d = ReconnectFlapDetector(window_seconds=60.0, max_events=5)
+	for _ in range(5):
+		d.record_success()
+	assert d.should_give_up() is True
+	# Once latched, stays latched.
+	assert d.should_give_up() is True
+
+
+def test_detector_evicts_outside_window(monkeypatch: pytest.MonkeyPatch):
+	"""Events older than window_seconds drop out of the sliding window."""
+	now = [1000.0]
+	monkeypatch.setattr(time, 'monotonic', lambda: now[0])
+
+	# Spread across the window — never crosses threshold.
+	d = ReconnectFlapDetector(window_seconds=10.0, max_events=3)
+	d.record_success()  # t=1000
+	now[0] = 1011.0  # first event now outside the window
+	d.record_success()
+	now[0] = 1022.0  # second event now outside
+	d.record_success()
+	assert d.recent_count == 1
+	assert d.should_give_up() is False
+
+	# Bunched inside the window — crosses threshold.
+	d2 = ReconnectFlapDetector(window_seconds=10.0, max_events=3)
+	now[0] = 2000.0
+	for _ in range(3):
+		d2.record_success()
+	assert d2.should_give_up() is True
+
+
+def test_detector_reset_clears_latch_and_history():
+	d = ReconnectFlapDetector(window_seconds=60.0, max_events=2)
+	d.record_success()
+	d.record_success()
+	assert d.should_give_up() is True
+	d.reset()
+	assert d.recent_count == 0
+	assert d.should_give_up() is False
+
+
+def test_detector_rejects_invalid_config():
+	with pytest.raises(AssertionError):
+		ReconnectFlapDetector(window_seconds=0, max_events=5)
+	with pytest.raises(AssertionError):
+		ReconnectFlapDetector(window_seconds=10, max_events=0)
+
+
+# ---------------------------------------------------------------------------
+# BrowserSession wiring — drives the real _handle_ws_drop code path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def session():
+	"""A BrowserSession with tight flap thresholds and no real browser.
+
+	We never call start() — these tests drive the in-process WS-drop handler
+	to verify the dispatch latch and reset behaviour. The detector thresholds
+	are overridden so the test doesn't depend on the production constants.
+
+	The event_bus is stopped on teardown because bubus auto-starts a background
+	_run_loop task on first dispatch; leaving it running stalls the
+	session-scoped pytest-asyncio loop at end-of-session.
+	"""
+	s = BrowserSession()
+	s._reconnect_flap_detector = ReconnectFlapDetector(window_seconds=60.0, max_events=3)
+	# cdp_url is a read-only property on BrowserSession that proxies to
+	# browser_profile — pretend we're attached so _handle_ws_drop doesn't bail.
+	s.browser_profile.cdp_url = 'http://localhost:9222/'
+	try:
+		yield s
+	finally:
+		await s.event_bus.stop(clear=True, timeout=5)
+
+
+async def test_handle_ws_drop_dispatches_flap_event_exactly_once(session: BrowserSession):
+	"""Latching: many WS drops while the flap is tripped → one BrowserErrorEvent."""
+	events: list[BrowserErrorEvent] = []
+
+	async def _collect(e: BrowserErrorEvent) -> None:
+		events.append(e)
+
+	session.event_bus.on(BrowserErrorEvent, _collect)
+
+	# Drive 3 successful reconnects → detector latches at threshold=3.
+	flap = session._reconnect_flap()
+	for _ in range(3):
+		flap.record_success()
+
+	# Three subsequent WS drops while latched should produce exactly ONE event.
+	session._handle_ws_drop(None)
+	session._handle_ws_drop(None)
+	session._handle_ws_drop(None)
+
+	await session.event_bus.wait_until_idle(timeout=2.0)
+
+	assert len(events) == 1, f'expected exactly one ReconnectionFlapping event, got {len(events)}'
+	(err,) = events
+	assert err.error_type == 'ReconnectionFlapping'
+	assert err.details['window_seconds'] == 60.0
+	assert err.details['max_events'] == 3
+	assert err.details['recent_count'] == 3
+
+
+async def test_handle_ws_drop_under_threshold_does_not_dispatch(session: BrowserSession):
+	"""Under threshold, no flap event fires and the dispatch latch stays clear."""
+	events: list[BrowserErrorEvent] = []
+
+	async def _collect(e: BrowserErrorEvent) -> None:
+		events.append(e)
+
+	session.event_bus.on(BrowserErrorEvent, _collect)
+
+	flap = session._reconnect_flap()
+	flap.record_success()  # 1 of 3 — well under
+	flap.record_success()  # 2 of 3 — still under
+
+	# Drive the drop handler. We don't assert on whether a reconnect task is
+	# created (that requires a real CDP client) — we only assert the flap
+	# pathway stays silent.
+	session._handle_ws_drop(None)
+	await session.event_bus.wait_until_idle(timeout=1.0)
+
+	assert events == []
+	assert session._reconnect_flap_dispatched is False
+
+
+async def test_reset_clears_flap_state(session: BrowserSession):
+	"""reset() restores a fresh reconnect budget after a give-up."""
+	flap = session._reconnect_flap()
+	for _ in range(3):
+		flap.record_success()
+	session._handle_ws_drop(None)  # triggers dispatch + sets the latch
+	assert session._reconnect_flap_dispatched is True
+
+	await session.reset()
+
+	assert session._reconnect_flap_detector is not None
+	assert session._reconnect_flap_detector.recent_count == 0
+	assert session._reconnect_flap_detector.should_give_up() is False
+	assert session._reconnect_flap_dispatched is False


### PR DESCRIPTION
## Why

Fixes the second half of #4471. PR #4599 covers Part 1 (Chromium launch watchdog timeout); this PR addresses Part 2 (CDP WebSocket reconnect loop on attach mode). Context comment with two scoping questions for maintainers: #4471 (comment).

The bug log in the original report tells the story — each cycle technically *succeeds* (the WS reopens, `reconnect()` returns, attempt 1 logs success), but the new socket dies immediately and a fresh `_auto_reconnect` cycle spins up. The per-cycle `max_attempts=3` cap inside one call never trips because attempts within a cycle don't fail; cycles themselves loop. No cross-cycle flap detection exists today.

## What

* New `ReconnectFlapDetector` — encapsulates the sliding-window policy, uses `time.monotonic()`, lazy eviction, latches once tripped, fully unit-testable in isolation.
* `BrowserSession` records each reconnect success and consults the detector in `_handle_ws_drop`. If the detector says "give up," dispatch a single `BrowserErrorEvent(error_type="ReconnectionFlapping")` and stop spawning auto-reconnect tasks.
* Extracted the WS-drop handler closure into `_handle_ws_drop` so tests drive the real code path (no production-side test seams).
* `reset()` clears both the history and the dispatch latch so a manual recovery starts with a fresh budget.

Defaults: **5 reconnects within 60s** → give up. Configurable via `RECONNECT_FLAP_WINDOW_SECONDS` / `RECONNECT_FLAP_MAX_SUCCESSES` class attributes (also overridable per-instance for tests).

The "why does Chrome keep closing the new socket on Ubuntu 22.04 headless" question is intentionally out of scope here — flap detection should land regardless of whatever post-connect step Chrome is unhappy about. Happy to chase that as a follow-up issue once the defensive cap is in place.

## Test plan

- [x] `uv run pytest tests/ci/test_session_reconnect_flap.py` — 9/9 pass (detector unit + BrowserSession wiring)
- [x] `uv run pyright browser_use/browser/session.py` — 0 errors
- [x] `uv run ruff check && uv run ruff format --check` — clean
- [x] `uv run pytest tests/ci/` — 414 pass, 1 unrelated SSL/network failure (`test_init_list_templates`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects CDP WebSocket reconnect flapping and stops infinite auto-reconnect loops by emitting a terminal `BrowserErrorEvent` once a sliding-window threshold is hit. Defaults to 5 successful reconnects within 60s; `reset()` clears the budget. Addresses #4471 (Part 2).

- **Bug Fixes**
  - Added `ReconnectFlapDetector` (monotonic, sliding window, latch) to cap cross-cycle reconnects.
  - Wired into `BrowserSession`: record reconnect successes, check in `_handle_ws_drop`, dispatch one `ReconnectionFlapping` error, and skip spawning new auto-reconnect tasks when tripped.
  - Extracted the WS-drop closure into `_handle_ws_drop` for a single, testable code path.
  - Thresholds configurable via `RECONNECT_FLAP_WINDOW_SECONDS` and `RECONNECT_FLAP_MAX_SUCCESSES`; per-instance overrides supported; `reset()` clears history and the dispatch latch.

<sup>Written for commit b4301ba91a7c9fd0fd1492e043a271658e20aa0c. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4858?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

