### PR TITLE
fix(browser): exclude chrome-extension:// targets from get_all_page_targets

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -3218,8 +3218,9 @@ class BrowserSession(BaseModel):
 	async def _close_extension_options_pages(self) -> None:
 		"""Close any extension options/welcome pages that have opened."""
 		try:
-			# Get all page targets from SessionManager
-			page_targets = self.session_manager.get_all_page_targets()
+			# Get all page targets from SessionManager, including chrome-extension://
+			# targets so extension options/onboarding pages can be detected and closed.
+			page_targets = self.session_manager.get_all_page_targets(include_chrome_extensions=True)
 
 			for target in page_targets:
 				target_url = target.url

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -155,7 +155,10 @@ class SessionManager:
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
+			# Exclude chrome-extension:// targets (e.g. extension side panels expose
+			# a type='page' target). They must never be treated as steerable pages,
+			# matching BrowserSession._is_valid_target(include_chrome_extensions=False).
+			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
 				page_targets.append(target)
 		return page_targets
 

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -147,8 +147,15 @@ class SessionManager:
 			return None
 		return self._sessions.get(next(iter(session_ids)))
 
-	def get_all_page_targets(self) -> list:
+	def get_all_page_targets(self, include_chrome_extensions: bool = False) -> list:
 		"""Get all page/tab targets using owned data.
+
+		Args:
+			include_chrome_extensions: If True, also return chrome-extension:// page
+				targets. Off by default so they are never treated as steerable pages
+				(mirrors BrowserSession._is_valid_target(include_chrome_extensions=False)).
+				Only extension-cleanup code that explicitly needs to close extension
+				options/onboarding pages should opt in.
 
 		Returns:
 			List of Target objects for all page/tab targets
@@ -156,9 +163,10 @@ class SessionManager:
 		page_targets = []
 		for target in self._targets.values():
 			# Exclude chrome-extension:// targets (e.g. extension side panels expose
-			# a type='page' target). They must never be treated as steerable pages,
-			# matching BrowserSession._is_valid_target(include_chrome_extensions=False).
-			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
+			# a type='page' target). They must never be treated as steerable pages.
+			if target.target_type in ('page', 'tab') and (
+				include_chrome_extensions or not target.url.startswith('chrome-extension://')
+			):
 				page_targets.append(target)
 		return page_targets
 

--- a/tests/ci/browser/test_session_manager_targets.py
+++ b/tests/ci/browser/test_session_manager_targets.py
@@ -56,3 +56,22 @@ def test_regular_pages_and_tabs_still_returned():
 
 	# worker is excluded by target_type as before; the three page/tab targets remain
 	assert {t.target_id for t in result} == {'t1', 't2', 't3'}
+
+
+def test_include_chrome_extensions_opt_in():
+	"""Extension-cleanup code can opt in to see chrome-extension:// targets.
+
+	_close_extension_options_pages() relies on this to find and close extension
+	options/onboarding pages, so the opt-in must surface them.
+	"""
+	page = Target(target_id='t-page', target_type='page', url='https://example.com/')
+	options_page = Target(
+		target_id='t-opt',
+		target_type='page',
+		url='chrome-extension://abcdefghijklmnop/options.html',
+	)
+	mgr = _make_manager(page, options_page)
+
+	assert options_page not in mgr.get_all_page_targets()
+	assert options_page in mgr.get_all_page_targets(include_chrome_extensions=True)
+	assert page in mgr.get_all_page_targets(include_chrome_extensions=True)

--- a/tests/ci/browser/test_session_manager_targets.py
+++ b/tests/ci/browser/test_session_manager_targets.py
@@ -1,0 +1,58 @@
+"""
+Test SessionManager.get_all_page_targets() target filtering.
+
+Regression test for #4133: extension side panels are reported by CDP as
+type='page' targets with chrome-extension:// URLs. They must NOT be returned
+by get_all_page_targets(), otherwise crash-recovery focus, the tab list shown
+to the LLM, and initial connect can all switch the agent into the extension
+window.
+
+Usage:
+	uv run pytest tests/ci/browser/test_session_manager_targets.py -v -s
+"""
+
+from browser_use.browser.session import Target
+from browser_use.browser.session_manager import SessionManager
+
+
+def _make_manager(*targets: Target) -> SessionManager:
+	"""Build a SessionManager without a BrowserSession.
+
+	get_all_page_targets() only reads self._targets, so we bypass the
+	browser-dependent __init__ and populate the owned target dict directly
+	with real Target objects (no mocking of behavior).
+	"""
+	mgr = SessionManager.__new__(SessionManager)
+	mgr._targets = {t.target_id: t for t in targets}
+	return mgr
+
+
+def test_extension_side_panel_excluded():
+	"""chrome-extension:// targets with type='page' must be filtered out."""
+	page = Target(target_id='t-page', target_type='page', url='https://example.com/')
+	side_panel = Target(
+		target_id='t-ext',
+		target_type='page',
+		url='chrome-extension://abcdefghijklmnop/sidepanel.html',
+	)
+	mgr = _make_manager(page, side_panel)
+
+	result = mgr.get_all_page_targets()
+
+	assert page in result
+	assert side_panel not in result
+	assert [t.target_id for t in result] == ['t-page']
+
+
+def test_regular_pages_and_tabs_still_returned():
+	"""Non-extension page/tab targets are unaffected by the filter."""
+	http_page = Target(target_id='t1', target_type='page', url='https://example.com/')
+	blank_page = Target(target_id='t2', target_type='page', url='about:blank')
+	tab = Target(target_id='t3', target_type='tab', url='http://localhost:8000/')
+	worker = Target(target_id='t4', target_type='service_worker', url='https://example.com/sw.js')
+	mgr = _make_manager(http_page, blank_page, tab, worker)
+
+	result = mgr.get_all_page_targets()
+
+	# worker is excluded by target_type as before; the three page/tab targets remain
+	assert {t.target_id for t in result} == {'t1', 't2', 't3'}


### PR DESCRIPTION
## Problem

When browser-use connects to a Chrome instance that has extensions with side panels (Chrome `sidePanel` API), the side panel is reported by CDP as a `type: "page"` target with a `chrome-extension://` URL. The agent intermittently switches focus into the extension window:

1. Crash/detach recovery picks `page_targets[-1]` — if the side panel opened most recently, the agent starts navigating inside the extension window.
2. The side panel appears in the tab list shown to the LLM, which may cause the LLM to switch to it.
3. `connect()` may select the side panel as the initial page if it is the first discovered page target.

It is intermittent because it depends on the timing of the side panel opening relative to target discovery and crash recovery.

## Root cause

`SessionManager.get_all_page_targets()` (`browser_use/browser/session_manager.py:150`) filtered only by `target_type in ('page', 'tab')` with no URL-scheme check. `BrowserSession._is_valid_target()` already excludes `chrome-extension://` by default (`include_chrome_extensions=False`), but that method only guards `_cdp_get_all_pages()` / `get_all_frames()` — not `get_all_page_targets()`, which backs ~13 call sites including `crash_watchdog`, the tab list, and `connect()`.

## Fix

Exclude targets whose URL starts with `chrome-extension://` in `get_all_page_targets()`, mirroring the existing `_is_valid_target(include_chrome_extensions=False)` default. One-line behavioral change; no new dependencies; no refactor. `Target.url` is a pydantic field defaulting to `'about:blank'`, so the `.startswith()` check is always safe.

## Testing

Added `tests/ci/browser/test_session_manager_targets.py` using real `Target` objects (no mocking): asserts extension side panels are excluded while regular `http`/`https`/`about:blank`/`tab` targets are still returned. Verified the test fails without the fix and passes with it. `tests/ci/browser/test_tabs.py` (5 tests, exercises `get_all_page_targets` via tab listing) still passes. `uv run pyright` is clean.

## Related issues

Fixes #4133

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `chrome-extension://` targets from `SessionManager.get_all_page_targets()` by default to prevent switching into extension side panels. Add an opt-in `include_chrome_extensions=True` for cleanup so extension options/onboarding pages are still auto-closed; aligns with `BrowserSession._is_valid_target()` and fixes #4133.

- **Bug Fixes**
  - Skip `chrome-extension://` for `page`/`tab` targets by default; prevents side panels in crash recovery, the tab list, and initial connect.
  - Add `include_chrome_extensions` opt-in and use it in `_close_extension_options_pages()`; tests cover exclusion and opt-in behavior.

<sup>Written for commit 5f2c9b3b378acace160ea93706f4520ca69efeb5. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4859?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

