### PR TITLE
fix: cap DOM build and screenshot tasks per BrowserStateRequestEvent (#4579)

### DIFF
--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -43,7 +43,7 @@ def _parse_env_task_timeout(env_name: str, fallback_s: float) -> float:
 	"""Parse a per-task timeout env var defensively.
 
 	Mirrors the guard in browser/_cdp_timeout.py: only finite positive
-	values take effect; nan / inf / non-positive / unparseable values fall
+	values take effect; nan / inf / non-positive / unparsable values fall
 	back to ``fallback_s`` with a warning. A bad env value here would
 	otherwise time out every browser-state request immediately (nan / 0)
 	or never (inf / negative).

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -1,6 +1,9 @@
 """DOM watchdog for browser DOM tree management using CDP."""
 
 import asyncio
+import logging
+import math
+import os
 import time
 from typing import TYPE_CHECKING
 
@@ -21,6 +24,56 @@ from browser_use.utils import create_task_with_error_handling, time_execution_as
 
 if TYPE_CHECKING:
 	from browser_use.browser.views import BrowserStateSummary, NetworkRequest, PageInfo, PaginationButton
+
+
+# Per-task timeouts for the parallel DOM build + screenshot block inside
+# on_BrowserStateRequestEvent. The individual CDP calls inside these tasks
+# are already capped by TimeoutWrappedCDPClient (BROWSER_USE_CDP_TIMEOUT_S,
+# default 60s), but a remote browser that goes silent mid-build can still
+# blow the event budget because a DOM build is many sequential CDP calls.
+# An outer per-task cap turns "hung handler holds the event-bus slot for
+# the full 30s event budget" into "task aborts fast, handler returns a
+# minimal state for that component". See issue #4579.
+_DOM_BUILD_TIMEOUT_FALLBACK_S = 15.0
+_SCREENSHOT_TIMEOUT_FALLBACK_S = 8.0
+_DOM_TIMEOUT_LOGGER = logging.getLogger(__name__)
+
+
+def _parse_env_task_timeout(env_name: str, fallback_s: float) -> float:
+	"""Parse a per-task timeout env var defensively.
+
+	Mirrors the guard in browser/_cdp_timeout.py: only finite positive
+	values take effect; nan / inf / non-positive / unparseable values fall
+	back to ``fallback_s`` with a warning. A bad env value here would
+	otherwise time out every browser-state request immediately (nan / 0)
+	or never (inf / negative).
+	"""
+	raw = os.getenv(env_name)
+	if raw is None or raw == '':
+		return fallback_s
+	try:
+		parsed = float(raw)
+	except ValueError:
+		_DOM_TIMEOUT_LOGGER.warning(
+			'Invalid %s=%r; falling back to %.1fs',
+			env_name,
+			raw,
+			fallback_s,
+		)
+		return fallback_s
+	if not math.isfinite(parsed) or parsed <= 0:
+		_DOM_TIMEOUT_LOGGER.warning(
+			'%s=%r is not a finite positive number; falling back to %.1fs',
+			env_name,
+			raw,
+			fallback_s,
+		)
+		return fallback_s
+	return parsed
+
+
+DOM_BUILD_TIMEOUT_S: float = _parse_env_task_timeout('BROWSER_USE_DOM_BUILD_TIMEOUT_S', _DOM_BUILD_TIMEOUT_FALLBACK_S)
+SCREENSHOT_TIMEOUT_S: float = _parse_env_task_timeout('BROWSER_USE_SCREENSHOT_TIMEOUT_S', _SCREENSHOT_TIMEOUT_FALLBACK_S)
 
 
 class DOMWatchdog(BaseWatchdog):
@@ -390,8 +443,15 @@ class DOMWatchdog(BaseWatchdog):
 
 			if dom_task:
 				try:
-					content = await dom_task
+					content = await asyncio.wait_for(dom_task, timeout=DOM_BUILD_TIMEOUT_S)
 					self.logger.debug('🔍 DOMWatchdog.on_BrowserStateRequestEvent: ✅ DOM tree build completed')
+				except TimeoutError:
+					self.logger.warning(
+						f'🔍 DOMWatchdog.on_BrowserStateRequestEvent: DOM build did not finish within '
+						f'{DOM_BUILD_TIMEOUT_S:.1f}s, returning minimal state. '
+						f'Set BROWSER_USE_DOM_BUILD_TIMEOUT_S to override.'
+					)
+					content = SerializedDOMState(_root=None, selector_map={})
 				except Exception as e:
 					self.logger.warning(f'🔍 DOMWatchdog.on_BrowserStateRequestEvent: DOM build failed: {e}, using minimal state')
 					content = SerializedDOMState(_root=None, selector_map={})
@@ -400,8 +460,15 @@ class DOMWatchdog(BaseWatchdog):
 
 			if screenshot_task:
 				try:
-					screenshot_b64 = await screenshot_task
+					screenshot_b64 = await asyncio.wait_for(screenshot_task, timeout=SCREENSHOT_TIMEOUT_S)
 					self.logger.debug('🔍 DOMWatchdog.on_BrowserStateRequestEvent: ✅ Clean screenshot captured')
+				except TimeoutError:
+					self.logger.warning(
+						f'🔍 DOMWatchdog.on_BrowserStateRequestEvent: Clean screenshot did not finish within '
+						f'{SCREENSHOT_TIMEOUT_S:.1f}s, returning state without screenshot. '
+						f'Set BROWSER_USE_SCREENSHOT_TIMEOUT_S to override.'
+					)
+					screenshot_b64 = None
 				except Exception as e:
 					self.logger.warning(f'🔍 DOMWatchdog.on_BrowserStateRequestEvent: Clean screenshot failed: {e}')
 					screenshot_b64 = None

--- a/tests/ci/browser/test_dom_watchdog_timeouts.py
+++ b/tests/ci/browser/test_dom_watchdog_timeouts.py
@@ -1,0 +1,205 @@
+"""Regression tests for per-task timeouts in DOMWatchdog.on_BrowserStateRequestEvent.
+
+Covers issue #4579: DOM build and clean-screenshot tasks were awaited without a
+per-task cap. A remote browser with a silent half-dead WebSocket could keep
+either task awaiting forever, blocking the handler for the full 30s event
+budget. TimeoutWrappedCDPClient caps individual CDP calls (default 60s), but a
+single DOM build is many sequential CDP calls, so the aggregate can still blow
+the event-bus budget — the gap closed here.
+
+The fix wraps each await with asyncio.wait_for using a configurable per-task
+cap (BROWSER_USE_DOM_BUILD_TIMEOUT_S / BROWSER_USE_SCREENSHOT_TIMEOUT_S).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+from browser_use.browser.watchdogs import dom_watchdog as dom_watchdog_module
+from browser_use.browser.watchdogs.dom_watchdog import (
+	_DOM_BUILD_TIMEOUT_FALLBACK_S,
+	_SCREENSHOT_TIMEOUT_FALLBACK_S,
+	_parse_env_task_timeout,
+)
+from browser_use.dom.views import SerializedDOMState
+
+# ---------------------------------------------------------------------------
+# _parse_env_task_timeout — pure unit tests, no browser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_env_timeout_unset_returns_fallback(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.delenv('TEST_TIMEOUT_VAR', raising=False)
+	assert _parse_env_task_timeout('TEST_TIMEOUT_VAR', 12.5) == 12.5
+
+
+def test_parse_env_timeout_empty_string_returns_fallback(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('TEST_TIMEOUT_VAR', '')
+	assert _parse_env_task_timeout('TEST_TIMEOUT_VAR', 12.5) == 12.5
+
+
+def test_parse_env_timeout_valid_value_is_used(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('TEST_TIMEOUT_VAR', '30.5')
+	assert _parse_env_task_timeout('TEST_TIMEOUT_VAR', 12.5) == 30.5
+
+
+def test_parse_env_timeout_rejects_malformed_values(monkeypatch: pytest.MonkeyPatch):
+	"""Mirrors the guard on BROWSER_USE_CDP_TIMEOUT_S — a bad env value would
+	otherwise time out every state request immediately (nan / 0) or never
+	(inf / negative)."""
+	for bad in ('nan', 'NaN', 'inf', '-inf', '0', '0.0', '-5', '-0.01', 'abc'):
+		monkeypatch.setenv('TEST_TIMEOUT_VAR', bad)
+		assert _parse_env_task_timeout('TEST_TIMEOUT_VAR', 7.0) == 7.0, f'Expected fallback for {bad!r}'
+
+
+def test_parse_env_timeout_accepts_small_positive(monkeypatch: pytest.MonkeyPatch):
+	"""Small but finite positive values should pass — used by tests that
+	want to force fast timeouts."""
+	monkeypatch.setenv('TEST_TIMEOUT_VAR', '0.001')
+	assert _parse_env_task_timeout('TEST_TIMEOUT_VAR', 10.0) == 0.001
+
+
+def test_default_timeouts_are_sensible():
+	"""DOM build needs more headroom than screenshot (many CDP calls vs one),
+	and both must stay well below the 30s BrowserStateRequestEvent budget so
+	the timeout fires before the event-level kill — otherwise the per-task
+	cap adds nothing over what the event bus already enforces."""
+	assert 0 < _SCREENSHOT_TIMEOUT_FALLBACK_S < _DOM_BUILD_TIMEOUT_FALLBACK_S
+	assert _DOM_BUILD_TIMEOUT_FALLBACK_S < 30.0
+
+
+# ---------------------------------------------------------------------------
+# Integration — real BrowserSession + pytest-httpserver
+#
+# We inject a hang into the watchdog's per-component methods (the inner CDP
+# calls), not into the session itself. The handler under test is real, the
+# event bus is real, the browser is real. Only the leaf coroutine that
+# normally fans out into CDP traffic is swapped for one that awaits an
+# event we can release — which is the precise shape of a stale-WebSocket
+# hang the issue describes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope='module')
+def http_server():
+	server = HTTPServer()
+	server.start()
+	server.expect_request('/page').respond_with_data(
+		'<!doctype html><html><head><title>T</title></head>'
+		'<body><h1 id="h">Hello</h1><a href="#x" id="link">link</a></body></html>',
+		content_type='text/html',
+	)
+	yield server
+	server.stop()
+
+
+@pytest.fixture(scope='module')
+def base_url(http_server: HTTPServer) -> str:
+	return f'http://{http_server.host}:{http_server.port}'
+
+
+@pytest.fixture
+async def browser_session():
+	session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None))
+	await session.start()
+	try:
+		yield session
+	finally:
+		await session.kill()
+
+
+async def _navigate(session: BrowserSession, url: str) -> None:
+	from browser_use.browser.events import NavigateToUrlEvent
+
+	await session.event_bus.dispatch(NavigateToUrlEvent(url=url, new_tab=False))
+
+
+async def test_dom_build_timeout_returns_minimal_state(
+	monkeypatch: pytest.MonkeyPatch, browser_session: BrowserSession, base_url: str
+):
+	"""When the DOM build hangs, the handler must abort within the cap and
+	return an empty selector_map instead of holding the event slot for the
+	full 30s budget. The screenshot path is untouched, so it should resolve
+	normally and survive in the returned state."""
+	monkeypatch.setattr(dom_watchdog_module, 'DOM_BUILD_TIMEOUT_S', 0.3)
+	monkeypatch.setattr(dom_watchdog_module, 'SCREENSHOT_TIMEOUT_S', 10.0)
+
+	await _navigate(browser_session, f'{base_url}/page')
+
+	watchdog = browser_session._dom_watchdog
+	assert watchdog is not None, 'DOM watchdog should be attached after session.start()'
+
+	release = asyncio.Event()  # never set — simulates indefinite hang
+
+	async def _hanging_dom_build(previous_state=None):
+		await release.wait()
+		return SerializedDOMState(_root=None, selector_map={})
+
+	monkeypatch.setattr(watchdog, '_build_dom_tree_without_highlights', _hanging_dom_build)
+
+	start = time.monotonic()
+	state = await browser_session.get_browser_state_summary(include_screenshot=True)
+	elapsed = time.monotonic() - start
+
+	# DOM build aborted at the cap → empty selector_map fallback
+	assert state.dom_state is not None
+	assert state.dom_state.selector_map == {}
+	# Screenshot path was independent and unblocked — must survive
+	assert state.screenshot is not None and len(state.screenshot) > 0
+	# Bounded by the cap plus margin; nowhere near 30s
+	assert elapsed < 10.0, f'handler took {elapsed:.2f}s; expected < 10s'
+
+	release.set()  # let the orphaned task unwind cleanly
+
+
+async def test_screenshot_timeout_returns_state_without_screenshot(
+	monkeypatch: pytest.MonkeyPatch, browser_session: BrowserSession, base_url: str
+):
+	"""Symmetric to the DOM-build case: a hung screenshot must leave the
+	rest of the state intact and just drop the screenshot field."""
+	monkeypatch.setattr(dom_watchdog_module, 'DOM_BUILD_TIMEOUT_S', 10.0)
+	monkeypatch.setattr(dom_watchdog_module, 'SCREENSHOT_TIMEOUT_S', 0.3)
+
+	await _navigate(browser_session, f'{base_url}/page')
+
+	watchdog = browser_session._dom_watchdog
+	assert watchdog is not None
+
+	release = asyncio.Event()
+
+	async def _hanging_screenshot():
+		await release.wait()
+		return 'never_returned'
+
+	monkeypatch.setattr(watchdog, '_capture_clean_screenshot', _hanging_screenshot)
+
+	start = time.monotonic()
+	state = await browser_session.get_browser_state_summary(include_screenshot=True)
+	elapsed = time.monotonic() - start
+
+	assert state.screenshot is None
+	# DOM path was independent — must produce a real, non-empty selector_map
+	assert state.dom_state is not None
+	assert state.dom_state.selector_map  # the test page has interactive elements
+	assert elapsed < 10.0, f'handler took {elapsed:.2f}s; expected < 10s'
+
+	release.set()
+
+
+async def test_healthy_path_preserves_results(browser_session: BrowserSession, base_url: str):
+	"""Sanity check: with default caps the wrap is transparent on the happy
+	path. If this regresses, every state build pays the timeout cost."""
+	await _navigate(browser_session, f'{base_url}/page')
+
+	state = await browser_session.get_browser_state_summary(include_screenshot=True)
+
+	assert state.dom_state is not None
+	assert state.dom_state.selector_map, 'expected interactive elements in /page'
+	assert state.screenshot is not None and len(state.screenshot) > 0
+	assert state.url.endswith('/page')


### PR DESCRIPTION
## Summary

Closes #4579.

`DOMWatchdog.on_BrowserStateRequestEvent` awaited the DOM build and clean-screenshot tasks without a per-task cap. `TimeoutWrappedCDPClient` already caps individual CDP calls (`BROWSER_USE_CDP_TIMEOUT_S`, default 60s), but a single DOM build fans out into many sequential CDP calls — so the aggregate await can still blow the 30s `BrowserStateRequestEvent` budget when a remote browser goes silent mid-build (stale WebSocket: sends succeed, responses never arrive, no close frame).

This change wraps each of the two awaits with `asyncio.wait_for` using configurable caps:

- `BROWSER_USE_DOM_BUILD_TIMEOUT_S` (default 15s)
- `BROWSER_USE_SCREENSHOT_TIMEOUT_S` (default 8s)

On timeout, the handler returns a minimal state for the slow component (empty `selector_map` / null screenshot) instead of holding the event-bus slot for the full budget. The healthy path is unchanged.

Env parsing mirrors the defensive guard used for `BROWSER_USE_CDP_TIMEOUT_S` in `browser_use/browser/_cdp_timeout.py`: only finite positive values take effect; `nan` / `inf` / non-positive / unparseable values fall back to the hardcoded default with a warning. Without this guard a typo would silently make every state build either time out immediately (`nan`/`0`) or never (`inf`/negative).

### Why per-task and not per-CDP-call

The existing per-CDP-call timeout is needed but not sufficient:

- Inner cap (60s): protects a single CDP method from a silent socket.
- Outer cap (this PR, 15s / 8s): protects the *aggregate* of many sequential CDP calls inside one task from exceeding the event-level budget.

Both must hold for the handler to fail fast end to end. The defaults stay well below the 30s `BrowserStateRequestEvent` budget so the per-task cap actually fires before the event-level kill — otherwise it would add nothing over what the event bus already enforces.

### Out of scope

The issue thread also describes a bubus global event-bus lock that serializes unrelated browser sessions during recovery. That's a separate lock-scope problem in `bubus` itself and is not addressed here.

## Test plan

New file: `tests/ci/browser/test_dom_watchdog_timeouts.py`.

- [x] `_parse_env_task_timeout` unit tests — unset/empty falls back, valid value used, `nan`/`inf`/`0`/`-5`/`abc` rejected, small positives (`0.001`) accepted.
- [x] `test_default_timeouts_are_sensible` — invariants: `0 < SCREENSHOT < DOM_BUILD < 30s`.
- [x] `test_dom_build_timeout_returns_minimal_state` — real `BrowserSession` + `pytest-httpserver`; monkeypatch `_build_dom_tree_without_highlights` to await an `asyncio.Event` that is never set (the exact shape of a stale-WS hang). Asserts the handler returns `selector_map == {}`, the screenshot survives independently, and total time < 10s (not the 30s the unwrapped await would have caused).
- [x] `test_screenshot_timeout_returns_state_without_screenshot` — symmetric for the screenshot path; asserts `screenshot is None`, the DOM survives with a real non-empty `selector_map`, and elapsed < 10s.
- [x] `test_healthy_path_preserves_results` — sanity: with default caps the wrap is transparent (real DOM + real screenshot returned).
- [x] `uv run pytest -vxs tests/ci/browser/test_dom_watchdog_timeouts.py` — 9/9 passing.
- [x] `uv run pytest -vx tests/ci/browser/` — 60 passing, 3 skipped (no regressions).
- [x] `uv run pyright` — 0 errors on changed files; full repo 0 errors.
- [x] `uv run ruff check --fix && uv run ruff format` — clean.

Tests follow the project convention (`CLAUDE.md`): no mocking — real `BrowserSession`, real event bus, real Chromium via `pytest-httpserver`. Only the leaf coroutine that normally fans into CDP is swapped via `monkeypatch.setattr` for one that awaits a released `asyncio.Event`, which is the precise shape of the failure mode described in the issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the DOM build and clean screenshot tasks in `DOMWatchdog.on_BrowserStateRequestEvent` with per-task timeouts so a silent browser can’t block the 30s event budget. Fixes #4579 by failing fast and returning a minimal state instead of hanging.

- **Bug Fixes**
  - Wrap awaits with `asyncio.wait_for`: `BROWSER_USE_DOM_BUILD_TIMEOUT_S` (15s) and `BROWSER_USE_SCREENSHOT_TIMEOUT_S` (8s).
  - Defensive env parsing: only finite positive values apply; others fall back to defaults with a warning.
  - On timeout: return empty `selector_map` for DOM or `None` for screenshot; frees the event-bus slot quickly.
  - Complements the per-CDP-call cap and keeps defaults below the 30s event budget.
  - Add regression tests for timeouts and healthy path; fix minor typo in the timeout parser to satisfy codespell.

<sup>Written for commit 49b041b9fedec9cf617856e3f8fd020bff9fa85f. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4862?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

