### PR TITLE
patched python-dotenv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "psutil==7.2.2",
     "pydantic==2.12.5",
     "pyobjc==12.1; platform_system == 'darwin'",
-    "python-dotenv==1.2.1",
+    "python-dotenv==1.2.2",
     "requests==2.33.0",
     "screeninfo==0.8.1; platform_system != 'darwin'",
     "typing-extensions==4.15.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update `python-dotenv` from 1.2.1 to 1.2.2 to pull in upstream patch fixes and keep env loading reliable. No code changes; only the dependency in `pyproject.toml` was bumped.

<sup>Written for commit ab00e1a6acdeac8d193537f13fc83f3ebd63e8e1. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4863?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

