### PR TITLE
fix(mcp): default retry_with_browser_use_agent allowed_domains to None

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -403,8 +403,12 @@ class BrowserUseServer:
 							'allowed_domains': {
 								'type': 'array',
 								'items': {'type': 'string'},
-								'description': 'List of domains the agent is allowed to visit (security feature)',
-								'default': [],
+								'description': (
+									'List of domains the agent is allowed to visit (security feature). '
+									'Omit to use the server-configured profile defaults. '
+									'An empty list is treated the same as omitting the argument and '
+									'will NOT disable server-configured restrictions.'
+								),
 							},
 							'use_vision': {
 								'type': 'boolean',
@@ -490,7 +494,7 @@ class BrowserUseServer:
 				task=arguments['task'],
 				max_steps=arguments.get('max_steps', 100),
 				model=arguments.get('model'),
-				allowed_domains=arguments.get('allowed_domains', []),
+				allowed_domains=arguments.get('allowed_domains'),
 				use_vision=arguments.get('use_vision', True),
 			)
 
@@ -681,8 +685,11 @@ class BrowserUseServer:
 		# Get profile config and merge with tool parameters
 		profile_config = get_default_profile(self.config)
 
-		# Override allowed_domains if provided in tool call
-		if allowed_domains is not None:
+		# Override allowed_domains only when the client supplied a non-empty list.
+		# Treating an empty list as an override would silently disable any
+		# admin-configured allowlist on the default profile, since
+		# SecurityWatchdog interprets allowed_domains=[] as "no restrictions".
+		if allowed_domains:
 			profile_config['allowed_domains'] = allowed_domains
 
 		# Create browser profile using config

--- a/tests/ci/security/test_mcp_allowed_domains.py
+++ b/tests/ci/security/test_mcp_allowed_domains.py
@@ -1,0 +1,100 @@
+"""Tests for MCP server allowed_domains dispatch (GHSA-vfcm-843v-w6v3).
+
+The MCP `retry_with_browser_use_agent` tool used to default `allowed_domains` to
+`[]` when the client omitted the argument. That value was then forwarded to
+`BrowserProfile(allowed_domains=[])`, which `SecurityWatchdog` interprets as
+"no allowlist configured — allow every URL", silently disabling any
+admin-configured restrictions on the underlying profile.
+
+The fix is to default to `None` so the admin-configured profile defaults are
+preserved when the client omits the argument.
+"""
+
+from typing import Any
+
+import pytest
+
+from browser_use.mcp.server import BrowserUseServer
+
+
+@pytest.fixture
+def server() -> BrowserUseServer:
+	return BrowserUseServer()
+
+
+async def test_dispatch_passes_none_when_allowed_domains_omitted(server: BrowserUseServer) -> None:
+	"""Client omits `allowed_domains` → dispatcher must pass `None` to the agent runner."""
+	captured: dict[str, Any] = {}
+
+	async def recording_stub(**kwargs: Any) -> str:
+		captured.update(kwargs)
+		return 'ok'
+
+	server._retry_with_browser_use_agent = recording_stub  # type: ignore[method-assign]
+	await server._execute_tool('retry_with_browser_use_agent', {'task': 'noop'})
+
+	assert 'allowed_domains' in captured, 'dispatcher must forward the allowed_domains kwarg'
+	assert captured['allowed_domains'] is None, (
+		f'Expected None to preserve admin-configured profile defaults; '
+		f'got {captured["allowed_domains"]!r} which would disable SecurityWatchdog '
+		f'when passed as BrowserProfile(allowed_domains=...).'
+	)
+
+
+async def test_dispatch_forwards_explicit_list(server: BrowserUseServer) -> None:
+	"""Explicit non-empty list from client must reach the agent runner unchanged."""
+	captured: dict[str, Any] = {}
+
+	async def recording_stub(**kwargs: Any) -> str:
+		captured.update(kwargs)
+		return 'ok'
+
+	server._retry_with_browser_use_agent = recording_stub  # type: ignore[method-assign]
+	await server._execute_tool(
+		'retry_with_browser_use_agent',
+		{'task': 'noop', 'allowed_domains': ['example.test']},
+	)
+	assert captured['allowed_domains'] == ['example.test']
+
+
+async def test_explicit_empty_list_does_not_override_profile_defaults(server: BrowserUseServer) -> None:
+	"""Defense in depth: even when a client explicitly sends `allowed_domains=[]`,
+	`_retry_with_browser_use_agent` must NOT wipe profile defaults — empty list is
+	semantically equivalent to "no override" for the security boundary."""
+	# Patch the boundary just below the override decision: the BrowserProfile constructor.
+	# We capture the resolved allowed_domains and short-circuit before LLM/agent setup.
+	captured_profile_kwargs: dict[str, Any] = {}
+
+	from browser_use.mcp import server as server_module
+
+	original_browser_profile = server_module.BrowserProfile
+
+	class CapturingBrowserProfile:
+		def __init__(self, **kwargs: Any) -> None:
+			captured_profile_kwargs.update(kwargs)
+			raise _StopAgentSetup('captured')
+
+	server_module.BrowserProfile = CapturingBrowserProfile  # type: ignore[misc]
+
+	# Stub out the LLM construction path so we don't need real credentials —
+	# the override decision happens before BrowserProfile() is called regardless,
+	# but we need _retry_with_browser_use_agent to reach that point.
+	try:
+		with pytest.raises(_StopAgentSetup):
+			await server._retry_with_browser_use_agent(
+				task='noop',
+				allowed_domains=[],
+			)
+	finally:
+		server_module.BrowserProfile = original_browser_profile  # type: ignore[misc]
+
+	# The profile dict should NOT have allowed_domains overridden to [] —
+	# either the key is absent (profile defaults apply) or it carries whatever
+	# the admin-configured default was. Either way: not [].
+	assert captured_profile_kwargs.get('allowed_domains') != [], (
+		'Empty list from client wiped profile defaults — SecurityWatchdog would be disabled.'
+	)
+
+
+class _StopAgentSetup(Exception):
+	"""Marker exception used to short-circuit agent construction during testing."""


### PR DESCRIPTION
## Summary

Closes **GHSA-vfcm-843v-w6v3** (high, `triage`).

`retry_with_browser_use_agent` defaulted `allowed_domains` to `[]` when the MCP client omitted the argument, then forwarded that value to `BrowserProfile(allowed_domains=[])`. `SecurityWatchdog` treats an empty list as "no allowlist configured — allow every URL", silently disabling any admin-configured allowlist on the underlying profile.

## Changes

- `browser_use/mcp/server.py:493` — default changed from `[]` to `None` so admin-configured defaults are preserved when the client omits the argument.
- `browser_use/mcp/server.py:685` — override condition tightened (`if allowed_domains:`) so an explicit empty list from the client is treated as "no override" rather than "wipe the allowlist". Defense-in-depth for clients that round-trip the old schema default.
- `browser_use/mcp/server.py:403-411` — removed the misleading `'default': []` from the tool's input schema and clarified the docstring so MCP clients see the new contract.

## Test plan

- [x] `uv run pytest -vxs tests/ci/security/test_mcp_allowed_domains.py` — 3 new tests cover: (1) omitted arg → `None` forwarded, (2) explicit list forwarded unchanged, (3) explicit `[]` does not wipe profile defaults.
- [x] `uv run pyright browser_use/mcp/server.py tests/ci/security/test_mcp_allowed_domains.py` — clean.
- [x] `uv run ruff check` / `format` — clean.
- [ ] Full `uv run pytest -vxs tests/ci` on CI.

## Notes

This is one of the items in the post-0.12.6 security advisory triage. Other related fixes are in separate PRs so each can be reviewed and merged independently. **Do not auto-merge** — please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a security bug where `retry_with_browser_use_agent` could disable the domain allowlist by default. Omitting `allowed_domains` now preserves server profile defaults; an empty list no longer wipes restrictions (addresses GHSA-vfcm-843v-w6v3).

- **Bug Fixes**
  - Default `allowed_domains` to `None` instead of `[]` when the client omits it.
  - Apply overrides only when `allowed_domains` is a non-empty list.
  - Remove the schema’s `default: []` and clarify the input description to reflect the new contract.

<sup>Written for commit 92defb6eaefca28543dedcf710582f3d485bb751. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4864?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

