### PR TITLE
fix(security): canonicalize non-standard IPv4 forms in block_ip_addresses

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -138,21 +138,34 @@ class SecurityWatchdog(BaseWatchdog):
 	def _is_ip_address(self, host: str) -> bool:
 		"""Check if a hostname is an IP address (IPv4 or IPv6).
 
-		Args:
-			host: The hostname to check
-
-		Returns:
-			True if the host is an IP address, False otherwise
+		Recognizes non-standard IPv4 representations that Chromium resolves but
+		`ipaddress.ip_address()` rejects — decimal (`2130706433`), hex
+		(`0x7f000001`), octal (`0177.0.0.1`), and short forms (`127.1`,
+		`127.0.1`). Without this canonicalization, `block_ip_addresses=True`
+		can be bypassed by simply re-encoding the IP in one of these forms.
+		See GHSA-xrfv-gg9f-wwjp / GHSA-g27c-8gp4-28cv.
 		"""
 		import ipaddress
+		import socket
 
+		# Strip IPv6 bracket wrapping defensively; urlparse usually strips it,
+		# but a malformed url could leak it through.
+		bare = host.strip('[]')
+
+		# Standard dotted-quad IPv4 and full IPv6.
 		try:
-			# Try to parse as IP address (handles both IPv4 and IPv6)
-			ipaddress.ip_address(host)
+			ipaddress.ip_address(bare)
 			return True
-		except ValueError:
-			return False
-		except Exception:
+		except (ValueError, TypeError):
+			pass
+
+		# Non-standard IPv4 forms that the kernel resolver (and browsers) accept:
+		# decimal, hex, octal, and short-form. `inet_aton` is IPv4-only and
+		# accepts all of these; OSError means "not a parseable IPv4 in any form".
+		try:
+			socket.inet_aton(bare)
+			return True
+		except OSError:
 			return False
 
 	def _is_url_allowed(self, url: str) -> bool:

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -136,83 +136,37 @@ class SecurityWatchdog(BaseWatchdog):
 			return (host, f'www.{host}')  # ('example.com', 'www.example.com')
 
 	def _is_ip_address(self, host: str) -> bool:
-		"""Check if a hostname is an IP address (IPv4 or IPv6).
+		"""True iff `host` matches an IPv4 or IPv6 the browser would resolve.
 
-		Mirrors the host canonicalization the browser performs before applying
-		its IPv4 parser, so the classifier sees the same string the network
-		stack would resolve:
-
-		1. Strip IPv6 brackets.
-		2. Percent-decode (`%30x7f000001` → `0x7f000001`).
-		3. NFKC-normalize (fullwidth `１２７.０.０.１` → ASCII `127.0.0.1`;
-		   circled `①②⑦.⓪.⓪.①` → ASCII `127.0.0.1`).
-		4. Try `ipaddress.ip_address` (dotted-quad / IPv6).
-		5. Fall back to `socket.inet_aton` for non-standard IPv4 forms —
-		   decimal (`2130706433`), hex (`0x7f000001`), octal (`0177.0.0.1`),
-		   and short forms (`127.1`, `127.0.1`).
-
-		Without these steps `block_ip_addresses=True` is trivially bypassed by
-		re-encoding the IP in any of those forms.
-
-		See GHSA-xrfv-gg9f-wwjp / GHSA-g27c-8gp4-28cv.
+		Mirrors WHATWG host canonicalization so non-standard IPv4 encodings
+		(decimal, hex, octal, short-form, percent-encoded, Unicode digits)
+		can't bypass `block_ip_addresses`. Never raises — unrecognizable
+		hosts return False and fall through to domain-allowlist handling.
 		"""
 		import ipaddress
 		import socket
 		import unicodedata
 		from urllib.parse import unquote
 
-		# Strip IPv6 bracket wrapping defensively; urlparse usually strips it,
-		# but a malformed url could leak it through.
 		bare = host.strip('[]')
-
-		# Percent-decode the host before parsing. Browsers decode `%XX` escapes
-		# in the host component, so an unencoded check would miss
-		# `%30x7f000001` (→ '0x7f000001') and `%31%32%37.0.0.1` (→ '127.0.0.1').
-		# `unquote` is forgiving (leaves malformed `%`-sequences as-is) but we
-		# still wrap in try/except so any future encoding edge case can never
-		# crash the navigation security check.
 		try:
 			bare = unquote(bare)
 		except Exception:
 			pass
-
-		# NFKC-normalize so Unicode digit variants the browser canonicalizes to
-		# ASCII (fullwidth `１２７`, circled `①②⑦`, etc.) reach the IP parsers
-		# in their ASCII form. NFKC is a stdlib operation that does not raise
-		# for malformed input (surrogates pass through unchanged).
 		try:
 			bare = unicodedata.normalize('NFKC', bare)
 		except Exception:
 			pass
+		# IDNA label separators NFKC misses (U+3002, U+FF61 → U+3002).
+		bare = bare.replace('。', '.').replace('｡', '.')
 
-		# Fold IDNA label separators to ASCII `.`. Per RFC 3490 / UTS46 four
-		# code points act as label separators in IDNA processing: `.` (U+002E),
-		# `。` (U+3002), `．` (U+FF0E), `｡` (U+FF61). NFKC handles U+FF0E only
-		# and maps U+FF61 → U+3002 (still ideographic), leaving the IPv4 parser
-		# unable to match. WHATWG URL parsing folds all four to `.` before
-		# resolution, so we must do the same.
-		for _dot in ('。', '｡'):
-			if _dot in bare:
-				bare = bare.replace(_dot, '.')
-
-		# Standard dotted-quad IPv4 and full IPv6.
 		try:
 			ipaddress.ip_address(bare)
 			return True
-		except (ValueError, TypeError):
-			pass
 		except Exception:
-			# Be defensively conservative: any parser-internal failure means
-			# "we can't recognize this as a standard IP", not "crash the
-			# navigation security check". Falls through to inet_aton.
 			pass
-
-		# Non-standard IPv4 forms that the kernel resolver (and browsers) accept:
-		# decimal, hex, octal, and short-form. `inet_aton` is IPv4-only and
-		# accepts all of these; OSError means "not a parseable IPv4 in any form".
-		# It can also raise other exceptions (e.g. `UnicodeEncodeError` for
-		# lone-surrogate hostnames from URL-decoded malformed UTF-8) — treat
-		# any failure as "not a recognizable IP", never propagate.
+		# Non-standard IPv4 (decimal, hex, octal, short-form) — `inet_aton`
+		# accepts the same liberal forms the kernel resolver does.
 		try:
 			socket.inet_aton(bare)
 			return True

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -138,19 +138,27 @@ class SecurityWatchdog(BaseWatchdog):
 	def _is_ip_address(self, host: str) -> bool:
 		"""Check if a hostname is an IP address (IPv4 or IPv6).
 
-		Recognizes non-standard IPv4 representations that Chromium resolves but
-		`ipaddress.ip_address()` rejects — decimal (`2130706433`), hex
-		(`0x7f000001`), octal (`0177.0.0.1`), and short forms (`127.1`,
-		`127.0.1`). Also percent-decodes the host first, since Chromium decodes
-		`%XX` escapes before applying its IPv4 parser; without that step,
-		`http://%30x7f000001/` (decodes to `0x7f000001` → 127.0.0.1) and
-		`http://%31%32%37.0.0.1/` (decodes to `127.0.0.1`) would still bypass
-		`block_ip_addresses`.
+		Mirrors the host canonicalization the browser performs before applying
+		its IPv4 parser, so the classifier sees the same string the network
+		stack would resolve:
+
+		1. Strip IPv6 brackets.
+		2. Percent-decode (`%30x7f000001` → `0x7f000001`).
+		3. NFKC-normalize (fullwidth `１２７.０.０.１` → ASCII `127.0.0.1`;
+		   circled `①②⑦.⓪.⓪.①` → ASCII `127.0.0.1`).
+		4. Try `ipaddress.ip_address` (dotted-quad / IPv6).
+		5. Fall back to `socket.inet_aton` for non-standard IPv4 forms —
+		   decimal (`2130706433`), hex (`0x7f000001`), octal (`0177.0.0.1`),
+		   and short forms (`127.1`, `127.0.1`).
+
+		Without these steps `block_ip_addresses=True` is trivially bypassed by
+		re-encoding the IP in any of those forms.
 
 		See GHSA-xrfv-gg9f-wwjp / GHSA-g27c-8gp4-28cv.
 		"""
 		import ipaddress
 		import socket
+		import unicodedata
 		from urllib.parse import unquote
 
 		# Strip IPv6 bracket wrapping defensively; urlparse usually strips it,
@@ -165,6 +173,15 @@ class SecurityWatchdog(BaseWatchdog):
 		# crash the navigation security check.
 		try:
 			bare = unquote(bare)
+		except Exception:
+			pass
+
+		# NFKC-normalize so Unicode digit variants the browser canonicalizes to
+		# ASCII (fullwidth `１２７`, circled `①②⑦`, etc.) reach the IP parsers
+		# in their ASCII form. NFKC is a stdlib operation that does not raise
+		# for malformed input (surrogates pass through unchanged).
+		try:
+			bare = unicodedata.normalize('NFKC', bare)
 		except Exception:
 			pass
 

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -158,14 +158,22 @@ class SecurityWatchdog(BaseWatchdog):
 			return True
 		except (ValueError, TypeError):
 			pass
+		except Exception:
+			# Be defensively conservative: any parser-internal failure means
+			# "we can't recognize this as a standard IP", not "crash the
+			# navigation security check". Falls through to inet_aton.
+			pass
 
 		# Non-standard IPv4 forms that the kernel resolver (and browsers) accept:
 		# decimal, hex, octal, and short-form. `inet_aton` is IPv4-only and
 		# accepts all of these; OSError means "not a parseable IPv4 in any form".
+		# It can also raise other exceptions (e.g. `UnicodeEncodeError` for
+		# lone-surrogate hostnames from URL-decoded malformed UTF-8) — treat
+		# any failure as "not a recognizable IP", never propagate.
 		try:
 			socket.inet_aton(bare)
 			return True
-		except OSError:
+		except Exception:
 			return False
 
 	def _is_url_allowed(self, url: str) -> bool:

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -141,16 +141,32 @@ class SecurityWatchdog(BaseWatchdog):
 		Recognizes non-standard IPv4 representations that Chromium resolves but
 		`ipaddress.ip_address()` rejects — decimal (`2130706433`), hex
 		(`0x7f000001`), octal (`0177.0.0.1`), and short forms (`127.1`,
-		`127.0.1`). Without this canonicalization, `block_ip_addresses=True`
-		can be bypassed by simply re-encoding the IP in one of these forms.
+		`127.0.1`). Also percent-decodes the host first, since Chromium decodes
+		`%XX` escapes before applying its IPv4 parser; without that step,
+		`http://%30x7f000001/` (decodes to `0x7f000001` → 127.0.0.1) and
+		`http://%31%32%37.0.0.1/` (decodes to `127.0.0.1`) would still bypass
+		`block_ip_addresses`.
+
 		See GHSA-xrfv-gg9f-wwjp / GHSA-g27c-8gp4-28cv.
 		"""
 		import ipaddress
 		import socket
+		from urllib.parse import unquote
 
 		# Strip IPv6 bracket wrapping defensively; urlparse usually strips it,
 		# but a malformed url could leak it through.
 		bare = host.strip('[]')
+
+		# Percent-decode the host before parsing. Browsers decode `%XX` escapes
+		# in the host component, so an unencoded check would miss
+		# `%30x7f000001` (→ '0x7f000001') and `%31%32%37.0.0.1` (→ '127.0.0.1').
+		# `unquote` is forgiving (leaves malformed `%`-sequences as-is) but we
+		# still wrap in try/except so any future encoding edge case can never
+		# crash the navigation security check.
+		try:
+			bare = unquote(bare)
+		except Exception:
+			pass
 
 		# Standard dotted-quad IPv4 and full IPv6.
 		try:

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -185,6 +185,16 @@ class SecurityWatchdog(BaseWatchdog):
 		except Exception:
 			pass
 
+		# Fold IDNA label separators to ASCII `.`. Per RFC 3490 / UTS46 four
+		# code points act as label separators in IDNA processing: `.` (U+002E),
+		# `。` (U+3002), `．` (U+FF0E), `｡` (U+FF61). NFKC handles U+FF0E only
+		# and maps U+FF61 → U+3002 (still ideographic), leaving the IPv4 parser
+		# unable to match. WHATWG URL parsing folds all four to `.` before
+		# resolution, so we must do the same.
+		for _dot in ('。', '｡'):
+			if _dot in bare:
+				bare = bare.replace(_dot, '.')
+
 		# Standard dotted-quad IPv4 and full IPv6.
 		try:
 			ipaddress.ip_address(bare)

--- a/tests/ci/security/test_ip_blocking.py
+++ b/tests/ci/security/test_ip_blocking.py
@@ -618,3 +618,35 @@ class TestNonStandardIPv4Representations:
 		assert watchdog._is_ip_address('%') is False
 		assert watchdog._is_ip_address('%zz') is False
 		assert watchdog._is_ip_address('%2') is False
+
+	def test_unicode_normalized_ipv4_blocked(self):
+		"""Hostnames using fullwidth, circled, or other Unicode digit variants
+		that NFKC/IDNA-normalize to ASCII IPv4 literals must be blocked.
+
+		WHATWG URL canonicalization maps `１２７.０.０.１` (fullwidth digits),
+		`０x7f000001` (fullwidth zero + ASCII hex), and `①②⑦.⓪.⓪.①` (circled
+		digits) all to `127.0.0.1`. Without NFKC normalization in the
+		classifier, the new non-standard IPv4 blocking can be bypassed with
+		any equivalent Unicode digit form.
+		"""
+		watchdog = self._watchdog()
+		# Fullwidth digits (U+FF10..U+FF19) — NFKC → ASCII digits.
+		assert watchdog._is_url_allowed('http://１２７.０.０.１/') is False
+		# Fullwidth zero + ASCII hex 7f000001.
+		assert watchdog._is_url_allowed('http://０x7f000001/') is False
+		# Circled digits (U+2460+, U+24EA for zero).
+		assert watchdog._is_url_allowed('http://①②⑦.⓪.⓪.①/') is False
+		# Direct classifier checks.
+		assert watchdog._is_ip_address('１２７.０.０.１') is True
+		assert watchdog._is_ip_address('０x7f000001') is True
+		assert watchdog._is_ip_address('①②⑦.⓪.⓪.①') is True
+
+	def test_idn_domains_not_misclassified_as_ip(self):
+		"""Defense against false positives from the new normalization step:
+		legitimate IDN domains (Unicode letters / punycode) MUST NOT be
+		classified as IPs after NFKC."""
+		watchdog = self._watchdog()
+		assert watchdog._is_ip_address('café.example') is False
+		assert watchdog._is_ip_address('xn--caf-dma.example') is False
+		assert watchdog._is_ip_address('日本.example') is False
+		assert watchdog._is_ip_address('xn--wgv71a.example') is False

--- a/tests/ci/security/test_ip_blocking.py
+++ b/tests/ci/security/test_ip_blocking.py
@@ -650,3 +650,26 @@ class TestNonStandardIPv4Representations:
 		assert watchdog._is_ip_address('xn--caf-dma.example') is False
 		assert watchdog._is_ip_address('日本.example') is False
 		assert watchdog._is_ip_address('xn--wgv71a.example') is False
+
+	def test_idna_dot_separators_blocked(self):
+		"""Per RFC 3490 / UTS46, four code points act as label separators in
+		IDNA processing — `.` (U+002E), `。` (U+3002 IDEOGRAPHIC FULL STOP),
+		`．` (U+FF0E FULLWIDTH FULL STOP), `｡` (U+FF61 HALFWIDTH IDEOGRAPHIC
+		FULL STOP). WHATWG URL parsing maps all four to `.` before resolution,
+		so `http://127。0。0。1/` etc. reach 127.0.0.1.
+
+		NFKC alone is insufficient — it maps U+FF0E → U+002E and U+FF61 →
+		U+3002, but leaves U+3002 (the most common one) untouched. Classifier
+		must additionally fold U+3002 and U+FF61 to U+002E before IP parsing.
+		"""
+		watchdog = self._watchdog()
+		# All four dot variants must result in the IP being blocked.
+		assert watchdog._is_url_allowed('http://127。0。0。1/') is False  # U+3002
+		assert watchdog._is_url_allowed('http://127｡0｡0｡1/') is False  # U+FF61
+		assert watchdog._is_url_allowed('http://127．0．0．1/') is False  # U+FF0E
+		# Combined with circled-digit normalization.
+		assert watchdog._is_url_allowed('http://①②⑦。⓪。⓪。①/') is False
+		# Direct classifier checks.
+		assert watchdog._is_ip_address('127。0。0。1') is True
+		assert watchdog._is_ip_address('127｡0｡0｡1') is True
+		assert watchdog._is_ip_address('127．0．0．1') is True

--- a/tests/ci/security/test_ip_blocking.py
+++ b/tests/ci/security/test_ip_blocking.py
@@ -572,3 +572,19 @@ class TestNonStandardIPv4Representations:
 		assert watchdog._is_url_allowed('http://0x7f000001/') is False
 		# Sanity: legitimate domains still allowed.
 		assert watchdog._is_url_allowed('https://example.com/') is True
+
+	def test_malformed_unicode_hostnames_do_not_crash_classifier(self):
+		"""Hostnames with lone surrogates (e.g. `\\udcff` from URL-decoded
+		malformed UTF-8) must not crash `_is_ip_address` — `socket.inet_aton`
+		raises `UnicodeEncodeError` (not `OSError`) for surrogates, and the
+		classifier must treat that as "not an IP" rather than propagating.
+
+		Pre-existing defensive behavior in the original code (caught
+		`Exception`) — must be preserved when extending with `inet_aton`.
+		"""
+		watchdog = self._watchdog()
+		# Lone surrogates — common in URLs containing percent-encoded malformed UTF-8.
+		assert watchdog._is_ip_address('\udcff') is False
+		assert watchdog._is_ip_address('\ud800') is False
+		assert watchdog._is_ip_address('caf\udce9.local') is False
+		assert watchdog._is_ip_address('\udcff.example.com') is False

--- a/tests/ci/security/test_ip_blocking.py
+++ b/tests/ci/security/test_ip_blocking.py
@@ -299,17 +299,22 @@ class TestEdgeCases:
 		assert watchdog._is_url_allowed('chrome://newtab/') is True
 
 	def test_ipv4_lookalike_domains_allowed(self):
-		"""Test that domains that look like IPs but aren't are still allowed."""
+		"""Test that strings that look like IPs but cannot be resolved as IPs by
+		the kernel/browser are still treated as domain names and allowed.
+
+		Note: short-form IPv4 strings such as `1.2.3` (which Chromium resolves
+		as `1.2.0.3`) ARE recognized as IPs — see TestNonStandardIPv4Representations.
+		"""
 		browser_profile = BrowserProfile(block_ip_addresses=True, headless=True, user_data_dir=None)
 		browser_session = BrowserSession(browser_profile=browser_profile)
 		event_bus = EventBus()
 		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
 
-		# These look like IPs but have too many/few octets or invalid ranges
-		# The IP parser should reject them, so they're treated as domain names
-		assert watchdog._is_url_allowed('http://999.999.999.999/') is True  # Invalid IP range
-		assert watchdog._is_url_allowed('http://1.2.3.4.5/') is True  # Too many octets
-		assert watchdog._is_url_allowed('http://1.2.3/') is True  # Too few octets
+		# These look like IPs but cannot resolve as IPv4 in any form the browser accepts:
+		# - 999.999.999.999: out of range for every octet
+		# - 1.2.3.4.5: too many octets
+		assert watchdog._is_url_allowed('http://999.999.999.999/') is True
+		assert watchdog._is_url_allowed('http://1.2.3.4.5/') is True
 
 	def test_different_schemes_with_ips(self):
 		"""Test that IP blocking works across different URL schemes."""
@@ -373,12 +378,14 @@ class TestIsIPAddressHelper:
 		assert watchdog._is_ip_address('www.google.com') is False
 		assert watchdog._is_ip_address('localhost') is False
 
-		# Invalid IPs
+		# Invalid IPs (rejected by both ipaddress and inet_aton)
 		assert watchdog._is_ip_address('999.999.999.999') is False
-		assert watchdog._is_ip_address('1.2.3') is False
 		assert watchdog._is_ip_address('1.2.3.4.5') is False
 		assert watchdog._is_ip_address('not-an-ip') is False
 		assert watchdog._is_ip_address('') is False
+
+		# Short-form IPv4 strings (1.2.3 == 1.2.0.3) ARE valid IPs that
+		# browsers/kernel resolve — covered by TestNonStandardIPv4Representations.
 
 		# IPs with ports or paths (not valid for the helper - it only checks hostnames)
 		assert watchdog._is_ip_address('192.168.1.1:8080') is False
@@ -487,3 +494,81 @@ class TestComplexScenarios:
 
 		# Even localhost blocked
 		assert watchdog._is_url_allowed('http://127.0.0.1/') is False
+
+
+class TestNonStandardIPv4Representations:
+	"""Regression tests for GHSA-xrfv-gg9f-wwjp / GHSA-g27c-8gp4-28cv.
+
+	`ipaddress.ip_address()` only accepts the canonical dotted-quad form, but
+	Chromium also resolves decimal, hex, octal, and short-form IPv4 strings.
+	Without canonicalization, `block_ip_addresses=True` could be bypassed via:
+
+	  http://2130706433/      → 127.0.0.1 (decimal)
+	  http://0x7f000001/      → 127.0.0.1 (hex)
+	  http://0177.0.0.1/      → 127.0.0.1 (octal)
+	  http://127.1/           → 127.0.0.1 (short-form)
+	  http://127.0.1/         → 127.0.0.1 (short-form)
+	"""
+
+	def _watchdog(self) -> SecurityWatchdog:
+		profile = BrowserProfile(block_ip_addresses=True, headless=True, user_data_dir=None)
+		session = BrowserSession(browser_profile=profile)
+		return SecurityWatchdog(browser_session=session, event_bus=EventBus())
+
+	def test_decimal_ipv4_blocked(self):
+		"""Decimal integer IPv4 strings (browser-accepted) must be blocked."""
+		watchdog = self._watchdog()
+		assert watchdog._is_url_allowed('http://2130706433/') is False  # 127.0.0.1
+		assert watchdog._is_url_allowed('http://3232235521/') is False  # 192.168.0.1
+
+	def test_hex_ipv4_blocked(self):
+		"""Hex IPv4 strings (browser-accepted) must be blocked."""
+		watchdog = self._watchdog()
+		assert watchdog._is_url_allowed('http://0x7f000001/') is False  # 127.0.0.1
+		assert watchdog._is_url_allowed('http://0x7F.0x0.0x0.0x1/') is False
+
+	def test_octal_ipv4_blocked(self):
+		"""Octal IPv4 strings (browser-accepted) must be blocked."""
+		watchdog = self._watchdog()
+		assert watchdog._is_url_allowed('http://0177.0.0.1/') is False  # 127.0.0.1
+
+	def test_short_form_ipv4_blocked(self):
+		"""Short-form IPv4 strings (browser-accepted) must be blocked."""
+		watchdog = self._watchdog()
+		assert watchdog._is_url_allowed('http://127.1/') is False
+		assert watchdog._is_url_allowed('http://127.0.1/') is False
+		assert watchdog._is_url_allowed('http://10.1/') is False
+
+	def test_lookalike_domains_still_allowed(self):
+		"""Hostnames that look IP-ish but are not (e.g. embedded labels) must
+		remain unaffected — only browser-resolvable IP forms should be blocked."""
+		watchdog = self._watchdog()
+		# Real domains, not IPs — should not be incorrectly blocked.
+		assert watchdog._is_url_allowed('http://127.0.0.1.evil.com/') is True
+		assert watchdog._is_url_allowed('http://2130706433.evil.com/') is True
+		assert watchdog._is_url_allowed('http://example.com/') is True
+
+	def test_non_standard_forms_allowed_when_blocking_disabled(self):
+		"""Without block_ip_addresses, non-standard IPv4 strings are not blocked."""
+		profile = BrowserProfile(block_ip_addresses=False, headless=True, user_data_dir=None)
+		session = BrowserSession(browser_profile=profile)
+		watchdog = SecurityWatchdog(browser_session=session, event_bus=EventBus())
+		assert watchdog._is_url_allowed('http://2130706433/') is True
+		assert watchdog._is_url_allowed('http://0x7f000001/') is True
+
+	def test_non_standard_forms_blocked_inside_allowed_domains(self):
+		"""block_ip_addresses must override allowed_domains for non-standard forms
+		just as it does for the canonical form."""
+		profile = BrowserProfile(
+			block_ip_addresses=True,
+			allowed_domains=['*'],
+			headless=True,
+			user_data_dir=None,
+		)
+		session = BrowserSession(browser_profile=profile)
+		watchdog = SecurityWatchdog(browser_session=session, event_bus=EventBus())
+		# Even with '*' allowlist, the IP block must still fire.
+		assert watchdog._is_url_allowed('http://2130706433/') is False
+		assert watchdog._is_url_allowed('http://0x7f000001/') is False
+		# Sanity: legitimate domains still allowed.
+		assert watchdog._is_url_allowed('https://example.com/') is True

--- a/tests/ci/security/test_ip_blocking.py
+++ b/tests/ci/security/test_ip_blocking.py
@@ -588,3 +588,33 @@ class TestNonStandardIPv4Representations:
 		assert watchdog._is_ip_address('\ud800') is False
 		assert watchdog._is_ip_address('caf\udce9.local') is False
 		assert watchdog._is_ip_address('\udcff.example.com') is False
+
+	def test_percent_encoded_ipv4_blocked(self):
+		"""Percent-encoded hostnames that decode to IPs must be blocked.
+
+		Chromium percent-decodes the host before resolving — so
+		`http://%30x7f000001/` decodes to `0x7f000001` → `127.0.0.1`, and
+		`http://%31%32%37.0.0.1/` decodes to `127.0.0.1`. Without
+		percent-decoding inside the classifier, the IP block is bypassed
+		whenever the URL contains any `%`-encoded host bytes.
+		"""
+		watchdog = self._watchdog()
+		# Mixed encoding: %30 = '0', rest literal → '0x7f000001'
+		assert watchdog._is_url_allowed('http://%30x7f000001/') is False
+		# Fully encoded canonical form: %31%32%37 = '127'
+		assert watchdog._is_url_allowed('http://%31%32%37.0.0.1/') is False
+		# Fully encoded decimal form: → '2130706433'
+		assert watchdog._is_url_allowed('http://%32%31%33%30%37%30%36%34%33%33/') is False
+		# Direct classifier checks for the same decoded forms.
+		assert watchdog._is_ip_address('%30x7f000001') is True
+		assert watchdog._is_ip_address('%31%32%37.0.0.1') is True
+		assert watchdog._is_ip_address('%32%31%33%30%37%30%36%34%33%33') is True
+
+	def test_malformed_percent_encoding_does_not_crash(self):
+		"""Hostnames with malformed `%` escapes must not crash the classifier."""
+		watchdog = self._watchdog()
+		# `unquote` leaves bad `%`-sequences as-is; we must still treat the
+		# result as a non-IP rather than blowing up.
+		assert watchdog._is_ip_address('%') is False
+		assert watchdog._is_ip_address('%zz') is False
+		assert watchdog._is_ip_address('%2') is False


### PR DESCRIPTION
## Summary

Closes **GHSA-xrfv-gg9f-wwjp** and **GHSA-g27c-8gp4-28cv** (both high, `triage`, duplicate reports).

`SecurityWatchdog._is_ip_address` only recognized IP strings that `ipaddress.ip_address()` accepts — i.e. the canonical dotted-quad form and full IPv6. Chromium and the kernel resolver, however, also accept several non-standard IPv4 representations:

| Form | Resolves to |
|------|-------------|
| `http://2130706433/` | `127.0.0.1` (decimal int) |
| `http://0x7f000001/` | `127.0.0.1` (hex) |
| `http://0177.0.0.1/` | `127.0.0.1` (octal) |
| `http://127.1/`      | `127.0.0.1` (short-form) |
| `http://127.0.1/`    | `127.0.0.1` (short-form) |

`block_ip_addresses=True` was therefore trivially bypassed by re-encoding the IP in any of these forms.

## Changes

- `browser_use/browser/watchdogs/security_watchdog.py:_is_ip_address` — after `ipaddress.ip_address()` fails, fall back to `socket.inet_aton`. `inet_aton` accepts the same liberal IPv4 forms the kernel resolver does, so the classifier matches the browser's behavior.
- IPv6 brackets stripped defensively before parsing.

## Test plan

- [x] `uv run pytest -vxs tests/ci/security/test_ip_blocking.py` — 34/34 pass.
- [x] New `TestNonStandardIPv4Representations` class covers: decimal, hex, octal, short-form blocking; lookalike-domain non-interference (`127.0.0.1.evil.com`, `2130706433.evil.com`); interaction with `block_ip_addresses=False`; interaction with `allowed_domains=['*']`.
- [x] Existing `test_ipv4_lookalike_domains_allowed` was codifying the buggy behavior for `1.2.3` (which IS a short-form IPv4 == 1.2.0.3 that Chromium resolves). Removed that assertion and documented the cross-reference.
- [x] `uv run pyright` / `ruff check` / `ruff format` — clean.
- [ ] Full `uv run pytest -vxs tests/ci` on CI.

## Notes

Part of the post-0.12.6 security advisory triage. **Do not auto-merge** — please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes GHSA-xrfv-gg9f-wwjp and GHSA-g27c-8gp4-28cv by canonicalizing non-standard, percent-encoded, Unicode-variant, and IDNA-dot IPv4 hostnames so `block_ip_addresses=True` can’t be bypassed. Aligns detection with browser/kernel behavior by stripping IPv6 brackets, percent-decoding, NFKC-normalizing, folding IDNA label separators to `.`, and falling back to `socket.inet_aton`; also simplifies the `_is_ip_address` docstring with no behavior change.

- **Bug Fixes**
  - In `_is_ip_address`, strip `[]`, percent-decode, NFKC-normalize, fold `。`/`｡`/`．` to `.`, try `ipaddress.ip_address()`, then fall back to `socket.inet_aton` to catch decimal/hex/octal/short IPv4 (including `%XX`-encoded and Unicode-digit forms); catch all exceptions; lookalike domains (e.g., `127.0.0.1.evil.com`) remain allowed.

- **Tests**
  - Added coverage for decimal/hex/octal/short IPv4 forms, percent-encoded hosts, Unicode digit variants, IDNA dot separators (`。` `｡` `．`), IDN domains not misclassified, and malformed Unicode or `%` escapes; removed the outdated `1.2.3` assertion.

<sup>Written for commit 4866656bba7446a3e62c476c21d9dedeca9832c0. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4866?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

