### PR TITLE
Bump version from 0.12.6 to 0.12.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.12.6"
+version = "0.12.7"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps `browser-use` version from 0.12.6 to 0.12.7 to publish a patch release. Only updates pyproject.toml.

<sup>Written for commit c7085726d2c2dc640f93f43c304d78a5d5100ecb. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4869?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

