### PR TITLE
fix(daemon): restrict unix socket file to owner-only access

### DIFF
--- a/browser_use/skill_cli/daemon.py
+++ b/browser_use/skill_cli/daemon.py
@@ -398,10 +398,21 @@ class Daemon:
 		else:
 			# Unix: socket server
 			Path(sock_path).unlink(missing_ok=True)
-			self._server = await asyncio.start_unix_server(
-				self.handle_connection,
-				sock_path,
-			)
+			# Restrict the socket file to owner-only access. The HMAC auth token
+			# gates dispatch, but a permissive socket lets co-tenants probe.
+			old_umask = os.umask(0o077)
+			try:
+				self._server = await asyncio.start_unix_server(
+					self.handle_connection,
+					sock_path,
+				)
+			finally:
+				os.umask(old_umask)
+			# umask only floors permissions at creation; enforce 0o600 explicitly.
+			try:
+				os.chmod(sock_path, 0o600)
+			except OSError as e:
+				logger.warning(f'Could not chmod socket {sock_path} to 0o600: {e}')
 			logger.info(f'Listening on Unix socket {sock_path}')
 
 		# Write PID file after server is bound

--- a/tests/ci/security/test_daemon_socket_perms.py
+++ b/tests/ci/security/test_daemon_socket_perms.py
@@ -1,0 +1,77 @@
+"""Tests for daemon Unix socket file permissions.
+
+The HMAC auth token gates command dispatch, but the socket file itself is left
+world-accessible by `asyncio.start_unix_server`. On multi-user hosts that lets
+a hostile co-tenant `connect()` and probe behavior even before the handshake
+fails. The fix is to `chmod 0o600` the socket file right after bind, mirroring
+the auth-token file's permissions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from browser_use.skill_cli.daemon import Daemon
+
+skip_on_windows = pytest.mark.skipif(
+	sys.platform == 'win32',
+	reason='Daemon uses TCP, not Unix sockets, on Windows.',
+)
+
+
+@skip_on_windows
+async def test_daemon_unix_socket_file_is_0o600(monkeypatch: pytest.MonkeyPatch) -> None:
+	"""After bind, the Unix socket file must have permissions 0o600 (owner rw only)."""
+	# AF_UNIX paths are capped at ~104 bytes on macOS / ~108 on Linux, so the
+	# default pytest tmp_path (deep folders/...) is too long. Use a short /tmp dir.
+	short_home = Path(tempfile.mkdtemp(prefix='bu-perm-', dir='/tmp'))
+	monkeypatch.setenv('BROWSER_USE_HOME', str(short_home))
+
+	daemon = Daemon(headed=False, profile=None, session='perm_test')
+
+	run_task = asyncio.create_task(daemon.run())
+
+	from browser_use.skill_cli.utils import get_socket_path
+
+	sock_path = Path(get_socket_path('perm_test'))
+	# Wait for the daemon to bind. start_unix_server creates the file; the chmod
+	# (after the fix) runs immediately after.
+	for _ in range(100):
+		if sock_path.exists():
+			break
+		if run_task.done():
+			# Surface any exception that killed run() before the bind.
+			exc = run_task.exception()
+			if exc:
+				raise AssertionError(f'daemon.run() exited before binding socket: {exc!r}') from exc
+			pytest.fail('daemon.run() returned cleanly before binding socket')
+		await asyncio.sleep(0.1)
+	else:
+		run_task.cancel()
+		pytest.fail(f'daemon never created socket at {sock_path}')
+
+	try:
+		mode = stat.S_IMODE(os.stat(sock_path).st_mode)
+		assert mode == 0o600, (
+			f'Socket file at {sock_path} has mode {oct(mode)}, expected 0o600. '
+			f'World/group access lets co-tenants probe the daemon before the auth handshake.'
+		)
+	finally:
+		daemon._shutdown_event.set()
+		try:
+			await asyncio.wait_for(run_task, timeout=5)
+		except (TimeoutError, asyncio.CancelledError):
+			run_task.cancel()
+			try:
+				await run_task
+			except (asyncio.CancelledError, Exception):
+				pass
+		shutil.rmtree(short_home, ignore_errors=True)


### PR DESCRIPTION
## Summary

The per-session HMAC auth token (commit `de14b9aa`, pre-0.12.6) gates command dispatch on the daemon, but `asyncio.start_unix_server` creates the socket file with the process umask — which is `0o022` by default, leaving the socket at `0o755` (`srwxr-xr-x`). On multi-user hosts a co-tenant can `connect()` and probe behavior even though the handshake will ultimately fail.

This is the remaining sub-issue tracked by **GHSA-x6mv-rq4m-58g8** (the RCE primitive itself was already closed by the auth-token fix).

## Changes

- `browser_use/skill_cli/daemon.py:399-415` — wrap `start_unix_server` with `os.umask(0o077)` and explicitly `os.chmod(sock_path, 0o600)` after bind. Matches the posture of the auth-token file at line 353.

## Test plan

- [x] `uv run pytest -vxs tests/ci/security/test_daemon_socket_perms.py` — new test starts a real Daemon, waits for the bind, asserts os.stat returns 0o600, signals shutdown. Pre-fix this failed with 0o755. Uses /tmp for BROWSER_USE_HOME so the AF_UNIX path stays under the 104-byte macOS cap.
- [x] pyright / ruff check / ruff format — clean.

## Notes

Part of the post-0.12.7 security cleanup. **Do not auto-merge** — please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down the daemon’s Unix socket to owner-only access to block co-tenant probing on multi-user hosts. Addresses the remaining sub-issue from GHSA-x6mv-rq4m-58g8.

- **Bug Fixes**
  - Enforce owner-only permissions on the Unix socket: wrap `asyncio.start_unix_server` with `os.umask(0o077)` and explicitly `chmod(sock_path, 0o600)` after bind; logs a warning if chmod fails. Aligns with the auth-token file posture.
  - Add `tests/ci/security/test_daemon_socket_perms.py` to assert the socket mode is `0o600` after startup (skipped on Windows).

<sup>Written for commit 8c41cf795a0be1f84ed422897ffa866b1f4181c3. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4870?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

