### PR TITLE
fix(tools): refuse evaluate() on restricted browser profiles

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1775,23 +1775,15 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			terminates_sequence=True,
 		)
 		async def evaluate(code: str, browser_session: BrowserSession):
-			# Refuse on restricted profiles. SecurityWatchdog only hooks navigation,
-			# so evaluate() would otherwise let the agent fetch() internal URLs or
-			# read cookies/localStorage from any allowed origin's context, nullifying
-			# the configured restrictions entirely.
+			# SecurityWatchdog only hooks navigation, so evaluate() would bypass
+			# profile restrictions via fetch() / direct origin access.
 			profile = browser_session.browser_profile
 			if profile.allowed_domains or profile.prohibited_domains or profile.block_ip_addresses:
 				return ActionResult(
-					error=(
-						'evaluate() is disabled when allowed_domains, prohibited_domains, or '
-						'block_ip_addresses is set — this profile is configured as restricted, '
-						'and evaluate() would let an agent bypass those restrictions via fetch() '
-						'and direct origin access. Run on an unrestricted profile if you need '
-						'JS evaluation.'
-					)
+					error='evaluate() is disabled on profiles configured with allowed_domains, '
+					'prohibited_domains, or block_ip_addresses.'
 				)
 
-			# Execute JavaScript with proper error handling and promise support
 			cdp_session = await browser_session.get_or_create_cdp_session()
 
 			try:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1778,15 +1778,16 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			# Refuse on restricted profiles. SecurityWatchdog only hooks navigation,
 			# so evaluate() would otherwise let the agent fetch() internal URLs or
 			# read cookies/localStorage from any allowed origin's context, nullifying
-			# allowed_domains / block_ip_addresses entirely.
+			# the configured restrictions entirely.
 			profile = browser_session.browser_profile
-			if profile.allowed_domains or profile.block_ip_addresses:
+			if profile.allowed_domains or profile.prohibited_domains or profile.block_ip_addresses:
 				return ActionResult(
 					error=(
-						'evaluate() is disabled when allowed_domains or block_ip_addresses '
-						'is set — this profile is configured as restricted, and evaluate() '
-						'would let an agent bypass those restrictions via fetch() and direct '
-						'origin access. Run on an unrestricted profile if you need JS evaluation.'
+						'evaluate() is disabled when allowed_domains, prohibited_domains, or '
+						'block_ip_addresses is set — this profile is configured as restricted, '
+						'and evaluate() would let an agent bypass those restrictions via fetch() '
+						'and direct origin access. Run on an unrestricted profile if you need '
+						'JS evaluation.'
 					)
 				)
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1775,8 +1775,22 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			terminates_sequence=True,
 		)
 		async def evaluate(code: str, browser_session: BrowserSession):
-			# Execute JavaScript with proper error handling and promise support
+			# Refuse on restricted profiles. SecurityWatchdog only hooks navigation,
+			# so evaluate() would otherwise let the agent fetch() internal URLs or
+			# read cookies/localStorage from any allowed origin's context, nullifying
+			# allowed_domains / block_ip_addresses entirely.
+			profile = browser_session.browser_profile
+			if profile.allowed_domains or profile.block_ip_addresses:
+				return ActionResult(
+					error=(
+						'evaluate() is disabled when allowed_domains or block_ip_addresses '
+						'is set — this profile is configured as restricted, and evaluate() '
+						'would let an agent bypass those restrictions via fetch() and direct '
+						'origin access. Run on an unrestricted profile if you need JS evaluation.'
+					)
+				)
 
+			# Execute JavaScript with proper error handling and promise support
 			cdp_session = await browser_session.get_or_create_cdp_session()
 
 			try:

--- a/tests/ci/security/test_evaluate_restricted.py
+++ b/tests/ci/security/test_evaluate_restricted.py
@@ -24,8 +24,14 @@ from browser_use.tools.service import Tools
 
 
 class _StubProfile:
-	def __init__(self, allowed_domains: Any = None, block_ip_addresses: bool = False) -> None:
+	def __init__(
+		self,
+		allowed_domains: Any = None,
+		prohibited_domains: Any = None,
+		block_ip_addresses: bool = False,
+	) -> None:
 		self.allowed_domains = allowed_domains
+		self.prohibited_domains = prohibited_domains
 		self.block_ip_addresses = block_ip_addresses
 
 
@@ -68,6 +74,15 @@ async def test_evaluate_refused_when_block_ip_addresses_set() -> None:
 	result = await _run_evaluate(_StubProfile(block_ip_addresses=True))
 	assert result.error is not None
 	assert 'block_ip_addresses' in result.error.lower() or 'restricted' in result.error.lower()
+
+
+async def test_evaluate_refused_when_prohibited_domains_set() -> None:
+	"""`prohibited_domains` is the deny-list counterpart of `allowed_domains`;
+	SecurityWatchdog enforces both as navigation restrictions. Refuse evaluate()
+	when either is set — otherwise an agent can fetch() into the blocked domains."""
+	result = await _run_evaluate(_StubProfile(prohibited_domains=['evil.test']))
+	assert result.error is not None
+	assert 'prohibited_domains' in result.error.lower() or 'restricted' in result.error.lower()
 
 
 async def test_evaluate_refused_when_both_restrictions_set() -> None:

--- a/tests/ci/security/test_evaluate_restricted.py
+++ b/tests/ci/security/test_evaluate_restricted.py
@@ -1,0 +1,101 @@
+"""Tests for the evaluate() guard on restricted browser profiles.
+
+The agent's `evaluate()` action calls `Runtime.evaluate` directly through CDP.
+SecurityWatchdog only subscribes to navigation events, so JS running inside an
+already-allowed page can `fetch()` arbitrary internal URLs, read cookies and
+localStorage from any allowed origin's context, and otherwise act as if the
+restrictions weren't there.
+
+On profiles configured with `allowed_domains` or `block_ip_addresses`, the
+operator has signalled "this agent is constrained" — exposing an unmediated
+JS evaluation primitive contradicts that signal. The guard refuses
+`evaluate()` outright on such profiles; agents that need JS can be run on an
+unrestricted profile or the gate can be lifted explicitly later.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from browser_use.agent.views import ActionResult
+from browser_use.tools.service import Tools
+
+
+class _StubProfile:
+	def __init__(self, allowed_domains: Any = None, block_ip_addresses: bool = False) -> None:
+		self.allowed_domains = allowed_domains
+		self.block_ip_addresses = block_ip_addresses
+
+
+class _StubBrowserSession:
+	is_local = True
+	agent_focus_target_id: str | None = None
+	session_manager: Any = None
+	cdp_client: Any = None
+
+	def __init__(self, profile: _StubProfile) -> None:
+		self.browser_profile = profile
+
+	async def get_current_page_url(self) -> str:
+		return 'about:blank'
+
+	async def get_or_create_cdp_session(self) -> Any:
+		raise AssertionError('evaluate() must refuse before reaching CDP when restrictions are configured')
+
+
+async def _run_evaluate(profile: _StubProfile, code: str = '1 + 1') -> ActionResult:
+	tools = Tools()
+	result = await tools.registry.execute_action(
+		'evaluate',
+		{'code': code},
+		browser_session=_StubBrowserSession(profile),  # type: ignore[arg-type]
+	)
+	assert isinstance(result, ActionResult)
+	return result
+
+
+async def test_evaluate_refused_when_allowed_domains_set() -> None:
+	"""A non-empty `allowed_domains` list signals a restricted profile — refuse."""
+	result = await _run_evaluate(_StubProfile(allowed_domains=['example.com']))
+	assert result.error is not None
+	assert 'allowed_domains' in result.error.lower() or 'restricted' in result.error.lower()
+
+
+async def test_evaluate_refused_when_block_ip_addresses_set() -> None:
+	"""`block_ip_addresses=True` signals a restricted profile — refuse."""
+	result = await _run_evaluate(_StubProfile(block_ip_addresses=True))
+	assert result.error is not None
+	assert 'block_ip_addresses' in result.error.lower() or 'restricted' in result.error.lower()
+
+
+async def test_evaluate_refused_when_both_restrictions_set() -> None:
+	"""Belt and suspenders configuration — refuse."""
+	result = await _run_evaluate(_StubProfile(allowed_domains=['x.test'], block_ip_addresses=True))
+	assert result.error is not None
+
+
+async def test_evaluate_reaches_cdp_when_unrestricted() -> None:
+	"""No restrictions → evaluate() should proceed to CDP. Our stub raises
+	when `get_or_create_cdp_session` is called, so we observe via the wrapped
+	error that the guard did not short-circuit."""
+	tools = Tools()
+	with pytest.raises(RuntimeError, match='must refuse before reaching CDP'):
+		await tools.registry.execute_action(
+			'evaluate',
+			{'code': '1 + 1'},
+			browser_session=_StubBrowserSession(_StubProfile()),  # type: ignore[arg-type]
+		)
+
+
+async def test_evaluate_proceeds_when_allowed_domains_is_empty_list() -> None:
+	"""Empty allowed_domains is treated as 'no restriction' elsewhere in the
+	codebase (e.g. SecurityWatchdog). Be consistent: don't refuse evaluate()."""
+	tools = Tools()
+	with pytest.raises(RuntimeError, match='must refuse before reaching CDP'):
+		await tools.registry.execute_action(
+			'evaluate',
+			{'code': '1 + 1'},
+			browser_session=_StubBrowserSession(_StubProfile(allowed_domains=[])),  # type: ignore[arg-type]
+		)


### PR DESCRIPTION
## Summary

Closes **GHSA-p6cf-6hf7-xh7q** (critical) and **GHSA-hvch-rcrr-7g39** (critical).

The agent's `evaluate()` action calls `Runtime.evaluate` directly through CDP. `SecurityWatchdog` only subscribes to navigation events (`NavigateToUrlEvent`, `NavigationCompleteEvent`, `TabCreatedEvent`), so JS running inside an already-allowed page could:

- `fetch()` arbitrary internal URLs (SSRF inside the agent's network)
- Read `document.cookie` / `localStorage` / `sessionStorage` from any allowed origin's context
- Read `window.location` of cross-frame contexts
- Otherwise act as if `allowed_domains` / `block_ip_addresses` weren't configured

When a profile is configured with `allowed_domains` or `block_ip_addresses`, the operator has signalled "this agent is constrained". An unmediated JS evaluation primitive contradicts that signal.

## Changes

- `browser_use/tools/service.py:evaluate` — refuse the action with an explanatory `ActionResult(error=...)` when `profile.allowed_domains` is truthy or `profile.block_ip_addresses` is True.
- Empty `allowed_domains=[]` is treated as "no restriction" elsewhere (e.g. `SecurityWatchdog._is_url_allowed:195`). Behaves consistently — does not refuse in that case.

## Test plan

- [x] `uv run pytest -vxs tests/ci/security/test_evaluate_restricted.py` — 5 tests:
  - refused when `allowed_domains=['example.com']`
  - refused when `block_ip_addresses=True`
  - refused when both
  - proceeds to CDP on unrestricted profile (stub raises so the test observes the guard did NOT short-circuit)
  - proceeds when `allowed_domains=[]` (consistent with SecurityWatchdog treating empty as no-restriction)
- [x] pyright / ruff check / ruff format — clean.

## Notes

This is the chosen approach from the design options I sketched (refuse when restricted, vs route-through-event, vs lexical scan). Trade-off: agents running on locked-down profiles lose `evaluate()` entirely. Acceptable since restricted profiles are typically server-side / production agents that don't need arbitrary JS.

If a future use case needs evaluate() inside restricted profiles, the cleaner fix is to route through a watchdog-vetoable `ExecuteJavaScriptEvent` — that's a larger refactor.

**Do not auto-merge** — please review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuses `evaluate()` on restricted browser profiles to prevent bypassing domain/IP controls. Closes GHSA-p6cf-6hf7-xh7q and GHSA-hvch-rcrr-7g39 by blocking SSRF and cross-origin data access via `Runtime.evaluate`.

- **Bug Fixes**
  - In `browser_use/tools/service.py`, `evaluate()` now returns `ActionResult(error=...)` when `profile.allowed_domains`, `profile.prohibited_domains`, or `profile.block_ip_addresses` is set; `allowed_domains=[]` stays unrestricted.
  - Added `tests/ci/security/test_evaluate_restricted.py` covering refusal for `allowed_domains`, `prohibited_domains`, `block_ip_addresses`, and both; and pass-through on unrestricted and empty-`allowed_domains`.

- **Refactors**
  - Tightened the guard’s inline comment; no behavior change.

<sup>Written for commit f4d7ab49799351ce8493a797cdf73f8e1c941df5. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4871?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

