### PR TITLE
fix: relax anthropic dependency pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "uuid7==0.1.0",
     "google-genai==1.65.0",
     "openai==2.16.0",
-    "anthropic==0.76.0",
+    "anthropic>=0.76.0,<1.0.0",
     "groq==1.0.0",
     "ollama==0.6.1",
     "google-api-python-client==2.188.0",


### PR DESCRIPTION
## Summary
- relax the Anthropic SDK requirement from an exact 0.76.0 pin to a bounded 0.x range
- allow downstream projects using newer Anthropic 0.x releases, including 0.102.0, to satisfy browser-use metadata

## Verification
- uv run --with anthropic==0.102.0 python - <<'PY'
import anthropic
from browser_use.llm.anthropic.chat import ChatAnthropic
from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
print(f'anthropic {anthropic.__version__}')
print(ChatAnthropic(model='claude-sonnet-4-5').provider)
print(ChatAnthropicBedrock().provider)
PY
- uv pip check --python .venv/bin/python

Fixes #4868

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed `anthropic` SDK pin from `0.76.0` to `>=0.76.0,<1.0.0` to let downstream projects use newer 0.x releases (e.g., `0.102.0`) without dependency conflicts.

<sup>Written for commit bad8d0de88f0dd7f12b609aac08aec780bc3f3bc. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4872?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

