### PR TITLE
docs(skill_cli): document record CLI command from #4710 in All Commands

### DIFF
--- a/browser_use/skill_cli/README.md
+++ b/browser_use/skill_cli/README.md
@@ -189,6 +189,14 @@ browser-use --cdp-url ws://localhost:9222/devtools/browser/... state
 | `eval "js code"` | Execute JavaScript |
 | `extract "query"` | Extract data with LLM (not yet implemented) |
 
+### Recording
+| Command | Description |
+|---------|-------------|
+| `record start <path>` | Start recording browser session video to file (.mp4 recommended) |
+| `record start <path> --framerate 60` | Set recording framerate (default: 30) |
+| `record stop` | Stop recording and print saved file path |
+| `record status` | Show current recording status |
+
 ### Python (Persistent Session)
 ```bash
 browser-use python "x = 42"           # Set variable


### PR DESCRIPTION
## What

Add a `### Recording` subsection to `browser_use/skill_cli/README.md` under `## All Commands`, listing the four `record` CLI flows that landed in #4710 (sauravpanda, merged 2026-04-20).

## Why

PR #4710 added the `record start | stop | status` subcommand to `browser_use/skill_cli/main.py` (subparser at L785-794) and `browser_use/skill_cli/commands/browser.py` (handler at L774-826). browser-use 0.12.7 (released 2026-05-19) is the first user-visible release that ships the feature.

The repo-level `README.md` routes users to `browser_use/skill_cli/README.md` as the canonical "All Commands" reference. That file enumerates nine command groups (Navigation / Inspection / Interaction / Tabs / Cookies / Wait / Get / JavaScript & Data / Python) — none of them mention `record`, video, or capture, so users on 0.12.7 have no in-tree docs entry-point for the new flow.

## Diff (8 LOC additive)

Adds one new section between `### JavaScript & Data` and `### Python (Persistent Session)`, matching the table style used by the other groups. Each row is byte-grounded:

- `record start <path>` and the `--framerate` flag mirror `record_sub.add_parser('start', ...)` and the `--framerate` argparse option in `main.py:789-791`.
- `record stop` mirrors the help string at `main.py:793`.
- `record status` mirrors the help string at `main.py:794`.
- The `.mp4 recommended` hint and `default: 30` framerate come from the same argparse help strings + `RecordingWatchdog` defaults.

No source changes, no behavioral implications.

## Verification

- File still validates as Markdown; only an additive subsection is introduced.
- Anti-poach: `gh search prs --repo browser-use/browser-use --state open "record"` returned three open PRs (#4697, #4845, #4826) — all are recording **source-code** changes (timing/playback/observability) and do not touch `browser_use/skill_cli/README.md`. Zero file overlap.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Recording subsection to browser_use/skill_cli/README.md under All Commands to document the new `record` CLI flow.
Lists `record start <path>` (with optional `--framerate`, default 30), `record stop`, and `record status` for saving session video.

<sup>Written for commit b14537a35a09813920cd407b0f1f6e1f085a5ed9. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4873?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

