### PR TITLE
fix: relax Anthropic dependency pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "uuid7==0.1.0",
     "google-genai==1.65.0",
     "openai==2.16.0",
-    "anthropic==0.76.0",
+    "anthropic>=0.76.0,<1.0.0",
     "groq==1.0.0",
     "ollama==0.6.1",
     "google-api-python-client==2.188.0",


### PR DESCRIPTION
﻿## Summary

Relax the direct Anthropic SDK requirement from an exact `0.76.0` pin to the compatible pre-1.x range. This lets users upgrade to newer Anthropic releases, including `0.102.0`, without `pip check` reporting a broken `browser-use` requirement.

The existing Anthropic wrapper imports and serializer tests still work with `anthropic==0.102.0`, so the strict pin is unnecessarily blocking normal environment upgrades.

Fixes #4868.

## Validation

- `.\.venv\Scripts\python.exe -m pip install -e .` with `anthropic==0.102.0`
- `.\.venv\Scripts\python.exe -m pip check`
- `.\.venv\Scripts\python.exe -m py_compile browser_use\llm\anthropic\chat.py browser_use\llm\aws\chat_anthropic.py browser_use\llm\anthropic\serializer.py`
- `.\.venv\Scripts\python.exe -m pytest browser_use\llm\tests\test_anthropic_cache.py -q`
- `.\.venv\Scripts\python.exe -m pytest browser_use\llm\tests\test_chat_models.py::TestChatModels::test_anthropic_ainvoke_normal browser_use\llm\tests\test_chat_models.py::TestChatModels::test_anthropic_ainvoke_structured -q` *(skipped because `ANTHROPIC_API_KEY` is not set)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxed the `anthropic` SDK requirement to `>=0.76.0,<1.0.0` so environments can upgrade within 0.x without `pip check` conflicts. Verified our Anthropic wrapper and serializer with `anthropic==0.102.0`.

<sup>Written for commit ed9647414c2e224f96ac7231f4f374e38f78502a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

