### PR TITLE
fix(dom): expose accessibility labels for icon controls

### DIFF
--- a/browser_use/dom/serializer/clickable_elements.py
+++ b/browser_use/dom/serializer/clickable_elements.py
@@ -235,9 +235,11 @@ class ClickableElementDetector:
 			# Check if this small element has interactive properties
 			if node.attributes:
 				# Small elements with these attributes are likely interactive icons
-				icon_attributes = {'class', 'role', 'onclick', 'data-action', 'aria-label'}
+				icon_attributes = {'class', 'role', 'onclick', 'data-action', 'aria-label', 'title', 'aria-describedby'}
 				if any(attr in node.attributes for attr in icon_attributes):
 					return True
+			if node.ax_node and (node.ax_node.name or node.ax_node.description):
+				return True
 
 		# Final fallback: cursor style indicates interactivity (for cases Chrome missed)
 		if node.snapshot_node and node.snapshot_node.cursor_style and node.snapshot_node.cursor_style == 'pointer':

--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -1099,6 +1099,15 @@ class DOMTreeSerializer:
 				}
 			)
 
+		# Include accessibility tree name/description. These often contain the
+		# practical label for icon-only controls, including labels derived from
+		# title/aria-labelledby/aria-describedby tooltips.
+		if node.ax_node:
+			if 'ax_name' in include_attributes and node.ax_node.name:
+				attributes_to_include['ax_name'] = node.ax_node.name.strip()
+			if 'ax_description' in include_attributes and node.ax_node.description:
+				attributes_to_include['ax_description'] = node.ax_node.description.strip()
+
 		# Add format hints for date/time inputs to help LLMs use the correct format
 		# NOTE: These formats are standardized by HTML5 specification (ISO 8601), NOT locale-dependent
 		# The browser may DISPLAY dates in locale format (MM/DD/YYYY in US, DD/MM/YYYY in EU),

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -77,8 +77,9 @@ DEFAULT_INCLUDE_ATTRIBUTES = [
 	'level',
 	'busy',
 	'live',
-	# Accessibility name (contains text content for StaticText elements)
+	# Accessibility name/description (contains labels from the accessibility tree)
 	'ax_name',
+	'ax_description',
 ]
 
 STATIC_ATTRIBUTES = {
@@ -612,7 +613,13 @@ class EnhancedDOMTreeNode:
 					meaningful_text = self.attributes[attr]
 					break
 
-		# Fallback to text content if no meaningful attributes
+		# Fallback to accessibility tree name/description if no meaningful attributes
+		if not meaningful_text and self.ax_node and self.ax_node.name:
+			meaningful_text = self.ax_node.name
+		if not meaningful_text and self.ax_node and self.ax_node.description:
+			meaningful_text = self.ax_node.description
+
+		# Fallback to text content if no meaningful attributes or accessibility text
 		if not meaningful_text:
 			meaningful_text = self.get_all_children_text()
 

--- a/tests/ci/browser/test_dom_accessible_labels.py
+++ b/tests/ci/browser/test_dom_accessible_labels.py
@@ -1,0 +1,80 @@
+from browser_use.dom.serializer.clickable_elements import ClickableElementDetector
+from browser_use.dom.serializer.serializer import DOMTreeSerializer
+from browser_use.dom.views import (
+	DEFAULT_INCLUDE_ATTRIBUTES,
+	DOMRect,
+	EnhancedAXNode,
+	EnhancedDOMTreeNode,
+	EnhancedSnapshotNode,
+	NodeType,
+)
+
+
+def make_element(
+	*,
+	tag_name: str = 'button',
+	attributes: dict[str, str] | None = None,
+	ax_name: str | None = None,
+	ax_description: str | None = None,
+	width: float = 24,
+	height: float = 24,
+) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name=tag_name.upper(),
+		node_value='',
+		attributes=attributes or {},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-id',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=[],
+		ax_node=EnhancedAXNode(
+			ax_node_id='ax-1',
+			ignored=False,
+			role='button',
+			name=ax_name,
+			description=ax_description,
+			properties=None,
+			child_ids=None,
+		),
+		snapshot_node=EnhancedSnapshotNode(
+			is_clickable=None,
+			cursor_style=None,
+			bounds=DOMRect(x=0, y=0, width=width, height=height),
+			clientRects=None,
+			scrollRects=None,
+			computed_styles=None,
+			paint_order=None,
+			stacking_contexts=None,
+		),
+	)
+
+
+def test_serializer_includes_accessibility_name_and_description_for_icon_only_controls() -> None:
+	node = make_element(ax_name='Create Test', ax_description='Opens the create test dialog')
+
+	serialized_attrs = DOMTreeSerializer._build_attributes_string(node, DEFAULT_INCLUDE_ATTRIBUTES, '')
+
+	assert 'ax_name=Create Test' in serialized_attrs
+	assert 'ax_description=Opens the create test dialog' in serialized_attrs
+
+
+def test_meaningful_text_falls_back_to_accessibility_name() -> None:
+	node = make_element(ax_name='Create Test')
+
+	assert node.get_meaningful_text_for_llm() == 'Create Test'
+
+
+def test_small_title_only_icon_is_interactive() -> None:
+	node = make_element(tag_name='span', attributes={'title': 'Create Test'}, ax_name=None, ax_description=None)
+
+	assert ClickableElementDetector.is_interactive(node)

--- a/tests/ci/browser/test_dom_accessible_labels.py
+++ b/tests/ci/browser/test_dom_accessible_labels.py
@@ -16,6 +16,7 @@ def make_element(
 	attributes: dict[str, str] | None = None,
 	ax_name: str | None = None,
 	ax_description: str | None = None,
+	ax_role: str = 'button',
 	width: float = 24,
 	height: float = 24,
 ) -> EnhancedDOMTreeNode:
@@ -40,7 +41,7 @@ def make_element(
 		ax_node=EnhancedAXNode(
 			ax_node_id='ax-1',
 			ignored=False,
-			role='button',
+			role=ax_role,
 			name=ax_name,
 			description=ax_description,
 			properties=None,
@@ -75,6 +76,12 @@ def test_meaningful_text_falls_back_to_accessibility_name() -> None:
 
 
 def test_small_title_only_icon_is_interactive() -> None:
-	node = make_element(tag_name='span', attributes={'title': 'Create Test'}, ax_name=None, ax_description=None)
+	node = make_element(
+		tag_name='span',
+		attributes={'title': 'Create Test'},
+		ax_name=None,
+		ax_description=None,
+		ax_role='generic',
+	)
 
 	assert ClickableElementDetector.is_interactive(node)


### PR DESCRIPTION
## Summary
- Include accessibility tree names and descriptions in serialized DOM attributes so icon-only controls can expose labels derived from `title`, `aria-labelledby`, or `aria-describedby`.
- Let meaningful text fallback use AX name/description before raw child text.
- Treat small icon-sized elements with `title`, `aria-describedby`, AX name, or AX description as interactive candidates.
- Add regression tests for icon-only controls and title-only icon detection.

Fixes #4801.

## Testing
- `uv run pytest tests/ci/browser/test_dom_accessible_labels.py tests/ci/test_ax_name_matching.py -q`
- `uv run ruff check browser_use/dom/views.py browser_use/dom/serializer/serializer.py browser_use/dom/serializer/clickable_elements.py tests/ci/browser/test_dom_accessible_labels.py`
- `uv run ruff format --check browser_use/dom/views.py browser_use/dom/serializer/serializer.py browser_use/dom/serializer/clickable_elements.py tests/ci/browser/test_dom_accessible_labels.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose accessibility labels for icon-only controls by serializing accessibility tree name/description and using them as the main fallback for meaningful text. Improves interactive detection for small icon elements with tooltip titles or accessibility labels.

- **Bug Fixes**
  - Serialize ax_name and ax_description and add them to the default include list.
  - Prefer AX name/description over child text when deriving meaningful text.
  - Treat small elements with title, aria-describedby, or AX name/description as interactive; add targeted tests, including title-only icons.

<sup>Written for commit 39a15158bec8efdb911b66e0a52f24de15ff141c. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4880?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

