### PR TITLE
Fix MCP CDP session lifecycle

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -2058,9 +2058,10 @@ def run_main_interface(ctx: click.Context, debug: bool = False, **kwargs):
 			# Ignore telemetry errors in MCP mode to prevent any stdout contamination
 			pass
 		# Run as MCP server
+		from browser_use.mcp.config import build_mcp_config_overrides
 		from browser_use.mcp.server import main as mcp_main
 
-		asyncio.run(mcp_main())
+		asyncio.run(mcp_main(config_overrides=build_mcp_config_overrides(kwargs)))
 		return
 
 	# Check if prompt mode is activated

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -229,6 +229,7 @@ class FlatEnvConfig(BaseSettings):
 
 	# MCP-specific env vars
 	BROWSER_USE_CONFIG_PATH: str | None = Field(default=None)
+	BROWSER_USE_CDP_URL: str | None = Field(default=None)
 	BROWSER_USE_HEADLESS: bool | None = Field(default=None)
 	BROWSER_USE_ALLOWED_DOMAINS: str | None = Field(default=None)
 	BROWSER_USE_LLM_MODEL: str | None = Field(default=None)
@@ -469,6 +470,9 @@ class Config:
 		env_config = FlatEnvConfig()
 
 		# Apply MCP-specific env var overrides
+		if env_config.BROWSER_USE_CDP_URL:
+			config['browser_profile']['cdp_url'] = env_config.BROWSER_USE_CDP_URL
+
 		if env_config.BROWSER_USE_HEADLESS is not None:
 			config['browser_profile']['headless'] = env_config.BROWSER_USE_HEADLESS
 

--- a/browser_use/mcp/config.py
+++ b/browser_use/mcp/config.py
@@ -1,0 +1,69 @@
+"""Configuration helpers for the browser-use MCP server."""
+
+from typing import Any
+
+
+def build_mcp_config_overrides(kwargs: dict[str, Any]) -> dict[str, Any]:
+	"""Build transient MCP config overrides from top-level CLI options.
+
+	The MCP server uses the newer ``browser_profile``/``llm`` config shape,
+	while the interactive CLI stores options under ``browser``/``model``.
+	Do not persist these overrides: MCP launch arguments such as ``--cdp-url``
+	are runtime connection details and should only affect this server process.
+	"""
+	overrides: dict[str, Any] = {}
+	browser_profile: dict[str, Any] = {}
+	llm: dict[str, Any] = {}
+
+	if kwargs.get('model'):
+		llm['model'] = kwargs['model']
+
+	if kwargs.get('headless') is not None:
+		browser_profile['headless'] = kwargs['headless']
+	if kwargs.get('user_data_dir'):
+		browser_profile['user_data_dir'] = kwargs['user_data_dir']
+	if kwargs.get('profile_directory'):
+		browser_profile['profile_directory'] = kwargs['profile_directory']
+	if kwargs.get('cdp_url'):
+		browser_profile['cdp_url'] = kwargs['cdp_url']
+
+	window_width = kwargs.get('window_width')
+	window_height = kwargs.get('window_height')
+	if window_width or window_height:
+		browser_profile['window_size'] = {
+			'width': window_width or 1920,
+			'height': window_height or 1080,
+		}
+
+	proxy: dict[str, str] = {}
+	if kwargs.get('proxy_url'):
+		proxy['server'] = kwargs['proxy_url']
+	if kwargs.get('no_proxy'):
+		proxy['bypass'] = ','.join([p.strip() for p in kwargs['no_proxy'].split(',') if p.strip()])
+	if kwargs.get('proxy_username'):
+		proxy['username'] = kwargs['proxy_username']
+	if kwargs.get('proxy_password'):
+		proxy['password'] = kwargs['proxy_password']
+	if proxy:
+		browser_profile['proxy'] = proxy
+
+	if browser_profile:
+		overrides['browser_profile'] = browser_profile
+	if llm:
+		overrides['llm'] = llm
+
+	return overrides
+
+
+def merge_nested_config(base: dict[str, Any], overrides: dict[str, Any] | None) -> dict[str, Any]:
+	"""Return ``base`` with MCP runtime overrides applied recursively."""
+	if not overrides:
+		return base
+
+	merged = dict(base)
+	for key, value in overrides.items():
+		if isinstance(value, dict) and isinstance(merged.get(key), dict):
+			merged[key] = merge_nested_config(merged[key], value)
+		else:
+			merged[key] = value
+	return merged

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -95,6 +95,7 @@ from browser_use.browser import BrowserProfile, BrowserSession
 from browser_use.config import get_default_llm, get_default_profile, load_browser_use_config
 from browser_use.filesystem.file_system import FileSystem
 from browser_use.llm.openai.chat import ChatOpenAI
+from browser_use.mcp.config import merge_nested_config
 from browser_use.tools.service import Tools
 
 logger = logging.getLogger(__name__)
@@ -187,12 +188,12 @@ def get_parent_process_cmdline() -> str | None:
 class BrowserUseServer:
 	"""MCP Server for browser-use capabilities."""
 
-	def __init__(self, session_timeout_minutes: int = 10):
+	def __init__(self, session_timeout_minutes: int = 10, config_overrides: dict[str, Any] | None = None):
 		# Ensure all logging goes to stderr (in case new loggers were created)
 		_ensure_all_loggers_use_stderr()
 
 		self.server = Server('browser-use')
-		self.config = load_browser_use_config()
+		self.config = merge_nested_config(load_browser_use_config(), config_overrides)
 		self.agent: Agent | None = None
 		self.browser_session: BrowserSession | None = None
 		self.tools: Tools | None = None
@@ -510,9 +511,10 @@ class BrowserUseServer:
 
 		# Direct browser control tools (require active session)
 		elif tool_name.startswith('browser_'):
-			# Ensure browser session exists
-			if not self.browser_session:
-				await self._init_browser_session()
+			# Ensure browser session exists and is connected. A failed start can
+			# otherwise leave a BrowserSession object around with no root CDP client,
+			# causing follow-up tools to fail with "Root CDP client not initialized".
+			await self._ensure_browser_session()
 
 			if tool_name == 'browser_navigate':
 				return await self._navigate(arguments['url'], arguments.get('new_tab', False))
@@ -568,10 +570,39 @@ class BrowserUseServer:
 
 		return f'Unknown tool: {tool_name}'
 
+	def _is_browser_session_ready(self) -> bool:
+		"""Return True when the current browser session is usable for MCP tools."""
+		if not self.browser_session:
+			return False
+		try:
+			return bool(
+				self.browser_session.is_cdp_connected
+				and self.browser_session.session_manager is not None
+				and self.browser_session.agent_focus_target_id is not None
+			)
+		except Exception:
+			return False
+
+	async def _ensure_browser_session(self) -> None:
+		"""Ensure direct browser-control tools have a live CDP-backed session."""
+		if self._is_browser_session_ready():
+			return
+
+		await self._init_browser_session()
+
 	async def _init_browser_session(self, allowed_domains: list[str] | None = None, **kwargs):
 		"""Initialize browser session using config"""
-		if self.browser_session:
+		if self._is_browser_session_ready():
 			return
+
+		if self.browser_session:
+			stale_session = self.browser_session
+			self.active_sessions.pop(stale_session.id, None)
+			self.browser_session = None
+			try:
+				await stale_session.reset()
+			except Exception as e:
+				logger.debug(f'Error resetting stale browser session: {e}')
 
 		# Ensure all logging goes to stderr before browser initialization
 		_ensure_all_loggers_use_stderr()
@@ -604,9 +635,20 @@ class BrowserUseServer:
 		# Create browser profile
 		profile = BrowserProfile(**profile_data)
 
-		# Create browser session
-		self.browser_session = BrowserSession(browser_profile=profile)
-		await self.browser_session.start()
+		# Create browser session. Keep it local until start succeeds so a failed
+		# BrowserStartEvent cannot poison later MCP tool calls with a half-started
+		# session lacking a root CDP client.
+		browser_session = BrowserSession(browser_profile=profile)
+		try:
+			await browser_session.start()
+		except Exception:
+			try:
+				await browser_session.reset()
+			except Exception as reset_error:
+				logger.debug(f'Error resetting failed browser session: {reset_error}')
+			raise
+
+		self.browser_session = browser_session
 
 		# Track the session for management
 		self._track_session(self.browser_session)
@@ -1254,12 +1296,12 @@ class BrowserUseServer:
 				logger.warning('MCP client disconnected while writing to stdio; shutting down server cleanly.')
 
 
-async def main(session_timeout_minutes: int = 10):
+async def main(session_timeout_minutes: int = 10, config_overrides: dict[str, Any] | None = None):
 	if not MCP_AVAILABLE:
 		print('MCP SDK is required. Install with: pip install mcp', file=sys.stderr)
 		sys.exit(1)
 
-	server = BrowserUseServer(session_timeout_minutes=session_timeout_minutes)
+	server = BrowserUseServer(session_timeout_minutes=session_timeout_minutes, config_overrides=config_overrides)
 	server._telemetry.capture(
 		MCPServerTelemetryEvent(
 			version=get_browser_use_version(),

--- a/tests/ci/test_mcp_cdp_lifecycle.py
+++ b/tests/ci/test_mcp_cdp_lifecycle.py
@@ -2,7 +2,7 @@
 
 import json
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -116,7 +116,7 @@ async def test_direct_browser_tools_reinitialize_stale_session() -> None:
 	result = await server._execute_tool('browser_list_tabs', {})
 
 	assert calls == ['init-ready']
-	assert json.loads(result) == [
+	assert json.loads(cast(str, result)) == [
 		{'tab_id': '1234', 'url': 'https://example.com', 'title': 'Example Domain'},
 	]
 

--- a/tests/ci/test_mcp_cdp_lifecycle.py
+++ b/tests/ci/test_mcp_cdp_lifecycle.py
@@ -1,0 +1,151 @@
+"""Regression tests for MCP CDP runtime configuration and session lifecycle."""
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from browser_use.config import load_browser_use_config
+from browser_use.mcp import server as server_module
+from browser_use.mcp.config import build_mcp_config_overrides
+from browser_use.mcp.server import BrowserUseServer
+
+
+@pytest.fixture(autouse=True)
+def isolated_browser_use_config(tmp_path, monkeypatch):
+	"""Keep MCP config reads/writes out of the developer's real home dir."""
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(tmp_path / 'browseruse-config'))
+	monkeypatch.delenv('BROWSER_USE_CDP_URL', raising=False)
+	monkeypatch.delenv('BROWSER_USE_HEADLESS', raising=False)
+	monkeypatch.delenv('BROWSER_USE_ALLOWED_DOMAINS', raising=False)
+	monkeypatch.delenv('BROWSER_USE_LLM_MODEL', raising=False)
+
+
+def test_mcp_cli_overrides_include_cdp_url_and_do_not_use_interactive_config_shape() -> None:
+	overrides = build_mcp_config_overrides(
+		{
+			'model': 'gpt-4.1-mini',
+			'headless': True,
+			'user_data_dir': '/tmp/browser-profile',
+			'profile_directory': 'Default',
+			'cdp_url': 'http://127.0.0.1:9223',
+			'window_width': 1280,
+			'window_height': 720,
+			'proxy_url': 'http://proxy.internal:8080',
+			'no_proxy': 'localhost, 127.0.0.1',
+			'proxy_username': 'alice',
+			'proxy_password': 'secret',
+		}
+	)
+
+	assert overrides == {
+		'browser_profile': {
+			'headless': True,
+			'user_data_dir': '/tmp/browser-profile',
+			'profile_directory': 'Default',
+			'cdp_url': 'http://127.0.0.1:9223',
+			'window_size': {'width': 1280, 'height': 720},
+			'proxy': {
+				'server': 'http://proxy.internal:8080',
+				'bypass': 'localhost,127.0.0.1',
+				'username': 'alice',
+				'password': 'secret',
+			},
+		},
+		'llm': {'model': 'gpt-4.1-mini'},
+	}
+	assert 'browser' not in overrides
+	assert 'model' not in overrides
+
+
+def test_mcp_server_applies_transient_cli_overrides() -> None:
+	server = BrowserUseServer(
+		config_overrides={
+			'browser_profile': {'cdp_url': 'http://127.0.0.1:9223', 'headless': True},
+			'llm': {'model': 'gpt-4.1-mini'},
+		}
+	)
+
+	assert server.config['browser_profile']['cdp_url'] == 'http://127.0.0.1:9223'
+	assert server.config['browser_profile']['headless'] is True
+	assert server.config['llm']['model'] == 'gpt-4.1-mini'
+
+
+def test_mcp_config_supports_cdp_url_environment_override(monkeypatch) -> None:
+	monkeypatch.setenv('BROWSER_USE_CDP_URL', 'http://127.0.0.1:9223')
+
+	config = load_browser_use_config()
+
+	assert config['browser_profile']['cdp_url'] == 'http://127.0.0.1:9223'
+
+
+async def test_direct_browser_tools_reinitialize_stale_session() -> None:
+	server = BrowserUseServer()
+	calls: list[str] = []
+
+	class StaleSession:
+		id = 'stale-session'
+		is_cdp_connected = False
+		session_manager = None
+		agent_focus_target_id = None
+
+		async def reset(self) -> None:
+			calls.append('reset-stale')
+
+		async def get_tabs(self) -> list[Any]:
+			return []
+
+	class ReadySession:
+		id = 'ready-session'
+		is_cdp_connected = True
+		session_manager = object()
+		agent_focus_target_id = 'target-1234'
+
+		async def get_tabs(self) -> list[Any]:
+			return [SimpleNamespace(target_id='target-1234', url='https://example.com', title='Example Domain')]
+
+	async def fake_init_browser_session(*_args: Any, **_kwargs: Any) -> None:
+		calls.append('init-ready')
+		server.browser_session = ReadySession()  # type: ignore[assignment]
+
+	server.browser_session = StaleSession()  # type: ignore[assignment]
+	server.active_sessions['stale-session'] = {'session': server.browser_session}
+	server._init_browser_session = fake_init_browser_session  # type: ignore[method-assign]
+
+	result = await server._execute_tool('browser_list_tabs', {})
+
+	assert calls == ['init-ready']
+	assert json.loads(result) == [
+		{'tab_id': '1234', 'url': 'https://example.com', 'title': 'Example Domain'},
+	]
+
+
+async def test_failed_browser_start_does_not_leave_partial_session(monkeypatch) -> None:
+	reset_calls = 0
+
+	class FailingBrowserSession:
+		id = 'failed-session'
+		is_cdp_connected = False
+		session_manager = None
+		agent_focus_target_id = None
+
+		def __init__(self, **_kwargs: Any) -> None:
+			pass
+
+		async def start(self) -> None:
+			raise RuntimeError('connect failed')
+
+		async def reset(self) -> None:
+			nonlocal reset_calls
+			reset_calls += 1
+
+	monkeypatch.setattr(server_module, 'BrowserSession', FailingBrowserSession)
+	server = BrowserUseServer()
+
+	with pytest.raises(RuntimeError, match='connect failed'):
+		await server._init_browser_session()
+
+	assert reset_calls == 1
+	assert server.browser_session is None
+	assert server.active_sessions == {}


### PR DESCRIPTION
## Summary

- pass CLI runtime options such as `--cdp-url` into MCP server configuration instead of ignoring them
- add `BROWSER_USE_CDP_URL` as an MCP-friendly environment override
- make MCP direct browser tools recreate stale/failed browser sessions instead of reusing a half-started session with no root CDP client

Fixes #4846.

## Testing

- `uv run pytest tests/ci/test_mcp_cdp_lifecycle.py tests/ci/security/test_mcp_allowed_domains.py -q`
- `uv run ruff check browser_use/config.py browser_use/cli.py browser_use/mcp/config.py browser_use/mcp/server.py tests/ci/test_mcp_cdp_lifecycle.py tests/ci/security/test_mcp_allowed_domains.py`
- `uv run ruff format --check browser_use/config.py browser_use/cli.py browser_use/mcp/config.py browser_use/mcp/server.py tests/ci/test_mcp_cdp_lifecycle.py tests/ci/security/test_mcp_allowed_domains.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unreliable MCP CDP sessions by applying CLI/env config for the CDP URL and rebuilding stale/failed sessions so direct browser tools run reliably.

- **Bug Fixes**
  - Only use a session when CDP is connected and recreate stale sessions to avoid “Root CDP client not initialized” errors.
  - On failed start, reset and discard the partial session to prevent poisoning future tool calls.

- **New Features**
  - Pass CLI flags into MCP config via `build_mcp_config_overrides` (`--cdp-url`, `--headless`, proxy, window size, profile paths); `cli` forwards these to the MCP server and merges at startup with `merge_nested_config`.
  - Add `BROWSER_USE_CDP_URL` env override; add tests for CLI/env overrides, session lifecycle, and Pyright-narrowed tool result types.

<sup>Written for commit b7d2c0854d9ed421966bfe52ebd40f2b46b38b0c. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4881?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

