### PR TITLE
fix: use timezone-aware config timestamps

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cache
 from pathlib import Path
 from typing import Any
@@ -248,7 +248,7 @@ class DBStyleEntry(BaseModel):
 
 	id: str = Field(default_factory=lambda: str(uuid4()))
 	default: bool = Field(default=False)
-	created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+	created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
 
 class BrowserProfileEntry(DBStyleEntry):

--- a/tests/ci/test_config.py
+++ b/tests/ci/test_config.py
@@ -1,0 +1,11 @@
+from datetime import datetime, timezone
+
+from browser_use.config import DBStyleEntry
+
+
+def test_db_style_entry_created_at_is_timezone_aware():
+	entry = DBStyleEntry()
+	created_at = datetime.fromisoformat(entry.created_at)
+
+	assert created_at.tzinfo is not None
+	assert created_at.utcoffset() == timezone.utc.utcoffset(created_at)


### PR DESCRIPTION
## Summary

Replace the `DBStyleEntry.created_at` default factory with a timezone-aware UTC timestamp and add a small regression test.

## Bug

`datetime.utcnow()` is deprecated in Python 3.12 because it returns a naive datetime. New config entries currently serialize `created_at` without timezone information, which can emit deprecation warnings and makes the timestamp ambiguous.

## Before/After

Before:
```python
created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
```

After:
```python
created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
```

Generated config timestamps remain UTC, but now include an explicit `+00:00` offset.

## Verification

- `python -m compileall -q browser_use/config.py tests/ci/test_config.py`
- `git diff --check`

I also attempted the focused pytest command:

```bash
uv run pytest tests/ci/test_config.py
```

but this local environment is missing the repo test plugin `pytest_httpserver` loaded by `tests/ci/conftest.py`, so collection stops before this test runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make config timestamps UTC and timezone-aware to avoid deprecation warnings and ambiguous times. Adds a small test to lock this in.

- **Bug Fixes**
  - Replace `datetime.utcnow().isoformat()` with `datetime.now(timezone.utc).isoformat()` in `DBStyleEntry.created_at`.
  - Add a test to ensure `created_at` is timezone-aware and uses the UTC offset.

<sup>Written for commit 09803dd0a9816818ac635f84ebcbb8ef2cd8b844. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4883?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

