### PR TITLE
chore(llm): recommend gemini-3-flash-preview in examples and tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.yml
@@ -57,7 +57,7 @@ body:
     attributes:
       label: LLM Model
       description: Which LLM model are you using? (Optional)
-      placeholder: "e.g. ChatBrowserUse, gpt-4.1-mini, gemini-flash-latest, etc."
+      placeholder: "e.g. ChatBrowserUse, gpt-4.1-mini, gemini-3-flash-preview, etc."
 
   - type: input
     id: os

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ See [Supported Models](https://docs.browser-use.com/supported-models#supported-m
   load_dotenv()
 
   async def main():
-      llm = ChatGoogle(model="gemini-flash-latest")
+      llm = ChatGoogle(model="gemini-3-flash-preview")
       task = "Find the number 1 post on Show HN"
       agent = Agent(task=task, llm=llm)
       await agent.run()

--- a/CLOUD.md
+++ b/CLOUD.md
@@ -384,7 +384,7 @@ components:
         - value: gemini-flash-latest
         - value: gemini-flash-lite-latest
         - value: gemini-3-flash-preview
-        - value: gemini-3-flash-preview-lite
+        - value: gemini-3.1-flash-lite
         - value: claude-sonnet-4-20250514
         - value: gpt-4o
         - value: gpt-4o-mini

--- a/CLOUD.md
+++ b/CLOUD.md
@@ -383,6 +383,8 @@ components:
         - value: gemini-2.5-pro
         - value: gemini-flash-latest
         - value: gemini-flash-lite-latest
+        - value: gemini-3-flash-preview
+        - value: gemini-3-flash-preview-lite
         - value: claude-sonnet-4-20250514
         - value: gpt-4o
         - value: gpt-4o-mini

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -35,6 +35,7 @@ VerifiedGeminiModels = Literal[
 	'gemini-2.5-pro',
 	'gemini-3-pro-preview',
 	'gemini-3-flash-preview',
+	'gemini-3-flash-preview-lite',
 	'gemma-3-27b-it',
 	'gemma-3-4b',
 	'gemma-3-12b',

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -269,7 +269,7 @@ class ChatGoogle(BaseChatModel):
 		# Gemini 3 Flash: supports both, defaults to thinking_budget=-1
 		# Gemini 2.5: uses thinking_budget only
 		is_gemini_3_pro = 'gemini-3-pro' in self.model
-		is_gemini_3_flash = 'gemini-3-flash' in self.model
+		is_gemini_3_flash = 'gemini-3-flash' in self.model or 'gemini-3.1-flash' in self.model
 
 		if is_gemini_3_pro:
 			# Validate: thinking_budget should not be set for Gemini 3 Pro

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -35,7 +35,7 @@ VerifiedGeminiModels = Literal[
 	'gemini-2.5-pro',
 	'gemini-3-pro-preview',
 	'gemini-3-flash-preview',
-	'gemini-3-flash-preview-lite',
+	'gemini-3.1-flash-lite',
 	'gemma-3-27b-it',
 	'gemma-3-4b',
 	'gemma-3-12b',

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -34,6 +34,7 @@ VerifiedGeminiModels = Literal[
 	'gemini-flash-lite-latest',
 	'gemini-2.5-pro',
 	'gemini-3-pro-preview',
+	'gemini-3.1-pro-preview',
 	'gemini-3-flash-preview',
 	'gemini-3.1-flash-lite',
 	'gemma-3-27b-it',
@@ -268,7 +269,7 @@ class ChatGoogle(BaseChatModel):
 		# Gemini 3 Pro: uses thinking_level only
 		# Gemini 3 Flash: supports both, defaults to thinking_budget=-1
 		# Gemini 2.5: uses thinking_budget only
-		is_gemini_3_pro = 'gemini-3-pro' in self.model
+		is_gemini_3_pro = 'gemini-3-pro' in self.model or 'gemini-3.1-pro' in self.model
 		is_gemini_3_flash = 'gemini-3-flash' in self.model or 'gemini-3.1-flash' in self.model
 
 		if is_gemini_3_pro:

--- a/browser_use/tokens/mappings.py
+++ b/browser_use/tokens/mappings.py
@@ -2,5 +2,5 @@
 MODEL_TO_LITELLM: dict[str, str] = {
 	'gemini-flash-latest': 'gemini/gemini-flash-latest',
 	'gemini-3-flash-preview': 'gemini/gemini-3-flash-preview',
-	'gemini-3.1-flash-lite': 'gemini/gemini-3.1-flash-lite',
+	'gemini-3.1-flash-lite': 'gemini/gemini-3.1-flash-lite-preview',
 }

--- a/browser_use/tokens/mappings.py
+++ b/browser_use/tokens/mappings.py
@@ -2,5 +2,5 @@
 MODEL_TO_LITELLM: dict[str, str] = {
 	'gemini-flash-latest': 'gemini/gemini-flash-latest',
 	'gemini-3-flash-preview': 'gemini/gemini-3-flash-preview',
-	'gemini-3-flash-preview-lite': 'gemini/gemini-3-flash-preview-lite',
+	'gemini-3.1-flash-lite': 'gemini/gemini-3.1-flash-lite',
 }

--- a/browser_use/tokens/mappings.py
+++ b/browser_use/tokens/mappings.py
@@ -1,4 +1,6 @@
 # Mapping from model_name to LiteLLM model name
 MODEL_TO_LITELLM: dict[str, str] = {
 	'gemini-flash-latest': 'gemini/gemini-flash-latest',
+	'gemini-3-flash-preview': 'gemini/gemini-3-flash-preview',
+	'gemini-3-flash-preview-lite': 'gemini/gemini-3-flash-preview-lite',
 }

--- a/examples/browser/real_browser.py
+++ b/examples/browser/real_browser.py
@@ -37,7 +37,7 @@ async def main():
 	browser = Browser.from_system_chrome(profile_directory=profile)
 
 	agent = Agent(
-		llm=ChatGoogle(model='gemini-flash-latest'),
+		llm=ChatGoogle(model='gemini-3-flash-preview'),
 		task='go to amazon.com and search for pens to draw on whiteboards',
 		browser=browser,
 	)

--- a/examples/features/stop_externally.py
+++ b/examples/features/stop_externally.py
@@ -13,7 +13,7 @@ load_dotenv()
 
 from browser_use import Agent
 
-llm = ChatGoogle(model='gemini-flash-latest', temperature=1.0)
+llm = ChatGoogle(model='gemini-3-flash-preview', temperature=1.0)
 
 
 def check_is_task_stopped():

--- a/examples/getting_started/05_fast_agent.py
+++ b/examples/getting_started/05_fast_agent.py
@@ -31,7 +31,7 @@ async def main():
 	)
 	# from browser_use import ChatGoogle
 
-	# llm = ChatGoogle(model='gemini-flash-lite-latest')
+	# llm = ChatGoogle(model='gemini-3-flash-preview-lite')
 
 	# 2. Create speed-optimized browser profile
 	browser_profile = BrowserProfile(

--- a/examples/getting_started/05_fast_agent.py
+++ b/examples/getting_started/05_fast_agent.py
@@ -31,7 +31,7 @@ async def main():
 	)
 	# from browser_use import ChatGoogle
 
-	# llm = ChatGoogle(model='gemini-3-flash-preview-lite')
+	# llm = ChatGoogle(model='gemini-3.1-flash-lite')
 
 	# 2. Create speed-optimized browser profile
 	browser_profile = BrowserProfile(

--- a/examples/models/gemini.py
+++ b/examples/models/gemini.py
@@ -16,7 +16,7 @@ if not api_key:
 
 
 async def run_search():
-	llm = ChatGoogle(model='gemini-flash-latest', api_key=api_key)
+	llm = ChatGoogle(model='gemini-3-flash-preview', api_key=api_key)
 	agent = Agent(
 		llm=llm,
 		task='How many stars does the browser-use repo have?',

--- a/skills/cloud/references/api-v2.md
+++ b/skills/cloud/references/api-v2.md
@@ -302,7 +302,7 @@ Response includes: `{ items: [...], totalItems, pageNumber, pageSize }`
 | SessionStatus | `active`, `stopped` |
 | BrowserSessionStatus | `active`, `stopped` |
 | ProxyCountryCode | `us`, `uk`, `fr`, `it`, `jp`, `au`, `de`, `fi`, `ca`, `in` (+185 more) |
-| SupportedLLMs | `browser-use-llm`, `gpt-4.1`, `gpt-4.1-mini`, `o4-mini`, `o3`, `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-flash-latest`, `gemini-flash-lite-latest`, `claude-sonnet-4-20250514`, `gpt-4o`, `gpt-4o-mini`, `llama-4-maverick-17b-128e-instruct`, `claude-3-7-sonnet-20250219` |
+| SupportedLLMs | `browser-use-llm`, `gpt-4.1`, `gpt-4.1-mini`, `o4-mini`, `o3`, `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-flash-latest`, `gemini-flash-lite-latest`, `gemini-3-flash-preview`, `gemini-3-flash-preview-lite`, `claude-sonnet-4-20250514`, `gpt-4o`, `gpt-4o-mini`, `llama-4-maverick-17b-128e-instruct`, `claude-3-7-sonnet-20250219` |
 | UploadContentType | `image/jpg`, `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `image/svg+xml`, `application/pdf`, `application/msword`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`, `application/vnd.ms-excel`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, `text/plain`, `text/csv`, `text/markdown` |
 
 ## Response Schemas

--- a/skills/cloud/references/api-v2.md
+++ b/skills/cloud/references/api-v2.md
@@ -302,7 +302,7 @@ Response includes: `{ items: [...], totalItems, pageNumber, pageSize }`
 | SessionStatus | `active`, `stopped` |
 | BrowserSessionStatus | `active`, `stopped` |
 | ProxyCountryCode | `us`, `uk`, `fr`, `it`, `jp`, `au`, `de`, `fi`, `ca`, `in` (+185 more) |
-| SupportedLLMs | `browser-use-llm`, `gpt-4.1`, `gpt-4.1-mini`, `o4-mini`, `o3`, `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-flash-latest`, `gemini-flash-lite-latest`, `gemini-3-flash-preview`, `gemini-3-flash-preview-lite`, `claude-sonnet-4-20250514`, `gpt-4o`, `gpt-4o-mini`, `llama-4-maverick-17b-128e-instruct`, `claude-3-7-sonnet-20250219` |
+| SupportedLLMs | `browser-use-llm`, `gpt-4.1`, `gpt-4.1-mini`, `o4-mini`, `o3`, `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-flash-latest`, `gemini-flash-lite-latest`, `gemini-3-flash-preview`, `gemini-3.1-flash-lite`, `claude-sonnet-4-20250514`, `gpt-4o`, `gpt-4o-mini`, `llama-4-maverick-17b-128e-instruct`, `claude-3-7-sonnet-20250219` |
 | UploadContentType | `image/jpg`, `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `image/svg+xml`, `application/pdf`, `application/msword`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`, `application/vnd.ms-excel`, `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, `text/plain`, `text/csv`, `text/markdown` |
 
 ## Response Schemas

--- a/skills/open-source/references/quickstart.md
+++ b/skills/open-source/references/quickstart.md
@@ -64,7 +64,7 @@ import asyncio
 load_dotenv()
 
 async def main():
-    llm = ChatGoogle(model="gemini-flash-latest")
+    llm = ChatGoogle(model="gemini-3-flash-preview")
     agent = Agent(task="Find the number 1 post on Show HN", llm=llm)
     await agent.run()
 

--- a/tests/ci/evaluate_tasks.py
+++ b/tests/ci/evaluate_tasks.py
@@ -79,7 +79,7 @@ async def run_single_task(task_file):
 				'explanation': 'Skipped - Google API key not available (fork PR or missing secret)',
 			}
 
-		judge_llm = ChatGoogle(model='gemini-flash-lite-latest')
+		judge_llm = ChatGoogle(model='gemini-3-flash-preview-lite')
 		print('[DEBUG] LLMs initialized', file=sys.stderr)
 
 		# Each subprocess gets its own profile and session

--- a/tests/ci/evaluate_tasks.py
+++ b/tests/ci/evaluate_tasks.py
@@ -79,7 +79,7 @@ async def run_single_task(task_file):
 				'explanation': 'Skipped - Google API key not available (fork PR or missing secret)',
 			}
 
-		judge_llm = ChatGoogle(model='gemini-3-flash-preview-lite')
+		judge_llm = ChatGoogle(model='gemini-3.1-flash-lite')
 		print('[DEBUG] LLMs initialized', file=sys.stderr)
 
 		# Each subprocess gets its own profile and session

--- a/tests/ci/models/test_llm_google.py
+++ b/tests/ci/models/test_llm_google.py
@@ -4,11 +4,11 @@ from browser_use.llm.google.chat import ChatGoogle
 from tests.ci.models.model_test_helper import run_model_button_click_test
 
 
-async def test_google_gemini_flash_latest(httpserver):
-	"""Test Google gemini-flash-latest can click a button."""
+async def test_google_gemini_3_flash_preview(httpserver):
+	"""Test Google gemini-3-flash-preview can click a button."""
 	await run_model_button_click_test(
 		model_class=ChatGoogle,
-		model_name='gemini-flash-latest',
+		model_name='gemini-3-flash-preview',
 		api_key_env='GOOGLE_API_KEY',
 		extra_kwargs={},
 		httpserver=httpserver,


### PR DESCRIPTION
## Summary
- Adds `gemini-3-flash-preview-lite` to `VerifiedGeminiModels` and token mappings (the non-lite preview was already verified).
- Lists both `gemini-3-flash-preview[-lite]` alongside the existing `gemini-flash-latest` / `-lite-latest` aliases in `CLOUD.md` and `skills/cloud/references/api-v2.md` `SupportedLLMs` — the old aliases stay valid.
- Switches all example code / recommendations (`examples/`, `AGENTS.md`, `skills/open-source/references/quickstart.md`, bug-report placeholder) to `gemini-3-flash-preview`.
- Updates the Google CI button-click test and the `evaluate_tasks` judge LLM to `gemini-3-flash-preview` / `gemini-3-flash-preview-lite`.

The thinking-config branch at `browser_use/llm/google/chat.py:268` (`is_gemini_3_flash`) already handles both new names — defaults `thinking_budget=-1` for parity with the old `gemini-flash` substring path.

## Test plan
- [ ] `uv run pyright` clean (verified locally)
- [ ] pre-commit hooks pass (verified locally)
- [ ] `uv run pytest -vxs tests/ci/models/test_llm_google.py` against `GOOGLE_API_KEY` — confirm the new `gemini-3-flash-preview` test passes
- [ ] `uv run pytest -vxs tests/ci/evaluate_tasks.py` (or whatever CI invokes it) — confirm judge LLM swap still works
- [ ] Spot-check `examples/models/gemini.py` runs end-to-end against the new model

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch our recommended Google model to `gemini-3-flash-preview`, add `gemini-3.1-flash-lite`, and support `gemini-3.1-pro-preview`. Examples, docs, and CI now default to the new Flash models; existing `gemini-flash-*-latest` aliases still work.

- **New Features**
  - Added `gemini-3-flash-preview`, `gemini-3.1-flash-lite`, and `gemini-3.1-pro-preview` to verified models; mapped the first two in `MODEL_TO_LITELLM`.
  - Listed `gemini-3-flash-preview` and `gemini-3.1-flash-lite` in `CLOUD.md` and API `SupportedLLMs`.

- **Bug Fixes**
  - Route `gemini-3.1-flash-*` and `gemini-3.1-pro-*` through the correct thinking paths.
  - Map `gemini-3.1-flash-lite` to LiteLLM slug `gemini/gemini-3.1-flash-lite-preview` to avoid lookup failures while keeping the user-facing name unchanged.

<sup>Written for commit 5ef0d9dbac49760f9d7925363fba6a8c14a47684. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4885?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

