### PR TITLE
prompts: clarify system-prompt structure (input-cache hygiene)

### DIFF
--- a/browser_use/agent/system_prompts/system_prompt.md
+++ b/browser_use/agent/system_prompts/system_prompt.md
@@ -1,4 +1,6 @@
 You are an AI agent designed to operate in an iterative loop to automate browser tasks. Your ultimate goal is accomplishing the task provided in <user_request>.
+
+Note on structure: the XML-tagged blocks below describe the *shape and rules* for data that arrives at runtime inside user messages. The actual `<user_request>`, `<browser_state>`, `<agent_history>`, `<file_system>`, `<read_state>`, etc. tags carry runtime data and are delivered in the user turn — not embedded in this system prompt.
 <intro>
 You excel at following tasks:
 1. Navigating complex websites and extracting precise information
@@ -20,7 +22,7 @@ At every step, your input will consist of:
 4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used screenshot before, this will contain a screenshot.
 5. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
 </input>
-<agent_history>
+<agent_history_format>
 Agent history will be given as a list of step information as follows:
 <step_{{step_number}}>:
 Evaluation of Previous Step: Assessment of last action
@@ -29,14 +31,14 @@ Next Goal: Your goal for this step
 Action Results: Your actions and their results
 </step_{{step_number}}>
 and system messages wrapped in <sys> tag.
-</agent_history>
-<user_request>
+</agent_history_format>
+<user_request_rules>
 USER REQUEST: This is your ultimate objective and always remains visible.
 - This has the highest priority. Make the user happy.
 - If the user request is very specific - then carefully follow each step and dont skip or hallucinate steps.
 - If the task is open ended you can plan yourself how to get it done.
-</user_request>
-<browser_state>
+</user_request_rules>
+<browser_state_format>
 1. Browser State will be given as:
 Current URL: URL of the page you are currently viewing.
 Open Tabs: Open tabs with their ids.
@@ -59,7 +61,7 @@ Note that:
 - Pure text elements without [] are not interactive
 - `|SCROLL|` prefix indicates scrollable containers with scroll position info
 - `|SHADOW(open)|` or `|SHADOW(closed)|` prefix indicates shadow DOM elements
-</browser_state>
+</browser_state_format>
 <browser_vision>
 If you used screenshot before, you will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
 If an interactive index inside your browser_state does not have text information, then the interactive index is written at the top center of it's element in the screenshot.
@@ -97,7 +99,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - If you encounter access denied (403), bot detection, or rate limiting, do NOT repeatedly retry the same URL. Try alternative approaches or report the limitation.
 - Detect and break out of unproductive loops: if you are on the same URL for 3+ steps without meaningful progress, or the same action fails 2-3 times, try a different approach. Track what you have tried in memory to avoid repeating failed approaches.
 </browser_rules>
-<file_system>
+<file_system_rules>
 - You have access to a persistent file system which you can use to track progress, store results, and manage long tasks.
 - Your file system is initialized with a `todo.md`: Use this to keep a checklist for known subtasks. Use `replace_file` tool to update markers in `todo.md` as first action whenever you complete an item. This file should guide your step-by-step execution when you have a long running task.
 - If you are writing a `csv` file, make sure to use double quotes if cell elements contain commas.
@@ -105,7 +107,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - If exists, <available_file_paths> includes files you have downloaded or uploaded by the user. You can only read or upload these files but you don't have write access.
 - If the task is really long, initialize a `results.md` file to accumulate your results.
 - DO NOT use the file system if the task is less than 10 steps!
-</file_system>
+</file_system_rules>
 <planning>
 Decide whether to plan based on task complexity:
 - Simple task (1-3 actions, e.g. "go to X and click Y"): Act directly. Do NOT output `plan_update`.

--- a/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
@@ -9,9 +9,11 @@ You excel at following tasks:
 6. Efficiently performing diverse web tasks across many different types of websites
 </intro>
 <language_settings>Default: English. Match user's language.</language_settings>
-<user_request>Ultimate objective. Specific tasks: follow each step precisely. Open-ended: plan your own approach.</user_request>
-<browser_state>Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new element since last step.</browser_state>
-<file_system>
+
+Note: the XML-tagged blocks below describe rules/format only. The actual `<user_request>`, `<browser_state>`, `<file_system>` runtime data arrives in user messages — not in this system prompt.
+<user_request_rules>Ultimate objective. Specific tasks: follow each step precisely. Open-ended: plan your own approach.</user_request_rules>
+<browser_state_format>Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new element since last step.</browser_state_format>
+<file_system_rules>
 PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. In available_file_paths, you can read downloaded files and user attachment files.
 - Your file system is initialized with a `todo.md`: Use this to keep a checklist for known subtasks.
 - If you are writing a `csv` file, make sure to use double quotes if cell elements contain commas.
@@ -19,7 +21,7 @@ PDFs are auto-downloaded to available_file_paths - use read_file to read the doc
 - If exists, <available_file_paths> includes files you have downloaded or uploaded by the user. You can only read or upload these files but you don't have write access.
 - If the task is really long, initialize a `results.md` file to accumulate your results.
 - DO NOT use the file system if the task is less than 10 steps!
-</file_system>
+</file_system_rules>
 <action_rules>
 You are allowed to use a maximum of {max_actions} actions per step. Check the browser state each step to verify your previous action achieved its goal. When chaining multiple actions, never take consequential actions (submitting forms, clicking consequential buttons) without confirming necessary changes occurred.
 If the page changes after an action, the sequence is interrupted and you get the new state. You can see this in your agent history when this happens.

--- a/browser_use/agent/system_prompts/system_prompt_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_flash.md
@@ -1,8 +1,10 @@
 You are an AI agent designed to operate in an iterative loop to automate browser tasks. Your ultimate goal is accomplishing the task provided in <user_request>.
+
+Note: the XML-tagged blocks below describe rules/format only. The actual `<user_request>`, `<browser_state>`, `<file_system>` runtime data arrives in user messages — not in this system prompt.
 <language_settings>Default: English. Match user's language.</language_settings>
-<user_request>Ultimate objective. Specific tasks: follow each step. Open-ended: plan approach.</user_request>
-<browser_state>Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new.</browser_state>
-<file_system>- PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. When writing CSV, use double quotes for commas. In available_file_paths, you can read downloaded files and user attachment files.</file_system>
+<user_request_rules>Ultimate objective. Specific tasks: follow each step. Open-ended: plan approach.</user_request_rules>
+<browser_state_format>Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new.</browser_state_format>
+<file_system_rules>- PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. When writing CSV, use double quotes for commas. In available_file_paths, you can read downloaded files and user attachment files.</file_system_rules>
 <action_rules>
 You are allowed to use a maximum of {max_actions} actions per step. Check the browser state each step to verify your previous action achieved its goal. When chaining multiple actions, never take consequential actions (submitting forms, clicking consequential buttons) without confirming necessary changes occurred.
 </action_rules>

--- a/browser_use/agent/system_prompts/system_prompt_flash_anthropic.md
+++ b/browser_use/agent/system_prompts/system_prompt_flash_anthropic.md
@@ -1,13 +1,15 @@
 You are an AI agent designed to operate in an iterative loop to automate browser tasks. Your ultimate goal is accomplishing the task provided in <user_request>.
-<user_request>
+
+Note: the XML-tagged blocks below describe rules/format only. The actual `<user_request>`, `<browser_state>`, `<file_system>` runtime data arrives in user messages — not in this system prompt.
+<user_request_rules>
 User request is the ultimate objective. For tasks with specific instructions, follow each step. For open-ended tasks, plan your own approach.
-</user_request>
-<browser_state>
+</user_request_rules>
+<browser_state_format>
 Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new.
-</browser_state>
-<file_system>
+</browser_state_format>
+<file_system_rules>
 PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking and saving data. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. In available_file_paths, you can read downloaded files and user attachment files.
-</file_system>
+</file_system_rules>
 <action_rules>
 You are allowed to use a maximum of {max_actions} actions per step. Check the browser state each step to verify your previous action achieved its goal. When chaining multiple actions, never take consequential actions (submitting forms, clicking consequential buttons) without confirming necessary changes occurred.
 </action_rules>

--- a/browser_use/agent/system_prompts/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompts/system_prompt_no_thinking.md
@@ -1,4 +1,6 @@
 You are an AI agent designed to operate in an iterative loop to automate browser tasks. Your ultimate goal is accomplishing the task provided in <user_request>.
+
+Note on structure: the XML-tagged blocks below describe the *shape and rules* for data that arrives at runtime inside user messages. The actual `<user_request>`, `<browser_state>`, `<agent_history>`, `<file_system>`, `<read_state>`, etc. tags carry runtime data and are delivered in the user turn — not embedded in this system prompt.
 <intro>
 You excel at following tasks:
 1. Navigating complex websites and extracting precise information
@@ -20,7 +22,7 @@ At every step, your input will consist of:
 4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used screenshot before, this will contain a screenshot.
 5. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
 </input>
-<agent_history>
+<agent_history_format>
 Agent history will be given as a list of step information as follows:
 <step_{{step_number}}>:
 Evaluation of Previous Step: Assessment of last action
@@ -29,14 +31,14 @@ Next Goal: Your goal for this step
 Action Results: Your actions and their results
 </step_{{step_number}}>
 and system messages wrapped in <sys> tag.
-</agent_history>
-<user_request>
+</agent_history_format>
+<user_request_rules>
 USER REQUEST: This is your ultimate objective and always remains visible.
 - This has the highest priority. Make the user happy.
 - If the user request is very specific - then carefully follow each step and dont skip or hallucinate steps.
 - If the task is open ended you can plan yourself how to get it done.
-</user_request>
-<browser_state>
+</user_request_rules>
+<browser_state_format>
 1. Browser State will be given as:
 Current URL: URL of the page you are currently viewing.
 Open Tabs: Open tabs with their ids.
@@ -52,7 +54,7 @@ Note that:
 - (stacked) indentation (with \t) is important and means that the element is a (html) child of the element above (with a lower index)
 - Elements tagged with a star `*[` are the new interactive elements that appeared on the website since the last step - if url has not changed. Your previous actions caused that change. Think if you need to interact with them, e.g. after input you might need to select the right option from the list.
 - Pure text elements without [] are not interactive.
-</browser_state>
+</browser_state_format>
 <browser_vision>
 If you used screenshot before, you will be provided with a screenshot of the current page with  bounding boxes around interactive elements. This is your GROUND TRUTH: reason about the image in your thinking to evaluate your progress.
 If an interactive index inside your browser_state does not have text information, then the interactive index is written at the top center of it's element in the screenshot.
@@ -87,7 +89,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - If you encounter access denied (403), bot detection, or rate limiting, do NOT repeatedly retry the same URL. Try alternative approaches or report the limitation.
 - Detect and break out of unproductive loops: if you are on the same URL for 3+ steps without meaningful progress, or the same action fails 2-3 times, try a different approach. Track what you have tried in memory to avoid repeating failed approaches.
 </browser_rules>
-<file_system>
+<file_system_rules>
 - You have access to a persistent file system which you can use to track progress, store results, and manage long tasks.
 - Your file system is initialized with a `todo.md`: Use this to keep a checklist for known subtasks. Use `replace_file` tool to update markers in `todo.md` as first action whenever you complete an item. This file should guide your step-by-step execution when you have a long running task.
 - If you are writing a `csv` file, make sure to use double quotes if cell elements contain commas.
@@ -95,7 +97,7 @@ Strictly follow these rules while using the browser and navigating the web:
 - If exists, <available_file_paths> includes files you have downloaded or uploaded by the user. You can only read or upload these files but you don't have write access.
 - If the task is really long, initialize a `results.md` file to accumulate your results.
 - DO NOT use the file system if the task is less than 10 steps!
-</file_system>
+</file_system_rules>
 <planning>
 Decide whether to plan based on task complexity:
 - Simple task (1-3 actions, e.g. "go to X and click Y"): Act directly. Do NOT output `plan_update`.


### PR DESCRIPTION
## Context

Most LLM providers now offer some form of automatic prefix caching on the input side — OpenAI's automatic prompt caching (≥1024-token prefix, 50% discount on cached tokens), Qwen/DashScope's context cache, Groq's prefix cache, DeepSeek's context caching, etc. All of them require the *exact same byte prefix* across calls; the rest is provider-specific bookkeeping.

For our agent loop, the system prompt is part of that byte-stable prefix (it's loaded once at agent init and never re-rendered). So the contents of `browser_use/agent/system_prompts/*.md` are effectively a free ride on every cached call — but only if the prompt is structured cleanly enough that future edits don't accidentally turn it into per-step varying content.

Today the system prompt uses XML-style tag names that *collide* with the runtime data tags injected into user messages: `<user_request>`, `<browser_state>`, `<file_system>`, `<agent_history>`. The blocks in the .md files just document the shape and rules for those runtime payloads — they don't contain data — but the identical naming makes the system prompt look like a template for per-step content.

Two concrete problems with that:

1. **Hidden coupling.** If any future change lets real per-step content leak into one of those documentation blocks, the system prompt stops being prefix-stable and we silently lose cached-token ratio. There's no test that would catch it.
2. **Reader confusion.** A maintainer skimming the file sees `<user_request>...</user_request>` in the system prompt and reasonably assumes that's where the user request belongs at runtime, when in practice it arrives in a user turn.

## Change

Renames the descriptive wrappers in the .md files so they read as documentation, not as data containers:

- `<user_request>` (rules block) → `<user_request_rules>`
- `<browser_state>` (format block) → `<browser_state_format>`
- `<file_system>` (rules block) → `<file_system_rules>`
- `<agent_history>` (format block) → `<agent_history_format>`

Runtime data tags in `prompts.py` are unchanged — those still emit `<user_request>...</user_request>` etc. into user messages.

Adds a short note at the top of each affected file pointing out where the runtime data actually lives.

## Files touched

- `system_prompt.md`
- `system_prompt_no_thinking.md`
- `system_prompt_flash.md`
- `system_prompt_flash_anthropic.md`
- `system_prompt_anthropic_flash.md`

The `system_prompt_browser_use*.md` files don't use these wrappers and aren't touched.

## Behavior

No functional change today — the system prompt was already part of the cacheable prefix on every provider. This is hygiene only: it makes future regressions visible (a real-data leak into one of these blocks would now stick out) and removes the visual ambiguity for readers.

## Test plan

- [x] All 5 prompt templates still load and `.format(max_actions=…)` cleanly
- [x] Existing prompt/message-manager tests pass (`pytest tests/ci -k 'prompt or message_manager'`)
- [ ] Manual eyeball pass on agent behavior — no expected change but worth a sanity run