### PR TITLE
feat: forward cached_content into generate_content

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -99,6 +99,9 @@ class ChatGoogle(BaseChatModel):
 	config: types.GenerateContentConfigDict | None = None
 	include_system_in_user: bool = False
 	supports_structured_output: bool = True  # New flag
+	cached_content: str | None = (
+		None  # Gemini explicit CachedContent name (e.g. "cachedContents/abc123") to reuse a precomputed prefix across calls. Per-call override via ainvoke(..., cached_content=...).
+	)
 	max_retries: int = 5  # Number of retries for retryable errors
 	retryable_status_codes: list[int] = field(default_factory=lambda: [429, 500, 502, 503, 504])  # Status codes to retry on
 	retry_base_delay: float = 1.0  # Base delay in seconds for exponential backoff
@@ -320,6 +323,11 @@ class ChatGoogle(BaseChatModel):
 
 		if self.max_output_tokens is not None:
 			config['max_output_tokens'] = self.max_output_tokens
+
+		# Explicit Gemini CachedContent: per-call kwarg takes precedence over the instance default.
+		cached_content_name = kwargs.get('cached_content', self.cached_content)
+		if cached_content_name:
+			config['cached_content'] = cached_content_name
 
 		async def _make_api_call():
 			start_time = time.time()

--- a/tests/ci/models/test_llm_google.py
+++ b/tests/ci/models/test_llm_google.py
@@ -53,6 +53,40 @@ def test_x_goog_api_client_header_with_pydantic_http_options():
 	assert http_opts.get('headers', {}).get('x-goog-api-client', '').startswith('browser-use/')
 
 
+async def test_cached_content_threaded_into_config(monkeypatch):
+	"""Setting cached_content (instance default or per-call kwarg) should reach the generate_content call."""
+	from types import SimpleNamespace
+
+	from browser_use.llm.messages import UserMessage
+
+	captured: dict = {}
+
+	async def fake_generate_content(*, model, contents, config):
+		captured['config'] = dict(config) if config else {}
+		return SimpleNamespace(text='ok', parsed=None, usage_metadata=None, candidates=[])
+
+	def fake_get_client(self):
+		return SimpleNamespace(aio=SimpleNamespace(models=SimpleNamespace(generate_content=fake_generate_content)))
+
+	monkeypatch.setattr(ChatGoogle, 'get_client', fake_get_client)
+
+	# Instance default
+	chat = ChatGoogle(model='gemini-flash-latest', api_key='fake', cached_content='cachedContents/abc123')
+	await chat.ainvoke([UserMessage(content='hi')])
+	assert captured['config'].get('cached_content') == 'cachedContents/abc123'
+
+	# Per-call kwarg overrides instance default
+	captured.clear()
+	await chat.ainvoke([UserMessage(content='hi')], cached_content='cachedContents/override')
+	assert captured['config'].get('cached_content') == 'cachedContents/override'
+
+	# When unset, key is absent from config
+	captured.clear()
+	chat_no_cache = ChatGoogle(model='gemini-flash-latest', api_key='fake')
+	await chat_no_cache.ainvoke([UserMessage(content='hi')])
+	assert 'cached_content' not in captured['config']
+
+
 def test_x_goog_api_client_header_with_dict_http_options():
 	"""Test setting header when http_options is a dictionary (types.HttpOptionsDict)."""
 	from google.genai import types


### PR DESCRIPTION
## Context

Closes part of #4887 (item #4 — explicit CachedContent support).

Gemini's implicit context cache is great for the steady-state of an agent loop but has a ~5-minute TTL and is per-call best-effort. For long sessions (or sessions that go quiet for >5 minutes and resume), explicit `CachedContent` is the deterministic alternative: you create a named cache once with the prefix, then reference it on subsequent calls and Google bills the cached portion at the discounted rate, period.

The wrapper in `browser_use/llm/google/chat.py` already parses `cached_content_token_count` out of `response.usage_metadata` into `ChatInvokeUsage.prompt_cached_tokens`, so the savings are visible — it just had no way to *send* a cache reference.

## Change

- New `cached_content: str | None = None` field on `ChatGoogle`.
- New `cached_content` kwarg on `ainvoke()` — overrides the instance default for one call.
- When set, threads into `config['cached_content']` before all three `generate_content` calls (string output, native JSON, fallback JSON).

Per-call kwarg takes precedence over the instance default, so you can pin a cache for the whole session and still override per-call when needed.

## What's NOT in this PR

- Cache creation (`client.caches.create(...)`) is left to the caller. That gives users full control over TTL, contents, and lifecycle without coupling the LLM wrapper to agent-state decisions.
- Agent-side automatic cache lifecycle (create on first step, reuse on subsequent steps, refresh near TTL) is an obvious follow-up but a separate design discussion — it touches `agent/service.py` and depends on what the agent considers its "stable prefix."

## Usage

```python
from google.genai import types
from google import genai

client = genai.Client(api_key=...)
cache = await client.aio.caches.create(
    model='gemini-2.5-flash',
    config=types.CreateCachedContentConfig(
        contents=[...prefix turns...],
        system_instruction='...',
        ttl='3600s',
    ),
)

llm = ChatGoogle(model='gemini-2.5-flash', cached_content=cache.name)
# Every ainvoke() now references that cache.

# Per-call override:
await llm.ainvoke(messages, cached_content='cachedContents/other')
```

## Test plan

- [x] New unit test `test_cached_content_threaded_into_config` — verifies the kwarg flows into `generate_content`'s `config` dict, the per-call kwarg overrides the instance default, and when unset the key is absent (`pytest tests/ci/models/test_llm_google.py`).
- [x] Existing google tests still pass.
- [ ] Real-API smoke test against a Gemini model with an actual `cachedContents/...` resource (requires API key + paid quota — not in CI).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit Gemini CachedContent support to `ChatGoogle` by forwarding a `cached_content` name into all `generate_content` calls. Addresses #4887 (item 4) to enable deterministic cache reuse with discounted billing.

- **New Features**
  - Add `cached_content` on `ChatGoogle` with per-call override via `ainvoke(..., cached_content=...)`.
  - Thread to `config['cached_content']` for all paths; omit when unset.
  - Cache creation is caller-managed; usage already counts `prompt_cached_tokens`.

- **Migration**
  - No breaking changes; behavior is unchanged when `cached_content` is unset.
  - To adopt: create a Gemini cache and pass its name via `ChatGoogle(cached_content=...)` or `ainvoke(..., cached_content=...)`.

<sup>Written for commit ac5ff6dd15adb3f643bd6e0f98ff0f9cada1a284. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4889?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

