### PR TITLE
agent(history): freeze HistoryItem + lock byte-prefix property

### DIFF
--- a/browser_use/agent/message_manager/views.py
+++ b/browser_use/agent/message_manager/views.py
@@ -13,7 +13,12 @@ if TYPE_CHECKING:
 
 
 class HistoryItem(BaseModel):
-	"""Represents a single agent history item with its data and string representation"""
+	"""Represents a single agent history item with its data and string representation.
+
+	Frozen so that once appended to MessageManagerState.agent_history_items, the rendered
+	transcript prefix stays byte-identical across steps. This is what lets Gemini's implicit
+	cache (and similar caches) match the agent-history portion of the prompt step over step.
+	"""
 
 	step_number: int | None = None
 	evaluation_previous_goal: str | None = None
@@ -23,7 +28,7 @@ class HistoryItem(BaseModel):
 	error: str | None = None
 	system_message: str | None = None
 
-	model_config = ConfigDict(arbitrary_types_allowed=True)
+	model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
 	def model_post_init(self, __context) -> None:
 		"""Validate that error and system_message are not both provided"""

--- a/tests/ci/test_history_item_byte_stable.py
+++ b/tests/ci/test_history_item_byte_stable.py
@@ -1,0 +1,91 @@
+"""Lock down the byte-prefix property of agent history serialization.
+
+For Gemini's implicit cache (and similar provider caches) to hit step over step,
+the rendered string for steps 1..N at step N+1 must be byte-identical to the
+rendered string for steps 1..N at step N. This file asserts:
+
+1. HistoryItem is frozen — once appended, no mutation can later shift its bytes.
+2. Rendering items[:N] is a strict byte-prefix of rendering items[:N+1] under
+   the join used by agent_history_description (newline-separated to_string()).
+3. to_string() is itself deterministic — same fields in, same bytes out.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from browser_use.agent.message_manager.views import HistoryItem
+
+
+def _render(items: list[HistoryItem]) -> str:
+	return '\n'.join(item.to_string() for item in items)
+
+
+def test_history_item_is_frozen():
+	item = HistoryItem(step_number=1, memory='m', next_goal='g', action_results='r')
+	with pytest.raises(ValidationError):
+		item.memory = 'mutated'  # type: ignore[misc]
+
+
+def test_to_string_is_deterministic():
+	a = HistoryItem(
+		step_number=3,
+		evaluation_previous_goal='Verdict: Success',
+		memory='visited 2 pages',
+		next_goal='click Submit',
+		action_results='Action 1/1: clicked element 5',
+	)
+	b = HistoryItem(
+		step_number=3,
+		evaluation_previous_goal='Verdict: Success',
+		memory='visited 2 pages',
+		next_goal='click Submit',
+		action_results='Action 1/1: clicked element 5',
+	)
+	assert a.to_string() == b.to_string()
+
+
+def test_render_grows_by_strict_byte_prefix():
+	"""The cache property: appending a new history item must extend the rendered string,
+	never rewrite earlier bytes."""
+	items: list[HistoryItem] = []
+	prev = ''
+	for n in range(1, 8):
+		items.append(
+			HistoryItem(
+				step_number=n,
+				evaluation_previous_goal=f'eval {n}',
+				memory=f'mem {n}',
+				next_goal=f'goal {n}',
+				action_results=f'Action 1/1: did thing {n}',
+			)
+		)
+		current = _render(items)
+		assert current.startswith(prev), (
+			f'Step {n} broke byte-prefix property.\nPrev tail: {prev[-200:]!r}\nCurrent at prev len: {current[: len(prev)][-200:]!r}'
+		)
+		prev = current
+
+
+def test_prefix_property_holds_with_mixed_entry_shapes():
+	"""Errors, system messages, and full step entries should all preserve byte-prefix growth."""
+	items: list[HistoryItem] = [
+		HistoryItem(step_number=0, system_message='Agent initialized'),
+		HistoryItem(step_number=1, memory='m1', next_goal='g1', action_results='r1'),
+		HistoryItem(step_number=2, error='Agent failed to output in the right format.'),
+		HistoryItem(step_number=3, evaluation_previous_goal='eval', memory='m3', next_goal='g3', action_results='r3'),
+		HistoryItem(system_message='<follow_up_user_request> new task </follow_up_user_request>'),
+		HistoryItem(step_number=4, memory='m4', next_goal='g4', action_results='r4'),
+	]
+	prev = ''
+	for n in range(1, len(items) + 1):
+		current = _render(items[:n])
+		assert current.startswith(prev), f'Mixed-shape prefix broke at n={n}'
+		prev = current
+
+
+def test_optional_fields_dont_silently_collapse():
+	"""Conditional field inclusion in to_string() must not produce ambiguous output —
+	a None field today shouldn't render identically to a populated field tomorrow."""
+	with_memory = HistoryItem(step_number=1, memory='something', action_results='r').to_string()
+	without_memory = HistoryItem(step_number=1, action_results='r').to_string()
+	assert with_memory != without_memory, 'memory contribution to output collapsed to identity'


### PR DESCRIPTION
## Context

Closes part of #4887 (item #1 — make the per-step transcript append-only).

For Gemini's implicit cache (and similar provider caches) to actually hit step over step, the rendered transcript for steps 1..N-1 must be byte-identical at step N and at step N+1. The agent today appends `HistoryItem`s immutably in practice — every site I checked constructs a new item and `.append()`s it — but nothing in the type itself prevents a future caller from mutating one in place. That kind of mutation would silently kill the cache from that byte onward, and we'd only notice it as a slow erosion of cached-token-ratio.

## Change

1. Mark `HistoryItem` `frozen=True` via pydantic `ConfigDict`, so any mutation fails loud at runtime instead of silently burning input tokens later.
2. Add a regression test set (`tests/ci/test_history_item_byte_stable.py`) that asserts the cache property directly:
   - `render(items[:N])` is a strict byte-prefix of `render(items[:N+1])`
   - `to_string()` is deterministic for identical inputs
   - the prefix property holds across mixed entry shapes (normal steps, errors, system messages, follow-up tasks)
   - conditional field inclusion in `to_string()` doesn't collapse to ambiguous output (a populated field shouldn't render identically to a missing one)

The tests pass against current behavior — they're locking it down, not changing it.

## Known limitation (intentionally not in this PR)

`MessageManager.agent_history_description` does have one real cache-buster I noticed during the audit: when `max_history_items` is set and exceeded, the compaction logic at `message_manager/service.py:173-186` rewrites earlier bytes — the `[... N previous steps omitted...]` count changes every step past the cap, so the prefix is not stable past the boundary.

Fixing that properly means either (a) capping the omitted-count at a stable value, or (b) restructuring the compaction to omit at a fixed cutoff. Either way it's a bigger design call than this hygiene PR, so I left it for a follow-up. Calling it out in the commit message.

## Test plan

- [x] New byte-stability tests pass (`pytest tests/ci/test_history_item_byte_stable.py`).
- [x] Existing message_manager / history tests still pass (`pytest tests/ci -k 'message_manager or history'`).
- [x] `pyright` + `ruff` clean via pre-commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze `HistoryItem` to make agent step transcripts append-only and preserve byte-prefix stability for provider caches (e.g., Gemini). Adds regression tests to lock deterministic rendering and strict prefix growth. Part of #4887.

- **Refactors**
  - Set `frozen=True` in `pydantic` `ConfigDict` for `HistoryItem`; mutation now raises instead of silently changing rendered bytes.
  - Added regression tests to enforce: strict byte-prefix growth across steps, deterministic `to_string()`, stability with mixed entry shapes, and disambiguation of optional fields.

<sup>Written for commit 8236cc7506063d1400c58a236f625537bfbefee2. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4890?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

