### PR TITLE
feat(llm): surface cached input tokens for OpenAI-compatible providers

### DIFF
--- a/browser_use/llm/cerebras/chat.py
+++ b/browser_use/llm/cerebras/chat.py
@@ -62,9 +62,14 @@ class ChatCerebras(BaseChatModel):
 		if response.usage is None:
 			return None
 		# Cerebras uses the OpenAI-compatible SDK shape and surfaces
-		# `usage.prompt_tokens_details.cached_tokens` when its prefix cache hits.
+		# `usage.prompt_tokens_details.cached_tokens` when its prefix cache hits. The nested
+		# payload may arrive as a typed object or as a plain dict depending on SDK version /
+		# proxy — handle both shapes.
 		prompt_details = getattr(response.usage, 'prompt_tokens_details', None)
-		cached_tokens = getattr(prompt_details, 'cached_tokens', None) if prompt_details else None
+		if isinstance(prompt_details, dict):
+			cached_tokens = prompt_details.get('cached_tokens')
+		else:
+			cached_tokens = getattr(prompt_details, 'cached_tokens', None) if prompt_details else None
 		return ChatInvokeUsage(
 			prompt_tokens=response.usage.prompt_tokens,
 			prompt_cached_tokens=cached_tokens,

--- a/browser_use/llm/cerebras/chat.py
+++ b/browser_use/llm/cerebras/chat.py
@@ -59,18 +59,20 @@ class ChatCerebras(BaseChatModel):
 		return self.model
 
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
-		if response.usage is not None:
-			usage = ChatInvokeUsage(
-				prompt_tokens=response.usage.prompt_tokens,
-				prompt_cached_tokens=None,
-				prompt_cache_creation_tokens=None,
-				prompt_image_tokens=None,
-				completion_tokens=response.usage.completion_tokens,
-				total_tokens=response.usage.total_tokens,
-			)
-		else:
-			usage = None
-		return usage
+		if response.usage is None:
+			return None
+		# Cerebras uses the OpenAI-compatible SDK shape and surfaces
+		# `usage.prompt_tokens_details.cached_tokens` when its prefix cache hits.
+		prompt_details = getattr(response.usage, 'prompt_tokens_details', None)
+		cached_tokens = getattr(prompt_details, 'cached_tokens', None) if prompt_details else None
+		return ChatInvokeUsage(
+			prompt_tokens=response.usage.prompt_tokens,
+			prompt_cached_tokens=cached_tokens,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+			completion_tokens=response.usage.completion_tokens,
+			total_tokens=response.usage.total_tokens,
+		)
 
 	@overload
 	async def ainvoke(

--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -88,10 +88,15 @@ class ChatGroq(BaseChatModel):
 		if response.usage is None:
 			return None
 		# Groq is OpenAI-compatible: when prefix-cached models report it, they surface
-		# `usage.prompt_tokens_details.cached_tokens` like OpenAI. Read defensively — older
-		# SDK builds may not type the field.
+		# `usage.prompt_tokens_details.cached_tokens` like OpenAI. The nested payload may
+		# arrive as a typed object (newer SDK builds) or as a plain dict (older builds /
+		# proxied responses) — handle both shapes so cache hits aren't silently dropped in
+		# the compatibility path.
 		prompt_details = getattr(response.usage, 'prompt_tokens_details', None)
-		cached_tokens = getattr(prompt_details, 'cached_tokens', None) if prompt_details else None
+		if isinstance(prompt_details, dict):
+			cached_tokens = prompt_details.get('cached_tokens')
+		else:
+			cached_tokens = getattr(prompt_details, 'cached_tokens', None) if prompt_details else None
 		return ChatInvokeUsage(
 			prompt_tokens=response.usage.prompt_tokens,
 			completion_tokens=response.usage.completion_tokens,

--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -85,19 +85,21 @@ class ChatGroq(BaseChatModel):
 		return str(self.model)
 
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
-		usage = (
-			ChatInvokeUsage(
-				prompt_tokens=response.usage.prompt_tokens,
-				completion_tokens=response.usage.completion_tokens,
-				total_tokens=response.usage.total_tokens,
-				prompt_cached_tokens=None,  # Groq doesn't support cached tokens
-				prompt_cache_creation_tokens=None,
-				prompt_image_tokens=None,
-			)
-			if response.usage is not None
-			else None
+		if response.usage is None:
+			return None
+		# Groq is OpenAI-compatible: when prefix-cached models report it, they surface
+		# `usage.prompt_tokens_details.cached_tokens` like OpenAI. Read defensively — older
+		# SDK builds may not type the field.
+		prompt_details = getattr(response.usage, 'prompt_tokens_details', None)
+		cached_tokens = getattr(prompt_details, 'cached_tokens', None) if prompt_details else None
+		return ChatInvokeUsage(
+			prompt_tokens=response.usage.prompt_tokens,
+			completion_tokens=response.usage.completion_tokens,
+			total_tokens=response.usage.total_tokens,
+			prompt_cached_tokens=cached_tokens,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
 		)
-		return usage
 
 	@overload
 	async def ainvoke(

--- a/browser_use/llm/mistral/chat.py
+++ b/browser_use/llm/mistral/chat.py
@@ -100,9 +100,14 @@ class ChatMistral(BaseChatModel):
 		if not usage:
 			return None
 
+		# Mistral's chat-completions response follows the OpenAI convention for
+		# prefix-cache reporting: `usage.prompt_tokens_details.cached_tokens` when present.
+		prompt_details = usage.get('prompt_tokens_details') or {}
+		cached_tokens = prompt_details.get('cached_tokens') if isinstance(prompt_details, dict) else None
+
 		return ChatInvokeUsage(
 			prompt_tokens=usage.get('prompt_tokens', 0),
-			prompt_cached_tokens=None,
+			prompt_cached_tokens=cached_tokens,
 			prompt_cache_creation_tokens=None,
 			prompt_image_tokens=None,
 			completion_tokens=usage.get('completion_tokens', 0),

--- a/tests/ci/models/test_openai_compat_cached_tokens.py
+++ b/tests/ci/models/test_openai_compat_cached_tokens.py
@@ -27,6 +27,18 @@ def _fake_openai_usage(prompt: int, completion: int, cached: int | None) -> Simp
 	)
 
 
+def _fake_openai_usage_dict_details(prompt: int, completion: int, cached: int | None) -> SimpleNamespace:
+	"""Same shape but `prompt_tokens_details` arrives as a plain dict — the older-SDK /
+	proxied-response compatibility case that motivated the defensive read."""
+	details = {'cached_tokens': cached} if cached is not None else None
+	return SimpleNamespace(
+		prompt_tokens=prompt,
+		completion_tokens=completion,
+		total_tokens=prompt + completion,
+		prompt_tokens_details=details,
+	)
+
+
 def test_groq_surfaces_cached_tokens():
 	chat = ChatGroq(model='llama-3.3-70b-versatile', api_key='fake')
 	response = SimpleNamespace(usage=_fake_openai_usage(1200, 50, cached=900))
@@ -44,6 +56,16 @@ def test_groq_handles_missing_details():
 	assert usage.prompt_cached_tokens is None
 
 
+def test_groq_surfaces_cached_tokens_when_details_is_dict():
+	"""Older SDK builds / proxied responses deliver prompt_tokens_details as a plain dict
+	rather than a typed object — the compatibility path must still pick up the cache hit."""
+	chat = ChatGroq(model='llama-3.3-70b-versatile', api_key='fake')
+	response = SimpleNamespace(usage=_fake_openai_usage_dict_details(1200, 50, cached=900))
+	usage = chat._get_usage(response)  # type: ignore[arg-type]
+	assert usage is not None
+	assert usage.prompt_cached_tokens == 900
+
+
 def test_cerebras_surfaces_cached_tokens():
 	chat = ChatCerebras(model='llama3.1-70b', api_key='fake')
 	response = SimpleNamespace(usage=_fake_openai_usage(2048, 100, cached=1500))
@@ -58,6 +80,14 @@ def test_cerebras_handles_missing_details():
 	usage = chat._get_usage(response)  # type: ignore[arg-type]
 	assert usage is not None
 	assert usage.prompt_cached_tokens is None
+
+
+def test_cerebras_surfaces_cached_tokens_when_details_is_dict():
+	chat = ChatCerebras(model='llama3.1-70b', api_key='fake')
+	response = SimpleNamespace(usage=_fake_openai_usage_dict_details(2048, 100, cached=1500))
+	usage = chat._get_usage(response)  # type: ignore[arg-type]
+	assert usage is not None
+	assert usage.prompt_cached_tokens == 1500
 
 
 def test_mistral_surfaces_cached_tokens():

--- a/tests/ci/models/test_openai_compat_cached_tokens.py
+++ b/tests/ci/models/test_openai_compat_cached_tokens.py
@@ -1,0 +1,88 @@
+"""Surface OpenAI-compatible `prompt_tokens_details.cached_tokens` through provider usage parsers.
+
+OpenAI introduced `usage.prompt_tokens_details.cached_tokens` as the standard reporting
+field for automatic prefix caching in chat completions. Most OpenAI-compatible providers
+(Groq, Cerebras, Mistral, OpenRouter, ...) cloned the convention. When a wrapper drops
+this field, every cached call still costs the user money on paper — they just can't see
+the discount.
+
+These tests pin the parsers to actually read it.
+"""
+
+from types import SimpleNamespace
+
+from browser_use.llm.cerebras.chat import ChatCerebras
+from browser_use.llm.groq.chat import ChatGroq
+from browser_use.llm.mistral.chat import ChatMistral
+
+
+def _fake_openai_usage(prompt: int, completion: int, cached: int | None) -> SimpleNamespace:
+	"""Mimic the openai.types.CompletionUsage shape: usage.prompt_tokens_details.cached_tokens."""
+	details = SimpleNamespace(cached_tokens=cached) if cached is not None else None
+	return SimpleNamespace(
+		prompt_tokens=prompt,
+		completion_tokens=completion,
+		total_tokens=prompt + completion,
+		prompt_tokens_details=details,
+	)
+
+
+def test_groq_surfaces_cached_tokens():
+	chat = ChatGroq(model='llama-3.3-70b-versatile', api_key='fake')
+	response = SimpleNamespace(usage=_fake_openai_usage(1200, 50, cached=900))
+	usage = chat._get_usage(response)  # type: ignore[arg-type]
+	assert usage is not None
+	assert usage.prompt_tokens == 1200
+	assert usage.prompt_cached_tokens == 900
+
+
+def test_groq_handles_missing_details():
+	chat = ChatGroq(model='llama-3.3-70b-versatile', api_key='fake')
+	response = SimpleNamespace(usage=_fake_openai_usage(100, 20, cached=None))
+	usage = chat._get_usage(response)  # type: ignore[arg-type]
+	assert usage is not None
+	assert usage.prompt_cached_tokens is None
+
+
+def test_cerebras_surfaces_cached_tokens():
+	chat = ChatCerebras(model='llama3.1-70b', api_key='fake')
+	response = SimpleNamespace(usage=_fake_openai_usage(2048, 100, cached=1500))
+	usage = chat._get_usage(response)  # type: ignore[arg-type]
+	assert usage is not None
+	assert usage.prompt_cached_tokens == 1500
+
+
+def test_cerebras_handles_missing_details():
+	chat = ChatCerebras(model='llama3.1-70b', api_key='fake')
+	response = SimpleNamespace(usage=_fake_openai_usage(50, 10, cached=None))
+	usage = chat._get_usage(response)  # type: ignore[arg-type]
+	assert usage is not None
+	assert usage.prompt_cached_tokens is None
+
+
+def test_mistral_surfaces_cached_tokens():
+	chat = ChatMistral(model='mistral-large-latest', api_key='fake')
+	usage = chat._build_usage(
+		{
+			'prompt_tokens': 1500,
+			'completion_tokens': 80,
+			'total_tokens': 1580,
+			'prompt_tokens_details': {'cached_tokens': 1024},
+		}
+	)
+	assert usage is not None
+	assert usage.prompt_tokens == 1500
+	assert usage.prompt_cached_tokens == 1024
+
+
+def test_mistral_handles_missing_details():
+	chat = ChatMistral(model='mistral-large-latest', api_key='fake')
+	usage = chat._build_usage({'prompt_tokens': 200, 'completion_tokens': 30, 'total_tokens': 230})
+	assert usage is not None
+	assert usage.prompt_cached_tokens is None
+
+
+def test_mistral_returns_none_on_empty_usage():
+	chat = ChatMistral(model='mistral-large-latest', api_key='fake')
+	assert chat._build_usage(None) is None
+	assert chat._build_usage({}) is None


### PR DESCRIPTION
## Context

OpenAI introduced automatic prefix caching for chat completions in late 2024 — prompts of ≥1024 tokens that share a byte-stable prefix with a recent call get the matching portion billed at half price, and the response reports the hit via:

```
usage.prompt_tokens_details.cached_tokens
```

Most OpenAI-compatible providers cloned the convention. Groq, Cerebras, and Mistral all surface `usage.prompt_tokens_details.cached_tokens` (when their cache hits) on chat-completion responses. The discount lands on the invoice either way — but our wrappers for those three were dropping the field on the floor, so `ChatInvokeUsage.prompt_cached_tokens` always came back `None` and there was no way to observe cache effectiveness from inside the agent.

## Change

Read `prompt_tokens_details.cached_tokens` defensively in:

- `browser_use/llm/groq/chat.py`
- `browser_use/llm/cerebras/chat.py`
- `browser_use/llm/mistral/chat.py`

`getattr` / `dict.get` rather than typed attribute access, so older SDK builds that don't type `prompt_tokens_details` still work. This matches the pattern already used in `openrouter/chat.py` and `vercel/chat.py` — just propagating the existing convention to the remaining wrappers.

## Already wired (no change needed)

OpenAI, Anthropic, Google, Azure, OpenRouter, Vercel, LiteLLM, AWS (Anthropic), and the in-house BrowserUse provider all already surface their respective cached-token fields. Audit done in the same pass.

## Out of scope

- **DeepSeek**: returns `usage=None` entirely from the relevant code path — surfacing its native `prompt_cache_hit_tokens` / `prompt_cache_miss_tokens` needs a bigger plumbing change. Follow-up.
- **Ollama**: same, returns `usage=None`. Ollama doesn't have prefix caching, but the prompt/completion counts themselves are also dropped. Follow-up.
- **AWS Bedrock raw / OCI**: APIs don't report cached tokens at all.

## Test plan

- [x] New unit tests at `tests/ci/models/test_openai_compat_cached_tokens.py` — assert each parser reads the field when present and stays `None` when absent (7 cases).
- [x] All existing provider model tests still pass (`pytest tests/ci/models/`).
- [x] pyright + ruff clean via pre-commit.
- [ ] Real-API smoke run against a Groq prefix-cached model isn't in CI but the field shape is contracted by the OpenAI SDK type, which Groq mirrors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface cached input tokens for OpenAI‑compatible providers so agents can see prefix‑cache savings in `ChatInvokeUsage.prompt_cached_tokens`.

- **New Features**
  - Read `usage.prompt_tokens_details.cached_tokens` for `groq`, `cerebras`, and `mistral`.

- **Bug Fixes**
  - Handle dict-shaped `prompt_tokens_details` in `groq` and `cerebras` parsers (older SDKs/proxies).
  - Add regression tests for both shapes; confirm `None` when the field is absent.

<sup>Written for commit cb3feab2ecc5d3c87f49cc2951689065a635c1c1. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4892?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

