### PR TITLE
fix: write text files with utf-8

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -110,12 +110,14 @@ class BaseFile(BaseModel, ABC):
 
 	def sync_to_disk_sync(self, path: Path) -> None:
 		file_path = path / self.full_name
-		file_path.write_text(self.content)
+		file_path.write_text(self.content, encoding='utf-8')
 
 	async def sync_to_disk(self, path: Path) -> None:
 		file_path = path / self.full_name
 		with ThreadPoolExecutor() as executor:
-			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content))
+			await asyncio.get_running_loop().run_in_executor(
+				executor, lambda: file_path.write_text(self.content, encoding='utf-8')
+			)
 
 	async def write(self, content: str, path: Path) -> None:
 		self.write_file_content(content)
@@ -283,7 +285,7 @@ class PdfFile(BaseFile):
 
 	async def sync_to_disk(self, path: Path) -> None:
 		with ThreadPoolExecutor() as executor:
-			await asyncio.get_event_loop().run_in_executor(executor, lambda: self.sync_to_disk_sync(path))
+			await asyncio.get_running_loop().run_in_executor(executor, lambda: self.sync_to_disk_sync(path))
 
 
 class DocxFile(BaseFile):
@@ -323,7 +325,7 @@ class DocxFile(BaseFile):
 
 	async def sync_to_disk(self, path: Path) -> None:
 		with ThreadPoolExecutor() as executor:
-			await asyncio.get_event_loop().run_in_executor(executor, lambda: self.sync_to_disk_sync(path))
+			await asyncio.get_running_loop().run_in_executor(executor, lambda: self.sync_to_disk_sync(path))
 
 
 class HtmlFile(BaseFile):


### PR DESCRIPTION
## Summary
- Write generated text-based file-system content with explicit UTF-8 encoding
- Use `asyncio.get_running_loop()` in async disk sync paths that already run inside coroutines

## Problem
`Path.write_text()` defaults to the platform encoding when `encoding` is not provided. That can make generated markdown/text/json/csv/html/xml content depend on the user's locale, especially on Windows. The async sync helpers also use `asyncio.get_event_loop()` inside async methods where the running loop is the intended loop.

## Before / After
Before, text file writes used the platform default encoding, and async executor calls resolved the event loop through legacy `get_event_loop()` behavior.

After, text writes use UTF-8 explicitly and async helpers use the currently running loop.

## Verification
- `python -m compileall -q browser_use\filesystem\file_system.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force UTF-8 when writing generated text files and use `asyncio.get_running_loop()` in async disk paths. This ensures cross-platform encoding consistency and avoids legacy event loop behavior.

- **Bug Fixes**
  - Write text files with `encoding='utf-8'` to avoid locale-dependent outputs.
  - Use `asyncio.get_running_loop()` in coroutines for executor calls.

<sup>Written for commit 19c661591987c31530d7c6f018204d7955ecbec2. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4893?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

