### PR TITLE
fix: bump openai pin for downstream compatibility

### DIFF
--- a/examples/custom-functions/cua.py
+++ b/examples/custom-functions/cua.py
@@ -261,6 +261,8 @@ async def openai_cua_fallback(params: OpenAICUAAction, browser_session: BrowserS
 			raise Exception('No computer calls found in CUA response')
 
 		action = computer_call.action
+		if action is None:
+			raise Exception('No computer action found in CUA response')
 		print(f'🎬 Executing CUA action: {action.type} - {action}')
 
 		action_result = await handle_model_action(browser_session, action)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "google-genai==1.65.0",
-    "openai==2.26.0",
+    "openai==2.36.0",
     "anthropic==0.76.0",
     "groq==1.0.0",
     "ollama==0.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "google-genai==1.65.0",
-    "openai==2.16.0",
+    "openai==2.26.0",
     "anthropic==0.76.0",
     "groq==1.0.0",
     "ollama==0.6.1",


### PR DESCRIPTION
## Summary

Updates the pinned OpenAI SDK dependency from `openai==2.16.0` to `openai==2.36.0`.

This keeps the OpenAI SDK dependency pinned while improving compatibility with downstream packages and applications that require newer OpenAI SDK 2.x versions.

For example:

- `litellm` requires `openai>=2.20.0,<3.0.0`
- `openai-agents` requires `openai>=2.36.0,<3`

Fixes #4285.

## Tests

- `uv sync --all-extras --dev`
- `uv lock --check`
- `./bin/test.sh`
- `./bin/lint.sh`

## Notes

The OpenAI SDK update changed `ResponseComputerToolCall.action` to be optional, which caused a pyright error in `examples/custom-functions/cua.py`. I added a follow-up commit to guard the missing-action case.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `openai` to 2.36.0 to satisfy downstream packages (e.g., `openai-agents`, `litellm`) and prevent CUA crashes by guarding missing computer actions. Fixes #4285.

- **Dependencies**
  - Pin `openai` to `2.36.0` (from `2.16.0`).

- **Bug Fixes**
  - Guard missing `action` in `examples/custom-functions/cua.py`.

<sup>Written for commit ab6a972f7bc75cea7f5ec98e73cb85c8f2d349bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





