### PR TITLE
Move user request before agent history

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -327,9 +327,6 @@ Available tabs:
 			_todo_contents = '[empty todo.md, fill it when applicable]'
 
 		agent_state = f"""
-<user_request>
-{self.task}
-</user_request>
 <file_system>
 {self.file_system.describe() if self.file_system else 'No file system available'}
 </file_system>
@@ -347,6 +344,9 @@ Available tabs:
 			available_file_paths_text = '\n'.join(self.available_file_paths)
 			agent_state += f'<available_file_paths>{available_file_paths_text}\nUse with absolute paths</available_file_paths>\n'
 		return agent_state
+
+	def _get_user_request_description(self) -> str:
+		return f'<user_request>\n{self.task}\n</user_request>\n\n'
 
 	def _get_step_meta_description(self) -> str:
 		# Per-step varying metadata (step counter, wall-clock date). Kept out of <agent_state> so it
@@ -401,7 +401,8 @@ Available tabs:
 
 		# Build complete state description
 		state_description = (
-			'<agent_history>\n'
+			self._get_user_request_description()
+			+ '<agent_history>\n'
 			+ (self.agent_history_description.strip('\n') if self.agent_history_description else '')
 			+ '\n</agent_history>\n\n'
 		)

--- a/browser_use/agent/system_prompts/system_prompt.md
+++ b/browser_use/agent/system_prompts/system_prompt.md
@@ -14,12 +14,19 @@ You excel at following tasks:
 </language_settings>
 <input>
 At every step, your input will consist of:
-1. <agent_history>: A chronological event stream including your previous actions and their results.
-2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
-3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
-4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used screenshot before, this will contain a screenshot.
-5. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
+1. <user_request>: Your ultimate objective.
+2. <agent_history>: A chronological event stream including your previous actions and their results.
+3. <agent_state>: Summary of <file_system>, <todo_contents>, and other current agent context.
+4. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
+5. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used screenshot before, this will contain a screenshot.
+6. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
 </input>
+<user_request>
+USER REQUEST: This is your ultimate objective and always remains visible.
+- This has the highest priority. Make the user happy.
+- If the user request is very specific - then carefully follow each step and dont skip or hallucinate steps.
+- If the task is open ended you can plan yourself how to get it done.
+</user_request>
 <agent_history>
 Agent history will be given as a list of step information as follows:
 <step_{{step_number}}>:
@@ -30,12 +37,6 @@ Action Results: Your actions and their results
 </step_{{step_number}}>
 and system messages wrapped in <sys> tag.
 </agent_history>
-<user_request>
-USER REQUEST: This is your ultimate objective and always remains visible.
-- This has the highest priority. Make the user happy.
-- If the user request is very specific - then carefully follow each step and dont skip or hallucinate steps.
-- If the task is open ended you can plan yourself how to get it done.
-</user_request>
 <browser_state>
 1. Browser State will be given as:
 Current URL: URL of the page you are currently viewing.

--- a/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
@@ -101,12 +101,19 @@ BEFORE calling `done` with `success=true`, you MUST perform this verification:
 </task_completion_rules>
 <input>
 At every step, your input will consist of:
-1. <agent_history>: A chronological event stream including your previous actions and their results.
-2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
-3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
-4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. This is your GROUND TRUTH.
-5. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
+1. <user_request>: Your ultimate objective.
+2. <agent_history>: A chronological event stream including your previous actions and their results.
+3. <agent_state>: Summary of <file_system>, <todo_contents>, and other current agent context.
+4. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
+5. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. This is your GROUND TRUTH.
+6. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
 </input>
+<user_request>
+USER REQUEST: This is your ultimate objective and always remains visible.
+- This has the highest priority. Make the user happy.
+- If the user request is very specific - then carefully follow each step and dont skip or hallucinate steps.
+- If the task is open ended you can plan yourself how to get it done.
+</user_request>
 <agent_history>
 Agent history will be given as a list of step information as follows:
 <step_{{step_number}}>:

--- a/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
@@ -111,7 +111,7 @@ At every step, your input will consist of:
 <user_request>
 USER REQUEST: This is your ultimate objective and always remains visible.
 - This has the highest priority. Make the user happy.
-- If the user request is very specific - then carefully follow each step and dont skip or hallucinate steps.
+- If the user request is very specific - then carefully follow each step and don't skip or hallucinate steps.
 - If the task is open ended you can plan yourself how to get it done.
 </user_request>
 <agent_history>

--- a/browser_use/agent/system_prompts/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompts/system_prompt_no_thinking.md
@@ -14,12 +14,19 @@ You excel at following tasks:
 </language_settings>
 <input>
 At every step, your input will consist of:
-1. <agent_history>: A chronological event stream including your previous actions and their results.
-2. <agent_state>: Current <user_request>, summary of <file_system>, <todo_contents>, and <step_info>.
-3. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
-4. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used screenshot before, this will contain a screenshot.
-5. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
+1. <user_request>: Your ultimate objective.
+2. <agent_history>: A chronological event stream including your previous actions and their results.
+3. <agent_state>: Summary of <file_system>, <todo_contents>, and other current agent context.
+4. <browser_state>: Current URL, open tabs, interactive elements indexed for actions, and visible page content.
+5. <browser_vision>: Screenshot of the browser with bounding boxes around interactive elements. If you used screenshot before, this will contain a screenshot.
+6. <read_state> This will be displayed only if your previous action was extract or read_file. This data is only shown in the current step.
 </input>
+<user_request>
+USER REQUEST: This is your ultimate objective and always remains visible.
+- This has the highest priority. Make the user happy.
+- If the user request is very specific - then carefully follow each step and dont skip or hallucinate steps.
+- If the task is open ended you can plan yourself how to get it done.
+</user_request>
 <agent_history>
 Agent history will be given as a list of step information as follows:
 <step_{{step_number}}>:
@@ -30,12 +37,6 @@ Action Results: Your actions and their results
 </step_{{step_number}}>
 and system messages wrapped in <sys> tag.
 </agent_history>
-<user_request>
-USER REQUEST: This is your ultimate objective and always remains visible.
-- This has the highest priority. Make the user happy.
-- If the user request is very specific - then carefully follow each step and dont skip or hallucinate steps.
-- If the task is open ended you can plan yourself how to get it done.
-</user_request>
 <browser_state>
 1. Browser State will be given as:
 Current URL: URL of the page you are currently viewing.

--- a/tests/ci/test_prompt_step_meta_suffix.py
+++ b/tests/ci/test_prompt_step_meta_suffix.py
@@ -1,6 +1,7 @@
 """Lock per-step varying metadata (step counter, wall-clock date) at the tail of the user message.
 
 The agent's user message looks roughly:
+  <user_request>...</user_request>
   <agent_history>...</agent_history>
   <agent_state>...</agent_state>
   <browser_state>...</browser_state>
@@ -60,6 +61,8 @@ def test_step_info_lives_at_suffix(tmp_path):
 	assert isinstance(content, str)
 
 	assert '<step_info>' in content
+	assert content.index('<user_request>') < content.index('<agent_history>')
+	assert content.index('</agent_history>') < content.index('<agent_state>')
 	# Suffix: step_info must come after agent_state and browser_state.
 	assert content.index('<agent_state>') < content.index('<step_info>')
 	assert content.index('<browser_state>') < content.index('<step_info>')
@@ -68,6 +71,16 @@ def test_step_info_lives_at_suffix(tmp_path):
 	state_start = content.index('<agent_state>')
 	state_end = content.index('</agent_state>')
 	assert '<step_info>' not in content[state_start:state_end], 'per-step metadata leaked into <agent_state> prefix region'
+	assert '<user_request>' not in content[state_start:state_end], 'user request leaked back into <agent_state>'
+
+
+def test_agent_history_end_marker_is_present_once(tmp_path):
+	content = _make_prompt(tmp_path).get_user_message(use_vision=False).content
+	assert isinstance(content, str)
+
+	assert content.count('</agent_history>') == 1, (
+		'super important: LLM gateway cache splitting expects exactly one </agent_history> marker'
+	)
 
 
 def test_prefix_up_to_step_info_is_stable_across_steps(tmp_path):


### PR DESCRIPTION
## Summary
- move the rendered <user_request> block before <agent_history> in the per-step agent user message
- keep <agent_state> for file system, todo, plan, sensitive data, and file path context
- update system prompt docs and the prompt-shape test so the cacheable prefix order is locked

## Why
Putting the stable user request before the append-only agent history gives implicit and explicit provider caches a better stable prefix. The end of <agent_history> is still the expanding part; compaction will naturally create a new stable prefix once the compacted memory block changes.

## Tests
- uv run ruff check browser_use/agent/prompts.py tests/ci/test_prompt_step_meta_suffix.py
- uv run pytest tests/ci/test_prompt_step_meta_suffix.py -q
- PATH="/Users/magnus/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin:$PATH" uv run pre-commit run --files browser_use/agent/prompts.py browser_use/agent/system_prompts/system_prompt.md browser_use/agent/system_prompts/system_prompt_anthropic_flash.md browser_use/agent/system_prompts/system_prompt_no_thinking.md tests/ci/test_prompt_step_meta_suffix.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the <user_request> block before <agent_history> to create a more stable prefix and improve provider caching. Updated all system prompts (incl. Anthropic Flash) and tests to lock the new order and require exactly one </agent_history>; <agent_state> remains for file system, todo, plan, sensitive data, and file paths.

- **Refactors**
  - Render <user_request> before <agent_history> in get_user_message via _get_user_request_description(); remove it from <agent_state>.
  - Update system_prompt.md, system_prompt_no_thinking.md, and system_prompt_anthropic_flash.md to show <user_request> first and document it under <input>.
  - Strengthen tests to assert ordering (<user_request> before <agent_history> and before <agent_state>), prevent leaks into <agent_state>, and ensure exactly one </agent_history> marker.

<sup>Written for commit 08ef25d41d5371c6145efe75ed07b7b5669802ed. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4896?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

