### PR TITLE
Bump version to 0.12.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.12.7"
+version = "0.12.8"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [


### PR DESCRIPTION
## Summary
- bump browser-use package version to 0.12.8 for the next release

## Tests
- uv run ruff check pyproject.toml
- PATH="/Users/magnus/.local/share/uv/python/cpython-3.11-macos-aarch64-none/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/opt/homebrew/bin:/Users/magnus/.codex/tmp/arg0/codex-arg0LWaL9w:/opt/homebrew/lib/node_modules/@openai/codex/node_modules/@openai/codex-darwin-arm64/vendor/aarch64-apple-darwin/path:/Users/magnus/.superset/bin:/Users/magnus/.whatdidido:/Users/magnus/.browser-use-env/bin:/Users/magnus/.local/bin:/Users/magnus/.bun/bin:/Users/magnus/.orbstack/bin:/Users/magnus/.orbstack/bin" uv run pre-commit run --files pyproject.toml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `browser-use` to 0.12.8 to publish the next patch release. Updates the `version` in pyproject.toml from 0.12.7 to 0.12.8.

<sup>Written for commit e973caeae1f94b423484441a22b5df2a6cf4f83c. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4899?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

