### PR TITLE
Revert ChatGoogle cached_content forwarding

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -99,9 +99,6 @@ class ChatGoogle(BaseChatModel):
 	config: types.GenerateContentConfigDict | None = None
 	include_system_in_user: bool = False
 	supports_structured_output: bool = True  # New flag
-	cached_content: str | None = (
-		None  # Gemini explicit CachedContent name (e.g. "cachedContents/abc123") to reuse a precomputed prefix across calls. Per-call override via ainvoke(..., cached_content=...).
-	)
 	max_retries: int = 5  # Number of retries for retryable errors
 	retryable_status_codes: list[int] = field(default_factory=lambda: [429, 500, 502, 503, 504])  # Status codes to retry on
 	retry_base_delay: float = 1.0  # Base delay in seconds for exponential backoff
@@ -323,11 +320,6 @@ class ChatGoogle(BaseChatModel):
 
 		if self.max_output_tokens is not None:
 			config['max_output_tokens'] = self.max_output_tokens
-
-		# Explicit Gemini CachedContent: per-call kwarg takes precedence over the instance default.
-		cached_content_name = kwargs.get('cached_content', self.cached_content)
-		if cached_content_name:
-			config['cached_content'] = cached_content_name
 
 		async def _make_api_call():
 			start_time = time.time()

--- a/tests/ci/models/test_llm_google.py
+++ b/tests/ci/models/test_llm_google.py
@@ -53,40 +53,6 @@ def test_x_goog_api_client_header_with_pydantic_http_options():
 	assert http_opts.get('headers', {}).get('x-goog-api-client', '').startswith('browser-use/')
 
 
-async def test_cached_content_threaded_into_config(monkeypatch):
-	"""Setting cached_content (instance default or per-call kwarg) should reach the generate_content call."""
-	from types import SimpleNamespace
-
-	from browser_use.llm.messages import UserMessage
-
-	captured: dict = {}
-
-	async def fake_generate_content(*, model, contents, config):
-		captured['config'] = dict(config) if config else {}
-		return SimpleNamespace(text='ok', parsed=None, usage_metadata=None, candidates=[])
-
-	def fake_get_client(self):
-		return SimpleNamespace(aio=SimpleNamespace(models=SimpleNamespace(generate_content=fake_generate_content)))
-
-	monkeypatch.setattr(ChatGoogle, 'get_client', fake_get_client)
-
-	# Instance default
-	chat = ChatGoogle(model='gemini-flash-latest', api_key='fake', cached_content='cachedContents/abc123')
-	await chat.ainvoke([UserMessage(content='hi')])
-	assert captured['config'].get('cached_content') == 'cachedContents/abc123'
-
-	# Per-call kwarg overrides instance default
-	captured.clear()
-	await chat.ainvoke([UserMessage(content='hi')], cached_content='cachedContents/override')
-	assert captured['config'].get('cached_content') == 'cachedContents/override'
-
-	# When unset, key is absent from config
-	captured.clear()
-	chat_no_cache = ChatGoogle(model='gemini-flash-latest', api_key='fake')
-	await chat_no_cache.ainvoke([UserMessage(content='hi')])
-	assert 'cached_content' not in captured['config']
-
-
 def test_x_goog_api_client_header_with_dict_http_options():
 	"""Test setting header when http_options is a dictionary (types.HttpOptionsDict)."""
 	from google.genai import types


### PR DESCRIPTION
## Summary
- Revert #4889 (`ChatGoogle.cached_content` field and per-call `cached_content` forwarding).
- Remove the now-unused cached-content unit test.

## Why
Cloud explicit caching does not need the OSS convenience API: the gateway injects `cached_content` through a copied `ChatGoogle.config` dict on its request-local model. Keeping the public field/kwarg exposes a sharp edge because Gemini rejects cachedContent calls that also send live `system_instruction`, which normal `ChatGoogle` messages can still do.

## Tests
- `uv run pytest tests/ci/models/test_llm_google.py -q`
- `uv run pre-commit run --all-files`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts `ChatGoogle` `cached_content` forwarding to Gemini and removes the field and per-call passthrough. This avoids Gemini errors when `cachedContent` is sent with live `system_instruction`; the gateway still injects caching, so the obsolete unit test is removed.

<sup>Written for commit 22939a25803cf588642d4e1e63be6aa8f6a2b4f5. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4900?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

