### PR TITLE
fix: read cli history as utf-8

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -278,7 +278,7 @@ def load_user_config() -> dict[str, Any]:
 	history_file = CONFIG.BROWSER_USE_CONFIG_DIR / 'command_history.json'
 	if history_file.exists():
 		try:
-			with open(history_file) as f:
+			with open(history_file, encoding='utf-8') as f:
 				config['command_history'] = json.load(f)
 		except (FileNotFoundError, json.JSONDecodeError):
 			config['command_history'] = []


### PR DESCRIPTION
## Summary
- read CLI command history JSON with explicit UTF-8 encoding
- keep the read path consistent with the existing UTF-8 write path in `save_user_config()`

## Before / after
Before, `load_user_config()` used the platform default encoding when reading `command_history.json`.
After, it reads the file as UTF-8, matching the way the file is written.

## Verification
- `python -m py_compile browser_use/cli.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read CLI command history (`command_history.json`) as UTF-8 to match how we write it. This prevents decoding errors on systems with non-UTF-8 default encodings.

<sup>Written for commit f50c458d9b7c4f6114c501e69848d5b87888755e. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4904?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

