### PR TITLE
fix: prevent credential loss when domain-scoped sensitive_data shares key names

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -32,7 +32,14 @@ _groq_bad_request_error: type | None = None
 
 
 def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]] | None) -> dict[str, str]:
-	"""Flatten legacy and domain-scoped sensitive data into placeholder -> value mappings."""
+	"""Flatten legacy and domain-scoped sensitive data into placeholder -> value mappings.
+
+	For domain-scoped entries (nested dicts), keys are namespaced as ``{domain}:{key}``
+	so that identically-named credentials from different domains (e.g. a ``password``
+	for ``site-a.com`` and a ``password`` for ``site-b.com``) are both retained and
+	redacted independently.  Without the namespace, whichever domain is iterated last
+	would silently overwrite the others, causing earlier secrets to leak into logs.
+	"""
 	if not sensitive_data:
 		return {}
 
@@ -41,7 +48,7 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 		if isinstance(content, dict):
 			for key, val in content.items():
 				if val:
-					sensitive_values[key] = val
+					sensitive_values[f'{key_or_domain}:{key}'] = val
 		elif content:
 			sensitive_values[key_or_domain] = content
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,84 @@
+"""Unit tests for browser_use.utils."""
+
+import pytest
+from browser_use.utils import collect_sensitive_data_values, redact_sensitive_string
+
+
+class TestCollectSensitiveDataValues:
+    """Tests for collect_sensitive_data_values."""
+
+    def test_returns_empty_dict_for_none(self):
+        assert collect_sensitive_data_values(None) == {}
+
+    def test_returns_empty_dict_for_empty(self):
+        assert collect_sensitive_data_values({}) == {}
+
+    def test_flat_format(self):
+        result = collect_sensitive_data_values({"token": "abc123", "key": "xyz"})
+        assert result == {"token": "abc123", "key": "xyz"}
+
+    def test_domain_scoped_format_single_domain(self):
+        result = collect_sensitive_data_values(
+            {"example.com": {"username": "alice", "password": "s3cr3t"}}
+        )
+        assert result == {
+            "example.com:username": "alice",
+            "example.com:password": "s3cr3t",
+        }
+
+    def test_domain_scoped_format_multiple_domains_same_key_names(self):
+        """Credentials with the same key name across domains must not overwrite each other.
+
+        Previously, iterating over domain-scoped entries wrote ``sensitive_values[key] = val``
+        directly, so whichever domain was iterated last would silently overwrite earlier ones.
+        A ``password`` belonging to ``site-a.com`` would be lost when ``site-b.com``'s
+        ``password`` was processed next — meaning ``site-a.com``'s secret was never redacted.
+        """
+        sensitive_data = {
+            "site-a.com": {"token": "token-aaa", "password": "pass-aaa"},
+            "site-b.com": {"token": "token-bbb", "password": "pass-bbb"},
+        }
+        result = collect_sensitive_data_values(sensitive_data)
+
+        # All four secrets must be present under their namespaced keys
+        assert result["site-a.com:token"] == "token-aaa"
+        assert result["site-a.com:password"] == "pass-aaa"
+        assert result["site-b.com:token"] == "token-bbb"
+        assert result["site-b.com:password"] == "pass-bbb"
+        assert len(result) == 4
+
+    def test_domain_scoped_skips_empty_values(self):
+        result = collect_sensitive_data_values(
+            {"example.com": {"username": "alice", "password": ""}}
+        )
+        assert "example.com:password" not in result
+        assert result == {"example.com:username": "alice"}
+
+    def test_mixed_flat_and_domain_scoped(self):
+        sensitive_data = {
+            "api_key": "flat-secret",
+            "site.com": {"token": "domain-secret"},
+        }
+        result = collect_sensitive_data_values(sensitive_data)
+        assert result["api_key"] == "flat-secret"
+        assert result["site.com:token"] == "domain-secret"
+
+
+class TestRedactSensitiveString:
+    """Tests for redact_sensitive_string."""
+
+    def test_redacts_all_collected_secrets(self):
+        sensitive_data = {
+            "site-a.com": {"token": "token-aaa"},
+            "site-b.com": {"token": "token-bbb"},
+        }
+        sensitive_values = collect_sensitive_data_values(sensitive_data)
+        log_line = "Calling site-a with token-aaa and site-b with token-bbb"
+        redacted = redact_sensitive_string(log_line, sensitive_values)
+        assert "token-aaa" not in redacted
+        assert "token-bbb" not in redacted
+
+    def test_no_false_redaction_for_unrelated_text(self):
+        sensitive_values = collect_sensitive_data_values({"key": "hunter2"})
+        log_line = "The user typed something else entirely"
+        assert redact_sensitive_string(log_line, sensitive_values) == log_line


### PR DESCRIPTION
## Bug

`collect_sensitive_data_values` in `browser_use/utils.py` flattened domain-scoped sensitive data by writing directly into `sensitive_values[key]`. When two domains define a credential under the same key name — which is the common case (e.g. both `site-a.com` and `site-b.com` have a `password` or `token` field) — each iteration overwrote the previous value. Only the last domain's secret survived; the earlier ones were silently dropped and **never redacted from logs**.

**Minimal reproduction:**
```python
sensitive_data = {
    "site-a.com": {"token": "token-aaa"},
    "site-b.com": {"token": "token-bbb"},
}
result = collect_sensitive_data_values(sensitive_data)
# Before fix: {"token": "token-bbb"}   ← token-aaa is lost and will appear in logs
# After fix:  {"site-a.com:token": "token-aaa", "site-b.com:token": "token-bbb"}
```

## Fix

Namespace each domain-scoped value as `{domain}:{key}` so all secrets are retained independently. The `redact_sensitive_string` function replaces values (not keys), so the namespace only appears in the `<secret>…</secret>` placeholder in sanitised output — which is actually more informative, because it identifies which domain the credential belongs to.

Flat-format entries (`{"api_key": "value"}`) are unchanged.

## Tests

Added `tests/test_utils.py` with 9 unit tests covering:
- flat format unchanged
- single-domain scoped format
- multi-domain collision case (regression test for this bug)
- empty-value skipping
- mixed flat + domain-scoped
- redaction correctness for multi-domain secrets

All 9 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes credential loss in `collect_sensitive_data_values` by namespacing domain-scoped keys as `{domain}:{key}` so same-named secrets across domains don’t overwrite each other and are all redacted from logs.

- **Bug Fixes**
  - Namespace nested domain entries to avoid key collisions; flat keys unchanged.
  - Added tests for multi-domain collisions, mixed formats, empty values, and redaction correctness.

<sup>Written for commit 64358259029701c0ae776ec854d3551b860fbbb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

