### PR TITLE
feat(agent): support suspendable HITL tool pauses

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 	from browser_use.agent.service import Agent
 
 	# from browser_use.agent.service import Agent
-	from browser_use.agent.views import ActionModel, ActionResult, AgentHistoryList
+	from browser_use.agent.views import ActionModel, ActionResult, AgentHistoryList, PauseResult, ToolPauseState
 	from browser_use.browser import BrowserProfile, BrowserSession
 	from browser_use.browser import BrowserSession as Browser
 	from browser_use.dom.service import DomService
@@ -79,6 +79,8 @@ _LAZY_IMPORTS = {
 	'ActionModel': ('browser_use.agent.views', 'ActionModel'),
 	'ActionResult': ('browser_use.agent.views', 'ActionResult'),
 	'AgentHistoryList': ('browser_use.agent.views', 'AgentHistoryList'),
+	'PauseResult': ('browser_use.agent.views', 'PauseResult'),
+	'ToolPauseState': ('browser_use.agent.views', 'ToolPauseState'),
 	'BrowserSession': ('browser_use.browser', 'BrowserSession'),
 	'Browser': ('browser_use.browser', 'BrowserSession'),  # Alias for BrowserSession
 	'BrowserProfile': ('browser_use.browser', 'BrowserProfile'),
@@ -139,6 +141,8 @@ __all__ = [
 	'ActionResult',
 	'ActionModel',
 	'AgentHistoryList',
+	'PauseResult',
+	'ToolPauseState',
 	# Chat models
 	'ChatOpenAI',
 	'ChatGoogle',

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -151,8 +151,9 @@ class PendingToolPause:
 	reason: str | None
 	created_at: float
 	timeout: float | None
-	timeout_behavior: Literal['continue', 'stop']
+	pause_timeout_action: Literal['stop', 'continue', 'error']
 	metadata: dict[str, Any] | None
+	context: dict[str, Any] | None
 	loop: asyncio.AbstractEventLoop
 	future: asyncio.Future[ActionResult]
 	completed: bool = False
@@ -4028,8 +4029,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			reason=pause.reason,
 			created_at=pause.created_at,
 			timeout=pause.timeout,
-			timeout_behavior=pause.timeout_behavior,
+			pause_timeout_action=pause.pause_timeout_action,
 			metadata=pause.metadata,
+			context=pause.context,
 		)
 
 	def get_pending_tool_pause(self) -> ToolPauseState | None:
@@ -4072,21 +4074,22 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			reason=pause_result.reason,
 			created_at=time.time(),
 			timeout=pause_result.timeout,
-			timeout_behavior=pause_result.timeout_behavior,
+			pause_timeout_action=pause_result.pause_timeout_action,
 			metadata=pause_result.metadata,
+			context=pause_result.context,
 			loop=loop,
 			future=loop.create_future(),
 		)
 		self._pending_tool_pause = pause
 		self.logger.info(
-			'pause_requested pause_id=%s step=%s action_index=%s tool_name=%s reason=%s timeout=%s timeout_behavior=%s',
+			'pause_requested pause_id=%s step=%s action_index=%s tool_name=%s reason=%s timeout=%s pause_timeout_action=%s',
 			pause.pause_id,
 			pause.step,
 			pause.action_index,
 			pause.tool_name,
 			pause.reason,
 			pause.timeout,
-			pause.timeout_behavior,
+			pause.pause_timeout_action,
 		)
 		return None
 
@@ -4117,6 +4120,51 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		return 'provided' if source else None
 
+	def _format_tool_pause_context(self, context: dict[str, Any] | None) -> str | None:
+		"""Format non-sensitive pause context for LLM-visible action memory."""
+
+		if not context:
+			return None
+		try:
+			context_text = json.dumps(context, ensure_ascii=False, sort_keys=True, default=str)
+		except Exception:
+			context_text = str(context)
+		return context_text[:1000]
+
+	def _tool_pause_metadata(
+		self,
+		pause: PendingToolPause,
+		*,
+		resolved: bool = False,
+		timeout: bool = False,
+	) -> dict[str, Any]:
+		"""Build privacy-safe pause correlation metadata for resolved action results."""
+
+		metadata: dict[str, Any] = {
+			'tool_pause_id': pause.pause_id,
+			'tool_name': pause.tool_name,
+			'reason': pause.reason,
+			'pause_context': pause.context,
+		}
+		if resolved:
+			metadata['tool_pause_resolved'] = True
+		if timeout:
+			metadata.update(
+				{
+					'tool_pause_timeout': True,
+					'pause_timeout_action': pause.pause_timeout_action,
+				}
+			)
+		return metadata
+
+	def _tool_pause_memory(self, pause: PendingToolPause, prefix: str) -> str:
+		"""Append formatted pause context to a LLM-visible memory string."""
+
+		context_summary = self._format_tool_pause_context(pause.context)
+		if context_summary:
+			return f'{prefix} Pause context: {context_summary}'
+		return prefix
+
 	async def _resolve_pause_result_for_action(
 		self,
 		pause_result: PauseResult,
@@ -4142,13 +4190,20 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				result = pause.future.result()
 			else:
 				timeout_text = f'{pause.timeout:g}' if pause.timeout is not None else 'unknown'
-				result = ActionResult(error=f'Tool pause timed out after {timeout_text} seconds')
+				metadata = self._tool_pause_metadata(pause, timeout=True)
+				if pause.pause_timeout_action == 'continue':
+					memory = self._tool_pause_memory(
+						pause, f'No external input received for tool {pause.tool_name} before timeout.'
+					)
+					result = ActionResult(extracted_content=memory, long_term_memory=memory, metadata=metadata)
+				else:
+					result = ActionResult(error=f'Tool pause timed out after {timeout_text} seconds', metadata=metadata)
 				pause.cancelled = True
 				pause.completed = True
 				self._resolve_tool_pause_future_threadsafe(pause, result)
 				elapsed_wait_time = time.time() - pause.created_at
 				self.logger.info(
-					'pause_timeout pause_id=%s step=%s action_index=%s tool_name=%s reason=%s elapsed_wait_time=%.3f timeout=%s status=%s',
+					'pause_timeout pause_id=%s step=%s action_index=%s tool_name=%s reason=%s elapsed_wait_time=%.3f timeout=%s pause_timeout_action=%s',
 					pause.pause_id,
 					pause.step,
 					pause.action_index,
@@ -4156,9 +4211,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					pause.reason,
 					elapsed_wait_time,
 					pause.timeout,
-					pause.timeout_behavior,
+					pause.pause_timeout_action,
 				)
-				if pause.timeout_behavior == 'stop':
+				if pause.pause_timeout_action == 'stop':
 					self.state.stopped = True
 		finally:
 			if self._pending_tool_pause is pause:
@@ -4182,25 +4237,21 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			action_result = ActionResult(
 				extracted_content=result,
 				include_extracted_content_only_once=True,
-				long_term_memory=f'External input received for tool {pause.tool_name}.',
-				metadata={
-					'tool_pause_resolved': True,
-					'tool_pause_id': pause.pause_id,
-					'tool_name': pause.tool_name,
-					'reason': pause.reason,
-				},
+				long_term_memory=self._tool_pause_memory(pause, f'External input received for tool {pause.tool_name}.'),
+				metadata=self._tool_pause_metadata(pause, resolved=True),
 			)
 		elif result.is_done:
 			return False
 		else:
-			merged_metadata = {
-				**(result.metadata or {}),
-				'tool_pause_resolved': True,
-				'tool_pause_id': pause.pause_id,
-				'tool_name': pause.tool_name,
-				'reason': pause.reason,
-			}
-			action_result = result.model_copy(update={'metadata': merged_metadata})
+			pause_metadata = self._tool_pause_metadata(pause, resolved=True)
+			merged_metadata = {**(result.metadata or {}), **pause_metadata}
+			memory_prefix = result.long_term_memory or f'External input received for tool {pause.tool_name}.'
+			action_result = result.model_copy(
+				update={
+					'metadata': merged_metadata,
+					'long_term_memory': self._tool_pause_memory(pause, memory_prefix),
+				}
+			)
 
 		pause.completed = True
 		self._resolve_tool_pause_future_threadsafe(pause, action_result)
@@ -4222,7 +4273,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		"""Resolve the current pending tool pause with a cancellation error."""
 
 		pause = self._pending_tool_pause
-		if pause is None or pause.completed or pause.cancelled:
+		if pause is None:
+			return
+		if pause.completed or pause.cancelled:
+			if self._pending_tool_pause is pause:
+				self._pending_tool_pause = None
 			return
 
 		pause.cancelled = True
@@ -4239,6 +4294,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			elapsed_wait_time,
 			reason,
 		)
+		if self._pending_tool_pause is pause:
+			self._pending_tool_pause = None
 
 	async def cancel_tool_pause(self, token: str, reason: str | None = None) -> bool:
 		"""Cancel a pending tool-level HITL pause with its secret token."""
@@ -4262,6 +4319,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			elapsed_wait_time,
 			cancel_reason,
 		)
+		if self._pending_tool_pause is pause:
+			self._pending_tool_pause = None
 		return True
 
 	def resume(self) -> None:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -4,9 +4,11 @@ import inspect
 import json
 import logging
 import re
+import secrets
 import tempfile
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 from urllib.parse import urlparse
@@ -58,8 +60,10 @@ from browser_use.agent.views import (
 	DetectedVariable,
 	JudgementResult,
 	MessageCompactionSettings,
+	PauseResult,
 	PlanItem,
 	StepMetadata,
+	ToolPauseState,
 )
 from browser_use.browser.events import _get_timeout
 from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
@@ -126,6 +130,33 @@ Context = TypeVar('Context')
 
 
 AgentHookFunc = Callable[['Agent'], Awaitable[None]]
+
+
+@dataclass
+class PendingToolPause:
+	"""Runtime-only state for one tool-level human-in-the-loop pause.
+
+	This intentionally lives on the Agent instance rather than in AgentState:
+	the future and event loop are runtime objects and must not be serialized into
+	history, checkpoints, traces, or cloud payloads. Public correlation should use
+	pause_id; token is a secret bearer token for resume/cancel only.
+	"""
+
+	token: str
+	pause_id: str
+	step: int
+	action_index: int
+	tool_name: str
+	prompt: str
+	reason: str | None
+	created_at: float
+	timeout: float | None
+	timeout_behavior: Literal['continue', 'stop']
+	metadata: dict[str, Any] | None
+	loop: asyncio.AbstractEventLoop
+	future: asyncio.Future[ActionResult]
+	completed: bool = False
+	cancelled: bool = False
 
 
 class Agent(Generic[Context, AgentStructuredOutput]):
@@ -600,6 +631,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Event-based pause control (kept out of AgentState for serialization)
 		self._external_pause_event = asyncio.Event()
 		self._external_pause_event.set()
+
+		# Tool-level HITL pause state is runtime-only. It stores the pending future
+		# and secret resume/cancel token outside AgentState so these values never get
+		# serialized into history, checkpoints, traces, or cloud/event payloads.
+		self._pending_tool_pause: PendingToolPause | None = None
 
 	def _enhance_task_with_schema(self, task: str, output_model_schema: type[AgentStructuredOutput] | None) -> str:
 		"""Enhance task description with output schema information if provided."""
@@ -2254,7 +2290,13 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			except Exception as e:
 				raise e
 
-		await self.step(step_info)
+		try:
+			await self._run_step_with_suspendable_timeout(step_info)
+		except TimeoutError:
+			error_msg = f'Step timed out after {self.settings.step_timeout} seconds'
+			self.logger.error(f'⏰ {error_msg}')
+			self.state.consecutive_failures += 1
+			self.state.last_result = [ActionResult(error=error_msg)]
 
 		if self.history.is_done():
 			await self.log_completion()
@@ -2415,6 +2457,58 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		return None
 
+	async def _run_step_with_suspendable_timeout(self, step_info: AgentStepInfo | None) -> None:
+		"""Run one step while excluding tool-pause external wait from step_timeout.
+
+		The step coroutine can enter a HITL suspended sub-state by registering
+		``self._pending_tool_pause`` and awaiting its future inside ``multi_act()``.
+		While such a pause is pending, this outer guard parks the active step timer
+		instead of cancelling the step task at wall-clock ``step_timeout``.
+		"""
+
+		step_timeout = self.settings.step_timeout
+		step_task = asyncio.create_task(self.step(step_info))
+		active_started_at = time.monotonic()
+		active_elapsed = 0.0
+
+		try:
+			while not step_task.done():
+				pause = self._pending_tool_pause
+				if pause is not None and not pause.completed and not pause.cancelled:
+					active_elapsed += time.monotonic() - active_started_at
+					if active_elapsed >= step_timeout:
+						raise TimeoutError
+					wait_set: set[asyncio.Future | asyncio.Task] = {step_task, pause.future}
+					await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED)
+					active_started_at = time.monotonic()
+					continue
+
+				remaining = step_timeout - active_elapsed
+				if remaining <= 0:
+					raise TimeoutError
+
+				poll_interval = min(remaining, 0.05)
+				done, _pending = await asyncio.wait({step_task}, timeout=poll_interval)
+				if done:
+					break
+				active_elapsed += time.monotonic() - active_started_at
+				active_started_at = time.monotonic()
+
+			await step_task
+		except BaseException:
+			self._cancel_pending_tool_pause('step execution cancelled')
+			if self._pending_tool_pause is not None and (
+				self._pending_tool_pause.completed or self._pending_tool_pause.cancelled
+			):
+				self._pending_tool_pause = None
+			if not step_task.done():
+				step_task.cancel()
+				try:
+					await step_task
+				except asyncio.CancelledError:
+					pass
+			raise
+
 	async def _execute_step(
 		self,
 		step: int,
@@ -2441,10 +2535,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self.logger.debug(f'🚶 Starting step {step + 1}/{max_steps}...')
 
 		try:
-			await asyncio.wait_for(
-				self.step(step_info),
-				timeout=self.settings.step_timeout,
-			)
+			await self._run_step_with_suspendable_timeout(step_info)
 			self.logger.debug(f'✅ Completed step {step + 1}/{max_steps}')
 		except TimeoutError:
 			# Handle step timeout gracefully
@@ -2654,6 +2745,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			raise e
 
 		finally:
+			self._cancel_pending_tool_pause('agent run finished')
+			if self._pending_tool_pause is not None and (
+				self._pending_tool_pause.completed or self._pending_tool_pause.cancelled
+			):
+				self._pending_tool_pause = None
+
 			if should_delay_close and self._demo_mode_enabled and agent_run_error is None:
 				await asyncio.sleep(30)
 			if agent_run_error:
@@ -2707,7 +2804,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	@observe_debug(ignore_input=True, ignore_output=True)
 	@time_execution_async('--multi_act')
-	async def multi_act(self, actions: list[ActionModel]) -> list[ActionResult]:
+	async def multi_act(
+		self,
+		actions: list[ActionModel],
+		allow_tool_pause: bool = True,
+		tool_pause_unsupported_error: str = 'Tool pause is not supported in this action execution path in Phase 1',
+	) -> list[ActionResult]:
 		"""Execute multiple actions with page-change guards.
 
 		Two layers of protection prevent executing actions against stale DOM:
@@ -2715,6 +2817,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		     automatically abort remaining queued actions.
 		  2. Runtime detection: after every action, the current URL and focused target are compared
 		     to pre-action values. Any change aborts the remaining queue.
+
+		Tool-level HITL pauses are only supported from Agent-managed action
+		execution paths. Unsupported callers pass allow_tool_pause=False so a
+		PauseResult becomes a clear ActionResult error instead of a dangling pause.
 		"""
 		results: list[ActionResult] = []
 		total_actions = len(actions)
@@ -2768,6 +2874,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					available_file_paths=self.available_file_paths,
 					extraction_schema=self.extraction_schema,
 				)
+				if isinstance(result, PauseResult):
+					if not allow_tool_pause:
+						result = ActionResult(error=tool_pause_unsupported_error)
+					else:
+						result = await self._resolve_pause_result_for_action(result, action_name, i)
 
 				if result.error:
 					await self._demo_mode_log(
@@ -3265,7 +3376,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Execute initial actions if provided
 		if self.initial_actions and not self.state.follow_up_task:
 			self.logger.debug(f'⚡ Executing {len(self.initial_actions)} initial actions...')
-			result = await self.multi_act(self.initial_actions)
+			result = await self.multi_act(
+				self.initial_actions,
+				allow_tool_pause=False,
+				tool_pause_unsupported_error='Tool pause is not supported in initial_actions in Phase 1',
+			)
 			# update result 1 to mention that its was automatically loaded
 			if result and self.initial_url and result[0].long_term_memory:
 				result[0].long_term_memory = f'Found initial url and automatically loaded it. {result[0].long_term_memory}'
@@ -3439,7 +3554,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				# Execute any pending actions first to maintain correct order
 				# (e.g., if step is [click, extract], click must happen before extract)
 				if pending_actions:
-					batch_results = await self.multi_act(pending_actions)
+					batch_results = await self.multi_act(
+						pending_actions,
+						allow_tool_pause=False,
+						tool_pause_unsupported_error='Tool pause is not supported during history rerun in Phase 1',
+					)
 					results.extend(batch_results)
 					pending_actions = []
 
@@ -3501,7 +3620,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		# Execute any remaining pending actions
 		if pending_actions:
-			batch_results = await self.multi_act(pending_actions)
+			batch_results = await self.multi_act(
+				pending_actions,
+				allow_tool_pause=False,
+				tool_pause_unsupported_error='Tool pause is not supported during history rerun in Phase 1',
+			)
 			results.extend(batch_results)
 
 		return results
@@ -3891,6 +4014,255 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self.state.paused = True
 		self._external_pause_event.clear()
 
+	def _pending_tool_pause_to_state(self, pause: PendingToolPause) -> ToolPauseState:
+		"""Return the serializable external view of a pending tool pause."""
+
+		return ToolPauseState(
+			token=pause.token,
+			pause_id=pause.pause_id,
+			step=pause.step,
+			action_index=pause.action_index,
+			tool_name=pause.tool_name,
+			prompt=pause.prompt,
+			reason=pause.reason,
+			created_at=pause.created_at,
+			timeout=pause.timeout,
+			timeout_behavior=pause.timeout_behavior,
+			metadata=pause.metadata,
+		)
+
+	def get_pending_tool_pause(self) -> ToolPauseState | None:
+		"""Return the current pending tool pause, if it is still awaiting input.
+
+		Completed/cancelled pauses are hidden from callers even if the owning action has
+		not cleared the runtime object yet. This prevents late external
+		integrations from treating an already-resolved pause token as still valid.
+		"""
+
+		pause = self._pending_tool_pause
+		if pause is None or pause.completed or pause.cancelled:
+			return None
+		return self._pending_tool_pause_to_state(pause)
+
+	def _request_tool_pause(
+		self,
+		pause_result: PauseResult,
+		tool_name: str,
+		action_index: int = 0,
+	) -> ActionResult | None:
+		"""Register a pending tool pause for the current action.
+
+		Returns an ActionResult only when registration fails. On success,
+		_resolve_pause_result_for_action() awaits the external resolution and turns it
+		into this action's ActionResult.
+		"""
+
+		if self._pending_tool_pause is not None:
+			return ActionResult(error='Another tool pause is already pending')
+
+		loop = asyncio.get_running_loop()
+		pause = PendingToolPause(
+			token=secrets.token_urlsafe(32),
+			pause_id=uuid7str(),
+			step=self.state.n_steps,
+			action_index=action_index,
+			tool_name=tool_name,
+			prompt=pause_result.prompt,
+			reason=pause_result.reason,
+			created_at=time.time(),
+			timeout=pause_result.timeout,
+			timeout_behavior=pause_result.timeout_behavior,
+			metadata=pause_result.metadata,
+			loop=loop,
+			future=loop.create_future(),
+		)
+		self._pending_tool_pause = pause
+		self.logger.info(
+			'pause_requested pause_id=%s step=%s action_index=%s tool_name=%s reason=%s timeout=%s timeout_behavior=%s',
+			pause.pause_id,
+			pause.step,
+			pause.action_index,
+			pause.tool_name,
+			pause.reason,
+			pause.timeout,
+			pause.timeout_behavior,
+		)
+		return None
+
+	def _resolve_tool_pause_future_threadsafe(self, pause: PendingToolPause, result: ActionResult) -> None:
+		"""Resolve a pending tool pause future from the owning loop or another thread."""
+
+		def _set_result() -> None:
+			if not pause.future.done():
+				pause.future.set_result(result)
+
+		if pause.future.done():
+			return
+
+		try:
+			running_loop = asyncio.get_running_loop()
+		except RuntimeError:
+			running_loop = None
+
+		if running_loop is pause.loop:
+			_set_result()
+		elif pause.loop.is_running():
+			pause.loop.call_soon_threadsafe(_set_result)
+		else:
+			_set_result()
+
+	def _sanitize_tool_pause_log_source(self, source: str | None) -> str | None:
+		"""Return a privacy-safe source marker for pause lifecycle logs."""
+
+		return 'provided' if source else None
+
+	async def _resolve_pause_result_for_action(
+		self,
+		pause_result: PauseResult,
+		tool_name: str,
+		action_index: int,
+	) -> ActionResult:
+		"""Resolve a PauseResult inside the current action without finalizing the step."""
+
+		registration_result = self._request_tool_pause(pause_result, tool_name, action_index=action_index)
+		pause = self._pending_tool_pause
+		if registration_result is not None:
+			return registration_result
+		if pause is None:
+			return ActionResult(error='Tool pause registration failed')
+
+		try:
+			if pause.timeout is None:
+				result = await pause.future
+			else:
+				result = await asyncio.wait_for(asyncio.shield(pause.future), timeout=pause.timeout)
+		except TimeoutError:
+			if pause.future.done():
+				result = pause.future.result()
+			else:
+				timeout_text = f'{pause.timeout:g}' if pause.timeout is not None else 'unknown'
+				result = ActionResult(error=f'Tool pause timed out after {timeout_text} seconds')
+				pause.cancelled = True
+				pause.completed = True
+				self._resolve_tool_pause_future_threadsafe(pause, result)
+				elapsed_wait_time = time.time() - pause.created_at
+				self.logger.info(
+					'pause_timeout pause_id=%s step=%s action_index=%s tool_name=%s reason=%s elapsed_wait_time=%.3f timeout=%s status=%s',
+					pause.pause_id,
+					pause.step,
+					pause.action_index,
+					pause.tool_name,
+					pause.reason,
+					elapsed_wait_time,
+					pause.timeout,
+					pause.timeout_behavior,
+				)
+				if pause.timeout_behavior == 'stop':
+					self.state.stopped = True
+		finally:
+			if self._pending_tool_pause is pause:
+				self._pending_tool_pause = None
+
+		return result
+
+	async def resume_tool_pause(self, token: str, result: str | ActionResult, source: str | None = None) -> bool:
+		"""Resume a pending tool-level HITL pause with external input.
+
+		The secret token must match the current pending pause. Raw string input is
+		placed only in extracted_content for the next LLM step and is not copied into
+		long-term memory, metadata, or logs by default.
+		"""
+
+		pause = self._pending_tool_pause
+		if pause is None or pause.token != token or pause.completed or pause.cancelled:
+			return False
+
+		if isinstance(result, str):
+			action_result = ActionResult(
+				extracted_content=result,
+				include_extracted_content_only_once=True,
+				long_term_memory=f'External input received for tool {pause.tool_name}.',
+				metadata={
+					'tool_pause_resolved': True,
+					'tool_pause_id': pause.pause_id,
+					'tool_name': pause.tool_name,
+					'reason': pause.reason,
+				},
+			)
+		elif result.is_done:
+			return False
+		else:
+			merged_metadata = {
+				**(result.metadata or {}),
+				'tool_pause_resolved': True,
+				'tool_pause_id': pause.pause_id,
+				'tool_name': pause.tool_name,
+				'reason': pause.reason,
+			}
+			action_result = result.model_copy(update={'metadata': merged_metadata})
+
+		pause.completed = True
+		self._resolve_tool_pause_future_threadsafe(pause, action_result)
+		elapsed_wait_time = time.time() - pause.created_at
+		log_source = self._sanitize_tool_pause_log_source(source)
+		self.logger.info(
+			'pause_resumed pause_id=%s step=%s action_index=%s tool_name=%s reason=%s elapsed_wait_time=%.3f source=%s status=resolved',
+			pause.pause_id,
+			pause.step,
+			pause.action_index,
+			pause.tool_name,
+			pause.reason,
+			elapsed_wait_time,
+			log_source,
+		)
+		return True
+
+	def _cancel_pending_tool_pause(self, reason: str) -> None:
+		"""Resolve the current pending tool pause with a cancellation error."""
+
+		pause = self._pending_tool_pause
+		if pause is None or pause.completed or pause.cancelled:
+			return
+
+		pause.cancelled = True
+		pause.completed = True
+		self._resolve_tool_pause_future_threadsafe(pause, ActionResult(error=f'Tool pause cancelled because {reason}'))
+		elapsed_wait_time = time.time() - pause.created_at
+		self.logger.info(
+			'pause_cancelled pause_id=%s step=%s action_index=%s tool_name=%s reason=%s elapsed_wait_time=%.3f cancel_reason=%s status=cancelled',
+			pause.pause_id,
+			pause.step,
+			pause.action_index,
+			pause.tool_name,
+			pause.reason,
+			elapsed_wait_time,
+			reason,
+		)
+
+	async def cancel_tool_pause(self, token: str, reason: str | None = None) -> bool:
+		"""Cancel a pending tool-level HITL pause with its secret token."""
+
+		pause = self._pending_tool_pause
+		if pause is None or pause.token != token or pause.completed or pause.cancelled:
+			return False
+
+		pause.cancelled = True
+		pause.completed = True
+		cancel_reason = reason or 'cancelled'
+		self._resolve_tool_pause_future_threadsafe(pause, ActionResult(error=f'Tool pause cancelled: {cancel_reason}'))
+		elapsed_wait_time = time.time() - pause.created_at
+		self.logger.info(
+			'pause_cancelled pause_id=%s step=%s action_index=%s tool_name=%s reason=%s elapsed_wait_time=%.3f cancel_reason=%s status=cancelled',
+			pause.pause_id,
+			pause.step,
+			pause.action_index,
+			pause.tool_name,
+			pause.reason,
+			elapsed_wait_time,
+			cancel_reason,
+		)
+		return True
+
 	def resume(self) -> None:
 		"""Resume the agent"""
 		# TODO: Locally the browser got closed
@@ -3903,6 +4275,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		"""Stop the agent"""
 		self.logger.info('⏹️ Agent stopping')
 		self.state.stopped = True
+		self._cancel_pending_tool_pause('agent stopped')
 
 		# Signal pause event to unblock any waiting code so it can check the stopped state
 		self._external_pause_event.set()
@@ -3949,6 +4322,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 	async def close(self):
 		"""Close all resources"""
 		try:
+			self._cancel_pending_tool_pause('agent closed')
+
 			# Only close browser if keep_alive is False (or not set)
 			if self.browser_session is not None:
 				if not self.browser_session.browser_profile.keep_alive:

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generic, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model, field_validator, model_validator
 from typing_extensions import TypeVar
 from uuid_extensions import uuid7str
 
@@ -283,6 +283,63 @@ class AgentStepInfo:
 	def is_last_step(self) -> bool:
 		"""Check if this is the last step"""
 		return self.step_number >= self.max_steps - 1
+
+
+class PauseResult(BaseModel):
+	"""Result returned by a tool to request external human/operator input.
+
+	Tools should return this object quickly instead of awaiting a human response
+	inside the tool coroutine. The Agent runtime owns the pending pause token,
+	timeout, cancellation, and eventual conversion back into an ActionResult so
+	the human response can be shown to the next LLM step without weakening normal
+	action/step timeout guards.
+	"""
+
+	prompt: str = Field(description='Prompt shown to the external human/operator')
+	reason: str | None = Field(default=None, description='Machine-readable reason for the pause')
+	# None means "wait until resume/cancel/stop". Production integrations should
+	# usually provide a finite timeout or guarantee an external cancel/stop path.
+	timeout: float | None = Field(default=None, description='Optional per-pause timeout in seconds')
+	timeout_behavior: Literal['continue', 'stop'] = Field(
+		default='continue',
+		description='What to do when the external wait times out',
+	)
+	# Integration metadata must be non-sensitive. The runtime may expose this via
+	# get_pending_tool_pause(), so callers should not put secrets or raw human input here.
+	metadata: dict[str, Any] | None = Field(default=None, description='Non-sensitive integration metadata')
+
+	@field_validator('timeout')
+	@classmethod
+	def validate_timeout(cls, value: float | None) -> float | None:
+		if value is not None and value <= 0:
+			raise ValueError('PauseResult.timeout must be greater than 0 seconds')
+		return value
+
+
+class ToolPauseState(BaseModel):
+	"""Serializable summary of a pending tool-level pause for external integrations.
+
+	This model intentionally contains no asyncio.Future or other runtime-only
+	objects. External systems can read it to render approval/clarification UI and
+	then call resume_tool_pause() or cancel_tool_pause() with the secret token.
+	"""
+
+	# Secret bearer token used to authorize resume/cancel. It should only be
+	# returned by get_pending_tool_pause(), and must never be written to logs,
+	# history, trace files, metadata, or cloud/event payloads.
+	token: str
+	# Public correlation id. Safe to place in resolved action metadata and logs so
+	# pending/resolved lifecycle events can be joined without exposing the token.
+	pause_id: str
+	step: int
+	action_index: int
+	tool_name: str
+	prompt: str
+	reason: str | None = None
+	created_at: float
+	timeout: float | None = None
+	timeout_behavior: Literal['continue', 'stop'] = 'continue'
+	metadata: dict[str, Any] | None = None
 
 
 class JudgementResult(BaseModel):

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -300,13 +300,21 @@ class PauseResult(BaseModel):
 	# None means "wait until resume/cancel/stop". Production integrations should
 	# usually provide a finite timeout or guarantee an external cancel/stop path.
 	timeout: float | None = Field(default=None, description='Optional per-pause timeout in seconds')
-	timeout_behavior: Literal['continue', 'stop'] = Field(
-		default='continue',
+	pause_timeout_action: Literal['stop', 'continue', 'error'] = Field(
+		default='error',
 		description='What to do when the external wait times out',
 	)
 	# Integration metadata must be non-sensitive. The runtime may expose this via
 	# get_pending_tool_pause(), so callers should not put secrets or raw human input here.
 	metadata: dict[str, Any] | None = Field(default=None, description='Non-sensitive integration metadata')
+	context: dict[str, Any] | None = Field(
+		default=None,
+		description=(
+			'Non-sensitive context explaining why the pause was requested. '
+			'This may be surfaced to the next LLM turn, so it must not contain '
+			'secrets, credentials, tokens, or raw human input.'
+		),
+	)
 
 	@field_validator('timeout')
 	@classmethod
@@ -338,8 +346,9 @@ class ToolPauseState(BaseModel):
 	reason: str | None = None
 	created_at: float
 	timeout: float | None = None
-	timeout_behavior: Literal['continue', 'stop'] = 'continue'
+	pause_timeout_action: Literal['stop', 'continue', 'error'] = 'error'
 	metadata: dict[str, Any] | None = None
+	context: dict[str, Any] | None = None
 
 
 class JudgementResult(BaseModel):

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -90,7 +90,7 @@ _configure_mcp_server_logging()
 logging.disable(logging.CRITICAL)
 
 # Import browser_use modules
-from browser_use import ActionModel, Agent
+from browser_use import ActionModel, Agent, PauseResult
 from browser_use.browser import BrowserProfile, BrowserSession
 from browser_use.config import get_default_llm, get_default_profile, load_browser_use_config
 from browser_use.filesystem.file_system import FileSystem
@@ -1019,6 +1019,8 @@ class BrowserUseServer:
 			page_extraction_llm=self.llm,
 			file_system=self.file_system,
 		)
+		if isinstance(action_result, PauseResult):
+			return 'Error: Tool pause is not supported by direct MCP tool execution in Phase 1'
 
 		return action_result.extracted_content or 'No content extracted'
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -13,7 +13,7 @@ except ImportError:
 	Laminar = None  # type: ignore
 from pydantic import BaseModel
 
-from browser_use.agent.views import ActionModel, ActionResult
+from browser_use.agent.views import ActionModel, ActionResult, PauseResult
 from browser_use.browser import BrowserSession
 from browser_use.browser.events import (
 	ClickCoordinateEvent,
@@ -2124,7 +2124,7 @@ Validated Code (after quote fixing):
 		file_system: FileSystem | None = None,
 		extraction_schema: dict | None = None,
 		action_timeout: float | None = None,
-	) -> ActionResult:
+	) -> ActionResult | PauseResult:
 		"""Execute an action.
 
 		action_timeout: per-action wall-clock cap (seconds). Prevents actions from hanging
@@ -2197,6 +2197,11 @@ Validated Code (after quote fixing):
 				if isinstance(result, str):
 					return ActionResult(extracted_content=result)
 				elif isinstance(result, ActionResult):
+					return result
+				elif isinstance(result, PauseResult):
+					# Tool-level HITL pauses must be handled by Agent.multi_act(), not
+					# normalized here. Keeping the object intact lets the Agent resolve
+					# it inside the current multi_act action as an ActionResult.
 					return result
 				elif result is None:
 					return ActionResult()

--- a/tests/ci/browser/test_cross_origin_click.py
+++ b/tests/ci/browser/test_cross_origin_click.py
@@ -4,6 +4,7 @@ import asyncio
 
 import pytest
 
+from browser_use.agent.views import ActionResult
 from browser_use.browser.profile import BrowserProfile, ViewportSize
 from browser_use.browser.session import BrowserSession
 from browser_use.tools.service import Tools
@@ -119,6 +120,7 @@ class TestCrossOriginIframeClick:
 
 		try:
 			result = await tools.click(index=link_idx, browser_session=browser_session)
+			assert isinstance(result, ActionResult)
 
 			# Check for errors
 			if result.error:

--- a/tests/ci/browser/test_dom_serializer.py
+++ b/tests/ci/browser/test_dom_serializer.py
@@ -15,6 +15,7 @@ import pytest
 from pytest_httpserver import HTTPServer
 
 from browser_use.agent.service import Agent
+from browser_use.agent.views import ActionResult
 from browser_use.browser import BrowserSession
 from browser_use.browser.profile import BrowserProfile, ViewportSize
 from tests.ci.conftest import create_mock_llm
@@ -208,6 +209,7 @@ class TestDOMSerializer:
 		# Helper to call tools.click(index) and verify it worked
 		async def click(index: int, element_description: str, browser_session: BrowserSession):
 			result = await tools.click(index=index, browser_session=browser_session)
+			assert isinstance(result, ActionResult)
 			# Check both error field and extracted_content for failure messages
 			if result.error:
 				raise AssertionError(f'Click on {element_description} [{index}] failed: {result.error}')
@@ -410,6 +412,7 @@ class TestDOMSerializer:
 
 		async def click(index: int, element_description: str, browser_session: BrowserSession):
 			result = await tools.click(index=index, browser_session=browser_session)
+			assert isinstance(result, ActionResult)
 			if result.error:
 				raise AssertionError(f'Click on {element_description} [{index}] failed: {result.error}')
 			if result.extracted_content and (

--- a/tests/ci/browser/test_true_cross_origin_click.py
+++ b/tests/ci/browser/test_true_cross_origin_click.py
@@ -4,6 +4,7 @@ import asyncio
 
 import pytest
 
+from browser_use.agent.views import ActionResult
 from browser_use.browser.profile import BrowserProfile, ViewportSize
 from browser_use.browser.session import BrowserSession
 from browser_use.tools.service import Tools
@@ -117,6 +118,7 @@ class TestTrueCrossOriginIframeClick:
 
 		try:
 			result = await tools.click(index=link_idx, browser_session=browser_session)
+			assert isinstance(result, ActionResult)
 
 			# Check for errors
 			if result.error:

--- a/tests/ci/interactions/test_radio_buttons.py
+++ b/tests/ci/interactions/test_radio_buttons.py
@@ -7,6 +7,7 @@ so that CDP click dispatch works for radio buttons whose labels visually overlap
 import pytest
 from pytest_httpserver import HTTPServer
 
+from browser_use.agent.views import ActionResult
 from browser_use.browser import BrowserSession
 from browser_use.browser.profile import BrowserProfile
 from browser_use.tools.service import Tools
@@ -208,6 +209,7 @@ class TestRadioButtons:
 		assert idx is not None, 'Could not find radio-blue in selector map'
 
 		result = await tools.click(index=idx, browser_session=browser_session)
+		assert isinstance(result, ActionResult)
 		assert result.error is None, f'Click failed: {result.error}'
 
 		is_checked, result_text = await _get_checked_and_result(browser_session, 'radio-blue')
@@ -223,6 +225,7 @@ class TestRadioButtons:
 		assert idx is not None, 'Could not find radio-banana in selector map'
 
 		result = await tools.click(index=idx, browser_session=browser_session)
+		assert isinstance(result, ActionResult)
 		assert result.error is None, f'Click failed: {result.error}'
 
 		is_checked, result_text = await _get_checked_and_result(browser_session, 'radio-banana')
@@ -238,6 +241,7 @@ class TestRadioButtons:
 		assert idx is not None, 'Could not find radio-large in selector map'
 
 		result = await tools.click(index=idx, browser_session=browser_session)
+		assert isinstance(result, ActionResult)
 		assert result.error is None, f'Click failed: {result.error}'
 
 		is_checked, result_text = await _get_checked_and_result(browser_session, 'radio-large')
@@ -253,6 +257,7 @@ class TestRadioButtons:
 		red_idx = await browser_session.get_index_by_id('radio-red')
 		assert red_idx is not None
 		result = await tools.click(index=red_idx, browser_session=browser_session)
+		assert isinstance(result, ActionResult)
 		assert result.error is None, f'Click red failed: {result.error}'
 
 		is_red_checked, _ = await _get_checked_and_result(browser_session, 'radio-red')
@@ -263,6 +268,7 @@ class TestRadioButtons:
 		green_idx = await browser_session.get_index_by_id('radio-green')
 		assert green_idx is not None
 		result = await tools.click(index=green_idx, browser_session=browser_session)
+		assert isinstance(result, ActionResult)
 		assert result.error is None, f'Click green failed: {result.error}'
 
 		is_green_checked, result_text = await _get_checked_and_result(browser_session, 'radio-green')

--- a/tests/ci/test_action_timeout.py
+++ b/tests/ci/test_action_timeout.py
@@ -12,12 +12,13 @@ with an ActionResult(error=...) instead of hanging.
 """
 
 import asyncio
+import logging
 import time
 from typing import Any
 
 import pytest
 
-from browser_use.agent.views import ActionModel, ActionResult
+from browser_use.agent.views import ActionModel, ActionResult, PauseResult
 from browser_use.tools.service import Tools
 
 
@@ -30,6 +31,25 @@ class _StubActionModel(ActionModel):
 
 	hung_action: dict[str, Any] | None = None
 	fast_action: dict[str, Any] | None = None
+
+
+@pytest.fixture(autouse=True)
+def _suppress_expected_tools_logs():
+	"""Keep this regression test quiet while it intentionally exercises error paths.
+
+	Several tests below deliberately trigger action timeout and malformed timeout
+	configuration branches. Those branches should log in production, but with
+	pytest log_cli enabled they look like test failures even when assertions pass.
+	Suppress only the tools service logger for this file so CI output stays clear.
+	"""
+
+	tools_logger = logging.getLogger('browser_use.tools.service')
+	previous_disabled = tools_logger.disabled
+	tools_logger.disabled = True
+	try:
+		yield
+	finally:
+		tools_logger.disabled = previous_disabled
 
 
 @pytest.mark.asyncio
@@ -91,6 +111,44 @@ async def test_act_passes_through_fast_handler():
 
 
 @pytest.mark.asyncio
+async def test_act_passes_through_pause_result():
+	"""PauseResult must reach Agent.multi_act() without being converted to ActionResult."""
+	tools = Tools()
+	pause_result = PauseResult(prompt='Approve?', reason='approval', timeout=1.0)
+
+	async def _pause_execute_action(**_kwargs):
+		return pause_result
+
+	tools.registry.execute_action = _pause_execute_action  # type: ignore[assignment]
+
+	action = _StubActionModel(fast_action={'x': 1})
+	result = await tools.act(action=action, browser_session=None, action_timeout=5.0)  # type: ignore[arg-type]
+
+	assert isinstance(result, PauseResult)
+	assert result is pause_result
+	assert result.prompt == 'Approve?'
+	assert result.reason == 'approval'
+	assert result.timeout == 1.0
+
+
+@pytest.mark.asyncio
+async def test_direct_action_helper_passes_through_pause_result():
+	"""tools.some_action(...) helpers inherit Tools.act() behaviour and do not create Agent pending pauses."""
+	tools = Tools()
+	pause_result = PauseResult(prompt='Approve direct helper?', reason='approval', timeout=1.0)
+
+	@tools.action('Ask for direct helper approval')
+	async def direct_pause_action() -> PauseResult:
+		return pause_result
+
+	result = await tools.direct_pause_action(browser_session=None)  # type: ignore[arg-type]
+
+	assert isinstance(result, PauseResult)
+	assert result is pause_result
+	assert result.prompt == 'Approve direct helper?'
+
+
+@pytest.mark.asyncio
 async def test_act_rejects_invalid_action_timeout_override():
 	"""An invalid action_timeout override (nan / inf / <=0) must fall back to
 	the default, not silently defeat the timeout (nan → immediate timeout,
@@ -111,12 +169,14 @@ async def test_act_rejects_invalid_action_timeout_override():
 	action = _StubActionModel(fast_action={'x': 1})
 	result = await tools.act(action=action, browser_session=None, action_timeout=float('nan'))  # type: ignore[arg-type]
 	assert calls['n'] == 1
+	assert isinstance(result, ActionResult)
 	assert result.error is None
 	assert result.extracted_content == 'done'
 
 	# inf / non-positive values also fall back cleanly.
 	for bad in (float('inf'), 0.0, -5.0):
 		result = await tools.act(action=action, browser_session=None, action_timeout=bad)  # type: ignore[arg-type]
+		assert isinstance(result, ActionResult)
 		assert result.error is None, f'override {bad!r} should have fallen back'
 
 

--- a/tests/ci/test_agent_hitl_pause.py
+++ b/tests/ci/test_agent_hitl_pause.py
@@ -1,0 +1,1065 @@
+import asyncio
+import logging
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from browser_use.agent.service import Agent, PendingToolPause
+from browser_use.agent.views import ActionModel, ActionResult, AgentHistory, AgentHistoryList, AgentStepInfo, PauseResult
+from browser_use.browser.views import BrowserStateHistory, BrowserStateSummary
+from browser_use.dom.views import SerializedDOMState
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.tools.service import Tools
+from tests.ci.conftest import create_mock_llm
+
+
+@pytest.fixture(autouse=True)
+def _suppress_expected_agent_logs():
+	"""Keep HITL pause unit tests focused on assertions, not lifecycle logs.
+
+	The code paths under test intentionally emit pause_resumed/pause_cancelled and
+	browser cleanup logs. Those logs are useful in production, but noisy in this
+	unit test file because pytest log_cli prints them even when tests pass.
+	"""
+
+	previous_disable_level = logging.root.manager.disable
+	logging.disable(logging.INFO)
+	try:
+		yield
+	finally:
+		logging.disable(previous_disable_level)
+
+
+def _make_test_agent() -> Agent:
+	return Agent(task='Test HITL pause', llm=create_mock_llm(actions=None))
+
+
+def _install_pending_pause(agent: Agent, *, token: str = 'secret-token') -> PendingToolPause:
+	loop = asyncio.get_running_loop()
+	pause = PendingToolPause(
+		token=token,
+		pause_id='public-pause-id',
+		step=1,
+		action_index=0,
+		tool_name='ask_approval',
+		prompt='Approve?',
+		reason='approval',
+		created_at=time.time(),
+		timeout=10.0,
+		timeout_behavior='continue',
+		metadata={'request_id': 'abc123'},
+		loop=loop,
+		future=loop.create_future(),
+	)
+	agent._pending_tool_pause = pause
+	return pause
+
+
+class _PauseActionModel(ActionModel):
+	"""Minimal ActionModel slot for exercising Agent.multi_act() plumbing."""
+
+	pause_action: dict[str, Any] | None = None
+	followup_action: dict[str, Any] | None = None
+	done: dict[str, Any] | None = None
+
+
+def _make_recording_llm(actions: list[str], seen_messages: list[list[Any]]) -> BaseChatModel:
+	"""Create a mock LLM that records each prompt and returns scripted JSON actions."""
+
+	llm = AsyncMock(spec=BaseChatModel)
+	llm.model = 'mock-llm'
+	llm.provider = 'mock'
+	llm.name = 'mock-llm'
+	llm.model_name = 'mock-llm'
+	llm._verified_api_keys = True
+	action_index = 0
+
+	async def _ainvoke(*args, **kwargs):
+		nonlocal action_index
+		messages = list(args[0]) if args else []
+		seen_messages.append(messages)
+		output_format = args[1] if len(args) >= 2 else kwargs.get('output_format')
+		action_json = actions[min(action_index, len(actions) - 1)]
+		action_index += 1
+		if output_format is None:
+			return ChatInvokeCompletion(completion=action_json, usage=None)
+		return ChatInvokeCompletion(completion=output_format.model_validate_json(action_json), usage=None)
+
+	llm.ainvoke.side_effect = _ainvoke
+	return llm
+
+
+def _empty_browser_state() -> BrowserStateSummary:
+	return BrowserStateSummary(
+		dom_state=SerializedDOMState(_root=None, selector_map={}),
+		url='about:blank',
+		title='Test page',
+		tabs=[],
+	)
+
+
+def test_pause_result_is_importable_from_top_level_package():
+	"""PauseResult should be part of the public browser_use API."""
+	from browser_use import PauseResult, ToolPauseState
+
+	pause = PauseResult(
+		prompt='Approve payment?', reason='approval', timeout=300, timeout_behavior='stop', metadata={'request_id': 'abc123'}
+	)
+	state = ToolPauseState(
+		token='secret-token',
+		pause_id='public-pause-id',
+		step=1,
+		action_index=0,
+		tool_name='ask_approval',
+		prompt=pause.prompt,
+		reason=pause.reason,
+		created_at=123.0,
+		timeout=pause.timeout,
+		timeout_behavior=pause.timeout_behavior,
+		metadata=pause.metadata,
+	)
+
+	assert pause.prompt == 'Approve payment?'
+	assert pause.reason == 'approval'
+	assert pause.timeout == 300
+	assert pause.timeout_behavior == 'stop'
+	assert state.token == 'secret-token'
+	assert state.pause_id == 'public-pause-id'
+	assert state.action_index == 0
+	assert state.timeout_behavior == 'stop'
+
+
+def test_pause_result_rejects_non_positive_timeout():
+	"""PauseResult timeout must be positive when provided."""
+	from browser_use.agent.views import PauseResult
+
+	for timeout in (0, -1):
+		with pytest.raises(ValidationError, match='PauseResult.timeout must be greater than 0 seconds'):
+			PauseResult(prompt='Approve?', timeout=timeout)
+
+	assert PauseResult(prompt='Approve?', timeout=None).timeout is None
+	assert PauseResult(prompt='Approve?', timeout=0.1).timeout == 0.1
+
+
+@pytest.mark.asyncio
+async def test_tool_pause_query_resume_and_late_resume():
+	"""External integrations can query a pending pause and resume it once with its secret token."""
+	agent = _make_test_agent()
+	try:
+		assert agent.get_pending_tool_pause() is None
+		assert await agent.resume_tool_pause('missing-token', 'ignored') is False
+
+		pause = _install_pending_pause(agent)
+		state = agent.get_pending_tool_pause()
+
+		assert state is not None
+		assert state.token == 'secret-token'
+		assert state.pause_id == 'public-pause-id'
+		assert state.step == 1
+		assert state.action_index == 0
+		assert state.tool_name == 'ask_approval'
+		assert state.prompt == 'Approve?'
+		assert state.reason == 'approval'
+		assert state.timeout == 10.0
+		assert state.timeout_behavior == 'continue'
+		assert state.metadata == {'request_id': 'abc123'}
+
+		assert await agent.resume_tool_pause('wrong-token', 'ignored') is False
+		assert await agent.resume_tool_pause('secret-token', 'approved', source='unit-test') is True
+		assert agent.get_pending_tool_pause() is None
+		assert await agent.resume_tool_pause('secret-token', 'late answer') is False
+
+		resolved = await pause.future
+		assert isinstance(resolved, ActionResult)
+		assert resolved.extracted_content == 'approved'
+		assert resolved.include_extracted_content_only_once is True
+		assert resolved.long_term_memory == 'External input received for tool ask_approval.'
+		assert 'approved' not in resolved.long_term_memory
+		assert resolved.metadata == {
+			'tool_pause_resolved': True,
+			'tool_pause_id': 'public-pause-id',
+			'tool_name': 'ask_approval',
+			'reason': 'approval',
+		}
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_tool_pause_cancel_and_stop_reject_late_resume():
+	"""Cancelled/stopped pauses complete with an error and cannot be resumed later."""
+	agent = _make_test_agent()
+	try:
+		pause = _install_pending_pause(agent)
+
+		assert await agent.cancel_tool_pause('wrong-token', 'ignored') is False
+		assert await agent.cancel_tool_pause('secret-token', 'test cancel') is True
+		assert agent.get_pending_tool_pause() is None
+		assert await agent.resume_tool_pause('secret-token', 'late answer') is False
+
+		cancelled = await pause.future
+		assert isinstance(cancelled, ActionResult)
+		assert cancelled.error == 'Tool pause cancelled: test cancel'
+
+		stop_pause = _install_pending_pause(agent, token='stop-token')
+		agent.stop()
+		assert agent.get_pending_tool_pause() is None
+		assert await agent.resume_tool_pause('stop-token', 'late answer') is False
+
+		stopped = await stop_pause.future
+		assert isinstance(stopped, ActionResult)
+		assert stopped.error == 'Tool pause cancelled because agent stopped'
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_request_tool_pause_uses_secret_token_and_returns_no_action_placeholder():
+	"""Requesting a pause should register runtime state without returning an ActionResult."""
+	agent = _make_test_agent()
+	try:
+		registration_result = agent._request_tool_pause(
+			PauseResult(prompt='Approve?', reason='approval', timeout=1.0, metadata={'request_id': 'abc123'}),
+			'ask_approval',
+			action_index=0,
+		)
+		state = agent.get_pending_tool_pause()
+
+		assert registration_result is None
+		assert state is not None
+		assert state.tool_name == 'ask_approval'
+		assert state.action_index == 0
+		assert state.token != state.pause_id
+		assert len(state.token) >= 32
+		assert state.metadata == {'request_id': 'abc123'}
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_final_step_pause_resolves_as_current_action_result(monkeypatch: pytest.MonkeyPatch):
+	"""A final-step pause is still the current action result and does not require a follow-up step."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		async def _pause_act(**_kwargs):
+			return PauseResult(prompt='Approve on final step?', timeout=2.0)
+
+		agent.tools.act = _pause_act  # type: ignore[method-assign]
+
+		async def _resume_when_pending():
+			while True:
+				pause = agent.get_pending_tool_pause()
+				if pause is not None:
+					break
+				await asyncio.sleep(0.01)
+			assert await agent.resume_tool_pause(pause.token, 'approved on final step') is True
+
+		resume_task = asyncio.create_task(_resume_when_pending())
+		results = await agent.multi_act([_PauseActionModel(pause_action={'x': 1})])
+		await resume_task
+
+		assert len(results) == 1
+		assert results[0].extracted_content == 'approved on final step'
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_resolved_tool_pause_history_does_not_expose_secret_token(tmp_path):
+	"""Resolved action history may contain pause_id, but must not contain the secret resume token."""
+	agent = _make_test_agent()
+	try:
+		registration_result = agent._request_tool_pause(PauseResult(prompt='Approve?', reason='approval'), 'ask_approval')
+		state = agent.get_pending_tool_pause()
+		assert registration_result is None
+		assert state is not None
+		assert agent._pending_tool_pause is not None
+		pause = agent._pending_tool_pause
+
+		assert await agent.resume_tool_pause(state.token, 'approved') is True
+		resolved = await pause.future
+
+		assert state.pause_id in str(resolved.model_dump())
+		assert state.token not in str(resolved.model_dump())
+
+		history = AgentHistoryList(
+			history=[
+				AgentHistory(
+					model_output=None,
+					result=[resolved],
+					state=BrowserStateHistory(url='about:blank', title='Test page', tabs=[], interacted_element=[]),
+				)
+			]
+		)
+		serialized_history = str(history.model_dump())
+
+		assert state.pause_id in serialized_history
+		assert state.token not in serialized_history
+		assert state.pause_id != state.token
+
+		history_path = tmp_path / 'history.json'
+		history.save_to_file(history_path)
+		saved_history = history_path.read_text(encoding='utf-8')
+		assert state.pause_id in saved_history
+		assert state.token not in saved_history
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_request_tool_pause_rejects_second_pending_pause():
+	"""Only one external tool pause may be pending because Phase 1 has a single resume token slot."""
+	agent = _make_test_agent()
+	try:
+		first = _install_pending_pause(agent)
+
+		second = agent._request_tool_pause(
+			PauseResult(prompt='Second approval?', reason='approval'),
+			'ask_second_approval',
+		)
+
+		assert second is not None
+		assert second.error == 'Another tool pause is already pending'
+		assert agent._pending_tool_pause is first
+		state = agent.get_pending_tool_pause()
+		assert state is not None
+		assert state.token == 'secret-token'
+		assert state.tool_name == 'ask_approval'
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_resume_tool_pause_merges_custom_action_result_metadata():
+	"""Custom ActionResult resumes preserve caller data while adding pause correlation metadata."""
+	agent = _make_test_agent()
+	try:
+		pause = _install_pending_pause(agent)
+		custom_result = ActionResult(
+			extracted_content='custom approved',
+			include_extracted_content_only_once=True,
+			long_term_memory='Custom resume summary without raw secret data.',
+			metadata={'request_id': 'abc123', 'tool_pause_id': 'caller-cannot-spoof-pause-id'},
+		)
+
+		assert await agent.resume_tool_pause('secret-token', custom_result, source='unit-test') is True
+		resolved = await pause.future
+
+		assert resolved.extracted_content == 'custom approved'
+		assert resolved.include_extracted_content_only_once is True
+		assert resolved.long_term_memory == 'Custom resume summary without raw secret data.'
+		assert resolved.metadata == {
+			'request_id': 'abc123',
+			'tool_pause_id': 'public-pause-id',
+			'tool_pause_resolved': True,
+			'tool_name': 'ask_approval',
+			'reason': 'approval',
+		}
+		assert resolved is not custom_result
+		assert custom_result.metadata == {'request_id': 'abc123', 'tool_pause_id': 'caller-cannot-spoof-pause-id'}
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_pause_lifecycle_logs_do_not_expose_token_or_raw_human_input(monkeypatch: pytest.MonkeyPatch):
+	"""Lifecycle logs should expose only privacy-safe correlation fields."""
+	agent = _make_test_agent()
+	try:
+		captured_logs: list[str] = []
+
+		def _capture_info(message: str, *args, **_kwargs):
+			captured_logs.append(message % args if args else message)
+
+		monkeypatch.setattr(agent.logger, 'info', _capture_info)
+
+		registration_result = agent._request_tool_pause(
+			PauseResult(prompt='Approve?', reason='approval', timeout=1.0),
+			'ask_approval',
+		)
+		state = agent.get_pending_tool_pause()
+		assert state is not None
+		assert registration_result is None
+
+		raw_human_input = 'raw-human-secret-approval-text'
+		raw_source_input = 'source-contains-raw-human-secret-approval-text'
+		assert await agent.resume_tool_pause(state.token, raw_human_input, source=raw_source_input) is True
+
+		log_text = '\n'.join(captured_logs)
+		assert 'pause_requested' in log_text
+		assert 'pause_resumed' in log_text
+		assert state.pause_id in log_text
+		assert state.token not in log_text
+		assert raw_human_input not in log_text
+		assert raw_source_input not in log_text
+		assert 'source=provided' in log_text
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_close_cancels_pending_tool_pause():
+	"""Closing an agent directly should resolve any pending tool pause future."""
+	agent = _make_test_agent()
+	pause = _install_pending_pause(agent)
+
+	await agent.close()
+
+	assert agent.get_pending_tool_pause() is None
+	assert pause.future.done() is True
+	closed = pause.future.result()
+	assert closed.error == 'Tool pause cancelled because agent closed'
+
+
+@pytest.mark.asyncio
+async def test_resume_tool_pause_rejects_done_action_result_and_allows_cancel_cleanup():
+	"""Phase 1 resumes cannot turn a pending pause into a run-terminating done action."""
+	agent = _make_test_agent()
+	try:
+		pause = _install_pending_pause(agent)
+		done_result = ActionResult(is_done=True, success=True, extracted_content='approved and done')
+
+		assert await agent.resume_tool_pause('secret-token', done_result, source='unit-test') is False
+		state = agent.get_pending_tool_pause()
+		assert state is not None
+		assert state.token == 'secret-token'
+		assert pause.future.done() is False
+
+		assert await agent.cancel_tool_pause('secret-token', 'cleanup after rejected done result') is True
+		cancelled = await pause.future
+		assert cancelled.error == 'Tool pause cancelled: cleanup after rejected done result'
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_take_step_waits_for_tool_pause_after_step(monkeypatch: pytest.MonkeyPatch):
+	"""Manual take_step() should support the same in-step HITL pause flow as run()."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		async def _pause_act(**_kwargs):
+			return PauseResult(prompt='Approve during take_step?', timeout=2.0)
+
+		agent.tools.act = _pause_act  # type: ignore[method-assign]
+
+		async def _fake_step(_step_info=None):
+			agent.state.last_result = await agent.multi_act([_PauseActionModel(pause_action={'x': 1})])
+
+		monkeypatch.setattr(agent, 'step', _fake_step)
+
+		async def _resume_after_pause_is_visible():
+			while True:
+				state = agent.get_pending_tool_pause()
+				if state is not None:
+					break
+				await asyncio.sleep(0.01)
+			assert await agent.resume_tool_pause(state.token, 'approved during take_step') is True
+
+		resume_task = asyncio.create_task(_resume_after_pause_is_visible())
+		done, valid = await agent.take_step(AgentStepInfo(step_number=1, max_steps=3))
+		await asyncio.wait_for(resume_task, timeout=1)
+
+		assert (done, valid) == (False, False)
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+		assert agent.state.last_result is not None
+		assert agent.state.last_result[0].extracted_content == 'approved during take_step'
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_act_rejects_pause_result_when_tool_pause_not_allowed(monkeypatch: pytest.MonkeyPatch):
+	"""Initial actions should not create pending tool pauses in Phase 1."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		async def _pause_act(**_kwargs):
+			return PauseResult(prompt='Approve initial action?')
+
+		agent.tools.act = _pause_act  # type: ignore[method-assign]
+
+		results = await agent.multi_act(
+			[_PauseActionModel(pause_action={'x': 1})],
+			allow_tool_pause=False,
+			tool_pause_unsupported_error='Tool pause is not supported in initial_actions in Phase 1',
+		)
+
+		assert len(results) == 1
+		assert results[0].error == 'Tool pause is not supported in initial_actions in Phase 1'
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_history_rerun_rejects_pause_result_without_pending_pause(monkeypatch: pytest.MonkeyPatch):
+	"""History replay should return a clear unsupported error instead of hanging on HITL pause."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _browser_state(_browser_session, **_kwargs):
+			return _empty_browser_state()
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_browser_state_summary', _browser_state)
+
+		async def _pause_act(**_kwargs):
+			return PauseResult(prompt='Approve replayed action?')
+
+		agent.tools.act = _pause_act  # type: ignore[method-assign]
+
+		history_item = AgentHistory(
+			model_output=agent.AgentOutput(
+				evaluation_previous_goal='Replay',
+				memory=None,
+				next_goal='Replay pause action',
+				action=[{'navigate': {'url': 'https://example.com'}}],  # type: ignore[list-item]
+			),
+			result=[ActionResult()],
+			state=BrowserStateHistory(url='about:blank', title='Replay', tabs=[], interacted_element=[None]),
+		)
+
+		results = await agent._execute_history_step(history_item, delay=0)
+
+		assert len(results) == 1
+		assert results[0].error == 'Tool pause is not supported during history rerun in Phase 1'
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_act_resolves_pause_result_in_current_action_and_continues(monkeypatch: pytest.MonkeyPatch):
+	"""A PauseResult resolves to the current action result and does not break the remaining action sequence."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		calls = 0
+
+		async def _act(action: ActionModel, **_kwargs):
+			nonlocal calls
+			calls += 1
+			action_data = action.model_dump(exclude_unset=True)
+			if calls == 1:
+				assert action_data.get('pause_action') is not None
+				return PauseResult(prompt='Approve first action?', reason='approval', timeout=2.0)
+			assert action_data.get('followup_action') is not None
+			return ActionResult(extracted_content='second action executed')
+
+		agent.tools.act = _act  # type: ignore[method-assign]
+
+		async def _resume_when_pending():
+			while True:
+				pause = agent.get_pending_tool_pause()
+				if pause is not None:
+					break
+				await asyncio.sleep(0.01)
+			assert pause.action_index == 0
+			assert await agent.resume_tool_pause(pause.token, 'approved first action') is True
+
+		resume_task = asyncio.create_task(_resume_when_pending())
+		results = await agent.multi_act(
+			[
+				_PauseActionModel(pause_action={'x': 1}),
+				_PauseActionModel(followup_action={'x': 2}),
+			],
+		)
+		await resume_task
+
+		assert calls == 2
+		assert len(results) == 2
+		assert results[0].extracted_content == 'approved first action'
+		assert results[1].extracted_content == 'second action executed'
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_act_resolves_two_pause_results_serially(monkeypatch: pytest.MonkeyPatch):
+	"""Two pause actions in one multi_act() should resolve one-by-one without concurrent pending pauses."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		calls = 0
+
+		async def _act(action: ActionModel, **_kwargs):
+			nonlocal calls
+			calls += 1
+			action_data = action.model_dump(exclude_unset=True)
+			assert action_data.get('pause_action') is not None
+			return PauseResult(prompt=f'Approve action {calls}?', reason='approval', timeout=2.0)
+
+		agent.tools.act = _act  # type: ignore[method-assign]
+		seen_pause_ids: list[str] = []
+
+		async def _resume_two_pauses():
+			for expected_index, response in enumerate(['approved first pause', 'approved second pause']):
+				while True:
+					pause = agent.get_pending_tool_pause()
+					if pause is not None and pause.pause_id not in seen_pause_ids:
+						break
+					await asyncio.sleep(0.01)
+				assert pause.action_index == expected_index
+				seen_pause_ids.append(pause.pause_id)
+				assert await agent.resume_tool_pause(pause.token, response, source='unit-test') is True
+
+		resume_task = asyncio.create_task(_resume_two_pauses())
+		results = await agent.multi_act(
+			[
+				_PauseActionModel(pause_action={'x': 1}),
+				_PauseActionModel(pause_action={'x': 2}),
+			],
+		)
+		await resume_task
+
+		assert calls == 2
+		assert len(results) == 2
+		assert results[0].extracted_content == 'approved first pause'
+		assert results[1].extracted_content == 'approved second pause'
+		assert len(set(seen_pause_ids)) == 2
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_act_stops_before_later_pause_when_prior_action_changes_page(monkeypatch: pytest.MonkeyPatch):
+	"""A normal ActionResult that changes page state must prevent later queued pause/actions from running."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+		current_url = 'about:blank'
+
+		async def _current_url(_browser_session):
+			return current_url
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		calls = 0
+
+		async def _act(action: ActionModel, **_kwargs):
+			nonlocal calls, current_url
+			calls += 1
+			if calls == 1:
+				current_url = 'https://example.com/changed'
+				return ActionResult(extracted_content='first action changed page')
+			return PauseResult(prompt='This pause should not be requested')
+
+		agent.tools.act = _act  # type: ignore[method-assign]
+
+		results = await agent.multi_act(
+			[
+				_PauseActionModel(followup_action={'x': 1}),
+				_PauseActionModel(pause_action={'x': 2}),
+			],
+		)
+
+		assert calls == 1
+		assert len(results) == 1
+		assert results[0].extracted_content == 'first action changed page'
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_act_stops_after_pause_when_page_changes_during_external_wait(monkeypatch: pytest.MonkeyPatch):
+	"""A resolved PauseResult should still run the normal post-action page-change guard."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+		current_url = 'about:blank'
+
+		async def _current_url(_browser_session):
+			return current_url
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		calls = 0
+
+		async def _act(action: ActionModel, **_kwargs):
+			nonlocal calls
+			calls += 1
+			if calls == 1:
+				return PauseResult(prompt='Approve first action?', timeout=2.0)
+			return ActionResult(extracted_content='second action should not execute')
+
+		agent.tools.act = _act  # type: ignore[method-assign]
+
+		async def _resume_after_page_change():
+			nonlocal current_url
+			while True:
+				pause = agent.get_pending_tool_pause()
+				if pause is not None:
+					break
+				await asyncio.sleep(0.01)
+			current_url = 'https://example.com/changed-during-pause'
+			assert await agent.resume_tool_pause(pause.token, 'approved after page changed') is True
+
+		resume_task = asyncio.create_task(_resume_after_page_change())
+		results = await agent.multi_act(
+			[
+				_PauseActionModel(pause_action={'x': 1}),
+				_PauseActionModel(followup_action={'x': 2}),
+			],
+		)
+		await resume_task
+
+		assert calls == 1
+		assert len(results) == 1
+		assert results[0].extracted_content == 'approved after page changed'
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_act_stops_after_pause_resumes_with_action_result_error(monkeypatch: pytest.MonkeyPatch):
+	"""A PauseResult resumed as an ActionResult(error=...) should inherit ActionResult short-circuit behavior."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		calls = 0
+
+		async def _act(action: ActionModel, **_kwargs):
+			nonlocal calls
+			calls += 1
+			if calls == 1:
+				return PauseResult(prompt='Approve first action?', timeout=2.0)
+			return ActionResult(extracted_content='second action should not execute')
+
+		agent.tools.act = _act  # type: ignore[method-assign]
+
+		async def _resume_with_error():
+			while True:
+				pause = agent.get_pending_tool_pause()
+				if pause is not None:
+					break
+				await asyncio.sleep(0.01)
+			assert await agent.resume_tool_pause(pause.token, ActionResult(error='human rejected action')) is True
+
+		resume_task = asyncio.create_task(_resume_with_error())
+		results = await agent.multi_act(
+			[
+				_PauseActionModel(pause_action={'x': 1}),
+				_PauseActionModel(followup_action={'x': 2}),
+			],
+		)
+		await resume_task
+
+		assert calls == 1
+		assert len(results) == 1
+		assert results[0].error == 'human rejected action'
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_multi_act_pause_timeout_behavior_stop_stops_agent(monkeypatch: pytest.MonkeyPatch):
+	"""timeout_behavior='stop' should stop the agent and prevent follow-up actions from running."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		calls = 0
+
+		async def _act(action: ActionModel, **_kwargs):
+			nonlocal calls
+			calls += 1
+			action_data = action.model_dump(exclude_unset=True)
+			assert action_data.get('pause_action') is not None
+			return PauseResult(prompt='Approve?', timeout=0.01, timeout_behavior='stop')
+
+		agent.tools.act = _act  # type: ignore[method-assign]
+
+		results = await agent.multi_act(
+			[
+				_PauseActionModel(pause_action={'x': 1}),
+				_PauseActionModel(followup_action={'x': 2}),
+			],
+		)
+
+		assert calls == 1
+		assert len(results) == 1
+		assert results[0].error == 'Tool pause timed out after 0.01 seconds'
+		assert agent.state.stopped is True
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+		assert await agent.resume_tool_pause('missing-or-late-token', 'late answer') is False
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_run_stops_after_pause_timeout_behavior_stop_without_next_llm_turn(monkeypatch: pytest.MonkeyPatch):
+	"""timeout_behavior='stop' should stop the run loop, not merely return an action error."""
+	tools = Tools()
+
+	@tools.action('Ask a human to approve before continuing')
+	async def ask_approval() -> PauseResult:
+		return PauseResult(prompt='Approve?', reason='approval', timeout=0.01, timeout_behavior='stop')
+
+	seen_messages: list[list[Any]] = []
+	llm = _make_recording_llm(
+		[
+			"""
+			{
+				"thinking": "Need approval",
+				"evaluation_previous_goal": "Starting",
+				"memory": "Need external approval",
+				"next_goal": "Ask for approval",
+				"action": [{"ask_approval": {}}]
+			}
+			""",
+			"""
+			{
+				"thinking": "Should not run",
+				"evaluation_previous_goal": "Bypassed approval",
+				"memory": "This turn should not happen",
+				"next_goal": "Finish",
+				"action": [{"done": {"text": "Should not happen", "success": true}}]
+			}
+			""",
+		],
+		seen_messages,
+	)
+	agent = Agent(task='Test HITL pause stop timeout', llm=llm, tools=tools, step_timeout=1, use_judge=False)
+	try:
+		assert agent.browser_session is not None
+
+		async def _start(_browser_session):
+			return None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		async def _browser_state(_browser_session, **_kwargs):
+			return _empty_browser_state()
+
+		async def _close():
+			return None
+
+		monkeypatch.setattr(type(agent.browser_session), 'start', _start)
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+		monkeypatch.setattr(type(agent.browser_session), 'get_browser_state_summary', _browser_state)
+		monkeypatch.setattr(agent, 'close', _close)
+
+		async def _pause_act(action: ActionModel, **_kwargs):
+			action_data = action.model_dump(exclude_unset=True)
+			if action_data.get('ask_approval') is not None:
+				return PauseResult(prompt='Approve?', reason='approval', timeout=0.01, timeout_behavior='stop')
+			return ActionResult(is_done=True, success=True, extracted_content='Should not happen')
+
+		agent.tools.act = _pause_act  # type: ignore[method-assign]
+
+		history = await agent.run(max_steps=3)
+
+		assert agent.state.stopped is True
+		assert len(seen_messages) == 1
+		assert history.is_done() is False
+		assert history.errors()[-1] == 'Tool pause timed out after 0.01 seconds'
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_step_timeout_counts_active_time_before_pause(monkeypatch: pytest.MonkeyPatch):
+	"""A tool cannot exceed active step_timeout before returning PauseResult and then hide in pause wait."""
+	agent = Agent(task='Test active timeout before HITL pause', llm=create_mock_llm(actions=None), step_timeout=1)
+	try:
+
+		async def _fake_step(_step_info=None):
+			# Simulate a synchronous/blocking tool that only requests HITL after the
+			# active step budget has already been consumed.
+			time.sleep(1.1)  # noqa: ASYNC251 - intentionally blocks to exercise active timeout accounting
+			_install_pending_pause(agent)
+			assert agent._pending_tool_pause is not None
+			await agent._pending_tool_pause.future
+
+		monkeypatch.setattr(agent, 'step', _fake_step)
+
+		with pytest.raises(TimeoutError):
+			await asyncio.wait_for(
+				agent._run_step_with_suspendable_timeout(AgentStepInfo(step_number=0, max_steps=3)),
+				timeout=2,
+			)
+
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_suspendable_step_cleans_pending_pause(monkeypatch: pytest.MonkeyPatch):
+	"""Cancelling the outer step runner must not leave the inner step task or pending pause alive."""
+	agent = _make_test_agent()
+	try:
+		pause_started = asyncio.Event()
+
+		async def _fake_step(_step_info=None):
+			_install_pending_pause(agent)
+			assert agent._pending_tool_pause is not None
+			pause_started.set()
+			await agent._pending_tool_pause.future
+
+		monkeypatch.setattr(agent, 'step', _fake_step)
+
+		step_task = asyncio.create_task(agent._run_step_with_suspendable_timeout(AgentStepInfo(step_number=0, max_steps=3)))
+		await asyncio.wait_for(pause_started.wait(), timeout=1)
+
+		step_task.cancel()
+		with pytest.raises(asyncio.CancelledError):
+			await step_task
+
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+		assert await agent.resume_tool_pause('secret-token', 'late answer') is False
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_run_resumes_tool_pause_and_next_llm_turn_sees_human_response(monkeypatch: pytest.MonkeyPatch):
+	"""A tool PauseResult is resumed and injected into the next LLM turn."""
+	tools = Tools()
+
+	@tools.action('Ask a human to approve the operation')
+	async def ask_approval() -> PauseResult:
+		return PauseResult(prompt='Approve?', reason='approval', timeout=2.0)
+
+	seen_messages: list[list[Any]] = []
+	llm = _make_recording_llm(
+		[
+			"""
+			{
+				"thinking": "Need approval",
+				"evaluation_previous_goal": "Starting",
+				"memory": "Need external approval",
+				"next_goal": "Ask for approval",
+				"action": [{"ask_approval": {}}]
+			}
+			""",
+			"""
+			{
+				"thinking": "Approval received",
+				"evaluation_previous_goal": "Approval was received",
+				"memory": "Human approved the operation",
+				"next_goal": "Finish",
+				"action": [{"done": {"text": "Saw approval", "success": true}}]
+			}
+			""",
+		],
+		seen_messages,
+	)
+	agent = Agent(task='Test HITL pause e2e', llm=llm, tools=tools, step_timeout=1, use_judge=False)
+	try:
+		assert agent.browser_session is not None
+
+		async def _start(_browser_session):
+			return None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		async def _browser_state(_browser_session, **_kwargs):
+			return _empty_browser_state()
+
+		async def _close():
+			return None
+
+		monkeypatch.setattr(type(agent.browser_session), 'start', _start)
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+		monkeypatch.setattr(type(agent.browser_session), 'get_browser_state_summary', _browser_state)
+		monkeypatch.setattr(agent, 'close', _close)
+
+		async def _pause_act(action: ActionModel, **_kwargs):
+			action_data = action.model_dump(exclude_unset=True)
+			if action_data.get('ask_approval') is not None:
+				return PauseResult(prompt='Approve?', reason='approval', timeout=2.0)
+			return ActionResult(is_done=True, success=True, extracted_content='Saw approval')
+
+		agent.tools.act = _pause_act  # type: ignore[method-assign]
+
+		async def _resume_after_step_timeout_budget():
+			while True:
+				pause = agent.get_pending_tool_pause()
+				if pause is not None:
+					break
+				await asyncio.sleep(0.01)
+			await asyncio.sleep(1.1)
+			assert await agent.resume_tool_pause(pause.token, 'approved by human') is True
+
+		resume_task = asyncio.create_task(_resume_after_step_timeout_budget())
+		history = await agent.run(max_steps=3)
+		await resume_task
+
+		assert all(error is None for error in history.errors())
+		assert history.is_done()
+		assert len(seen_messages) >= 2
+		second_turn_text = '\n'.join(str(message) for message in seen_messages[1])
+		assert 'approved by human' in second_turn_text
+		assert 'Step 1 timed out after 1 seconds' not in '\n'.join(str(error) for error in history.errors() if error)
+	finally:
+		await agent.close()

--- a/tests/ci/test_agent_hitl_pause.py
+++ b/tests/ci/test_agent_hitl_pause.py
@@ -50,8 +50,9 @@ def _install_pending_pause(agent: Agent, *, token: str = 'secret-token') -> Pend
 		reason='approval',
 		created_at=time.time(),
 		timeout=10.0,
-		timeout_behavior='continue',
+		pause_timeout_action='error',
 		metadata={'request_id': 'abc123'},
+		context={'operation': 'approval', 'risk_level': 'medium'},
 		loop=loop,
 		future=loop.create_future(),
 	)
@@ -107,7 +108,12 @@ def test_pause_result_is_importable_from_top_level_package():
 	from browser_use import PauseResult, ToolPauseState
 
 	pause = PauseResult(
-		prompt='Approve payment?', reason='approval', timeout=300, timeout_behavior='stop', metadata={'request_id': 'abc123'}
+		prompt='Approve payment?',
+		reason='approval',
+		timeout=300,
+		pause_timeout_action='stop',
+		metadata={'request_id': 'abc123'},
+		context={'operation': 'payment', 'amount': 5000},
 	)
 	state = ToolPauseState(
 		token='secret-token',
@@ -119,18 +125,21 @@ def test_pause_result_is_importable_from_top_level_package():
 		reason=pause.reason,
 		created_at=123.0,
 		timeout=pause.timeout,
-		timeout_behavior=pause.timeout_behavior,
+		pause_timeout_action=pause.pause_timeout_action,
 		metadata=pause.metadata,
+		context=pause.context,
 	)
 
 	assert pause.prompt == 'Approve payment?'
 	assert pause.reason == 'approval'
 	assert pause.timeout == 300
-	assert pause.timeout_behavior == 'stop'
+	assert pause.pause_timeout_action == 'stop'
+	assert pause.context == {'operation': 'payment', 'amount': 5000}
 	assert state.token == 'secret-token'
 	assert state.pause_id == 'public-pause-id'
 	assert state.action_index == 0
-	assert state.timeout_behavior == 'stop'
+	assert state.pause_timeout_action == 'stop'
+	assert state.context == {'operation': 'payment', 'amount': 5000}
 
 
 def test_pause_result_rejects_non_positive_timeout():
@@ -165,8 +174,9 @@ async def test_tool_pause_query_resume_and_late_resume():
 		assert state.prompt == 'Approve?'
 		assert state.reason == 'approval'
 		assert state.timeout == 10.0
-		assert state.timeout_behavior == 'continue'
+		assert state.pause_timeout_action == 'error'
 		assert state.metadata == {'request_id': 'abc123'}
+		assert state.context == {'operation': 'approval', 'risk_level': 'medium'}
 
 		assert await agent.resume_tool_pause('wrong-token', 'ignored') is False
 		assert await agent.resume_tool_pause('secret-token', 'approved', source='unit-test') is True
@@ -177,13 +187,16 @@ async def test_tool_pause_query_resume_and_late_resume():
 		assert isinstance(resolved, ActionResult)
 		assert resolved.extracted_content == 'approved'
 		assert resolved.include_extracted_content_only_once is True
-		assert resolved.long_term_memory == 'External input received for tool ask_approval.'
+		assert resolved.long_term_memory == (
+			'External input received for tool ask_approval. Pause context: {"operation": "approval", "risk_level": "medium"}'
+		)
 		assert 'approved' not in resolved.long_term_memory
 		assert resolved.metadata == {
 			'tool_pause_resolved': True,
 			'tool_pause_id': 'public-pause-id',
 			'tool_name': 'ask_approval',
 			'reason': 'approval',
+			'pause_context': {'operation': 'approval', 'risk_level': 'medium'},
 		}
 	finally:
 		await agent.close()
@@ -199,6 +212,7 @@ async def test_tool_pause_cancel_and_stop_reject_late_resume():
 		assert await agent.cancel_tool_pause('wrong-token', 'ignored') is False
 		assert await agent.cancel_tool_pause('secret-token', 'test cancel') is True
 		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
 		assert await agent.resume_tool_pause('secret-token', 'late answer') is False
 
 		cancelled = await pause.future
@@ -208,6 +222,7 @@ async def test_tool_pause_cancel_and_stop_reject_late_resume():
 		stop_pause = _install_pending_pause(agent, token='stop-token')
 		agent.stop()
 		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
 		assert await agent.resume_tool_pause('stop-token', 'late answer') is False
 
 		stopped = await stop_pause.future
@@ -360,13 +375,16 @@ async def test_resume_tool_pause_merges_custom_action_result_metadata():
 
 		assert resolved.extracted_content == 'custom approved'
 		assert resolved.include_extracted_content_only_once is True
-		assert resolved.long_term_memory == 'Custom resume summary without raw secret data.'
+		assert resolved.long_term_memory == (
+			'Custom resume summary without raw secret data. Pause context: {"operation": "approval", "risk_level": "medium"}'
+		)
 		assert resolved.metadata == {
 			'request_id': 'abc123',
 			'tool_pause_id': 'public-pause-id',
 			'tool_pause_resolved': True,
 			'tool_name': 'ask_approval',
 			'reason': 'approval',
+			'pause_context': {'operation': 'approval', 'risk_level': 'medium'},
 		}
 		assert resolved is not custom_result
 		assert custom_result.metadata == {'request_id': 'abc123', 'tool_pause_id': 'caller-cannot-spoof-pause-id'}
@@ -386,8 +404,9 @@ async def test_pause_lifecycle_logs_do_not_expose_token_or_raw_human_input(monke
 
 		monkeypatch.setattr(agent.logger, 'info', _capture_info)
 
+		pause_context = {'operation': 'approval', 'risk_level': 'high'}
 		registration_result = agent._request_tool_pause(
-			PauseResult(prompt='Approve?', reason='approval', timeout=1.0),
+			PauseResult(prompt='Approve?', reason='approval', timeout=1.0, context=pause_context),
 			'ask_approval',
 		)
 		state = agent.get_pending_tool_pause()
@@ -405,6 +424,7 @@ async def test_pause_lifecycle_logs_do_not_expose_token_or_raw_human_input(monke
 		assert state.token not in log_text
 		assert raw_human_input not in log_text
 		assert raw_source_input not in log_text
+		assert str(pause_context) not in log_text
 		assert 'source=provided' in log_text
 	finally:
 		await agent.close()
@@ -419,6 +439,7 @@ async def test_close_cancels_pending_tool_pause():
 	await agent.close()
 
 	assert agent.get_pending_tool_pause() is None
+	assert agent._pending_tool_pause is None
 	assert pause.future.done() is True
 	closed = pause.future.result()
 	assert closed.error == 'Tool pause cancelled because agent closed'
@@ -809,8 +830,8 @@ async def test_multi_act_stops_after_pause_resumes_with_action_result_error(monk
 
 
 @pytest.mark.asyncio
-async def test_multi_act_pause_timeout_behavior_stop_stops_agent(monkeypatch: pytest.MonkeyPatch):
-	"""timeout_behavior='stop' should stop the agent and prevent follow-up actions from running."""
+async def test_pause_timeout_action_error_returns_error_result(monkeypatch: pytest.MonkeyPatch):
+	"""pause_timeout_action='error' should return an error result without stopping the agent."""
 	agent = _make_test_agent()
 	try:
 		assert agent.browser_session is not None
@@ -827,7 +848,7 @@ async def test_multi_act_pause_timeout_behavior_stop_stops_agent(monkeypatch: py
 			calls += 1
 			action_data = action.model_dump(exclude_unset=True)
 			assert action_data.get('pause_action') is not None
-			return PauseResult(prompt='Approve?', timeout=0.01, timeout_behavior='stop')
+			return PauseResult(prompt='Approve?', reason='approval', timeout=0.01, pause_timeout_action='error')
 
 		agent.tools.act = _act  # type: ignore[method-assign]
 
@@ -841,6 +862,128 @@ async def test_multi_act_pause_timeout_behavior_stop_stops_agent(monkeypatch: py
 		assert calls == 1
 		assert len(results) == 1
 		assert results[0].error == 'Tool pause timed out after 0.01 seconds'
+		metadata = results[0].metadata
+		assert metadata is not None
+		assert metadata == {
+			'tool_pause_timeout': True,
+			'tool_pause_id': metadata['tool_pause_id'],
+			'tool_name': 'pause_action',
+			'reason': 'approval',
+			'pause_timeout_action': 'error',
+			'pause_context': None,
+		}
+		assert agent.state.stopped is False
+		assert agent.get_pending_tool_pause() is None
+		assert agent._pending_tool_pause is None
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_pause_timeout_action_continue_returns_non_error_result_and_continues_actions(monkeypatch: pytest.MonkeyPatch):
+	"""pause_timeout_action='continue' should not trigger multi_act's error break."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		calls = 0
+
+		async def _act(action: ActionModel, **_kwargs):
+			nonlocal calls
+			calls += 1
+			action_data = action.model_dump(exclude_unset=True)
+			if calls == 1:
+				assert action_data.get('pause_action') is not None
+				return PauseResult(
+					prompt='Optional human hint?',
+					reason='optional_hint',
+					timeout=0.01,
+					pause_timeout_action='continue',
+					context={'operation': 'background_fetch'},
+				)
+			assert action_data.get('followup_action') is not None
+			return ActionResult(extracted_content='followup executed')
+
+		agent.tools.act = _act  # type: ignore[method-assign]
+
+		results = await agent.multi_act(
+			[
+				_PauseActionModel(pause_action={'x': 1}),
+				_PauseActionModel(followup_action={'x': 2}),
+			],
+		)
+
+		assert calls == 2
+		assert len(results) == 2
+		assert results[0].error is None
+		assert results[0].extracted_content == (
+			'No external input received for tool pause_action before timeout. Pause context: {"operation": "background_fetch"}'
+		)
+		assert results[0].long_term_memory == results[0].extracted_content
+		metadata = results[0].metadata
+		assert metadata is not None
+		assert metadata == {
+			'tool_pause_timeout': True,
+			'tool_pause_id': metadata['tool_pause_id'],
+			'tool_name': 'pause_action',
+			'reason': 'optional_hint',
+			'pause_timeout_action': 'continue',
+			'pause_context': {'operation': 'background_fetch'},
+		}
+		assert results[1].extracted_content == 'followup executed'
+		assert agent.state.stopped is False
+	finally:
+		await agent.close()
+
+
+@pytest.mark.asyncio
+async def test_pause_timeout_action_stop_stops_agent(monkeypatch: pytest.MonkeyPatch):
+	"""pause_timeout_action='stop' should stop the agent and prevent follow-up actions from running."""
+	agent = _make_test_agent()
+	try:
+		assert agent.browser_session is not None
+
+		async def _current_url(_browser_session):
+			return 'about:blank'
+
+		monkeypatch.setattr(type(agent.browser_session), 'get_current_page_url', _current_url)
+
+		calls = 0
+
+		async def _act(action: ActionModel, **_kwargs):
+			nonlocal calls
+			calls += 1
+			action_data = action.model_dump(exclude_unset=True)
+			assert action_data.get('pause_action') is not None
+			return PauseResult(prompt='Approve?', timeout=0.01, pause_timeout_action='stop')
+
+		agent.tools.act = _act  # type: ignore[method-assign]
+
+		results = await agent.multi_act(
+			[
+				_PauseActionModel(pause_action={'x': 1}),
+				_PauseActionModel(followup_action={'x': 2}),
+			],
+		)
+
+		assert calls == 1
+		assert len(results) == 1
+		assert results[0].error == 'Tool pause timed out after 0.01 seconds'
+		metadata = results[0].metadata
+		assert metadata is not None
+		assert metadata == {
+			'tool_pause_timeout': True,
+			'tool_pause_id': metadata['tool_pause_id'],
+			'tool_name': 'pause_action',
+			'reason': None,
+			'pause_timeout_action': 'stop',
+			'pause_context': None,
+		}
 		assert agent.state.stopped is True
 		assert agent.get_pending_tool_pause() is None
 		assert agent._pending_tool_pause is None
@@ -850,13 +993,13 @@ async def test_multi_act_pause_timeout_behavior_stop_stops_agent(monkeypatch: py
 
 
 @pytest.mark.asyncio
-async def test_run_stops_after_pause_timeout_behavior_stop_without_next_llm_turn(monkeypatch: pytest.MonkeyPatch):
-	"""timeout_behavior='stop' should stop the run loop, not merely return an action error."""
+async def test_run_stops_after_pause_timeout_action_stop_without_next_llm_turn(monkeypatch: pytest.MonkeyPatch):
+	"""pause_timeout_action='stop' should stop the run loop, not merely return an action error."""
 	tools = Tools()
 
 	@tools.action('Ask a human to approve before continuing')
 	async def ask_approval() -> PauseResult:
-		return PauseResult(prompt='Approve?', reason='approval', timeout=0.01, timeout_behavior='stop')
+		return PauseResult(prompt='Approve?', reason='approval', timeout=0.01, pause_timeout_action='stop')
 
 	seen_messages: list[list[Any]] = []
 	llm = _make_recording_llm(
@@ -906,7 +1049,7 @@ async def test_run_stops_after_pause_timeout_behavior_stop_without_next_llm_turn
 		async def _pause_act(action: ActionModel, **_kwargs):
 			action_data = action.model_dump(exclude_unset=True)
 			if action_data.get('ask_approval') is not None:
-				return PauseResult(prompt='Approve?', reason='approval', timeout=0.01, timeout_behavior='stop')
+				return PauseResult(prompt='Approve?', reason='approval', timeout=0.01, pause_timeout_action='stop')
 			return ActionResult(is_done=True, success=True, extracted_content='Should not happen')
 
 		agent.tools.act = _pause_act  # type: ignore[method-assign]
@@ -981,13 +1124,18 @@ async def test_cancelled_suspendable_step_cleans_pending_pause(monkeypatch: pyte
 
 
 @pytest.mark.asyncio
-async def test_run_resumes_tool_pause_and_next_llm_turn_sees_human_response(monkeypatch: pytest.MonkeyPatch):
-	"""A tool PauseResult is resumed and injected into the next LLM turn."""
+async def test_pause_context_is_visible_to_next_llm_turn(monkeypatch: pytest.MonkeyPatch):
+	"""A resolved tool pause should expose non-sensitive context to the next LLM turn."""
 	tools = Tools()
+	pause_context = {
+		'operation': 'payment',
+		'amount': 5000,
+		'approval_reason': 'high_risk_payment',
+	}
 
 	@tools.action('Ask a human to approve the operation')
 	async def ask_approval() -> PauseResult:
-		return PauseResult(prompt='Approve?', reason='approval', timeout=2.0)
+		return PauseResult(prompt='Approve?', reason='approval', timeout=2.0, context=pause_context)
 
 	seen_messages: list[list[Any]] = []
 	llm = _make_recording_llm(
@@ -1037,7 +1185,7 @@ async def test_run_resumes_tool_pause_and_next_llm_turn_sees_human_response(monk
 		async def _pause_act(action: ActionModel, **_kwargs):
 			action_data = action.model_dump(exclude_unset=True)
 			if action_data.get('ask_approval') is not None:
-				return PauseResult(prompt='Approve?', reason='approval', timeout=2.0)
+				return PauseResult(prompt='Approve?', reason='approval', timeout=2.0, context=pause_context)
 			return ActionResult(is_done=True, success=True, extracted_content='Saw approval')
 
 		agent.tools.act = _pause_act  # type: ignore[method-assign]
@@ -1060,6 +1208,9 @@ async def test_run_resumes_tool_pause_and_next_llm_turn_sees_human_response(monk
 		assert len(seen_messages) >= 2
 		second_turn_text = '\n'.join(str(message) for message in seen_messages[1])
 		assert 'approved by human' in second_turn_text
+		assert 'payment' in second_turn_text
+		assert '5000' in second_turn_text
+		assert 'high_risk_payment' in second_turn_text
 		assert 'Step 1 timed out after 1 seconds' not in '\n'.join(str(error) for error in history.errors() if error)
 	finally:
 		await agent.close()


### PR DESCRIPTION
## Summary

Part of #4798.

This PR implements the Phase 1 HITL tool pause MVP for browser-use.

It introduces a first-class `PauseResult` return type that tools can use to request external human/operator input. The Agent runtime owns the pending pause lifecycle, including token generation, resume/cancel APIs, timeout handling, stop/run-shutdown cleanup, and privacy-safe lifecycle logging.

The pause is resolved inside the current `multi_act()` action, so the resumed value becomes the current action's `ActionResult`. This preserves existing `multi_act()` and `ActionResult` semantics, including error breaks, `is_done`, `terminates_sequence`, and page-change guards.

This also adds suspendable step timeout accounting: active execution time still counts toward `step_timeout`, while external human wait time does not consume the step timeout budget.

This PR also adds per-pause timeout behavior via `pause_timeout_action` and non-sensitive pause `context` propagation so the next LLM turn can reason about why the pause happened.

## What changed

- Added public HITL models:
  - `PauseResult`
  - `ToolPauseState`

- Added Agent runtime support for one pending tool pause:
  - `get_pending_tool_pause()`
  - `resume_tool_pause()`
  - `cancel_tool_pause()`
  - stop/run-shutdown cleanup

- Added per-pause timeout behavior on `PauseResult`:
  - `timeout=None` for externally resolved pauses
  - positive timeout validation
  - `pause_timeout_action="error"` returns a timeout `ActionResult(error=...)`
  - `pause_timeout_action="continue"` returns a non-error timeout result and allows normal `multi_act()` continuation
  - `pause_timeout_action="stop"` marks the agent as stopped to prevent approval-gate bypasses after timeout

- Added non-sensitive `PauseResult.context`.

- Propagated pause context into resolved `ActionResult` metadata as `pause_context`.

- Propagated pause context into LLM-visible memory so the next reasoning step can see why the pause happened.

- Added suspendable step timeout accounting:
  - active execution time still counts toward `step_timeout`
  - external human wait time does not consume `step_timeout`
  - normal non-pausing tools remain protected by existing timeout behavior

- Updated `multi_act()` to resolve `PauseResult` inside the current action instead of ending the step with a placeholder.

- Preserved existing `multi_act()` guards after the resolved `ActionResult`:
  - error breaks
  - `is_done`
  - `terminates_sequence`
  - page-change guards

- Added unsupported guards for Phase 1 paths that do not own Agent pending pause runtime:
  - `initial_actions`
  - history rerun
  - MCP/direct tool execution

- Updated `Tools.act()` and `Tools.__getattr__` direct helpers to pass through `PauseResult` without creating Agent pending pause state; Agent-managed `multi_act()` is the consumer that resolves it.

- Ensured privacy boundaries:
  - secret resume/cancel tokens are not written to logs, history, `ActionResult` metadata, or long-term memory
  - raw human input is only returned as the resolved action's `extracted_content` by default
  - raw human input is not copied into logs, `ActionResult` metadata, or long-term memory by default
  - public correlation uses `pause_id`
  - `PauseResult.context` is intended for non-sensitive pause context and may be surfaced to the next LLM turn

- Added and updated regression coverage for HITL pause behavior, timeout behavior, direct `Tools.act()` behavior, `multi_act()` guards, context propagation, and pyright type narrowing.

## State flow clarification

The resolved pause is not injected as a separate post-step placeholder or backfill.

In the current implementation, the pause is resolved inside the current `multi_act()` action. The resolved value becomes that action's normal `ActionResult`, then reaches `state.last_result` through the existing action-result flow.

## Phase 1 limitations

- `initial_actions`, history rerun, and MCP/direct execution paths do not create Agent pending pauses in Phase 1.
- Per-tool pause defaults, richer docs, and form-specific pause helpers are left for later phases.
- Formal eventbus/cloud lifecycle events such as `pause_requested`, `pause_resumed`, `pause_cancelled`, and `pause_timeout` are left for a follow-up. This PR only emits privacy-safe lifecycle logs.

## Verification

Ran formatting, lint, type checking, pre-commit, and targeted regression tests.

```bash
uv run ruff check --fix \
  browser_use/__init__.py \
  browser_use/agent/service.py \
  browser_use/agent/views.py \
  browser_use/mcp/server.py \
  browser_use/tools/service.py \
  tests/ci/test_action_timeout.py \
  tests/ci/test_agent_hitl_pause.py \
  tests/ci/browser/test_cross_origin_click.py \
  tests/ci/browser/test_dom_serializer.py \
  tests/ci/browser/test_true_cross_origin_click.py \
  tests/ci/interactions/test_radio_buttons.py

uv run ruff format \
  browser_use/__init__.py \
  browser_use/agent/service.py \
  browser_use/agent/views.py \
  browser_use/mcp/server.py \
  browser_use/tools/service.py \
  tests/ci/test_action_timeout.py \
  tests/ci/test_agent_hitl_pause.py \
  tests/ci/browser/test_cross_origin_click.py \
  tests/ci/browser/test_dom_serializer.py \
  tests/ci/browser/test_true_cross_origin_click.py \
  tests/ci/interactions/test_radio_buttons.py

uv run --no-sync pyright

uv python install 3.11

uv run --no-sync pre-commit run --all-files --show-diff-on-failure

uv run pytest \
  tests/ci/test_action_timeout.py \
  tests/ci/test_agent_hitl_pause.py \
  tests/ci/test_multi_act_guards.py \
  tests/ci/browser/test_cross_origin_click.py \
  tests/ci/browser/test_dom_serializer.py \
  tests/ci/browser/test_true_cross_origin_click.py \
  tests/ci/interactions/test_radio_buttons.py \
  -q
```

Results:

```text
ruff check: passed
ruff format: passed, 11 files unchanged
pyright: 0 errors, 1 pre-existing warning in browser_use/skill_cli/__init__.py
uv python install 3.11: Python 3.11 already installed
pre-commit: passed
pytest: 56 passed
```

Additional coverage includes:

- `pause_timeout_action="error"` returns a timeout error result.
- `pause_timeout_action="continue"` returns a non-error timeout result and allows follow-up actions.
- `pause_timeout_action="stop"` stops the agent and prevents follow-up actions.
- `PauseResult.context` is propagated into resolved metadata.
- `PauseResult.context` is propagated into LLM-visible memory.
- Pause context is visible to the next LLM reasoning step.
- Lifecycle logs do not expose secret tokens, raw human input, raw source input, or pause context.
- Resolved pause metadata cannot be spoofed by caller-provided metadata.
- Late resume/cancel after resolution is rejected.
- Windows line-ending checks passed through pre-commit mixed line ending.