### PR TITLE
Add Bilig WorkPaper integration example

### DIFF
--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -23,6 +23,8 @@ This directory is for examples that show Browser Use working with external produ
 
 External projects listed here are maintained outside this repository. A listing is a pointer for users, not a support guarantee from Browser Use maintainers.
 
+- [Bilig WorkPaper](https://github.com/proompteng/bilig) - Formula workbook readback for browser agents that need deterministic spreadsheet-style calculations. Maintained by @gregkonush.
+
 Add entries in this format:
 
 ```markdown

--- a/examples/integrations/bilig_workpaper/README.md
+++ b/examples/integrations/bilig_workpaper/README.md
@@ -1,0 +1,37 @@
+# Bilig WorkPaper
+
+This example gives a Browser Use agent a custom tool for exact formula readback with
+[`@bilig/workpaper`](https://github.com/proompteng/bilig). The browser agent can gather
+quote inputs from a page, then delegate the formula workbook calculation to Bilig instead
+of doing arithmetic in the LLM.
+
+The tool starts Bilig's local formula-readback server, writes a conversion-rate input,
+reads dependent forecast formulas, verifies persistence/restore behavior, and returns a
+structured JSON proof.
+
+## Requirements
+
+- Node.js and npm, for `npm exec --package @bilig/workpaper`
+- Browser Use development environment installed with `uv sync`
+- `BROWSER_USE_API_KEY` only for the full browser-agent run
+
+## Run the no-key smoke test
+
+From the repository root:
+
+```bash
+uv run python examples/integrations/bilig_workpaper/bilig_workpaper_example.py --smoke
+```
+
+The smoke test does not call an LLM. It directly runs the custom tool path and should
+print a `verified: true` JSON object with before/after ARR values.
+
+## Run with a Browser Use agent
+
+```bash
+export BROWSER_USE_API_KEY=...
+uv run python examples/integrations/bilig_workpaper/bilig_workpaper_example.py
+```
+
+The agent opens a small quote-input page, reads the conversion rate, calls the Bilig
+tool, and reports the computed WorkPaper output.

--- a/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
+++ b/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
@@ -1,0 +1,249 @@
+"""Browser Use integration for deterministic Bilig WorkPaper formula readback."""
+
+import argparse
+import asyncio
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, ConfigDict, Field
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+from browser_use import ActionResult, Agent, ChatBrowserUse, Tools
+
+BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.86.1'
+
+
+class FormulaReadbackRequest(BaseModel):
+	"""Input passed from the browser agent to the Bilig WorkPaper tool."""
+
+	conversion_rate: float = Field(
+		default=0.4,
+		ge=0,
+		le=1,
+		description='Conversion rate to write into the WorkPaper input cell.',
+	)
+	package_spec: str = Field(
+		default=BILIG_WORKPAPER_PACKAGE,
+		description='npm package spec used to start the Bilig formula-readback server.',
+	)
+	timeout_seconds: int = Field(
+		default=45,
+		ge=5,
+		le=120,
+		description='Maximum time to start the local Bilig server and read the proof.',
+	)
+
+
+class ForecastValues(BaseModel):
+	"""Computed forecast values returned by Bilig."""
+
+	model_config = ConfigDict(populate_by_name=True)
+
+	expected_customers: float = Field(alias='expectedCustomers')
+	expected_arr: float = Field(alias='expectedArr')
+	expansion_arr: float = Field(alias='expansionArr')
+	target_gap: float = Field(alias='targetGap')
+
+
+class FormulaReadbackChecks(BaseModel):
+	"""Verification checks returned by Bilig."""
+
+	model_config = ConfigDict(populate_by_name=True)
+
+	previous_value: float = Field(alias='previousValue')
+	new_value: float = Field(alias='newValue')
+	formulas_persisted: bool = Field(alias='formulasPersisted')
+	restored_matches_after: bool = Field(alias='restoredMatchesAfter')
+	computed_output_changed: bool = Field(alias='computedOutputChanged')
+	serialized_bytes: int = Field(alias='serializedBytes')
+
+
+class FormulaReadbackProof(BaseModel):
+	"""Structured proof object returned by the Bilig formula-readback server."""
+
+	model_config = ConfigDict(populate_by_name=True)
+
+	verified: bool
+	edited_cell: str = Field(alias='editedCell')
+	before: ForecastValues
+	after: ForecastValues
+	restored: ForecastValues
+	formula_contracts: dict[str, str] = Field(alias='formulaContracts')
+	checks: FormulaReadbackChecks
+
+
+def _find_open_port() -> int:
+	with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+		sock.bind(('127.0.0.1', 0))
+		return int(sock.getsockname()[1])
+
+
+def _post_formula_readback(port: int, request: FormulaReadbackRequest) -> FormulaReadbackProof:
+	url = f'http://127.0.0.1:{port}/api/workpaper/n8n/forecast'
+	body = json.dumps(
+		{
+			'sheetName': 'Inputs',
+			'address': 'B3',
+			'value': request.conversion_rate,
+		}
+	).encode('utf-8')
+	http_request = urllib.request.Request(
+		url,
+		data=body,
+		headers={'content-type': 'application/json'},
+		method='POST',
+	)
+	with urllib.request.urlopen(http_request, timeout=5) as response:
+		payload = json.loads(response.read().decode('utf-8'))
+	return FormulaReadbackProof.model_validate(payload)
+
+
+def run_bilig_formula_readback(request: FormulaReadbackRequest) -> FormulaReadbackProof:
+	"""Start Bilig's local formula server and return a verified WorkPaper proof."""
+
+	port = _find_open_port()
+	command = [
+		'npm',
+		'exec',
+		'--yes',
+		'--package',
+		request.package_spec,
+		'--',
+		'bilig-n8n-formula-server',
+		'--host',
+		'127.0.0.1',
+		'--port',
+		str(port),
+	]
+	process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+	deadline = time.monotonic() + request.timeout_seconds
+
+	try:
+		last_error: Exception | None = None
+		while time.monotonic() < deadline:
+			if process.poll() is not None:
+				stdout, stderr = process.communicate()
+				raise RuntimeError(f'Bilig server exited early with code {process.returncode}: {stderr or stdout}')
+			try:
+				return _post_formula_readback(port, request)
+			except (ConnectionError, urllib.error.URLError) as exc:
+				last_error = exc
+				time.sleep(0.2)
+			except TimeoutError as exc:
+				last_error = exc
+				time.sleep(0.2)
+
+		raise TimeoutError(f'Bilig formula server did not become ready within {request.timeout_seconds}s: {last_error}')
+	finally:
+		if process.poll() is None:
+			process.terminate()
+			try:
+				process.wait(timeout=5)
+			except subprocess.TimeoutExpired:
+				process.kill()
+				process.wait(timeout=5)
+
+
+def create_bilig_workpaper_tools() -> Tools:
+	"""Create Browser Use tools backed by Bilig WorkPaper."""
+
+	tools = Tools()
+
+	@tools.action(
+		'Run a Bilig WorkPaper formula readback proof for a quote forecast. '
+		'Use this when exact workbook formulas should compute the result instead of the LLM.',
+		param_model=FormulaReadbackRequest,
+	)
+	async def verify_workpaper_formula_readback(params: FormulaReadbackRequest) -> ActionResult:
+		"""Write an input cell, recalculate formulas, and return Bilig's structured proof."""
+
+		try:
+			proof = await asyncio.to_thread(run_bilig_formula_readback, params)
+		except Exception as exc:
+			return ActionResult(error=f'Bilig WorkPaper formula readback failed: {exc}')
+
+		summary = (
+			f'Bilig verified {proof.edited_cell}: expected ARR changed from '
+			f'{proof.before.expected_arr} to {proof.after.expected_arr}; '
+			f'restored readback matched: {proof.checks.restored_matches_after}.'
+		)
+		return ActionResult(
+			extracted_content=proof.model_dump_json(by_alias=True, indent=2),
+			long_term_memory=summary,
+		)
+
+	return tools
+
+
+def _quote_input_page(conversion_rate: float) -> str:
+	html = f"""<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Bilig quote inputs</title>
+	</head>
+	<body>
+		<h1>Quote forecast inputs</h1>
+		<dl>
+			<dt>Pipeline accounts</dt>
+			<dd>20</dd>
+			<dt>Conversion rate</dt>
+			<dd>{conversion_rate}</dd>
+			<dt>ARR per customer</dt>
+			<dd>12000</dd>
+		</dl>
+	</body>
+</html>"""
+	return 'data:text/html,' + urllib.parse.quote(html)
+
+
+async def run_agent(conversion_rate: float) -> None:
+	"""Run the full Browser Use agent with the Bilig WorkPaper custom tool."""
+
+	load_dotenv()
+	if not os.getenv('BROWSER_USE_API_KEY'):
+		raise RuntimeError('Set BROWSER_USE_API_KEY or run this file with --smoke for the no-key proof.')
+
+	task = (
+		f'Open this quote input page: {_quote_input_page(conversion_rate)}. '
+		'Read the conversion rate from the page, then call verify_workpaper_formula_readback with that rate. '
+		'Report the edited cell, expected ARR after recalculation, target gap, and whether Bilig verified persistence.'
+	)
+	agent = Agent(task=task, llm=ChatBrowserUse(), tools=create_bilig_workpaper_tools())
+	await agent.run()
+
+
+def parse_args() -> argparse.Namespace:
+	parser = argparse.ArgumentParser(description='Run the Browser Use + Bilig WorkPaper integration example.')
+	parser.add_argument('--smoke', action='store_true', help='Run the Bilig tool path without an LLM or browser session.')
+	parser.add_argument('--conversion-rate', type=float, default=0.4, help='Conversion rate to write into Inputs!B3.')
+	parser.add_argument(
+		'--package-spec', default=BILIG_WORKPAPER_PACKAGE, help='npm package spec for the Bilig WorkPaper package.'
+	)
+	return parser.parse_args()
+
+
+def main() -> None:
+	args = parse_args()
+	request = FormulaReadbackRequest(conversion_rate=args.conversion_rate, package_spec=args.package_spec)
+
+	if args.smoke:
+		proof = run_bilig_formula_readback(request)
+		print(proof.model_dump_json(by_alias=True, indent=2))
+		return
+
+	asyncio.run(run_agent(conversion_rate=args.conversion_rate))
+
+
+if __name__ == '__main__':
+	main()

--- a/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
+++ b/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
@@ -21,7 +21,7 @@ sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from browser_use import ActionResult, Agent, ChatBrowserUse, Tools
 
-BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.96.0'
+BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@latest'
 
 
 class FormulaReadbackRequest(BaseModel):

--- a/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
+++ b/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
@@ -7,6 +7,7 @@ import os
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -31,10 +32,6 @@ class FormulaReadbackRequest(BaseModel):
 		ge=0,
 		le=1,
 		description='Conversion rate to write into the WorkPaper input cell.',
-	)
-	package_spec: str = Field(
-		default=BILIG_WORKPAPER_PACKAGE,
-		description='npm package spec used to start the Bilig formula-readback server.',
 	)
 	timeout_seconds: int = Field(
 		default=45,
@@ -117,7 +114,7 @@ def run_bilig_formula_readback(request: FormulaReadbackRequest) -> FormulaReadba
 		'exec',
 		'--yes',
 		'--package',
-		request.package_spec,
+		BILIG_WORKPAPER_PACKAGE,
 		'--',
 		'bilig-n8n-formula-server',
 		'--host',
@@ -125,33 +122,35 @@ def run_bilig_formula_readback(request: FormulaReadbackRequest) -> FormulaReadba
 		'--port',
 		str(port),
 	]
-	process = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-	deadline = time.monotonic() + request.timeout_seconds
+	with tempfile.TemporaryFile(mode='w+', encoding='utf-8') as process_log:
+		process = subprocess.Popen(command, stdout=process_log, stderr=subprocess.STDOUT, text=True)
+		deadline = time.monotonic() + request.timeout_seconds
 
-	try:
-		last_error: Exception | None = None
-		while time.monotonic() < deadline:
-			if process.poll() is not None:
-				stdout, stderr = process.communicate()
-				raise RuntimeError(f'Bilig server exited early with code {process.returncode}: {stderr or stdout}')
-			try:
-				return _post_formula_readback(port, request)
-			except (ConnectionError, urllib.error.URLError) as exc:
-				last_error = exc
-				time.sleep(0.2)
-			except TimeoutError as exc:
-				last_error = exc
-				time.sleep(0.2)
+		try:
+			last_error: Exception | None = None
+			while time.monotonic() < deadline:
+				if process.poll() is not None:
+					process_log.seek(0)
+					output = process_log.read().strip()
+					raise RuntimeError(f'Bilig server exited early with code {process.returncode}: {output}')
+				try:
+					return _post_formula_readback(port, request)
+				except (ConnectionError, urllib.error.URLError) as exc:
+					last_error = exc
+					time.sleep(0.2)
+				except TimeoutError as exc:
+					last_error = exc
+					time.sleep(0.2)
 
-		raise TimeoutError(f'Bilig formula server did not become ready within {request.timeout_seconds}s: {last_error}')
-	finally:
-		if process.poll() is None:
-			process.terminate()
-			try:
-				process.wait(timeout=5)
-			except subprocess.TimeoutExpired:
-				process.kill()
-				process.wait(timeout=5)
+			raise TimeoutError(f'Bilig formula server did not become ready within {request.timeout_seconds}s: {last_error}')
+		finally:
+			if process.poll() is None:
+				process.terminate()
+				try:
+					process.wait(timeout=5)
+				except subprocess.TimeoutExpired:
+					process.kill()
+					process.wait(timeout=5)
 
 
 def create_bilig_workpaper_tools() -> Tools:
@@ -227,15 +226,12 @@ def parse_args() -> argparse.Namespace:
 	parser = argparse.ArgumentParser(description='Run the Browser Use + Bilig WorkPaper integration example.')
 	parser.add_argument('--smoke', action='store_true', help='Run the Bilig tool path without an LLM or browser session.')
 	parser.add_argument('--conversion-rate', type=float, default=0.4, help='Conversion rate to write into Inputs!B3.')
-	parser.add_argument(
-		'--package-spec', default=BILIG_WORKPAPER_PACKAGE, help='npm package spec for the Bilig WorkPaper package.'
-	)
 	return parser.parse_args()
 
 
 def main() -> None:
 	args = parse_args()
-	request = FormulaReadbackRequest(conversion_rate=args.conversion_rate, package_spec=args.package_spec)
+	request = FormulaReadbackRequest(conversion_rate=args.conversion_rate)
 
 	if args.smoke:
 		proof = run_bilig_formula_readback(request)

--- a/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
+++ b/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
@@ -21,7 +21,7 @@ sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from browser_use import ActionResult, Agent, ChatBrowserUse, Tools
 
-BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.90.0'
+BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.90.8'
 
 
 class FormulaReadbackRequest(BaseModel):

--- a/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
+++ b/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
@@ -21,7 +21,7 @@ sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from browser_use import ActionResult, Agent, ChatBrowserUse, Tools
 
-BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.90.8'
+BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.94.0'
 
 
 class FormulaReadbackRequest(BaseModel):

--- a/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
+++ b/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
@@ -21,7 +21,7 @@ sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from browser_use import ActionResult, Agent, ChatBrowserUse, Tools
 
-BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.94.0'
+BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.96.0'
 
 
 class FormulaReadbackRequest(BaseModel):

--- a/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
+++ b/examples/integrations/bilig_workpaper/bilig_workpaper_example.py
@@ -21,7 +21,7 @@ sys.path.append(str(Path(__file__).resolve().parents[3]))
 
 from browser_use import ActionResult, Agent, ChatBrowserUse, Tools
 
-BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.86.1'
+BILIG_WORKPAPER_PACKAGE = '@bilig/workpaper@0.90.0'
 
 
 class FormulaReadbackRequest(BaseModel):


### PR DESCRIPTION
## Summary

Adds a focused Browser Use integration example for Bilig WorkPaper formula readback.

The example gives a Browser Use agent a typed custom tool that:

- starts Bilig's local formula-readback server through `npm exec --package @bilig/workpaper@latest`
- writes a conversion-rate input into a WorkPaper forecast
- reads recalculated dependent formulas
- verifies persistence and restore behavior
- returns structured JSON to the agent

It also includes a no-key smoke mode so maintainers can verify the integration path without an LLM call or Browser Use API key.

## Why

Browser agents are good at gathering context from pages, but exact spreadsheet-style formulas are better handled by a deterministic tool. This example shows that split: Browser Use reads the quote-input page, then Bilig owns formula calculation and readback.

## Validation

```bash
python3 -m py_compile examples/integrations/bilig_workpaper/bilig_workpaper_example.py
uv run ruff format --check examples/integrations/bilig_workpaper/bilig_workpaper_example.py
uv run ruff check examples/integrations/bilig_workpaper/bilig_workpaper_example.py
uv run python examples/integrations/bilig_workpaper/bilig_workpaper_example.py --smoke
git diff --check upstream/main...HEAD
uv run pre-commit run --files examples/integrations/README.md examples/integrations/bilig_workpaper/README.md examples/integrations/bilig_workpaper/bilig_workpaper_example.py
```

Smoke output verified the no-key tool path: edited `Inputs!B3`, changed expected ARR from `60000` to `96000`, preserved formulas, restored readback at `96000`, and returned `verified: true`.

Current public Bilig check, refreshed 2026-06-02:

```bash
npm view @bilig/workpaper version
npm exec --yes --package @bilig/workpaper@latest -- bilig-evaluate --door agent-mcp --json
```

`npm view @bilig/workpaper version` returned `0.157.0`.

The public evaluator returned `verified: true`, listed 8 MCP tools, edited `Inputs!B3`, restored readback at `96000`, verified restart readback at `96000`, and reported package versions `@bilig/workpaper@0.157.0` and `xlsx-formula-recalc@0.157.0`.
