### PR TITLE
fix: use utf-8 for user state files

### DIFF
--- a/browser_use/skill_cli/daemon.py
+++ b/browser_use/skill_cli/daemon.py
@@ -86,7 +86,7 @@ class Daemon:
 		state_path = get_home_dir() / f'{self.session}.state.json'
 		tmp_path = state_path.with_suffix('.state.json.tmp')
 		try:
-			with open(tmp_path, 'w') as f:
+			with open(tmp_path, 'w', encoding='utf-8') as f:
 				json.dump(state, f)
 				f.flush()
 				os.fsync(f.fileno())

--- a/browser_use/sync/auth.py
+++ b/browser_use/sync/auth.py
@@ -59,7 +59,7 @@ class CloudAuthConfig(BaseModel):
 		config_path = CONFIG.BROWSER_USE_CONFIG_DIR / 'cloud_auth.json'
 		if config_path.exists():
 			try:
-				with open(config_path) as f:
+				with open(config_path, encoding='utf-8') as f:
 					data = json.load(f)
 				return cls.model_validate(data)
 			except Exception:
@@ -73,7 +73,7 @@ class CloudAuthConfig(BaseModel):
 		CONFIG.BROWSER_USE_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
 		config_path = CONFIG.BROWSER_USE_CONFIG_DIR / 'cloud_auth.json'
-		with open(config_path, 'w') as f:
+		with open(config_path, 'w', encoding='utf-8') as f:
 			json.dump(self.model_dump(mode='json'), f, indent=2, default=str)
 
 		# Set restrictive permissions (owner read/write only) for security

--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -100,12 +100,12 @@ class ProductTelemetry:
 		try:
 			if not os.path.exists(self.USER_ID_PATH):
 				os.makedirs(os.path.dirname(self.USER_ID_PATH), exist_ok=True)
-				with open(self.USER_ID_PATH, 'w') as f:
+				with open(self.USER_ID_PATH, 'w', encoding='utf-8') as f:
 					new_user_id = uuid7str()
 					f.write(new_user_id)
 				self._curr_user_id = new_user_id
 			else:
-				with open(self.USER_ID_PATH) as f:
+				with open(self.USER_ID_PATH, encoding='utf-8') as f:
 					self._curr_user_id = f.read()
 		except Exception:
 			self._curr_user_id = 'UNKNOWN_USER_ID'


### PR DESCRIPTION
## Summary
- read and write cloud auth config with explicit UTF-8 encoding
- read and write telemetry user-id files with explicit UTF-8 encoding
- write skill CLI daemon state JSON with explicit UTF-8 encoding

## Before / after
Before, these local JSON/text state files used the platform default text encoding.
After, they use UTF-8 explicitly, keeping user state portable across Windows and other non-UTF-8 locales.

## Verification
- `python -m py_compile browser_use/sync/auth.py browser_use/telemetry/service.py browser_use/skill_cli/daemon.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use UTF-8 for all local user state reads/writes to avoid locale-specific encoding issues. This keeps configs and telemetry portable across Windows and other non-UTF-8 systems.

- **Bug Fixes**
  - Cloud auth config (`cloud_auth.json`): read/write with UTF-8.
  - Telemetry user ID file: read/write with UTF-8.
  - Skill CLI daemon state JSON: write with UTF-8.

<sup>Written for commit d6ba9a120c22639cb2a468899ccf98ee442e3b57. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4910?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

