### PR TITLE
docs: clarify WebSocket wording in comments

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -38,7 +38,7 @@ class DomService:
 
 	Either browser or page must be provided.
 
-	TODO: currently we start a new websocket connection PER STEP, we should definitely keep this persistent
+	TODO: currently we start a new WebSocket connection PER STEP, we should definitely keep this persistent
 	"""
 
 	logger: logging.Logger

--- a/browser_use/skill_cli/browser.py
+++ b/browser_use/skill_cli/browser.py
@@ -161,7 +161,7 @@ class CLIBrowserSession(BrowserSession):
 	async def stop(self) -> None:
 		"""Disconnect from the browser.
 
-		For --connect/--cdp-url: just close the websocket (we don't own the browser).
+		For --connect/--cdp-url: just close the WebSocket (we don't own the browser).
 		For cloud: stop the remote browser via API before disconnecting.
 		"""
 		self._intentional_stop = True


### PR DESCRIPTION
Updates two internal comments to use the standard WebSocket capitalization. No runtime behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes WebSocket capitalization in internal comments for consistency. No runtime behavior changes.

Updates comments in `browser_use/dom/service.py` and `browser_use/skill_cli/browser.py`.

<sup>Written for commit 6c89adb9bcf5588c24b7d1510abe4b54bc898335. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4914?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

