### PR TITLE
Pass session id to judge LLM calls

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1602,6 +1602,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Only pass request_type for ChatBrowserUse (other providers don't support it)
 		if self.judge_llm.provider == 'browser-use':
 			kwargs['request_type'] = 'judge'
+			kwargs['session_id'] = self.session_id
 
 		try:
 			response = await self.judge_llm.ainvoke(input_messages, **kwargs)


### PR DESCRIPTION
## Summary
- pass the agent `session_id` into Browser Use judge LLM calls when using `ChatBrowserUse`

## Tests
- `uv run python -m py_compile browser_use/agent/service.py`
- `uv run pre-commit run --files browser_use/agent/service.py`



