### PR TITLE
fix: make news monitor text IO deterministic

### DIFF
--- a/examples/apps/news-use/news_monitor.py
+++ b/examples/apps/news-use/news_monitor.py
@@ -8,6 +8,7 @@ import argparse
 import asyncio
 import hashlib
 import json
+import locale
 import logging
 import os
 import time
@@ -173,13 +174,22 @@ async def extract_latest_article(site_url: str, debug: bool = False) -> dict:
 # ---------------------------------------------------------
 
 
+def _load_json_file(file_path: str):
+	"""Load JSON, tolerating files written with the platform's legacy encoding."""
+	try:
+		with open(file_path, encoding='utf-8') as f:
+			return json.load(f)
+	except UnicodeDecodeError:
+		with open(file_path, encoding=locale.getpreferredencoding(False)) as f:
+			return json.load(f)
+
+
 def load_seen_hashes(file_path: str = 'news_data.json') -> set:
 	"""Load already-saved article URL hashes from disk for dedup across restarts."""
 	if not os.path.exists(file_path):
 		return set()
 	try:
-		with open(file_path, encoding='utf-8') as f:
-			items = json.load(f)
+		items = _load_json_file(file_path)
 		return {entry['hash'] for entry in items if 'hash' in entry}
 	except Exception:
 		return set()
@@ -196,8 +206,7 @@ def save_article(article: dict, file_path: str = 'news_data.json'):
 	existing = []
 	if os.path.exists(file_path):
 		try:
-			with open(file_path, encoding='utf-8') as f:
-				existing = json.load(f)
+			existing = _load_json_file(file_path)
 		except Exception:
 			existing = []
 

--- a/examples/apps/news-use/news_monitor.py
+++ b/examples/apps/news-use/news_monitor.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
 from dateutil import parser as dtparser
@@ -178,7 +178,7 @@ def load_seen_hashes(file_path: str = 'news_data.json') -> set:
 	if not os.path.exists(file_path):
 		return set()
 	try:
-		with open(file_path) as f:
+		with open(file_path, encoding='utf-8') as f:
 			items = json.load(f)
 		return {entry['hash'] for entry in items if 'hash' in entry}
 	except Exception:
@@ -196,7 +196,7 @@ def save_article(article: dict, file_path: str = 'news_data.json'):
 	existing = []
 	if os.path.exists(file_path):
 		try:
-			with open(file_path) as f:
+			with open(file_path, encoding='utf-8') as f:
 				existing = json.load(f)
 		except Exception:
 			existing = []
@@ -205,7 +205,7 @@ def save_article(article: dict, file_path: str = 'news_data.json'):
 	# Keep last 100
 	existing = existing[-100:]
 
-	with open(file_path, 'w') as f:
+	with open(file_path, 'w', encoding='utf-8') as f:
 		json.dump(existing, f, ensure_ascii=False, indent=2)
 
 
@@ -219,7 +219,7 @@ def _fmt(ts_raw: str) -> str:
 	try:
 		return dtparser.parse(ts_raw).strftime('%Y-%m-%d %H:%M:%S')
 	except Exception:
-		return datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+		return datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
 
 
 async def run_once(url: str, output_path: str, debug: bool):


### PR DESCRIPTION
## Summary

Thanks for maintaining browser-use. This is a small robustness fix for the `examples/apps/news-use/news_monitor.py` example.

## What changed

- Read and write the JSON output file with explicit UTF-8 encoding
- Replace the fallback `datetime.utcnow()` call with timezone-aware `datetime.now(timezone.utc)`

## Why

The example writes article data with `ensure_ascii=False`, so explicit UTF-8 keeps saved multilingual article text portable on Windows and other non-UTF-8 locale environments. The UTC fallback timestamp also avoids using deprecated naive UTC datetime APIs.

## Verification

- `python -m py_compile examples/apps/news-use/news_monitor.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the news monitor example deterministic across platforms by standardizing UTF-8 JSON writes and using a timezone-aware UTC timestamp fallback, while still loading legacy files saved with system encodings. This prevents garbled non-ASCII text, avoids naive UTC datetimes, and preserves existing data.

- **Bug Fixes**
  - Load `news_data.json` with a tolerant reader (UTF-8 first, then `locale.getpreferredencoding(False)`), and write with explicit `encoding='utf-8'` and `ensure_ascii=False` in `examples/apps/news-use/news_monitor.py`.
  - Replace `datetime.utcnow()` with `datetime.now(timezone.utc)` and import `timezone`.

<sup>Written for commit 3d5fb92391eba743627e1314720e9ee1540203c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

