### PR TITLE
feat(openai): support Responses API in ChatOpenAI

### DIFF
--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -11,10 +11,7 @@ from pydantic import BaseModel
 
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
-# Canonical RESPONSES_API_ONLY_MODELS lives in browser_use.llm.openai.chat — re-exported
-# here so existing `from browser_use.llm.azure.chat import RESPONSES_API_ONLY_MODELS`
-# keeps working. Both providers share one list.
-from browser_use.llm.openai.chat import RESPONSES_API_ONLY_MODELS
+from browser_use.llm.openai.chat import RESPONSES_API_ONLY_MODELS  # re-exported for backwards compatibility
 from browser_use.llm.openai.like import ChatOpenAILike
 from browser_use.llm.openai.responses_serializer import ResponsesAPIMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer

--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -11,23 +11,18 @@ from pydantic import BaseModel
 
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
+# Canonical RESPONSES_API_ONLY_MODELS lives in browser_use.llm.openai.chat — re-exported
+# here so existing `from browser_use.llm.azure.chat import RESPONSES_API_ONLY_MODELS`
+# keeps working. Both providers share one list.
+from browser_use.llm.openai.chat import RESPONSES_API_ONLY_MODELS
 from browser_use.llm.openai.like import ChatOpenAILike
 from browser_use.llm.openai.responses_serializer import ResponsesAPIMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
+__all__ = ['ChatAzureOpenAI', 'RESPONSES_API_ONLY_MODELS']
+
 T = TypeVar('T', bound=BaseModel)
-
-
-# List of models that only support the Responses API
-RESPONSES_API_ONLY_MODELS: list[str] = [
-	'gpt-5.1-codex',
-	'gpt-5.1-codex-mini',
-	'gpt-5.1-codex-max',
-	'gpt-5-codex',
-	'codex-mini-latest',
-	'computer-use-preview',
-]
 
 
 @dataclass

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -25,7 +25,12 @@ T = TypeVar('T', bound=BaseModel)
 
 # Models that only support the Responses API. ChatOpenAI's `use_responses_api='auto'`
 # routes these through `/v1/responses`; everything else stays on Chat Completions.
+# This is the canonical list; ChatAzureOpenAI re-exports it so both providers stay
+# in sync. Add new Codex / computer-use models here.
 RESPONSES_API_ONLY_MODELS: list[str] = [
+	'gpt-5.3-codex',
+	'gpt-5.3-codex-spark',
+	'gpt-5.2-codex',
 	'gpt-5.1-codex',
 	'gpt-5.1-codex-mini',
 	'gpt-5.1-codex-max',

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -6,6 +6,7 @@ import httpx
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
 from openai.types.chat import ChatCompletionContentPartTextParam
 from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.responses import Response
 from openai.types.shared.chat_model import ChatModel
 from openai.types.shared_params.reasoning_effort import ReasoningEffort
 from openai.types.shared_params.response_format_json_schema import JSONSchema, ResponseFormatJSONSchema
@@ -14,11 +15,24 @@ from pydantic import BaseModel
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
+from browser_use.llm.openai.responses_serializer import ResponsesAPIMessageSerializer
 from browser_use.llm.openai.serializer import OpenAIMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
+
+
+# Models that only support the Responses API. ChatOpenAI's `use_responses_api='auto'`
+# routes these through `/v1/responses`; everything else stays on Chat Completions.
+RESPONSES_API_ONLY_MODELS: list[str] = [
+	'gpt-5.1-codex',
+	'gpt-5.1-codex-mini',
+	'gpt-5.1-codex-max',
+	'gpt-5-codex',
+	'codex-mini-latest',
+	'computer-use-preview',
+]
 
 
 @dataclass
@@ -76,6 +90,12 @@ class ChatOpenAI(BaseChatModel):
 		]
 	)
 
+	# Responses API support. True/False = explicit; 'auto' = enable only for
+	# RESPONSES_API_ONLY_MODELS (Codex / computer-use-preview). Reasoning models
+	# (gpt-5, o-series) still default to Chat Completions for backwards compat;
+	# pass `use_responses_api=True` to opt them in.
+	use_responses_api: bool | str = 'auto'
+
 	# Static
 	@property
 	def provider(self) -> str:
@@ -120,6 +140,36 @@ class ChatOpenAI(BaseChatModel):
 	def name(self) -> str:
 		return str(self.model)
 
+	def _should_use_responses_api(self) -> bool:
+		"""Determine if the Responses API should be used based on model and settings."""
+		if isinstance(self.use_responses_api, bool):
+			return self.use_responses_api
+
+		# Auto-detect: use Responses API for models that require it
+		model_lower = str(self.model).lower()
+		for responses_only_model in RESPONSES_API_ONLY_MODELS:
+			if responses_only_model.lower() in model_lower:
+				return True
+		return False
+
+	def _get_usage_from_responses(self, response: Response) -> ChatInvokeUsage | None:
+		"""Extract usage information from a Responses API response."""
+		if response.usage is None:
+			return None
+
+		cached_tokens = None
+		if response.usage.input_tokens_details is not None:
+			cached_tokens = getattr(response.usage.input_tokens_details, 'cached_tokens', None)
+
+		return ChatInvokeUsage(
+			prompt_tokens=response.usage.input_tokens,
+			prompt_cached_tokens=cached_tokens,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+			completion_tokens=response.usage.output_tokens,
+			total_tokens=response.usage.total_tokens,
+		)
+
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
 		if response.usage is not None:
 			# Note: completion_tokens already includes reasoning_tokens per OpenAI API docs.
@@ -141,6 +191,109 @@ class ChatOpenAI(BaseChatModel):
 
 		return usage
 
+	async def _ainvoke_responses_api(
+		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		"""
+		Invoke the model using the Responses API (`/v1/responses`).
+
+		Used for models that require it (e.g. ``gpt-5-codex``, ``computer-use-preview``)
+		or whenever ``use_responses_api`` is explicitly set to ``True``. The Responses
+		API routes reasoning content to typed output items separately from the
+		structured payload, which avoids the trailing-character JSON failures that
+		Chat Completions sometimes produces for reasoning models.
+		"""
+		input_messages = ResponsesAPIMessageSerializer.serialize_messages(messages)
+
+		try:
+			model_params: dict[str, Any] = {
+				'model': self.model,
+				'input': input_messages,
+			}
+
+			if self.temperature is not None:
+				model_params['temperature'] = self.temperature
+
+			if self.max_completion_tokens is not None:
+				model_params['max_output_tokens'] = self.max_completion_tokens
+
+			if self.top_p is not None:
+				model_params['top_p'] = self.top_p
+
+			if self.service_tier is not None:
+				model_params['service_tier'] = self.service_tier
+
+			# Reasoning models use the `reasoning` parameter rather than `reasoning_effort`,
+			# and don't accept `temperature` on Responses.
+			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+				model_params['reasoning'] = {'effort': self.reasoning_effort}
+				model_params.pop('temperature', None)
+
+			if output_format is None:
+				response = await self.get_client().responses.create(**model_params)
+				return ChatInvokeCompletion(
+					completion=response.output_text or '',
+					usage=self._get_usage_from_responses(response),
+					stop_reason=response.status if response.status else None,
+				)
+
+			json_schema = SchemaOptimizer.create_optimized_json_schema(
+				output_format,
+				remove_min_items=self.remove_min_items_from_schema,
+				remove_defaults=self.remove_defaults_from_schema,
+			)
+
+			if not self.dont_force_structured_output:
+				model_params['text'] = {
+					'format': {
+						'type': 'json_schema',
+						'name': 'agent_output',
+						'strict': True,
+						'schema': json_schema,
+					}
+				}
+
+			# Add JSON schema to system prompt if requested
+			if self.add_schema_to_system_prompt and input_messages and input_messages[0].get('role') == 'system':
+				schema_text = f'\n<json_schema>\n{json_schema}\n</json_schema>'
+				content = input_messages[0].get('content', '')
+				if isinstance(content, str):
+					input_messages[0]['content'] = content + schema_text
+				elif isinstance(content, list):
+					input_messages[0]['content'] = list(content) + [{'type': 'input_text', 'text': schema_text}]
+				model_params['input'] = input_messages
+
+			response = await self.get_client().responses.create(**model_params)
+
+			if not response.output_text:
+				raise ModelProviderError(
+					message='Failed to parse structured output from model response',
+					status_code=500,
+					model=self.name,
+				)
+
+			parsed = output_format.model_validate_json(response.output_text)
+			return ChatInvokeCompletion(
+				completion=parsed,
+				usage=self._get_usage_from_responses(response),
+				stop_reason=response.status if response.status else None,
+			)
+
+		except ModelProviderError:
+			raise
+
+		except RateLimitError as e:
+			raise ModelRateLimitError(message=e.message, model=self.name) from e
+
+		except APIConnectionError as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e
+
+		except APIStatusError as e:
+			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
+
+		except Exception as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -155,6 +308,9 @@ class ChatOpenAI(BaseChatModel):
 		"""
 		Invoke the model with the given messages.
 
+		Routes to either the Responses API or the Chat Completions API based on
+		the model and ``use_responses_api`` setting.
+
 		Args:
 			messages: List of chat messages
 			output_format: Optional Pydantic model class for structured output
@@ -162,6 +318,8 @@ class ChatOpenAI(BaseChatModel):
 		Returns:
 			Either a string response or an instance of output_format
 		"""
+		if self._should_use_responses_api():
+			return await self._ainvoke_responses_api(messages, output_format, **kwargs)
 
 		openai_messages = OpenAIMessageSerializer.serialize_messages(messages)
 

--- a/tests/ci/models/test_openai_responses_api.py
+++ b/tests/ci/models/test_openai_responses_api.py
@@ -1,0 +1,58 @@
+"""Tests for OpenAI Responses API support in ChatOpenAI."""
+
+from browser_use.llm.openai.chat import RESPONSES_API_ONLY_MODELS, ChatOpenAI
+
+
+class TestChatOpenAIShouldUseResponsesAPI:
+	"""Tests for the _should_use_responses_api method on ChatOpenAI."""
+
+	def test_use_responses_api_true(self):
+		"""use_responses_api=True forces the Responses API for any model."""
+		llm = ChatOpenAI(model='gpt-4o', api_key='test', use_responses_api=True)
+		assert llm._should_use_responses_api() is True
+
+	def test_use_responses_api_false(self):
+		"""use_responses_api=False forces Chat Completions even for Responses-only models."""
+		llm = ChatOpenAI(model='gpt-5-codex', api_key='test', use_responses_api=False)
+		assert llm._should_use_responses_api() is False
+
+	def test_use_responses_api_auto_with_responses_only_model(self):
+		"""'auto' mode detects every model in RESPONSES_API_ONLY_MODELS."""
+		for model_name in RESPONSES_API_ONLY_MODELS:
+			llm = ChatOpenAI(model=model_name, api_key='test', use_responses_api='auto')
+			assert llm._should_use_responses_api() is True, f'Expected Responses API for {model_name}'
+
+	def test_use_responses_api_auto_with_regular_model(self):
+		"""'auto' mode keeps regular models on Chat Completions."""
+		regular_models = ['gpt-4o', 'gpt-4.1-mini', 'gpt-3.5-turbo', 'gpt-4']
+		for model_name in regular_models:
+			llm = ChatOpenAI(model=model_name, api_key='test', use_responses_api='auto')
+			assert llm._should_use_responses_api() is False, f'Expected Chat Completions for {model_name}'
+
+	def test_use_responses_api_auto_with_reasoning_model(self):
+		"""'auto' mode keeps reasoning models (gpt-5, o-series) on Chat Completions for
+		backwards compatibility — users opt in explicitly with use_responses_api=True."""
+		reasoning_models = ['gpt-5', 'gpt-5-mini', 'gpt-5-nano', 'o3', 'o3-mini', 'o4-mini']
+		for model_name in reasoning_models:
+			llm = ChatOpenAI(model=model_name, api_key='test', use_responses_api='auto')
+			assert llm._should_use_responses_api() is False, (
+				f'Reasoning model {model_name} should default to Chat Completions under auto mode'
+			)
+
+	def test_use_responses_api_auto_is_default(self):
+		"""'auto' is the default value for use_responses_api."""
+		llm = ChatOpenAI(model='gpt-4o', api_key='test')
+		assert llm.use_responses_api == 'auto'
+
+	def test_responses_api_only_models_list(self):
+		"""RESPONSES_API_ONLY_MODELS contains the expected models."""
+		expected_models = [
+			'gpt-5.1-codex',
+			'gpt-5.1-codex-mini',
+			'gpt-5.1-codex-max',
+			'gpt-5-codex',
+			'codex-mini-latest',
+			'computer-use-preview',
+		]
+		for model in expected_models:
+			assert model in RESPONSES_API_ONLY_MODELS, f'{model} should be in RESPONSES_API_ONLY_MODELS'


### PR DESCRIPTION
Closes #4921

## Summary

Adds Responses API support to `ChatOpenAI`, mirroring the existing `ChatAzureOpenAI` implementation. Models that require `/v1/responses` (Codex variants, `computer-use-preview`) now work out of the box on the OpenAI client, and reasoning models can opt in explicitly. Also consolidates the previously-duplicated `RESPONSES_API_ONLY_MODELS` constant so OpenAI and Azure stay in sync.

## Changes

- `browser_use/llm/openai/chat.py`
  - New field: `use_responses_api: bool | str = 'auto'`.
  - New canonical constant: `RESPONSES_API_ONLY_MODELS` (re-exported by `ChatAzureOpenAI`).
  - New methods: `_should_use_responses_api`, `_get_usage_from_responses`, `_ainvoke_responses_api` — ported from `ChatAzureOpenAI`, adapted for the OpenAI client.
  - `ainvoke` now routes through `_ainvoke_responses_api(...)` when `_should_use_responses_api()` returns true, otherwise falls through to the existing Chat Completions path unchanged.
  - Structured output on the Responses path uses `text.format = {'type': 'json_schema', 'strict': True, ...}` and parses via `output_format.model_validate_json(response.output_text)`.

- `browser_use/llm/azure/chat.py`
  - `RESPONSES_API_ONLY_MODELS` now imported from `browser_use.llm.openai.chat` rather than duplicated locally. Re-exported via `__all__` so `from browser_use.llm.azure.chat import RESPONSES_API_ONLY_MODELS` still works.

- `tests/ci/models/test_openai_responses_api.py` (new)
  - 7 unit tests mirroring `test_azure_responses_api.py::TestChatAzureOpenAIShouldUseResponsesAPI`.
  - Covers explicit `True`/`False`, `'auto'` with Responses-only models, `'auto'` with regular models, `'auto'` with reasoning models (asserts they stay on Chat Completions for backwards compat), default value, and the `RESPONSES_API_ONLY_MODELS` list.

## Design notes

### `'auto'` is conservative

`'auto'` only enables Responses for models in `RESPONSES_API_ONLY_MODELS`. Reasoning models (gpt-5, o-series) stay on Chat Completions by default — users opt them in with `use_responses_api=True`. This mirrors `ChatAzureOpenAI`'s rule exactly and keeps the change backwards compatible.

### Single source of truth for `RESPONSES_API_ONLY_MODELS`

Previously the same six-entry list was duplicated in both `openai/chat.py` (added in the first commit of this PR) and `azure/chat.py`. With both providers needing the same list — and OpenAI shipping more Codex variants over time — the duplication was already a drift risk. Rationale for consolidating in `openai/`:

- The list describes **OpenAI's API surface** (which models OpenAI gates to `/v1/responses`). Azure relays the same gating.
- `ChatAzureOpenAI` already imports from `browser_use.llm.openai.responses_serializer`, so the cross-package import direction is an established pattern.
- Adding new Codex models (e.g. the gpt-5.2-codex / gpt-5.3-codex variants surfaced in OpenAI's Codex model catalog) now touches one place.

Existing `from browser_use.llm.azure.chat import RESPONSES_API_ONLY_MODELS` keeps working via re-export.

### `RESPONSES_API_ONLY_MODELS` updated

Added per OpenAI's Codex model catalog:
- `gpt-5.2-codex`
- `gpt-5.3-codex`
- `gpt-5.3-codex-spark`

### Pre-existing infrastructure reused

The serializer (`ResponsesAPIMessageSerializer`) and schema optimizer were already shipped in the package; this PR just wires them through `ChatOpenAI`.

## Test plan

- [x] `pytest tests/ci/models/test_openai_responses_api.py` — 7/7 pass.
- [x] `pytest tests/ci/models/test_azure_responses_api.py` — 15/15 pass (2 skipped without Azure creds). Confirms the Azure path still works after switching to the re-exported constant.
- [ ] Maintainer-side integration check against an OpenAI account with access to a Responses-only model (e.g. `gpt-5-codex` or `computer-use-preview`).