### PR TITLE
fix(agent): make flash prompts more cache friendly

### DIFF
--- a/browser_use/agent/system_prompts/system_prompt_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_flash.md
@@ -1,8 +1,9 @@
-You are an AI agent designed to operate in an iterative loop to automate browser tasks. Your ultimate goal is accomplishing the task provided in <user_request>.
+You are an AI agent designed to operate in an iterative loop to automate browser tasks. The user's request is provided in subsequent user messages and is the ultimate objective.
 <language_settings>Default: English. Match user's language.</language_settings>
-<user_request>Ultimate objective. Specific tasks: follow each step. Open-ended: plan approach.</user_request>
-<browser_state>Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new.</browser_state>
-<file_system>- PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. When writing CSV, use double quotes for commas. In available_file_paths, you can read downloaded files and user attachment files.</file_system>
+<input_flow>
+Per-step user messages provide the stable task request, browser state, agent history, file-system context, and any read/extract results. Treat those runtime messages as the source of truth rather than this static system prompt.
+</input_flow>
+<file_system_guidance>PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. When writing CSV, use double quotes for commas.</file_system_guidance>
 <action_rules>
 You are allowed to use a maximum of {max_actions} actions per step. Check the browser state each step to verify your previous action achieved its goal. When chaining multiple actions, never take consequential actions (submitting forms, clicking consequential buttons) without confirming necessary changes occurred.
 </action_rules>

--- a/browser_use/agent/system_prompts/system_prompt_flash_anthropic.md
+++ b/browser_use/agent/system_prompts/system_prompt_flash_anthropic.md
@@ -1,13 +1,10 @@
-You are an AI agent designed to operate in an iterative loop to automate browser tasks. Your ultimate goal is accomplishing the task provided in <user_request>.
-<user_request>
-User request is the ultimate objective. For tasks with specific instructions, follow each step. For open-ended tasks, plan your own approach.
-</user_request>
-<browser_state>
-Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new.
-</browser_state>
-<file_system>
-PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking and saving data. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. In available_file_paths, you can read downloaded files and user attachment files.
-</file_system>
+You are an AI agent designed to operate in an iterative loop to automate browser tasks. The user's request is provided in subsequent user messages and is the ultimate objective.
+<input_flow>
+Per-step user messages provide the stable task request, browser state, agent history, file-system context, and any read/extract results. Treat those runtime messages as the source of truth rather than this static system prompt.
+</input_flow>
+<file_system_guidance>
+PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking and saving data. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. You can read downloaded files and user attachment files listed in available_file_paths.
+</file_system_guidance>
 <action_rules>
 You are allowed to use a maximum of {max_actions} actions per step. Check the browser state each step to verify your previous action achieved its goal. When chaining multiple actions, never take consequential actions (submitting forms, clicking consequential buttons) without confirming necessary changes occurred.
 </action_rules>


### PR DESCRIPTION
## Summary
- remove placeholder runtime data blocks from the Flash system prompt preamble
- replace them with static prose describing where per-step user request, browser state, history, and file context arrive
- preserve action rules, output schema, and file-system guidance while making the prefix friendlier to Gemini implicit caching

Addresses #4887

## Validation
- `git diff --check`
- Python template assertion script verifying the Flash prompt preambles no longer contain `<user_request>`, `<browser_state>`, or `<file_system>` placeholder blocks before `<action_rules>`, and still contain `<input_flow>` plus `{max_actions}`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Flash system prompts easier to cache by removing dynamic placeholders and adding static input-flow guidance. Behavior stays the same while improving implicit caching; aligns with #4887.

- **Refactors**
  - Replace `user_request`, `browser_state`, and `file_system` blocks with `input_flow` and `file_system_guidance`.
  - Clarify that per-step user messages are the source of truth, not the system prompt.
  - Preserve `action_rules`, `{max_actions}`, and existing file-system guidance.

<sup>Written for commit 743ff24ecb867787c81e87fde8abb5a54ff29cb6. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4923?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

