### PR TITLE
fix: wrong template name in CLI README

### DIFF
--- a/browser_use/skill_cli/README.md
+++ b/browser_use/skill_cli/README.md
@@ -34,7 +34,7 @@ browser-use setup    # Run setup wizard (optional)
 ```bash
 browser-use init                          # Interactive template selection
 browser-use init --list                   # List available templates
-browser-use init --template basic         # Generate specific template
+browser-use init --template default        # Generate specific template
 browser-use init --output my_script.py    # Specify output file
 browser-use init --force                  # Overwrite existing files
 ```


### PR DESCRIPTION
## Summary
The CLI README shows `browser-use init --template basic` as an example, but `basic` is not one of the available templates. The main README lists the built-in templates as `default`, `advanced`, and `tools`. The example should use `default` to match what the project actually ships.

## How to reproduce
Run `browser-use init --template basic` — it will either fail or fall back to interactive selection. Then check the main README which lists the available templates as `default`, `advanced`, and `tools`.

## Test plan
Run `browser-use init --template default` and confirm it generates a `browser_use_default.py` file with a working example.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI README example by replacing `basic` with `default` in `browser-use init --template` to match the available templates.

<sup>Written for commit 8223101758001313f7e603c2308b9d0ed6956acf. Summary will update on new commits. <a href="https://cubic.dev/pr/browser-use/browser-use/pull/4928?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

