### PR TITLE
docs(models): fix ChatBrowserUse default + bu-latest pricing (bu-latest now = bu-2-0)

### DIFF
--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -59,8 +59,8 @@ Optimized for browser automation — highest accuracy, fastest speed, lowest tok
 ```python
 from browser_use import Agent, ChatBrowserUse
 
-llm = ChatBrowserUse()                    # bu-latest (default)
-llm = ChatBrowserUse(model='bu-2-0')      # Premium model
+llm = ChatBrowserUse()                    # bu-2-0 (default, = bu-latest)
+llm = ChatBrowserUse(model='bu-1-0')      # Previous generation model
 ```
 
 **Env:** `BROWSER_USE_API_KEY` — get at https://cloud.browser-use.com/new-api-key
@@ -68,8 +68,8 @@ llm = ChatBrowserUse(model='bu-2-0')      # Premium model
 **Models & Pricing (per 1M tokens):**
 | Model | Input | Cached | Output |
 |-------|-------|--------|--------|
-| bu-1-0 / bu-latest (default) | $0.20 | $0.02 | $2.00 |
-| bu-2-0 (premium) | $0.60 | $0.06 | $3.50 |
+| bu-2-0 / bu-latest (default) | $0.60 | $0.06 | $3.50 |
+| bu-1-0 (previous generation) | $0.20 | $0.02 | $2.00 |
 | browser-use/bu-30b-a3b-preview (OSS) | — | — | — |
 
 ## OpenAI


### PR DESCRIPTION
The Supported-LLM-Models reference (`skills/open-source/references/models.md`) still lists `bu-latest` as the default at `bu-1-0` pricing, but `ChatBrowserUse()` now defaults to `bu-2-0` and `bu-latest` normalizes to `bu-2-0`:

- `chat.py:47` — `model: str = 'bu-2-0'` (default)
- `chat.py:78-79` — `bu-latest` → `bu-2-0`
- `tokens/custom_pricing.py:31` — `CUSTOM_MODEL_PRICING['bu-latest'] = CUSTOM_MODEL_PRICING['bu-2-0']`

So the doc shows the wrong default cost ($0.20/$0.02/$2.00 instead of $0.60/$0.06/$3.50 — a ~3x input-cost difference). This corrects the comment and the pricing table so `bu-latest (default)` sits on the `bu-2-0` row, matching the `chat.py` docstring which already labels `bu-2-0`/`bu-latest` as default and `bu-1-0` as previous generation. All numbers byte-grounded from `custom_pricing.py:12-25`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the models reference to match current `ChatBrowserUse()` behavior: the default is `bu-2-0` and `bu-latest` maps to `bu-2-0`. Updated the example comment and pricing table to show `bu-2-0 / bu-latest (default)` at $0.60/$0.06/$3.50, with `bu-1-0` labeled as previous generation.

<sup>Written for commit 658ee37acc9fd1c50c8a74e9f5e93ddbf9b45b2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4931?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

