### PR TITLE
fix(schema): allow stripping string length constraints

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -602,7 +602,7 @@ class ChatGoogle(BaseChatModel):
 					# Only strip 'title' when it's a JSON Schema metadata field (not inside 'properties')
 					# 'title' as a metadata field appears at schema level, not as a property name
 					is_metadata_title = key == 'title' and parent_key != 'properties'
-					if key not in ['additionalProperties', 'default'] and not is_metadata_title:
+					if key not in ['additionalProperties', 'default', 'minLength', 'maxLength'] and not is_metadata_title:
 						cleaned_value = clean_schema(value, parent_key=key)
 						# Handle empty object properties - Gemini doesn't allow empty OBJECT types
 						if (

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -48,6 +48,9 @@ class ChatOpenAI(BaseChatModel):
 	remove_defaults_from_schema: bool = (
 		False  # If True, remove default values from JSON schema (for compatibility with some providers)
 	)
+	remove_string_length_constraints_from_schema: bool = (
+		False  # If True, remove minLength/maxLength from JSON schema (for compatibility with some providers)
+	)
 
 	# Client initialization parameters
 	api_key: str | None = None
@@ -229,6 +232,7 @@ class ChatOpenAI(BaseChatModel):
 						output_format,
 						remove_min_items=self.remove_min_items_from_schema,
 						remove_defaults=self.remove_defaults_from_schema,
+						remove_string_length_constraints=self.remove_string_length_constraints_from_schema,
 					),
 				}
 

--- a/browser_use/llm/schema.py
+++ b/browser_use/llm/schema.py
@@ -14,6 +14,7 @@ class SchemaOptimizer:
 		*,
 		remove_min_items: bool = False,
 		remove_defaults: bool = False,
+		remove_string_length_constraints: bool = False,
 	) -> dict[str, Any]:
 		"""
 		Create the most optimized schema by flattening all $ref/$defs while preserving
@@ -23,6 +24,7 @@ class SchemaOptimizer:
 			model: The Pydantic model to optimize
 			remove_min_items: If True, remove minItems from the schema
 			remove_defaults: If True, remove default values from the schema
+			remove_string_length_constraints: If True, remove minLength/maxLength from the schema
 
 		Returns:
 			Optimized schema with all $refs resolved and strict mode compatibility
@@ -74,6 +76,8 @@ class SchemaOptimizer:
 						continue  # Skip minItems/min_items
 					elif key == 'default' and remove_defaults:
 						continue  # Skip default values
+					elif key in ('minLength', 'maxLength') and remove_string_length_constraints:
+						continue  # Skip minLength/maxLength
 
 					# Keep all anyOf structures (action unions) and resolve any $refs within
 					elif key == 'anyOf' and isinstance(value, list):
@@ -87,7 +91,7 @@ class SchemaOptimizer:
 							in_properties=(key == 'properties'),
 						)
 
-					# Keep essential validation fields
+					# Keep essential validation fields (exclude minLength/maxLength if remove_string_length_constraints)
 					elif key in [
 						'required',
 						'minimum',
@@ -97,7 +101,7 @@ class SchemaOptimizer:
 						'maxItems',
 						'pattern',
 						'default',
-					]:
+					] and not (key in ('minLength', 'maxLength') and remove_string_length_constraints):
 						optimized[key] = value if not isinstance(value, (dict, list)) else optimize_schema(value, defs_lookup)
 
 					# Recursively process all other fields
@@ -158,11 +162,11 @@ class SchemaOptimizer:
 		ensure_additional_properties_false(optimized_schema)
 		SchemaOptimizer._make_strict_compatible(optimized_schema)
 
-		# Final pass to remove minItems/min_items and default values if requested
-		if remove_min_items or remove_defaults:
+		# Final pass to remove minItems/min_items, default values, and string length constraints if requested
+		if remove_min_items or remove_defaults or remove_string_length_constraints:
 
 			def remove_forbidden_fields(obj: Any) -> None:
-				"""Recursively remove minItems/min_items and default values"""
+				"""Recursively remove forbidden fields from the schema"""
 				if isinstance(obj, dict):
 					# Remove forbidden keys
 					if remove_min_items:
@@ -170,6 +174,9 @@ class SchemaOptimizer:
 						obj.pop('min_items', None)
 					if remove_defaults:
 						obj.pop('default', None)
+					if remove_string_length_constraints:
+						obj.pop('minLength', None)
+						obj.pop('maxLength', None)
 					# Recursively process all values
 					for value in obj.values():
 						if isinstance(value, (dict, list)):

--- a/tests/ci/models/test_llm_schema_optimizer.py
+++ b/tests/ci/models/test_llm_schema_optimizer.py
@@ -3,7 +3,7 @@ Tests for the SchemaOptimizer to ensure it correctly processes and
 optimizes the schemas for agent actions without losing information.
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from browser_use.agent.views import AgentOutput
 from browser_use.llm.schema import SchemaOptimizer
@@ -16,6 +16,12 @@ class ProductInfo(BaseModel):
 	price: str
 	title: str
 	rating: float | None = None
+
+
+class FixedLengthCode(BaseModel):
+	"""A sample structured output model with constrained string length."""
+
+	code: str = Field(min_length=4, max_length=4)
 
 
 def test_optimizer_preserves_all_fields_in_structured_done_action():
@@ -74,3 +80,21 @@ def test_gemini_schema_retains_required_fields():
 
 	required_fields = set(schema['required'])
 	assert {'price', 'title'}.issubset(required_fields), 'Mandatory fields must stay required for Gemini.'
+
+
+def test_optimizer_can_remove_string_length_constraints():
+	"""Schema optimizer should optionally strip minLength/maxLength for provider compatibility."""
+	schema = SchemaOptimizer.create_optimized_json_schema(FixedLengthCode)
+	code_schema = schema['properties']['code']
+
+	assert code_schema['minLength'] == 4
+	assert code_schema['maxLength'] == 4
+
+	compatible_schema = SchemaOptimizer.create_optimized_json_schema(
+		FixedLengthCode,
+		remove_string_length_constraints=True,
+	)
+	compatible_code_schema = compatible_schema['properties']['code']
+
+	assert 'minLength' not in compatible_code_schema
+	assert 'maxLength' not in compatible_code_schema


### PR DESCRIPTION
## Summary

OpenAI-compatible providers that reject JSON Schema `minLength`/`maxLength` can now use structured output without 400s from browser-use action schemas, including actions with fixed-length tab IDs. `ChatOpenAI` exposes `remove_string_length_constraints_from_schema`, the shared schema optimizer removes those constraints only when requested, and Gemini schema cleanup drops those unsupported fields consistently.

## Test Plan

- `uv run python -m pytest tests/ci/models/test_llm_schema_optimizer.py browser_use/llm/tests/test_mistral_schema.py`
- `uv run ruff check tests/ci/models/test_llm_schema_optimizer.py browser_use/llm/schema.py browser_use/llm/openai/chat.py browser_use/llm/google/chat.py`
- `uv run ruff format --check tests/ci/models/test_llm_schema_optimizer.py browser_use/llm/schema.py browser_use/llm/openai/chat.py browser_use/llm/google/chat.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow optionally stripping string length constraints (minLength/maxLength) from JSON Schema to prevent 400s with some OpenAI-compatible providers and keep structured actions (e.g., fixed-length tab IDs) working. Gemini schema cleanup is aligned to drop these unsupported fields.

- **Bug Fixes**
  - `ChatOpenAI`: added remove_string_length_constraints_from_schema flag and passed it to the optimizer.
  - Schema optimizer can remove minLength/maxLength when requested; tests added for a fixed-length string model.
  - Gemini schema cleanup now removes minLength/maxLength consistently.

<sup>Written for commit 4fa7adf844b8b704ed90a6023588ee742bf24773. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

