### PR TITLE
feat(browser): optionally export full storage state

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1372,22 +1372,34 @@ class BrowserSession(BaseModel):
 		"""Clear all cookies."""
 		await self.cdp_client.send.Network.clearBrowserCookies()
 
-	async def export_storage_state(self, output_path: str | Path | None = None) -> dict[str, Any]:
+	async def export_storage_state(
+		self, output_path: str | Path | None = None, *, include_storage: bool = False
+	) -> dict[str, Any]:
 		"""Export all browser cookies and storage to storage_state format.
 
 		Extracts decrypted cookies via CDP, bypassing keychain encryption.
+		By default only cookies are exported. Set include_storage=True to also
+		export localStorage/sessionStorage for origins currently present in the
+		page frame tree. Browser storage may contain sensitive tokens.
 
 		Args:
 			output_path: Optional path to save storage_state.json. If None, returns dict only.
+			include_storage: If True, include localStorage/sessionStorage origins.
 
 		Returns:
-			Storage state dict with cookies in Playwright format.
+			Storage state dict in Playwright format.
 
 		"""
 		from pathlib import Path
 
-		# Get all cookies using Storage.getCookies (returns decrypted cookies from all domains)
-		cookies = await self._cdp_get_cookies()
+		if include_storage:
+			raw_storage_state = await self._cdp_get_storage_state()
+			cookies = raw_storage_state.get('cookies', [])
+			origins = raw_storage_state.get('origins', [])
+		else:
+			# Get all cookies using Storage.getCookies (returns decrypted cookies from all domains)
+			cookies = await self._cdp_get_cookies()
+			origins = []
 
 		# Convert CDP cookie format to Playwright storage_state format
 		storage_state = {
@@ -1404,7 +1416,7 @@ class BrowserSession(BaseModel):
 				}
 				for c in cookies
 			],
-			'origins': [],  # Could add localStorage/sessionStorage extraction if needed
+			'origins': origins,
 		}
 
 		if output_path:
@@ -1413,7 +1425,8 @@ class BrowserSession(BaseModel):
 			output_file = Path(output_path).expanduser().resolve()
 			output_file.parent.mkdir(parents=True, exist_ok=True)
 			output_file.write_text(json.dumps(storage_state, indent=2, ensure_ascii=False), encoding='utf-8')
-			self.logger.info(f'💾 Exported {len(cookies)} cookies to {output_file}')
+			origins_message = f' and {len(origins)} origins' if include_storage else ''
+			self.logger.info(f'💾 Exported {len(cookies)} cookies{origins_message} to {output_file}')
 
 		return storage_state
 

--- a/examples/browser/save_cookies.py
+++ b/examples/browser/save_cookies.py
@@ -1,5 +1,5 @@
 """
-Export cookies and storage state from your real Chrome browser
+Export cookies and browser storage from your real Chrome browser
 
 This allows you to save your authenticated sessions for later use
 without needing to connect to the Chrome profile every time
@@ -40,8 +40,10 @@ async def main():
 	browser = Browser.from_system_chrome(profile_directory=profile)
 
 	await browser.start()
-	await browser.export_storage_state('storage_state.json')
-	await browser.stop()
+	try:
+		await browser.export_storage_state('storage_state.json', include_storage=True)
+	finally:
+		await browser.stop()
 	print('Storage state exported to storage_state.json')
 
 

--- a/skills/open-source/references/browser.md
+++ b/skills/open-source/references/browser.md
@@ -128,8 +128,11 @@ profiles = Browser.list_chrome_profiles()
 ### Storage State Persistence
 
 ```python
-# Export cookies/localStorage
+# Export cookies only
 await browser.export_storage_state('auth.json')
+
+# Export cookies plus localStorage/sessionStorage
+await browser.export_storage_state('auth.json', include_storage=True)
 
 # Load on next run
 browser = Browser(storage_state='auth.json')

--- a/tests/ci/browser/test_storage_state_export.py
+++ b/tests/ci/browser/test_storage_state_export.py
@@ -1,0 +1,83 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+
+COOKIE = {
+	'name': 'session',
+	'value': 'abc123',
+	'domain': '.example.com',
+	'path': '/',
+	'expires': 1893456000,
+	'httpOnly': True,
+	'secure': True,
+	'sameSite': 'Lax',
+}
+
+ORIGIN = {
+	'origin': 'https://example.com',
+	'localStorage': [{'name': 'token', 'value': 'xyz789'}],
+	'sessionStorage': [{'name': 'tab', 'value': '1'}],
+}
+
+
+@pytest.fixture
+def browser_session() -> BrowserSession:
+	return BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None))
+
+
+@pytest.mark.asyncio
+async def test_export_storage_state_defaults_to_cookies_only(
+	browser_session: BrowserSession,
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	calls: list[str] = []
+
+	async def fake_get_cookies(self: BrowserSession) -> list[dict[str, Any]]:
+		calls.append('cookies')
+		return [COOKIE]
+
+	async def fake_get_storage_state(self: BrowserSession) -> dict[str, Any]:
+		calls.append('storage')
+		return {'cookies': [COOKIE], 'origins': [ORIGIN]}
+
+	monkeypatch.setattr(BrowserSession, '_cdp_get_cookies', fake_get_cookies)
+	monkeypatch.setattr(BrowserSession, '_cdp_get_storage_state', fake_get_storage_state)
+
+	storage_state = await browser_session.export_storage_state()
+
+	assert calls == ['cookies']
+	assert storage_state['cookies'] == [COOKIE]
+	assert storage_state['origins'] == []
+
+
+@pytest.mark.asyncio
+async def test_export_storage_state_can_include_browser_storage(
+	browser_session: BrowserSession,
+	tmp_path: Path,
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	calls: list[str] = []
+
+	async def fake_get_cookies(self: BrowserSession) -> list[dict[str, Any]]:
+		calls.append('cookies')
+		return [COOKIE]
+
+	async def fake_get_storage_state(self: BrowserSession) -> dict[str, Any]:
+		calls.append('storage')
+		return {'cookies': [COOKIE], 'origins': [ORIGIN]}
+
+	monkeypatch.setattr(BrowserSession, '_cdp_get_cookies', fake_get_cookies)
+	monkeypatch.setattr(BrowserSession, '_cdp_get_storage_state', fake_get_storage_state)
+
+	output_path = tmp_path / 'storage_state.json'
+	storage_state = await browser_session.export_storage_state(output_path, include_storage=True)
+
+	assert calls == ['storage']
+	assert storage_state['cookies'] == [COOKIE]
+	assert storage_state['origins'] == [ORIGIN]
+	assert json.loads(output_path.read_text(encoding='utf-8')) == storage_state


### PR DESCRIPTION
## Summary

`export_storage_state()` can now export full Playwright-compatible storage state when callers explicitly opt in with `include_storage=True`. The default remains cookies-only to avoid unexpectedly exporting localStorage/sessionStorage tokens, while users who need auth state from browser storage can capture the existing CDP-backed origins data through the public API.

The real-browser cookie export example now uses the public full-storage option and guarantees the browser is stopped after export. The browser reference docs show both cookies-only and full-storage export paths.

## Test Plan

- `uv run python -m pytest tests/ci/browser/test_storage_state_export.py`
- `uv run ruff check browser_use/browser/session.py examples/browser/save_cookies.py tests/ci/browser/test_storage_state_export.py`
- `uv run ruff format --check browser_use/browser/session.py examples/browser/save_cookies.py tests/ci/browser/test_storage_state_export.py`
- `uv run pyright browser_use/browser/session.py tests/ci/browser/test_storage_state_export.py`
- `git diff --check`
