### PR TITLE
fix: warn on boolean input text indices

### DIFF
--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -1,7 +1,10 @@
+import logging
 from typing import Generic, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from pydantic.json_schema import SkipJsonSchema
+
+logger = logging.getLogger(__name__)
 
 
 # Action Input Models
@@ -84,6 +87,17 @@ class InputTextAction(BaseModel):
 	index: int = Field(ge=0, description='from browser_state')
 	text: str = Field(description='Text to enter. With clear=True, text="" clears the field without typing.')
 	clear: bool = Field(default=True, description='Clear existing text before typing. Set to False to append instead.')
+
+	@field_validator('index', mode='before')
+	@classmethod
+	def warn_bool_index(cls, value):
+		if isinstance(value, bool):
+			logger.warning(
+				'Coercing boolean input_text index %s to %d; model output should use an integer element index.',
+				value,
+				int(value),
+			)
+		return value
 
 
 class DoneAction(BaseModel):

--- a/tests/ci/infrastructure/test_tool_views.py
+++ b/tests/ci/infrastructure/test_tool_views.py
@@ -1,0 +1,16 @@
+from unittest.mock import Mock
+
+import browser_use.tools.views as tool_views
+from browser_use.tools.views import InputTextAction
+
+
+def test_input_text_action_warns_on_boolean_index(monkeypatch):
+	warning = Mock()
+	monkeypatch.setattr(tool_views.logger, 'warning', warning)
+
+	params = InputTextAction.model_validate({'index': True, 'text': 'email'})
+
+	assert params.index == 1
+	warning.assert_called_once()
+	assert 'Coercing boolean input_text index %s to %d' in warning.call_args.args[0]
+	assert warning.call_args.args[1:] == (True, 1)


### PR DESCRIPTION
## Summary
- warn when `input_text.index` is a JSON boolean before pydantic coerces it to an integer
- keep the existing lax Python behavior so current agents do not start failing validation
- add a focused regression test for the boolean-index case from #4796

Fixes #4796

## To verify
- python -m pytest tests\ci\infrastructure\test_tool_views.py -q
- python -m ruff check browser_use\tools\views.py tests\ci\infrastructure\test_tool_views.py
- python -m ruff format --check browser_use\tools\views.py tests\ci\infrastructure\test_tool_views.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warn when `InputTextAction.index` is a JSON boolean via a `pydantic` `field_validator` (before validation), and keep bool→int coercion (True→1, False→0) for compatibility. Add a regression test verifying the warning log and the coercion; fixes #4796.

<sup>Written for commit 137c1be8e64448dc1534485ad7361c6df8445eb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

