### PR TITLE
fix(registry): guard set_index() against StopIteration on empty action_data

### DIFF
--- a/browser_use/tools/registry/views.py
+++ b/browser_use/tools/registry/views.py
@@ -80,6 +80,8 @@ class ActionModel(BaseModel):
 		"""Overwrite the index of the action"""
 		# Get the action name and params
 		action_data = self.model_dump(exclude_unset=True)
+		if not action_data:
+			return
 		action_name = next(iter(action_data.keys()))
 		action_params = getattr(self, action_name)
 

--- a/tests/ci/test_action_model_set_index.py
+++ b/tests/ci/test_action_model_set_index.py
@@ -1,0 +1,13 @@
+"""Unit tests for ActionModel.set_index() edge cases."""
+
+from browser_use.tools.registry.views import ActionModel
+
+
+def test_set_index_no_fields_does_not_raise():
+    """ActionModel subclass with no fields set must not raise StopIteration."""
+
+    class DoneParams(ActionModel):
+        pass
+
+    m = DoneParams()
+    m.set_index(0)  # must complete without raising StopIteration


### PR DESCRIPTION
## What's broken

`ActionModel.set_index()` crashes with `StopIteration` whenever it is called on an action model that has no fields set — for example, a parameterless action like `done`. The call to `next(iter(action_data.keys()))` on line 83 of `browser_use/tools/registry/views.py` blows up when `model_dump(exclude_unset=True)` returns an empty dict.

## Why it happens

There is no guard before the `next(iter(...))` call. The sibling method `get_index()` already handles this correctly with `if not params: return None` at line 72, but `set_index()` lacks the equivalent check.

## Fix

Added `if not action_data: return` immediately after building `action_data`, before any attempt to iterate its keys. This matches the existing pattern in `get_index()` and keeps the change minimal (two lines).

## Test

Added `tests/ci/test_action_model_set_index.py` with a single test: instantiate an `ActionModel` subclass that has no fields and call `set_index(0)` — asserts it completes without raising `StopIteration`.

Fixes #4943

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent StopIteration in `ActionModel.set_index()` for parameterless actions by early-returning when `model_dump(exclude_unset=True)` is empty, matching `get_index()`. Adds a unit test that verifies `set_index(0)` on an empty model does not raise.

<sup>Written for commit 50c65b7d73f73449caeccb58da26d2ed6d68e3da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

