### PR TITLE
fix(groq): read tool_calls arguments for ToolCallingModels in structured output

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -170,17 +170,25 @@ class ChatGroq(BaseChatModel):
 
 		if self.model in ToolCallingModels:
 			response = await self._invoke_with_tool_calling(groq_messages, output_format, schema)
+			tool_calls = response.choices[0].message.tool_calls
+			if not tool_calls or not tool_calls[0].function.arguments:
+				raise ModelProviderError(
+					message='No tool call arguments in response',
+					status_code=500,
+					model=self.name,
+				)
+			raw_json = tool_calls[0].function.arguments
 		else:
 			response = await self._invoke_with_json_schema(groq_messages, output_format, schema)
+			if not response.choices[0].message.content:
+				raise ModelProviderError(
+					message='No content in response',
+					status_code=500,
+					model=self.name,
+				)
+			raw_json = response.choices[0].message.content
 
-		if not response.choices[0].message.content:
-			raise ModelProviderError(
-				message='No content in response',
-				status_code=500,
-				model=self.name,
-			)
-
-		parsed_response = output_format.model_validate_json(response.choices[0].message.content)
+		parsed_response = output_format.model_validate_json(raw_json)
 		usage = self._get_usage(response)
 
 		return ChatInvokeCompletion(

--- a/tests/ci/models/test_llm_groq.py
+++ b/tests/ci/models/test_llm_groq.py
@@ -1,0 +1,40 @@
+"""Test ChatGroq structured output via tool-calling path."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+
+class DummyOutput(BaseModel):
+	answer: str
+
+
+class TestChatGroqToolCallingStructuredOutput:
+	"""Test that _invoke_structured_output correctly reads tool_calls when model uses tool-calling path."""
+
+	@pytest.mark.asyncio
+	async def test_tool_calling_path_returns_parsed_output(self):
+		"""ToolCallingModels return content=None; JSON lives in tool_calls[0].function.arguments."""
+		from browser_use.llm.groq.chat import ChatGroq
+
+		chat = ChatGroq(model='moonshotai/kimi-k2-instruct')
+
+		mock_tool_call = MagicMock()
+		mock_tool_call.function.arguments = '{"answer": "42"}'
+
+		mock_message = MagicMock()
+		mock_message.content = None
+		mock_message.tool_calls = [mock_tool_call]
+
+		mock_choice = MagicMock()
+		mock_choice.message = mock_message
+
+		mock_completion = MagicMock()
+		mock_completion.choices = [mock_choice]
+		mock_completion.usage = None
+
+		with patch.object(chat, '_invoke_with_tool_calling', return_value=mock_completion):
+			result = await chat._invoke_structured_output([], DummyOutput)
+
+		assert result.completion.answer == '42'


### PR DESCRIPTION
## What's broken

Calling `ainvoke(messages, OutputModel)` with any model in `ToolCallingModels` (e.g. `moonshotai/kimi-k2-instruct`) always raises `ModelProviderError('No content in response')`. Groq returns `message.content = None` for tool-call responses and puts the structured JSON in `message.tool_calls[0].function.arguments` instead. The guard at line 176 checked `message.content` unconditionally regardless of which invocation path was taken, so it always fired.

## Why it happens

`_invoke_structured_output` branches on `ToolCallingModels` to pick the right API call, but then reads `message.content` for both paths — ignoring that the tool-calling path never populates `content`.

## Fix

After `_invoke_with_tool_calling`, extract `raw_json` from `tool_calls[0].function.arguments`. After `_invoke_with_json_schema`, extract it from `message.content`. Each path now has its own presence check before parsing.

## Test

Added `tests/ci/models/test_llm_groq.py` with a unit test that mocks `_invoke_with_tool_calling` returning `content=None` and a tool call carrying the JSON. Asserts the parsed model output is correct.

Fixes #4945

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes structured output for Groq tool-calling models so `ainvoke(..., OutputModel)` returns parsed results. For `ToolCallingModels` (e.g., `moonshotai/kimi-k2-instruct`), JSON is now read from `tool_calls[0].function.arguments`; the JSON Schema path still uses `message.content`.

- **Bug Fixes**
  - Read `tool_calls[0].function.arguments` for `ToolCallingModels`; raise "No tool call arguments in response" when missing.
  - Keep `message.content` parsing for the JSON Schema path with its own presence check.
  - Add a unit test for the tool-calling structured output. Fixes #4945.

<sup>Written for commit c43616c2d2319924834103791a0ea1823c79bc1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

