### PR TITLE
fix(views): AgentHistoryList.last_action() crashes with IndexError

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -700,7 +700,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def last_action(self) -> None | dict:
 		"""Last action in history"""
-		if self.history and self.history[-1].model_output:
+		if self.history and self.history[-1].model_output and self.history[-1].model_output.action:
 			return self.history[-1].model_output.action[-1].model_dump(exclude_none=True, mode='json')
 		return None
 

--- a/tests/ci/test_agent_views.py
+++ b/tests/ci/test_agent_views.py
@@ -1,0 +1,20 @@
+"""Tests for browser_use.agent.views"""
+
+import json
+import os
+import tempfile
+
+from browser_use.agent.views import AgentOutput, AgentHistoryList
+
+
+def test_last_action_returns_none_on_empty_action_list():
+    """last_action() must return None (not raise IndexError) when action list is empty."""
+    history_data = {"history": [{"model_output": {"evaluation_previous_goal": "g", "memory": "m", "next_goal": "n", "action": []}, "result": [{"is_done": True}], "state": {"url": "http://test.com", "title": "t", "tabs": [], "interacted_element": [None]}}]}
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(history_data, f)
+        tmpfile = f.name
+    try:
+        history = AgentHistoryList.load_from_file(tmpfile, AgentOutput)
+        assert history.last_action() is None
+    finally:
+        os.unlink(tmpfile)


### PR DESCRIPTION
## What's broken

`AgentHistoryList.last_action()` raises `IndexError: list index out of range` when `model_output.action` is an empty list. This is reachable via the public `load_from_file`/`load_from_dict` API when a saved history JSON contains an empty action array — Pydantic does not enforce `min_items` at runtime, so the shape is valid. The guard on line 703 only checks that `model_output` is not `None`, but an `AgentOutput` with `action=[]` is truthy, so execution reaches `action[-1]`.

## Why it happens

The truthiness check `if self.history and self.history[-1].model_output:` does not account for the case where `model_output.action` is an empty list.

## Fix

Extended the guard to `if self.history and self.history[-1].model_output and self.history[-1].model_output.action:` so that an empty action list causes the method to return `None` instead of crashing.

## Test

Added `test_last_action_returns_none_on_empty_action_list` in `tests/ci/test_agent_views.py` that loads a history file with an empty action array and asserts `last_action()` returns `None` without raising.

Fixes #4947

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a crash in `AgentHistoryList.last_action()` when the last `model_output` has an empty `action` list. The method now returns `None` instead of raising `IndexError`, ensuring safe loads via `load_from_file`/`load_from_dict`.

- **Bug Fixes**
  - Added a guard to check `model_output.action` is non-empty before indexing; return `None` otherwise.
  - Added `test_last_action_returns_none_on_empty_action_list` to cover loading a history JSON with an empty `action` array.

<sup>Written for commit d62ff58d3fd3d7dadd34e70f239b643bc689f2f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

