### PR TITLE
Fix OpenRouter example import

### DIFF
--- a/examples/models/openrouter.py
+++ b/examples/models/openrouter.py
@@ -1,7 +1,6 @@
-"""
-Simple try of the agent.
+"""Simple OpenRouter example.
 
-@dev You need to add OPENAI_API_KEY to your environment variables.
+@dev You need to add OPENROUTER_API_KEY to your environment variables.
 """
 
 import asyncio
@@ -9,15 +8,13 @@ import os
 
 from dotenv import load_dotenv
 
-from browser_use import Agent, ChatOpenAI
+from browser_use import Agent, ChatOpenRouter
 
 load_dotenv()
 
-# All the models are type safe from OpenAI in case you need a list of supported models
-llm = ChatOpenAI(
+llm = ChatOpenRouter(
 	# model='x-ai/grok-4',
 	model='deepcogito/cogito-v2.1-671b',
-	base_url='https://openrouter.ai/api/v1',
 	api_key=os.getenv('OPENROUTER_API_KEY'),
 )
 agent = Agent(


### PR DESCRIPTION
## Summary
- update the OpenRouter example to use the native ChatOpenRouter class
- correct the setup note to reference OPENROUTER_API_KEY
- remove the OpenAI-compatible base_url workaround from the OpenRouter-specific example

## Verification
- python3 -m py_compile examples/models/openrouter.py

Fixes #4755

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the OpenRouter example to `ChatOpenRouter` and remove the OpenAI-compatible `base_url`. Reference `OPENROUTER_API_KEY` in the setup note so it runs natively against OpenRouter (fixes #4755).

<sup>Written for commit e600bd3d430ab81f41225b160fdd0c217f73b0ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

