### PR TITLE
fix: guard against empty action list in last_action()

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -700,7 +700,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def last_action(self) -> None | dict:
 		"""Last action in history"""
-		if self.history and self.history[-1].model_output:
+		if self.history and self.history[-1].model_output and self.history[-1].model_output.action:
 			return self.history[-1].model_output.action[-1].model_dump(exclude_none=True, mode='json')
 		return None
 


### PR DESCRIPTION
## Problem

`AgentHistoryList.last_action()` crashes with `IndexError: list index out of range` when the action list is empty (`action=[]`).

`model_output` is a pydantic model whose `action` field is marked `min_items: 1` in the JSON schema — but this constraint is not enforced at the Python level. So it's possible to have an `AgentOutput` with `action=[]`, and the current guard `if self.history[-1].model_output` is not enough: a non-`None` object is truthy even with an empty list inside.

## Fix

```diff
-       if self.history and self.history[-1].model_output:
+       if self.history and self.history[-1].model_output and self.history[-1].model_output.action:
            return self.history[-1].model_output.action[-1].model_dump(exclude_none=True, mode='json')
```

Add `and self.history[-1].model_output.action` to the guard. Empty action lists are falsy, so the method returns `None` instead of crashing. Calls that hit this path already handle `None` return (the type signature is `-> None | dict`).

## Verification

- Scanned the entire repo — this is the only `.action[-1]` access. All other usages of `model_output.action` use `for action in ...` iteration or `len()`, both safe with empty lists.
- `agent_steps()` on line 896 already uses the same pattern (`if h.model_output and h.model_output.action`).

Fixes #4947