### PR TITLE
docs: fix profile-use repository link

### DIFF
--- a/browser_use/skill_cli/README.md
+++ b/browser_use/skill_cli/README.md
@@ -260,7 +260,7 @@ browser-use open https://abc.trycloudflare.com
 
 ## Profile Management
 
-The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/profile-use) Go binary, which syncs local browser cookies to Browser-Use cloud.
+The `profile` subcommand delegates to the [profile-use](https://github.com/browser-use/profile-use-releases) Go binary, which syncs local browser cookies to Browser-Use cloud.
 
 The binary is managed at `~/.browser-use/bin/profile-use` and auto-downloaded on first use.
 


### PR DESCRIPTION
## Summary
- Update the `profile-use` link in the skill CLI README to the active releases repository.

## Why
- `browser-use/profile-use` no longer resolves, while `browser-use/profile-use-releases` hosts the pre-built profile-use binaries referenced by the README.

## Validation
- Checked the target repository exists and has releases.
- Ran `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `profile-use` link in `browser_use/skill_cli/README.md` to point to `https://github.com/browser-use/profile-use-releases`, which hosts the prebuilt binary. Prevents 404s and directs users to the correct Go binary used by the `profile` subcommand.

<sup>Written for commit 3eb8acaf1592c34aba78249db71265d68931b78d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

