### PR TITLE
fix(groq): read tool_calls arguments for ToolCallingModels in structured output

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -170,17 +170,25 @@ class ChatGroq(BaseChatModel):
 
 		if self.model in ToolCallingModels:
 			response = await self._invoke_with_tool_calling(groq_messages, output_format, schema)
+			tool_calls = response.choices[0].message.tool_calls
+			if not tool_calls or not tool_calls[0].function.arguments:
+				raise ModelProviderError(
+					message='No tool call arguments in response',
+					status_code=500,
+					model=self.name,
+				)
+			raw_json = tool_calls[0].function.arguments
 		else:
 			response = await self._invoke_with_json_schema(groq_messages, output_format, schema)
+			if not response.choices[0].message.content:
+				raise ModelProviderError(
+					message='No content in response',
+					status_code=500,
+					model=self.name,
+				)
+			raw_json = response.choices[0].message.content
 
-		if not response.choices[0].message.content:
-			raise ModelProviderError(
-				message='No content in response',
-				status_code=500,
-				model=self.name,
-			)
-
-		parsed_response = output_format.model_validate_json(response.choices[0].message.content)
+		parsed_response = output_format.model_validate_json(raw_json)
 		usage = self._get_usage(response)
 
 		return ChatInvokeCompletion(

--- a/tests/ci/models/test_llm_groq.py
+++ b/tests/ci/models/test_llm_groq.py
@@ -1,0 +1,82 @@
+"""Test ChatGroq structured output for tool-calling and JSON-schema paths."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+
+class DummyOutput(BaseModel):
+	answer: str
+
+
+class TestChatGroqStructuredOutput:
+	@pytest.mark.asyncio
+	async def test_tool_calling_path_returns_parsed_output(self):
+		"""ToolCallingModels return content=None; JSON lives in tool_calls[0].function.arguments."""
+		from browser_use.llm.groq.chat import ChatGroq
+
+		chat = ChatGroq(model='moonshotai/kimi-k2-instruct')
+
+		mock_tool_call = MagicMock()
+		mock_tool_call.function.arguments = '{"answer": "42"}'
+
+		mock_message = MagicMock()
+		mock_message.content = None
+		mock_message.tool_calls = [mock_tool_call]
+
+		mock_choice = MagicMock()
+		mock_choice.message = mock_message
+
+		mock_completion = MagicMock()
+		mock_completion.choices = [mock_choice]
+		mock_completion.usage = None
+
+		with patch.object(chat, '_invoke_with_tool_calling', return_value=mock_completion):
+			result = await chat._invoke_structured_output([], DummyOutput)
+
+		assert result.completion.answer == '42'
+
+	@pytest.mark.asyncio
+	async def test_json_schema_path_returns_parsed_output(self):
+		"""JsonSchemaModels return structured JSON in message.content."""
+		from browser_use.llm.groq.chat import ChatGroq
+
+		chat = ChatGroq(model='meta-llama/llama-4-scout-17b-16e-instruct')
+
+		mock_message = MagicMock()
+		mock_message.content = '{"answer": "hello"}'
+		mock_message.tool_calls = None
+
+		mock_choice = MagicMock()
+		mock_choice.message = mock_message
+
+		mock_completion = MagicMock()
+		mock_completion.choices = [mock_choice]
+		mock_completion.usage = None
+
+		with patch.object(chat, '_invoke_with_json_schema', return_value=mock_completion):
+			result = await chat._invoke_structured_output([], DummyOutput)
+
+		assert result.completion.answer == 'hello'
+
+	@pytest.mark.asyncio
+	async def test_tool_calling_path_raises_when_arguments_missing(self):
+		from browser_use.llm.exceptions import ModelProviderError
+		from browser_use.llm.groq.chat import ChatGroq
+
+		chat = ChatGroq(model='moonshotai/kimi-k2-instruct')
+
+		mock_message = MagicMock()
+		mock_message.content = None
+		mock_message.tool_calls = []
+
+		mock_choice = MagicMock()
+		mock_choice.message = mock_message
+
+		mock_completion = MagicMock()
+		mock_completion.choices = [mock_choice]
+
+		with patch.object(chat, '_invoke_with_tool_calling', return_value=mock_completion):
+			with pytest.raises(ModelProviderError, match='No tool call arguments in response'):
+				await chat._invoke_structured_output([], DummyOutput)


### PR DESCRIPTION
## Summary
- Fix ChatGroq structured output for ToolCallingModels (e.g. moonshotai/kimi-k2-instruct)
- Groq returns JSON in tool_calls[0].function.arguments with message.content=None; parse each invocation path separately
- Add unit tests for tool-calling path, JSON schema path, and missing-arguments error case

Fixes #4945

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix structured output parsing for Groq tool-calling models by reading JSON from tool call arguments. Prevents failures when `message.content` is None and aligns behavior with JSON-schema models.

- **Bug Fixes**
  - For ToolCallingModels, parse from `tool_calls[0].function.arguments` (e.g., `moonshotai/kimi-k2-instruct`).
  - Keep JSON-schema path reading from `message.content`; both paths now validate into the same model.
  - Raise a clear error when tool call arguments are missing and add tests for tool-calling, JSON-schema, and error cases.

<sup>Written for commit 2e67d6fa300b66595e43208ebb2302a23a6c4eeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

