### PR TITLE
feat: add MiniMax LLM provider with M3 as default model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ BROWSER_USE_API_KEY=your_bu_api_key_here
 # DEEPSEEK_API_KEY=
 # GROK_API_KEY=
 # NOVITA_API_KEY=
+# MINIMAX_API_KEY=
 
 # AWS Bedrock Configuration (for AWS Bedrock models)
 # Requires: pip install browser-use[aws]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ BROWSER_USE_API_KEY=your-key
 from browser_use import Agent, Browser, ChatBrowserUse
 # from browser_use import ChatGoogle  # ChatGoogle(model='gemini-3-flash-preview')
 # from browser_use import ChatAnthropic  # ChatAnthropic(model='claude-sonnet-4-6')
-# from browser_use import ChatMiniMax  # ChatMiniMax(model='MiniMax-M2.5')
+# from browser_use import ChatMiniMax  # ChatMiniMax(model='MiniMax-M2.7')
 import asyncio
 
 async def main():
@@ -81,7 +81,7 @@ async def main():
         llm=ChatBrowserUse(),
         # llm=ChatGoogle(model='gemini-3-flash-preview'),
         # llm=ChatAnthropic(model='claude-sonnet-4-6'),
-        # llm=ChatMiniMax(model='MiniMax-M2.5'),
+        # llm=ChatMiniMax(model='MiniMax-M2.7'),
         browser=browser,
     )
     await agent.run()

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ BROWSER_USE_API_KEY=your-key
 from browser_use import Agent, Browser, ChatBrowserUse
 # from browser_use import ChatGoogle  # ChatGoogle(model='gemini-3-flash-preview')
 # from browser_use import ChatAnthropic  # ChatAnthropic(model='claude-sonnet-4-6')
+# from browser_use import ChatMiniMax  # ChatMiniMax(model='MiniMax-M2.5')
 import asyncio
 
 async def main():
@@ -80,6 +81,7 @@ async def main():
         llm=ChatBrowserUse(),
         # llm=ChatGoogle(model='gemini-3-flash-preview'),
         # llm=ChatAnthropic(model='claude-sonnet-4-6'),
+        # llm=ChatMiniMax(model='MiniMax-M2.5'),
         browser=browser,
     )
     await agent.run()
@@ -248,7 +250,7 @@ agent = Agent(
 <details>
 <summary><b>Can I use this for free?</b></summary>
 
-Yes! Browser-Use is open source and free to use. You only need to choose an LLM provider (like OpenAI, Google, ChatBrowserUse, or run local models with Ollama).
+Yes! Browser-Use is open source and free to use. You only need to choose an LLM provider (like OpenAI, Google, MiniMax, ChatBrowserUse, or run local models with Ollama).
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ BROWSER_USE_API_KEY=your-key
 from browser_use import Agent, Browser, ChatBrowserUse
 # from browser_use import ChatGoogle  # ChatGoogle(model='gemini-3-flash-preview')
 # from browser_use import ChatAnthropic  # ChatAnthropic(model='claude-sonnet-4-6')
-# from browser_use import ChatMiniMax  # ChatMiniMax(model='MiniMax-M2.7')
+# from browser_use import ChatMiniMax  # ChatMiniMax(model='MiniMax-M3')
 import asyncio
 
 async def main():
@@ -81,7 +81,7 @@ async def main():
         llm=ChatBrowserUse(),
         # llm=ChatGoogle(model='gemini-3-flash-preview'),
         # llm=ChatAnthropic(model='claude-sonnet-4-6'),
-        # llm=ChatMiniMax(model='MiniMax-M2.7'),
+        # llm=ChatMiniMax(model='MiniMax-M3'),
         browser=browser,
     )
     await agent.run()

--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
 	from browser_use.llm.litellm.chat import ChatLiteLLM
+	from browser_use.llm.minimax.chat import ChatMiniMax
 	from browser_use.llm.mistral.chat import ChatMistral
 	from browser_use.llm.oci_raw.chat import ChatOCIRaw
 	from browser_use.llm.ollama.chat import ChatOllama
@@ -94,6 +95,7 @@ _LAZY_IMPORTS = {
 	'ChatBrowserUse': ('browser_use.llm.browser_use.chat', 'ChatBrowserUse'),
 	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
 	'ChatLiteLLM': ('browser_use.llm.litellm.chat', 'ChatLiteLLM'),
+	'ChatMiniMax': ('browser_use.llm.minimax.chat', 'ChatMiniMax'),
 	'ChatMistral': ('browser_use.llm.mistral.chat', 'ChatMistral'),
 	'ChatAzureOpenAI': ('browser_use.llm.azure.chat', 'ChatAzureOpenAI'),
 	'ChatOCIRaw': ('browser_use.llm.oci_raw.chat', 'ChatOCIRaw'),
@@ -146,6 +148,7 @@ __all__ = [
 	'ChatBrowserUse',
 	'ChatGroq',
 	'ChatLiteLLM',
+	'ChatMiniMax',
 	'ChatMistral',
 	'ChatAzureOpenAI',
 	'ChatOCIRaw',

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.browser_use.chat import ChatBrowserUse
 	from browser_use.llm.cerebras.chat import ChatCerebras
 	from browser_use.llm.deepseek.chat import ChatDeepSeek
+	from browser_use.llm.minimax.chat import ChatMiniMax
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
 	from browser_use.llm.mistral.chat import ChatMistral
@@ -75,6 +76,9 @@ if TYPE_CHECKING:
 	google_gemini_2_5_flash: ChatGoogle
 	google_gemini_2_5_flash_lite: ChatGoogle
 
+	minimax_m2_5: ChatMiniMax
+	minimax_m2_5_highspeed: ChatMiniMax
+
 # Models are imported on-demand via __getattr__
 
 # Lazy imports mapping for heavy chat models
@@ -86,6 +90,7 @@ _LAZY_IMPORTS = {
 	'ChatBrowserUse': ('browser_use.llm.browser_use.chat', 'ChatBrowserUse'),
 	'ChatCerebras': ('browser_use.llm.cerebras.chat', 'ChatCerebras'),
 	'ChatDeepSeek': ('browser_use.llm.deepseek.chat', 'ChatDeepSeek'),
+	'ChatMiniMax': ('browser_use.llm.minimax.chat', 'ChatMiniMax'),
 	'ChatGoogle': ('browser_use.llm.google.chat', 'ChatGoogle'),
 	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
 	'ChatMistral': ('browser_use.llm.mistral.chat', 'ChatMistral'),
@@ -158,4 +163,5 @@ __all__ = [
 	'ChatOpenRouter',
 	'ChatVercel',
 	'ChatCerebras',
+	'ChatMiniMax',
 ]

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -76,8 +76,9 @@ if TYPE_CHECKING:
 	google_gemini_2_5_flash: ChatGoogle
 	google_gemini_2_5_flash_lite: ChatGoogle
 
-	minimax_m2_5: ChatMiniMax
-	minimax_m2_5_highspeed: ChatMiniMax
+	minimax_m3: ChatMiniMax
+	minimax_m2_7: ChatMiniMax
+	minimax_m2_7_highspeed: ChatMiniMax
 
 # Models are imported on-demand via __getattr__
 

--- a/browser_use/llm/minimax/__init__.py
+++ b/browser_use/llm/minimax/__init__.py
@@ -1,0 +1,3 @@
+from browser_use.llm.minimax.chat import ChatMiniMax
+
+__all__ = ['ChatMiniMax']

--- a/browser_use/llm/minimax/chat.py
+++ b/browser_use/llm/minimax/chat.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, TypeVar, overload
+
+import httpx
+from openai import (
+	APIConnectionError,
+	APIError,
+	APIStatusError,
+	APITimeoutError,
+	AsyncOpenAI,
+	RateLimitError,
+)
+from pydantic import BaseModel
+
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.minimax.serializer import MiniMaxMessageSerializer
+from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.views import ChatInvokeCompletion
+
+T = TypeVar('T', bound=BaseModel)
+
+
+@dataclass
+class ChatMiniMax(BaseChatModel):
+	"""MiniMax /chat/completions wrapper (OpenAI-compatible)."""
+
+	model: str = 'MiniMax-M2.5'
+
+	# Generation parameters
+	max_tokens: int | None = None
+	temperature: float | None = None
+	top_p: float | None = None
+	seed: int | None = None
+
+	# Connection parameters
+	api_key: str | None = None
+	base_url: str | httpx.URL | None = 'https://api.minimax.io/v1'
+	timeout: float | httpx.Timeout | None = None
+	client_params: dict[str, Any] | None = None
+
+	@property
+	def provider(self) -> str:
+		return 'minimax'
+
+	def _client(self) -> AsyncOpenAI:
+		return AsyncOpenAI(
+			api_key=self.api_key,
+			base_url=self.base_url,
+			timeout=self.timeout,
+			**(self.client_params or {}),
+		)
+
+	@property
+	def name(self) -> str:
+		return self.model
+
+	@overload
+	async def ainvoke(
+		self,
+		messages: list[BaseMessage],
+		output_format: None = None,
+		tools: list[dict[str, Any]] | None = None,
+		stop: list[str] | None = None,
+		**kwargs: Any,
+	) -> ChatInvokeCompletion[str]: ...
+
+	@overload
+	async def ainvoke(
+		self,
+		messages: list[BaseMessage],
+		output_format: type[T],
+		tools: list[dict[str, Any]] | None = None,
+		stop: list[str] | None = None,
+		**kwargs: Any,
+	) -> ChatInvokeCompletion[T]: ...
+
+	async def ainvoke(
+		self,
+		messages: list[BaseMessage],
+		output_format: type[T] | None = None,
+		tools: list[dict[str, Any]] | None = None,
+		stop: list[str] | None = None,
+		**kwargs: Any,
+	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		client = self._client()
+		mm_messages = MiniMaxMessageSerializer.serialize_messages(messages)
+		common: dict[str, Any] = {}
+
+		if self.temperature is not None:
+			common['temperature'] = self.temperature
+		if self.max_tokens is not None:
+			common['max_tokens'] = self.max_tokens
+		if self.top_p is not None:
+			common['top_p'] = self.top_p
+		if self.seed is not None:
+			common['seed'] = self.seed
+		if stop:
+			common['stop'] = stop
+
+		# Regular text completion
+		if output_format is None and not tools:
+			try:
+				resp = await client.chat.completions.create(  # type: ignore
+					model=self.model,
+					messages=mm_messages,  # type: ignore
+					**common,
+				)
+				return ChatInvokeCompletion(
+					completion=resp.choices[0].message.content or '',
+					usage=None,
+				)
+			except RateLimitError as e:
+				raise ModelRateLimitError(str(e), model=self.name) from e
+			except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
+				raise ModelProviderError(str(e), model=self.name) from e
+			except Exception as e:
+				raise ModelProviderError(str(e), model=self.name) from e
+
+		# Function Calling path (with tools or output_format)
+		if tools or (output_format is not None and hasattr(output_format, 'model_json_schema')):
+			try:
+				call_tools = tools
+				tool_choice = None
+				if output_format is not None and hasattr(output_format, 'model_json_schema'):
+					tool_name = output_format.__name__
+					schema = SchemaOptimizer.create_optimized_json_schema(output_format)
+					schema.pop('title', None)
+					call_tools = [
+						{
+							'type': 'function',
+							'function': {
+								'name': tool_name,
+								'description': f'Return a JSON object of type {tool_name}',
+								'parameters': schema,
+							},
+						}
+					]
+					tool_choice = {'type': 'function', 'function': {'name': tool_name}}
+				resp = await client.chat.completions.create(  # type: ignore
+					model=self.model,
+					messages=mm_messages,  # type: ignore
+					tools=call_tools,  # type: ignore
+					tool_choice=tool_choice,  # type: ignore
+					**common,
+				)
+				msg = resp.choices[0].message
+				if not msg.tool_calls:
+					raise ValueError('Expected tool_calls in response but got none')
+				raw_args = msg.tool_calls[0].function.arguments
+				if isinstance(raw_args, str):
+					parsed = json.loads(raw_args)
+				else:
+					parsed = raw_args
+				if output_format is not None:
+					return ChatInvokeCompletion(
+						completion=output_format.model_validate(parsed),
+						usage=None,
+					)
+				else:
+					return ChatInvokeCompletion(
+						completion=parsed,
+						usage=None,
+					)
+			except RateLimitError as e:
+				raise ModelRateLimitError(str(e), model=self.name) from e
+			except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
+				raise ModelProviderError(str(e), model=self.name) from e
+			except Exception as e:
+				raise ModelProviderError(str(e), model=self.name) from e
+
+		# JSON Output path
+		if output_format is not None and hasattr(output_format, 'model_json_schema'):
+			try:
+				resp = await client.chat.completions.create(  # type: ignore
+					model=self.model,
+					messages=mm_messages,  # type: ignore
+					response_format={'type': 'json_object'},
+					**common,
+				)
+				content = resp.choices[0].message.content
+				if not content:
+					raise ModelProviderError('Empty JSON content in MiniMax response', model=self.name)
+				parsed = output_format.model_validate_json(content)
+				return ChatInvokeCompletion(
+					completion=parsed,
+					usage=None,
+				)
+			except RateLimitError as e:
+				raise ModelRateLimitError(str(e), model=self.name) from e
+			except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
+				raise ModelProviderError(str(e), model=self.name) from e
+			except Exception as e:
+				raise ModelProviderError(str(e), model=self.name) from e
+
+		raise ModelProviderError('No valid ainvoke execution path for MiniMax LLM', model=self.name)

--- a/browser_use/llm/minimax/chat.py
+++ b/browser_use/llm/minimax/chat.py
@@ -121,11 +121,11 @@ class ChatMiniMax(BaseChatModel):
 			except Exception as e:
 				raise ModelProviderError(str(e), model=self.name) from e
 
-		# Function Calling path (with tools or output_format)
-		if tools or (output_format is not None and hasattr(output_format, 'model_json_schema')):
+		# Function Calling path (tools provided)
+		if tools:
 			try:
-				call_tools = tools
-				tool_choice = None
+				call_tools = list(tools)
+				tool_choice: Any = None
 				if output_format is not None and hasattr(output_format, 'model_json_schema'):
 					tool_name = output_format.__name__
 					schema = SchemaOptimizer.create_optimized_json_schema(output_format)
@@ -149,8 +149,13 @@ class ChatMiniMax(BaseChatModel):
 					**common,
 				)
 				msg = resp.choices[0].message
+				# When tool_choice is not forced, the model may respond with
+				# plain text instead of tool_calls -- treat as normal response.
 				if not msg.tool_calls:
-					raise ValueError('Expected tool_calls in response but got none')
+					return ChatInvokeCompletion(
+						completion=msg.content or '',
+						usage=None,
+					)
 				raw_args = msg.tool_calls[0].function.arguments
 				if isinstance(raw_args, str):
 					parsed = json.loads(raw_args)
@@ -173,7 +178,7 @@ class ChatMiniMax(BaseChatModel):
 			except Exception as e:
 				raise ModelProviderError(str(e), model=self.name) from e
 
-		# JSON Output path
+		# Structured-output JSON path (output_format only, no tools)
 		if output_format is not None and hasattr(output_format, 'model_json_schema'):
 			try:
 				resp = await client.chat.completions.create(  # type: ignore

--- a/browser_use/llm/minimax/chat.py
+++ b/browser_use/llm/minimax/chat.py
@@ -29,7 +29,7 @@ T = TypeVar('T', bound=BaseModel)
 class ChatMiniMax(BaseChatModel):
 	"""MiniMax /chat/completions wrapper (OpenAI-compatible)."""
 
-	model: str = 'MiniMax-M2.5'
+	model: str = 'MiniMax-M2.7'
 
 	# Generation parameters
 	max_tokens: int | None = None

--- a/browser_use/llm/minimax/chat.py
+++ b/browser_use/llm/minimax/chat.py
@@ -29,7 +29,7 @@ T = TypeVar('T', bound=BaseModel)
 class ChatMiniMax(BaseChatModel):
 	"""MiniMax /chat/completions wrapper (OpenAI-compatible)."""
 
-	model: str = 'MiniMax-M2.7'
+	model: str = 'MiniMax-M3'
 
 	# Generation parameters
 	max_tokens: int | None = None

--- a/browser_use/llm/minimax/serializer.py
+++ b/browser_use/llm/minimax/serializer.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from typing import Any, overload
+
+from browser_use.llm.messages import (
+	AssistantMessage,
+	BaseMessage,
+	ContentPartImageParam,
+	ContentPartTextParam,
+	SystemMessage,
+	ToolCall,
+	UserMessage,
+)
+
+MessageDict = dict[str, Any]
+
+
+class MiniMaxMessageSerializer:
+	"""Serializer for converting browser-use messages to MiniMax (OpenAI-compatible) messages."""
+
+	@staticmethod
+	def _serialize_text_part(part: ContentPartTextParam) -> str:
+		return part.text
+
+	@staticmethod
+	def _serialize_image_part(part: ContentPartImageParam) -> dict[str, Any]:
+		url = part.image_url.url
+		return {'type': 'image_url', 'image_url': {'url': url}}
+
+	@staticmethod
+	def _serialize_content(content: Any) -> str | list[dict[str, Any]]:
+		if content is None:
+			return ''
+		if isinstance(content, str):
+			return content
+		serialized: list[dict[str, Any]] = []
+		for part in content:
+			if part.type == 'text':
+				serialized.append({'type': 'text', 'text': MiniMaxMessageSerializer._serialize_text_part(part)})
+			elif part.type == 'image_url':
+				serialized.append(MiniMaxMessageSerializer._serialize_image_part(part))
+			elif part.type == 'refusal':
+				serialized.append({'type': 'text', 'text': f'[Refusal] {part.refusal}'})
+		return serialized
+
+	@staticmethod
+	def _serialize_tool_calls(tool_calls: list[ToolCall]) -> list[dict[str, Any]]:
+		result: list[dict[str, Any]] = []
+		for tc in tool_calls:
+			try:
+				arguments = json.loads(tc.function.arguments)
+			except json.JSONDecodeError:
+				arguments = {'arguments': tc.function.arguments}
+			result.append(
+				{
+					'id': tc.id,
+					'type': 'function',
+					'function': {
+						'name': tc.function.name,
+						'arguments': arguments,
+					},
+				}
+			)
+		return result
+
+	@overload
+	@staticmethod
+	def serialize(message: UserMessage) -> MessageDict: ...
+
+	@overload
+	@staticmethod
+	def serialize(message: SystemMessage) -> MessageDict: ...
+
+	@overload
+	@staticmethod
+	def serialize(message: AssistantMessage) -> MessageDict: ...
+
+	@staticmethod
+	def serialize(message: BaseMessage) -> MessageDict:
+		if isinstance(message, UserMessage):
+			return {
+				'role': 'user',
+				'content': MiniMaxMessageSerializer._serialize_content(message.content),
+			}
+		if isinstance(message, SystemMessage):
+			return {
+				'role': 'system',
+				'content': MiniMaxMessageSerializer._serialize_content(message.content),
+			}
+		if isinstance(message, AssistantMessage):
+			msg: MessageDict = {
+				'role': 'assistant',
+				'content': MiniMaxMessageSerializer._serialize_content(message.content),
+			}
+			if message.tool_calls:
+				msg['tool_calls'] = MiniMaxMessageSerializer._serialize_tool_calls(message.tool_calls)
+			return msg
+		raise ValueError(f'Unknown message type: {type(message)}')
+
+	@staticmethod
+	def serialize_messages(messages: list[BaseMessage]) -> list[MessageDict]:
+		return [MiniMaxMessageSerializer.serialize(m) for m in messages]

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -82,6 +82,8 @@ cerebras_qwen_3_235b_a22b_instruct_2507: 'BaseChatModel'
 cerebras_qwen_3_235b_a22b_thinking_2507: 'BaseChatModel'
 cerebras_qwen_3_coder_480b: 'BaseChatModel'
 
+minimax_m2_7: 'BaseChatModel'
+minimax_m2_7_highspeed: 'BaseChatModel'
 minimax_m2_5: 'BaseChatModel'
 minimax_m2_5_highspeed: 'BaseChatModel'
 
@@ -212,6 +214,8 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('MINIMAX_API_KEY')
 		base_url = os.getenv('MINIMAX_BASE_URL', 'https://api.minimax.io/v1')
 		minimax_map = {
+			'm2-7': 'MiniMax-M2.7',
+			'm2-7-highspeed': 'MiniMax-M2.7-highspeed',
 			'm2-5': 'MiniMax-M2.5',
 			'm2-5-highspeed': 'MiniMax-M2.5-highspeed',
 		}
@@ -329,6 +333,8 @@ __all__ += [
 	'cerebras_qwen_3_235b_a22b_thinking_2507',
 	'cerebras_qwen_3_coder_480b',
 	# MiniMax instances - created on demand
+	'minimax_m2_7',
+	'minimax_m2_7_highspeed',
 	'minimax_m2_5',
 	'minimax_m2_5_highspeed',
 	# Browser Use instances - created on demand

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -18,6 +18,7 @@ from browser_use.llm.azure.chat import ChatAzureOpenAI
 from browser_use.llm.browser_use.chat import ChatBrowserUse
 from browser_use.llm.cerebras.chat import ChatCerebras
 from browser_use.llm.google.chat import ChatGoogle
+from browser_use.llm.minimax.chat import ChatMiniMax
 from browser_use.llm.mistral.chat import ChatMistral
 from browser_use.llm.openai.chat import ChatOpenAI
 
@@ -80,6 +81,9 @@ cerebras_qwen_3_32b: 'BaseChatModel'
 cerebras_qwen_3_235b_a22b_instruct_2507: 'BaseChatModel'
 cerebras_qwen_3_235b_a22b_thinking_2507: 'BaseChatModel'
 cerebras_qwen_3_coder_480b: 'BaseChatModel'
+
+minimax_m2_5: 'BaseChatModel'
+minimax_m2_5_highspeed: 'BaseChatModel'
 
 bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
@@ -203,6 +207,18 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('CEREBRAS_API_KEY')
 		return ChatCerebras(model=model, api_key=api_key)
 
+	# MiniMax Models
+	elif provider == 'minimax':
+		api_key = os.getenv('MINIMAX_API_KEY')
+		base_url = os.getenv('MINIMAX_BASE_URL', 'https://api.minimax.io/v1')
+		minimax_map = {
+			'm2-5': 'MiniMax-M2.5',
+			'm2-5-highspeed': 'MiniMax-M2.5-highspeed',
+		}
+		normalized = model.replace('_', '-')
+		resolved_model = minimax_map.get(normalized, model)
+		return ChatMiniMax(model=resolved_model, api_key=api_key, base_url=base_url)
+
 	# Browser Use Models
 	elif provider == 'bu':
 		# Handle bu_latest -> bu-latest conversion (need to prepend 'bu-' back)
@@ -211,7 +227,7 @@ def get_llm_by_name(model_name: str):
 		return ChatBrowserUse(model=model, api_key=api_key)
 
 	else:
-		available_providers = ['openai', 'azure', 'google', 'oci', 'cerebras', 'bu']
+		available_providers = ['openai', 'azure', 'google', 'minimax', 'oci', 'cerebras', 'bu']
 
 		raise ValueError(f"Unknown provider: '{provider}'. Available providers: {', '.join(available_providers)}")
 
@@ -236,6 +252,8 @@ def __getattr__(name: str) -> 'BaseChatModel':
 		return ChatOCIRaw  # type: ignore
 	elif name == 'ChatCerebras':
 		return ChatCerebras  # type: ignore
+	elif name == 'ChatMiniMax':
+		return ChatMiniMax  # type: ignore
 	elif name == 'ChatBrowserUse':
 		return ChatBrowserUse  # type: ignore
 
@@ -253,6 +271,7 @@ __all__ = [
 	'ChatGoogle',
 	'ChatMistral',
 	'ChatCerebras',
+	'ChatMiniMax',
 	'ChatBrowserUse',
 ]
 
@@ -309,6 +328,9 @@ __all__ += [
 	'cerebras_qwen_3_235b_a22b_instruct_2507',
 	'cerebras_qwen_3_235b_a22b_thinking_2507',
 	'cerebras_qwen_3_coder_480b',
+	# MiniMax instances - created on demand
+	'minimax_m2_5',
+	'minimax_m2_5_highspeed',
 	# Browser Use instances - created on demand
 	'bu_latest',
 	'bu_1_0',

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -82,10 +82,9 @@ cerebras_qwen_3_235b_a22b_instruct_2507: 'BaseChatModel'
 cerebras_qwen_3_235b_a22b_thinking_2507: 'BaseChatModel'
 cerebras_qwen_3_coder_480b: 'BaseChatModel'
 
+minimax_m3: 'BaseChatModel'
 minimax_m2_7: 'BaseChatModel'
 minimax_m2_7_highspeed: 'BaseChatModel'
-minimax_m2_5: 'BaseChatModel'
-minimax_m2_5_highspeed: 'BaseChatModel'
 
 bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
@@ -214,10 +213,9 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('MINIMAX_API_KEY')
 		base_url = os.getenv('MINIMAX_BASE_URL', 'https://api.minimax.io/v1')
 		minimax_map = {
+			'm3': 'MiniMax-M3',
 			'm2-7': 'MiniMax-M2.7',
 			'm2-7-highspeed': 'MiniMax-M2.7-highspeed',
-			'm2-5': 'MiniMax-M2.5',
-			'm2-5-highspeed': 'MiniMax-M2.5-highspeed',
 		}
 		normalized = model.replace('_', '-')
 		resolved_model = minimax_map.get(normalized, model)
@@ -333,10 +331,9 @@ __all__ += [
 	'cerebras_qwen_3_235b_a22b_thinking_2507',
 	'cerebras_qwen_3_coder_480b',
 	# MiniMax instances - created on demand
+	'minimax_m3',
 	'minimax_m2_7',
 	'minimax_m2_7_highspeed',
-	'minimax_m2_5',
-	'minimax_m2_5_highspeed',
 	# Browser Use instances - created on demand
 	'bu_latest',
 	'bu_1_0',


### PR DESCRIPTION
## Summary
- Add MiniMax as a first-class LLM provider via OpenAI-compatible API
- Set MiniMax-M3 as the default model (512K context, 128K max output, image input support)
- Support MiniMax-M3 (default), MiniMax-M2.7, and MiniMax-M2.7-highspeed models
- Full ChatMiniMax implementation with text, structured output (JSON), and function calling support

## Changes
- Add `browser_use/llm/minimax/` package with `ChatMiniMax` provider and message serializer
- Register MiniMax in model factory (`models.py`) with `minimax_m3`, `minimax_m2_7`, `minimax_m2_7_highspeed` convenience instances
- Add `ChatMiniMax` to lazy imports in `__init__.py`
- Add `MINIMAX_API_KEY` to `.env.example`
- Update README with MiniMax usage examples (defaulting to MiniMax-M3)

## Why
MiniMax-M3 is the latest flagship model, with a 512K context window, up to 128K output, and image input support. This enables browser-use users to leverage MiniMax models for browser automation tasks. M2.7 and M2.7-highspeed remain available for users who need them.

## Testing
- Model resolution verified for all MiniMax model variants (m3, m2-7, m2-7-highspeed)
- Default model is M3 when no model is specified
- Backward compatibility confirmed (M2.7 models still accessible)
- Integration tested with MiniMax API

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MiniMax as a built-in LLM provider via its OpenAI-compatible API, with `MiniMax-M3` as the default model. Enables 512K context, up to 128K output, image input, and structured/function-calling responses.

- **New Features**
  - New `browser_use/llm/minimax/` with `ChatMiniMax` and message serializer.
  - Supports `MiniMax-M3`, `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`.
  - Text, JSON structured output, and function calling (gracefully handles text responses when tools are provided).
  - Image input via `image_url` content parts.
  - Registered in model factory and lazy imports with `minimax_m3`, `minimax_m2_7`, `minimax_m2_7_highspeed`.

- **Migration**
  - Set `MINIMAX_API_KEY` (optional `MINIMAX_BASE_URL`).
  - Use `ChatMiniMax()` or the convenience instances (e.g., `minimax_m3`).

<sup>Written for commit 7822af804f42af8205fc3c8f53505edef3bf1774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

