### PR TITLE
feat(tools): enforce browser action policies

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.openai.chat import ChatOpenAI
 	from browser_use.llm.vercel.chat import ChatVercel
 	from browser_use.sandbox import sandbox
+	from browser_use.tools.policy import ActionPolicy, ActionPolicyDecision
 	from browser_use.tools.service import Controller, Tools
 
 	# Lazy imports mapping - only import when actually accessed
@@ -85,6 +86,8 @@ _LAZY_IMPORTS = {
 	# Tools (moderate weight)
 	'Tools': ('browser_use.tools.service', 'Tools'),
 	'Controller': ('browser_use.tools.service', 'Controller'),  # alias
+	'ActionPolicy': ('browser_use.tools.policy', 'ActionPolicy'),
+	'ActionPolicyDecision': ('browser_use.tools.policy', 'ActionPolicyDecision'),
 	# DOM service (moderate weight)
 	'DomService': ('browser_use.dom.service', 'DomService'),
 	# Chat models (very heavy imports)
@@ -139,6 +142,8 @@ __all__ = [
 	'ActionResult',
 	'ActionModel',
 	'AgentHistoryList',
+	'ActionPolicy',
+	'ActionPolicyDecision',
 	# Chat models
 	'ChatOpenAI',
 	'ChatGoogle',

--- a/browser_use/tools/policy.py
+++ b/browser_use/tools/policy.py
@@ -97,6 +97,31 @@ class ActionPolicy(BaseModel):
 			raise ActionPolicyViolation(decision)
 		return decision
 
+	def assert_current_url_available(self, action_name: str, params: BaseModel | dict[str, Any]) -> None:
+		"""Fail closed when a domain-scoped policy cannot inspect the current page URL."""
+
+		if not self.requires_current_url(action_name, params):
+			return
+		params_dict = params.model_dump(mode='json') if isinstance(params, BaseModel) else params
+		raise ActionPolicyViolation(
+			ActionPolicyDecision(
+				allowed=False,
+				action_name=action_name,
+				risk=self.custom_action_risks.get(action_name, _default_action_risk(action_name)),
+				reason='Current page URL is unavailable; domain-scoped action policy cannot be evaluated safely.',
+				target_url=_target_url_for_action(action_name, params_dict),
+				matched_rule='current_url_unavailable',
+			)
+		)
+
+	def requires_current_url(self, action_name: str, params: BaseModel | dict[str, Any]) -> bool:
+		"""Return whether this policy must inspect the current URL for this action."""
+
+		if self.allowed_domains is None and not self.blocked_domains:
+			return False
+		params_dict = params.model_dump(mode='json') if isinstance(params, BaseModel) else params
+		return _target_url_for_action(action_name, params_dict) is None
+
 	def _evaluate_action_name(
 		self, action_name: str, risk: ActionRisk, current_url: str | None, target_url: str | None
 	) -> ActionPolicyDecision | None:

--- a/browser_use/tools/policy.py
+++ b/browser_use/tools/policy.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from browser_use.utils import match_url_with_domain_pattern
+
+ActionRisk = Literal['read', 'navigation', 'interactive', 'transactional']
+
+READ_ACTIONS = {
+	'done',
+	'extract',
+	'find_elements',
+	'get_dropdown_options',
+	'go_back',
+	'screenshot',
+	'search_page',
+	'scroll',
+	'switch_tab',
+	'wait',
+}
+NAVIGATION_ACTIONS = {'navigate', 'search'}
+INTERACTIVE_ACTIONS = {'click', 'input', 'select_dropdown_option', 'send_keys'}
+TRANSACTIONAL_ACTIONS = {'save_pdf', 'upload_file'}
+
+
+class ActionPolicyDecision(BaseModel):
+	"""Result of evaluating one browser action against an action policy."""
+
+	allowed: bool
+	action_name: str
+	risk: ActionRisk
+	reason: str
+	current_url: str | None = None
+	target_url: str | None = None
+	matched_rule: str | None = None
+
+
+class ActionPolicyViolation(RuntimeError):
+	"""Raised when an action policy blocks an action before execution."""
+
+	def __init__(self, decision: ActionPolicyDecision):
+		self.decision = decision
+		super().__init__(decision.reason)
+
+
+class ActionPolicy(BaseModel):
+	"""Pre-execution guardrails for browser actions.
+
+	The policy is evaluated centrally in the action registry, so it applies to
+	default browser actions, MCP-backed tools, and custom registered actions.
+	"""
+
+	read_only: bool = False
+	allowed_actions: set[str] | None = None
+	blocked_actions: set[str] = Field(default_factory=set)
+	allowed_domains: list[str] | None = None
+	blocked_domains: list[str] = Field(default_factory=list)
+	block_interactive: bool = False
+	block_transactional: bool = True
+	custom_action_risks: dict[str, ActionRisk] = Field(default_factory=dict)
+
+	def evaluate(
+		self, action_name: str, params: BaseModel | dict[str, Any], current_url: str | None = None
+	) -> ActionPolicyDecision:
+		"""Evaluate whether an action should run."""
+
+		params_dict = params.model_dump(mode='json') if isinstance(params, BaseModel) else params
+		target_url = _target_url_for_action(action_name, params_dict)
+		risk = self.custom_action_risks.get(action_name, _default_action_risk(action_name))
+
+		decision = self._evaluate_action_name(action_name, risk, current_url, target_url)
+		if decision is not None:
+			return decision
+
+		url_decision = self._evaluate_urls(action_name, risk, current_url, target_url)
+		if url_decision is not None:
+			return url_decision
+
+		return ActionPolicyDecision(
+			allowed=True,
+			action_name=action_name,
+			risk=risk,
+			reason='Action allowed by policy.',
+			current_url=current_url,
+			target_url=target_url,
+		)
+
+	def assert_allowed(
+		self, action_name: str, params: BaseModel | dict[str, Any], current_url: str | None = None
+	) -> ActionPolicyDecision:
+		"""Evaluate an action and raise if it is blocked."""
+
+		decision = self.evaluate(action_name, params, current_url=current_url)
+		if not decision.allowed:
+			raise ActionPolicyViolation(decision)
+		return decision
+
+	def _evaluate_action_name(
+		self, action_name: str, risk: ActionRisk, current_url: str | None, target_url: str | None
+	) -> ActionPolicyDecision | None:
+		if self.allowed_actions is not None and action_name not in self.allowed_actions:
+			return _blocked(action_name, risk, 'Action is not in allowed_actions.', 'allowed_actions', current_url, target_url)
+		if action_name in self.blocked_actions:
+			return _blocked(action_name, risk, 'Action is listed in blocked_actions.', 'blocked_actions', current_url, target_url)
+		if self.read_only and risk != 'read':
+			return _blocked(action_name, risk, f'Read-only policy blocks {risk} actions.', 'read_only', current_url, target_url)
+		if self.block_interactive and risk in {'interactive', 'transactional'}:
+			return _blocked(action_name, risk, f'Policy blocks {risk} actions.', 'block_interactive', current_url, target_url)
+		if self.block_transactional and risk == 'transactional':
+			return _blocked(
+				action_name, risk, 'Policy blocks transactional actions.', 'block_transactional', current_url, target_url
+			)
+		return None
+
+	def _evaluate_urls(
+		self, action_name: str, risk: ActionRisk, current_url: str | None, target_url: str | None
+	) -> ActionPolicyDecision | None:
+		for url, label in ((target_url, 'target_url'), (current_url, 'current_url')):
+			if not url:
+				continue
+			if _matches_any(url, self.blocked_domains):
+				return _blocked(
+					action_name, risk, f'Policy blocks {label} domain: {url}', 'blocked_domains', current_url, target_url
+				)
+			if self.allowed_domains is not None and not _matches_any(url, self.allowed_domains):
+				return _blocked(
+					action_name,
+					risk,
+					f'Policy does not allow {label} domain: {url}',
+					'allowed_domains',
+					current_url,
+					target_url,
+				)
+		return None
+
+
+def _blocked(
+	action_name: str,
+	risk: ActionRisk,
+	reason: str,
+	matched_rule: str,
+	current_url: str | None,
+	target_url: str | None,
+) -> ActionPolicyDecision:
+	return ActionPolicyDecision(
+		allowed=False,
+		action_name=action_name,
+		risk=risk,
+		reason=reason,
+		current_url=current_url,
+		target_url=target_url,
+		matched_rule=matched_rule,
+	)
+
+
+def _default_action_risk(action_name: str) -> ActionRisk:
+	if action_name in READ_ACTIONS:
+		return 'read'
+	if action_name in NAVIGATION_ACTIONS:
+		return 'navigation'
+	if action_name in TRANSACTIONAL_ACTIONS:
+		return 'transactional'
+	if action_name in INTERACTIVE_ACTIONS:
+		return 'interactive'
+	return 'interactive'
+
+
+def _target_url_for_action(action_name: str, params: dict[str, Any]) -> str | None:
+	if action_name == 'navigate':
+		url = params.get('url')
+		return str(url) if url else None
+	if action_name == 'search':
+		engine = str(params.get('engine') or 'google').lower()
+		search_domains = {
+			'duckduckgo': 'https://duckduckgo.com',
+			'google': 'https://www.google.com',
+			'bing': 'https://www.bing.com',
+		}
+		return search_domains.get(engine)
+	return None
+
+
+def _matches_any(url: str, patterns: list[str]) -> bool:
+	return any(match_url_with_domain_pattern(url, pattern) for pattern in patterns)

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -16,6 +16,7 @@ from browser_use.filesystem.file_system import FileSystem
 from browser_use.llm.base import BaseChatModel
 from browser_use.observability import observe_debug
 from browser_use.telemetry.service import ProductTelemetry
+from browser_use.tools.policy import ActionPolicy, ActionPolicyViolation
 from browser_use.tools.registry.views import (
 	ActionModel,
 	ActionRegistry,
@@ -32,11 +33,12 @@ logger = logging.getLogger(__name__)
 class Registry(Generic[Context]):
 	"""Service for registering and managing actions"""
 
-	def __init__(self, exclude_actions: list[str] | None = None):
+	def __init__(self, exclude_actions: list[str] | None = None, action_policy: ActionPolicy | None = None):
 		self.registry = ActionRegistry()
 		self.telemetry = ProductTelemetry()
 		# Create a new list to avoid mutable default argument issues
 		self.exclude_actions = list(exclude_actions) if exclude_actions is not None else []
+		self.action_policy = action_policy
 
 	def exclude_action(self, action_name: str) -> None:
 		"""Exclude an action from the registry after initialization.
@@ -350,18 +352,20 @@ class Registry(Generic[Context]):
 			except Exception as e:
 				raise ValueError(f'Invalid parameters {params} for action {action_name}: {type(e)}: {e}') from e
 
+			current_url = None
+			if browser_session and browser_session.agent_focus_target_id:
+				try:
+					target = browser_session.session_manager.get_target(browser_session.agent_focus_target_id)
+					if target:
+						current_url = target.url
+				except Exception:
+					pass
+
 			if sensitive_data:
-				# Get current URL if browser_session is provided
-				current_url = None
-				if browser_session and browser_session.agent_focus_target_id:
-					try:
-						# Get current page info from session_manager
-						target = browser_session.session_manager.get_target(browser_session.agent_focus_target_id)
-						if target:
-							current_url = target.url
-					except Exception:
-						pass
 				validated_params = self._replace_sensitive_data(validated_params, sensitive_data, current_url)
+
+			if self.action_policy is not None:
+				self.action_policy.assert_allowed(action_name, validated_params, current_url=current_url)
 
 			# Build special context dict
 			special_context = {
@@ -405,6 +409,8 @@ class Registry(Generic[Context]):
 				raise RuntimeError(f'Error executing action {action_name}: {str(e)}') from e
 		except TimeoutError as e:
 			raise RuntimeError(f'Error executing action {action_name} due to timeout.') from e
+		except ActionPolicyViolation as e:
+			raise RuntimeError(f'Action policy blocked {action_name}: {e.decision.reason}') from e
 		except Exception as e:
 			raise RuntimeError(f'Error executing action {action_name}: {str(e)}') from e
 

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -353,20 +353,19 @@ class Registry(Generic[Context]):
 				raise ValueError(f'Invalid parameters {params} for action {action_name}: {type(e)}: {e}') from e
 
 			current_url = None
-			current_url_lookup_failed = False
 			if browser_session and browser_session.agent_focus_target_id:
 				try:
 					target = browser_session.session_manager.get_target(browser_session.agent_focus_target_id)
 					if target:
 						current_url = target.url
 				except Exception:
-					current_url_lookup_failed = True
+					pass
 
 			if sensitive_data:
 				validated_params = self._replace_sensitive_data(validated_params, sensitive_data, current_url)
 
 			if self.action_policy is not None:
-				if current_url_lookup_failed:
+				if current_url is None:
 					self.action_policy.assert_current_url_available(action_name, validated_params)
 				self.action_policy.assert_allowed(action_name, validated_params, current_url=current_url)
 

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -353,18 +353,21 @@ class Registry(Generic[Context]):
 				raise ValueError(f'Invalid parameters {params} for action {action_name}: {type(e)}: {e}') from e
 
 			current_url = None
+			current_url_lookup_failed = False
 			if browser_session and browser_session.agent_focus_target_id:
 				try:
 					target = browser_session.session_manager.get_target(browser_session.agent_focus_target_id)
 					if target:
 						current_url = target.url
 				except Exception:
-					pass
+					current_url_lookup_failed = True
 
 			if sensitive_data:
 				validated_params = self._replace_sensitive_data(validated_params, sensitive_data, current_url)
 
 			if self.action_policy is not None:
+				if current_url_lookup_failed:
+					self.action_policy.assert_current_url_available(action_name, validated_params)
 				self.action_policy.assert_allowed(action_name, validated_params, current_url=current_url)
 
 			# Build special context dict

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -35,6 +35,7 @@ from browser_use.filesystem.file_system import FileSystem
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.messages import SystemMessage, UserMessage
 from browser_use.observability import observe_debug
+from browser_use.tools.policy import ActionPolicy
 from browser_use.tools.registry.service import Registry
 from browser_use.tools.utils import get_click_description
 from browser_use.tools.views import (
@@ -423,8 +424,9 @@ class Tools(Generic[Context]):
 		exclude_actions: list[str] | None = None,
 		output_model: type[T] | None = None,
 		display_files_in_done_text: bool = True,
+		action_policy: ActionPolicy | None = None,
 	):
-		self.registry = Registry[Context](exclude_actions if exclude_actions is not None else [])
+		self.registry = Registry[Context](exclude_actions if exclude_actions is not None else [], action_policy=action_policy)
 		self.display_files_in_done_text = display_files_in_done_text
 		self._output_model: type[BaseModel] | None = output_model
 		self._coordinate_clicking_enabled: bool = False

--- a/examples/features/action_policy.py
+++ b/examples/features/action_policy.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from browser_use import ActionPolicy, Agent, ChatOpenAI, Tools
+
+
+async def main():
+	llm = ChatOpenAI(model='gpt-4.1-mini')
+
+	# Good for research / monitoring tasks: the agent can inspect pages but cannot
+	# click, type, upload files, or navigate outside the allowed domains.
+	read_only_tools = Tools(
+		action_policy=ActionPolicy(
+			read_only=True,
+			allowed_domains=['browser-use.com', '*.browser-use.com', 'github.com'],
+		)
+	)
+	research_agent = Agent(
+		task='Read the Browser Use docs and summarize what MCP tools are available.',
+		llm=llm,
+		tools=read_only_tools,
+	)
+	await research_agent.run()
+
+	# For workflows that need clicks/forms, keep the domain boundary and still
+	# block transactional actions such as file uploads unless explicitly allowed.
+	scoped_tools = Tools(
+		action_policy=ActionPolicy(
+			allowed_domains=['example.com'],
+			block_transactional=True,
+		)
+	)
+	form_agent = Agent(
+		task='Open example.com and interact only if needed to inspect the page.',
+		llm=llm,
+		tools=scoped_tools,
+	)
+	await form_agent.run()
+
+
+if __name__ == '__main__':
+	asyncio.run(main())

--- a/tests/ci/security/test_action_policy.py
+++ b/tests/ci/security/test_action_policy.py
@@ -1,7 +1,10 @@
+from typing import cast
+
 import pytest
 from pydantic import BaseModel
 
 from browser_use.agent.views import ActionResult
+from browser_use.browser.session import BrowserSession
 from browser_use.tools.policy import ActionPolicy
 from browser_use.tools.registry.service import Registry
 from browser_use.tools.service import Tools
@@ -105,6 +108,6 @@ async def test_domain_policy_fails_closed_when_current_url_lookup_fails():
 		return ActionResult(extracted_content=params.text)
 
 	with pytest.raises(RuntimeError, match='Current page URL is unavailable'):
-		await registry.execute_action('click', {'text': 'Sign in'}, browser_session=FailingBrowserSession())
+		await registry.execute_action('click', {'text': 'Sign in'}, browser_session=cast(BrowserSession, FailingBrowserSession()))
 
 	assert executed is False

--- a/tests/ci/security/test_action_policy.py
+++ b/tests/ci/security/test_action_policy.py
@@ -1,0 +1,83 @@
+import pytest
+from pydantic import BaseModel
+
+from browser_use.agent.views import ActionResult
+from browser_use.tools.policy import ActionPolicy
+from browser_use.tools.registry.service import Registry
+from browser_use.tools.service import Tools
+
+
+class TextParams(BaseModel):
+	text: str
+
+
+class NavigateParams(BaseModel):
+	url: str
+	new_tab: bool = False
+
+
+class UploadParams(BaseModel):
+	path: str
+
+
+@pytest.mark.asyncio
+async def test_read_only_policy_blocks_interactive_actions_before_execution():
+	executed = False
+	registry = Registry(action_policy=ActionPolicy(read_only=True))
+
+	@registry.action('', param_model=TextParams)
+	async def input(params: TextParams):
+		nonlocal executed
+		executed = True
+		return ActionResult(extracted_content=params.text)
+
+	with pytest.raises(RuntimeError, match='Action policy blocked input'):
+		await registry.execute_action('input', {'text': 'hello'})
+
+	assert executed is False
+
+
+@pytest.mark.asyncio
+async def test_action_policy_blocks_navigation_target_outside_allowed_domains():
+	executed = False
+	registry = Registry(action_policy=ActionPolicy(allowed_domains=['example.com'], block_transactional=False))
+
+	@registry.action('', param_model=NavigateParams)
+	async def navigate(params: NavigateParams):
+		nonlocal executed
+		executed = True
+		return ActionResult(extracted_content=f'Navigated to {params.url}')
+
+	with pytest.raises(RuntimeError, match='Policy does not allow target_url domain'):
+		await registry.execute_action('navigate', {'url': 'https://evil.com/phish', 'new_tab': False})
+
+	assert executed is False
+
+	result = await registry.execute_action('navigate', {'url': 'https://example.com/docs', 'new_tab': False})
+	assert result.extracted_content == 'Navigated to https://example.com/docs'
+	assert executed is True
+
+
+@pytest.mark.asyncio
+async def test_transactional_actions_are_blocked_by_default():
+	executed = False
+	registry = Registry(action_policy=ActionPolicy())
+
+	@registry.action('', param_model=UploadParams)
+	async def upload_file(params: UploadParams):
+		nonlocal executed
+		executed = True
+		return ActionResult(extracted_content=f'Uploaded {params.path}')
+
+	with pytest.raises(RuntimeError, match='Policy blocks transactional actions'):
+		await registry.execute_action('upload_file', {'path': '/tmp/report.pdf'})
+
+	assert executed is False
+
+
+@pytest.mark.asyncio
+async def test_tools_passes_action_policy_to_default_registry():
+	tools = Tools(action_policy=ActionPolicy(read_only=True))
+
+	with pytest.raises(RuntimeError, match='Action policy blocked navigate'):
+		await tools.registry.execute_action('navigate', {'url': 'https://example.com', 'new_tab': False})

--- a/tests/ci/security/test_action_policy.py
+++ b/tests/ci/security/test_action_policy.py
@@ -20,6 +20,16 @@ class UploadParams(BaseModel):
 	path: str
 
 
+class FailingSessionManager:
+	def get_target(self, target_id: str):
+		raise RuntimeError(f'Cannot resolve target {target_id}')
+
+
+class FailingBrowserSession:
+	agent_focus_target_id = 'target-1'
+	session_manager = FailingSessionManager()
+
+
 @pytest.mark.asyncio
 async def test_read_only_policy_blocks_interactive_actions_before_execution():
 	executed = False
@@ -81,3 +91,20 @@ async def test_tools_passes_action_policy_to_default_registry():
 
 	with pytest.raises(RuntimeError, match='Action policy blocked navigate'):
 		await tools.registry.execute_action('navigate', {'url': 'https://example.com', 'new_tab': False})
+
+
+@pytest.mark.asyncio
+async def test_domain_policy_fails_closed_when_current_url_lookup_fails():
+	executed = False
+	registry = Registry(action_policy=ActionPolicy(allowed_domains=['example.com'], block_transactional=False))
+
+	@registry.action('', param_model=TextParams)
+	async def click(params: TextParams):
+		nonlocal executed
+		executed = True
+		return ActionResult(extracted_content=params.text)
+
+	with pytest.raises(RuntimeError, match='Current page URL is unavailable'):
+		await registry.execute_action('click', {'text': 'Sign in'}, browser_session=FailingBrowserSession())
+
+	assert executed is False


### PR DESCRIPTION
## Summary
- add `ActionPolicy` for pre-execution browser action guardrails
- enforce policies centrally in `Registry.execute_action()` so default tools, custom actions, and MCP-backed tools use the same gate
- support read-only mode, allowed/blocked action sets, domain allow/block lists, and transactional-action blocking
- expose `ActionPolicy` from `browser_use` and add a feature example

Refs #4634.

## Why this matters
Browser agents need a guard between LLM intent and real browser execution. `allowed_domains` helps at the navigation layer, but users also need action-level boundaries: research-only runs should not click/type/upload, and domain-scoped workflows should fail before a risky action executes.

This PR keeps the default behavior unchanged unless a policy is passed into `Tools(action_policy=...)`.

## Tests
- `PYTHONPATH=. /Users/ritwij/Library/Python/3.9/bin/uv run --dev pytest tests/ci/security/test_action_policy.py -q`
- `PYTHONPATH=. /Users/ritwij/Library/Python/3.9/bin/uv run --dev pytest tests/ci/security/test_action_policy.py tests/ci/infrastructure/test_registry_core.py tests/ci/infrastructure/test_registry_action_parameter_injection.py -q`
- `/Users/ritwij/Library/Python/3.9/bin/uv run --dev ruff check browser_use/tools/policy.py browser_use/tools/registry/service.py browser_use/tools/service.py browser_use/__init__.py tests/ci/security/test_action_policy.py examples/features/action_policy.py`
- `/Users/ritwij/Library/Python/3.9/bin/uv run --dev ruff format browser_use/tools/policy.py browser_use/tools/registry/service.py browser_use/tools/service.py browser_use/__init__.py tests/ci/security/test_action_policy.py examples/features/action_policy.py --check`

## Notes
- I read the project contribution notes before opening this.
- AI assistance was used to draft and review parts of the patch; I set up the repo locally and ran the checks above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add pre-execution browser action guardrails with a new `ActionPolicy` enforced in `Registry.execute_action()` across all tools. Behavior is unchanged unless a policy is provided; transactional actions are blocked by default, and domain-scoped policies now require the current URL and fail closed if it’s unavailable.

- **New Features**
  - Add `ActionPolicy` and `ActionPolicyDecision` with risk levels (read, navigation, interactive, transactional) and custom overrides.
  - Enforce policy in `Registry.execute_action()` for all tools; violations raise a clear error before any action runs.
  - Support read-only mode; allow/block actions; allow/block domains; optional blocks for interactive/transactional; current/target URL checks. `Tools` accepts `action_policy`. Types exported from `browser_use`.

- **Bug Fixes**
  - Require current URL for domain-scoped policies; block with a clear error if it cannot be read.

<sup>Written for commit 25431529f15d52bf30605c65d07d623194be7c75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

