### PR TITLE
fix(utils): raise ValueError instead of bare Exception in merge_dicts

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -481,17 +481,20 @@ def is_unsafe_pattern(pattern: str) -> bool:
 	return '*' in bare_domain
 
 
+_NEW_TAB_URLS: frozenset[str] = frozenset(
+	{
+		'about:blank',
+		'chrome://new-tab-page/',
+		'chrome://new-tab-page',
+		'chrome://newtab/',
+		'chrome://newtab',
+	}
+)
+
+
 def is_new_tab_page(url: str) -> bool:
-	"""
-	Check if a URL is a new tab page (about:blank, chrome://new-tab-page, or chrome://newtab).
-
-	Args:
-		url: The URL to check
-
-	Returns:
-		bool: True if the URL is a new tab page, False otherwise
-	"""
-	return url in ('about:blank', 'chrome://new-tab-page/', 'chrome://new-tab-page', 'chrome://newtab/', 'chrome://newtab')
+	"""Check if a URL is a new tab page (about:blank, chrome://new-tab-page, or chrome://newtab)."""
+	return url in _NEW_TAB_URLS
 
 
 def match_url_with_domain_pattern(url: str, domain_pattern: str, log_warnings: bool = False) -> bool:
@@ -604,7 +607,7 @@ def merge_dicts(a: dict, b: dict, path: tuple[str, ...] = ()):
 			elif isinstance(a[key], list) and isinstance(b[key], list):
 				a[key] = a[key] + b[key]
 			elif a[key] != b[key]:
-				raise Exception('Conflict at ' + '.'.join(path + (str(key),)))
+				raise ValueError('Conflict at ' + '.'.join(path + (str(key),)))
 		else:
 			a[key] = b[key]
 	return a


### PR DESCRIPTION
Bare Exception is an anti-pattern; callers can't selectively catch it without also swallowing every other exception type. ValueError is the semantically correct choice for conflicting values during a merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch merge_dicts to raise ValueError on conflicts so callers can handle merge errors explicitly. Also refactor is_new_tab_page by moving new-tab URLs into a shared frozenset; no behavior change.

- **Refactors**
  - merge_dicts: raise ValueError on conflicting keys; error message unchanged.
  - is_new_tab_page: use _NEW_TAB_URLS (frozenset) for membership; URL set unchanged.

<sup>Written for commit 1a55720b3b8ea86a882c91703ca14364a5799946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

