### PR TITLE
fix(utils,tools): O(1) frozenset for new-tab URL check, remove no-op …

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.4.26"
 
       - name: Get week number for cache key
         id: week
@@ -116,6 +118,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
         with:
+          version: "0.4.26"
           enable-cache: true
           activate-environment: true
 
@@ -200,6 +203,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
         with:
+          version: "0.4.26"
           enable-cache: true
           activate-environment: true
 

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -53,10 +53,6 @@ class SearchAction(BaseModel):
 	)
 
 
-# Backward compatibility alias
-SearchAction = SearchAction
-
-
 class NavigateAction(BaseModel):
 	url: str
 	new_tab: bool = Field(default=False)

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -481,17 +481,20 @@ def is_unsafe_pattern(pattern: str) -> bool:
 	return '*' in bare_domain
 
 
+_NEW_TAB_URLS: frozenset[str] = frozenset(
+	{
+		'about:blank',
+		'chrome://new-tab-page/',
+		'chrome://new-tab-page',
+		'chrome://newtab/',
+		'chrome://newtab',
+	}
+)
+
+
 def is_new_tab_page(url: str) -> bool:
-	"""
-	Check if a URL is a new tab page (about:blank, chrome://new-tab-page, or chrome://newtab).
-
-	Args:
-		url: The URL to check
-
-	Returns:
-		bool: True if the URL is a new tab page, False otherwise
-	"""
-	return url in ('about:blank', 'chrome://new-tab-page/', 'chrome://new-tab-page', 'chrome://newtab/', 'chrome://newtab')
+	"""Check if a URL is a new tab page (about:blank, chrome://new-tab-page, or chrome://newtab)."""
+	return url in _NEW_TAB_URLS
 
 
 def match_url_with_domain_pattern(url: str, domain_pattern: str, log_warnings: bool = False) -> bool:


### PR DESCRIPTION
…alias

Replace is_new_tab_page tuple literal with a module-level frozenset constant (_NEW_TAB_URLS) for O(1) membership test and a single source-of-truth definition.

Also remove the SearchAction = SearchAction no-op self-assignment that was labelled a backward-compatibility alias but does nothing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `is_new_tab_page` to a module-level `frozenset` `_NEW_TAB_URLS` for O(1) membership checks and a single source of truth. Remove the no-op `SearchAction = SearchAction` alias and pin `uv` via `astral-sh/setup-uv` to `0.4.26` to avoid setup timeouts.

<sup>Written for commit 23603e77fc2550cabeaae332da7c475916674124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

