### PR TITLE
  feat(tools): add hover action to agent for CSS :hover interactions and dropdown menus

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -328,6 +328,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		)
 		if supports_coordinate_clicking:
 			self.tools.set_coordinate_clicking(True)
+			self.tools.set_coordinate_hovering(True)
 
 		# Handle skills vs skill_ids parameter (skills takes precedence)
 		if skills and skill_ids:

--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -144,6 +144,23 @@ class ClickCoordinateEvent(BaseEvent[dict]):
 	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ClickCoordinateEvent', 15.0))  # seconds
 
 
+class HoverElementEvent(ElementSelectedEvent[dict[str, Any] | None]):
+	"""Hover over an element."""
+
+	node: 'EnhancedDOMTreeNode'
+
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverElementEvent', 5.0))  # seconds
+
+
+class HoverCoordinateEvent(BaseEvent[dict]):
+	"""Hover at specific coordinates."""
+
+	coordinate_x: int
+	coordinate_y: int
+
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverCoordinateEvent', 5.0))  # seconds
+
+
 class TypeTextEvent(ElementSelectedEvent[dict | None]):
 	"""Type text into an element."""
 

--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -149,7 +149,7 @@ class HoverElementEvent(ElementSelectedEvent[dict[str, Any] | None]):
 
 	node: 'EnhancedDOMTreeNode'
 
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverElementEvent', 5.0))  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverElementEvent', 10.0))  # seconds
 
 
 class HoverCoordinateEvent(BaseEvent[dict]):
@@ -158,7 +158,7 @@ class HoverCoordinateEvent(BaseEvent[dict]):
 	coordinate_x: int
 	coordinate_y: int
 
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverCoordinateEvent', 5.0))  # seconds
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverCoordinateEvent', 10.0))  # seconds
 
 
 class TypeTextEvent(ElementSelectedEvent[dict | None]):

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -453,8 +453,13 @@ class DefaultActionWatchdog(BaseWatchdog):
 		except Exception:
 			raise
 
+	@observe_debug(ignore_input=True, ignore_output=True, name='hover_element_event')
 	async def on_HoverElementEvent(self, event: HoverElementEvent) -> dict[str, Any] | None:
-		"""Handle hover over element via CDP mouseMoved."""
+		"""Handle hover request on an element using CDP Input.dispatchMouseEvent with mouseMoved.
+
+		This triggers genuine CSS :hover state transitions and the full DOM event cascade
+		(mouseenter, mouseover, mousemove), unlike synthetic dispatchEvent calls.
+		"""
 		try:
 			# Check if session is alive before attempting any operations
 			if not self.browser_session.agent_focus_target_id:
@@ -493,7 +498,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 					params={'backendNodeId': backend_node_id}, session_id=session_id
 				)
 				await asyncio.sleep(0.05)  # Wait for scroll to complete
-				self.logger.debug('Scrolled element into view before hover')
+				self.logger.debug('Scrolled element into view before getting coordinates')
 			except Exception as e:
 				self.logger.debug(f'Failed to scroll element into view: {e}')
 
@@ -502,37 +507,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# If we still don't have coordinates, fall back to JS hover
 			if not element_rect:
-				self.logger.warning('Could not get element geometry for hover, falling back to JavaScript hover events')
-				try:
-					result = await cdp_session.cdp_client.send.DOM.resolveNode(
-						params={'backendNodeId': backend_node_id},
-						session_id=session_id,
-					)
-					assert 'object' in result and 'objectId' in result['object'], (
-						'Failed to find DOM element based on backendNodeId, maybe page content changed?'
-					)
-					object_id = result['object']['objectId']
-
-					await cdp_session.cdp_client.send.Runtime.callFunctionOn(
-						params={
-							'functionDeclaration': """function() {
-								const evts = ['mouseover', 'mouseenter', 'mousemove'];
-								evts.forEach(name => {
-									this.dispatchEvent(new MouseEvent(name, { bubbles: true, cancelable: true }));
-								});
-							}""",
-							'objectId': object_id,
-						},
-						session_id=session_id,
-					)
-					await asyncio.sleep(0.1)
-					return None
-				except Exception as js_e:
-					self.logger.warning(f'JavaScript hover also failed: {js_e}')
-					if 'No node with given id found' in str(js_e):
-						raise Exception('Element with given id not found')
-					else:
-						raise Exception(f'Failed to hover over element: {js_e}')
+				self.logger.warning('Could not get element geometry from any method, falling back to JavaScript hover')
+				return await self._hover_element_with_js(element_node, cdp_session, session_id)
 
 			# Calculate center point
 			center_x = element_rect.x + element_rect.width / 2
@@ -568,36 +544,9 @@ class DefaultActionWatchdog(BaseWatchdog):
 					},
 				}
 
-			except Exception as e:
-				self.logger.warning(f'CDP mouseMoved failed: {type(e).__name__}: {e}')
-				# Fall back to JavaScript hover events
-				try:
-					result = await cdp_session.cdp_client.send.DOM.resolveNode(
-						params={'backendNodeId': backend_node_id},
-						session_id=session_id,
-					)
-					assert 'object' in result and 'objectId' in result['object'], (
-						'Failed to find DOM element based on backendNodeId'
-					)
-					object_id = result['object']['objectId']
-
-					await cdp_session.cdp_client.send.Runtime.callFunctionOn(
-						params={
-							'functionDeclaration': """function() {
-								const evts = ['mouseover', 'mouseenter', 'mousemove'];
-								evts.forEach(name => {
-									this.dispatchEvent(new MouseEvent(name, { bubbles: true, cancelable: true }));
-								});
-							}""",
-							'objectId': object_id,
-						},
-						session_id=session_id,
-					)
-					await asyncio.sleep(0.1)
-					return None
-				except Exception as js_e:
-					self.logger.warning(f'JavaScript hover fallback also failed: {js_e}')
-					raise Exception(f'Failed to hover over element: {e}')
+			except Exception as cdp_e:
+				self.logger.warning(f'CDP mouseMoved failed: {type(cdp_e).__name__}: {cdp_e}, falling back to JavaScript hover')
+				return await self._hover_element_with_js(element_node, cdp_session, session_id)
 
 		except BrowserError as e:
 			raise e
@@ -613,8 +562,86 @@ class DefaultActionWatchdog(BaseWatchdog):
 				long_term_memory=f'Failed to hover over element {element_info}. The element may not be interactable or visible.',
 			)
 
+	async def _hover_element_with_js(
+		self, element_node: EnhancedDOMTreeNode, cdp_session, session_id: str
+	) -> dict[str, Any] | None:
+		"""Hover over an element using JavaScript event dispatch when CDP mouseMoved fails or no geometry available.
+
+		Dispatches mouseover/mouseenter/mousemove events with proper coordinates
+		from the element's bounding rect, and returns hover metadata.
+		"""
+		backend_node_id = element_node.backend_node_id
+		try:
+			result = await cdp_session.cdp_client.send.DOM.resolveNode(
+				params={'backendNodeId': backend_node_id},
+				session_id=session_id,
+			)
+			assert 'object' in result and 'objectId' in result['object'], (
+				'Failed to find DOM element based on backendNodeId, maybe page content changed?'
+			)
+			object_id = result['object']['objectId']
+
+			# Get bounding rect for coordinate injection into MouseEvent
+			bounds_result = await cdp_session.cdp_client.send.Runtime.callFunctionOn(
+				params={
+					'functionDeclaration': 'function() { const r = this.getBoundingClientRect(); return { x: r.x, y: r.y, width: r.width, height: r.height }; }',
+					'objectId': object_id,
+					'returnByValue': True,
+				},
+				session_id=session_id,
+			)
+			bounds = bounds_result.get('result', {}).get('value')
+			center_x = (bounds.get('x', 0) + bounds.get('width', 0) / 2) if bounds else 0
+			center_y = (bounds.get('y', 0) + bounds.get('height', 0) / 2) if bounds else 0
+
+			await cdp_session.cdp_client.send.Runtime.callFunctionOn(
+				params={
+					'functionDeclaration': """function(cx, cy) {
+						const evts = ['mouseover', 'mouseenter', 'mousemove'];
+						evts.forEach(name => {
+							this.dispatchEvent(new MouseEvent(name, {
+								bubbles: true,
+								cancelable: true,
+								clientX: cx,
+								clientY: cy,
+								screenX: cx,
+								screenY: cy
+							}));
+						});
+					}""",
+					'objectId': object_id,
+					'arguments': [{'value': center_x}, {'value': center_y}],
+				},
+				session_id=session_id,
+			)
+			await asyncio.sleep(0.1)
+
+			# Return hover metadata matching the CDP success path format
+			if bounds:
+				return {
+					'hover_x': center_x,
+					'hover_y': center_y,
+					'element_bbox': {
+						'x': int(bounds.get('x', 0)),
+						'y': int(bounds.get('y', 0)),
+						'width': int(bounds.get('width', 0)),
+						'height': int(bounds.get('height', 0)),
+					},
+				}
+			return None
+		except Exception as js_e:
+			self.logger.warning(f'CDP JavaScript hover also failed: {js_e}')
+			if 'No node with given id found' in str(js_e):
+				raise Exception('Element with given id not found')
+			else:
+				raise Exception(f'Failed to hover over element: {js_e}')
+
+	@observe_debug(ignore_input=True, ignore_output=True, name='hover_coordinate_event')
 	async def on_HoverCoordinateEvent(self, event: HoverCoordinateEvent) -> dict[str, Any] | None:
-		"""Handle hover at coordinates via CDP Input.dispatchMouseEvent."""
+		"""Handle hover at specific viewport coordinates using CDP Input.dispatchMouseEvent with mouseMoved.
+
+		This triggers genuine CSS :hover state transitions at the given viewport position.
+		"""
 		try:
 			# Check if session is alive before attempting any operations
 			if not self.browser_session.agent_focus_target_id:
@@ -627,6 +654,13 @@ class DefaultActionWatchdog(BaseWatchdog):
 			# Get CDP session
 			cdp_session = await self.browser_session.get_or_create_cdp_session()
 			session_id = cdp_session.session_id
+
+			# Clamp coordinates to viewport bounds
+			layout_metrics = await cdp_session.cdp_client.send.Page.getLayoutMetrics(session_id=session_id)
+			viewport_width = layout_metrics['layoutViewport']['clientWidth']
+			viewport_height = layout_metrics['layoutViewport']['clientHeight']
+			coordinate_x = max(0, min(viewport_width - 1, coordinate_x))
+			coordinate_y = max(0, min(viewport_height - 1, coordinate_y))
 
 			self.logger.debug(f'👆 Hovering at ({coordinate_x}, {coordinate_y})...')
 

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -476,7 +476,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 			raise
 
 	async def _hover_element_node_impl(self, element_node: EnhancedDOMTreeNode) -> dict[str, Any] | None:
-		"""Hover over an element using pure CDP with multiple fallback methods for getting element geometry. 
+		"""Hover over an element using pure CDP with multiple fallback methods for getting element geometry.
 
 		Args:
 			element_node: The DOM element to hover over

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+from typing import Any
 
 from cdp_use.cdp.input.commands import DispatchKeyEventParameters
 
@@ -13,6 +14,8 @@ from browser_use.browser.events import (
 	GetDropdownOptionsEvent,
 	GoBackEvent,
 	GoForwardEvent,
+	HoverCoordinateEvent,
+	HoverElementEvent,
 	RefreshEvent,
 	ScrollEvent,
 	ScrollToTextEvent,
@@ -32,6 +35,8 @@ from browser_use.observability import observe_debug
 ClickCoordinateEvent.model_rebuild()
 ClickElementEvent.model_rebuild()
 GetDropdownOptionsEvent.model_rebuild()
+HoverCoordinateEvent.model_rebuild()
+HoverElementEvent.model_rebuild()
 SelectDropdownOptionEvent.model_rebuild()
 TypeTextEvent.model_rebuild()
 ScrollEvent.model_rebuild()
@@ -447,6 +452,202 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 		except Exception:
 			raise
+
+	async def on_HoverElementEvent(self, event: HoverElementEvent) -> dict[str, Any] | None:
+		"""Handle hover over element via CDP mouseMoved."""
+		try:
+			# Check if session is alive before attempting any operations
+			if not self.browser_session.agent_focus_target_id:
+				error_msg = 'Cannot execute hover: browser session is corrupted (target_id=None). Session may have crashed.'
+				self.logger.error(f'{error_msg}')
+				raise BrowserError(error_msg)
+
+			element_node = event.node
+			hover_metadata = await self._hover_element_node_impl(element_node)
+
+			# Check for validation errors
+			if isinstance(hover_metadata, dict) and 'validation_error' in hover_metadata:
+				self.logger.info(f'{hover_metadata["validation_error"]}')
+				return hover_metadata
+
+			return hover_metadata
+
+		except Exception:
+			raise
+
+	async def _hover_element_node_impl(self, element_node: EnhancedDOMTreeNode) -> dict[str, Any] | None:
+		"""Hover over an element using pure CDP with multiple fallback methods for getting element geometry. 
+
+		Args:
+			element_node: The DOM element to hover over
+		"""
+		try:
+			# Get CDP client for the element's frame context
+			cdp_session = await self.browser_session.cdp_client_for_node(element_node)
+			session_id = cdp_session.session_id
+			backend_node_id = element_node.backend_node_id
+
+			# Scroll element into view FIRST before getting coordinates
+			try:
+				await cdp_session.cdp_client.send.DOM.scrollIntoViewIfNeeded(
+					params={'backendNodeId': backend_node_id}, session_id=session_id
+				)
+				await asyncio.sleep(0.05)  # Wait for scroll to complete
+				self.logger.debug('Scrolled element into view before hover')
+			except Exception as e:
+				self.logger.debug(f'Failed to scroll element into view: {e}')
+
+			# Get element coordinates using the unified method (3-layer fallback)
+			element_rect = await self.browser_session.get_element_coordinates(backend_node_id, cdp_session)
+
+			# If we still don't have coordinates, fall back to JS hover
+			if not element_rect:
+				self.logger.warning('Could not get element geometry for hover, falling back to JavaScript hover events')
+				try:
+					result = await cdp_session.cdp_client.send.DOM.resolveNode(
+						params={'backendNodeId': backend_node_id},
+						session_id=session_id,
+					)
+					assert 'object' in result and 'objectId' in result['object'], (
+						'Failed to find DOM element based on backendNodeId, maybe page content changed?'
+					)
+					object_id = result['object']['objectId']
+
+					await cdp_session.cdp_client.send.Runtime.callFunctionOn(
+						params={
+							'functionDeclaration': """function() {
+								const evts = ['mouseover', 'mouseenter', 'mousemove'];
+								evts.forEach(name => {
+									this.dispatchEvent(new MouseEvent(name, { bubbles: true, cancelable: true }));
+								});
+							}""",
+							'objectId': object_id,
+						},
+						session_id=session_id,
+					)
+					await asyncio.sleep(0.1)
+					return None
+				except Exception as js_e:
+					self.logger.warning(f'JavaScript hover also failed: {js_e}')
+					if 'No node with given id found' in str(js_e):
+						raise Exception('Element with given id not found')
+					else:
+						raise Exception(f'Failed to hover over element: {js_e}')
+
+			# Calculate center point
+			center_x = element_rect.x + element_rect.width / 2
+			center_y = element_rect.y + element_rect.height / 2
+
+			# Get viewport dimensions for clamping
+			layout_metrics = await cdp_session.cdp_client.send.Page.getLayoutMetrics(session_id=session_id)
+			viewport_width = layout_metrics['layoutViewport']['clientWidth']
+			viewport_height = layout_metrics['layoutViewport']['clientHeight']
+
+			# Clamp hover point to viewport bounds
+			center_x = max(0, min(viewport_width - 1, center_x))
+			center_y = max(0, min(viewport_height - 1, center_y))
+
+			# Move mouse to element center via CDP
+			try:
+				self.logger.debug(f'👆 Hovering over element at x: {center_x}px y: {center_y}px ...')
+				await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
+					params={'type': 'mouseMoved', 'x': center_x, 'y': center_y},
+					session_id=session_id,
+				)
+				await asyncio.sleep(0.1)  # Allow CSS :hover effects to trigger
+				self.logger.debug('👆 Hovered successfully using x,y coordinates')
+
+				return {
+					'hover_x': center_x,
+					'hover_y': center_y,
+					'element_bbox': {
+						'x': int(element_rect.x),
+						'y': int(element_rect.y),
+						'width': int(element_rect.width),
+						'height': int(element_rect.height),
+					},
+				}
+
+			except Exception as e:
+				self.logger.warning(f'CDP mouseMoved failed: {type(e).__name__}: {e}')
+				# Fall back to JavaScript hover events
+				try:
+					result = await cdp_session.cdp_client.send.DOM.resolveNode(
+						params={'backendNodeId': backend_node_id},
+						session_id=session_id,
+					)
+					assert 'object' in result and 'objectId' in result['object'], (
+						'Failed to find DOM element based on backendNodeId'
+					)
+					object_id = result['object']['objectId']
+
+					await cdp_session.cdp_client.send.Runtime.callFunctionOn(
+						params={
+							'functionDeclaration': """function() {
+								const evts = ['mouseover', 'mouseenter', 'mousemove'];
+								evts.forEach(name => {
+									this.dispatchEvent(new MouseEvent(name, { bubbles: true, cancelable: true }));
+								});
+							}""",
+							'objectId': object_id,
+						},
+						session_id=session_id,
+					)
+					await asyncio.sleep(0.1)
+					return None
+				except Exception as js_e:
+					self.logger.warning(f'JavaScript hover fallback also failed: {js_e}')
+					raise Exception(f'Failed to hover over element: {e}')
+
+		except BrowserError as e:
+			raise e
+		except Exception as e:
+			# Extract key element info for error message
+			element_info = f'<{element_node.tag_name or "unknown"}'
+			if element_node.backend_node_id:
+				element_info += f' index={element_node.backend_node_id}'
+			element_info += '>'
+
+			raise BrowserError(
+				message=f'Failed to hover over element: {str(e)}',
+				long_term_memory=f'Failed to hover over element {element_info}. The element may not be interactable or visible.',
+			)
+
+	async def on_HoverCoordinateEvent(self, event: HoverCoordinateEvent) -> dict[str, Any] | None:
+		"""Handle hover at coordinates via CDP Input.dispatchMouseEvent."""
+		try:
+			# Check if session is alive before attempting any operations
+			if not self.browser_session.agent_focus_target_id:
+				error_msg = 'Cannot execute hover: browser session is corrupted (target_id=None). Session may have crashed.'
+				self.logger.error(f'{error_msg}')
+				raise BrowserError(error_msg)
+
+			coordinate_x, coordinate_y = event.coordinate_x, event.coordinate_y
+
+			# Get CDP session
+			cdp_session = await self.browser_session.get_or_create_cdp_session()
+			session_id = cdp_session.session_id
+
+			self.logger.debug(f'👆 Hovering at ({coordinate_x}, {coordinate_y})...')
+
+			# Move mouse to coordinates via CDP
+			await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
+				params={'type': 'mouseMoved', 'x': coordinate_x, 'y': coordinate_y},
+				session_id=session_id,
+			)
+			await asyncio.sleep(0.1)  # Allow CSS :hover effects to trigger
+
+			self.logger.debug(f'👆 Hovered successfully at ({coordinate_x}, {coordinate_y})')
+
+			return {'hover_x': coordinate_x, 'hover_y': coordinate_y}
+
+		except BrowserError as e:
+			raise e
+		except Exception as e:
+			raise BrowserError(
+				message=f'Failed to hover at coordinates: {e}',
+				long_term_memory=f'Failed to hover at coordinates ({event.coordinate_x}, {event.coordinate_y}). The coordinates may be outside viewport or the page may have changed.',
+			)
 
 	async def on_TypeTextEvent(self, event: TypeTextEvent) -> dict | None:
 		"""Handle text input request with CDP."""

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -21,6 +21,8 @@ from browser_use.browser.events import (
 	CloseTabEvent,
 	GetDropdownOptionsEvent,
 	GoBackEvent,
+	HoverCoordinateEvent,
+	HoverElementEvent,
 	NavigateToUrlEvent,
 	ScrollEvent,
 	ScrollToTextEvent,
@@ -752,21 +754,18 @@ class Tools(Generic[Context]):
 			param_model=HoverAction,
 		)
 		async def hover(params: HoverAction, browser_session: BrowserSession) -> ActionResult:
-			"""Hover over an element using CDP mouse events with smooth movement."""
 			try:
-				# Handle hover by coordinates
 				if params.coordinate_x is not None and params.coordinate_y is not None:
-					# Convert coordinates from LLM size to original viewport size if resizing was used
 					actual_x, actual_y = _convert_llm_coordinates_to_viewport(
 						params.coordinate_x, params.coordinate_y, browser_session
 					)
 
-					page = await browser_session.must_get_current_page()
+					event = browser_session.event_bus.dispatch(HoverCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y))
+					await event
+					hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
 
-					# Smooth mouse movement to target coordinates
-					mouse = await page.mouse
-					await mouse.move(actual_x, actual_y)
-					await asyncio.sleep(0.1)  # Allow CSS :hover effects to trigger
+					if isinstance(hover_metadata, dict) and 'validation_error' in hover_metadata:
+						return ActionResult(error=hover_metadata['validation_error'])
 
 					memory = f'Hovered at coordinate {params.coordinate_x}, {params.coordinate_y}'
 					logger.info(f'👆 {memory}')
@@ -775,7 +774,6 @@ class Tools(Generic[Context]):
 						metadata={'hover_x': actual_x, 'hover_y': actual_y},
 					)
 
-				# Handle hover by index
 				if params.index is not None:
 					node = await browser_session.get_element_by_index(params.index)
 					if node is None:
@@ -783,26 +781,18 @@ class Tools(Generic[Context]):
 						logger.warning(f'⚠️ {msg}')
 						return ActionResult(extracted_content=msg)
 
-					# Highlight the element being hovered (truly non-blocking)
 					create_task_with_error_handling(
-						browser_session.highlight_interaction_element(node), name='highlight_hover_element', suppress_exceptions=True
+						browser_session.highlight_interaction_element(node),
+						name='highlight_hover_element',
+						suppress_exceptions=True,
 					)
 
-					# Get element bounding box to find center
-					if not node.snapshot_node or not node.snapshot_node.bounds:
-						return ActionResult(error=f'Could not get bounding box for element {params.index}')
+					event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
+					await event
+					hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
 
-					bounds = node.snapshot_node.bounds
-					center_x = int(bounds.x + bounds.width / 2)
-					center_y = int(bounds.y + bounds.height / 2)
-
-					page = await browser_session.must_get_current_page()
-					mouse = await page.mouse
-
-					# Two-step hover: move to center first (enter element), then to target position
-					# This triggers :hover effects more reliably than jumping directly to position
-					await mouse.move(center_x, center_y)
-					await asyncio.sleep(0.1)
+					if isinstance(hover_metadata, dict) and 'validation_error' in hover_metadata:
+						return ActionResult(error=hover_metadata['validation_error'])
 
 					element_desc = get_click_description(node)
 					memory = f'Hovered over {element_desc}'
@@ -811,9 +801,9 @@ class Tools(Generic[Context]):
 						extracted_content=memory,
 						metadata={
 							'hover_index': params.index,
-							'hover_x': center_x,
-							'hover_y': center_y,
-							'element_bbox': {'x': int(bounds.x), 'y': int(bounds.y), 'width': int(bounds.width), 'height': int(bounds.height)},
+							'hover_x': hover_metadata.get('hover_x') if isinstance(hover_metadata, dict) else None,
+							'hover_y': hover_metadata.get('hover_y') if isinstance(hover_metadata, dict) else None,
+							'element_bbox': hover_metadata.get('element_bbox') if isinstance(hover_metadata, dict) else None,
 						},
 					)
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -45,6 +45,7 @@ from browser_use.tools.views import (
 	ExtractAction,
 	FindElementsAction,
 	GetDropdownOptionsAction,
+	HoverAction,
 	InputTextAction,
 	NavigateAction,
 	NoParamsAction,
@@ -745,6 +746,85 @@ class Tools(Generic[Context]):
 
 		# Register click action (index-only by default)
 		self._register_click_action()
+
+		@self.registry.action(
+			'Hover over element by index or coordinates. Use to trigger dropdown menus, tooltips, or CSS hover effects.',
+			param_model=HoverAction,
+		)
+		async def hover(params: HoverAction, browser_session: BrowserSession) -> ActionResult:
+			"""Hover over an element using CDP mouse events with smooth movement."""
+			try:
+				# Handle hover by coordinates
+				if params.coordinate_x is not None and params.coordinate_y is not None:
+					# Convert coordinates from LLM size to original viewport size if resizing was used
+					actual_x, actual_y = _convert_llm_coordinates_to_viewport(
+						params.coordinate_x, params.coordinate_y, browser_session
+					)
+
+					page = await browser_session.must_get_current_page()
+
+					# Smooth mouse movement to target coordinates
+					mouse = await page.mouse
+					await mouse.move(actual_x, actual_y)
+					await asyncio.sleep(0.1)  # Allow CSS :hover effects to trigger
+
+					memory = f'Hovered at coordinate {params.coordinate_x}, {params.coordinate_y}'
+					logger.info(f'👆 {memory}')
+					return ActionResult(
+						extracted_content=memory,
+						metadata={'hover_x': actual_x, 'hover_y': actual_y},
+					)
+
+				# Handle hover by index
+				if params.index is not None:
+					node = await browser_session.get_element_by_index(params.index)
+					if node is None:
+						msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+						logger.warning(f'⚠️ {msg}')
+						return ActionResult(extracted_content=msg)
+
+					# Highlight the element being hovered (truly non-blocking)
+					create_task_with_error_handling(
+						browser_session.highlight_interaction_element(node), name='highlight_hover_element', suppress_exceptions=True
+					)
+
+					# Get element bounding box to find center
+					if not node.snapshot_node or not node.snapshot_node.bounds:
+						return ActionResult(error=f'Could not get bounding box for element {params.index}')
+
+					bounds = node.snapshot_node.bounds
+					center_x = int(bounds.x + bounds.width / 2)
+					center_y = int(bounds.y + bounds.height / 2)
+
+					page = await browser_session.must_get_current_page()
+					mouse = await page.mouse
+
+					# Two-step hover: move to center first (enter element), then to target position
+					# This triggers :hover effects more reliably than jumping directly to position
+					await mouse.move(center_x, center_y)
+					await asyncio.sleep(0.1)
+
+					element_desc = get_click_description(node)
+					memory = f'Hovered over {element_desc}'
+					logger.info(f'👆 {memory}')
+					return ActionResult(
+						extracted_content=memory,
+						metadata={
+							'hover_index': params.index,
+							'hover_x': center_x,
+							'hover_y': center_y,
+							'element_bbox': {'x': int(bounds.x), 'y': int(bounds.y), 'width': int(bounds.width), 'height': int(bounds.height)},
+						},
+					)
+
+				return ActionResult(error='Either index or coordinates must be provided for hover action')
+
+			except BrowserError as e:
+				return handle_browser_error(e)
+			except Exception as e:
+				error_msg = f'Failed to hover: {str(e)}'
+				logger.error(f'Failed to hover: {type(e).__name__}: {e}')
+				return ActionResult(error=error_msg)
 
 		@self.registry.action(
 			'Input text into element by index. Clears existing text by default; pass text="" to clear only, or clear=False to append.',

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -47,7 +47,8 @@ from browser_use.tools.views import (
 	ExtractAction,
 	FindElementsAction,
 	GetDropdownOptionsAction,
-	HoverAction,
+	HoverElementAction,
+	HoverElementActionIndexOnly,
 	InputTextAction,
 	NavigateAction,
 	NoParamsAction,
@@ -431,6 +432,7 @@ class Tools(Generic[Context]):
 		self.display_files_in_done_text = display_files_in_done_text
 		self._output_model: type[BaseModel] | None = output_model
 		self._coordinate_clicking_enabled: bool = False
+		self._coordinate_hovering_enabled: bool = False
 
 		"""Register all default browser actions"""
 
@@ -749,72 +751,89 @@ class Tools(Generic[Context]):
 		# Register click action (index-only by default)
 		self._register_click_action()
 
-		@self.registry.action(
-			'Hover over element by index or coordinates. Use to trigger dropdown menus, tooltips, or CSS hover effects.',
-			param_model=HoverAction,
-		)
-		async def hover(params: HoverAction, browser_session: BrowserSession) -> ActionResult:
+		async def _hover_by_index(
+			params: HoverElementAction | HoverElementActionIndexOnly, browser_session: BrowserSession
+		) -> ActionResult:
+			assert params.index is not None
 			try:
-				if params.coordinate_x is not None and params.coordinate_y is not None:
-					actual_x, actual_y = _convert_llm_coordinates_to_viewport(
-						params.coordinate_x, params.coordinate_y, browser_session
-					)
+				assert params.index != 0, (
+					'Cannot hover on element with index 0. If there are no interactive elements use wait(), refresh(), etc. to troubleshoot'
+				)
 
-					event = browser_session.event_bus.dispatch(HoverCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y))
-					await event
-					hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+				node = await browser_session.get_element_by_index(params.index)
+				if node is None:
+					msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+					logger.warning(f'⚠️ {msg}')
+					return ActionResult(extracted_content=msg)
 
-					if isinstance(hover_metadata, dict) and 'validation_error' in hover_metadata:
-						return ActionResult(error=hover_metadata['validation_error'])
+				create_task_with_error_handling(
+					browser_session.highlight_interaction_element(node),
+					name='highlight_hover_element',
+					suppress_exceptions=True,
+				)
 
-					memory = f'Hovered at coordinate {params.coordinate_x}, {params.coordinate_y}'
-					logger.info(f'👆 {memory}')
-					return ActionResult(
-						extracted_content=memory,
-						metadata={'hover_x': actual_x, 'hover_y': actual_y},
-					)
+				event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
+				await event
+				hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
 
-				if params.index is not None:
-					node = await browser_session.get_element_by_index(params.index)
-					if node is None:
-						msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
-						logger.warning(f'⚠️ {msg}')
-						return ActionResult(extracted_content=msg)
+				if isinstance(hover_metadata, dict) and 'validation_error' in hover_metadata:
+					return ActionResult(error=hover_metadata['validation_error'])
 
-					create_task_with_error_handling(
-						browser_session.highlight_interaction_element(node),
-						name='highlight_hover_element',
-						suppress_exceptions=True,
-					)
-
-					event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
-					await event
-					hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
-
-					if isinstance(hover_metadata, dict) and 'validation_error' in hover_metadata:
-						return ActionResult(error=hover_metadata['validation_error'])
-
-					element_desc = get_click_description(node)
-					memory = f'Hovered over {element_desc}'
-					logger.info(f'👆 {memory}')
-					return ActionResult(
-						extracted_content=memory,
-						metadata={
-							'hover_index': params.index,
-							'hover_x': hover_metadata.get('hover_x') if isinstance(hover_metadata, dict) else None,
-							'hover_y': hover_metadata.get('hover_y') if isinstance(hover_metadata, dict) else None,
-							'element_bbox': hover_metadata.get('element_bbox') if isinstance(hover_metadata, dict) else None,
-						},
-					)
-
-				return ActionResult(error='Either index or coordinates must be provided for hover action')
-
+				element_desc = get_click_description(node)
+				memory = f'Hovered over {element_desc}'
+				logger.info(f'👆 {memory}')
+				return ActionResult(
+					extracted_content=memory,
+					metadata={
+						'hover_index': params.index,
+						'hover_x': hover_metadata.get('hover_x') if isinstance(hover_metadata, dict) else None,
+						'hover_y': hover_metadata.get('hover_y') if isinstance(hover_metadata, dict) else None,
+						'element_bbox': hover_metadata.get('element_bbox') if isinstance(hover_metadata, dict) else None,
+					},
+				)
 			except BrowserError as e:
 				return handle_browser_error(e)
 			except Exception as e:
-				error_msg = f'Failed to hover: {str(e)}'
-				logger.error(f'Failed to hover: {type(e).__name__}: {e}')
+				error_msg = f'Failed to hover element {params.index}: {str(e)}'
 				return ActionResult(error=error_msg)
+
+		async def _hover_by_coordinate(params: HoverElementAction, browser_session: BrowserSession) -> ActionResult:
+			if params.coordinate_x is None or params.coordinate_y is None:
+				return ActionResult(error='Both coordinate_x and coordinate_y must be provided')
+
+			try:
+				actual_x, actual_y = _convert_llm_coordinates_to_viewport(
+					params.coordinate_x, params.coordinate_y, browser_session
+				)
+
+				# Highlight the coordinate being hovered (truly non-blocking)
+				asyncio.create_task(browser_session.highlight_coordinate_click(actual_x, actual_y))
+
+				event = browser_session.event_bus.dispatch(HoverCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y))
+				await event
+				hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+
+				if isinstance(hover_metadata, dict) and 'validation_error' in hover_metadata:
+					return ActionResult(error=hover_metadata['validation_error'])
+
+				memory = f'Hovered at coordinate {params.coordinate_x}, {params.coordinate_y}'
+				logger.info(f'👆 {memory}')
+				return ActionResult(
+					extracted_content=memory,
+					metadata={'hover_x': actual_x, 'hover_y': actual_y},
+				)
+			except BrowserError as e:
+				return handle_browser_error(e)
+			except Exception as e:
+				error_msg = f'Failed to hover at coordinates ({params.coordinate_x}, {params.coordinate_y}).'
+				return ActionResult(error=error_msg)
+
+		# Store hover handlers for re-registration
+		self._hover_by_index = _hover_by_index
+		self._hover_by_coordinate = _hover_by_coordinate
+
+		# Register hover action (index-only by default)
+		self._register_hover_action()
 
 		@self.registry.action(
 			'Input text into element by index. Clears existing text by default; pass text="" to clear only, or clear=False to append.',
@@ -2180,6 +2199,54 @@ Validated Code (after quote fixing):
 		self._coordinate_clicking_enabled = enabled
 		self._register_click_action()
 		logger.debug(f'Coordinate clicking {"enabled" if enabled else "disabled"}')
+
+	def _register_hover_action(self) -> None:
+		"""Register the hover action with or without coordinate support based on current setting."""
+		# Remove existing hover action if present
+		if 'hover' in self.registry.registry.actions:
+			del self.registry.registry.actions['hover']
+
+		if self._coordinate_hovering_enabled:
+			# Register hover action WITH coordinate support
+			@self.registry.action(
+				'Hover over element by index or coordinates. Use to trigger dropdown menus, tooltips, or CSS hover effects.',
+				param_model=HoverElementAction,
+			)
+			async def hover(params: HoverElementAction, browser_session: BrowserSession):
+				# Validate that either index or coordinates are provided
+				if params.index is None and (params.coordinate_x is None or params.coordinate_y is None):
+					return ActionResult(error='Must provide either index or both coordinate_x and coordinate_y')
+
+				# Try index-based hovering first if index is provided
+				if params.index is not None:
+					return await self._hover_by_index(params, browser_session)
+				# Coordinate-based hovering when index is not provided
+				else:
+					return await self._hover_by_coordinate(params, browser_session)
+		else:
+			# Register hover action WITHOUT coordinate support (index only)
+			@self.registry.action(
+				'Hover over element by index. Use to trigger dropdown menus, tooltips, or CSS hover effects.',
+				param_model=HoverElementActionIndexOnly,
+			)
+			async def hover(params: HoverElementActionIndexOnly, browser_session: BrowserSession):
+				return await self._hover_by_index(params, browser_session)
+
+	def set_coordinate_hovering(self, enabled: bool) -> None:
+		"""Enable or disable coordinate-based hovering.
+
+		When enabled, the hover action accepts both index and coordinate parameters.
+		When disabled (default), only index-based hovering is available.
+
+		Args:
+			enabled: True to enable coordinate hovering, False to disable
+		"""
+		if enabled == self._coordinate_hovering_enabled:
+			return  # No change needed
+
+		self._coordinate_hovering_enabled = enabled
+		self._register_hover_action()
+		logger.debug(f'Coordinate hovering {"enabled" if enabled else "disabled"}')
 
 	# Act --------------------------------------------------------------------
 	@observe_debug(ignore_input=True, ignore_output=True, name='act')

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -80,12 +80,16 @@ class ClickElementActionIndexOnly(BaseModel):
 	index: int = Field(ge=1, description='Element index from browser_state')
 
 
-class HoverAction(BaseModel):
-	model_config = ConfigDict(extra='forbid')
-
+class HoverElementAction(BaseModel):
 	index: int | None = Field(default=None, ge=1, description='Element index from browser_state')
 	coordinate_x: int | None = Field(default=None, description='Horizontal coordinate relative to viewport left edge')
 	coordinate_y: int | None = Field(default=None, description='Vertical coordinate relative to viewport top edge')
+
+
+class HoverElementActionIndexOnly(BaseModel):
+	model_config = ConfigDict(title='HoverElementAction')
+
+	index: int = Field(ge=1, description='Element index from browser_state')
 
 
 class InputTextAction(BaseModel):

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -81,6 +81,8 @@ class ClickElementActionIndexOnly(BaseModel):
 
 
 class HoverAction(BaseModel):
+	model_config = ConfigDict(extra='forbid')
+
 	index: int | None = Field(default=None, ge=1, description='Element index from browser_state')
 	coordinate_x: int | None = Field(default=None, description='Horizontal coordinate relative to viewport left edge')
 	coordinate_y: int | None = Field(default=None, description='Vertical coordinate relative to viewport top edge')

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -80,6 +80,12 @@ class ClickElementActionIndexOnly(BaseModel):
 	index: int = Field(ge=1, description='Element index from browser_state')
 
 
+class HoverAction(BaseModel):
+	index: int | None = Field(default=None, ge=1, description='Element index from browser_state')
+	coordinate_x: int | None = Field(default=None, description='Horizontal coordinate relative to viewport left edge')
+	coordinate_y: int | None = Field(default=None, description='Vertical coordinate relative to viewport top edge')
+
+
 class InputTextAction(BaseModel):
 	index: int = Field(ge=0, description='from browser_state')
 	text: str = Field(description='Text to enter. With clear=True, text="" clears the field without typing.')

--- a/examples/features/hover_interaction.py
+++ b/examples/features/hover_interaction.py
@@ -1,0 +1,78 @@
+# Goal: Demonstrates the hover action for triggering CSS dropdown menus, tooltips, and hover effects.
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use import Agent, ChatOpenAI
+from browser_use.browser import BrowserProfile, BrowserSession
+
+if not os.getenv('OPENAI_API_KEY'):
+	raise ValueError('OPENAI_API_KEY is not set')
+
+llm = ChatOpenAI(base_url=os.getenv('OPENAI_API_BASE_URL', None), model=os.getenv('LLM_MODEL', 'gpt-4.1-mini'))
+
+browser_profile = BrowserProfile(headless=False)
+browser_session = BrowserSession(browser_profile=browser_profile)
+
+# Example 1: Hover over CSS dropdown menu to reveal and select sub-items
+agent1 = Agent(
+	task="""Go to https://semantic-ui.com/modules/dropdown.html#/definition and:
+	1. Find a dropdown menu that requires hovering to reveal sub-items
+	2. Hover over the menu trigger to reveal the dropdown
+	3. Click on one of the revealed sub-items
+	4. Report what item you selected""",
+	llm=llm,
+	browser_session=browser_session,
+)
+
+# Example 2: Hover over tooltips to read hidden content
+agent2 = Agent(
+	task="""Go to https://getbootstrap.com/docs/5.3/components/tooltips/ and:
+	1. Hover over each tooltip button to reveal the tooltip text
+	2. Read and report what each tooltip says
+	3. Make sure to hover over at least 3 different tooltips""",
+	llm=llm,
+	browser_session=browser_session,
+)
+
+# Example 3: Hover at specific coordinates for precision targeting
+agent3 = Agent(
+	task="""Navigate to a page with a map or interactive grid, then hover over specific areas
+	to reveal information panels or highlights. Use coordinate-based hover when
+	element indices are not available for the target area.""",
+	llm=llm,
+	browser_session=browser_session,
+)
+
+
+async def main():
+	print('Choose which hover example to run:')
+	print('1. CSS dropdown menu hover (Semantic UI)')
+	print('2. Tooltip hover interactions (Bootstrap)')
+	print('3. Coordinate-based hover targeting')
+
+	choice = input('Enter choice (1-3): ').strip()
+
+	if choice == '1':
+		print('Running Example 1: CSS dropdown menu hover...')
+		await agent1.run()
+	elif choice == '2':
+		print('Running Example 2: Tooltip hover interactions...')
+		await agent2.run()
+	elif choice == '3':
+		print('Running Example 3: Coordinate-based hover targeting...')
+		await agent3.run()
+	else:
+		print('Invalid choice. Running Example 1 by default...')
+		await agent1.run()
+
+
+if __name__ == '__main__':
+	asyncio.run(main())

--- a/tests/ci/interactions/test_hover.py
+++ b/tests/ci/interactions/test_hover.py
@@ -193,13 +193,13 @@ class TestHoverByIndex:
 		menu_index = await browser_session.get_index_by_id('nav-menu')
 		assert menu_index is not None, 'Could not find nav-menu element'
 
-		# Before hover: submenu should be hidden
+		# Before hover: submenu computed display should be "none"
 		cdp_session = await browser_session.get_or_create_cdp_session()
 		result = await cdp_session.cdp_client.send.Runtime.evaluate(
-			params={'expression': "document.getElementById('submenu').style.display", 'returnByValue': True},
+			params={'expression': "window.getComputedStyle(document.getElementById('submenu')).display", 'returnByValue': True},
 			session_id=cdp_session.session_id,
 		)
-		assert result.get('result', {}).get('value', '') in ('', 'none'), f'Submenu should be hidden before hover, got: {result}'
+		assert result.get('result', {}).get('value', '') == 'none', f'Submenu should be hidden before hover, got: {result}'
 
 		# Hover over the menu element
 		hover_result = await tools.hover(index=menu_index, browser_session=browser_session)
@@ -212,16 +212,14 @@ class TestHoverByIndex:
 		assert 'hover_x' in hover_result.metadata
 		assert 'hover_y' in hover_result.metadata
 
-		# After hover: submenu should be visible (CSS :hover activated)
+		# After hover: submenu computed display should be "block" (CSS :hover activated)
 		result = await cdp_session.cdp_client.send.Runtime.evaluate(
-			params={'expression': "document.getElementById('submenu').style.display", 'returnByValue': True},
+			params={'expression': "window.getComputedStyle(document.getElementById('submenu')).display", 'returnByValue': True},
 			session_id=cdp_session.session_id,
 		)
 		display_value = result.get('result', {}).get('value', '')
-		# CSS :hover may set display to 'block' or the computed style may differ
-		# Check that it's no longer 'none'
-		assert display_value != 'none' or display_value == '', (
-			f'Submenu should be visible after hover, got display: {display_value}'
+		assert display_value == 'block', (
+			f'Submenu should be visible after hover (computed display="block"), got: {display_value}'
 		)
 
 	async def test_hover_triggers_css_tooltip(self, tools, browser_session: BrowserSession, base_url):

--- a/tests/ci/interactions/test_hover.py
+++ b/tests/ci/interactions/test_hover.py
@@ -218,9 +218,7 @@ class TestHoverByIndex:
 			session_id=cdp_session.session_id,
 		)
 		display_value = result.get('result', {}).get('value', '')
-		assert display_value == 'block', (
-			f'Submenu should be visible after hover (computed display="block"), got: {display_value}'
-		)
+		assert display_value == 'block', f'Submenu should be visible after hover (computed display="block"), got: {display_value}'
 
 	async def test_hover_triggers_css_tooltip(self, tools, browser_session: BrowserSession, base_url):
 		"""Hover over element to reveal CSS :hover tooltip."""

--- a/tests/ci/interactions/test_hover.py
+++ b/tests/ci/interactions/test_hover.py
@@ -1,4 +1,4 @@
-"""Test HoverAction functionality.
+"""Test HoverElementAction functionality.
 
 Tests hover action via the Tools interface and via direct event bus dispatch,
 covering index-based hover, coordinate-based hover, and CSS :hover activation.
@@ -294,6 +294,7 @@ class TestHoverByCoordinates:
 
 	async def test_hover_at_coordinates(self, tools, browser_session: BrowserSession, base_url):
 		"""Hover at specific viewport coordinates to trigger mouse events."""
+		tools.set_coordinate_hovering(True)
 		await tools.navigate(url=f'{base_url}/hover-coords', new_tab=False, browser_session=browser_session)
 		await browser_session.get_browser_state_summary()
 
@@ -319,6 +320,7 @@ class TestHoverByCoordinates:
 
 	async def test_hover_at_coordinates_triggers_css_hover(self, tools, browser_session: BrowserSession, base_url):
 		"""Hover at coordinates should trigger CSS :hover state changes."""
+		tools.set_coordinate_hovering(True)
 		await tools.navigate(url=f'{base_url}/hover-coords', new_tab=False, browser_session=browser_session)
 		await browser_session.get_browser_state_summary()
 
@@ -384,3 +386,37 @@ class TestHoverEventBus:
 		assert isinstance(hover_metadata, dict)
 		assert hover_metadata.get('hover_x') == 350
 		assert hover_metadata.get('hover_y') == 150
+
+
+class TestHoverActionRegistration:
+	"""Test hover action registration toggle and edge cases."""
+
+	def test_default_index_only_mode(self, tools):
+		"""By default, hover action should be registered in index-only mode."""
+		assert not tools._coordinate_hovering_enabled
+		hover_action = tools.registry.registry.actions['hover']
+		assert hover_action.param_model.__name__ == 'HoverElementActionIndexOnly'
+
+	def test_coordinate_hovering_toggle(self, tools):
+		"""Toggling coordinate hovering should switch the registered param_model."""
+		# Enable coordinate hovering
+		tools.set_coordinate_hovering(True)
+		assert tools._coordinate_hovering_enabled
+		hover_action = tools.registry.registry.actions['hover']
+		assert hover_action.param_model.__name__ == 'HoverElementAction'
+
+		# Disable coordinate hovering
+		tools.set_coordinate_hovering(False)
+		assert not tools._coordinate_hovering_enabled
+		hover_action = tools.registry.registry.actions['hover']
+		assert hover_action.param_model.__name__ == 'HoverElementActionIndexOnly'
+
+	async def test_hover_index_zero(self, tools, browser_session: BrowserSession, base_url):
+		"""Hover with index=0 should raise ValidationError due to ge=1 constraint."""
+		await tools.navigate(url=f'{base_url}/hover-css', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+
+		from pydantic import ValidationError
+
+		with pytest.raises(ValidationError):
+			await tools.hover(index=0, browser_session=browser_session)

--- a/tests/ci/interactions/test_hover.py
+++ b/tests/ci/interactions/test_hover.py
@@ -1,0 +1,390 @@
+"""Test HoverAction functionality.
+
+Tests hover action via the Tools interface and via direct event bus dispatch,
+covering index-based hover, coordinate-based hover, and CSS :hover activation.
+"""
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from browser_use.agent.views import ActionResult
+from browser_use.browser import BrowserSession
+from browser_use.browser.events import HoverCoordinateEvent, HoverElementEvent
+from browser_use.browser.profile import BrowserProfile
+from browser_use.tools.service import Tools
+
+# HTML fixture: CSS :hover dropdown menu — the primary use case
+HOVER_CSS_DROPDOWN_HTML = """<!DOCTYPE html>
+<html>
+<head>
+	<title>Hover CSS Dropdown Test</title>
+	<style>
+		.nav-menu { position: relative; display: inline-block; cursor: pointer; }
+		.nav-item { padding: 10px 20px; background: #333; color: white; cursor: pointer; }
+		.submenu {
+			display: none;
+			position: absolute;
+			top: 100%;
+			left: 0;
+			background: #444;
+			min-width: 160px;
+			z-index: 1000;
+		}
+		.nav-menu:hover .submenu { display: block; }
+		.submenu-item { padding: 8px 16px; color: white; cursor: pointer; }
+		.submenu-item:hover { background: #555; }
+		#result { margin-top: 20px; padding: 10px; border: 1px solid #ddd; }
+	</style>
+</head>
+<body>
+	<h1>Hover CSS Dropdown Test</h1>
+	<p>Hover over the menu item below to reveal the dropdown submenu.</p>
+	<div class="nav-menu" id="nav-menu">
+		<div class="nav-item">Products</div>
+		<div class="submenu" id="submenu">
+			<div class="submenu-item" onclick="selectItem('Electronics')">Electronics</div>
+			<div class="submenu-item" onclick="selectItem('Books')">Books</div>
+			<div class="submenu-item" onclick="selectItem('Clothing')">Clothing</div>
+		</div>
+	</div>
+	<div id="result">No item selected</div>
+	<script>
+		function selectItem(name) {
+			document.getElementById('result').textContent = 'Selected: ' + name;
+		}
+	</script>
+</body>
+</html>"""
+
+# HTML fixture: CSS :hover tooltip
+HOVER_TOOLTIP_HTML = """<!DOCTYPE html>
+<html>
+<head>
+	<title>Hover Tooltip Test</title>
+	<style>
+		.tooltip-container { position: relative; display: inline-block; margin: 50px; cursor: pointer; }
+		.tooltip-trigger { padding: 10px 20px; background: #2196F3; color: white; cursor: pointer; }
+		.tooltip-content {
+			display: none;
+			position: absolute;
+			bottom: 100%;
+			left: 50%;
+			transform: translateX(-50%);
+			background: #333;
+			color: white;
+			padding: 8px 12px;
+			border-radius: 4px;
+			white-space: nowrap;
+			z-index: 1000;
+		}
+		.tooltip-container:hover .tooltip-content { display: block; }
+		#status { margin-top: 20px; padding: 10px; }
+	</style>
+</head>
+<body>
+	<h1>Hover Tooltip Test</h1>
+	<p>Hover over the button below to see the tooltip.</p>
+	<div class="tooltip-container" id="tooltip-container">
+		<div class="tooltip-trigger" id="tooltip-trigger">Hover me</div>
+		<div class="tooltip-content" id="tooltip-content">Hidden tooltip text revealed!</div>
+	</div>
+	<div id="status">Tooltip not shown</div>
+	<script>
+		var container = document.getElementById('tooltip-container');
+		container.addEventListener('mouseenter', function() {
+			document.getElementById('status').textContent = 'Tooltip shown';
+		});
+		container.addEventListener('mouseleave', function() {
+			document.getElementById('status').textContent = 'Tooltip hidden';
+		});
+	</script>
+</body>
+</html>"""
+
+# HTML fixture: positioned elements for coordinate-based hover testing
+HOVER_COORDS_HTML = """<!DOCTYPE html>
+<html>
+<head>
+	<title>Hover Coordinate Test</title>
+	<style>
+		.target {
+			position: absolute;
+			width: 100px;
+			height: 100px;
+			background: #ccc;
+			border: 2px solid #999;
+		}
+		#target-a { left: 100px; top: 100px; }
+		#target-b { left: 300px; top: 100px; }
+		#target-a:hover { background: #4CAF50; }
+		#target-b:hover { background: #FF9800; }
+		#log { position: absolute; left: 100px; top: 300px; padding: 10px; border: 1px solid #ddd; min-width: 200px; }
+	</style>
+</head>
+<body>
+	<h1>Hover Coordinate Test</h1>
+	<div class="target" id="target-a">Target A</div>
+	<div class="target" id="target-b">Target B</div>
+	<div id="log">No hover events</div>
+	<script>
+		var targets = document.querySelectorAll('.target');
+		targets.forEach(function(t) {
+			t.addEventListener('mouseenter', function() {
+				document.getElementById('log').textContent = 'Hovered: ' + t.id;
+			});
+		});
+	</script>
+</body>
+</html>"""
+
+
+@pytest.fixture(scope='session')
+def http_server():
+	"""Create and provide a test HTTP server that serves static content."""
+	server = HTTPServer()
+	server.start()
+
+	server.expect_request('/hover-css').respond_with_data(HOVER_CSS_DROPDOWN_HTML, content_type='text/html')
+	server.expect_request('/hover-tooltip').respond_with_data(HOVER_TOOLTIP_HTML, content_type='text/html')
+	server.expect_request('/hover-coords').respond_with_data(HOVER_COORDS_HTML, content_type='text/html')
+
+	yield server
+	server.stop()
+
+
+@pytest.fixture(scope='session')
+def base_url(http_server):
+	"""Return the base URL for the test HTTP server."""
+	return f'http://{http_server.host}:{http_server.port}'
+
+
+@pytest.fixture(scope='module')
+async def browser_session():
+	"""Create and provide a headless BrowserSession for testing."""
+	session = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=True,
+			chromium_sandbox=False,
+		)
+	)
+	await session.start()
+	yield session
+	await session.kill()
+	await session.event_bus.stop(clear=True, timeout=5)
+
+
+@pytest.fixture(scope='function')
+def tools():
+	"""Create and provide a fresh Tools instance."""
+	return Tools()
+
+
+class TestHoverByIndex:
+	"""Test hover action using element index."""
+
+	async def test_hover_triggers_css_hover_dropdown(self, tools, browser_session: BrowserSession, base_url):
+		"""Hover over nav menu item to reveal CSS :hover dropdown submenu."""
+		await tools.navigate(url=f'{base_url}/hover-css', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+
+		# Find the nav-menu element by ID
+		menu_index = await browser_session.get_index_by_id('nav-menu')
+		assert menu_index is not None, 'Could not find nav-menu element'
+
+		# Before hover: submenu should be hidden
+		cdp_session = await browser_session.get_or_create_cdp_session()
+		result = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': "document.getElementById('submenu').style.display", 'returnByValue': True},
+			session_id=cdp_session.session_id,
+		)
+		assert result.get('result', {}).get('value', '') in ('', 'none'), f'Submenu should be hidden before hover, got: {result}'
+
+		# Hover over the menu element
+		hover_result = await tools.hover(index=menu_index, browser_session=browser_session)
+
+		# Verify action result
+		assert isinstance(hover_result, ActionResult)
+		assert hover_result.error is None, f'Hover action failed: {hover_result.error}'
+		assert hover_result.extracted_content is not None and 'Hovered over' in hover_result.extracted_content
+		assert hover_result.metadata is not None
+		assert 'hover_x' in hover_result.metadata
+		assert 'hover_y' in hover_result.metadata
+
+		# After hover: submenu should be visible (CSS :hover activated)
+		result = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': "document.getElementById('submenu').style.display", 'returnByValue': True},
+			session_id=cdp_session.session_id,
+		)
+		display_value = result.get('result', {}).get('value', '')
+		# CSS :hover may set display to 'block' or the computed style may differ
+		# Check that it's no longer 'none'
+		assert display_value != 'none' or display_value == '', (
+			f'Submenu should be visible after hover, got display: {display_value}'
+		)
+
+	async def test_hover_triggers_css_tooltip(self, tools, browser_session: BrowserSession, base_url):
+		"""Hover over element to reveal CSS :hover tooltip."""
+		await tools.navigate(url=f'{base_url}/hover-tooltip', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+
+		tooltip_index = await browser_session.get_index_by_id('tooltip-container')
+		assert tooltip_index is not None, 'Could not find tooltip-container element'
+
+		# Before hover: status should say "Tooltip not shown"
+		cdp_session = await browser_session.get_or_create_cdp_session()
+		result = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': "document.getElementById('status').textContent", 'returnByValue': True},
+			session_id=cdp_session.session_id,
+		)
+		assert result.get('result', {}).get('value', '') == 'Tooltip not shown'
+
+		# Hover over the tooltip trigger
+		hover_result = await tools.hover(index=tooltip_index, browser_session=browser_session)
+		assert isinstance(hover_result, ActionResult)
+		assert hover_result.error is None, f'Hover action failed: {hover_result.error}'
+		assert hover_result.extracted_content is not None and 'Hovered over' in hover_result.extracted_content
+
+		# After hover: status should say "Tooltip shown"
+		result = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': "document.getElementById('status').textContent", 'returnByValue': True},
+			session_id=cdp_session.session_id,
+		)
+		status_text = result.get('result', {}).get('value', '')
+		assert 'Tooltip shown' in status_text, f'Expected "Tooltip shown", got: {status_text}'
+
+	async def test_hover_invalid_index(self, tools, browser_session: BrowserSession, base_url):
+		"""Hover with an index that doesn't exist on the page."""
+		await tools.navigate(url=f'{base_url}/hover-css', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+
+		# Use a very large index that won't exist
+		hover_result = await tools.hover(index=9999, browser_session=browser_session)
+
+		assert isinstance(hover_result, ActionResult)
+		assert hover_result.extracted_content is not None
+		assert 'not available' in hover_result.extracted_content
+
+	async def test_hover_element_without_bounds(self, tools, browser_session: BrowserSession, base_url):
+		"""Hover over element via event bus when element has no bounding box — should return validation_error."""
+		await tools.navigate(url=f'{base_url}/hover-css', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+
+		menu_index = await browser_session.get_index_by_id('nav-menu')
+		assert menu_index is not None
+
+		node = await browser_session.get_element_by_index(menu_index)
+		assert node is not None
+
+		# Force a scenario where bounds are missing by creating a node without snapshot_node
+		# The element actually has bounds, so we test via event bus dispatch with a crafted scenario
+		# Instead, verify that a normal element with bounds does NOT return validation_error
+		event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
+		await event
+		hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+
+		assert hover_metadata is not None
+		assert isinstance(hover_metadata, dict)
+		assert 'validation_error' not in hover_metadata, (
+			f'Expected no validation error for element with bounds, got: {hover_metadata}'
+		)
+		assert 'hover_x' in hover_metadata
+		assert 'hover_y' in hover_metadata
+
+
+class TestHoverByCoordinates:
+	"""Test hover action using viewport coordinates."""
+
+	async def test_hover_at_coordinates(self, tools, browser_session: BrowserSession, base_url):
+		"""Hover at specific viewport coordinates to trigger mouse events."""
+		await tools.navigate(url=f'{base_url}/hover-coords', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+
+		# Target A is positioned at left=100, top=100, width=100, height=100
+		# Center: (150, 150)
+		hover_result = await tools.hover(coordinate_x=150, coordinate_y=150, browser_session=browser_session)
+
+		assert isinstance(hover_result, ActionResult)
+		assert hover_result.error is None, f'Coordinate hover failed: {hover_result.error}'
+		assert hover_result.extracted_content is not None and 'Hovered at coordinate' in hover_result.extracted_content
+		assert hover_result.metadata is not None
+		assert 'hover_x' in hover_result.metadata
+		assert 'hover_y' in hover_result.metadata
+
+		# Verify target-a received the hover event
+		cdp_session = await browser_session.get_or_create_cdp_session()
+		result = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': "document.getElementById('log').textContent", 'returnByValue': True},
+			session_id=cdp_session.session_id,
+		)
+		log_text = result.get('result', {}).get('value', '')
+		assert 'target-a' in log_text.lower(), f'Expected target-a to be hovered, got: {log_text}'
+
+	async def test_hover_at_coordinates_triggers_css_hover(self, tools, browser_session: BrowserSession, base_url):
+		"""Hover at coordinates should trigger CSS :hover state changes."""
+		await tools.navigate(url=f'{base_url}/hover-coords', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+
+		# Hover over Target A center (150, 150)
+		await tools.hover(coordinate_x=150, coordinate_y=150, browser_session=browser_session)
+
+		# Check that Target A's background changed (CSS :hover sets it to green #4CAF50)
+		cdp_session = await browser_session.get_or_create_cdp_session()
+		result = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={
+				'expression': "window.getComputedStyle(document.getElementById('target-a')).backgroundColor",
+				'returnByValue': True,
+			},
+			session_id=cdp_session.session_id,
+		)
+		bg_color = result.get('result', {}).get('value', '')
+		# CSS :hover changes background from grey (#ccc → rgb(204,204,204)) to green (#4CAF50 → rgb(76,175,80))
+		assert '76, 175, 80' in bg_color or '4caf50' in bg_color.lower(), (
+			f'Expected green background on target-a after hover, got: {bg_color}'
+		)
+
+
+class TestHoverEventBus:
+	"""Test hover event dispatch directly through the event bus."""
+
+	async def test_hover_element_event_direct(self, tools, browser_session: BrowserSession, base_url):
+		"""Dispatch HoverElementEvent directly and verify metadata in event result."""
+		await tools.navigate(url=f'{base_url}/hover-css', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+
+		menu_index = await browser_session.get_index_by_id('nav-menu')
+		assert menu_index is not None
+
+		node = await browser_session.get_element_by_index(menu_index)
+		assert node is not None
+
+		event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
+		await event
+		hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+
+		assert hover_metadata is not None
+		assert isinstance(hover_metadata, dict)
+		assert 'hover_x' in hover_metadata
+		assert 'hover_y' in hover_metadata
+		assert 'element_bbox' in hover_metadata
+		assert isinstance(hover_metadata['element_bbox'], dict)
+		assert 'x' in hover_metadata['element_bbox']
+		assert 'y' in hover_metadata['element_bbox']
+		assert 'width' in hover_metadata['element_bbox']
+		assert 'height' in hover_metadata['element_bbox']
+
+	async def test_hover_coordinate_event_direct(self, tools, browser_session: BrowserSession, base_url):
+		"""Dispatch HoverCoordinateEvent directly and verify metadata in event result."""
+		await tools.navigate(url=f'{base_url}/hover-coords', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+
+		# Hover at (350, 150) — center of Target B
+		event = browser_session.event_bus.dispatch(HoverCoordinateEvent(coordinate_x=350, coordinate_y=150))
+		await event
+		hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+
+		assert hover_metadata is not None
+		assert isinstance(hover_metadata, dict)
+		assert hover_metadata.get('hover_x') == 350
+		assert hover_metadata.get('hover_y') == 150


### PR DESCRIPTION
Resolves #4964 

## Summary

- Adds `HoverAction` and `hover` action to the Tools registry, enabling the Agent to trigger real browser hover interactions via CDP `Input.dispatchMouseEvent` (type `mouseMoved`)
- Supports hover by element index and by viewport coordinates, consistent with the existing `ClickElementAction` pattern
- Follows the event-driven architecture: Tools dispatches `HoverElementEvent` / `HoverCoordinateEvent` via the `bubus` event bus; `DefaultActionWatchdog` handles CDP interaction
- Includes scroll-into-view, viewport clamping, JS fallback on coordinate/mouseMoved failure, and session integrity checks

## Why this matters

The Agent currently has no dedicated hover action. The only available mechanism is `evaluate()` (JavaScript `dispatchEvent`), which is fundamentally inadequate:

- **CSS `:hover` never activates** — `dispatchEvent` fires synthetic DOM events without updating the browser's internal mouse position, so CSS `:hover` rules remain inactive
- **No proper event cascade** — real hover produces `mouseenter → mouseover → mousemove` with correct coordinates; synthetic dispatch produces events with `screenX/screenY = 0`
- **LLM overhead** — composing correct JS per hover target wastes context tokens and is error-prone

Most dropdown menus, tooltips, and reveal-on-hover UI patterns depend on CSS `:hover` state, making `evaluate()` ineffective for these common interaction patterns. `HoverAction` uses the same CDP mechanism the browser uses for real mouse movement, so CSS `:hover` activates correctly and the full DOM event cascade fires with accurate coordinates.

## Tests

- `uv run pytest -vxs tests/ci/interactions/test_hover.py` — covers:
  - Hover by index on CSS `:hover` dropdown reveal
  - Hover by index on CSS `:hover` tooltip reveal
  - Hover by coordinates triggering `mouseenter` events
  - Hover by coordinates triggering CSS `:hover` background changes
  - Direct event bus dispatch verification for both `HoverElementEvent` and `HoverCoordinateEvent`
  - Error handling: invalid index, element bounds validation
- `uv run pytest -vxs tests/ci` — full CI suite regression check
- `uv run pyright` — type checking


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real `hover` action that moves the mouse via CDP so CSS :hover works, letting the agent open dropdowns, tooltips, and hover-only UI. Coordinate-based hovering auto-enables when the model supports coordinate clicking.

- **New Features**
  - Tools: register `hover` (`HoverAction`); index-only by default, opt-in coordinates via `Tools.set_coordinate_hovering(True)`; auto-enabled when `supports_coordinate_clicking` is detected by the agent.
  - Events: `HoverElementEvent` and `HoverCoordinateEvent` on `bubus`; handled by `DefaultActionWatchdog` using CDP `Input.dispatchMouseEvent` (`mouseMoved`).
  - Reliability: scroll-into-view, viewport clamping, session checks; JS fallback if geometry/CDP fails.
  - Metadata: returns hover x/y and element bounding box.
  - Examples/Tests: `examples/features/hover_interaction.py`; `tests/ci/interactions/test_hover.py` covers dropdowns, tooltips, coordinates, registration toggle; visibility checks use `getComputedStyle`.

- **Refactors**
  - Align `hover` with the click action pattern, including dynamic re-registration when toggling coordinate support.

<sup>Written for commit 13bdbef9a24dcc81cc5f04954b7d1d5072776f31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



