### PR TITLE
fix: export ChatOpenRouter and other missing chat models from top-level package

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -55,8 +55,12 @@ if TYPE_CHECKING:
 	from browser_use.dom.service import DomService
 	from browser_use.llm import models
 	from browser_use.llm.anthropic.chat import ChatAnthropic
+	from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
+	from browser_use.llm.aws.chat_bedrock import ChatAWSBedrock
 	from browser_use.llm.azure.chat import ChatAzureOpenAI
 	from browser_use.llm.browser_use.chat import ChatBrowserUse
+	from browser_use.llm.cerebras.chat import ChatCerebras
+	from browser_use.llm.deepseek.chat import ChatDeepSeek
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
 	from browser_use.llm.litellm.chat import ChatLiteLLM
@@ -64,6 +68,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.oci_raw.chat import ChatOCIRaw
 	from browser_use.llm.ollama.chat import ChatOllama
 	from browser_use.llm.openai.chat import ChatOpenAI
+	from browser_use.llm.openrouter.chat import ChatOpenRouter
 	from browser_use.llm.vercel.chat import ChatVercel
 	from browser_use.sandbox import sandbox
 	from browser_use.tools.service import Controller, Tools
@@ -91,13 +96,18 @@ _LAZY_IMPORTS = {
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
 	'ChatGoogle': ('browser_use.llm.google.chat', 'ChatGoogle'),
 	'ChatAnthropic': ('browser_use.llm.anthropic.chat', 'ChatAnthropic'),
+	'ChatAnthropicBedrock': ('browser_use.llm.aws.chat_anthropic', 'ChatAnthropicBedrock'),
+	'ChatAWSBedrock': ('browser_use.llm.aws.chat_bedrock', 'ChatAWSBedrock'),
 	'ChatBrowserUse': ('browser_use.llm.browser_use.chat', 'ChatBrowserUse'),
+	'ChatCerebras': ('browser_use.llm.cerebras.chat', 'ChatCerebras'),
+	'ChatDeepSeek': ('browser_use.llm.deepseek.chat', 'ChatDeepSeek'),
 	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
 	'ChatLiteLLM': ('browser_use.llm.litellm.chat', 'ChatLiteLLM'),
 	'ChatMistral': ('browser_use.llm.mistral.chat', 'ChatMistral'),
 	'ChatAzureOpenAI': ('browser_use.llm.azure.chat', 'ChatAzureOpenAI'),
 	'ChatOCIRaw': ('browser_use.llm.oci_raw.chat', 'ChatOCIRaw'),
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
+	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
 	# LLM models module
 	'models': ('browser_use.llm.models', None),
@@ -143,13 +153,18 @@ __all__ = [
 	'ChatOpenAI',
 	'ChatGoogle',
 	'ChatAnthropic',
+	'ChatAnthropicBedrock',
+	'ChatAWSBedrock',
 	'ChatBrowserUse',
+	'ChatCerebras',
+	'ChatDeepSeek',
 	'ChatGroq',
 	'ChatLiteLLM',
 	'ChatMistral',
 	'ChatAzureOpenAI',
 	'ChatOCIRaw',
 	'ChatOllama',
+	'ChatOpenRouter',
 	'ChatVercel',
 	'Tools',
 	'Controller',


### PR DESCRIPTION
## Summary

Fixes #4755.

The [supported models docs](https://docs.browser-use.com/open-source/supported-models#openrouter) tell users to import providers from the top-level package, e.g.:

```python
from browser_use import ChatOpenRouter
```

But several providers were only registered in `browser_use/llm/__init__.py`, **not** in the top-level `browser_use/__init__.py`. So the documented import raised:

```
AttributeError: module 'browser_use' has no attribute 'ChatOpenRouter'
```

The classes that existed in `browser_use.llm` but were missing from the top-level package:

- `ChatOpenRouter`
- `ChatDeepSeek`
- `ChatCerebras`
- `ChatAWSBedrock`
- `ChatAnthropicBedrock`

(The other 11 providers — `ChatOpenAI`, `ChatGoogle`, `ChatAnthropic`, etc. — were already exported, which is why only some imports failed.)

## Changes

Brings `browser_use/__init__.py` in line with `browser_use/llm/__init__.py` by adding the five missing providers to:

- the `_LAZY_IMPORTS` mapping (with the same module paths already used in `browser_use/llm/__init__.py`),
- the `__all__` list, and
- the `TYPE_CHECKING` import stubs (for IDE autocomplete / linters).

No runtime behavior changes for existing imports — the lazy-import mechanism is unchanged, these entries are simply registered so the documented top-level imports resolve.

## Verification

```python
from browser_use import (
    ChatOpenRouter,
    ChatDeepSeek,
    ChatCerebras,
    ChatAWSBedrock,
    ChatAnthropicBedrock,
)
```

now imports successfully instead of raising `AttributeError`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export missing chat providers from top-level `browser_use` so imports like `from browser_use import ChatOpenRouter` work as documented. Aligns `browser_use/__init__.py` with `browser_use/llm/__init__.py` with no runtime behavior changes.

- **Bug Fixes**
  - Export `ChatOpenRouter`, `ChatDeepSeek`, `ChatCerebras`, `ChatAWSBedrock`, `ChatAnthropicBedrock` at the package root.
  - Update `_LAZY_IMPORTS`, `__all__`, and TYPE_CHECKING stubs in `browser_use/__init__.py`.

<sup>Written for commit 4440d6cec7d8b484a999305bfd0e7e9636ef961b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

