### PR TITLE
fix(llm): surface token usage for Ollama and DeepSeek instead of dropping it

### DIFF
--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -20,7 +20,7 @@ from browser_use.llm.deepseek.serializer import DeepSeekMessageSerializer
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
-from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
 
@@ -58,6 +58,32 @@ class ChatDeepSeek(BaseChatModel):
 	@property
 	def name(self) -> str:
 		return self.model
+
+	def _get_usage(self, response: Any) -> ChatInvokeUsage | None:
+		"""Build usage info from a DeepSeek (OpenAI-compatible) response.
+
+		DeepSeek returns the standard OpenAI `usage` block and reports cache hits
+		via the top-level `prompt_cache_hit_tokens` field, also mirroring the
+		`prompt_tokens_details.cached_tokens` shape on newer responses.
+		"""
+		usage = getattr(response, 'usage', None)
+		if usage is None:
+			return None
+
+		cached_tokens = getattr(usage, 'prompt_cache_hit_tokens', None)
+		if cached_tokens is None:
+			details = getattr(usage, 'prompt_tokens_details', None)
+			if details is not None:
+				cached_tokens = getattr(details, 'cached_tokens', None)
+
+		return ChatInvokeUsage(
+			prompt_tokens=usage.prompt_tokens,
+			prompt_cached_tokens=cached_tokens,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+			completion_tokens=usage.completion_tokens,
+			total_tokens=usage.total_tokens,
+		)
 
 	@overload
 	async def ainvoke(
@@ -125,7 +151,7 @@ class ChatDeepSeek(BaseChatModel):
 				)
 				return ChatInvokeCompletion(
 					completion=resp.choices[0].message.content or '',
-					usage=None,
+					usage=self._get_usage(resp),
 				)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e
@@ -173,13 +199,13 @@ class ChatDeepSeek(BaseChatModel):
 				if output_format is not None:
 					return ChatInvokeCompletion(
 						completion=output_format.model_validate(parsed),
-						usage=None,
+						usage=self._get_usage(resp),
 					)
 				else:
 					# If no output_format, return dict directly
 					return ChatInvokeCompletion(
 						completion=parsed,
-						usage=None,
+						usage=self._get_usage(resp),
 					)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e
@@ -203,7 +229,7 @@ class ChatDeepSeek(BaseChatModel):
 				parsed = output_format.model_validate_json(content)
 				return ChatInvokeCompletion(
 					completion=parsed,
-					usage=None,
+					usage=self._get_usage(resp),
 				)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -11,7 +11,7 @@ from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
-from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
 
@@ -57,6 +57,30 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def _get_usage(self, response: Any) -> ChatInvokeUsage | None:
+		"""Build usage info from an Ollama chat response.
+
+		Ollama reports input/output token counts as `prompt_eval_count` and
+		`eval_count`. It has no prefix caching, so the cache fields stay None.
+		"""
+		prompt_tokens = getattr(response, 'prompt_eval_count', None)
+		completion_tokens = getattr(response, 'eval_count', None)
+
+		if prompt_tokens is None and completion_tokens is None:
+			return None
+
+		prompt_tokens = prompt_tokens or 0
+		completion_tokens = completion_tokens or 0
+
+		return ChatInvokeUsage(
+			prompt_tokens=prompt_tokens,
+			prompt_cached_tokens=None,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+			completion_tokens=completion_tokens,
+			total_tokens=prompt_tokens + completion_tokens,
+		)
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -78,7 +102,7 @@ class ChatOllama(BaseChatModel):
 					options=self.ollama_options,
 				)
 
-				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
+				return ChatInvokeCompletion(completion=response.message.content or '', usage=self._get_usage(response))
 			else:
 				schema = output_format.model_json_schema()
 
@@ -93,7 +117,7 @@ class ChatOllama(BaseChatModel):
 				if output_format is not None:
 					completion = output_format.model_validate_json(completion)
 
-				return ChatInvokeCompletion(completion=completion, usage=None)
+				return ChatInvokeCompletion(completion=completion, usage=self._get_usage(response))
 
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/tests/ci/models/test_llm_usage.py
+++ b/tests/ci/models/test_llm_usage.py
@@ -1,0 +1,86 @@
+"""Unit tests for token-usage parsing in the Ollama and DeepSeek wrappers.
+
+These wrappers previously dropped all usage information (`usage=None`). The
+`_get_usage` helpers now build a `ChatInvokeUsage` from the provider response.
+The tests use lightweight fakes so they run without any network access or API
+keys.
+"""
+
+from types import SimpleNamespace
+
+from browser_use.llm.deepseek.chat import ChatDeepSeek
+from browser_use.llm.ollama.chat import ChatOllama
+
+
+def test_ollama_usage_parsed_from_response():
+	llm = ChatOllama(model='llama3')
+	response = SimpleNamespace(prompt_eval_count=12, eval_count=34)
+
+	usage = llm._get_usage(response)
+
+	assert usage is not None
+	assert usage.prompt_tokens == 12
+	assert usage.completion_tokens == 34
+	assert usage.total_tokens == 46
+	assert usage.prompt_cached_tokens is None
+
+
+def test_ollama_usage_none_when_counts_missing():
+	llm = ChatOllama(model='llama3')
+	response = SimpleNamespace()
+
+	assert llm._get_usage(response) is None
+
+
+def test_ollama_usage_handles_partial_counts():
+	llm = ChatOllama(model='llama3')
+	response = SimpleNamespace(prompt_eval_count=None, eval_count=5)
+
+	usage = llm._get_usage(response)
+
+	assert usage is not None
+	assert usage.prompt_tokens == 0
+	assert usage.completion_tokens == 5
+	assert usage.total_tokens == 5
+
+
+def test_deepseek_usage_parsed_from_response():
+	llm = ChatDeepSeek()
+	usage_obj = SimpleNamespace(
+		prompt_tokens=100,
+		completion_tokens=20,
+		total_tokens=120,
+		prompt_cache_hit_tokens=64,
+	)
+	response = SimpleNamespace(usage=usage_obj)
+
+	usage = llm._get_usage(response)
+
+	assert usage is not None
+	assert usage.prompt_tokens == 100
+	assert usage.completion_tokens == 20
+	assert usage.total_tokens == 120
+	assert usage.prompt_cached_tokens == 64
+
+
+def test_deepseek_usage_falls_back_to_prompt_tokens_details():
+	llm = ChatDeepSeek()
+	usage_obj = SimpleNamespace(
+		prompt_tokens=80,
+		completion_tokens=10,
+		total_tokens=90,
+		prompt_tokens_details=SimpleNamespace(cached_tokens=16),
+	)
+	response = SimpleNamespace(usage=usage_obj)
+
+	usage = llm._get_usage(response)
+
+	assert usage is not None
+	assert usage.prompt_cached_tokens == 16
+
+
+def test_deepseek_usage_none_when_missing():
+	llm = ChatDeepSeek()
+	response = SimpleNamespace(usage=None)
+
+	assert llm._get_usage(response) is None


### PR DESCRIPTION
## Summary

`ChatOllama` and `ChatDeepSeek` hardcoded `usage=None` on every return path, so `ChatInvokeCompletion.usage` was always `None` for these providers even though both APIs report token counts. This makes it impossible to observe token consumption (and cache effectiveness) from inside the agent when using Ollama or DeepSeek.

This is the follow-up explicitly called out as out-of-scope in [#4892](https://github.com/browser-use/browser-use/pull/4892):

> **DeepSeek**: returns `usage=None` entirely … Follow-up.
> **Ollama**: same, returns `usage=None` … the prompt/completion counts themselves are also dropped. Follow-up.

## Changes

- **`browser_use/llm/ollama/chat.py`** — add `_get_usage()` that reads the Ollama response's `prompt_eval_count` / `eval_count` into `ChatInvokeUsage`. Ollama has no prefix caching, so the cache fields stay `None`. Returns `None` when the response carries no counts. Wired into both `ainvoke` return paths.
- **`browser_use/llm/deepseek/chat.py`** — add `_get_usage()` that reads the standard OpenAI-compatible `resp.usage` (`prompt_tokens` / `completion_tokens` / `total_tokens`) and surfaces cache hits from DeepSeek's `prompt_cache_hit_tokens`, falling back to `prompt_tokens_details.cached_tokens`. Wired into all four return paths (text, function-calling with/without `output_format`, JSON-output).
- **`tests/ci/models/test_llm_usage.py`** (new) — 6 unit tests covering both helpers with `SimpleNamespace` fakes (full counts, missing usage, partial counts, DeepSeek cache-hit field, and the `prompt_tokens_details` fallback). No network access or API keys required.

## Notes

- Reads are defensive (`getattr`) so older SDK builds / proxies that omit `prompt_tokens_details` or `prompt_cache_hit_tokens` still work — matching the existing pattern in `openrouter/chat.py` and `openai/chat.py`.
- No behavior change other than `usage` now being populated; all completion values are unchanged.
- This is independent of #4892 — those wrappers dropped usage unconditionally, so the fix doesn't depend on that PR landing first.

## Test plan

- [x] `_get_usage` logic verified against all 6 cases (full counts, missing, partial, DeepSeek cache hit, `prompt_tokens_details` fallback, missing usage).
- [ ] Maintainer-side `pytest tests/ci/models/test_llm_usage.py` in CI.
- [ ] Optional real-API smoke check against an Ollama server and a DeepSeek key to confirm the live response field names.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate token usage for `ChatOllama` and `ChatDeepSeek` so agents can track token spend and cache hits. Previously `usage` was always `None`; now it’s parsed from provider responses.

- **Bug Fixes**
  - `ChatOllama`: added `_get_usage()` to map `prompt_eval_count` and `eval_count` into `ChatInvokeUsage`; applied to both `ainvoke` paths.
  - `ChatDeepSeek`: added `_get_usage()` to read OpenAI-style `usage` and cache hits via `prompt_cache_hit_tokens` (fallback to `prompt_tokens_details.cached_tokens`); applied to all return paths.
  - Tests: added `tests/ci/models/test_llm_usage.py` covering counts, missing/partial usage, and cache-hit fallback.

<sup>Written for commit 546f9e0c61412e4baad4a17b8cfaf20cc40f3781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

