### PR TITLE
fix: parse Groq tool-call structured output

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -170,17 +170,30 @@ class ChatGroq(BaseChatModel):
 
 		if self.model in ToolCallingModels:
 			response = await self._invoke_with_tool_calling(groq_messages, output_format, schema)
+			message = response.choices[0].message
+			if not message.tool_calls:
+				raise ModelProviderError(
+					message='No tool calls in response',
+					status_code=500,
+					model=self.name,
+				)
+
+			raw_args = message.tool_calls[0].function.arguments
+			if isinstance(raw_args, str):
+				parsed_response = output_format.model_validate_json(raw_args)
+			else:
+				parsed_response = output_format.model_validate(raw_args)
 		else:
 			response = await self._invoke_with_json_schema(groq_messages, output_format, schema)
+			if not response.choices[0].message.content:
+				raise ModelProviderError(
+					message='No content in response',
+					status_code=500,
+					model=self.name,
+				)
 
-		if not response.choices[0].message.content:
-			raise ModelProviderError(
-				message='No content in response',
-				status_code=500,
-				model=self.name,
-			)
+			parsed_response = output_format.model_validate_json(response.choices[0].message.content)
 
-		parsed_response = output_format.model_validate_json(response.choices[0].message.content)
 		usage = self._get_usage(response)
 
 		return ChatInvokeCompletion(

--- a/browser_use/llm/tests/test_chat_models.py
+++ b/browser_use/llm/tests/test_chat_models.py
@@ -1,4 +1,6 @@
 import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from pydantic import BaseModel
@@ -225,6 +227,35 @@ class TestChatModels:
 		assert isinstance(completion, CapitalResponse)
 		assert completion.country.lower() == self.EXPECTED_FRANCE_COUNTRY
 		assert completion.capital.lower() == self.EXPECTED_FRANCE_CAPITAL
+
+	@pytest.mark.asyncio
+	async def test_groq_ainvoke_structured_tool_calling_reads_arguments(self):
+		chat = ChatGroq(model='moonshotai/kimi-k2-instruct', temperature=0)
+		create = AsyncMock(
+			return_value=SimpleNamespace(
+				usage=None,
+				choices=[
+					SimpleNamespace(
+						message=SimpleNamespace(
+							content=None,
+							tool_calls=[
+								SimpleNamespace(function=SimpleNamespace(arguments='{"country": "france", "capital": "paris"}'))
+							],
+						)
+					)
+				],
+			)
+		)
+		client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+		chat.get_client = lambda: client
+
+		response = await chat.ainvoke(self.STRUCTURED_MESSAGES, output_format=CapitalResponse)
+
+		assert isinstance(response.completion, CapitalResponse)
+		assert response.completion.country == self.EXPECTED_FRANCE_COUNTRY
+		assert response.completion.capital == self.EXPECTED_FRANCE_CAPITAL
+		create.assert_awaited_once()
+		assert 'tools' in create.call_args.kwargs
 
 	# OpenRouter Tests
 	@pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- parse Groq structured output from tool-call arguments for models that use `tool_choice=required`
- keep the JSON schema path reading `message.content`
- add a mocked regression test for the Groq tool-calling response shape where `content` is null

## Why
`moonshotai/kimi-k2-instruct` goes through the tool-calling branch. Groq returns the structured payload in `message.tool_calls[0].function.arguments`, while `message.content` can be null. The old shared parsing path raised `No content in response` before looking at the tool call.

## Validation
- python -m py_compile browser_use\llm\groq\chat.py browser_use\llm\tests\test_chat_models.py
- python -m pytest browser_use\llm\tests\test_chat_models.py::TestChatModels::test_groq_ainvoke_structured_tool_calling_reads_arguments -q
- python -m ruff check browser_use\llm\groq\chat.py browser_use\llm\tests\test_chat_models.py
- python -m ruff format --check browser_use\llm\groq\chat.py browser_use\llm\tests\test_chat_models.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Groq structured output parsing for tool-calling models. If `message.content` is null, parse `message.tool_calls[0].function.arguments` (string or object) and validate; keep JSON-schema parsing for non-tool-calling models.

- **Bug Fixes**
  - Raise clear errors when `tool_calls` is missing or when `content` is missing in the non-tool-calling path.
  - Add a regression test that mocks the tool-call response, ensures `tools` are sent, and validates parsed arguments.

<sup>Written for commit 56cf11b10855ad598bd02467b0450ebd31c5ec06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

