### PR TITLE
fix: recover from trailing garbage in LLM JSON responses

### DIFF
--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.deepseek.serializer import DeepSeekMessageSerializer
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.json_utils import safe_validate_json
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion
@@ -200,7 +201,7 @@ class ChatDeepSeek(BaseChatModel):
 				content = resp.choices[0].message.content
 				if not content:
 					raise ModelProviderError('Empty JSON content in DeepSeek response', model=self.name)
-				parsed = output_format.model_validate_json(content)
+				parsed = safe_validate_json(output_format, content)
 				return ChatInvokeCompletion(
 					completion=parsed,
 					usage=None,

--- a/browser_use/llm/json_utils.py
+++ b/browser_use/llm/json_utils.py
@@ -1,0 +1,99 @@
+"""Shared JSON parsing utilities for LLM providers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+T = TypeVar('T', bound=BaseModel)
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_first_json_object(text: str) -> str | None:
+	"""Extract the first complete JSON object from text that may contain trailing garbage.
+
+	Some reasoning models (GPT-5, o-series, DeepSeek-R1, etc.) return valid
+	JSON followed by extraneous trailing bracket characters (e.g. ']}}]').
+	This helper walks the string character-by-character with a bracket stack,
+	and returns just the first complete JSON object or array.
+
+	Returns ``None`` if no balanced JSON object is found.
+	"""
+	start = None
+	for i, ch in enumerate(text):
+		if ch in ('{', '['):
+			start = i
+			break
+	if start is None:
+		return None
+
+	stack: list[str] = []
+	in_string = False
+	escaped = False
+
+	for i in range(start, len(text)):
+		ch = text[i]
+
+		if escaped:
+			escaped = False
+			continue
+
+		if ch == '\\' and in_string:
+			escaped = True
+			continue
+
+		if ch == '"' and not escaped:
+			in_string = not in_string
+			continue
+
+		if in_string:
+			continue
+
+		if ch in ('{', '['):
+			stack.append(ch)
+		elif ch == '}':
+			if stack and stack[-1] == '{':
+				stack.pop()
+				if not stack:
+					return text[start : i + 1]
+		elif ch == ']':
+			if stack and stack[-1] == '[':
+				stack.pop()
+				if not stack:
+					return text[start : i + 1]
+
+	return None
+
+
+def safe_validate_json(output_format: type[T], content: str) -> T:
+	"""Validate *content* as JSON against *output_format*, with trailing-garbage recovery.
+
+	Tries ``output_format.model_validate_json(content)`` first.  If that
+	fails because the JSON is malformed (e.g. trailing bracket characters
+	from reasoning models), attempts to extract the first balanced JSON
+	object and re-validate.  Raises the original error if recovery also
+	fails.
+	"""
+	try:
+		return output_format.model_validate_json(content)
+	except (json.JSONDecodeError, ValidationError) as err:
+		# Only attempt recovery for JSON syntax errors, not schema mismatches
+		if isinstance(err, ValidationError) and not _is_json_syntax_error(err):
+			raise
+		extracted = _extract_first_json_object(content)
+		if extracted is not None and extracted != content:
+			logger.debug('Recovered JSON by stripping trailing garbage (%d → %d chars)', len(content), len(extracted))
+			return output_format.model_validate_json(extracted)
+		raise
+
+
+def _is_json_syntax_error(err: ValidationError) -> bool:
+	"""Return True if the ValidationError is about invalid JSON syntax (not schema)."""
+	for e in err.errors():
+		if e.get('type') == 'json_invalid':
+			return True
+	return False

--- a/browser_use/llm/litellm/chat.py
+++ b/browser_use/llm/litellm/chat.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.json_utils import safe_validate_json
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
@@ -211,7 +212,7 @@ class ChatLiteLLM(BaseChatModel):
 					status_code=500,
 					model=self.name,
 				)
-			parsed = output_format.model_validate_json(content)
+			parsed = safe_validate_json(output_format, content)
 			return ChatInvokeCompletion(
 				completion=parsed,
 				thinking=thinking,

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Mapping
-from dataclasses import field
+from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar, overload
 
 import httpx
@@ -22,6 +22,7 @@ from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 T = TypeVar('T', bound=BaseModel)
 
 
+@dataclass
 class ChatOpenAI(BaseChatModel):
 	"""
 	A wrapper around AsyncOpenAI that implements the BaseLLM protocol.

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import field
 from typing import Any, Literal, TypeVar, overload
 
 import httpx
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.json_utils import safe_validate_json
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.openai.serializer import OpenAIMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer
@@ -21,7 +22,6 @@ from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 T = TypeVar('T', bound=BaseModel)
 
 
-@dataclass
 class ChatOpenAI(BaseChatModel):
 	"""
 	A wrapper around AsyncOpenAI that implements the BaseLLM protocol.
@@ -281,7 +281,7 @@ class ChatOpenAI(BaseChatModel):
 
 				usage = self._get_usage(response)
 
-				parsed = output_format.model_validate_json(choice.message.content)
+				parsed = safe_validate_json(output_format, choice.message.content)
 
 				return ChatInvokeCompletion(
 					completion=parsed,

--- a/browser_use/llm/openrouter/chat.py
+++ b/browser_use/llm/openrouter/chat.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.json_utils import safe_validate_json
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.openrouter.serializer import OpenRouterMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer
@@ -193,7 +194,7 @@ class ChatOpenRouter(BaseChatModel):
 					)
 				usage = self._get_usage(response)
 
-				parsed = output_format.model_validate_json(response.choices[0].message.content)
+				parsed = safe_validate_json(output_format, response.choices[0].message.content)
 
 				return ChatInvokeCompletion(
 					completion=parsed,

--- a/browser_use/llm/vercel/chat.py
+++ b/browser_use/llm/vercel/chat.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.json_utils import safe_validate_json
 from browser_use.llm.messages import BaseMessage, ContentPartTextParam, SystemMessage
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.vercel.serializer import VercelMessageSerializer
@@ -655,7 +656,7 @@ class ChatVercel(BaseChatModel):
 						)
 
 					usage = self._get_usage(response)
-					parsed = output_format.model_validate_json(content)
+					parsed = safe_validate_json(output_format, content)
 
 					return ChatInvokeCompletion(
 						completion=parsed,


### PR DESCRIPTION
## Problem

Reasoning models (GPT-5, o-series, DeepSeek-R1) sometimes append extraneous bracket characters after valid JSON output, causing `model_validate_json()` to fail with:

```
Invalid JSON: trailing characters at line 2 column 1
```

This makes structured output unreliable for any thinking/reasoning model, forcing users to retry steps that should have succeeded on the first attempt. Reported in #4970.

## Solution

Added `safe_validate_json()` utility in `browser_use/llm/json_utils.py` that wraps Pydantic`::`s JSON validation with automatic recovery:

1. Try `model_validate_json(content)` as normal
2. On `JSONDecodeError`, extract the first balanced JSON object using a bracket-depth stack
3. Re-validate the extracted JSON

The recovery only triggers for JSON syntax errors (`json_invalid`), not for schema mismatches — so real validation errors still propagate correctly.

## Changes

- **`browser_use/llm/json_utils.py`** (new): `safe_validate_json()` + `_extract_first_json_object()` utilities
- **`browser_use/llm/openai/chat.py`**: Use `safe_validate_json` for structured output parsing
- **`browser_use/llm/vercel/chat.py`**: Same
- **`browser_use/llm/deepseek/chat.py`**: Same
- **`browser_use/llm/openrouter/chat.py`**: Same
- **`browser_use/llm/litellm/chat.py`**: Same

All five LLM providers that parse structured JSON output now benefit from trailing-garbage recovery.

## Testing

Verified with several trailing-garbage patterns:
- `{"action":[...]}]}}]}}` — trailing brackets
- `{"action":[...]}\n]}}]}}` — trailing brackets on new line  
- Valid JSON passes through unchanged (no overhead)
- Schema validation errors still raise correctly (not silently swallowed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recover from trailing garbage in LLM JSON responses by extracting the first balanced JSON object, and restore `@dataclass` on `ChatOpenAI`. Applied across structured-output paths for OpenAI, Vercel, DeepSeek, OpenRouter, and LiteLLM. Fixes #4970.

- **Bug Fixes**
  - Added `safe_validate_json()` in `browser_use/llm/json_utils.py` with bracket-stack recovery.
  - Switched providers to `safe_validate_json()`; only recovers JSON syntax errors (schema mismatches still raise).
  - Restored `@dataclass` on `ChatOpenAI` to fix initialization and typing issues.

<sup>Written for commit 61d3854d21fcf5dfcf458c1a20d406953145f524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

