### PR TITLE
feat: add hover action for triggering CSS :hover patterns

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -144,6 +144,23 @@ class ClickCoordinateEvent(BaseEvent[dict]):
 	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ClickCoordinateEvent', 15.0))  # seconds
 
 
+class HoverElementEvent(ElementSelectedEvent[dict | None]):
+	"""Hover over an element to trigger CSS :hover effects (dropdowns, tooltips, hover-reveal patterns)."""
+
+	node: 'EnhancedDOMTreeNode'
+
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverElementEvent', 10.0))  # seconds
+
+
+class HoverCoordinateEvent(BaseEvent[dict]):
+	"""Hover at specific viewport coordinates to trigger CSS :hover effects."""
+
+	coordinate_x: int
+	coordinate_y: int
+
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverCoordinateEvent', 10.0))  # seconds
+
+
 class TypeTextEvent(ElementSelectedEvent[dict | None]):
 	"""Type text into an element."""
 

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -527,7 +527,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 		except Exception as e:
 			raise BrowserError(
 				message=f'Failed to hover over element: {str(e)}',
-				long_term_memory=f'Failed to hover over element. The element may have changed or the page may have been updated.',
+				long_term_memory='Failed to hover over element. The element may have changed or the page may have been updated.',
 			)
 
 	@observe_debug(ignore_input=True, ignore_output=True, name='hover_coordinate_event')
@@ -588,9 +588,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 				long_term_memory=f'Failed to hover at coordinates ({event.coordinate_x}, {event.coordinate_y}). The coordinates may be outside viewport.',
 			)
 
-	async def _hover_element_js_fallback(
-		self, element_node: EnhancedDOMTreeNode, cdp_session, session_id: str
-	) -> dict | None:
+	async def _hover_element_js_fallback(self, element_node: EnhancedDOMTreeNode, cdp_session, session_id: str) -> dict | None:
 		"""Fallback: dispatch mouseover + mouseenter + mousemove via JavaScript on the element."""
 		try:
 			backend_node_id = element_node.backend_node_id
@@ -645,16 +643,16 @@ class DefaultActionWatchdog(BaseWatchdog):
 			await asyncio.sleep(0.1)
 
 			hover_result = js_result.get('result', {}).get('value', {})
-			self.logger.debug(f'🖱️ JS hover fallback succeeded for element at ({hover_result.get("hover_x", 0):.0f}, {hover_result.get("hover_y", 0):.0f})')
+			self.logger.debug(
+				f'🖱️ JS hover fallback succeeded for element at ({hover_result.get("hover_x", 0):.0f}, {hover_result.get("hover_y", 0):.0f})'
+			)
 			return hover_result if isinstance(hover_result, dict) else {}
 
 		except Exception as e:
 			self.logger.error(f'JS hover fallback failed: {type(e).__name__}: {e}')
 			raise BrowserError(f'Failed to hover over element via JS fallback: {e}')
 
-	async def _hover_coordinate_js_fallback(
-		self, x: float, y: float, cdp_session, session_id: str
-	) -> dict | None:
+	async def _hover_coordinate_js_fallback(self, x: float, y: float, cdp_session, session_id: str) -> dict | None:
 		"""Fallback: dispatch hover events via JavaScript at specific coordinates."""
 		try:
 			js_code = f"""

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -13,6 +13,8 @@ from browser_use.browser.events import (
 	GetDropdownOptionsEvent,
 	GoBackEvent,
 	GoForwardEvent,
+	HoverCoordinateEvent,
+	HoverElementEvent,
 	RefreshEvent,
 	ScrollEvent,
 	ScrollToTextEvent,
@@ -32,6 +34,8 @@ from browser_use.observability import observe_debug
 ClickCoordinateEvent.model_rebuild()
 ClickElementEvent.model_rebuild()
 GetDropdownOptionsEvent.model_rebuild()
+HoverElementEvent.model_rebuild()
+HoverCoordinateEvent.model_rebuild()
 SelectDropdownOptionEvent.model_rebuild()
 TypeTextEvent.model_rebuild()
 ScrollEvent.model_rebuild()
@@ -447,6 +451,256 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 		except Exception:
 			raise
+
+	@observe_debug(ignore_input=True, ignore_output=True, name='hover_element_event')
+	async def on_HoverElementEvent(self, event: HoverElementEvent) -> dict | None:
+		"""Handle hover request on an element using CDP Input.dispatchMouseEvent with mouseMoved.
+
+		This triggers genuine CSS :hover state transitions and the full DOM event cascade
+		(mouseenter, mouseover, mousemove), unlike synthetic dispatchEvent calls.
+		"""
+		try:
+			# Check if session is alive before attempting any operations
+			if not self.browser_session.agent_focus_target_id:
+				error_msg = 'Cannot execute hover: browser session is corrupted (target_id=None). Session may have crashed.'
+				self.logger.error(f'{error_msg}')
+				raise BrowserError(error_msg)
+
+			element_node = event.node
+			index_for_logging = element_node.backend_node_id or 'unknown'
+
+			cdp_session = await self.browser_session.cdp_client_for_node(element_node)
+			session_id = cdp_session.session_id
+			backend_node_id = element_node.backend_node_id
+
+			# Scroll element into view first
+			try:
+				await cdp_session.cdp_client.send.DOM.scrollIntoViewIfNeeded(
+					params={'backendNodeId': backend_node_id}, session_id=session_id
+				)
+				await asyncio.sleep(0.05)  # Wait for scroll to complete
+			except Exception as e:
+				self.logger.debug(f'Failed to scroll element into view before hover: {e}')
+
+			# Get viewport dimensions for clamping
+			layout_metrics = await cdp_session.cdp_client.send.Page.getLayoutMetrics(session_id=session_id)
+			viewport_width = layout_metrics['layoutViewport']['clientWidth']
+			viewport_height = layout_metrics['layoutViewport']['clientHeight']
+
+			# Get element coordinates
+			element_rect = await self.browser_session.get_element_coordinates(backend_node_id, cdp_session)
+
+			if element_rect is not None:
+				# Calculate center point of the element
+				center_x = element_rect.x + element_rect.width / 2
+				center_y = element_rect.y + element_rect.height / 2
+
+				# Clamp to viewport bounds
+				center_x = max(0, min(viewport_width - 1, center_x))
+				center_y = max(0, min(viewport_height - 1, center_y))
+
+				# Dispatch mouseMoved event via CDP - this triggers genuine CSS :hover
+				try:
+					await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
+						params={
+							'type': 'mouseMoved',
+							'x': center_x,
+							'y': center_y,
+						},
+						session_id=session_id,
+					)
+					await asyncio.sleep(0.1)  # Wait for :hover CSS effects to apply
+
+					self.logger.debug(f'🖱️ Hovered element {index_for_logging} at ({center_x:.0f}, {center_y:.0f})')
+					return {'hover_x': center_x, 'hover_y': center_y}
+				except Exception as cdp_e:
+					self.logger.warning(f'CDP mouseMoved failed: {type(cdp_e).__name__}: {cdp_e}, trying JS fallback')
+					# Fallback: dispatch mouseover/mouseenter/mousemove via JS
+					return await self._hover_element_js_fallback(element_node, cdp_session, session_id)
+			else:
+				# No bounding box, fall back to JS
+				self.logger.warning('Could not get element coordinates, falling back to JavaScript hover')
+				return await self._hover_element_js_fallback(element_node, cdp_session, session_id)
+
+		except BrowserError:
+			raise
+		except Exception as e:
+			raise BrowserError(
+				message=f'Failed to hover over element: {str(e)}',
+				long_term_memory=f'Failed to hover over element. The element may have changed or the page may have been updated.',
+			)
+
+	@observe_debug(ignore_input=True, ignore_output=True, name='hover_coordinate_event')
+	async def on_HoverCoordinateEvent(self, event: HoverCoordinateEvent) -> dict | None:
+		"""Handle hover at specific viewport coordinates using CDP Input.dispatchMouseEvent with mouseMoved.
+
+		This triggers genuine CSS :hover state transitions at the given viewport position.
+		"""
+		try:
+			# Check if session is alive
+			if not self.browser_session.agent_focus_target_id:
+				error_msg = 'Cannot execute hover: browser session is corrupted (target_id=None). Session may have crashed.'
+				self.logger.error(f'{error_msg}')
+				raise BrowserError(error_msg)
+
+			cdp_session = await self.browser_session.get_or_create_cdp_session()
+			session_id = cdp_session.session_id
+
+			# Get viewport dimensions for clamping
+			layout_metrics = await cdp_session.cdp_client.send.Page.getLayoutMetrics(session_id=session_id)
+			viewport_width = layout_metrics['layoutViewport']['clientWidth']
+			viewport_height = layout_metrics['layoutViewport']['clientHeight']
+
+			# Clamp coordinates to viewport bounds
+			clamped_x = max(0, min(viewport_width - 1, event.coordinate_x))
+			clamped_y = max(0, min(viewport_height - 1, event.coordinate_y))
+
+			if clamped_x != event.coordinate_x or clamped_y != event.coordinate_y:
+				self.logger.debug(
+					f'Clamped hover coordinates from ({event.coordinate_x}, {event.coordinate_y}) '
+					f'to ({clamped_x}, {clamped_y}) within viewport'
+				)
+
+			try:
+				# Dispatch mouseMoved event via CDP
+				await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
+					params={
+						'type': 'mouseMoved',
+						'x': clamped_x,
+						'y': clamped_y,
+					},
+					session_id=session_id,
+				)
+				await asyncio.sleep(0.1)  # Wait for :hover CSS effects to apply
+
+				self.logger.debug(f'🖱️ Hovered at coordinates ({clamped_x}, {clamped_y})')
+				return {'hover_x': clamped_x, 'hover_y': clamped_y}
+			except Exception as cdp_e:
+				self.logger.warning(f'CDP mouseMoved at coordinates failed: {type(cdp_e).__name__}: {cdp_e}, trying JS fallback')
+				# Fallback: dispatch events via JS at the target coordinates
+				return await self._hover_coordinate_js_fallback(clamped_x, clamped_y, cdp_session, session_id)
+
+		except BrowserError:
+			raise
+		except Exception as e:
+			raise BrowserError(
+				message=f'Failed to hover at coordinates: {str(e)}',
+				long_term_memory=f'Failed to hover at coordinates ({event.coordinate_x}, {event.coordinate_y}). The coordinates may be outside viewport.',
+			)
+
+	async def _hover_element_js_fallback(
+		self, element_node: EnhancedDOMTreeNode, cdp_session, session_id: str
+	) -> dict | None:
+		"""Fallback: dispatch mouseover + mouseenter + mousemove via JavaScript on the element."""
+		try:
+			backend_node_id = element_node.backend_node_id
+
+			result = await cdp_session.cdp_client.send.DOM.resolveNode(
+				params={'backendNodeId': backend_node_id},
+				session_id=session_id,
+			)
+			if 'object' not in result or 'objectId' not in result['object']:
+				raise Exception('Failed to resolve DOM element for JS hover fallback')
+
+			object_id = result['object']['objectId']
+
+			# Dispatch mouseover + mouseenter + mousemove in correct cascade order
+			js_code = """
+			function() {
+				const rect = this.getBoundingClientRect();
+				const x = rect.left + rect.width / 2;
+				const y = rect.top + rect.height / 2;
+
+				const events = [
+					new MouseEvent('mouseover', {
+						bubbles: true, cancelable: true, view: window,
+						clientX: x, clientY: y, screenX: x, screenY: y
+					}),
+					new MouseEvent('mouseenter', {
+						bubbles: false, cancelable: true, view: window,
+						clientX: x, clientY: y, screenX: x, screenY: y
+					}),
+					new MouseEvent('mousemove', {
+						bubbles: true, cancelable: true, view: window,
+						clientX: x, clientY: y, screenX: x, screenY: y
+					})
+				];
+
+				for (const event of events) {
+					this.dispatchEvent(event);
+				}
+
+				return {hover_x: x, hover_y: y};
+			}
+			"""
+
+			js_result = await cdp_session.cdp_client.send.Runtime.callFunctionOn(
+				params={
+					'objectId': object_id,
+					'functionDeclaration': js_code,
+					'returnByValue': True,
+				},
+				session_id=session_id,
+			)
+			await asyncio.sleep(0.1)
+
+			hover_result = js_result.get('result', {}).get('value', {})
+			self.logger.debug(f'🖱️ JS hover fallback succeeded for element at ({hover_result.get("hover_x", 0):.0f}, {hover_result.get("hover_y", 0):.0f})')
+			return hover_result if isinstance(hover_result, dict) else {}
+
+		except Exception as e:
+			self.logger.error(f'JS hover fallback failed: {type(e).__name__}: {e}')
+			raise BrowserError(f'Failed to hover over element via JS fallback: {e}')
+
+	async def _hover_coordinate_js_fallback(
+		self, x: float, y: float, cdp_session, session_id: str
+	) -> dict | None:
+		"""Fallback: dispatch hover events via JavaScript at specific coordinates."""
+		try:
+			js_code = f"""
+			(function() {{
+				const el = document.elementFromPoint({x}, {y});
+				if (!el) return {{hover_x: {x}, hover_y: {y}, target: null}};
+
+				const events = [
+					new MouseEvent('mouseover', {{
+						bubbles: true, cancelable: true, view: window,
+						clientX: {x}, clientY: {y}, screenX: {x}, screenY: {y}
+					}}),
+					new MouseEvent('mouseenter', {{
+						bubbles: false, cancelable: true, view: window,
+						clientX: {x}, clientY: {y}, screenX: {x}, screenY: {y}
+					}}),
+					new MouseEvent('mousemove', {{
+						bubbles: true, cancelable: true, view: window,
+						clientX: {x}, clientY: {y}, screenX: {x}, screenY: {y}
+					}})
+				];
+
+				for (const event of events) {{
+					el.dispatchEvent(event);
+				}}
+
+				return {{hover_x: {x}, hover_y: {y}, target: el.tagName}};
+			}})()
+			"""
+
+			js_result = await cdp_session.cdp_client.send.Runtime.evaluate(
+				params={
+					'expression': js_code,
+					'returnByValue': True,
+				},
+				session_id=session_id,
+			)
+			await asyncio.sleep(0.1)
+
+			hover_result = js_result.get('result', {}).get('value', {})
+			self.logger.debug(f'🖱️ JS coordinate hover fallback succeeded at ({x}, {y})')
+			return hover_result if isinstance(hover_result, dict) else {'hover_x': x, 'hover_y': y}
+
+		except Exception as e:
+			self.logger.error(f'JS coordinate hover fallback failed: {type(e).__name__}: {e}')
+			raise BrowserError(f'Failed to hover at coordinates via JS fallback: {e}')
 
 	async def on_TypeTextEvent(self, event: TypeTextEvent) -> dict | None:
 		"""Handle text input request with CDP."""

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -19,6 +19,8 @@ from browser_use.browser.events import (
 	ClickCoordinateEvent,
 	ClickElementEvent,
 	CloseTabEvent,
+	HoverCoordinateEvent,
+	HoverElementEvent,
 	GetDropdownOptionsEvent,
 	GoBackEvent,
 	NavigateToUrlEvent,
@@ -38,7 +40,8 @@ from browser_use.observability import observe_debug
 from browser_use.tools.registry.service import Registry
 from browser_use.tools.utils import get_click_description
 from browser_use.tools.views import (
-	ClickElementAction,
+		HoverElementAction,
+		ClickElementAction,
 	ClickElementActionIndexOnly,
 	CloseTabAction,
 	DoneAction,
@@ -66,6 +69,8 @@ logger = logging.getLogger(__name__)
 # Import EnhancedDOMTreeNode and rebuild event models that have forward references to it
 # This must be done after all imports are complete
 ClickElementEvent.model_rebuild()
+HoverElementEvent.model_rebuild()
+HoverCoordinateEvent.model_rebuild()
 TypeTextEvent.model_rebuild()
 ScrollEvent.model_rebuild()
 UploadFileEvent.model_rebuild()
@@ -739,12 +744,91 @@ class Tools(Generic[Context]):
 				error_msg = f'Failed to click element {params.index}: {str(e)}'
 				return ActionResult(error=error_msg)
 
-		# Store click handlers for re-registration
-		self._click_by_index = _click_by_index
-		self._click_by_coordinate = _click_by_coordinate
+		
+			async def _hover_by_index(params: HoverElementAction, browser_session: BrowserSession) -> ActionResult:
+				"""Hover over an element by index to trigger CSS :hover effects (dropdowns, tooltips, hover-reveal patterns)."""
+				assert params.index is not None
+				try:
+					assert params.index != 0, (
+						'Cannot hover on element with index 0. If there are no interactive elements use wait(), refresh(), etc. to troubleshoot'
+					)
 
-		# Register click action (index-only by default)
-		self._register_click_action()
+					# Look up the node from the selector map
+					node = await browser_session.get_element_by_index(params.index)
+					if node is None:
+						msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+						logger.warning(f'⚠️ {msg}')
+						return ActionResult(extracted_content=msg)
+
+					# Get description of hovered element
+					element_desc = get_click_description(node)
+
+					# Highlight the element being hovered (truly non-blocking)
+					create_task_with_error_handling(
+						browser_session.highlight_interaction_element(node), name='highlight_hover_element', suppress_exceptions=True
+					)
+
+					event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
+					await event
+					# Wait for handler to complete and get any exception or metadata
+					hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+
+					memory = f'Hovered {element_desc}'
+					logger.info(f'🖱️ {memory}')
+
+					return ActionResult(
+						extracted_content=memory,
+						metadata=hover_metadata if isinstance(hover_metadata, dict) else None,
+					)
+				except BrowserError as e:
+					return handle_browser_error(e)
+				except Exception as e:
+					error_msg = f'Failed to hover element {params.index}: {str(e)}'
+					return ActionResult(error=error_msg)
+
+			async def _hover_by_coordinate(params: HoverElementAction, browser_session: BrowserSession) -> ActionResult:
+				"""Hover at specific coordinates to trigger CSS :hover effects."""
+				if params.coordinate_x is None or params.coordinate_y is None:
+					return ActionResult(error='Both coordinate_x and coordinate_y must be provided')
+
+				try:
+					# Convert coordinates from LLM size to original viewport size if resizing was used
+					actual_x, actual_y = _convert_llm_coordinates_to_viewport(
+						params.coordinate_x, params.coordinate_y, browser_session
+					)
+
+					# Highlight the coordinate being hovered (truly non-blocking)
+					asyncio.create_task(browser_session.highlight_coordinate_click(actual_x, actual_y))
+
+					# Dispatch HoverCoordinateEvent
+					event = browser_session.event_bus.dispatch(
+						HoverCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y)
+					)
+					await event
+					hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+
+					memory = f'Hovered at coordinate {params.coordinate_x}, {params.coordinate_y}'
+					logger.info(f'🖱️ {memory}')
+
+					return ActionResult(
+						extracted_content=memory,
+						metadata={'hover_x': actual_x, 'hover_y': actual_y},
+					)
+				except BrowserError as e:
+					return handle_browser_error(e)
+				except Exception as e:
+					error_msg = f'Failed to hover at coordinates ({params.coordinate_x}, {params.coordinate_y}).'
+					return ActionResult(error=error_msg)
+
+			# Store click handlers for re-registration
+			self._click_by_index = _click_by_index
+			self._click_by_coordinate = _click_by_coordinate
+			self._hover_by_index = _hover_by_index
+			self._hover_by_coordinate = _hover_by_coordinate
+
+			# Register click action (index-only by default)
+			self._register_click_action()
+			self._register_hover_action()
 
 		@self.registry.action(
 			'Input text into element by index. Clears existing text by default; pass text="" to clear only, or clear=False to append.',
@@ -2088,6 +2172,29 @@ Validated Code (after quote fixing):
 			)
 			async def click(params: ClickElementActionIndexOnly, browser_session: BrowserSession):
 				return await self._click_by_index(params, browser_session)
+
+	
+	def _register_hover_action(self) -> None:
+		"""Register the hover action with both index and coordinate support."""
+		# Remove existing hover action if present
+		if 'hover' in self.registry.registry.actions:
+			del self.registry.registry.actions['hover']
+
+		@self.registry.action(
+			'Trigger CSS :hover state on an element to reveal dropdowns, tooltips, hover-reveal patterns. Either provide index or coordinates.',
+			param_model=HoverElementAction,
+		)
+		async def hover(params: HoverElementAction, browser_session: BrowserSession):
+			# Validate that either index or coordinates are provided
+			if params.index is None and (params.coordinate_x is None or params.coordinate_y is None):
+				return ActionResult(error='Must provide either index or both coordinate_x and coordinate_y')
+
+			# Try index-based hovering first if index is provided
+			if params.index is not None:
+				return await self._hover_by_index(params, browser_session)
+			# Coordinate-based hovering when index is not provided
+			else:
+				return await self._hover_by_coordinate(params, browser_session)
 
 	def set_coordinate_clicking(self, enabled: bool) -> None:
 		"""Enable or disable coordinate-based clicking.

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -19,10 +19,10 @@ from browser_use.browser.events import (
 	ClickCoordinateEvent,
 	ClickElementEvent,
 	CloseTabEvent,
-	HoverCoordinateEvent,
-	HoverElementEvent,
 	GetDropdownOptionsEvent,
 	GoBackEvent,
+	HoverCoordinateEvent,
+	HoverElementEvent,
 	NavigateToUrlEvent,
 	ScrollEvent,
 	ScrollToTextEvent,
@@ -40,14 +40,14 @@ from browser_use.observability import observe_debug
 from browser_use.tools.registry.service import Registry
 from browser_use.tools.utils import get_click_description
 from browser_use.tools.views import (
-		HoverElementAction,
-		ClickElementAction,
+	ClickElementAction,
 	ClickElementActionIndexOnly,
 	CloseTabAction,
 	DoneAction,
 	ExtractAction,
 	FindElementsAction,
 	GetDropdownOptionsAction,
+	HoverElementAction,
 	InputTextAction,
 	NavigateAction,
 	NoParamsAction,
@@ -744,7 +744,6 @@ class Tools(Generic[Context]):
 				error_msg = f'Failed to click element {params.index}: {str(e)}'
 				return ActionResult(error=error_msg)
 
-		
 			async def _hover_by_index(params: HoverElementAction, browser_session: BrowserSession) -> ActionResult:
 				"""Hover over an element by index to trigger CSS :hover effects (dropdowns, tooltips, hover-reveal patterns)."""
 				assert params.index is not None
@@ -765,7 +764,9 @@ class Tools(Generic[Context]):
 
 					# Highlight the element being hovered (truly non-blocking)
 					create_task_with_error_handling(
-						browser_session.highlight_interaction_element(node), name='highlight_hover_element', suppress_exceptions=True
+						browser_session.highlight_interaction_element(node),
+						name='highlight_hover_element',
+						suppress_exceptions=True,
 					)
 
 					event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
@@ -801,9 +802,7 @@ class Tools(Generic[Context]):
 					asyncio.create_task(browser_session.highlight_coordinate_click(actual_x, actual_y))
 
 					# Dispatch HoverCoordinateEvent
-					event = browser_session.event_bus.dispatch(
-						HoverCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y)
-					)
+					event = browser_session.event_bus.dispatch(HoverCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y))
 					await event
 					hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
 
@@ -2173,7 +2172,6 @@ Validated Code (after quote fixing):
 			async def click(params: ClickElementActionIndexOnly, browser_session: BrowserSession):
 				return await self._click_by_index(params, browser_session)
 
-	
 	def _register_hover_action(self) -> None:
 		"""Register the hover action with both index and coordinate support."""
 		# Remove existing hover action if present

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -744,90 +744,88 @@ class Tools(Generic[Context]):
 				error_msg = f'Failed to click element {params.index}: {str(e)}'
 				return ActionResult(error=error_msg)
 
-			async def _hover_by_index(params: HoverElementAction, browser_session: BrowserSession) -> ActionResult:
-				"""Hover over an element by index to trigger CSS :hover effects (dropdowns, tooltips, hover-reveal patterns)."""
-				assert params.index is not None
-				try:
-					assert params.index != 0, (
-						'Cannot hover on element with index 0. If there are no interactive elements use wait(), refresh(), etc. to troubleshoot'
-					)
+		async def _hover_by_index(params: HoverElementAction, browser_session: BrowserSession) -> ActionResult:
+			"""Hover over an element by index to trigger CSS :hover effects (dropdowns, tooltips, hover-reveal patterns)."""
+			assert params.index is not None
+			try:
+				assert params.index != 0, (
+					'Cannot hover on element with index 0. If there are no interactive elements use wait(), refresh(), etc. to troubleshoot'
+				)
 
-					# Look up the node from the selector map
-					node = await browser_session.get_element_by_index(params.index)
-					if node is None:
-						msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
-						logger.warning(f'⚠️ {msg}')
-						return ActionResult(extracted_content=msg)
+				# Look up the node from the selector map
+				node = await browser_session.get_element_by_index(params.index)
+				if node is None:
+					msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+					logger.warning(f'⚠️ {msg}')
+					return ActionResult(extracted_content=msg)
 
-					# Get description of hovered element
-					element_desc = get_click_description(node)
+				# Get description of hovered element
+				element_desc = get_click_description(node)
 
-					# Highlight the element being hovered (truly non-blocking)
-					create_task_with_error_handling(
-						browser_session.highlight_interaction_element(node),
-						name='highlight_hover_element',
-						suppress_exceptions=True,
-					)
+				# Highlight the element being hovered (truly non-blocking)
+				create_task_with_error_handling(
+					browser_session.highlight_interaction_element(node),
+					name='highlight_hover_element',
+					suppress_exceptions=True,
+				)
 
-					event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
-					await event
-					# Wait for handler to complete and get any exception or metadata
-					hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+				event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
+				await event
+				# Wait for handler to complete and get any exception or metadata
+				hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
 
-					memory = f'Hovered {element_desc}'
-					logger.info(f'🖱️ {memory}')
+				memory = f'Hovered {element_desc}'
+				logger.info(f'🖱️ {memory}')
 
-					return ActionResult(
-						extracted_content=memory,
-						metadata=hover_metadata if isinstance(hover_metadata, dict) else None,
-					)
-				except BrowserError as e:
-					return handle_browser_error(e)
-				except Exception as e:
-					error_msg = f'Failed to hover element {params.index}: {str(e)}'
-					return ActionResult(error=error_msg)
+				return ActionResult(
+					extracted_content=memory,
+					metadata=hover_metadata if isinstance(hover_metadata, dict) else None,
+				)
+			except BrowserError as e:
+				return handle_browser_error(e)
+			except Exception as e:
+				error_msg = f'Failed to hover element {params.index}: {str(e)}'
+				return ActionResult(error=error_msg)
 
-			async def _hover_by_coordinate(params: HoverElementAction, browser_session: BrowserSession) -> ActionResult:
-				"""Hover at specific coordinates to trigger CSS :hover effects."""
-				if params.coordinate_x is None or params.coordinate_y is None:
-					return ActionResult(error='Both coordinate_x and coordinate_y must be provided')
+		async def _hover_by_coordinate(params: HoverElementAction, browser_session: BrowserSession) -> ActionResult:
+			"""Hover at specific coordinates to trigger CSS :hover effects."""
+			if params.coordinate_x is None or params.coordinate_y is None:
+				return ActionResult(error='Both coordinate_x and coordinate_y must be provided')
 
-				try:
-					# Convert coordinates from LLM size to original viewport size if resizing was used
-					actual_x, actual_y = _convert_llm_coordinates_to_viewport(
-						params.coordinate_x, params.coordinate_y, browser_session
-					)
+			try:
+				# Convert coordinates from LLM size to original viewport size if resizing was used
+				actual_x, actual_y = _convert_llm_coordinates_to_viewport(params.coordinate_x, params.coordinate_y, browser_session)
 
-					# Highlight the coordinate being hovered (truly non-blocking)
-					asyncio.create_task(browser_session.highlight_coordinate_click(actual_x, actual_y))
+				# Highlight the coordinate being hovered (truly non-blocking)
+				asyncio.create_task(browser_session.highlight_coordinate_click(actual_x, actual_y))
 
-					# Dispatch HoverCoordinateEvent
-					event = browser_session.event_bus.dispatch(HoverCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y))
-					await event
-					hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+				# Dispatch HoverCoordinateEvent
+				event = browser_session.event_bus.dispatch(HoverCoordinateEvent(coordinate_x=actual_x, coordinate_y=actual_y))
+				await event
+				hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
 
-					memory = f'Hovered at coordinate {params.coordinate_x}, {params.coordinate_y}'
-					logger.info(f'🖱️ {memory}')
+				memory = f'Hovered at coordinate {params.coordinate_x}, {params.coordinate_y}'
+				logger.info(f'🖱️ {memory}')
 
-					return ActionResult(
-						extracted_content=memory,
-						metadata={'hover_x': actual_x, 'hover_y': actual_y},
-					)
-				except BrowserError as e:
-					return handle_browser_error(e)
-				except Exception as e:
-					error_msg = f'Failed to hover at coordinates ({params.coordinate_x}, {params.coordinate_y}).'
-					return ActionResult(error=error_msg)
+				return ActionResult(
+					extracted_content=memory,
+					metadata={'hover_x': actual_x, 'hover_y': actual_y},
+				)
+			except BrowserError as e:
+				return handle_browser_error(e)
+			except Exception as e:
+				error_msg = f'Failed to hover at coordinates ({params.coordinate_x}, {params.coordinate_y}).'
+				return ActionResult(error=error_msg)
 
-			# Store click handlers for re-registration
-			self._click_by_index = _click_by_index
-			self._click_by_coordinate = _click_by_coordinate
-			self._hover_by_index = _hover_by_index
-			self._hover_by_coordinate = _hover_by_coordinate
+		# Store click handlers for re-registration
+		self._click_by_index = _click_by_index
+		self._click_by_coordinate = _click_by_coordinate
+		self._hover_by_index = _hover_by_index
+		self._hover_by_coordinate = _hover_by_coordinate
 
-			# Register click action (index-only by default)
-			self._register_click_action()
-			self._register_hover_action()
+		# Register click action (index-only by default)
+		self._register_click_action()
+		self._register_hover_action()
 
 		@self.registry.action(
 			'Input text into element by index. Clears existing text by default; pass text="" to clear only, or clear=False to append.',

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -794,7 +794,9 @@ class Tools(Generic[Context]):
 
 			try:
 				# Convert coordinates from LLM size to original viewport size if resizing was used
-				actual_x, actual_y = _convert_llm_coordinates_to_viewport(params.coordinate_x, params.coordinate_y, browser_session)
+				actual_x, actual_y = _convert_llm_coordinates_to_viewport(
+					params.coordinate_x, params.coordinate_y, browser_session
+				)
 
 				# Highlight the coordinate being hovered (truly non-blocking)
 				asyncio.create_task(browser_session.highlight_coordinate_click(actual_x, actual_y))

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -74,6 +74,12 @@ class ClickElementAction(BaseModel):
 	# click_count: int = 1  # TODO
 
 
+class HoverElementAction(BaseModel):
+	index: int | None = Field(default=None, ge=1, description='Element index from browser_state')
+	coordinate_x: int | None = Field(default=None, description='Horizontal coordinate relative to viewport left edge')
+	coordinate_y: int | None = Field(default=None, description='Vertical coordinate relative to viewport top edge')
+
+
 class ClickElementActionIndexOnly(BaseModel):
 	model_config = ConfigDict(title='ClickElementAction')
 


### PR DESCRIPTION
Adds hover action to the browser agent action set, dispatching CDP mouseMoved events on target elements.

Closes #4964

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `hover` action to trigger real CSS :hover effects (dropdowns, tooltips, hover-reveal) in the browser agent. Uses CDP mouse move with a JS fallback, and fully registers helpers to satisfy #4964.

- **New Features**
  - New `hover` action in the registry; accepts `index` or `coordinate_x/coordinate_y` and converts LLM coords to viewport.
  - `HoverElementEvent` and `HoverCoordinateEvent` with timeouts; scrolls into view and clamps to viewport.
  - Uses CDP `Input.dispatchMouseEvent` with `mouseMoved`; JS fallback dispatches `mouseover`/`mouseenter`/`mousemove`.
  - Returns `hover_x`/`hover_y` metadata and highlights the target; validates params and registers action handlers.

<sup>Written for commit 76c92cd0d77514ea0f0c145aacf4d75eccf87877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

