### PR TITLE
fix: improve icon-only button detection using tooltips and aria-labels

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3647,8 +3647,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			hist_attrs = historical_element.attributes
 			hist_name = historical_element.node_name.lower()
 
-			# Try matching by unique identifiers: name, id, or aria-label
-			for attr_key in ['name', 'id', 'aria-label']:
+			# Try matching by unique identifiers: name, id, aria-label, or title
+			for attr_key in ['name', 'id', 'aria-label', 'title']:
 				if attr_key in hist_attrs and hist_attrs[attr_key]:
 					for idx, elem in selector_items:
 						if (
@@ -3664,10 +3664,16 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 						break
 
 			if highlight_index is None:
-				tried_attrs = [k for k in ['name', 'id', 'aria-label'] if k in hist_attrs and hist_attrs[k]]
+				tried_attrs = [k for k in ['name', 'id', 'aria-label', 'title'] if k in hist_attrs and hist_attrs[k]]
 				# Log what was tried and what's available on the page for debugging
 				same_node_elements = [
-					(idx, elem.attributes.get('aria-label') or elem.attributes.get('id') or elem.attributes.get('name'))
+					(
+						idx,
+						elem.attributes.get('aria-label')
+						or elem.attributes.get('title')
+						or elem.attributes.get('id')
+						or elem.attributes.get('name'),
+					)
 					for idx, elem in selector_items
 					if elem.node_name.lower() == hist_name and elem.attributes
 				]
@@ -3698,7 +3704,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		# Add key identifying attributes
 		if elem.attributes:
-			for key in ['name', 'id', 'aria-label', 'type']:
+			for key in ['name', 'id', 'aria-label', 'title', 'type']:
 				if key in elem.attributes and elem.attributes[key]:
 					parts.append(f'{key}="{elem.attributes[key]}"')
 

--- a/browser_use/dom/serializer/clickable_elements.py
+++ b/browser_use/dom/serializer/clickable_elements.py
@@ -235,7 +235,7 @@ class ClickableElementDetector:
 			# Check if this small element has interactive properties
 			if node.attributes:
 				# Small elements with these attributes are likely interactive icons
-				icon_attributes = {'class', 'role', 'onclick', 'data-action', 'aria-label'}
+				icon_attributes = {'class', 'role', 'onclick', 'data-action', 'aria-label', 'title', 'data-tooltip', 'data-original-title', 'data-bs-title', 'data-title'}
 				if any(attr in node.attributes for attr in icon_attributes):
 					return True
 

--- a/browser_use/dom/serializer/clickable_elements.py
+++ b/browser_use/dom/serializer/clickable_elements.py
@@ -235,7 +235,18 @@ class ClickableElementDetector:
 			# Check if this small element has interactive properties
 			if node.attributes:
 				# Small elements with these attributes are likely interactive icons
-				icon_attributes = {'class', 'role', 'onclick', 'data-action', 'aria-label', 'title', 'data-tooltip', 'data-original-title', 'data-bs-title', 'data-title'}
+				icon_attributes = {
+					'class',
+					'role',
+					'onclick',
+					'data-action',
+					'aria-label',
+					'title',
+					'data-tooltip',
+					'data-original-title',
+					'data-bs-title',
+					'data-title',
+				}
 				if any(attr in node.attributes for attr in icon_attributes):
 					return True
 

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -117,6 +117,10 @@ class DomService:
 					elif subtree_root.attributes:
 						text = (
 							subtree_root.attributes.get('placeholder', '')
+							or subtree_root.attributes.get('data-tooltip', '')
+							or subtree_root.attributes.get('data-original-title', '')
+							or subtree_root.attributes.get('data-bs-title', '')
+							or subtree_root.attributes.get('data-title', '')
 							or subtree_root.attributes.get('title', '')
 							or subtree_root.attributes.get('aria-label', '')
 						)[:40]
@@ -1185,11 +1189,15 @@ class DomService:
 			text = node.get_all_children_text().lower().strip()
 			aria_label = node.attributes.get('aria-label', '').lower()
 			title = node.attributes.get('title', '').lower()
+			data_tooltip = node.attributes.get('data-tooltip', '').lower()
+			data_original_title = node.attributes.get('data-original-title', '').lower()
+			data_bs_title = node.attributes.get('data-bs-title', '').lower()
+			data_title = node.attributes.get('data-title', '').lower()
 			class_name = node.attributes.get('class', '').lower()
 			role = node.attributes.get('role', '').lower()
 
 			# Combine all text sources for pattern matching
-			all_text = f'{text} {aria_label} {title} {class_name}'.strip()
+			all_text = f'{text} {aria_label} {title} {data_tooltip} {data_original_title} {data_bs_title} {data_title} {class_name}'.strip()
 
 			# Check if it's disabled
 			is_disabled = (
@@ -1222,7 +1230,13 @@ class DomService:
 						'button_type': button_type,
 						'backend_node_id': node.backend_node_id,
 						'selector_index': index,
-						'text': node.get_all_children_text().strip() or aria_label or title,
+						'text': node.get_all_children_text().strip()
+						or aria_label
+						or title
+						or data_tooltip
+						or data_original_title
+						or data_bs_title
+						or data_title,
 						'selector': node.xpath,
 						'is_disabled': is_disabled,
 					}

--- a/browser_use/dom/utils.py
+++ b/browser_use/dom/utils.py
@@ -71,6 +71,10 @@ def generate_css_selector_for_element(enhanced_node) -> str | None:
 		# Media attributes
 		'alt',
 		'title',
+		'data-tooltip',
+		'data-original-title',
+		'data-bs-title',
+		'data-title',
 		'src',
 		# Custom stable attributes (add any application-specific ones)
 		'href',

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -16,6 +16,11 @@ from browser_use.observability import observe_debug
 
 # Serializer types
 DEFAULT_INCLUDE_ATTRIBUTES = [
+	'data-tooltip',
+	'data-original-title',
+	'data-bs-title',
+	'data-title',
+	'data-tip',
 	'title',
 	'type',
 	'checked',
@@ -89,6 +94,10 @@ STATIC_ATTRIBUTES = {
 	'placeholder',
 	'aria-label',
 	'title',
+	'data-tooltip',
+	'data-original-title',
+	'data-bs-title',
+	'data-title',
 	# 'aria-expanded',
 	'role',
 	'data-testid',
@@ -609,7 +618,7 @@ class EnhancedDOMTreeNode:
 		meaningful_text = ''
 		if hasattr(self, 'attributes') and self.attributes:
 			# Priority order: value, aria-label, title, placeholder, alt, text content
-			for attr in ['value', 'aria-label', 'title', 'placeholder', 'alt']:
+			for attr in ['value', 'aria-label', 'title', 'data-tooltip', 'data-original-title', 'data-bs-title', 'data-title', 'placeholder', 'alt']:
 				if attr in self.attributes and self.attributes[attr]:
 					meaningful_text = self.attributes[attr]
 					break

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -618,7 +618,17 @@ class EnhancedDOMTreeNode:
 		meaningful_text = ''
 		if hasattr(self, 'attributes') and self.attributes:
 			# Priority order: value, aria-label, title, placeholder, alt, text content
-			for attr in ['value', 'aria-label', 'title', 'data-tooltip', 'data-original-title', 'data-bs-title', 'data-title', 'placeholder', 'alt']:
+			for attr in [
+				'value',
+				'aria-label',
+				'title',
+				'data-tooltip',
+				'data-original-title',
+				'data-bs-title',
+				'data-title',
+				'placeholder',
+				'alt',
+			]:
 				if attr in self.attributes and self.attributes[attr]:
 					meaningful_text = self.attributes[attr]
 					break

--- a/browser_use/tools/utils.py
+++ b/browser_use/tools/utils.py
@@ -74,8 +74,8 @@ def get_click_description(node: EnhancedDOMTreeNode) -> str:
 		short_text = text[:30] + ('...' if len(text) > 30 else '')
 		parts.append(f'"{short_text}"')
 
-	# Add key attributes like id, name, aria-label
-	for attr in ['id', 'name', 'aria-label']:
+	# Add key attributes like id, name, aria-label, title
+	for attr in ['id', 'name', 'aria-label', 'title', 'data-tooltip']:
 		if node.attributes.get(attr):
 			parts.append(f'{attr}={node.attributes[attr][:20]}')
 


### PR DESCRIPTION
Enhances element detection for icon-only buttons using tooltip/aria-label text.

## Problem
Icon-only buttons (e.g., a + button with only a tooltip saying "Create Test") were often missed by the browser agent. When a button lacks visible text content and has no aria-label, but has a tooltip (via HTML title attribute or JS tooltip library data attributes), the agent could not reliably identify or describe the element.

## Changes
- **clickable_elements.py**: Added `title`, `data-tooltip`, `data-original-title`, `data-bs-title`, `data-title` to icon detection attributes — small icon-sized elements with tooltip attributes are now detected as interactive
- **views.py**: Added tooltip data attributes to `DEFAULT_INCLUDE_ATTRIBUTES` (shown to LLM), `STATIC_ATTRIBUTES` (used for element hashing), and `get_meaningful_text_for_llm()` priority chain
- **service.py**: Added tooltip data attributes to hidden element text fallback, pagination detection all_text, and pagination button text fallback
- **utils.py**: Added tooltip data attributes to `SAFE_ATTRIBUTES` for CSS selector generation
- **agent/service.py**: Added `title` to history replay matching attributes and element error formatting
- **tools/utils.py**: Added `title` and `data-tooltip` to click description key attributes

Fixes #4801

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects icon-only buttons using tooltip and aria-label text so the browser agent stops missing them; supports common tooltip attributes across detection, serialization, selectors, and replay. Fixes #4801.

- **Bug Fixes**
  - Icon detection: treat small elements with `title`, `data-tooltip`, `data-original-title`, `data-bs-title`, `data-title` as interactive.
  - DOM serialization and selectors: include tooltip attrs (`title`, `data-tooltip`, `data-original-title`, `data-bs-title`, `data-title`, `data-tip`) in serialized attributes, element hashing, and safe attributes.
  - Text fallbacks and pagination: use tooltip attrs when deriving element text and when detecting pagination.
  - History replay and errors: include `title` in element matching and error messages.
  - Click descriptions: add `title` and `data-tooltip` to improve action summaries.

<sup>Written for commit e44dd6ac23d1734d5683ece94741e547799e5930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

