### PR TITLE
fix: correct Chrome DevTools typo in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_element_detection_bug.yml
+++ b/.github/ISSUE_TEMPLATE/1_element_detection_bug.yml
@@ -46,7 +46,7 @@ body:
       label: Screenshots, Description, and task prompt given to Agent
       description: |
         A description of the issue + screenshots, and the full task prompt you're giving the agent (redact sensitive data).  
-        To help us fix it even faster, screenshot the Chome devtools [`Computed Styles` pane](https://developer.chrome.com/docs/devtools/css/reference#computed) for each failing element.
+        To help us fix it even faster, screenshot the Chrome DevTools [`Computed Styles` pane](https://developer.chrome.com/docs/devtools/css/reference#computed) for each failing element.
       placeholder: |
         🎯 High-level goal: Compare the prices of 3 items on a few different seller pages
         💬 Agent(task='''


### PR DESCRIPTION
## Summary

- Fix a typo in the page interaction issue template: `Chome devtools` -> `Chrome DevTools`.

## Validation

- `git diff --check`
- `uv run pre-commit run --all-files`

## AI assistance

This PR was prepared with AI assistance from Codex.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typo in the element detection bug issue template: "Chome devtools" -> "Chrome DevTools" to clarify the instructions.

<sup>Written for commit d06bdc50cad4238827dd391c88b5198311db20da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

