### PR TITLE
[codex] add bu3 max browser-use model

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,27 +65,26 @@ browser
 ```
 # .env
 BROWSER_USE_API_KEY=your-key
-# GOOGLE_API_KEY=your-key
 # ANTHROPIC_API_KEY=your-key
+# OPENAI_API_KEY=your-key
 ```
 
 **3. Run your first agent:**
 ```python
-from browser_use import Agent, Browser, ChatBrowserUse
-# from browser_use import ChatGoogle  # ChatGoogle(model='gemini-3-flash-preview')
-# from browser_use import ChatAnthropic  # ChatAnthropic(model='claude-sonnet-4-6')
+from browser_use import Agent, Browser, ChatAnthropic, ChatBrowserUse, ChatOpenAI
 import asyncio
 
 async def main():
     browser = Browser(
         # use_cloud=True,  # Use a stealth browser on Browser Use Cloud
     )
+    llm = ChatBrowserUse(model='bu-3-max')
+    # llm = ChatAnthropic(model='claude-opus-4-8')
+    # llm = ChatOpenAI(model='gpt-5.5')
 
     agent = Agent(
         task="Find the number of stars of the browser-use repo",
-        llm=ChatBrowserUse(),
-        # llm=ChatGoogle(model='gemini-3-flash-preview'),
-        # llm=ChatAnthropic(model='claude-sonnet-4-6'),
+        llm=llm,
         browser=browser,
     )
     await agent.run()
@@ -225,7 +224,7 @@ curl -o ~/.claude/skills/browser-use/SKILL.md \
 <details>
 <summary><b>What's the best model to use?</b></summary>
 
-We optimized **ChatBrowserUse()** specifically for browser automation tasks. On avg it completes tasks 3-5x faster than other models with SOTA accuracy.
+We optimized **ChatBrowserUse(model='bu-3-max')** specifically for browser automation tasks. On avg it completes tasks 3-5x faster than other models with SOTA accuracy.
 
 **Pricing (per 1M tokens):**
 - Input tokens: $0.20

--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -58,6 +58,7 @@ class ChatBrowserUse(BaseChatModel):
 
 		Args:
 			model: Model name to use. Options:
+				- 'bu-3-max': BU3 Max
 				- 'bu-2-0' or 'bu-latest': Default model (latest premium)
 				- 'bu-1-0': Previous generation model
 				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
@@ -69,7 +70,7 @@ class ChatBrowserUse(BaseChatModel):
 			retry_max_delay: Maximum delay in seconds between retries (default: 60.0).
 		"""
 		# Validate model name - allow bu-* and browser-use/* patterns
-		valid_models = ['bu-latest', 'bu-1-0', 'bu-2-0']
+		valid_models = ['bu-latest', 'bu-1-0', 'bu-2-0', 'bu-3-max']
 		is_valid = model in valid_models or model.startswith('browser-use/')
 		if not is_valid:
 			raise ValueError(f"Invalid model: '{model}'. Must be one of {valid_models} or start with 'browser-use/'")

--- a/browser_use/rust/service.py
+++ b/browser_use/rust/service.py
@@ -1121,6 +1121,14 @@ def _llm_env_overrides(llm: Any) -> dict[str, str]:
 			overrides['LLM_BROWSER_OPENAI_API_KEY'] = api_key
 		if base_url:
 			overrides['LLM_BROWSER_OPENAI_BASE_URL'] = base_url
+	elif provider == 'browser-use':
+		if api_key:
+			overrides['LLM_BROWSER_BROWSER_USE_API_KEY'] = api_key
+		if base_url:
+			normalized_base_url = base_url.rstrip('/')
+			if not normalized_base_url.endswith('/v1'):
+				normalized_base_url += '/v1'
+			overrides['LLM_BROWSER_BROWSER_USE_BASE_URL'] = normalized_base_url
 	elif provider == 'anthropic':
 		if api_key:
 			overrides['LLM_BROWSER_ANTHROPIC_API_KEY'] = api_key

--- a/tests/ci/models/test_llm_browseruse.py
+++ b/tests/ci/models/test_llm_browseruse.py
@@ -4,6 +4,15 @@ from browser_use.llm.browser_use.chat import ChatBrowserUse
 from tests.ci.models.model_test_helper import run_model_button_click_test
 
 
+def test_browseruse_accepts_bu_3_max(monkeypatch):
+	"""BU3 Max is a valid Browser Use hosted model id."""
+	monkeypatch.setenv('BROWSER_USE_API_KEY', 'test-api-key')
+
+	llm = ChatBrowserUse(model='bu-3-max')
+
+	assert llm.model == 'bu-3-max'
+
+
 async def test_browseruse_bu_latest(httpserver):
 	"""Test Browser Use bu-latest can click a button."""
 	await run_model_button_click_test(

--- a/tests/ci/test_rust_agent.py
+++ b/tests/ci/test_rust_agent.py
@@ -3278,6 +3278,8 @@ def test_rust_agent_bridges_llm_credentials_to_terminal_env(monkeypatch):
 		'OPENROUTER_API_KEY',
 		'OPENROUTER_BASE_URL',
 		'DEEPSEEK_API_KEY',
+		'LLM_BROWSER_BROWSER_USE_API_KEY',
+		'LLM_BROWSER_BROWSER_USE_BASE_URL',
 	):
 		monkeypatch.delenv(key, raising=False)
 	monkeypatch.setenv('LLM_BROWSER_OPENAI_API_KEY', 'ambient-openai-key')
@@ -3299,6 +3301,10 @@ def test_rust_agent_bridges_llm_credentials_to_terminal_env(monkeypatch):
 		task='OpenRouter credentials.',
 		llm=LLM('openrouter', 'openrouter/model', api_key='llm-openrouter-key', base_url='https://openrouter.example/api/v1'),
 	)
+	browser_use_agent = Agent(
+		task='Browser Use credentials.',
+		llm=LLM('browser-use', 'bu-3-max', api_key='llm-browser-use-key', base_url='https://browser-use.example'),
+	)
 	deepseek_agent = Agent(
 		task='DeepSeek credentials.',
 		llm=LLM('deepseek', 'deepseek-chat', api_key='llm-deepseek-key', base_url='https://ignored.example'),
@@ -3309,6 +3315,7 @@ def test_rust_agent_bridges_llm_credentials_to_terminal_env(monkeypatch):
 	)._run_env()
 	anthropic_env = anthropic_agent._run_env()
 	openrouter_env = openrouter_agent._run_env()
+	browser_use_env = browser_use_agent._run_env()
 	deepseek_env = deepseek_agent._run_env()
 
 	assert openai_env['LLM_BROWSER_OPENAI_API_KEY'] == 'llm-openai-key'
@@ -3317,6 +3324,8 @@ def test_rust_agent_bridges_llm_credentials_to_terminal_env(monkeypatch):
 	assert anthropic_env['LLM_BROWSER_ANTHROPIC_BASE_URL'] == 'https://anthropic.example'
 	assert openrouter_env['OPENROUTER_API_KEY'] == 'llm-openrouter-key'
 	assert openrouter_env['OPENROUTER_BASE_URL'] == 'https://openrouter.example/api/v1'
+	assert browser_use_env['LLM_BROWSER_BROWSER_USE_API_KEY'] == 'llm-browser-use-key'
+	assert browser_use_env['LLM_BROWSER_BROWSER_USE_BASE_URL'] == 'https://browser-use.example/v1'
 	assert deepseek_env['DEEPSEEK_API_KEY'] == 'llm-deepseek-key'
 	assert 'LLM_BROWSER_OPENAI_COMPAT_BASE_URL' not in deepseek_env
 	assert ambient_env['LLM_BROWSER_ANTHROPIC_API_KEY'] == 'ambient-anthropic-key'
@@ -3334,6 +3343,11 @@ def test_rust_agent_bridges_llm_credentials_to_terminal_env(monkeypatch):
 	assert openrouter_agent._sdk_run_params(max_steps=3, task=openrouter_agent.task)['llm'] | {'timeout': None} == {
 		'provider': 'openrouter',
 		'model': 'openrouter/model',
+		'timeout': None,
+	}
+	assert browser_use_agent._sdk_run_params(max_steps=3, task=browser_use_agent.task)['llm'] | {'timeout': None} == {
+		'provider': 'browser-use',
+		'model': 'bu-3-max',
 		'timeout': None,
 	}
 	assert deepseek_agent._sdk_run_params(max_steps=3, task=deepseek_agent.task)['llm'] | {'timeout': None} == {


### PR DESCRIPTION
## Summary
- add `bu-3-max` as a valid `ChatBrowserUse` model id
- update the README quickstart to use BU3 Max by default
- show Anthropic 4.8 and OpenAI 5.5 as one-line alternatives
- pass `ChatBrowserUse` credentials/base URL through to the Rust terminal SDK path

## Validation
- `uv run pre-commit run --files browser_use/rust/service.py tests/ci/test_rust_agent.py README.md browser_use/llm/browser_use/chat.py tests/ci/models/test_llm_browseruse.py`
- `uv run pytest tests/ci/test_rust_agent.py -q -k 'bridges_llm_credentials_to_terminal_env'`
- `uv run pytest tests/ci/models/test_llm_browseruse.py -q`
- direct `ChatAnthropic(model="claude-opus-4-8")` smoke returned `anthropic-48-ok`
- direct `ChatOpenAI(model="gpt-5.5")` smoke returned `openai-55-ok`

## Notes
- Existing BU1/BU2 behavior is unchanged.
