### PR TITLE
fix(agent): harden _extract_start_url URL gating — skip local paths (incl. quoted) and match file extensions on the path, not as a substring (#4794)

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 if TYPE_CHECKING:
 	from browser_use.skills.views import Skill
@@ -2392,20 +2392,21 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					token_start = original_position
 					while token_start > 0 and not task_without_emails[token_start - 1].isspace():
 						token_start -= 1
-					local_path_token = task_without_emails[token_start : match.end()]
+					local_path_token = task_without_emails[token_start : match.end()].lstrip('\'"(<[{')
 					if re.match(r'^(?:[A-Za-z]:)?(?:~|\.{1,2})?[/\\]', local_path_token):
 						self.logger.debug(f'Excluding local filesystem path from auto-navigation: {local_path_token}')
 						continue
 
-				# Check if URL ends with a file extension that should be excluded
+				# Exclude URLs that point at a downloadable file, not a web page.
+				# Match the final path segment's extension only: testing whether any
+				# '.ext' appears as a substring wrongly drops everyday sites whose host or
+				# path merely contains a short extension token ('.py' in 'docs.python.org',
+				# '.doc' in 'my.docs.google.com').
 				url_lower = url.lower()
-				should_exclude = False
-				for ext in excluded_extensions:
-					if f'.{ext}' in url_lower:
-						should_exclude = True
-						break
-
-				if should_exclude:
+				url_no_scheme = re.sub(r'^[a-z][a-z0-9+.-]*://', '', url_lower).split('?', 1)[0].split('#', 1)[0]
+				last_segment = unquote(url_no_scheme.rstrip('/').rsplit('/', 1)[-1]).split(';', 1)[0]
+				file_ext = last_segment.rsplit('.', 1)[-1] if '.' in last_segment else ''
+				if file_ext in excluded_extensions:
 					self.logger.debug(f'Excluding URL with file extension from auto-navigation: {url}')
 					continue
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2383,6 +2383,20 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					self.logger.debug(f'Excluding placeholder URL from auto-navigation: {url}')
 					continue
 
+				# Skip URL-looking tokens that are actually local filesystem paths
+				# (e.g. an uploaded file like "/app/x_capabilities.html"): the domain
+				# pattern's [a-zA-Z0-9-] class excludes '_', so the path tail gets
+				# captured (e.g. "capabilities.html") and force-navigated. Skip any
+				# candidate whose whitespace-delimited token is a local path.
+				if not url.startswith(('http://', 'https://')):
+					token_start = original_position
+					while token_start > 0 and not task_without_emails[token_start - 1].isspace():
+						token_start -= 1
+					local_path_token = task_without_emails[token_start : match.end()]
+					if re.match(r'^(?:[A-Za-z]:)?(?:~|\.{1,2})?[/\\]', local_path_token):
+						self.logger.debug(f'Excluding local filesystem path from auto-navigation: {local_path_token}')
+						continue
+
 				# Check if URL ends with a file extension that should be excluded
 				url_lower = url.lower()
 				should_exclude = False

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2392,7 +2392,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					token_start = original_position
 					while token_start > 0 and not task_without_emails[token_start - 1].isspace():
 						token_start -= 1
-					local_path_token = task_without_emails[token_start : match.end()].lstrip('\'"(<[{')
+					local_path_token = task_without_emails[token_start : match.end()].lstrip('\'"`(<[{')
 					if re.match(r'^(?:[A-Za-z]:)?(?:~|\.{1,2})?[/\\]', local_path_token):
 						self.logger.debug(f'Excluding local filesystem path from auto-navigation: {local_path_token}')
 						continue

--- a/browser_use/rust/service.py
+++ b/browser_use/rust/service.py
@@ -1366,7 +1366,7 @@ def _extract_start_url(task: str) -> str | None:
 				token_start = match.start()
 				while token_start > 0 and not task_without_emails[token_start - 1].isspace():
 					token_start -= 1
-				local_path_token = task_without_emails[token_start : match.end()].lstrip('\'"(<[{')
+				local_path_token = task_without_emails[token_start : match.end()].lstrip('\'"`(<[{')
 				if re.match(r'^(?:[A-Za-z]:)?(?:~|\.{1,2})?[/\\]', local_path_token):
 					continue
 			url_no_scheme = re.sub(r'^[a-z][a-z0-9+.-]*://', '', url_lower).split('?', 1)[0].split('#', 1)[0]

--- a/browser_use/rust/service.py
+++ b/browser_use/rust/service.py
@@ -19,7 +19,7 @@ from contextlib import nullcontext, suppress
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Generic, Literal
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 from bubus import EventBus
 from pydantic import BaseModel, ValidationError, create_model
@@ -1366,10 +1366,13 @@ def _extract_start_url(task: str) -> str | None:
 				token_start = match.start()
 				while token_start > 0 and not task_without_emails[token_start - 1].isspace():
 					token_start -= 1
-				local_path_token = task_without_emails[token_start : match.end()]
+				local_path_token = task_without_emails[token_start : match.end()].lstrip('\'"(<[{')
 				if re.match(r'^(?:[A-Za-z]:)?(?:~|\.{1,2})?[/\\]', local_path_token):
 					continue
-			if any(f'.{ext}' in url_lower for ext in excluded_extensions):
+			url_no_scheme = re.sub(r'^[a-z][a-z0-9+.-]*://', '', url_lower).split('?', 1)[0].split('#', 1)[0]
+			last_segment = unquote(url_no_scheme.rstrip('/').rsplit('/', 1)[-1]).split(';', 1)[0]
+			file_ext = last_segment.rsplit('.', 1)[-1] if '.' in last_segment else ''
+			if file_ext in excluded_extensions:
 				continue
 			context_start = max(0, match.start() - 20)
 			context_text = task_without_emails[context_start : match.start()]

--- a/browser_use/rust/service.py
+++ b/browser_use/rust/service.py
@@ -1358,6 +1358,17 @@ def _extract_start_url(task: str) -> str | None:
 			url_lower = url.lower()
 			if is_placeholder_url(url):
 				continue
+			# Skip URL-looking tokens that are actually local filesystem paths
+			# (e.g. an uploaded file like "/app/x_capabilities.html"): the domain
+			# pattern excludes '_' from its char class, so the path tail gets
+			# captured as a bare URL and force-navigated. Skip local-path tokens.
+			if not url.startswith(('http://', 'https://')):
+				token_start = match.start()
+				while token_start > 0 and not task_without_emails[token_start - 1].isspace():
+					token_start -= 1
+				local_path_token = task_without_emails[token_start : match.end()]
+				if re.match(r'^(?:[A-Za-z]:)?(?:~|\.{1,2})?[/\\]', local_path_token):
+					continue
 			if any(f'.{ext}' in url_lower for ext in excluded_extensions):
 				continue
 			context_start = max(0, match.start() - 20)

--- a/tests/ci/test_rust_agent.py
+++ b/tests/ci/test_rust_agent.py
@@ -4108,6 +4108,17 @@ def test_rust_agent_exposes_task_helper_methods():
 	numbered_task = '1. Navigate to https://elibrary.ferc.gov/eLibrary/search.\\n2. Ensure "General Search" is selected.'
 	assert agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'
 	assert browser_use_agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'
+	# Both implementations stay in lockstep on file-extension gating (#4794):
+	# host/path substring extension tokens must NOT exclude real sites, genuine
+	# file URLs (incl. ;path-params) MUST drop, and quoted local paths are skipped.
+	for extract in (agent._extract_start_url, browser_use_agent._extract_start_url):
+		assert extract('Open docs.python.org/3/library and find the os module.') == 'https://docs.python.org/3/library'
+		assert extract('Check my.docs.google.com for the sheet.') == 'https://my.docs.google.com'
+		assert extract('Open https://example.com/report.pdf and summarize it.') is None
+		assert extract('Fetch https://example.com/data.json;v=1 now.') is None
+		assert extract('Open https://example.com/report.pdf/ then stop.') is None
+		assert extract('Open https://example.com/report%2Epdf now.') is None
+		assert extract('Open "/app/x_capabilities.html" and summarize it.') is None
 
 
 def test_rust_agent_exposes_url_text_helper_methods():
@@ -7639,3 +7650,34 @@ def test_extract_start_url_skips_local_filesystem_paths():
 		rust_service._extract_start_url('Go to https://example.com/index.html now.')
 		== 'https://example.com/index.html'
 	)
+
+
+def test_extract_start_url_matches_file_extensions_on_path_not_substring():
+	# Everyday sites whose host/path merely contains a short extension token
+	# ('.py' inside 'docs.python.org', '.doc' inside 'my.docs.google.com') must
+	# still be auto-navigated; only a real trailing file extension is excluded.
+	import browser_use.rust.service as rust_service
+
+	assert (
+		rust_service._extract_start_url('Open docs.python.org/3/library and find the os module.')
+		== 'https://docs.python.org/3/library'
+	)
+	assert rust_service._extract_start_url('Check my.docs.google.com for the sheet.') == 'https://my.docs.google.com'
+	assert rust_service._extract_start_url('Go to www.python.org/downloads now.') == 'https://www.python.org/downloads'
+	# A genuine downloadable file in the path is still dropped (no regression).
+	assert rust_service._extract_start_url('Open https://example.com/report.pdf and summarize it.') is None
+	assert rust_service._extract_start_url('Read example.com/data.json please.') is None
+	# Trailing prose punctuation must not defeat the drop (sanitize_url_candidate
+	# strips trailing .,;:!?()[] before the extension check).
+	assert rust_service._extract_start_url('Open (https://example.com/report.pdf) now.') is None
+	assert rust_service._extract_start_url('See example.com/data.json.') is None
+	assert rust_service._extract_start_url('Grab https://example.com/archive.tar.gz!') is None
+
+
+def test_extract_start_url_skips_quoted_local_filesystem_paths():
+	# Local paths wrapped in quotes/parens must also be skipped: surrounding
+	# delimiters must not defeat the local-path guard.
+	import browser_use.rust.service as rust_service
+
+	assert rust_service._extract_start_url('Open "/app/x_capabilities.html" and summarize it.') is None
+	assert rust_service._extract_start_url('Process (/tmp/data.html) for me.') is None

--- a/tests/ci/test_rust_agent.py
+++ b/tests/ci/test_rust_agent.py
@@ -7623,3 +7623,19 @@ def test_rust_history_surfaces_terminal_session_interrupted_message():
 	assert history.is_done() is False
 	assert history.errors() == ['Rust terminal session was interrupted: interrupted by send_input']
 	assert history.action_results()[-1].error == 'Rust terminal session was interrupted: interrupted by send_input'
+
+
+def test_extract_start_url_skips_local_filesystem_paths():
+	# A local file path (e.g. an uploaded .html) must not be auto-navigated:
+	# the domain regex would otherwise capture the path tail as a bare URL
+	# and force-navigate to it as the agent's first action (issue #4794).
+	import browser_use.rust.service as rust_service
+
+	assert rust_service._extract_start_url('Open the file /app/x_capabilities.html and summarize it.') is None
+	assert rust_service._extract_start_url('Read ~/Downloads/report.htm please.') is None
+	# Real web URLs (with or without scheme) are still detected — no regression.
+	assert rust_service._extract_start_url('Open example.com and report the title.') == 'https://example.com'
+	assert (
+		rust_service._extract_start_url('Go to https://example.com/index.html now.')
+		== 'https://example.com/index.html'
+	)

--- a/tests/ci/test_rust_agent.py
+++ b/tests/ci/test_rust_agent.py
@@ -4119,6 +4119,7 @@ def test_rust_agent_exposes_task_helper_methods():
 		assert extract('Open https://example.com/report.pdf/ then stop.') is None
 		assert extract('Open https://example.com/report%2Epdf now.') is None
 		assert extract('Open "/app/x_capabilities.html" and summarize it.') is None
+		assert extract('Open `/app/x_capabilities.html` and summarize it.') is None
 
 
 def test_rust_agent_exposes_url_text_helper_methods():
@@ -7681,3 +7682,4 @@ def test_extract_start_url_skips_quoted_local_filesystem_paths():
 
 	assert rust_service._extract_start_url('Open "/app/x_capabilities.html" and summarize it.') is None
 	assert rust_service._extract_start_url('Process (/tmp/data.html) for me.') is None
+	assert rust_service._extract_start_url('Open `/app/x_capabilities.html` and summarize it.') is None


### PR DESCRIPTION
Fixes #4794.

`_extract_start_url` (used when `directly_open_url=True`, the default) scans the task text and force-injects an initial `navigate` action before the LLM acts. This PR hardens that URL-gating against two false-decision classes, in both the agent and rust copies, with regression tests covering both implementations.

**1. Local filesystem paths were force-navigated (#4794).**
A local file path in the task — e.g. an uploaded `/app/x_capabilities.html` — matched the domain regex (the domain char class `[a-zA-Z0-9-]` excludes `_`, so `x_capabilities.html` is captured as `capabilities.html`) and was navigated to as the agent's first action, then blocked by the SecurityWatchdog, derailing the run. Such candidates are now skipped. Quoted/parenthesised local paths (e.g. `"/app/x.html"`) are skipped too — leading quote/paren delimiters are stripped before the local-path check.

**2. Everyday sites were wrongly excluded as "files".**
The excluded-extension filter tested `f'.{ext}'` as a **substring of the whole URL**, so any host/path merely containing a short extension token was dropped from auto-navigation: `docs.python.org` (`.py`), `www.python.org` (`.py`), `my.docs.google.com` (`.doc`), and any `.css`/`.js`/`.md` host. Exclusion is now decided from the **final path segment** (scheme/query/fragment stripped, trailing slash removed, percent-decoded, `;`path-params split), so genuine downloadable-file URLs still drop (`report.pdf`, `report.pdf/`, `data.json;v=1`, `report%2Epdf`, `archive.tar.gz`) while real pages are kept (`index.html`, `example.com/report.pdf/view` — a page, not a file).

**Deliberate scope note:** exclusion keys on the **path**, not the query string. A URL like `example.com/download?file=report.pdf` (a download *endpoint*) or `example.com/view?doc=report.pdf` (a viewer *page*) is kept — the old substring check dropped both, which over-excluded navigable viewer/search pages. Navigation policy is still enforced downstream by the SecurityWatchdog.
