### PR TITLE
fix(llm): surface token usage for Ollama and DeepSeek instead of dropping it

### DIFF
--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -20,7 +20,7 @@ from browser_use.llm.deepseek.serializer import DeepSeekMessageSerializer
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
-from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
 
@@ -58,6 +58,24 @@ class ChatDeepSeek(BaseChatModel):
 	@property
 	def name(self) -> str:
 		return self.model
+
+	def _get_usage(self, response: Any) -> ChatInvokeUsage | None:
+		if getattr(response, 'usage', None) is not None:
+			usage_obj = response.usage
+
+			prompt_cached_tokens = getattr(usage_obj, 'prompt_cache_hit_tokens', None)
+			if prompt_cached_tokens is None and getattr(usage_obj, 'prompt_tokens_details', None) is not None:
+				prompt_cached_tokens = getattr(usage_obj.prompt_tokens_details, 'cached_tokens', None)
+
+			return ChatInvokeUsage(
+				prompt_tokens=usage_obj.prompt_tokens,
+				prompt_cached_tokens=prompt_cached_tokens,
+				prompt_cache_creation_tokens=None,
+				prompt_image_tokens=None,
+				completion_tokens=usage_obj.completion_tokens,
+				total_tokens=usage_obj.total_tokens,
+			)
+		return None
 
 	@overload
 	async def ainvoke(
@@ -125,7 +143,7 @@ class ChatDeepSeek(BaseChatModel):
 				)
 				return ChatInvokeCompletion(
 					completion=resp.choices[0].message.content or '',
-					usage=None,
+					usage=self._get_usage(resp),
 				)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e
@@ -173,13 +191,13 @@ class ChatDeepSeek(BaseChatModel):
 				if output_format is not None:
 					return ChatInvokeCompletion(
 						completion=output_format.model_validate(parsed),
-						usage=None,
+						usage=self._get_usage(resp),
 					)
 				else:
 					# If no output_format, return dict directly
 					return ChatInvokeCompletion(
 						completion=parsed,
-						usage=None,
+						usage=self._get_usage(resp),
 					)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e
@@ -203,7 +221,7 @@ class ChatDeepSeek(BaseChatModel):
 				parsed = output_format.model_validate_json(content)
 				return ChatInvokeCompletion(
 					completion=parsed,
-					usage=None,
+					usage=self._get_usage(resp),
 				)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -11,7 +11,7 @@ from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
-from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
 
@@ -57,6 +57,28 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def _get_usage(self, response: Any) -> ChatInvokeUsage | None:
+		prompt_tokens = None
+		completion_tokens = None
+
+		if isinstance(response, Mapping):
+			prompt_tokens = response.get('prompt_eval_count')
+			completion_tokens = response.get('eval_count')
+		else:
+			prompt_tokens = getattr(response, 'prompt_eval_count', None)
+			completion_tokens = getattr(response, 'eval_count', None)
+
+		if prompt_tokens is not None and completion_tokens is not None:
+			return ChatInvokeUsage(
+				prompt_tokens=prompt_tokens,
+				prompt_cached_tokens=None,
+				prompt_cache_creation_tokens=None,
+				prompt_image_tokens=None,
+				completion_tokens=completion_tokens,
+				total_tokens=prompt_tokens + completion_tokens,
+			)
+		return None
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -78,7 +100,7 @@ class ChatOllama(BaseChatModel):
 					options=self.ollama_options,
 				)
 
-				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
+				return ChatInvokeCompletion(completion=response.message.content or '', usage=self._get_usage(response))
 			else:
 				schema = output_format.model_json_schema()
 
@@ -93,7 +115,7 @@ class ChatOllama(BaseChatModel):
 				if output_format is not None:
 					completion = output_format.model_validate_json(completion)
 
-				return ChatInvokeCompletion(completion=completion, usage=None)
+				return ChatInvokeCompletion(completion=completion, usage=self._get_usage(response))
 
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/tests/ci/models/test_llm_usage.py
+++ b/tests/ci/models/test_llm_usage.py
@@ -1,7 +1,6 @@
 """Tests for DeepSeek and Ollama LLM usage tracking."""
 
 from types import SimpleNamespace
-import pytest
 
 from browser_use.llm.deepseek.chat import ChatDeepSeek
 from browser_use.llm.ollama.chat import ChatOllama
@@ -60,7 +59,7 @@ def test_deepseek_get_usage_none():
 	llm = ChatDeepSeek(api_key='fake')
 	response = SimpleNamespace(usage=None)
 	assert llm._get_usage(response) is None
-	
+
 	response_no_attr = SimpleNamespace()
 	assert llm._get_usage(response_no_attr) is None
 

--- a/tests/ci/models/test_llm_usage.py
+++ b/tests/ci/models/test_llm_usage.py
@@ -1,0 +1,108 @@
+"""Tests for DeepSeek and Ollama LLM usage tracking."""
+
+from types import SimpleNamespace
+import pytest
+
+from browser_use.llm.deepseek.chat import ChatDeepSeek
+from browser_use.llm.ollama.chat import ChatOllama
+from browser_use.llm.views import ChatInvokeUsage
+
+
+def test_deepseek_get_usage_full():
+	"""Test ChatDeepSeek._get_usage with deepseek prompt_cache_hit_tokens field."""
+	llm = ChatDeepSeek(api_key='fake')
+	response = SimpleNamespace(
+		usage=SimpleNamespace(
+			prompt_tokens=100,
+			completion_tokens=50,
+			total_tokens=150,
+			prompt_cache_hit_tokens=40,
+		)
+	)
+	usage = llm._get_usage(response)
+	assert usage == ChatInvokeUsage(
+		prompt_tokens=100,
+		prompt_cached_tokens=40,
+		prompt_cache_creation_tokens=None,
+		prompt_image_tokens=None,
+		completion_tokens=50,
+		total_tokens=150,
+	)
+
+
+def test_deepseek_get_usage_fallback():
+	"""Test ChatDeepSeek._get_usage falling back to prompt_tokens_details.cached_tokens."""
+	llm = ChatDeepSeek(api_key='fake')
+	response = SimpleNamespace(
+		usage=SimpleNamespace(
+			prompt_tokens=100,
+			completion_tokens=50,
+			total_tokens=150,
+			prompt_tokens_details=SimpleNamespace(
+				cached_tokens=30,
+			),
+		)
+	)
+	# prompt_cache_hit_tokens is missing
+	usage = llm._get_usage(response)
+	assert usage == ChatInvokeUsage(
+		prompt_tokens=100,
+		prompt_cached_tokens=30,
+		prompt_cache_creation_tokens=None,
+		prompt_image_tokens=None,
+		completion_tokens=50,
+		total_tokens=150,
+	)
+
+
+def test_deepseek_get_usage_none():
+	"""Test ChatDeepSeek._get_usage with missing usage details."""
+	llm = ChatDeepSeek(api_key='fake')
+	response = SimpleNamespace(usage=None)
+	assert llm._get_usage(response) is None
+	
+	response_no_attr = SimpleNamespace()
+	assert llm._get_usage(response_no_attr) is None
+
+
+def test_ollama_get_usage_mapping():
+	"""Test ChatOllama._get_usage with dictionary response."""
+	llm = ChatOllama(model='fake')
+	response = {
+		'prompt_eval_count': 80,
+		'eval_count': 40,
+	}
+	usage = llm._get_usage(response)
+	assert usage == ChatInvokeUsage(
+		prompt_tokens=80,
+		prompt_cached_tokens=None,
+		prompt_cache_creation_tokens=None,
+		prompt_image_tokens=None,
+		completion_tokens=40,
+		total_tokens=120,
+	)
+
+
+def test_ollama_get_usage_object():
+	"""Test ChatOllama._get_usage with response object."""
+	llm = ChatOllama(model='fake')
+	response = SimpleNamespace(
+		prompt_eval_count=90,
+		eval_count=35,
+	)
+	usage = llm._get_usage(response)
+	assert usage == ChatInvokeUsage(
+		prompt_tokens=90,
+		prompt_cached_tokens=None,
+		prompt_cache_creation_tokens=None,
+		prompt_image_tokens=None,
+		completion_tokens=35,
+		total_tokens=125,
+	)
+
+
+def test_ollama_get_usage_none():
+	"""Test ChatOllama._get_usage with missing counts."""
+	llm = ChatOllama(model='fake')
+	assert llm._get_usage({}) is None
+	assert llm._get_usage(SimpleNamespace()) is None


### PR DESCRIPTION
## Summary

This PR fixes #4967. Previously, token usage was hardcoded to `None` for both DeepSeek and Ollama wrappers (`ChatDeepSeek` and `ChatOllama`), making it impossible to observe token consumption or calculate costs when using these LLM providers. 

This change parses and populates `ChatInvokeUsage` correctly from the API responses.

## Changes

### 1. DeepSeek Wrapper (`browser_use/llm/deepseek/chat.py`)
- Added `_get_usage()` helper to extract standard OpenAI-compatible usage fields (`prompt_tokens`, `completion_tokens`, `total_tokens`).
- Surfaces cache hits from DeepSeek's `prompt_cache_hit_tokens` and falls back to standard `prompt_tokens_details.cached_tokens` defensively.
- Wired usage parsing into all `ainvoke` return paths.

### 2. Ollama Wrapper (`browser_use/llm/ollama/chat.py`)
- Added `_get_usage()` helper to extract `prompt_eval_count` (mapped to `prompt_tokens`) and `eval_count` (mapped to `completion_tokens`) from the response (handles both dictionary and object representations).
- Wired usage parsing into both `ainvoke` return paths.

### 3. Tests (`tests/ci/models/test_llm_usage.py`)
- Created a comprehensive test suite covering usage extraction scenarios (complete responses, partial/missing responses, DeepSeek cache-hit, and prompt details fallback) without requiring network access.

## Validation

All new unit tests passed successfully:
```bash
pytest --noconftest -o addopts="" tests/ci/models/test_llm_usage.py
```

```text
tests/ci/models/test_llm_usage.py::test_deepseek_get_usage_full PASSED
tests/ci/models/test_llm_usage.py::test_deepseek_get_usage_fallback PASSED
tests/ci/models/test_llm_usage.py::test_deepseek_get_usage_none PASSED
tests/ci/models/test_llm_usage.py::test_ollama_get_usage_mapping PASSED
tests/ci/models/test_llm_usage.py::test_ollama_get_usage_object PASSED
tests/ci/models/test_llm_usage.py::test_ollama_get_usage_none PASSED
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose token usage for DeepSeek and Ollama so `ainvoke` returns prompt, completion, and total tokens (with DeepSeek cache hits) instead of `None`. This enables cost tracking and better observability.

- **Bug Fixes**
  - DeepSeek: added `_get_usage` parsing OpenAI-style usage; includes cache hits via `prompt_cache_hit_tokens` or `prompt_tokens_details.cached_tokens`; wired into all `ainvoke` paths.
  - Ollama: added `_get_usage` mapping `prompt_eval_count` → prompt tokens and `eval_count` → completion tokens; wired into both `ainvoke` paths.
  - Tests: added offline unit tests covering full, fallback, object/dict responses, and missing usage.

- **Refactors**
  - Applied `ruff` formatting and cleaned imports; no functional changes.

<sup>Written for commit 42476134206fe724e0fe49a12c846aa02fec6e06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

