### PR TITLE
fix(llm): extract thinking tags and sanitize json code blocks

### DIFF
--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -20,6 +20,7 @@ from browser_use.llm.deepseek.serializer import DeepSeekMessageSerializer
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.utils import clean_and_extract_json
 from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
@@ -123,8 +124,11 @@ class ChatDeepSeek(BaseChatModel):
 					messages=ds_messages,  # type: ignore
 					**common,
 				)
+				raw_content = resp.choices[0].message.content or ''
+				cleaned_content, thinking = clean_and_extract_json(raw_content)
 				return ChatInvokeCompletion(
-					completion=resp.choices[0].message.content or '',
+					completion=cleaned_content,
+					thinking=thinking,
 					usage=None,
 				)
 			except RateLimitError as e:
@@ -169,16 +173,21 @@ class ChatDeepSeek(BaseChatModel):
 					parsed = json.loads(raw_args)
 				else:
 					parsed = raw_args
+				thinking = None
+				if getattr(msg, 'content', None):
+					_, thinking = clean_and_extract_json(msg.content)
 				# --------- Fix: only use model_validate when output_format is not None ----------
 				if output_format is not None:
 					return ChatInvokeCompletion(
 						completion=output_format.model_validate(parsed),
+						thinking=thinking,
 						usage=None,
 					)
 				else:
 					# If no output_format, return dict directly
 					return ChatInvokeCompletion(
 						completion=parsed,
+						thinking=thinking,
 						usage=None,
 					)
 			except RateLimitError as e:
@@ -197,12 +206,12 @@ class ChatDeepSeek(BaseChatModel):
 					response_format={'type': 'json_object'},
 					**common,
 				)
-				content = resp.choices[0].message.content
-				if not content:
-					raise ModelProviderError('Empty JSON content in DeepSeek response', model=self.name)
-				parsed = output_format.model_validate_json(content)
+				raw_content = resp.choices[0].message.content or ''
+				cleaned_content, thinking = clean_and_extract_json(raw_content)
+				parsed = output_format.model_validate_json(cleaned_content)
 				return ChatInvokeCompletion(
 					completion=parsed,
+					thinking=thinking,
 					usage=None,
 				)
 			except RateLimitError as e:

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -11,6 +11,7 @@ from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
+from browser_use.llm.utils import clean_and_extract_json
 from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
@@ -78,7 +79,13 @@ class ChatOllama(BaseChatModel):
 					options=self.ollama_options,
 				)
 
-				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
+				raw_content = response.message.content or ''
+				cleaned_content, thinking = clean_and_extract_json(raw_content)
+				return ChatInvokeCompletion(
+					completion=cleaned_content,
+					thinking=thinking,
+					usage=None,
+				)
 			else:
 				schema = output_format.model_json_schema()
 
@@ -89,11 +96,18 @@ class ChatOllama(BaseChatModel):
 					options=self.ollama_options,
 				)
 
-				completion = response.message.content or ''
+				raw_content = response.message.content or ''
+				cleaned_content, thinking = clean_and_extract_json(raw_content)
 				if output_format is not None:
-					completion = output_format.model_validate_json(completion)
+					completion = output_format.model_validate_json(cleaned_content)
+				else:
+					completion = cleaned_content
 
-				return ChatInvokeCompletion(completion=completion, usage=None)
+				return ChatInvokeCompletion(
+					completion=completion,
+					thinking=thinking,
+					usage=None,
+				)
 
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -98,10 +98,7 @@ class ChatOllama(BaseChatModel):
 
 				raw_content = response.message.content or ''
 				cleaned_content, thinking = clean_and_extract_json(raw_content)
-				if output_format is not None:
-					completion = output_format.model_validate_json(cleaned_content)
-				else:
-					completion = cleaned_content
+				completion = output_format.model_validate_json(cleaned_content)
 
 				return ChatInvokeCompletion(
 					completion=completion,

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -16,6 +16,7 @@ from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.openai.serializer import OpenAIMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.utils import clean_and_extract_json
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
@@ -214,9 +215,12 @@ class ChatOpenAI(BaseChatModel):
 						model=self.name,
 					)
 
+				raw_content = choice.message.content or ''
+				cleaned_content, thinking = clean_and_extract_json(raw_content)
 				usage = self._get_usage(response)
 				return ChatInvokeCompletion(
-					completion=choice.message.content or '',
+					completion=cleaned_content,
+					thinking=thinking,
 					usage=usage,
 					stop_reason=choice.finish_reason,
 				)
@@ -279,12 +283,15 @@ class ChatOpenAI(BaseChatModel):
 						model=self.name,
 					)
 
+				raw_content = choice.message.content or ''
+				cleaned_content, thinking = clean_and_extract_json(raw_content)
 				usage = self._get_usage(response)
 
-				parsed = output_format.model_validate_json(choice.message.content)
+				parsed = output_format.model_validate_json(cleaned_content)
 
 				return ChatInvokeCompletion(
 					completion=parsed,
+					thinking=thinking,
 					usage=usage,
 					stop_reason=choice.finish_reason,
 				)

--- a/browser_use/llm/utils.py
+++ b/browser_use/llm/utils.py
@@ -21,8 +21,12 @@ def clean_and_extract_json(content: str) -> tuple[str, str | None]:
 	cleaned = cleaned.strip()
 
 	# 2. Strip markdown code blocks (e.g. ```json ... ``` or ``` ... ```)
-	# Use regex search so fences are removed even when surrounded by prose text.
-	fence_match = re.search(r'```(?:json)?\s*\n?([\s\S]*?)\n?```', cleaned)
+	# Prefer explicitly-labelled ```json blocks; only fall back to a plain ```
+	# block when no json-labelled fence is present. This avoids selecting the
+	# wrong block when multiple fenced sections exist in the response.
+	fence_match = re.search(r'```json\s*\n?([\s\S]*?)\n?```', cleaned)
+	if not fence_match:
+		fence_match = re.search(r'```\s*\n?([\s\S]*?)\n?```', cleaned)
 	if fence_match:
 		cleaned = fence_match.group(1).strip()
 

--- a/browser_use/llm/utils.py
+++ b/browser_use/llm/utils.py
@@ -21,9 +21,9 @@ def clean_and_extract_json(content: str) -> tuple[str, str | None]:
 	cleaned = cleaned.strip()
 
 	# 2. Strip markdown code blocks (e.g. ```json ... ``` or ``` ... ```)
-	if cleaned.startswith('```json') and cleaned.endswith('```'):
-		cleaned = cleaned[7:-3].strip()
-	elif cleaned.startswith('```') and cleaned.endswith('```'):
-		cleaned = cleaned[3:-3].strip()
+	# Use regex search so fences are removed even when surrounded by prose text.
+	fence_match = re.search(r'```(?:json)?\s*\n?([\s\S]*?)\n?```', cleaned)
+	if fence_match:
+		cleaned = fence_match.group(1).strip()
 
 	return cleaned, thinking

--- a/browser_use/llm/utils.py
+++ b/browser_use/llm/utils.py
@@ -1,0 +1,29 @@
+"""Utilities for LLM response processing and sanitization."""
+
+import re
+
+
+def clean_and_extract_json(content: str) -> tuple[str, str | None]:
+	"""
+	Clean the response content and extract thinking block and JSON string.
+
+	Returns:
+		tuple[str, str | None]: (cleaned_json_content, thinking_text)
+	"""
+	thinking = None
+	# 1. Extract and remove <think>...</think> tags and contents
+	think_match = re.search(r'<think>(.*?)</think>', content, re.DOTALL)
+	if think_match:
+		thinking = think_match.group(1).strip()
+
+	cleaned = re.sub(r'<think>.*?</think>', '', content, flags=re.DOTALL)
+	cleaned = re.sub(r'.*?</think>', '', cleaned, flags=re.DOTALL)
+	cleaned = cleaned.strip()
+
+	# 2. Strip markdown code blocks (e.g. ```json ... ``` or ``` ... ```)
+	if cleaned.startswith('```json') and cleaned.endswith('```'):
+		cleaned = cleaned[7:-3].strip()
+	elif cleaned.startswith('```') and cleaned.endswith('```'):
+		cleaned = cleaned[3:-3].strip()
+
+	return cleaned, thinking

--- a/tests/ci/models/test_llm_thinking.py
+++ b/tests/ci/models/test_llm_thinking.py
@@ -41,3 +41,11 @@ def test_clean_and_extract_json_stray_tags():
 	cleaned, thinking = clean_and_extract_json(content)
 	assert cleaned == '{"action": "done"}'
 	assert thinking is None
+
+
+def test_clean_and_extract_json_prose_wrapped():
+	"""Test that fenced blocks are extracted even when surrounded by prose text."""
+	content = 'Here is the result:\n```json\n{"action": "click"}\n```\nLet me know if this helps.'
+	cleaned, thinking = clean_and_extract_json(content)
+	assert cleaned == '{"action": "click"}'
+	assert thinking is None

--- a/tests/ci/models/test_llm_thinking.py
+++ b/tests/ci/models/test_llm_thinking.py
@@ -49,3 +49,11 @@ def test_clean_and_extract_json_prose_wrapped():
 	cleaned, thinking = clean_and_extract_json(content)
 	assert cleaned == '{"action": "click"}'
 	assert thinking is None
+
+
+def test_clean_and_extract_json_multiple_fences():
+	"""Test that ```json block is preferred over a plain ``` block that appears first."""
+	content = 'Example:\n```python\nx = 1\n```\nActual output:\n```json\n{"action": "done"}\n```'
+	cleaned, thinking = clean_and_extract_json(content)
+	assert cleaned == '{"action": "done"}'
+	assert thinking is None

--- a/tests/ci/models/test_llm_thinking.py
+++ b/tests/ci/models/test_llm_thinking.py
@@ -1,0 +1,43 @@
+"""Tests for thinking tags extraction and markdown code block cleaning."""
+
+from browser_use.llm.utils import clean_and_extract_json
+
+
+def test_clean_and_extract_json_plain():
+	"""Test with normal JSON string without thinking tags or code blocks."""
+	content = '{"action": "test"}'
+	cleaned, thinking = clean_and_extract_json(content)
+	assert cleaned == '{"action": "test"}'
+	assert thinking is None
+
+
+def test_clean_and_extract_json_only_thinking():
+	"""Test extracting thinking block and leaving raw JSON."""
+	content = '<think>I should navigate</think>{"action": "navigate"}'
+	cleaned, thinking = clean_and_extract_json(content)
+	assert cleaned == '{"action": "navigate"}'
+	assert thinking == 'I should navigate'
+
+
+def test_clean_and_extract_json_markdown():
+	"""Test stripping markdown formatting code blocks."""
+	content = '```json\n{"action": "click"}\n```'
+	cleaned, thinking = clean_and_extract_json(content)
+	assert cleaned == '{"action": "click"}'
+	assert thinking is None
+
+
+def test_clean_and_extract_json_both():
+	"""Test both thinking tag and markdown code blocks together."""
+	content = '<think>\nThinking hard...\n</think>\n```json\n{"action": "done"}\n```'
+	cleaned, thinking = clean_and_extract_json(content)
+	assert cleaned == '{"action": "done"}'
+	assert thinking == 'Thinking hard...'
+
+
+def test_clean_and_extract_json_stray_tags():
+	"""Test recovery from stray/unmatched closing think tags."""
+	content = 'stale thought</think>{"action": "done"}'
+	cleaned, thinking = clean_and_extract_json(content)
+	assert cleaned == '{"action": "done"}'
+	assert thinking is None


### PR DESCRIPTION
## Summary
Resolves #4970. Prevents `ValidationError` and JSON parsing crashes when reasoning models (such as DeepSeek R1 or GPT-5.5) output thinking blocks (`<think>...</think>`) or markdown formatting code blocks (```` ```json ````) before/around their structured JSON response.

## Changes
- Created a utility helper `clean_and_extract_json` in `browser_use/llm/utils.py` that strips `<think>` tags (populating the `thinking` field of `ChatInvokeCompletion`) and sanitizes markdown formatting.
- Integrated the helper in the invocation pipelines of `browser_use/llm/openai/chat.py` (OpenAI), `browser_use/llm/deepseek/chat.py` (DeepSeek), and `browser_use/llm/ollama/chat.py` (Ollama).
- Added unit tests in `tests/ci/models/test_llm_thinking.py` covering various output structures.

## Testing
Created and executed local unit tests validating the extraction and cleaning logic. All 5 tests passed successfully:
- `test_clean_and_extract_json_plain` (normal JSON string without thinking tags or code blocks)
- `test_clean_and_extract_json_only_thinking` (extracting thinking block and leaving raw JSON)
- `test_clean_and_extract_json_markdown` (stripping markdown formatting code blocks)
- `test_clean_and_extract_json_both` (both thinking tag and markdown code blocks together)
- `test_clean_and_extract_json_stray_tags` (recovery from stray/unmatched closing think tags)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts `<think>` tags and sanitizes fenced code blocks (including prose-wrapped) in LLM outputs to prevent JSON parsing errors and crashes. Adds a `thinking` field to `ChatInvokeCompletion`.

- **Bug Fixes**
  - Added `clean_and_extract_json` in `browser_use/llm/utils.py` using regex search to strip markdown fences even when surrounded by prose; prefers ` ```json ` fences over plain ` ``` ` when multiple blocks exist; also removes `<think>` content before parsing.
  - Integrated cleaning in `browser_use/llm/openai/chat.py`, `browser_use/llm/deepseek/chat.py`, and `browser_use/llm/ollama/chat.py`; responses include optional `thinking` and use cleaned JSON for validation. Fixed a Pyright return type issue in `ChatOllama.ainvoke` to always return `ChatInvokeCompletion`.
  - Added tests in `tests/ci/models/test_llm_thinking.py` covering plain JSON, thinking-only, markdown, combined, stray tags, prose-wrapped fences, and preferring ` ```json ` over plain fences when both are present.

<sup>Written for commit d02a615718952f5c4700bdae20ba551a56e688a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

