### PR TITLE
fix(downloads): reject Windows reserved device names in download filename sanitizer

### DIFF
--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -60,6 +60,14 @@ _NETWORK_DOWNLOAD_FILE_EXTENSIONS = {
 
 _GENERIC_TEXT_ATTACHMENT_NAMES = {'f', 'download', 'response', 'data', 'callback'}
 
+# Windows reserved device names (case-insensitive, with or without an extension): saving a file
+# named CON / NUL / COM1 / ... on Windows targets the device rather than a file, causing silent
+# data loss or an OSError. Matched against the stem (the text before the first dot).
+_WINDOWS_RESERVED_NAMES = frozenset({'CON', 'PRN', 'AUX', 'NUL'} | {f'COM{i}' for i in range(1, 10)} | {f'LPT{i}' for i in range(1, 10)})
+# Windows also treats the Latin-1 superscript digits in COM¹/COM²/COM³ and LPT¹/LPT²/LPT³ as the
+# COM1-3 / LPT1-3 devices, so fold ¹²³ -> 123 before the reserved-name check.
+_WINDOWS_SUPERSCRIPT_DIGITS = str.maketrans('¹²³', '123')
+
 
 def _filename_from_content_disposition(content_disposition: str) -> str | None:
 	filename_match = re.search(r'filename[^;=\n]*=(([\'"]).*?\2|[^;\n]*)', content_disposition)
@@ -1470,6 +1478,12 @@ class DownloadsWatchdog(BaseWatchdog):
 		name = os.path.basename(name.rsplit('/', 1)[-1])
 		if name in ('', '.', '..'):
 			return 'download'
+		# On Windows a reserved device name aliases hardware even with an extension (CON.pdf opens
+		# the console), so writing a page-supplied download under such a name silently loses data
+		# or raises OSError. Prefix '_' to keep a valid, non-device filename.
+		stem = name.split('.', 1)[0].rstrip(' ').upper().translate(_WINDOWS_SUPERSCRIPT_DIGITS)
+		if stem in _WINDOWS_RESERVED_NAMES:
+			name = '_' + name
 		return name
 
 	@staticmethod

--- a/tests/ci/security/test_download_filename_sanitization.py
+++ b/tests/ci/security/test_download_filename_sanitization.py
@@ -65,6 +65,25 @@ class TestSanitizeDownloadFilename:
 		assert DownloadsWatchdog._sanitize_download_filename('résumé.pdf') == 'résumé.pdf'
 		assert DownloadsWatchdog._sanitize_download_filename('文档.pdf') == '文档.pdf'
 
+	def test_windows_reserved_device_names_prefixed(self) -> None:
+		# On Windows, CON/NUL/COM1/... alias devices even with an extension (CON.pdf opens the
+		# console), so prefix '_' to keep a valid filename instead of silently losing the download.
+		assert DownloadsWatchdog._sanitize_download_filename('CON.pdf') == '_CON.pdf'
+		assert DownloadsWatchdog._sanitize_download_filename('nul') == '_nul'
+		assert DownloadsWatchdog._sanitize_download_filename('COM1.txt') == '_COM1.txt'
+		assert DownloadsWatchdog._sanitize_download_filename('LPT9.tar.gz') == '_LPT9.tar.gz'
+		assert DownloadsWatchdog._sanitize_download_filename('AUX') == '_AUX'
+		# Trailing-space/dot variants also alias the device on Windows.
+		assert DownloadsWatchdog._sanitize_download_filename('con ') == '_con '
+		# Windows maps Latin-1 superscript ¹²³ to COM1-3 / LPT1-3 device names.
+		assert DownloadsWatchdog._sanitize_download_filename('COM¹.txt') == '_COM¹.txt'
+		assert DownloadsWatchdog._sanitize_download_filename('LPT³') == '_LPT³'
+
+	def test_reserved_name_lookalikes_preserved(self) -> None:
+		# Names that merely contain a reserved token must not be rewritten.
+		for ok in ('console.log', 'connection.json', 'com10.txt', 'lpt0.bin', 'report-CON.pdf', '.con', 'COM⁴.txt'):
+			assert DownloadsWatchdog._sanitize_download_filename(ok) == ok, f'{ok!r} should be preserved'
+
 
 class TestIsPathContained:
 	def test_file_inside_dir_returns_true(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Adjacent completeness gap to the page-input->filesystem hardening family (#4865/#4866/#4867 = GHSA-rv9j-wqjp-2fv4): `_sanitize_download_filename()` reduces a page-controlled filename (CDP `suggestedFilename` / `Content-Disposition`) to a safe basename but did not filter Windows reserved device names. On Windows, a download named `CON`/`NUL`/`COM1`.pdf etc. targets the console/null/serial device instead of a file — silent data loss, or an `OSError` that breaks the downloads watchdog. Same reach as #4867 (passive on any `Content-Disposition: attachment` response).

Fix: prefix `_` when the stem (text before the first dot, case-insensitive, trailing spaces stripped) is a reserved name — `CON`/`PRN`/`AUX`/`NUL`, `COM1`-`9`, `LPT1`-`9`, plus the `COM¹/²/³` and `LPT¹/²/³` superscript aliases Windows also reserves. `CON.pdf` -> `_CON.pdf`, `nul` -> `_nul`; lookalikes (`console.log`, `com10.txt`, `lpt0.bin`, `.con`) are untouched. Extends the existing GHSA-rv9j sanitizer test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the download filename sanitizer to block Windows reserved device names by prefixing an underscore when the stem matches one. This prevents silent data loss and OSErrors in the downloads watchdog on Windows.

- Bug Fixes
  - Handles `CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9` (case-insensitive; trims trailing spaces; works with extensions; maps `¹²³` to `123`).
  - Preserves lookalikes like `console.log`, `com10.txt`, `.con`.
  - Added tests for reserved names, trailing-space variants, and superscript cases.

<sup>Written for commit e23c23c5547884dfbcfa10aa22860ab89205086e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

