### PR TITLE
fix: reset fallback LLM state at the start of each run()

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2494,6 +2494,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		on_step_end: AgentHookFunc | None = None,
 	) -> AgentHistoryList[AgentStructuredOutput]:
 		"""Execute the task with maximum number of steps"""
+		# Reset fallback LLM state if switched in a previous run
+		if self._using_fallback_llm:
+			self.llm = self._original_llm
+			self._using_fallback_llm = False
+			self.logger.info(f'🔄 Reset LLM back to primary model: {self.current_llm_model}')
 
 		loop = asyncio.get_event_loop()
 		agent_run_error: str | None = None  # Initialize error tracking variable


### PR DESCRIPTION
### problem

when the agent switches to `fallback_llm` due to a rate limit or provider error, `self.llm` is permanently replaced and `self._using_fallback_llm` is never reset. on subsequent calls to `run()` via `add_new_task`, the agent stays on the inferior fallback model even if the primary LLM has recovered.

### cause

`_try_switch_to_fallback_llm` mutates `self.llm` in place with no path back to the original. `_original_llm` was never stored.

### fix

- store `self._original_llm = llm` in `__init__`
- reset `self.llm` and `self._using_fallback_llm` at the top of `run()` before any steps execute

### affected pattern

```python
agent = Agent(task="...", llm=primary, fallback_llm=fallback)
await agent.run()              # primary fails, switches to fallback
agent.add_new_task("...")
await agent.run()              # was: still on fallback. now: back on primary
```

this only affects multi-run workflows using `add_new_task`, single `run()` calls are unaffected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets the agent back to the primary LLM at the start of each run if a previous run switched to the fallback, and logs the reset for visibility. Fixes a bug where multi-run flows via add_new_task stayed on the fallback even after the primary recovered.

<sup>Written for commit 4792bd1ce3e8a39de6c03bb258e5ce86c3157798. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



