### PR TITLE
fix(integrations/gmail): recurse into nested multipart parts so 2FA/HTML email bodies aren't returned empty

### DIFF
--- a/browser_use/integrations/gmail/service.py
+++ b/browser_use/integrations/gmail/service.py
@@ -5,6 +5,7 @@ This service provides a clean interface for agents to interact with Gmail.
 """
 
 import base64
+import binascii
 import logging
 import os
 from pathlib import Path
@@ -205,21 +206,62 @@ class GmailService:
 			'raw_message': message,
 		}
 
+	@staticmethod
+	def _decode_part_data(data: str | None) -> str | None:
+		"""Best-effort base64url -> utf-8 decode; returns ``None`` on missing/malformed data."""
+		if not data:
+			return None
+		try:
+			return base64.urlsafe_b64decode(data).decode('utf-8')
+		except (binascii.Error, ValueError, UnicodeDecodeError):
+			return None
+
 	def _extract_body(self, payload: dict[str, Any]) -> str:
-		"""Extract email body from payload"""
-		body = ''
+		"""Extract the email body, recursing into nested ``multipart/*`` containers.
 
-		if payload.get('body', {}).get('data'):
-			# Simple email body
-			body = base64.urlsafe_b64decode(payload['body']['data']).decode('utf-8')
-		elif payload.get('parts'):
-			# Multi-part email
-			for part in payload['parts']:
-				if part['mimeType'] == 'text/plain' and part.get('body', {}).get('data'):
-					part_body = base64.urlsafe_b64decode(part['body']['data']).decode('utf-8')
-					body += part_body
-				elif part['mimeType'] == 'text/html' and not body and part.get('body', {}).get('data'):
-					# Fallback to HTML if no plain text
-					body = base64.urlsafe_b64decode(part['body']['data']).decode('utf-8')
+		Gmail nests the actual text leaves inside intermediate ``multipart/*`` parts for
+		most real HTML and 2FA/OTP emails (e.g. ``multipart/mixed`` -> ``multipart/alternative``
+		-> ``text/plain``). The previous implementation only scanned the top-level ``parts``
+		and matched ``text/plain``/``text/html`` directly, so any body wrapped in an
+		intermediate ``multipart/*`` part was silently returned as ``''``.
 
-		return body
+		Traversal is depth- and count-bounded and decodes each leaf defensively, so a
+		malformed or adversarially nested MIME tree degrades to a best-effort body (or
+		``''``) instead of raising.
+		"""
+		# Simple, single-part body
+		simple = self._decode_part_data(payload.get('body', {}).get('data'))
+		if simple is not None:
+			return simple
+
+		plain_chunks: list[str] = []
+		html_fallback = ''
+		max_depth = 50  # real emails nest a few levels; guards against hostile/recursive trees
+		budget = [5000]  # cap total parts visited
+
+		def walk(part: dict[str, Any], depth: int) -> None:
+			nonlocal html_fallback
+			if depth > max_depth or budget[0] <= 0:
+				return
+			budget[0] -= 1
+			mime_type = part.get('mimeType', '')
+			if mime_type == 'text/plain':
+				text = self._decode_part_data(part.get('body', {}).get('data'))
+				if text is not None:
+					plain_chunks.append(text)
+			elif mime_type == 'text/html' and not html_fallback:
+				text = self._decode_part_data(part.get('body', {}).get('data'))
+				if text is not None:
+					html_fallback = text
+			elif part.get('parts'):
+				# ``multipart/*`` container (or any part carrying nested parts) -> recurse
+				for sub_part in part['parts']:
+					walk(sub_part, depth + 1)
+
+		for part in payload.get('parts', []):
+			walk(part, 1)
+
+		# Prefer concatenated plain text; fall back to HTML only when no plain text exists
+		if plain_chunks:
+			return ''.join(plain_chunks)
+		return html_fallback

--- a/tests/ci/test_gmail_extract_body.py
+++ b/tests/ci/test_gmail_extract_body.py
@@ -1,0 +1,100 @@
+"""Regression tests for GmailService._extract_body nested-multipart handling.
+
+Reproduces the silent-empty-body bug where text leaves nested inside intermediate
+``multipart/*`` containers (the common shape for HTML and 2FA/OTP emails) were
+dropped because the extractor only scanned the top-level ``parts``. Also covers
+defensive handling of malformed and adversarially nested payloads.
+"""
+
+import base64
+
+from browser_use.integrations.gmail.service import GmailService
+
+
+def _b64(text: str) -> str:
+	return base64.urlsafe_b64encode(text.encode('utf-8')).decode('ascii')
+
+
+def _service() -> GmailService:
+	# _extract_body uses no instance state, so skip __init__ (which needs OAuth config).
+	return GmailService.__new__(GmailService)
+
+
+def test_nested_multipart_alternative_prefers_plain_text():
+	payload = {
+		'mimeType': 'multipart/mixed',
+		'parts': [
+			{
+				'mimeType': 'multipart/alternative',
+				'parts': [
+					{'mimeType': 'text/plain', 'body': {'data': _b64('Your code is 123456')}},
+					{'mimeType': 'text/html', 'body': {'data': _b64('<p>Your code is 123456</p>')}},
+				],
+			},
+			{'mimeType': 'application/pdf', 'filename': 'x.pdf', 'body': {'attachmentId': 'a1'}},
+		],
+	}
+	assert _service()._extract_body(payload) == 'Your code is 123456'
+
+
+def test_nested_html_only_falls_back_to_html():
+	payload = {
+		'mimeType': 'multipart/mixed',
+		'parts': [
+			{
+				'mimeType': 'multipart/related',
+				'parts': [
+					{'mimeType': 'text/html', 'body': {'data': _b64('<p>Hello</p>')}},
+				],
+			},
+		],
+	}
+	assert _service()._extract_body(payload) == '<p>Hello</p>'
+
+
+def test_simple_top_level_body_unchanged():
+	payload = {'mimeType': 'text/plain', 'body': {'data': _b64('plain top level')}}
+	assert _service()._extract_body(payload) == 'plain top level'
+
+
+def test_flat_multipart_still_works():
+	payload = {
+		'mimeType': 'multipart/alternative',
+		'parts': [
+			{'mimeType': 'text/plain', 'body': {'data': _b64('flat plain')}},
+			{'mimeType': 'text/html', 'body': {'data': _b64('<p>flat</p>')}},
+		],
+	}
+	assert _service()._extract_body(payload) == 'flat plain'
+
+
+def test_empty_payload_returns_empty_string():
+	assert _service()._extract_body({'mimeType': 'multipart/mixed'}) == ''
+
+
+def test_malformed_nested_leaf_does_not_block_valid_sibling():
+	# A malformed base64 leaf must be skipped, not abort the whole traversal.
+	payload = {
+		'mimeType': 'multipart/mixed',
+		'parts': [
+			{
+				'mimeType': 'multipart/alternative',
+				'parts': [
+					{'mimeType': 'text/plain', 'body': {'data': '!!!not-valid-base64!!!'}},
+					{'mimeType': 'text/plain', 'body': {'data': _b64('recovered body')}},
+				],
+			},
+		],
+	}
+	assert _service()._extract_body(payload) == 'recovered body'
+
+
+def test_deeply_nested_payload_does_not_raise():
+	# Build a pathologically deep multipart tree; extraction must not raise.
+	leaf = {'mimeType': 'text/plain', 'body': {'data': _b64('deep')}}
+	node = leaf
+	for _ in range(500):
+		node = {'mimeType': 'multipart/mixed', 'parts': [node]}
+	# Should return '' (beyond depth bound) rather than raising RecursionError.
+	result = _service()._extract_body(node)
+	assert isinstance(result, str)


### PR DESCRIPTION
### Problem

`GmailService._extract_body` only iterates the **top-level** `payload["parts"]` and matches `text/plain` / `text/html` directly:

```python
elif payload.get('parts'):
    for part in payload['parts']:
        if part['mimeType'] == 'text/plain' ...
        elif part['mimeType'] == 'text/html' and not body ...
```

But Gmail (`format='full'`) returns the actual text leaves **nested inside intermediate `multipart/*` containers** for most real HTML emails and 2FA/OTP messages — e.g. `multipart/mixed` → `multipart/alternative` → `text/plain`. When the top-level part is `multipart/*`, no branch matches and there is no recursion, so the body is silently returned as `''`.

This breaks the documented 2FA/OTP read flow (`examples/integrations/gmail_2fa_integration.py` relies on `body` to read the verification code) and returns empty bodies for common HTML/attachment-bearing emails.

### Fix

- Walk `parts` **recursively**, descending into `multipart/*` containers.
- Prefer concatenated `text/plain`; fall back to `text/html` only when no plain text is found (preserves the previous preference order).
- Traversal is **depth- and count-bounded** and each leaf is decoded **defensively** (`binascii.Error` / `UnicodeDecodeError` are skipped), so a malformed or adversarially nested MIME tree degrades to a best-effort body instead of raising.

### Tests

Adds `tests/ci/test_gmail_extract_body.py` — the first regression coverage for `_extract_body`:
- nested `multipart/alternative` prefers plain text
- nested HTML-only falls back to HTML
- simple single-part body unchanged
- flat multipart still works
- malformed nested leaf is skipped without blocking a valid sibling
- deeply nested payload does not raise

Pure additive behavior change scoped to body extraction; no public API change.