### PR TITLE
fix(security): case-insensitive matching for set-optimized and host-glob allowed/prohibited domains

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -738,9 +738,19 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	@field_validator('allowed_domains', 'prohibited_domains', mode='after')
 	@classmethod
 	def optimize_large_domain_lists(cls, v: list[str] | set[str] | None) -> list[str] | set[str] | None:
-		"""Convert large domain lists (>=100 items) to sets for O(1) lookup performance."""
-		if v is None or isinstance(v, set):
+		"""Convert large domain lists (>=100 items) to sets for O(1) lookup performance.
+
+		Set entries are lowercased because the set fast path in ``SecurityWatchdog`` compares
+		against ``urlparse(...).hostname``, which is always lowercase. Without this
+		normalization a set entry like ``Facebook.com`` would never match host ``facebook.com``,
+		silently breaking an allowlist or -- more dangerously -- letting a prohibited-domain
+		rule be bypassed. (List entries already match case-insensitively in the slow path.)
+		"""
+		if v is None:
 			return v
+
+		if isinstance(v, set):
+			return {d.lower() if isinstance(d, str) else d for d in v}
 
 		if len(v) >= DOMAIN_OPTIMIZATION_THRESHOLD:
 			logger.warning(
@@ -748,7 +758,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 				f'Note: Pattern matching (*.domain.com, etc.) is not supported for lists >= {DOMAIN_OPTIMIZATION_THRESHOLD} items. '
 				f'Use exact domains only or keep list size < {DOMAIN_OPTIMIZATION_THRESHOLD} for pattern support.'
 			)
-			return set(v)
+			return {d.lower() if isinstance(d, str) else d for d in v}
 
 		return v
 

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -262,8 +262,10 @@ class SecurityWatchdog(BaseWatchdog):
 
 			# Check if pattern matches the host
 			if pattern.startswith('*.'):
-				# Pattern like *.example.com should match subdomains and main domain
-				domain_part = pattern[2:]  # Remove *.
+				# Pattern like *.example.com should match subdomains and main domain.
+				# Lowercase the pattern's domain part: host is already lowercase
+				# (urlparse hostname), so an uppercase pattern would otherwise never match.
+				domain_part = pattern[2:].lower()  # Remove *.
 				if host == domain_part or host.endswith('.' + domain_part):
 					# Only match http/https URLs for domain-only patterns
 					if scheme in ['http', 'https']:
@@ -273,11 +275,14 @@ class SecurityWatchdog(BaseWatchdog):
 				if fnmatch.fnmatch(url, pattern):
 					return True
 			else:
-				# Use fnmatch for other glob patterns
-				if fnmatch.fnmatch(
-					full_url_pattern if '://' in pattern else host,
-					pattern,
-				):
+				# Use fnmatch for other glob patterns. Host-only patterns match
+				# case-insensitively (domains are case-insensitive and host is already
+				# lowercase); full-URL patterns keep their case because URL paths are
+				# case-sensitive.
+				if '://' in pattern:
+					if fnmatch.fnmatch(full_url_pattern, pattern):
+						return True
+				elif fnmatch.fnmatch(host, pattern.lower()):
 					return True
 		else:
 			# Exact match

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -567,3 +567,71 @@ class TestDomainListOptimization:
 		# Should work correctly
 		assert watchdog._is_url_allowed('https://blocked0.com') is False
 		assert watchdog._is_url_allowed('https://example.com') is True
+
+	def test_set_path_prohibited_domains_are_case_insensitive(self):
+		"""A prohibited-domain set with mixed-case entries must still block the lowercase host.
+
+		Regression: hosts come from ``urlparse().hostname`` (always lowercase), but set entries
+		were compared verbatim, so ``{'Facebook.com'}`` failed to block ``facebook.com`` -- a
+		silent prohibited-domain bypass.
+		"""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(prohibited_domains={'Facebook.com'}, headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert isinstance(browser_session.browser_profile.prohibited_domains, set)
+		# Must block regardless of the case used when configuring the rule.
+		assert watchdog._is_url_allowed('https://facebook.com') is False
+		assert watchdog._is_url_allowed('https://www.facebook.com') is False
+		# Unrelated host stays allowed.
+		assert watchdog._is_url_allowed('https://example.com') is True
+
+	def test_set_path_allowed_domains_are_case_insensitive(self):
+		"""An allowlist set with mixed-case entries must still allow the lowercase host."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains={'Example.com'}, headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert isinstance(browser_session.browser_profile.allowed_domains, set)
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('https://www.example.com') is True
+		assert watchdog._is_url_allowed('https://other.com') is False
+
+	def test_glob_pattern_is_case_insensitive(self):
+		"""A ``*.Domain.com`` glob with uppercase letters must still match lowercase hosts."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['*.Example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('https://sub.example.com') is True
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('https://example.org') is False
+
+	def test_generic_host_glob_is_case_insensitive(self):
+		"""A non-``*.``-prefixed host glob with uppercase letters must still match the host."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['web*.Example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('https://web1.example.com') is True
+		assert watchdog._is_url_allowed('https://api.example.com') is False


### PR DESCRIPTION
### Problem

Hosts are derived from `urlparse(url).hostname`, which is **always lowercase**, but several domain-matching paths compared against the user-supplied values **verbatim**:

1. **Set fast path** (`security_watchdog.py`) — when `allowed_domains`/`prohibited_domains` is a `set` (passed directly, or a list auto-promoted to a set at `>= 100` entries), the lowercase host is checked against un-normalized set entries:
   ```python
   host_variant, host_alt = self._get_domain_variants(host)   # lowercase
   return host_variant not in prohibited_domains and host_alt not in prohibited_domains
   ```
   So `prohibited_domains={'Facebook.com'}` does **not** block host `facebook.com` — a silent **prohibited-domain bypass**. Symmetrically, `allowed_domains={'Example.com'}` silently fails the allowlist (`facebook.com`-style false negative).

2. **`*.` glob** — `domain_part = pattern[2:]` was not lowercased, so `*.Example.com` never matched `sub.example.com`.

3. **Generic host-only glob** — `fnmatch.fnmatch(host, pattern)` compared the lowercase host against the raw pattern, so `web*.Example.com` never matched `web1.example.com`.

The list exact-match slow path already handles this (`host.lower() == pattern.lower()`); these set/glob paths were inconsistent with it, and with the case-insensitive impl in `utils.py` (`match_url_with_domain_pattern`).

### Fix

- **`profile.py` `optimize_large_domain_lists`**: lowercase domain **set** entries (both the directly-passed-set branch and the `>=100` list→set conversion). Domains are case-insensitive, and the set fast path compares against an already-lowercase host, so this is the correct normalization point (keeps the O(1) lookup).
- **`security_watchdog.py`**: lowercase the pattern in the `*.` glob branch and in the generic **host-only** fnmatch branch.

### Repro (prohibited bypass)

```python
profile = BrowserProfile(prohibited_domains={'Facebook.com'})
# before: _is_url_allowed('https://facebook.com') -> True   (bypass!)
# after:  _is_url_allowed('https://facebook.com') -> False  (blocked)
```

### Tests

Adds to `tests/ci/security/test_domain_filtering.py`: set-path prohibited (bypass regression), set-path allowed, `*.`-glob, and generic host-glob — all in mixed case.

### Scope / known limitation

This PR fixes the **host-matching** paths only. **Full-URL glob** patterns (`scheme://host/path` containing wildcards, e.g. `https://*.Example.com/admin/*`) are deliberately left matching case-sensitively across the whole URL, because correctly splitting the case-insensitive host from the case-sensitive path is a larger, separate change and I didn't want to refactor the URL-glob matcher in a security-sensitive path within this fix. Happy to follow up on that separately if you'd like it in scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes case-insensitive domain matching for sets and host globs to prevent prohibited-domain bypasses and false negatives on allowlists. Ensures `Facebook.com` blocks `facebook.com` and `*.Example.com` matches lowercase hosts.

- **Bug Fixes**
  - Lowercase domain set entries in `BrowserProfile` validator for both direct sets and auto-promoted lists (>=100) to keep O(1) lookups correct.
  - In `SecurityWatchdog`, lowercase the domain part for `*.` globs and use lowercase for host-only `fnmatch` patterns; full-URL globs remain case-sensitive.
  - Added mixed-case regression tests for set-path allow/prohibit and both glob types.

<sup>Written for commit a990ff1f45edfd71e4b28ddcaee7a88ddd7eff96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

