### PR TITLE
fix(agent): preserve all actions when history metadata is partial

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -826,9 +826,9 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 		for h in self.history:
 			if h.model_output:
-				# Guard against None interacted_element before zipping
-				interacted_elements = h.state.interacted_element or [None] * len(h.model_output.action)
-				for action, interacted_element in zip(h.model_output.action, interacted_elements):
+				interacted_elements = h.state.interacted_element or []
+				for i, action in enumerate(h.model_output.action):
+					interacted_element = interacted_elements[i] if i < len(interacted_elements) else None
 					output = action.model_dump(exclude_none=True, mode='json')
 					output['interacted_element'] = interacted_element
 					outputs.append(output)
@@ -841,10 +841,10 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 		for h in self.history:
 			step_actions = []
 			if h.model_output:
-				# Guard against None interacted_element before zipping
-				interacted_elements = h.state.interacted_element or [None] * len(h.model_output.action)
-				# Zip actions with interacted elements and results
-				for action, interacted_element, result in zip(h.model_output.action, interacted_elements, h.result):
+				interacted_elements = h.state.interacted_element or []
+				for i, action in enumerate(h.model_output.action):
+					interacted_element = interacted_elements[i] if i < len(interacted_elements) else None
+					result = h.result[i] if i < len(h.result) else None
 					action_output = action.model_dump(exclude_none=True, mode='json')
 					action_output['interacted_element'] = interacted_element
 					# Only keep long_term_memory from result

--- a/tests/ci/test_agent_history.py
+++ b/tests/ci/test_agent_history.py
@@ -1,0 +1,65 @@
+from browser_use.agent.views import ActionResult, AgentHistory, AgentHistoryList, AgentOutput
+from browser_use.browser.views import BrowserStateHistory
+from browser_use.tools.service import Tools
+
+
+def _make_history_with_partial_metadata(
+	results: list[ActionResult],
+	interacted_elements: list[None],
+) -> AgentHistoryList:
+	tools = Tools()
+	ActionModel = tools.registry.create_action_model()
+	AgentOutputWithActions = AgentOutput.type_with_custom_actions(ActionModel)
+
+	return AgentHistoryList(
+		history=[
+			AgentHistory(
+				model_output=AgentOutputWithActions(
+					evaluation_previous_goal='Opened the page',
+					memory='Need to report the result',
+					next_goal='Finish',
+					action=[
+						ActionModel(done={'text': 'first action', 'success': False}),
+						ActionModel(done={'text': 'second action', 'success': True}),
+					],
+				),
+				result=results,
+				state=BrowserStateHistory(
+					url='https://example.com',
+					title='Example',
+					tabs=[],
+					interacted_element=interacted_elements,
+				),
+			)
+		]
+	)
+
+
+def test_model_actions_preserves_actions_when_interacted_elements_shorter():
+	history = _make_history_with_partial_metadata(
+		results=[
+			ActionResult(long_term_memory='first result'),
+			ActionResult(long_term_memory='second result'),
+		],
+		interacted_elements=[None],
+	)
+
+	actions = history.model_actions()
+
+	assert [action['done']['text'] for action in actions] == ['first action', 'second action']
+	assert actions[0]['interacted_element'] is None
+	assert actions[1]['interacted_element'] is None
+
+
+def test_action_history_preserves_actions_when_results_shorter():
+	history = _make_history_with_partial_metadata(
+		results=[ActionResult(long_term_memory='first result')],
+		interacted_elements=[None, None],
+	)
+
+	action_history = history.action_history()
+
+	assert len(action_history) == 1
+	assert [action['done']['text'] for action in action_history[0]] == ['first action', 'second action']
+	assert action_history[0][0]['result'] == 'first result'
+	assert action_history[0][1]['result'] is None

--- a/tests/ci/test_agent_history.py
+++ b/tests/ci/test_agent_history.py
@@ -19,8 +19,8 @@ def _make_history_with_partial_metadata(
 					memory='Need to report the result',
 					next_goal='Finish',
 					action=[
-						ActionModel(done={'text': 'first action', 'success': False}),
-						ActionModel(done={'text': 'second action', 'success': True}),
+						ActionModel.model_validate({'done': {'text': 'first action', 'success': False}}),
+						ActionModel.model_validate({'done': {'text': 'second action', 'success': True}}),
 					],
 				),
 				result=results,


### PR DESCRIPTION
## Summary

- Preserve every action returned by `AgentHistoryList.model_actions()` when `interacted_element` metadata is shorter than the action list.
- Preserve every action returned by `AgentHistoryList.action_history()` when `interacted_element` or `result` metadata is shorter than the action list.
- Add regression coverage for partial history metadata so exported trajectories do not silently drop actions.

## Root Cause

Both helpers iterated with `zip(...)` over model actions plus optional per-action metadata. Python `zip` stops at the shortest input, so a history step with two model actions but one interacted element or one result exported only the first action.

## Why this matters

These helpers are used for trace inspection and downstream action-history consumers. Silently truncating the exported history can make debugging and eval reports disagree with the actual actions produced by the model.

## Testing

- RED before the fix: `uv run pytest tests/ci/test_agent_history.py -q` failed because `model_actions()` returned only `['first action']` for a two-action step with one interacted element.
- `uv run pytest tests/ci/test_agent_history.py tests/ci/test_sandbox_structured_output.py -q` passed: 10 passed.
- `uv run ruff check browser_use/agent/views.py tests/ci/test_agent_history.py` passed.
- `uv run pyright browser_use/agent/views.py tests/ci/test_agent_history.py` passed.
- `uv run pre-commit run --files browser_use/agent/views.py tests/ci/test_agent_history.py` passed.
- Pre-push full `pytest -q` reached 716 passed / 36 skipped, then failed once in `tests/ci/test_rust_agent.py::test_rust_agent_constructor_type_hints_match_browser_use_core_params` on a type object identity assertion. The failing test passed when rerun directly with `uv run pytest tests/ci/test_rust_agent.py::test_rust_agent_constructor_type_hints_match_browser_use_core_params -q`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes action history export to always include all actions even when `interacted_element` or `result` metadata is shorter. Prevents silent truncation in `AgentHistoryList.model_actions()` and `AgentHistoryList.action_history()`.

- **Bug Fixes**
  - Replaced zip-based iteration with index-safe loops; missing metadata now defaults to `None` instead of dropping actions.
  - Preserves alignment of actions with `interacted_element` and `result` without truncation.
  - Added regression tests to cover partial history metadata and ensure exported trajectories keep all actions.

<sup>Written for commit 3c9e44f9cacb329264bebdd441c79e8a72ea2283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

