### PR TITLE
Validate Rust terminal SDK server binary

### DIFF
--- a/browser_use/rust/service.py
+++ b/browser_use/rust/service.py
@@ -12,6 +12,7 @@ import mimetypes
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 import time
 from collections.abc import Awaitable, Callable
@@ -188,21 +189,34 @@ def find_browser_use_terminal_binary() -> str:
 	but_home = Path(os.environ.get('BUT_HOME', '~/.browser-use-terminal')).expanduser()
 	but_install_dir = Path(os.environ.get('BUT_INSTALL_DIR', '~/.local/bin')).expanduser()
 	candidates = [
-		Path.cwd() / 'target' / 'debug' / 'browser-use-terminal',
-		Path.cwd().parent / 'terminal' / 'target' / 'debug' / 'browser-use-terminal',
 		but_home / 'packages' / 'standalone' / 'current' / 'bin' / 'browser-use-terminal',
 		but_install_dir / 'browser-use-terminal',
 	]
 	for candidate in candidates:
-		if candidate.exists():
+		if candidate.exists() and _terminal_supports_sdk_server(candidate):
 			return str(candidate)
 	path_binary = shutil.which('browser-use-terminal')
-	if path_binary:
+	if path_binary and _terminal_supports_sdk_server(Path(path_binary)):
 		return path_binary
 	raise RustAgentError(
 		f'Could not find browser-use-terminal. Install Browser Use Terminal with `{TERMINAL_INSTALL_COMMAND}`, '
 		'or set BROWSER_USE_TERMINAL_BINARY to a built terminal CLI.'
 	)
+
+
+def _terminal_supports_sdk_server(binary: Path) -> bool:
+	"""Return whether a terminal binary supports the SDK server subcommand required by this wrapper."""
+	try:
+		result = subprocess.run(
+			[str(binary), '--help'],
+			capture_output=True,
+			text=True,
+			timeout=5,
+			check=False,
+		)
+	except (OSError, subprocess.SubprocessError):
+		return False
+	return 'sdk-server' in f'{result.stdout}\n{result.stderr}'
 
 
 class RustSdkJsonRpcError(RustAgentError):

--- a/tests/ci/test_rust_agent.py
+++ b/tests/ci/test_rust_agent.py
@@ -2635,7 +2635,8 @@ def test_rust_terminal_binary_finds_default_terminal_install(monkeypatch, tmp_pa
 
 	binary = tmp_path / '.browser-use-terminal' / 'packages' / 'standalone' / 'current' / 'bin' / 'browser-use-terminal'
 	binary.parent.mkdir(parents=True)
-	binary.write_text('#!/bin/sh\n')
+	binary.write_text('#!/bin/sh\nif [ "$1" = "--help" ]; then\n  echo "sdk-server"\nfi\n')
+	binary.chmod(0o755)
 
 	monkeypatch.delenv('BROWSER_USE_TERMINAL_BINARY', raising=False)
 	monkeypatch.chdir(tmp_path)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate that the selected `browser-use-terminal` binary supports the SDK server to avoid launching incompatible CLIs. We now probe `--help` and only use binaries that advertise the `sdk-server` subcommand.

- **Bug Fixes**
  - Check `--help` output (5s timeout) and require `sdk-server` to be present.
  - Accept binaries from `BUT_HOME` standalone, `BUT_INSTALL_DIR`, or PATH only; drop local debug target paths to avoid picking outdated builds.
  - Raise a clear error with the install hint if no valid binary is found.
  - Fix discovery test to echo `sdk-server` on `--help` and set the stub binary executable.

<sup>Written for commit b4e3fb833a9eb25e3f4d8a6de8116ce58312d31c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

