### PR TITLE
Fix prerelease version upgrade check

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -670,18 +670,49 @@ async def check_latest_browser_use_version() -> str | None:
 	"""Check the latest version of browser-use from PyPI asynchronously.
 
 	Returns:
-		The latest version string if successful, None if failed
+		The latest version string if PyPI has a newer version, None otherwise.
 	"""
 	try:
 		async with httpx.AsyncClient(timeout=3.0) as client:
 			response = await client.get('https://pypi.org/pypi/browser-use/json')
 			if response.status_code == 200:
 				data = response.json()
-				return data['info']['version']
+				latest_version = data['info']['version']
+				if _is_newer_browser_use_version(latest_version, get_browser_use_version()):
+					return latest_version
 	except Exception:
 		# Silently fail - we don't want to break agent startup due to network issues
 		pass
 	return None
+
+
+def _is_newer_browser_use_version(latest_version: str, current_version: str) -> bool:
+	"""Return True when latest_version should be considered an upgrade for current_version."""
+	try:
+		from packaging.version import Version
+
+		return Version(latest_version) > Version(current_version)
+	except Exception:
+		latest_key = _browser_use_version_key(latest_version)
+		current_key = _browser_use_version_key(current_version)
+		if latest_key is None or current_key is None:
+			return latest_version != current_version
+		return latest_key > current_key
+
+
+def _browser_use_version_key(version: str) -> tuple[tuple[int, ...], int, int, int] | None:
+	"""Small PEP 440-ish fallback for browser-use versions when packaging is unavailable."""
+	match = re.match(r'^v?(\d+(?:\.\d+)*)(?:(a|b|rc)(\d+))?(?:\.post(\d+))?', version.strip().lower())
+	if not match:
+		return None
+
+	release = tuple(int(part) for part in match.group(1).split('.'))
+	phase = match.group(2)
+	phase_number = int(match.group(3) or 0)
+	post_number = int(match.group(4) or 0)
+	phase_rank = {'a': 0, 'b': 1, 'rc': 2}.get(phase, 3)
+
+	return release, phase_rank, phase_number, post_number
 
 
 @cache

--- a/tests/ci/infrastructure/test_version_check.py
+++ b/tests/ci/infrastructure/test_version_check.py
@@ -1,0 +1,13 @@
+from browser_use.utils import _is_newer_browser_use_version
+
+
+def test_prerelease_is_newer_than_previous_stable():
+	assert _is_newer_browser_use_version('0.12.9', '0.13.0rc3') is False
+
+
+def test_stable_release_is_newer_than_same_release_candidate():
+	assert _is_newer_browser_use_version('0.13.0', '0.13.0rc3') is True
+
+
+def test_later_release_candidate_is_newer():
+	assert _is_newer_browser_use_version('0.13.0rc4', '0.13.0rc3') is True


### PR DESCRIPTION
Fixes the startup warning that treated latest stable 0.12.9 as newer than local 0.13.0rc3. Adds focused tests for stable/prerelease comparison.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the startup upgrade warning by correctly comparing stable and prerelease versions; only shows an update when PyPI truly has a newer release.

- **Bug Fixes**
  - Use `packaging`’s `Version` comparison, with a small PEP 440-like fallback when `packaging` isn’t available.
  - Update `check_latest_browser_use_version()` to return the PyPI version only if it’s newer; otherwise returns None.
  - Add tests covering stable vs prerelease, stable over same RC, and RC progression (e.g., `0.12.9` < `0.13.0rc3` < `0.13.0`).

<sup>Written for commit a75b950dc74f7f382a913c5f2379867deed2c79d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

