### PR TITLE
Install browser-use-core in dev env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,4 +242,9 @@ dev-dependencies = [
     # "pytest-playwright-asyncio>=0.7.0",  # not actually needed I think
     "pytest-timeout==2.4.0",
     "pydantic_settings==2.12.0",
+    "browser-use-core==0.13.0rc2; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "browser-use-core==0.13.0rc2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.0rc2; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.0rc2; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "browser-use-core==0.13.0rc2; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
 ]


### PR DESCRIPTION
Adds the browser-use-core platform package to uv dev dependencies so plain local repo commands like `uv run examples/beta_agent/basic.py` can discover the packaged terminal binary without requiring `--extra core`. The published base package still keeps browser-use-core behind the `[core]` extra.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `browser-use-core` to dev dependencies so local `uv run` (e.g., `uv run examples/beta_agent/basic.py`) finds the terminal binary without `--extra core`. Publishing behavior is unchanged; `[core]` still gates the package in the base distribution.

- **Dependencies**
  - Added `browser-use-core==0.13.0rc2` as a dev-only dependency with markers for macOS (arm64, x86_64), Linux (x86_64, aarch64), and Windows (AMD64/x86_64).

<sup>Written for commit 3358a467854dbcc6312b4efd346b2db31e8a01e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/4999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

