### PR TITLE
[codex] Fix beta agent example LLM defaults

### DIFF
--- a/examples/beta_agent/basic.py
+++ b/examples/beta_agent/basic.py
@@ -2,16 +2,30 @@
 
 Set BROWSER_USE_TERMINAL_BINARY when the terminal binary is not on PATH.
 Set BU_CDP_URL or BROWSER_USE_CDP_URL to attach to a remote Browser Use cloud browser.
+Set BU_PROVIDER=openai or BU_PROVIDER=anthropic to choose a provider explicitly.
+Set BU_MODEL to override the provider default.
 """
 
 import asyncio
 import os
 
-from browser_use.beta import Agent, BrowserSession, ChatBrowserUse
+from browser_use.beta import Agent, BrowserSession, ChatAnthropic, ChatOpenAI
 
-# from browser_use.beta import ChatOpenAI  # ChatOpenAI(model='gpt-5.5')
-# from browser_use.beta import ChatGoogle  # ChatGoogle(model='gemini-3.1-pro-preview')
-# from browser_use.beta import ChatAnthropic  # ChatAnthropic(model='claude-opus-4-8')
+
+def build_llm():
+	provider = os.environ.get('BU_PROVIDER', '').strip().lower()
+	if not provider:
+		if os.environ.get('OPENAI_API_KEY'):
+			provider = 'openai'
+		elif os.environ.get('ANTHROPIC_API_KEY'):
+			provider = 'anthropic'
+
+	if provider == 'openai':
+		return ChatOpenAI(model=os.environ.get('BU_MODEL', 'gpt-5-mini'))
+	if provider == 'anthropic':
+		return ChatAnthropic(model=os.environ.get('BU_MODEL', 'claude-sonnet-4-6'))
+
+	raise RuntimeError('Set OPENAI_API_KEY or ANTHROPIC_API_KEY, or set BU_PROVIDER=openai|anthropic.')
 
 
 async def main() -> None:
@@ -22,10 +36,7 @@ async def main() -> None:
 
 	agent = Agent(
 		task=task,
-		llm=ChatBrowserUse(),
-		# llm=ChatOpenAI(model='gpt-5.5'),
-		# llm=ChatGoogle(model='gemini-3.1-pro-preview'),
-		# llm=ChatAnthropic(model='claude-opus-4-8'),  # Sonnet also works well.
+		llm=build_llm(),
 		browser_session=browser_session,
 	)
 	history = await agent.run(max_steps=max_steps)


### PR DESCRIPTION
## Summary
- Update the Rust-backed beta agent example to choose OpenAI or Anthropic from local env instead of defaulting to ChatBrowserUse.
- Add BU_PROVIDER and BU_MODEL overrides for explicit example runs.

## Why
The packaged Rust SDK path works with OpenAI and Anthropic, but the example defaulted to ChatBrowserUse/bu-2-0. In live testing, that path started the Rust SDK successfully but failed on the first model turn with `HTTP 400: The requested model bu-2-0 does not exist` from the terminal-backed run.

## Validation
- `uv run ruff check examples/beta_agent/basic.py`
- `uv run python -m py_compile examples/beta_agent/basic.py`
- `uv run pytest -q tests/ci/test_beta_agent.py`
- `BU_TASK="Open https://example.com and report the page title." BU_MAX_STEPS=6 uv run python examples/beta_agent/basic.py`
- `BU_PROVIDER=anthropic BU_TASK="Open https://example.com and report the page title." BU_MAX_STEPS=6 uv run python examples/beta_agent/basic.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the beta agent example to auto-select OpenAI or Anthropic from local env and adds `BU_PROVIDER`/`BU_MODEL` overrides, replacing the broken `ChatBrowserUse` default. Prevents 400s from the terminal path (missing `bu-2-0`) and makes the example runnable out of the box.

- **New Features**
  - Auto-detects provider from `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`.
  - Explicit overrides via `BU_PROVIDER=openai|anthropic` and `BU_MODEL`.

- **Bug Fixes**
  - Replaces default `ChatBrowserUse` with a `build_llm()` that returns `ChatOpenAI` or `ChatAnthropic`.
  - Removes reliance on the invalid `bu-2-0` model in terminal-backed runs.

<sup>Written for commit c4a9ad5fbdc8d6320b23601da594c5854c2ac931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

