### PR TITLE
Add local terminal source discovery

### DIFF
--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -204,7 +204,47 @@ def find_browser_use_terminal_binary() -> str:
 		return path_binary
 	raise BetaAgentError(
 		f'Could not find browser-use-terminal. Install Browser Use Terminal with `{TERMINAL_INSTALL_COMMAND}`, '
-		'install browser-use-core, or set BROWSER_USE_TERMINAL_BINARY to a built terminal CLI.'
+		'install browser-use-core, set BROWSER_USE_TERMINAL_SOURCE_DIR to a terminal checkout, '
+		'or set BROWSER_USE_TERMINAL_BINARY to a built terminal CLI.'
+	)
+
+
+def find_browser_use_terminal_command() -> list[str]:
+	"""Find the command prefix used to start the Rust-backed Browser Use Agent."""
+	env_path = os.environ.get('BROWSER_USE_TERMINAL_BINARY')
+	if env_path:
+		return [env_path]
+	source_command = _find_terminal_source_command()
+	if source_command:
+		return source_command
+	return [find_browser_use_terminal_binary()]
+
+
+def _find_terminal_source_command() -> list[str] | None:
+	source_dir = os.environ.get('BROWSER_USE_TERMINAL_SOURCE_DIR')
+	if not source_dir:
+		return None
+	source_root = _resolve_terminal_source_root(source_dir)
+	return [
+		'cargo',
+		'run',
+		'-q',
+		'--manifest-path',
+		str(source_root / 'Cargo.toml'),
+		'-p',
+		'browser-use-cli',
+		'--',
+	]
+
+
+def _resolve_terminal_source_root(source_dir: str) -> Path:
+	source_path = Path(source_dir).expanduser()
+	for candidate in (source_path, *source_path.parents):
+		if (candidate / 'Cargo.toml').exists() and (candidate / 'crates' / 'browser-use-cli' / 'Cargo.toml').exists():
+			return candidate
+	raise BetaAgentError(
+		'BROWSER_USE_TERMINAL_SOURCE_DIR must point to the browser-use terminal source checkout, or a path inside it. '
+		'Expected to find Cargo.toml and crates/browser-use-cli/Cargo.toml.'
 	)
 
 
@@ -279,6 +319,7 @@ class RustSdkClient:
 			raise BetaAgentError(
 				f'Could not start Rust SDK server command {command!r}. '
 				f'Install Browser Use Terminal with `{TERMINAL_INSTALL_COMMAND}`, '
+				'set BROWSER_USE_TERMINAL_SOURCE_DIR to a terminal checkout, '
 				'or set BROWSER_USE_TERMINAL_BINARY to a built terminal CLI.'
 			) from exc
 		self._reader_task = asyncio.create_task(self._read_stdout())
@@ -6257,7 +6298,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	def _sdk_server_argv(self) -> list[str]:
 		explicit = os.environ.get('BROWSER_USE_SDK_SERVER')
-		command = [explicit] if explicit else [find_browser_use_terminal_binary()]
+		command = [explicit] if explicit else find_browser_use_terminal_command()
 		return [
 			*command,
 			*self._state_dir_args(),
@@ -6284,13 +6325,15 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			self._sdk_client = None
 			raise BetaAgentError(
 				'Failed to negotiate browser-use-terminal SDK protocol via runtime.ping. '
-				'Install a compatible browser-use-core package or set BROWSER_USE_TERMINAL_BINARY to a compatible binary.'
+				'Install a compatible browser-use-core package, set BROWSER_USE_TERMINAL_SOURCE_DIR to a terminal checkout, '
+				'or set BROWSER_USE_TERMINAL_BINARY to a compatible binary.'
 			) from exc
 		await self._sdk_client.close()
 		self._sdk_client = None
 		raise BetaAgentError(
 			f'Unsupported browser-use-terminal SDK protocol {protocol_version!r}; expected 1. '
-			'Install a compatible browser-use-core package or set BROWSER_USE_TERMINAL_BINARY to a compatible binary.'
+			'Install a compatible browser-use-core package, set BROWSER_USE_TERMINAL_SOURCE_DIR to a terminal checkout, '
+			'or set BROWSER_USE_TERMINAL_BINARY to a compatible binary.'
 		)
 
 	def _sdk_llm_payload(self) -> dict[str, Any]:

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -21,6 +21,7 @@ def _disable_beta_agent_latest_version_check(monkeypatch):
 
 	monkeypatch.setattr(beta_service, 'check_latest_browser_use_version', no_latest_version)
 	monkeypatch.delenv('DEFAULT_LLM', raising=False)
+	monkeypatch.delenv('BROWSER_USE_TERMINAL_SOURCE_DIR', raising=False)
 	monkeypatch.setenv('BROWSER_USE_API_KEY', 'test-browser-use-api-key')
 
 
@@ -2658,6 +2659,7 @@ def test_rust_terminal_binary_missing_error_mentions_install(monkeypatch):
 	message = str(exc_info.value)
 	assert 'https://browser-use.com/terminal/install.sh' in message
 	assert 'browser-use-core' in message
+	assert 'BROWSER_USE_TERMINAL_SOURCE_DIR' in message
 	assert 'BROWSER_USE_TERMINAL_BINARY' in message
 
 
@@ -2676,6 +2678,99 @@ def test_rust_terminal_binary_prefers_packaged_binary(monkeypatch):
 	monkeypatch.setattr(beta_service.shutil, 'which', lambda binary_name: None)
 
 	assert beta_service.find_browser_use_terminal_binary() == '/tmp/packaged-browser-use-terminal'
+
+
+def test_rust_terminal_command_uses_terminal_source_dir(monkeypatch, tmp_path):
+	import browser_use.beta.service as beta_service
+
+	source_root = tmp_path / 'terminal'
+	(source_root / 'crates' / 'browser-use-cli').mkdir(parents=True)
+	(source_root / 'Cargo.toml').write_text('[workspace]\n')
+	(source_root / 'crates' / 'browser-use-cli' / 'Cargo.toml').write_text('[package]\nname = "browser-use-cli"\n')
+
+	monkeypatch.delenv('BROWSER_USE_TERMINAL_BINARY', raising=False)
+	monkeypatch.setenv('BROWSER_USE_TERMINAL_SOURCE_DIR', str(source_root))
+	monkeypatch.setitem(sys.modules, 'browser_use_core', None)
+
+	assert beta_service.find_browser_use_terminal_command() == [
+		'cargo',
+		'run',
+		'-q',
+		'--manifest-path',
+		str(source_root / 'Cargo.toml'),
+		'-p',
+		'browser-use-cli',
+		'--',
+	]
+
+
+def test_beta_agent_sdk_server_argv_uses_terminal_source_dir(monkeypatch, tmp_path):
+	from browser_use.beta import Agent
+
+	class LLM:
+		model = 'gpt-test'
+
+	source_root = tmp_path / 'terminal'
+	(source_root / 'crates' / 'browser-use-cli').mkdir(parents=True)
+	(source_root / 'Cargo.toml').write_text('[workspace]\n')
+	(source_root / 'crates' / 'browser-use-cli' / 'Cargo.toml').write_text('[package]\nname = "browser-use-cli"\n')
+
+	monkeypatch.delenv('BROWSER_USE_TERMINAL_BINARY', raising=False)
+	monkeypatch.setenv('BROWSER_USE_TERMINAL_SOURCE_DIR', str(source_root))
+
+	agent = Agent(task='report title', llm=LLM())
+
+	assert agent._sdk_server_argv() == [
+		'cargo',
+		'run',
+		'-q',
+		'--manifest-path',
+		str(source_root / 'Cargo.toml'),
+		'-p',
+		'browser-use-cli',
+		'--',
+		'sdk-server',
+		'--transport',
+		'stdio',
+	]
+
+
+def test_rust_terminal_command_accepts_package_dir_inside_source_checkout(monkeypatch, tmp_path):
+	import browser_use.beta.service as beta_service
+
+	source_root = tmp_path / 'terminal'
+	package_dir = source_root / 'packages' / 'browser-use-core'
+	(source_root / 'crates' / 'browser-use-cli').mkdir(parents=True)
+	package_dir.mkdir(parents=True)
+	(source_root / 'Cargo.toml').write_text('[workspace]\n')
+	(source_root / 'crates' / 'browser-use-cli' / 'Cargo.toml').write_text('[package]\nname = "browser-use-cli"\n')
+
+	monkeypatch.delenv('BROWSER_USE_TERMINAL_BINARY', raising=False)
+	monkeypatch.setenv('BROWSER_USE_TERMINAL_SOURCE_DIR', str(package_dir))
+
+	assert beta_service.find_browser_use_terminal_command()[:7] == [
+		'cargo',
+		'run',
+		'-q',
+		'--manifest-path',
+		str(source_root / 'Cargo.toml'),
+		'-p',
+		'browser-use-cli',
+	]
+
+
+def test_rust_terminal_command_invalid_source_dir_errors(monkeypatch, tmp_path):
+	import browser_use.beta.service as beta_service
+
+	monkeypatch.delenv('BROWSER_USE_TERMINAL_BINARY', raising=False)
+	monkeypatch.setenv('BROWSER_USE_TERMINAL_SOURCE_DIR', str(tmp_path / 'missing-terminal'))
+
+	with pytest.raises(beta_service.BetaAgentError) as exc_info:
+		beta_service.find_browser_use_terminal_command()
+
+	message = str(exc_info.value)
+	assert 'BROWSER_USE_TERMINAL_SOURCE_DIR' in message
+	assert 'crates/browser-use-cli/Cargo.toml' in message
 
 
 def test_rust_terminal_binary_finds_default_terminal_install(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add a dev-only BROWSER_USE_TERMINAL_SOURCE_DIR override for browser_use.beta
- let the beta Agent start the Rust SDK server through cargo run when pointed at a terminal checkout or a path inside it
- keep the existing fallback order for published installs: explicit binary, browser-use-core package, standalone install, PATH

## Local DX
This lets local browser-use testing point at a terminal checkout without publishing browser-use-core every time:

```bash
BROWSER_USE_TERMINAL_SOURCE_DIR=/path/to/llm-browser-rust-wheel \
  uv run examples/beta_agent/basic.py
```

Discovery now looks like:

```
BROWSER_USE_TERMINAL_BINARY
        |
        v
BROWSER_USE_TERMINAL_SOURCE_DIR -> cargo run -p browser-use-cli -- sdk-server --transport stdio
        |
        v
browser-use-core package / standalone install / PATH
```

## Checks
- uv run ruff check browser_use/beta/service.py tests/ci/test_beta_agent.py
- uv run pytest -q tests/ci/test_beta_agent.py -k "terminal_command or terminal_binary_missing or terminal_binary_prefers_packaged_binary or terminal_binary_finds_default_terminal_install or translates_browser_use_args"
- uv run pytest -q tests/ci/test_beta_agent.py -k "sdk_server_argv_uses_terminal_source_dir"
- local runtime ping through cargo source dir returned sdk_protocol_version=1


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local terminal source discovery so the beta Agent can start the Rust SDK server from a local `browser-use-terminal` checkout via cargo. This speeds up local testing by avoiding `browser-use-core` publishes while keeping the existing fallback order.

- **New Features**
  - New dev-only env var BROWSER_USE_TERMINAL_SOURCE_DIR. Point it at the terminal repo (or a path inside). The Agent runs: cargo run -p `browser-use-cli` -- sdk-server --transport stdio.
  - Discovery order: BROWSER_USE_TERMINAL_BINARY → BROWSER_USE_TERMINAL_SOURCE_DIR → packaged `browser-use-core` / standalone install / PATH.
  - Added command resolution helper and improved error messages. Tests cover source-dir command building and argv wiring.

<sup>Written for commit 797fa7d078c8a0b440bf7099231b9e9d37f2b621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

