### PR TITLE
Prepare browser-use rc4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.13.0rc3"
+version = "0.13.0rc4"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [
@@ -60,11 +60,11 @@ dependencies = [
 [project.optional-dependencies]
 cli = ["textual==7.4.0"]
 core = [
-    "browser-use-core==0.13.0rc2; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "browser-use-core==0.13.0rc2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.0rc2; sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.0rc2; sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "browser-use-core==0.13.0rc2; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
+    "browser-use-core==0.13.0rc4; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "browser-use-core==0.13.0rc4; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.0rc4; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.0rc4; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "browser-use-core==0.13.0rc4; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
 ]
 aws = ["boto3==1.42.37"]
 oci = ["oci==2.166.0"]


### PR DESCRIPTION
## Summary
- bump browser-use package version to 0.13.0rc4
- point the [core] extra at browser-use-core==0.13.0rc4 on all supported platforms

## Checks
- uv run --no-project python metadata assertion for browser-use version and [core] dependency pins
- pre-commit TOML checks during commit

## Note
Full `uv sync --all-extras` / install validation must wait until browser-use-core==0.13.0rc4 finishes publishing from terminal run https://github.com/browser-use/terminal/actions/runs/27166198498.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare rc4 release by bumping `browser-use` to 0.13.0rc4 and aligning the `[core]` extra to `browser-use-core` 0.13.0rc4 across all platforms. This keeps the wrapper and core in sync for clean installs.

- **Dependencies**
  - Set `browser-use` version to 0.13.0rc4.
  - Pin `browser-use-core==0.13.0rc4` for macOS (arm64, x86_64), Linux (x86_64, aarch64), and Windows (x86_64).

- **Migration**
  - No code changes. Install `[core]` after `browser-use-core` 0.13.0rc4 is published.

<sup>Written for commit 5fea46d182166dcaf6715b1599324dafeee9744f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

