### PR TITLE
Close beta SDK browser resources

### DIFF
--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -4844,6 +4844,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self._unregister_run_signal_handler()
 		await self._stop_eventbus_after_run()
 		await self._close_browser_resources()
+		await self._close_sdk_client_if_not_keep_alive()
 
 	async def _finalize_exceptional_run(self, max_steps: int, agent_run_error: str) -> None:
 		"""Mirror Browser Use run finalization for exceptions that escape Rust execution."""
@@ -6139,17 +6140,48 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 	async def close(self):
 		"""Close Browser Use session resources when the caller did not request keep-alive."""
 		await self._close_browser_resources()
-		if self._sdk_client is not None:
-			await self._sdk_client.close()
-			self._sdk_client = None
+		await self._close_sdk_client_if_not_keep_alive()
 		return None
+
+	def _should_keep_browser_alive(self) -> bool:
+		profile = getattr(self.browser_session, 'browser_profile', None) or self.browser_profile
+		return bool(getattr(profile, 'keep_alive', False))
+
+	async def _close_sdk_browser_resources(self) -> None:
+		"""Close Rust-owned SDK agent/browser resources when this run is not keep-alive."""
+		if self._should_keep_browser_alive() or self._sdk_client is None:
+			return
+		if isinstance(self._sdk_client, RustSdkClient) and self._sdk_client.process is None:
+			return
+		client = self._sdk_client
+		agent_id = self._sdk_agent_id
+		browser_id = self._sdk_browser_id
+		if agent_id:
+			with suppress(Exception):
+				await client.call('agent.close', {'agent_id': agent_id})
+		if browser_id:
+			with suppress(Exception):
+				await client.call('browser.close', {'browser_id': browser_id})
+		self._sdk_agent_id = None
+		self._sdk_browser_id = None
+		self.terminal_session_id = None
+
+	async def _close_sdk_client_if_not_keep_alive(self) -> None:
+		if self._should_keep_browser_alive() or self._sdk_client is None:
+			return
+		try:
+			await self._sdk_client.close()
+		except Exception as exc:
+			self.logger.error(f'Error closing Rust SDK client: {exc}')
+		else:
+			self._sdk_client = None
 
 	async def _close_browser_resources(self):
 		"""Close Browser Use session resources without tearing down the Rust SDK process."""
 		try:
+			await self._close_sdk_browser_resources()
 			if self.browser_session is not None:
-				profile = getattr(self.browser_session, 'browser_profile', None) or self.browser_profile
-				if not getattr(profile, 'keep_alive', False):
+				if not self._should_keep_browser_alive():
 					kill = getattr(self.browser_session, 'kill', None)
 					if callable(kill):
 						result = kill()

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -2772,7 +2772,7 @@ def test_beta_agent_sdk_browser_payload_includes_profile_domains_window_and_prox
 
 
 async def test_beta_agent_runs_through_sdk_and_reuses_session_for_followup(monkeypatch):
-	from browser_use.beta import Agent
+	from browser_use.beta import Agent, BrowserProfile, BrowserSession
 
 	class LLM:
 		model = 'fake'
@@ -2821,11 +2821,13 @@ async def test_beta_agent_runs_through_sdk_and_reuses_session_for_followup(monke
 	fake_sdk = FakeSdk()
 
 	async def fake_ensure_sdk_client(self):
+		self._sdk_client = fake_sdk
 		return fake_sdk
 
 	monkeypatch.setattr(Agent, '_ensure_sdk_client', fake_ensure_sdk_client)
 
-	agent = Agent(task='answer first', llm=LLM(), directly_open_url=False)
+	browser_session = BrowserSession(browser_profile=BrowserProfile(keep_alive=True), id='browser-session-1')
+	agent = Agent(task='answer first', llm=LLM(), browser_session=browser_session, directly_open_url=False)
 	first = await agent.run(max_steps=7)
 	followup = await agent.follow_up('answer second', max_steps=5)
 
@@ -5781,6 +5783,18 @@ def test_beta_agent_sync_state_counts_terminal_histories_monotonically():
 async def test_beta_agent_close_kills_non_keep_alive_browser_session():
 	from browser_use.beta import Agent
 
+	class FakeSdk:
+		def __init__(self):
+			self.calls = []
+			self.close_calls = 0
+
+		async def call(self, method, params=None):
+			self.calls.append((method, params or {}))
+			return {'ok': True}
+
+		async def close(self):
+			self.close_calls += 1
+
 	class BrowserProfile:
 		keep_alive = False
 
@@ -5795,9 +5809,23 @@ async def test_beta_agent_close_kills_non_keep_alive_browser_session():
 
 	session = BrowserSession()
 	agent = Agent(task='close session', browser_session=session, directly_open_url=False)
+	fake_sdk = FakeSdk()
+	agent._sdk_client = fake_sdk
+	agent._sdk_agent_id = 'agent-1'
+	agent._sdk_browser_id = 'browser-1'
+	agent.terminal_session_id = 'session-1'
 
 	await agent.close()
 
+	assert fake_sdk.calls == [
+		('agent.close', {'agent_id': 'agent-1'}),
+		('browser.close', {'browser_id': 'browser-1'}),
+	]
+	assert fake_sdk.close_calls == 1
+	assert agent._sdk_client is None
+	assert agent._sdk_agent_id is None
+	assert agent._sdk_browser_id is None
+	assert agent.terminal_session_id is None
 	assert session.kill_calls == 1
 
 	class KeepAliveProfile:
@@ -5806,9 +5834,20 @@ async def test_beta_agent_close_kills_non_keep_alive_browser_session():
 	keep_alive_session = BrowserSession()
 	keep_alive_session.browser_profile = KeepAliveProfile()
 	keep_alive_agent = Agent(task='keep session', browser_session=keep_alive_session, directly_open_url=False)
+	keep_alive_sdk = FakeSdk()
+	keep_alive_agent._sdk_client = keep_alive_sdk
+	keep_alive_agent._sdk_agent_id = 'agent-keep'
+	keep_alive_agent._sdk_browser_id = 'browser-keep'
+	keep_alive_agent.terminal_session_id = 'session-keep'
 
 	await keep_alive_agent.close()
 
+	assert keep_alive_sdk.calls == []
+	assert keep_alive_sdk.close_calls == 0
+	assert keep_alive_agent._sdk_client is keep_alive_sdk
+	assert keep_alive_agent._sdk_agent_id == 'agent-keep'
+	assert keep_alive_agent._sdk_browser_id == 'browser-keep'
+	assert keep_alive_agent.terminal_session_id == 'session-keep'
 	assert keep_alive_session.kill_calls == 0
 
 
@@ -5838,6 +5877,50 @@ async def test_beta_agent_close_logs_cleanup_errors_without_raising(monkeypatch)
 
 	assert await agent.close() is None
 	assert logger.errors == ['Error during cleanup: cleanup failed']
+
+
+async def test_beta_agent_finalize_run_cleanup_closes_sdk_resources():
+	from browser_use.beta import Agent
+
+	class FakeSdk:
+		def __init__(self):
+			self.calls = []
+			self.close_calls = 0
+
+		async def call(self, method, params=None):
+			self.calls.append((method, params or {}))
+			return {'ok': True}
+
+		async def close(self):
+			self.close_calls += 1
+
+	class BrowserProfile:
+		keep_alive = False
+
+	class BrowserSession:
+		browser_profile = BrowserProfile()
+
+		async def kill(self):
+			return None
+
+	agent = Agent(task='finalize session', browser_session=BrowserSession(), directly_open_url=False)
+	fake_sdk = FakeSdk()
+	agent._sdk_client = fake_sdk
+	agent._sdk_agent_id = 'agent-finalize'
+	agent._sdk_browser_id = 'browser-finalize'
+	agent.terminal_session_id = 'session-finalize'
+
+	await agent._finalize_run_cleanup()
+
+	assert fake_sdk.calls == [
+		('agent.close', {'agent_id': 'agent-finalize'}),
+		('browser.close', {'browser_id': 'browser-finalize'}),
+	]
+	assert fake_sdk.close_calls == 1
+	assert agent._sdk_client is None
+	assert agent._sdk_agent_id is None
+	assert agent._sdk_browser_id is None
+	assert agent.terminal_session_id is None
 
 
 async def test_beta_agent_check_stop_or_pause_matches_browser_use_lifecycle():


### PR DESCRIPTION
## Summary
- close Rust SDK agent/browser resources during beta agent cleanup when BrowserProfile.keep_alive is false
- keep SDK/browser resources alive for follow-up/reuse when keep_alive is true
- close the SDK client after run cleanup without turning a successful run into a cleanup exception

## Why
The beta Python API passes browser config into the Rust SDK, but the Rust SDK owns the browser it opens. Calling browser.close() on the Python BrowserSession only closes the Python-side wrapper, so examples like examples/beta_agent/basic.py could leave the Rust-opened browser alive after Agent.run().

## Tests
- uv run ruff check browser_use/beta/service.py tests/ci/test_beta_agent.py
- uv run pytest -q tests/ci/test_beta_agent.py -k "runs_through_sdk_and_reuses_session_for_followup or close_kills_non_keep_alive or finalize_run_cleanup_closes_sdk_resources"
- uv run pytest -q tests/ci/test_beta_agent.py
- uv run pre-commit run --files browser_use/beta/service.py tests/ci/test_beta_agent.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Properly close Rust SDK agent and browser resources when `keep_alive` is false, and safely shut down the SDK client during run cleanup. Preserve resources and IDs for follow-ups when `keep_alive` is true.

- **Bug Fixes**
  - Non-keep-alive: call `agent.close` and `browser.close` via the SDK, clear agent/browser/terminal IDs, then close the SDK client from both `close()` and `_finalize_run_cleanup()` (errors are logged, not raised).
  - Keep-alive: keep the SDK client and IDs intact; skip SDK teardown when `keep_alive` is true or `RustSdkClient.process` is `None`.
  - Centralized logic in `_should_keep_browser_alive`, `_close_sdk_browser_resources`, and `_close_sdk_client_if_not_keep_alive` to prevent orphaned processes and cleanup from impacting successful runs.

<sup>Written for commit 0cfe7bf7c5df4addeb1b4916d7845087859c0f2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

