### PR TITLE
Prepare browser-use 0.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.13.0rc4"
+version = "0.13.0"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [
@@ -60,11 +60,11 @@ dependencies = [
 [project.optional-dependencies]
 cli = ["textual==7.4.0"]
 core = [
-    "browser-use-core==0.13.0rc4; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "browser-use-core==0.13.0rc4; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.0rc4; sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.0rc4; sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "browser-use-core==0.13.0rc4; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
+    "browser-use-core==0.13.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "browser-use-core==0.13.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.0; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "browser-use-core==0.13.0; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
 ]
 aws = ["boto3==1.42.37"]
 oci = ["oci==2.166.0"]


### PR DESCRIPTION
## Summary
- bump browser-use package version from 0.13.0rc4 to 0.13.0
- point the `[core]` extra at browser-use-core==0.13.0 for all supported wheel platforms

## Release notes
This branch is intentionally based on the beta SDK browser cleanup fix from #5004. Merge #5004 first; after that this PR should reduce to the stable version/dependency bump.

Before merging this PR, browser-use-core==0.13.0 should be published from browser-use/terminal#95 so `uv sync --all-extras` can resolve.

Stable browser-use publishing should be done by creating/publishing GitHub release tag `0.13.0`, not by workflow_dispatch create_tag, because workflow_dispatch would bump rc tags.

## Checks run
- uv run --no-project python - <<PY metadata assertion for pyproject version/core deps
- uv run --no-project --with pre-commit pre-commit run --files pyproject.toml

## Not run yet
- uv sync / full project tests with `[core]`, because browser-use-core==0.13.0 is not on PyPI until terminal#95 is merged and tagged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `browser-use` to 0.13.0 and updates the `[core]` extra to use `browser-use-core==0.13.0` across supported platforms.

- **Dependencies**
  - Bump `browser-use` to `0.13.0`.
  - Set `[core]` extra to `browser-use-core==0.13.0` for macOS (arm64/x86_64), Linux (x86_64/aarch64), and Windows (AMD64/x86_64).

<sup>Written for commit 8512a89637bdde1718864260af840f829c1600cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

