### PR TITLE
feat(llm): accept provider-prefixed models in ChatBrowserUse

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,21 @@ For other LLM providers, see our [supported models documentation](https://docs.b
 </details>
 
 <details>
+<summary><b>Can I use Claude / GPT / Gemini through ChatBrowserUse?</b></summary>
+
+Yes. `ChatBrowserUse` accepts provider-prefixed model ids, so a single `BROWSER_USE_API_KEY` reaches all of them — no separate OpenAI/Anthropic/Google keys required:
+
+```python
+from browser_use import Agent, ChatBrowserUse
+
+llm = ChatBrowserUse(model='anthropic/claude-sonnet-4-6')  # or 'openai/gpt-5.5', 'google/gemini-3-pro'
+agent = Agent(task='...', llm=llm)
+```
+
+For the best speed and cost we still recommend the default `bu-*` models.
+</details>
+
+<details>
 <summary><b>Should I use the Browser Use system prompt with the open-source preview model?</b></summary>
 
 Yes. If you use `ChatBrowserUse(model='browser-use/bu-30b-a3b-preview')` with a normal `Agent(...)`, Browser Use still sends its default agent system prompt for you.

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -241,10 +241,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if flash_mode:
 			enable_planning = False
 
-		# Auto-configure llm_screenshot_size for Claude Sonnet models
+		# Auto-configure llm_screenshot_size for Claude Sonnet, including gateway ids like
+		# 'anthropic/claude-sonnet-4-6' (rsplit drops the provider prefix before matching).
 		if llm_screenshot_size is None:
 			model_name = getattr(llm, 'model', '')
-			if isinstance(model_name, str) and model_name.startswith('claude-sonnet'):
+			if isinstance(model_name, str) and model_name.rsplit('/', 1)[-1].startswith('claude-sonnet'):
 				llm_screenshot_size = (1400, 850)
 				logger.info('🖼️  Auto-configured LLM screenshot size for Claude Sonnet: 1400x850')
 

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -4310,7 +4310,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			enable_planning = False
 		if llm_screenshot_size is None:
 			model_name = getattr(llm, 'model', '')
-			if isinstance(model_name, str) and model_name.startswith('claude-sonnet'):
+			# rsplit drops the provider prefix so gateway ids like 'anthropic/claude-sonnet-4-6'
+			# get the same screenshot auto-config as direct Claude Sonnet models.
+			if isinstance(model_name, str) and model_name.rsplit('/', 1)[-1].startswith('claude-sonnet'):
 				llm_screenshot_size = (1400, 850)
 		if page_extraction_llm is None:
 			page_extraction_llm = llm

--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -63,6 +63,8 @@ class ChatBrowserUse(BaseChatModel):
 				- 'bu-3-max': Most capable model
 				- 'bu-1-0': Previous generation model
 				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
+				- Provider-prefixed ids resolved by the gateway, e.g. 'anthropic/claude-sonnet-4-6',
+				  'openai/gpt-5.5', 'google/gemini-3-pro'.
 			api_key: API key for browser-use cloud. Defaults to BROWSER_USE_API_KEY env var.
 			base_url: Base URL for the API. Defaults to BROWSER_USE_LLM_URL env var or production URL.
 			timeout: Request timeout in seconds.
@@ -70,11 +72,16 @@ class ChatBrowserUse(BaseChatModel):
 			retry_base_delay: Base delay in seconds for exponential backoff (default: 1.0).
 			retry_max_delay: Maximum delay in seconds between retries (default: 60.0).
 		"""
-		# Validate model name - allow bu-* and browser-use/* patterns
-		valid_models = ['bu-latest', 'bu-1-0', 'bu-2-0', 'bu-3', 'bu-3-max']
-		is_valid = model in valid_models or model.startswith('browser-use/')
+		# Accept 'bu-*' aliases and any provider-prefixed id; the gateway resolves the
+		# latter (anthropic/*, openai/*, google/*, browser-use/*), so we don't enumerate them.
+		bu_aliases = ['bu-latest', 'bu-1-0', 'bu-2-0', 'bu-3', 'bu-3-max']
+		is_valid = model in bu_aliases or '/' in model
 		if not is_valid:
-			raise ValueError(f"Invalid model: '{model}'. Must be one of {valid_models} or start with 'browser-use/'")
+			raise ValueError(
+				f"Invalid model: '{model}'. Use a 'bu-*' alias ({', '.join(bu_aliases)}) "
+				"or a provider-prefixed id like 'anthropic/claude-sonnet-4-6', "
+				"'openai/gpt-5.5', or 'google/gemini-3-pro'."
+			)
 
 		# Normalize bu-latest to the current latest model
 		if model == 'bu-latest':

--- a/examples/models/browser_use_llm.py
+++ b/examples/models/browser_use_llm.py
@@ -20,6 +20,9 @@ if not os.getenv('BROWSER_USE_API_KEY'):
 
 
 async def main():
+	# `bu-2-0` is the optimized default. ChatBrowserUse can also route to
+	# provider-prefixed models (e.g. 'anthropic/claude-sonnet-4-6', 'openai/gpt-5.5',
+	# 'google/gemini-3-pro') through the same gateway - see browser_use_provider_models.py.
 	agent = Agent(
 		task='Find the number of stars of the browser-use repo',
 		llm=ChatBrowserUse(model='bu-2-0'),

--- a/examples/models/browser_use_provider_models.py
+++ b/examples/models/browser_use_provider_models.py
@@ -1,0 +1,46 @@
+"""
+Point ChatBrowserUse at provider-prefixed models via the Browser Use gateway.
+
+`ChatBrowserUse` isn't limited to the `bu-*` models - it also accepts
+provider-prefixed ids:
+
+    - 'anthropic/claude-sonnet-4-6'
+    - 'openai/gpt-5.5'
+    - 'google/gemini-3-pro'
+
+A single `BROWSER_USE_API_KEY` reaches Claude, GPT, and Gemini without
+juggling separate OpenAI / Anthropic / Google keys. For the best speed and
+cost, the default `bu-*` models are still recommended.
+
+Setup:
+1. Get your API key from https://cloud.browser-use.com/new-api-key
+2. Set environment variable: export BROWSER_USE_API_KEY="your-key"
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from browser_use import Agent, ChatBrowserUse
+
+load_dotenv()
+
+if not os.getenv('BROWSER_USE_API_KEY'):
+	raise ValueError('BROWSER_USE_API_KEY is not set')
+
+# Swap this for any provider-prefixed id the gateway supports, e.g.
+#   'openai/gpt-5.5' or 'google/gemini-3-pro'
+MODEL = 'anthropic/claude-sonnet-4-6'
+
+
+async def main():
+	agent = Agent(
+		task='Find the number of stars of the browser-use repo',
+		llm=ChatBrowserUse(model=MODEL),
+	)
+	await agent.run()
+
+
+if __name__ == '__main__':
+	asyncio.run(main())

--- a/tests/ci/models/test_llm_browseruse.py
+++ b/tests/ci/models/test_llm_browseruse.py
@@ -1,7 +1,14 @@
-"""Test Browser Use model button click."""
+"""Tests for the ChatBrowserUse cloud client."""
+
+import pytest
 
 from browser_use.llm.browser_use.chat import ChatBrowserUse
+from browser_use.llm.messages import UserMessage
 from tests.ci.models.model_test_helper import run_model_button_click_test
+
+# A syntactically-valid key so the constructor doesn't bail before we reach the
+# code under test. These unit tests never hit the network.
+TEST_API_KEY = 'test-key-not-real'
 
 
 async def test_browseruse_bu_latest(httpserver):
@@ -13,3 +20,99 @@ async def test_browseruse_bu_latest(httpserver):
 		extra_kwargs={},
 		httpserver=httpserver,
 	)
+
+
+# --- Model validation -------------------------------------------------------
+
+
+def test_default_model_is_bu_2_0():
+	chat = ChatBrowserUse(api_key=TEST_API_KEY)
+	assert chat.model == 'bu-2-0'
+	assert chat.provider == 'browser-use'
+
+
+@pytest.mark.parametrize('alias', ['bu-1-0', 'bu-2-0', 'bu-3', 'bu-3-max'])
+def test_bu_aliases_are_accepted(alias):
+	chat = ChatBrowserUse(model=alias, api_key=TEST_API_KEY)
+	assert chat.model == alias
+	assert chat.name == alias
+	assert chat.provider == 'browser-use'
+
+
+def test_bu_latest_normalizes_to_bu_2_0():
+	chat = ChatBrowserUse(model='bu-latest', api_key=TEST_API_KEY)
+	assert chat.model == 'bu-2-0'
+	assert chat.name == 'bu-2-0'
+
+
+@pytest.mark.parametrize(
+	'model',
+	[
+		'anthropic/claude-sonnet-4-6',
+		'openai/gpt-5.5',
+		'google/gemini-3-pro',
+		'browser-use/bu-30b-a3b-preview',
+	],
+)
+def test_provider_prefixed_models_are_accepted(model):
+	"""Provider-prefixed ids are accepted and forwarded verbatim (the gateway resolves them)."""
+	chat = ChatBrowserUse(model=model, api_key=TEST_API_KEY)
+	assert chat.model == model
+	assert chat.name == model
+	# Always routes through the browser-use gateway, whatever the target model.
+	assert chat.provider == 'browser-use'
+
+
+@pytest.mark.parametrize('model', ['gpt-5', 'claude-sonnet-4-6', 'bu-9-9', 'random-model'])
+def test_bare_model_ids_are_rejected(model):
+	"""Bare ids (no bu-* alias, no provider/ prefix) are rejected."""
+	with pytest.raises(ValueError, match='Invalid model'):
+		ChatBrowserUse(model=model, api_key=TEST_API_KEY)
+
+
+async def test_provider_prefixed_model_forwarded_in_payload(httpserver):
+	"""The provider-prefixed id must be sent verbatim in the request body."""
+	httpserver.expect_request('/v1/chat/completions', method='POST').respond_with_json({'completion': 'hello from gateway'})
+
+	chat = ChatBrowserUse(
+		model='anthropic/claude-sonnet-4-6',
+		api_key=TEST_API_KEY,
+		base_url=httpserver.url_for('/').rstrip('/'),
+	)
+	result = await chat.ainvoke([UserMessage(content='hi')])
+
+	assert result.completion == 'hello from gateway'
+
+	# Check the posted body.
+	request, _ = httpserver.log[-1]
+	body = request.get_json()
+	assert body['model'] == 'anthropic/claude-sonnet-4-6'
+	assert body['request_type'] == 'browser_agent'
+
+
+# --- Agent screenshot auto-config -------------------------------------------
+
+
+# Both the classic and beta agents auto-config the Claude screenshot size, so both
+# must strip the provider prefix for gateway ids.
+@pytest.mark.parametrize('agent_path', ['classic', 'beta'])
+@pytest.mark.parametrize(
+	'model,expected_size',
+	[
+		# Claude Sonnet via the gateway keeps the auto-config; the prefix must not break detection.
+		('anthropic/claude-sonnet-4-6', (1400, 850)),
+		# Non-Claude models keep the default.
+		('bu-2-0', None),
+		('openai/gpt-5.5', None),
+	],
+)
+def test_claude_sonnet_screenshot_autoconfig_through_gateway(agent_path, model, expected_size):
+	if agent_path == 'classic':
+		from browser_use.agent.service import Agent
+	else:
+		from browser_use.beta import Agent
+
+	llm = ChatBrowserUse(model=model, api_key=TEST_API_KEY)
+	agent = Agent(task='test', llm=llm)
+	assert agent.browser_session is not None
+	assert agent.browser_session.llm_screenshot_size == expected_size


### PR DESCRIPTION
## What

`ChatBrowserUse` now accepts **provider-prefixed model ids** — `anthropic/*`, `openai/*`, `google/*` — alongside the existing `bu-*` aliases and `browser-use/*` models. A single `BROWSER_USE_API_KEY` can reach them:

```python
from browser_use import Agent, ChatBrowserUse

llm = ChatBrowserUse(model='anthropic/claude-sonnet-4-6')  # or 'openai/gpt-5.5', 'google/gemini-3-pro'
agent = Agent(task='...', llm=llm)
```

Closes ENG-5060.

## Changes

- `browser_use/llm/browser_use/chat.py` — model validation accepts a `bu-*` alias or any provider-prefixed id (`provider/model`); bare ids like `gpt-5` are still rejected with guidance toward the `provider/model` form. `bu-*` aliases and the `bu-latest` → `bu-2-0` normalization are unchanged.
- `browser_use/agent/service.py` — the Claude Sonnet `llm_screenshot_size` auto-config now also matches provider-prefixed Claude ids (e.g. `anthropic/claude-sonnet-4-6`), so it isn't lost when Claude is reached via `ChatBrowserUse`.
- Example, README FAQ entry, and tests.

## Test plan

- `uv run pytest tests/ci/models/test_llm_browseruse.py` — passing (1 skipped without an API key).
- `uv run pyright` — clean.
- pre-commit — passing.