### PR TITLE
Fix packaged agent tools env

### DIFF
--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -88,6 +88,7 @@ AgentNewStepCallback = (
 AgentDoneCallback = Callable[[AgentHistoryList], Awaitable[None]] | Callable[[AgentHistoryList], None]
 logger = logging.getLogger(__name__)
 TERMINAL_INSTALL_COMMAND = 'curl -fsSL https://browser-use.com/terminal/install.sh | sh'
+AGENT_TOOLS_DIR_ENV = 'BUT_AGENT_TOOLS_DIR'
 
 try:
 	from lmnr import Laminar  # type: ignore
@@ -217,6 +218,82 @@ def _find_packaged_browser_use_terminal_binary() -> str | None:
 		return binary_path('browser-use-terminal')
 	except Exception:
 		return None
+
+
+def _apply_agent_tools_env(env: dict[str, str]) -> None:
+	agent_tools_dir = _find_agent_tools_dir(env.get(AGENT_TOOLS_DIR_ENV))
+	if agent_tools_dir is None:
+		return
+	env[AGENT_TOOLS_DIR_ENV] = str(agent_tools_dir)
+	_prepend_env_path(env, agent_tools_dir)
+
+
+def _find_agent_tools_dir(preferred_dir: str | None = None) -> Path | None:
+	if preferred_dir:
+		preferred_path = Path(preferred_dir).expanduser()
+		return preferred_path if _agent_tools_dir_contains_ripgrep(preferred_path) else None
+
+	env_binary = os.environ.get('BROWSER_USE_TERMINAL_BINARY')
+	if env_binary:
+		agent_tools_dir = _agent_tools_dir_for_terminal_binary(env_binary)
+		if agent_tools_dir:
+			return agent_tools_dir
+
+	packaged_dir = _find_packaged_agent_tools_dir()
+	if packaged_dir:
+		return packaged_dir
+
+	try:
+		terminal_binary = find_browser_use_terminal_binary()
+	except BetaAgentError:
+		return None
+	return _agent_tools_dir_for_terminal_binary(terminal_binary)
+
+
+def _find_packaged_agent_tools_dir() -> Path | None:
+	try:
+		from browser_use_core import agent_tools_dir
+	except Exception:
+		agent_tools_dir = None
+
+	if agent_tools_dir is not None:
+		try:
+			candidate = Path(agent_tools_dir())
+		except Exception:
+			candidate = None
+		if candidate and _agent_tools_dir_contains_ripgrep(candidate):
+			return candidate
+
+	try:
+		from browser_use_core import binary_path
+	except Exception:
+		return None
+
+	try:
+		binary = Path(binary_path('browser-use-terminal'))
+	except Exception:
+		return None
+	candidate = binary.parent / 'agent-tools'
+	return candidate if _agent_tools_dir_contains_ripgrep(candidate) else None
+
+
+def _agent_tools_dir_for_terminal_binary(binary_path: str | Path) -> Path | None:
+	candidate = Path(binary_path).expanduser().parent / 'agent-tools'
+	return candidate if _agent_tools_dir_contains_ripgrep(candidate) else None
+
+
+def _agent_tools_dir_contains_ripgrep(directory: Path) -> bool:
+	return (directory / _agent_tools_ripgrep_name()).exists()
+
+
+def _agent_tools_ripgrep_name() -> str:
+	return 'rg.exe' if os.name == 'nt' else 'rg'
+
+
+def _prepend_env_path(env: dict[str, str], directory: Path) -> None:
+	directory_str = str(directory)
+	path_parts = [part for part in env.get('PATH', '').split(os.pathsep) if part and part != directory_str]
+	env['PATH'] = os.pathsep.join([directory_str, *path_parts])
 
 
 def _terminal_supports_sdk_server(binary: Path) -> bool:
@@ -6635,6 +6712,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		browser_mode = self._browser_mode()
 		env['LLM_BROWSER_BROWSER_MODE'] = browser_mode
 		env.setdefault('BROWSER_USE_PYTHON', sys.executable)
+		_apply_agent_tools_env(env)
 		cdp_url = _extract_cdp_url(self.browser_session) or _extract_profile_cdp_url(self.browser_profile)
 		if cdp_url:
 			env['BU_CDP_URL'] = cdp_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.13.0"
+version = "0.13.1"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [
@@ -60,11 +60,11 @@ dependencies = [
 [project.optional-dependencies]
 cli = ["textual==7.4.0"]
 core = [
-    "browser-use-core==0.13.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "browser-use-core==0.13.0; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.0; sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "browser-use-core==0.13.0; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
+    "browser-use-core==0.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "browser-use-core==0.13.1; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.1; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.1; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "browser-use-core==0.13.1; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
 ]
 aws = ["boto3==1.42.37"]
 oci = ["oci==2.166.0"]

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -2676,6 +2677,62 @@ def test_rust_terminal_binary_prefers_packaged_binary(monkeypatch):
 	monkeypatch.setattr(beta_service.shutil, 'which', lambda binary_name: None)
 
 	assert beta_service.find_browser_use_terminal_binary() == '/tmp/packaged-browser-use-terminal'
+
+
+def test_beta_agent_run_env_sets_packaged_agent_tools_dir(monkeypatch, tmp_path):
+	from browser_use.beta import Agent
+
+	class LLM:
+		model = 'gpt-test'
+
+	package_dir = tmp_path / 'browser_use_core'
+	terminal = package_dir / 'bin' / 'browser-use-terminal'
+	agent_tools = package_dir / 'bin' / 'agent-tools'
+	terminal.parent.mkdir(parents=True)
+	agent_tools.mkdir(parents=True)
+	terminal.write_text('#!/bin/sh\n')
+	(agent_tools / 'rg').write_text('#!/bin/sh\n')
+
+	class PackagedCore:
+		@staticmethod
+		def agent_tools_dir():
+			return str(agent_tools)
+
+		@staticmethod
+		def binary_path(binary_name):
+			assert binary_name == 'browser-use-terminal'
+			return str(terminal)
+
+	monkeypatch.delenv('BROWSER_USE_TERMINAL_BINARY', raising=False)
+	monkeypatch.delenv('BUT_AGENT_TOOLS_DIR', raising=False)
+	monkeypatch.setenv('PATH', '/usr/bin')
+	monkeypatch.setitem(sys.modules, 'browser_use_core', PackagedCore)
+
+	agent = Agent(task='report title', llm=LLM())
+	env = agent._run_env()
+
+	assert env['BUT_AGENT_TOOLS_DIR'] == str(agent_tools)
+	assert env['PATH'].split(os.pathsep)[0] == str(agent_tools)
+
+
+def test_beta_agent_run_env_preserves_explicit_agent_tools_dir(monkeypatch, tmp_path):
+	from browser_use.beta import Agent
+
+	class LLM:
+		model = 'gpt-test'
+
+	agent_tools = tmp_path / 'agent-tools'
+	agent_tools.mkdir()
+	(agent_tools / 'rg').write_text('#!/bin/sh\n')
+
+	monkeypatch.setenv('BUT_AGENT_TOOLS_DIR', str(agent_tools))
+	monkeypatch.setenv('PATH', '/usr/bin')
+
+	agent = Agent(task='report title', llm=LLM())
+	env = agent._run_env()
+
+	assert env['BUT_AGENT_TOOLS_DIR'] == str(agent_tools)
+	assert env['PATH'].split(os.pathsep)[0] == str(agent_tools)
 
 
 def test_rust_terminal_binary_finds_default_terminal_install(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- bump browser-use to 0.13.1
- pin the core extra to browser-use-core==0.13.1
- set BUT_AGENT_TOOLS_DIR and prepend PATH for the Rust beta Agent when packaged agent-tools/rg is available

## Dependency
- Depends on publishing browser-use-core 0.13.1 from https://github.com/browser-use/terminal/pull/100 before this package can resolve normally.

## Tests
- PYTHONPATH=/tmp/browser-use-rg-pr.2WM9Uq uv run --project /Users/greg/Documents/browser-use/core/library/browser-use pytest /tmp/browser-use-rg-pr.2WM9Uq/tests/ci/test_beta_agent.py -q
- uv run --project /Users/greg/Documents/browser-use/core/library/browser-use ruff check /tmp/browser-use-rg-pr.2WM9Uq/browser_use/beta/service.py /tmp/browser-use-rg-pr.2WM9Uq/tests/ci/test_beta_agent.py

Note: direct uv run from this branch cannot resolve until browser-use-core==0.13.1 is published to the package index.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the Rust beta Agent finds bundled CLI tools when `agent-tools/rg` is packaged. We set BUT_AGENT_TOOLS_DIR, prepend PATH, and bump `browser-use` and `browser-use-core` to 0.13.1.

- **Bug Fixes**
  - Detect packaged agent-tools via `browser_use_core.agent_tools_dir()` or next to the packaged terminal; verify `rg`/`rg.exe`, then set BUT_AGENT_TOOLS_DIR and prepend PATH. Preserves an explicit BUT_AGENT_TOOLS_DIR if set.
  - Added tests to cover packaged detection and env override behavior.

- **Dependencies**
  - Pin `browser-use-core==0.13.1` for all platforms; version set to `0.13.1`.
  - Requires `browser-use-core` 0.13.1 to be published before installation resolves.

<sup>Written for commit 8c9ed8281e3084a3c53a83e7ab5df5e7ed860a71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

