### PR TITLE
fix(groq): read structured output from tool calls for tool-calling models

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -170,23 +170,42 @@ class ChatGroq(BaseChatModel):
 
 		if self.model in ToolCallingModels:
 			response = await self._invoke_with_tool_calling(groq_messages, output_format, schema)
+			# Tool-calling models return ``message.content = None`` and place the
+			# structured JSON in ``tool_calls[0].function.arguments`` instead.
+			raw_content = self._extract_tool_call_arguments(response)
 		else:
 			response = await self._invoke_with_json_schema(groq_messages, output_format, schema)
+			raw_content = response.choices[0].message.content
 
-		if not response.choices[0].message.content:
+		if not raw_content:
 			raise ModelProviderError(
 				message='No content in response',
 				status_code=500,
 				model=self.name,
 			)
 
-		parsed_response = output_format.model_validate_json(response.choices[0].message.content)
+		parsed_response = output_format.model_validate_json(raw_content)
 		usage = self._get_usage(response)
 
 		return ChatInvokeCompletion(
 			completion=parsed_response,
 			usage=usage,
 		)
+
+	@staticmethod
+	def _extract_tool_call_arguments(response: ChatCompletion) -> str | None:
+		"""Return the structured JSON payload from the first tool call, if any.
+
+		Tool-calling models (see ``ToolCallingModels``) leave ``message.content``
+		empty and return the structured output as the arguments of the first tool
+		call. Fall back to ``message.content`` for models that ignore the forced
+		tool call and answer inline.
+		"""
+		message = response.choices[0].message
+		tool_calls = message.tool_calls
+		if tool_calls:
+			return tool_calls[0].function.arguments
+		return message.content
 
 	async def _invoke_with_tool_calling(self, groq_messages, output_format: type[T], schema) -> ChatCompletion:
 		"""Handle structured output using tool calling."""

--- a/tests/ci/models/test_llm_groq.py
+++ b/tests/ci/models/test_llm_groq.py
@@ -1,0 +1,61 @@
+"""Regression tests for Groq structured-output extraction.
+
+See https://github.com/browser-use/browser-use/issues/4945: models in
+``ToolCallingModels`` return ``message.content = None`` and place the structured
+JSON in ``tool_calls[0].function.arguments``. ``_invoke_structured_output`` must
+read from the tool call on that path instead of unconditionally requiring
+``message.content`` (which previously always raised ``ModelProviderError``).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.groq.chat import ChatGroq, ToolCallingModels
+
+
+class _Output(BaseModel):
+	value: str
+
+
+def _tool_call_response(arguments: str) -> MagicMock:
+	"""Build a ChatCompletion-like mock for a tool-calling reply (content=None)."""
+	tool_call = MagicMock()
+	tool_call.function.arguments = arguments
+
+	message = MagicMock()
+	message.content = None
+	message.tool_calls = [tool_call]
+
+	choice = MagicMock()
+	choice.message = message
+
+	response = MagicMock()
+	response.choices = [choice]
+	response.usage = None
+	return response
+
+
+def test_extract_tool_call_arguments_prefers_tool_calls():
+	response = _tool_call_response('{"value": "from-tool-call"}')
+	assert ChatGroq._extract_tool_call_arguments(response) == '{"value": "from-tool-call"}'
+
+
+def test_extract_tool_call_arguments_falls_back_to_content():
+	response = _tool_call_response('{"value": "x"}')
+	response.choices[0].message.tool_calls = []
+	response.choices[0].message.content = '{"value": "from-content"}'
+	assert ChatGroq._extract_tool_call_arguments(response) == '{"value": "from-content"}'
+
+
+@pytest.mark.asyncio
+async def test_structured_output_reads_tool_calls_for_tool_calling_models():
+	"""Tool-calling models must not raise 'No content in response' (issue #4945)."""
+	chat = ChatGroq(model=ToolCallingModels[0], api_key='test-key')
+	chat._invoke_with_tool_calling = AsyncMock(return_value=_tool_call_response('{"value": "ok"}'))
+
+	result = await chat._invoke_structured_output([], _Output)
+
+	assert result.completion == _Output(value='ok')
+	chat._invoke_with_tool_calling.assert_awaited_once()


### PR DESCRIPTION
## Problem

Closes #4945.

Models listed in `ToolCallingModels` (currently `moonshotai/kimi-k2-instruct`) return `message.content = None` and put the structured JSON in `tool_calls[0].function.arguments`. But `_invoke_structured_output` always checked `message.content`, so it raised `ModelProviderError('No content in response')` on every structured call routed through the tool-calling path:

```
File "browser_use/llm/groq/chat.py", line 177, in _invoke_structured_output
    raise ModelProviderError(message='No content in response', ...)
browser_use.llm.exceptions.ModelProviderError: No content in response
```

## Fix

- On the tool-calling path, read the payload from the first tool call via a small `_extract_tool_call_arguments` helper (falling back to `message.content` if the model ignores the forced tool call and answers inline).
- The JSON-schema path is unchanged — it still reads `message.content`.

## Tests

Added `tests/ci/models/test_llm_groq.py` with mock-based regression tests (no API key needed):
- `_extract_tool_call_arguments` prefers tool-call args and falls back to content
- `_invoke_structured_output` no longer raises for a tool-calling model when `content` is `None`

```
3 passed in 0.13s
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes structured output for Groq tool-calling models like `moonshotai/kimi-k2-instruct` by reading JSON from the first tool call instead of `message.content`, preventing "No content in response" errors. Adds a small helper to extract arguments and regression tests for tool-call and fallback-to-content paths.

<sup>Written for commit b3e8709b14170eed632adc9245ad56bd9381f995. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

