### PR TITLE
Add Obscura local CDP browser example

### DIFF
--- a/examples/browser/using_obscura.py
+++ b/examples/browser/using_obscura.py
@@ -1,0 +1,51 @@
+"""
+Use Obscura as a layout-free CDP backend for browser-use.
+
+Obscura (https://github.com/h4ckf0r0day/obscura) is a lightweight headless
+browser written in Rust. It runs real JavaScript via V8 and speaks the Chrome
+DevTools Protocol, but it has no layout or paint engine, which keeps it fast and
+light for text and DOM driven automation. It cannot take screenshots, so run the
+agent with use_vision=False.
+
+To run this example:
+1. Build obscura (see its README) and start its CDP server:
+   obscura serve --port 9222
+2. Verify it is up by opening http://localhost:9222/json/version
+3. Set the OPENAI_API_KEY environment variable.
+4. Launch this example.
+"""
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from browser_use import Agent
+from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.llm import ChatOpenAI
+
+# Obscura serves the CDP endpoint and /json/version just like headless Chrome.
+browser_session = BrowserSession(browser_profile=BrowserProfile(cdp_url='http://localhost:9222', is_local=True))
+
+
+async def main():
+	agent = Agent(
+		task='Go to https://news.ycombinator.com and report the titles of the top 5 stories',
+		llm=ChatOpenAI(model='gpt-4.1-mini'),
+		browser_session=browser_session,
+		# Obscura has no paint engine and cannot take screenshots, so drive the
+		# agent over the DOM only.
+		use_vision=False,
+	)
+
+	await agent.run()
+	await browser_session.kill()
+
+
+if __name__ == '__main__':
+	asyncio.run(main())


### PR DESCRIPTION
Adds `examples/browser/using_obscura.py`, next to the existing `using_cdp.py`, so browser-use can run on Obscura: a Rust headless browser that speaks the Chrome DevTools Protocol with no Chrome or Node dependency (single ~70 MB binary). Handy when you want fast DOM-driven automation without a full Chromium install.

Like `using_cdp.py`, the example starts from a running CDP server: launch `obscura serve`, point a `BrowserSession` at its endpoint, and run the agent. Obscura has no paint engine and cannot take screenshots, so the example sets `use_vision=False` and drives the agent over the DOM.

Obscura has no paint engine, so there is no browser screenshot to show. Verified the integration against a live obscura instead, with browser-use connecting over CDP, navigating, and reading the page back:

``` connected to obscura CDP, session started url: https://news.ycombinator.com/ title: Hacker News interactive elements perceived: 485 story-like link texts found: 29 (showing first 5)

• macOS Container Machines
• Mercedes-Benz starts large-scale production of electric axial flux motor
• Port React Compiler to Rust
• Upcoming breaking changes for npm v12
• How do you design a $30k electric pickup? Inside Ford's skunkworks ```

`ruff check` and `ruff format` pass, and the change is a single example file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new example that connects `browser-use` to Obscura via CDP for fast, DOM-only automation without Chrome or Node. It mirrors `using_cdp.py`, sets `use_vision=False`, and loads API keys via `dotenv`.

- **New Features**
  - Added `examples/browser/using_obscura.py` to run against Obscura’s CDP (`obscura serve --port 9222`) by pointing `BrowserSession` to `http://localhost:9222`.
  - Example task reads the top 5 Hacker News titles; expects `OPENAI_API_KEY` in the environment (loaded with `dotenv`).

<sup>Written for commit e88892a165dc1ddb8502cda370bdc7002e902b21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

