### PR TITLE
[ENG-4762] publish: gate publish_to_pypi behind release env

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -76,10 +76,37 @@ jobs:
   publish_to_pypi:
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write    # for the stable-branch push at the end
+      id-token: write    # for PyPI trusted-publishing OIDC
+      actions: read      # for the env protection verification step
     env:
       IN_DOCKER: 'True'
       ANONYMIZED_TELEMETRY: 'false'
     steps:
+      - name: Verify release environment is protected (fail-closed)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          ENV_NAME="release"
+          if ! RESP="$(gh api -H 'Accept: application/vnd.github+json' \
+              "/repos/${GITHUB_REPOSITORY}/environments/${ENV_NAME}" 2>/dev/null)"; then
+            echo "::error::Environment '${ENV_NAME}' does not exist (or is inaccessible). Create it at https://github.com/${GITHUB_REPOSITORY}/settings/environments/new with required reviewers and prevent_self_review enabled, then re-run."
+            exit 1
+          fi
+          HAS_REVIEWERS="$(echo "$RESP" | jq -r '[.protection_rules[]? | select(.type == "required_reviewers")] | length')"
+          if [ "${HAS_REVIEWERS:-0}" -lt 1 ]; then
+            echo "::error::Environment '${ENV_NAME}' exists but has no required-reviewers protection rule."
+            exit 1
+          fi
+          SELF_REVIEW_BLOCKED="$(echo "$RESP" | jq -r '[.protection_rules[]? | select(.type=="required_reviewers") | .prevent_self_review] | any')"
+          if [ "$SELF_REVIEW_BLOCKED" != "true" ]; then
+            echo "::error::Environment '${ENV_NAME}' must have prevent_self_review enabled. Without it, the gate collapses to one identity when the dispatcher is also a reviewer."
+            exit 1
+          fi
+          echo "::notice::Environment '${ENV_NAME}' is protected with prevent_self_review. OK."
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
         with:


### PR DESCRIPTION
## What this adds

A two-person approval gate on the PyPI publish job. Minimal change, preserves the existing release flow.

### Before
- Maintainer creates a GitHub Release → `publish_to_pypi` runs unattended → published to PyPI.
- Anyone with workflow-dispatch access (or a leaked token with workflow scope) could trigger publish single-handedly.

### After
- Maintainer creates a GitHub Release → `publish_to_pypi` starts → **pauses for approval** from a reviewer who is NOT the run actor (gregpr07/MagMueller/sauravpanda, prevent_self_review:true).
- Approver clicks approve → publish runs unchanged.

## What's added

1. `environment: release` on the `publish_to_pypi` job.
2. Fail-closed preflight step that verifies the env still has required reviewers and `prevent_self_review: true`. Same check the sdk pipeline uses — guards against silent env config drift.
3. `actions: read` permission on the publish job for the env check API call.

## What's NOT changed

- `tag_pre_release` job (RC bump flow) — unchanged.
- Triggers (`release: published` + `workflow_dispatch`) — unchanged.
- `uv publish --trusted-publishing always` — unchanged.
- `Push to stable branch` step — unchanged.

## Setup already live on the repo

- `release` environment created with 3 reviewers + prevent_self_review:true
- `Protect main` ruleset tightened: squash-only + workflow-guardians required_reviewers on `.github/workflows/**`
- Stale `PYPI_API_TOKEN` secret deleted (trusted-publishing supersedes)

## PyPI side note

The existing PyPI trusted publisher entry for `browser-use` does NOT have an Environment configured. After this PR merges and before the next release, the entry needs `Environment: release` added at https://pypi.org/manage/project/browser-use/settings/publishing/ — otherwise the OIDC token won't carry the env claim PyPI expects.

## Followups (NOT in this PR)

- `docker.yml` ships an image to Docker Hub on the same `release: published` event using static `DOCKER_USERNAME`/`DOCKER_PASSWORD`. That's a parallel publish vector that this PR does NOT close. Should be gated too in a separate PR.
- `TRIGGER_CLOUD_BUILD_GH_KEY` is a static cross-repo PAT that should migrate to fine-grained ≤30d (already on the followup list).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a two-person approval gate to the `publish_to_pypi` workflow by gating it behind the protected `release` environment. Implements ENG-4762 without changing triggers or the publish command.

- **New Features**
  - Gate `publish_to_pypi` with `environment: release` to require approval from a reviewer other than the actor (`prevent_self_review`).
  - Add a fail-closed preflight that verifies required reviewers and `prevent_self_review: true` on the environment.
  - Grant `actions: read` to the job for the env check.

- **Migration**
  - In PyPI trusted publisher for `browser-use`, set Environment to `release` before the next release to ensure the OIDC token includes the env claim.

<sup>Written for commit 1186d4cc44f8b7d4a7e88a6636c9d807ce6a1550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

