### PR TITLE
fix: skip extension page targets

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -155,7 +155,7 @@ class SessionManager:
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
+			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
 				page_targets.append(target)
 		return page_targets
 

--- a/browser_use/skill_cli/__init__.py
+++ b/browser_use/skill_cli/__init__.py
@@ -11,6 +11,11 @@ Usage:
     browser-use close
 """
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from browser_use.skill_cli.main import main
+
 __all__ = ['main']
 
 

--- a/tests/ci/browser/test_session_manager.py
+++ b/tests/ci/browser/test_session_manager.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 from browser_use.browser.session_manager import SessionManager
@@ -10,14 +11,15 @@ def _target(target_type: str, url: str):
 
 def test_get_all_page_targets_skips_chrome_extension_pages():
 	session_manager = SessionManager(MagicMock())
-	session_manager._targets = {
+	targets = {
 		'page': _target('page', 'https://example.com'),
 		'tab': _target('tab', 'about:blank'),
 		'extension': _target('page', 'chrome-extension://abcd/side-panel.html'),
 		'iframe': _target('iframe', 'https://example.com/frame'),
 	}
+	cast(Any, session_manager)._targets = targets
 
 	assert session_manager.get_all_page_targets() == [
-		session_manager._targets['page'],
-		session_manager._targets['tab'],
+		targets['page'],
+		targets['tab'],
 	]

--- a/tests/ci/browser/test_session_manager.py
+++ b/tests/ci/browser/test_session_manager.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from browser_use.browser.session_manager import SessionManager
+
+
+def _target(target_type: str, url: str):
+	return SimpleNamespace(target_type=target_type, url=url)
+
+
+def test_get_all_page_targets_skips_chrome_extension_pages():
+	session_manager = SessionManager(MagicMock())
+	session_manager._targets = {
+		'page': _target('page', 'https://example.com'),
+		'tab': _target('tab', 'about:blank'),
+		'extension': _target('page', 'chrome-extension://abcd/side-panel.html'),
+		'iframe': _target('iframe', 'https://example.com/frame'),
+	}
+
+	assert session_manager.get_all_page_targets() == [
+		session_manager._targets['page'],
+		session_manager._targets['tab'],
+	]


### PR DESCRIPTION
Fixes #4133.

`SessionManager.get_all_page_targets()` is used by initial connect, tab listing, and focus recovery. It was only filtering by CDP target type, so extension side panels reported as `type: "page"` could be treated as normal tabs and become the agent focus target.

This keeps ordinary page/tab targets, including `about:blank`, but skips `chrome-extension://` page targets before they reach those higher-level paths.

Validation:
- `python -m py_compile browser_use\browser\session_manager.py tests\ci\browser\test_session_manager.py`
- `python -m ruff check browser_use\browser\session_manager.py tests\ci\browser\test_session_manager.py`
- `python -m pytest tests\ci\browser\test_session_manager.py -q --basetemp .tmp\pytest-4133 -p no:cacheprovider` (`1 passed`)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip `chrome-extension://` page targets in `SessionManager.get_all_page_targets()` so extension side panels aren’t treated as tabs. Prevents wrong focus on initial connect, tab listing, and focus recovery.

- **Bug Fixes**
  - Exclude `chrome-extension://` pages when collecting tabs; add test.
  - Gate `main` import under `TYPE_CHECKING` in `browser_use/skill_cli/__init__.py`; export via `__all__` to satisfy Pyright.

<sup>Written for commit b101be2d0a7f49e58188cdb54d6e43d0bbaeb781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

