### PR TITLE
Bump OpenAI dependency for LiteLLM compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "google-genai==1.65.0",
-    "openai==2.16.0",
+    "openai==2.41.1",
     "anthropic==0.76.0",
     "groq==1.0.0",
     "ollama==0.6.1",


### PR DESCRIPTION
## Summary
- Bump the pinned OpenAI Python SDK dependency from 2.16.0 to 2.41.1.
- Keep the change focused on package metadata so Browser Use can resolve with current LiteLLM releases.

## Why
LiteLLM currently allows `openai>=2.20.0,<3.0.0`, but Browser Use pins `openai==2.16.0`. That strict lower version prevents installing both packages in the same environment even though both are compatible with OpenAI 2.x.

## Impact
Users can install Browser Use alongside the latest LiteLLM without dependency resolution conflicts.

## Demo
N/A - dependency metadata only.

## Validation
- `uv lock --check`
- `uv pip install --dry-run . litellm` resolved with `litellm==1.88.1`
- `uv run pre-commit run --files pyproject.toml`
- `uv run pre-commit run --all-files` (fails on existing unrelated `examples/custom-functions/cua.py:264` pyright optional-member access; changed-file hooks pass)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `openai` from 2.16.0 to 2.41.1 to match `litellm`’s supported range and avoid install conflicts when both packages are installed.

<sup>Written for commit deb418ad678d979b0717f04676f6c9b85b1a2692. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

