### PR TITLE
chore(llm): remove bu-3 / bu-3-max, default beta example to openai/gpt-5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ import asyncio
 async def main():
     agent = Agent(
         task="Find the number of stars of the browser-use repo",
-        llm=ChatBrowserUse(model='bu-3-max'),
+        llm=ChatBrowserUse(model='openai/gpt-5.5'),
+        # llm=ChatBrowserUse(model='bu-2-0'),  # Browser Use's own optimized model
         # llm=ChatOpenAI(model='gpt-5.5'),
         # llm=ChatAnthropic(model='claude-opus-4-8'),  # Sonnet also works well.
         browser_profile=BrowserProfile(
@@ -213,17 +214,7 @@ curl -o ~/.claude/skills/browser-use/SKILL.md \
 
 We optimized **ChatBrowserUse()** specifically for browser automation tasks. On avg it completes tasks 3-5x faster than other models with SOTA accuracy.
 
-**bu-3 pricing (per 1M tokens):**
-- Input tokens: $2.00
-- Cached input tokens: $0.20
-- Output tokens: $11.00
-
-**bu-3-max pricing (per 1M tokens):**
-- Input tokens: $2.50
-- Cached input tokens: $0.25
-- Output tokens: $50.00
-
-For other LLM providers, see our [supported models documentation](https://docs.browser-use.com/supported-models).
+For pricing and other LLM providers, see our [supported models documentation](https://docs.browser-use.com/supported-models).
 </details>
 
 <details>

--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -38,7 +38,7 @@ class ChatBrowserUse(BaseChatModel):
 	Usage:
 		agent = Agent(
 			task="Find the number of stars of the browser-use repo",
-			llm=ChatBrowserUse(model='bu-3-max'),
+			llm=ChatBrowserUse(model='openai/gpt-5.5'),
 		)
 	"""
 
@@ -59,8 +59,6 @@ class ChatBrowserUse(BaseChatModel):
 		Args:
 			model: Model name to use. Options:
 				- 'bu-2-0' or 'bu-latest': Default model (latest premium)
-				- 'bu-3': Fast premium model
-				- 'bu-3-max': Most capable model
 				- 'bu-1-0': Previous generation model
 				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
 				- Provider-prefixed ids resolved by the gateway, e.g. 'anthropic/claude-sonnet-4-6',
@@ -74,7 +72,7 @@ class ChatBrowserUse(BaseChatModel):
 		"""
 		# Accept 'bu-*' aliases and any provider-prefixed id; the gateway resolves the
 		# latter (anthropic/*, openai/*, google/*, browser-use/*), so we don't enumerate them.
-		bu_aliases = ['bu-latest', 'bu-1-0', 'bu-2-0', 'bu-3', 'bu-3-max']
+		bu_aliases = ['bu-latest', 'bu-1-0', 'bu-2-0']
 		is_valid = model in bu_aliases or '/' in model
 		if not is_valid:
 			raise ValueError(

--- a/browser_use/tokens/custom_pricing.py
+++ b/browser_use/tokens/custom_pricing.py
@@ -27,24 +27,6 @@ CUSTOM_MODEL_PRICING: dict[str, dict[str, Any]] = {
 		'max_input_tokens': None,  # Not specified
 		'max_output_tokens': None,  # Not specified
 	},
-	'bu-3': {
-		'input_cost_per_token': 2.00 / 1_000_000,  # $2.00 per 1M tokens
-		'output_cost_per_token': 11.00 / 1_000_000,  # $11.00 per 1M tokens
-		'cache_read_input_token_cost': 0.20 / 1_000_000,  # $0.20 per 1M tokens
-		'cache_creation_input_token_cost': None,  # Not charged
-		'max_tokens': None,  # Not specified
-		'max_input_tokens': None,  # Not specified
-		'max_output_tokens': None,  # Not specified
-	},
-	'bu-3-max': {
-		'input_cost_per_token': 2.50 / 1_000_000,  # $2.50 per 1M tokens
-		'output_cost_per_token': 50.00 / 1_000_000,  # $50.00 per 1M tokens
-		'cache_read_input_token_cost': 0.25 / 1_000_000,  # $0.25 per 1M tokens
-		'cache_creation_input_token_cost': None,  # Not charged
-		'max_tokens': None,  # Not specified
-		'max_input_tokens': None,  # Not specified
-		'max_output_tokens': None,  # Not specified
-	},
 	'claude-sonnet-4-6': {
 		'input_cost_per_token': 3.00 / 1_000_000,
 		'output_cost_per_token': 15.00 / 1_000_000,

--- a/examples/beta_agent/basic.py
+++ b/examples/beta_agent/basic.py
@@ -22,7 +22,8 @@ async def main() -> None:
 
 	agent = Agent(
 		task=task,
-		llm=ChatBrowserUse(),
+		llm=ChatBrowserUse(model='openai/gpt-5.5'),
+		# llm=ChatBrowserUse(),  # Browser Use's own optimized model (bu-2-0)
 		# llm=ChatOpenAI(model='gpt-5.5'),
 		# llm=ChatGoogle(model='gemini-3.1-pro-preview'),
 		# llm=ChatAnthropic(model='claude-opus-4-8'),  # Sonnet also works well.

--- a/tests/ci/models/test_llm_browseruse.py
+++ b/tests/ci/models/test_llm_browseruse.py
@@ -31,7 +31,7 @@ def test_default_model_is_bu_2_0():
 	assert chat.provider == 'browser-use'
 
 
-@pytest.mark.parametrize('alias', ['bu-1-0', 'bu-2-0', 'bu-3', 'bu-3-max'])
+@pytest.mark.parametrize('alias', ['bu-1-0', 'bu-2-0'])
 def test_bu_aliases_are_accepted(alias):
 	chat = ChatBrowserUse(model=alias, api_key=TEST_API_KEY)
 	assert chat.model == alias

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -3489,7 +3489,7 @@ def test_beta_agent_bridges_llm_credentials_to_terminal_env(monkeypatch):
 	)
 	browser_use_agent = Agent(
 		task='Browser Use credentials.',
-		llm=LLM('browser-use', 'bu-3-max', api_key='llm-browser-use-key', base_url='https://llm.example/v1'),
+		llm=LLM('browser-use', 'bu-2-0', api_key='llm-browser-use-key', base_url='https://llm.example/v1'),
 	)
 	ambient_env = Agent(
 		task='Ambient credentials.',
@@ -3534,7 +3534,7 @@ def test_beta_agent_bridges_llm_credentials_to_terminal_env(monkeypatch):
 	}
 	assert browser_use_agent._sdk_run_params(max_steps=3, task=browser_use_agent.task)['llm'] | {'timeout': None} == {
 		'provider': 'browser-use',
-		'model': 'bu-3-max',
+		'model': 'bu-2-0',
 		'timeout': None,
 	}
 

--- a/tests/ci/test_llm_retries.py
+++ b/tests/ci/test_llm_retries.py
@@ -17,15 +17,6 @@ class TestChatBrowserUseRetries:
 		"""Set up environment for ChatBrowserUse."""
 		monkeypatch.setenv('BROWSER_USE_API_KEY', 'test-api-key')
 
-	@pytest.mark.parametrize('model', ['bu-3', 'bu-3-max'])
-	def test_accepts_bu3_models(self, mock_env, model):
-		"""Test that BU3 model names are accepted."""
-		from browser_use.llm.browser_use.chat import ChatBrowserUse
-
-		client = ChatBrowserUse(model=model)
-
-		assert client.model == model
-
 	@pytest.mark.asyncio
 	async def test_retries_on_503_with_exponential_backoff(self, mock_env):
 		"""Test that 503 errors trigger retries with exponential backoff."""

--- a/tests/ci/test_openrouter_token_cost.py
+++ b/tests/ci/test_openrouter_token_cost.py
@@ -3,7 +3,6 @@ import pytest
 from browser_use.llm.openrouter.chat import ChatOpenRouter
 from browser_use.llm.views import ChatInvokeUsage
 from browser_use.tokens import openrouter_pricing
-from browser_use.tokens.custom_pricing import CUSTOM_MODEL_PRICING
 from browser_use.tokens.openrouter_pricing import model_pricing_from_openrouter_metadata
 from browser_use.tokens.service import TokenCost
 from browser_use.tokens.views import ModelPricing
@@ -35,23 +34,6 @@ def test_model_pricing_from_openrouter_metadata() -> None:
 	assert pricing.max_tokens == 1_048_576
 	assert pricing.max_input_tokens == 1_048_576
 	assert pricing.max_output_tokens == 16_384
-
-
-@pytest.mark.parametrize(
-	('model', 'input_cost', 'output_cost', 'cache_read_cost'),
-	[
-		('bu-3', 2.00, 11.00, 0.20),
-		('bu-3-max', 2.50, 50.00, 0.25),
-	],
-)
-def test_custom_browser_use_pricing_includes_bu3_models(
-	model: str, input_cost: float, output_cost: float, cache_read_cost: float
-) -> None:
-	pricing = CUSTOM_MODEL_PRICING[model]
-
-	assert pricing['input_cost_per_token'] == pytest.approx(input_cost / 1_000_000)
-	assert pricing['output_cost_per_token'] == pytest.approx(output_cost / 1_000_000)
-	assert pricing['cache_read_input_token_cost'] == pytest.approx(cache_read_cost / 1_000_000)
 
 
 async def test_openrouter_pricing_accepts_litellm_prefixed_model_ids(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What

Removes the `bu-3` and `bu-3-max` model ids everywhere they were surfaced, and switches the beta agent's default example to `openai/gpt-5.5` (routed through the Browser Use gateway via the provider-prefixed support added in ENG-5060).

## Changes

**Remove bu-3 / bu-3-max**
- `ChatBrowserUse`: dropped from the `bu_aliases` validation list (the error message auto-updates). Provider-prefixed ids like `openai/gpt-5.5` are still accepted.
- `browser_use/tokens/custom_pricing.py`: removed both pricing entries.
- `README.md`: removed the bu-3 / bu-3-max pricing blocks from the FAQ.
- Docstrings: removed the bu-3 / bu-3-max lines from the `ChatBrowserUse` model options.

**Default example → `openai/gpt-5.5`**
- README quickstart and `examples/beta_agent/basic.py` now use `ChatBrowserUse(model='openai/gpt-5.5')`, with `ChatBrowserUse(model='bu-2-0')` shown as a commented alternative.
- `ChatBrowserUse` class docstring usage example updated likewise.

**Tests**
- Removed `test_accepts_bu3_models` (test_llm_retries) and `test_custom_browser_use_pricing_includes_bu3_models` (test_openrouter_token_cost).
- Dropped `bu-3` / `bu-3-max` from the accepted-aliases parametrize in `test_llm_browseruse.py`.
- Swapped the beta-agent credential-bridging test from `bu-3-max` to `bu-2-0`.

## Notes
- The OSS model `browser-use/bu-30b-a3b-preview` is untouched (distinct from bu-3).
- Verified: `uv run pyright` clean; affected CI tests pass (`test_llm_browseruse`, `test_llm_retries`, `test_openrouter_token_cost`, `test_beta_agent` credential test).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `bu-3` and `bu-3-max` everywhere and set the beta agent example to `openai/gpt-5.5` via the gateway, aligning with provider-prefixed routing from ENG-5060. Updates docs, pricing, validation, and tests to reflect the new defaults.

- **Refactors**
  - Stop accepting `bu-3`/`bu-3-max` in `ChatBrowserUse`; keep `bu-latest`, `bu-1-0`, `bu-2-0`, and provider-prefixed IDs.
  - Remove custom pricing and README pricing blocks for `bu-3`/`bu-3-max`.
  - Update README, examples, and docstrings to use `openai/gpt-5.5` (show `bu-2-0` as an alternative).
  - Drop tests for `bu-3`/`bu-3-max`; switch beta-agent credential test to `bu-2-0`.
  - Note: `browser-use/bu-30b-a3b-preview` is unchanged.

- **Migration**
  - Replace `bu-3`/`bu-3-max` with `openai/gpt-5.5` or `bu-2-0`.
  - Provider-prefixed IDs (`openai/*`, `anthropic/*`, `google/*`, `browser-use/*`) continue to work through the gateway.

<sup>Written for commit 47a52790a6d17004058e8a14800219a3d51715ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

