### PR TITLE
test(beta): use openai/gpt-5.5 in the credential-bridging test

### DIFF
--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -3489,7 +3489,7 @@ def test_beta_agent_bridges_llm_credentials_to_terminal_env(monkeypatch):
 	)
 	browser_use_agent = Agent(
 		task='Browser Use credentials.',
-		llm=LLM('browser-use', 'bu-2-0', api_key='llm-browser-use-key', base_url='https://llm.example/v1'),
+		llm=LLM('browser-use', 'openai/gpt-5.5', api_key='llm-browser-use-key', base_url='https://llm.example/v1'),
 	)
 	ambient_env = Agent(
 		task='Ambient credentials.',
@@ -3534,7 +3534,7 @@ def test_beta_agent_bridges_llm_credentials_to_terminal_env(monkeypatch):
 	}
 	assert browser_use_agent._sdk_run_params(max_steps=3, task=browser_use_agent.task)['llm'] | {'timeout': None} == {
 		'provider': 'browser-use',
-		'model': 'bu-2-0',
+		'model': 'openai/gpt-5.5',
 		'timeout': None,
 	}
 


### PR DESCRIPTION
## What

Follow-up to #5020. Switches the `browser-use` case in `test_beta_agent_bridges_llm_credentials_to_terminal_env` from the interim `bu-2-0` to `openai/gpt-5.5`, so the test model matches the new default example.

The provider stays `'browser-use'`, so this still exercises the gateway credential-bridging path (`LLM_BROWSER_BROWSER_USE_API_KEY` / `_BASE_URL`) — only the model string changes to the gateway-routed `openai/gpt-5.5`.

## Testing

`uv run pytest tests/ci/test_beta_agent.py::test_beta_agent_bridges_llm_credentials_to_terminal_env` passes. Pre-commit hooks (ruff, pyright) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the `browser-use` case in the credential-bridging test to `openai/gpt-5.5` (from `bu-2-0`) to match the new default example. Keeps the `browser-use` provider so gateway credential-bridging coverage remains unchanged.

<sup>Written for commit 87d5f93abbe45be6aa952283154c4518bc8d5c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

