### PR TITLE
Bump browser-use-core to 0.13.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,11 @@ dependencies = [
 [project.optional-dependencies]
 cli = ["textual==7.4.0"]
 core = [
-    "browser-use-core==0.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "browser-use-core==0.13.1; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.1; sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.1; sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "browser-use-core==0.13.1; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
+    "browser-use-core==0.13.2; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "browser-use-core==0.13.2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.2; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.2; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "browser-use-core==0.13.2; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
 ]
 aws = ["boto3==1.42.37"]
 oci = ["oci==2.166.0"]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump `browser-use-core` from 0.13.1 to 0.13.2 across all platforms to pull in the latest fixes and keep builds consistent. Only version pins in `pyproject.toml` were changed; no code changes.

<sup>Written for commit 692f9199819b204cf1f4bd96f89d217257607069. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

