### PR TITLE
fix(dom): correct chunk offset overshoot when markdown ends with a newline

### DIFF
--- a/browser_use/dom/markdown_extractor.py
+++ b/browser_use/dom/markdown_extractor.py
@@ -365,8 +365,12 @@ def _parse_atomic_blocks(content: str) -> list[_AtomicBlock]:
 		)
 		offset = para_end
 
-	# Fix last block char_end: content may not end with \n
-	if blocks and content and not content.endswith('\n'):
+	# Fix last block char_end. Adding +1 per split line for the newline overshoots
+	# the true length by one in two cases: content has no trailing newline (the
+	# final line's +1 has no newline to account for), or content ends with a
+	# newline (str.split('\n') yields a spurious empty final element). Either way
+	# the last block must end exactly at len(content).
+	if blocks and content and blocks[-1].char_end != len(content):
 		blocks[-1] = _AtomicBlock(
 			block_type=blocks[-1].block_type,
 			lines=blocks[-1].lines,

--- a/tests/ci/test_markdown_chunking.py
+++ b/tests/ci/test_markdown_chunking.py
@@ -43,6 +43,25 @@ class TestChunkMarkdownBasic:
 		# Last chunk ends at content length
 		assert chunks[-1].char_offset_end == len(content)
 
+	def test_offsets_dont_overshoot_with_trailing_newline(self):
+		"""char_offset_end must equal len(content) even when content ends with a newline.
+
+		A trailing newline makes ``content.split('\\n')`` yield a spurious empty final
+		element. The per-line ``+1`` newline accounting must not push the last offset
+		one character past the end of the content, otherwise ``char_offset_end`` can
+		exceed ``len(content)`` and ``start_from_char`` resume logic mis-fires.
+		"""
+		content = '# Header\n\nParagraph one.\n\nParagraph two.\n'
+		chunks = chunk_markdown_by_structure(content, max_chunk_chars=20)
+		# Last offset must not overshoot the real content length
+		assert chunks[-1].char_offset_end == len(content), (
+			f'Last offset {chunks[-1].char_offset_end} overshoots content length {len(content)}'
+		)
+		# Full forward coverage with no gaps
+		assert chunks[0].char_offset_start == 0
+		for i in range(1, len(chunks)):
+			assert chunks[i].char_offset_start == chunks[i - 1].char_offset_end
+
 
 class TestChunkMarkdownHeaders:
 	"""Header boundary splitting."""


### PR DESCRIPTION
## Summary

`chunk_markdown_by_structure` could report a `char_offset_end` **one character past the end of the content** for the final chunk whenever the markdown ends with a trailing newline.

### Root cause

In `_parse_atomic_blocks`, each line gets `line_len = len(line) + 1` to account for the `\n` that `str.split('\n')` removed. But when `content` ends with a newline, `split('\n')` yields a spurious empty final element (`"a\n".split("\n") == ["a", ""]`). That phantom element adds an extra `+1`, so the last block's `char_end` — and therefore the last chunk's `char_offset_end` — becomes `len(content) + 1`.

The existing fix-up only handled the *opposite* case (content **without** a trailing newline):

```python
if blocks and content and not content.endswith('\n'):
    blocks[-1] = _AtomicBlock(..., char_end=len(content))
```

So trailing-newline content (the common case for extracted page markdown) slipped through.

### Fix

Clamp the final block's `char_end` to `len(content)` in **both** cases:

```python
if blocks and content and blocks[-1].char_end != len(content):
    blocks[-1] = _AtomicBlock(..., char_end=len(content))
```

### Impact

- Offsets now always stay within `[0, len(content)]`.
- `start_from_char` resume is corrected: passing `start_from_char == len(content)` now returns **no chunks** (fully consumed) instead of wrongly re-returning the final chunk, because the resume filter compares `chunk.char_offset_end > start_from_char`.

## Test

Added `test_offsets_dont_overshoot_with_trailing_newline`, which fails on the old code (`Last offset 42 overshoots content length 41`) and passes with the fix. Full chunking suite (24 tests) and `ruff check` pass.

```
uv run pytest tests/ci/test_markdown_chunking.py   # 24 passed
uv run ruff check browser_use/dom/markdown_extractor.py tests/ci/test_markdown_chunking.py  # All checks passed
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an off-by-one in markdown chunking when the content ends with a newline. The last chunk’s `char_offset_end` now equals `len(content)`, which also fixes end-of-content `start_from_char` resume.

- **Bug Fixes**
  - Clamp the final block’s `char_end` to `len(content)` in `_parse_atomic_blocks` for both trailing and non-trailing newline cases.
  - Add a regression test to ensure the final `char_offset_end` never overshoots and `start_from_char == len(content)` returns no chunks.

<sup>Written for commit eb6f640dfb5747660171b9f70f9994f538faa5db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

