### PR TITLE
Add ChatTrustedRouter provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,24 @@ For pricing and other LLM providers, see our [supported models documentation](ht
 </details>
 
 <details>
+<summary><b>Can I use TrustedRouter?</b></summary>
+
+Yes. TrustedRouter exposes an OpenAI-compatible API, so you can use it through `ChatOpenAI` with a custom `base_url`. This is useful for privacy-sensitive browser tasks because TrustedRouter uses open-source, verifiable attested routing and does not log prompts or outputs by default.
+
+```python
+import os
+from browser_use import Agent, ChatOpenAI
+
+llm = ChatOpenAI(
+    model='trustedrouter/zdr',
+    api_key=os.environ['TRUSTEDROUTER_API_KEY'],
+    base_url='https://api.trustedrouter.com/v1',
+)
+agent = Agent(task='...', llm=llm)
+```
+</details>
+
+<details>
 <summary><b>Can I use Claude / GPT / Gemini through ChatBrowserUse?</b></summary>
 
 Yes. `ChatBrowserUse` accepts provider-prefixed model ids, so a single `BROWSER_USE_API_KEY` reaches all of them — no separate OpenAI/Anthropic/Google keys required:

--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.openai.chat import ChatOpenAI
 	from browser_use.llm.openrouter.chat import ChatOpenRouter
 	from browser_use.llm.orcarouter.chat import ChatOrcaRouter
+	from browser_use.llm.trustedrouter.chat import ChatTrustedRouter
 	from browser_use.llm.vercel.chat import ChatVercel
 	from browser_use.sandbox import sandbox
 	from browser_use.tools.service import Controller, Tools
@@ -107,6 +108,7 @@ _LAZY_IMPORTS = {
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
 	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatOrcaRouter': ('browser_use.llm.orcarouter.chat', 'ChatOrcaRouter'),
+	'ChatTrustedRouter': ('browser_use.llm.trustedrouter.chat', 'ChatTrustedRouter'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
 	# LLM models module
 	'models': ('browser_use.llm.models', None),
@@ -165,6 +167,7 @@ __all__ = [
 	'ChatOllama',
 	'ChatOpenRouter',
 	'ChatOrcaRouter',
+	'ChatTrustedRouter',
 	'ChatVercel',
 	'Tools',
 	'Controller',

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.openai.chat import ChatOpenAI
 	from browser_use.llm.openrouter.chat import ChatOpenRouter
 	from browser_use.llm.orcarouter.chat import ChatOrcaRouter
+	from browser_use.llm.trustedrouter.chat import ChatTrustedRouter
 	from browser_use.llm.vercel.chat import ChatVercel
 
 	# Type stubs for model instances - enables IDE autocomplete
@@ -95,6 +96,7 @@ _LAZY_IMPORTS = {
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
 	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatOrcaRouter': ('browser_use.llm.orcarouter.chat', 'ChatOrcaRouter'),
+	'ChatTrustedRouter': ('browser_use.llm.trustedrouter.chat', 'ChatTrustedRouter'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
 }
 
@@ -159,6 +161,7 @@ __all__ = [
 	'ChatOllama',
 	'ChatOpenRouter',
 	'ChatOrcaRouter',
+	'ChatTrustedRouter',
 	'ChatVercel',
 	'ChatCerebras',
 ]

--- a/browser_use/llm/trustedrouter/chat.py
+++ b/browser_use/llm/trustedrouter/chat.py
@@ -1,0 +1,34 @@
+import os
+from dataclasses import dataclass, field
+
+import httpx
+
+from browser_use.llm.openai.like import ChatOpenAILike
+
+
+@dataclass
+class ChatTrustedRouter(ChatOpenAILike):
+	"""
+	A wrapper around TrustedRouter's chat API, an attested OpenAI-compatible router
+	with automatic model selection, zero-data-retention routes, and end-to-end
+	encrypted routes.
+
+	This class implements the BaseChatModel protocol for TrustedRouter's API.
+
+	Args:
+	    model (str): The TrustedRouter model or routing alias to use
+	        (e.g. "trustedrouter/auto", "trustedrouter/zdr", "trustedrouter/e2e").
+	    api_key (Optional[str]): The API key to use. Defaults to the
+	        TRUSTEDROUTER_API_KEY environment variable.
+	"""
+
+	# Model configuration
+	model: str = 'trustedrouter/auto'
+
+	# Client initialization parameters
+	api_key: str | None = field(default_factory=lambda: os.getenv('TRUSTEDROUTER_API_KEY'))
+	base_url: str | httpx.URL | None = 'https://api.trustedrouter.com/v1'
+
+	@property
+	def provider(self) -> str:
+		return 'trustedrouter'

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -45,6 +45,7 @@ Based on our [benchmark of real-world browser tasks](https://browser-use.com/pos
 - [Cerebras](#cerebras)
 - [Ollama (Local)](#ollama-local)
 - [OpenRouter](#openrouter)
+- [TrustedRouter](#trustedrouter)
 - [Vercel AI Gateway](#vercel-ai-gateway)
 - [OCI (Oracle)](#oci-oracle)
 - [LiteLLM (100+ Providers)](#litellm-100-providers)
@@ -206,6 +207,18 @@ llm = ChatOpenRouter(model="anthropic/claude-sonnet-4-6")
 ```
 
 **Env:** `OPENROUTER_API_KEY` | [Available models](https://openrouter.ai/models)
+
+## TrustedRouter
+
+Attested OpenAI-compatible router with automatic model selection, zero-data-retention routes, and end-to-end encrypted routes.
+
+```python
+from browser_use import Agent, ChatTrustedRouter
+
+llm = ChatTrustedRouter(model="trustedrouter/auto")  # or trustedrouter/zdr, trustedrouter/e2e
+```
+
+**Env:** `TRUSTEDROUTER_API_KEY` | [API keys](https://trustedrouter.com/console/api-keys)
 
 ## Vercel AI Gateway
 


### PR DESCRIPTION
Adds TrustedRouter (attested OpenAI-compatible router) as a first-class chat model, mirroring the ChatOpenRouter treatment:

- `browser_use/llm/trustedrouter/chat.py` — `ChatTrustedRouter(ChatOpenAILike)` with default `base_url`, `trustedrouter/auto` default model, and `TRUSTEDROUTER_API_KEY` env fallback
- registered in the lazy-import maps and `__all__` of both `browser_use` and `browser_use.llm`
- TrustedRouter section in `skills/open-source/references/models.md`

`ruff check` and `ruff format --check` pass; `from browser_use import ChatTrustedRouter` smoke-tested in a fresh venv.

This reworks the earlier docs-only version of this PR into a code integration.