### PR TITLE
fix: preserve keep-alive browser event bus

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3964,17 +3964,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					# Kill the browser session - this dispatches BrowserStopEvent,
 					# stops the EventBus with clear=True, and recreates a fresh EventBus
 					await self.browser_session.kill()
-				else:
-					# keep_alive=True sessions shouldn't keep the event loop alive after agent.run()
-					await self.browser_session.event_bus.stop(
-						clear=False,
-						timeout=_get_timeout('TIMEOUT_BrowserSessionEventBusStopOnAgentClose', 1.0),
-					)
-					try:
-						self.browser_session.event_bus.event_queue = None
-						self.browser_session.event_bus._on_idle = None
-					except Exception:
-						pass
 
 			# Close skill service if configured
 			if self.skill_service is not None:

--- a/tests/ci/test_agent_close.py
+++ b/tests/ci/test_agent_close.py
@@ -1,0 +1,75 @@
+from typing import Any, cast
+
+from browser_use.agent.service import Agent
+
+
+class FakeEventBus:
+	def __init__(self):
+		self.stop_calls = []
+		self.event_queue = object()
+		self._on_idle = object()
+
+	async def stop(self, **kwargs):
+		self.stop_calls.append(kwargs)
+
+
+class FakeBrowserProfile:
+	def __init__(self, keep_alive: bool):
+		self.keep_alive = keep_alive
+
+
+class FakeBrowserSession:
+	def __init__(self, keep_alive: bool):
+		self.id = 'fake-browser-session'
+		self.agent_focus_target_id = None
+		self.browser_profile = FakeBrowserProfile(keep_alive=keep_alive)
+		self.event_bus = FakeEventBus()
+		self.kill_calls = 0
+
+	async def kill(self):
+		self.kill_calls += 1
+
+
+class FakeSkillService:
+	def __init__(self):
+		self.close_calls = 0
+
+	async def close(self):
+		self.close_calls += 1
+
+
+def make_agent(browser_session: FakeBrowserSession, skill_service: FakeSkillService | None = None) -> Agent:
+	agent = cast(Any, object.__new__(Agent))
+	agent.browser_session = browser_session
+	agent.skill_service = skill_service
+	return cast(Agent, agent)
+
+
+async def test_agent_close_kills_non_keep_alive_browser_session():
+	session = FakeBrowserSession(keep_alive=False)
+	skill_service = FakeSkillService()
+	agent = make_agent(session, skill_service)
+
+	await agent.close()
+
+	assert session.kill_calls == 1
+	assert session.event_bus.stop_calls == []
+	assert session.event_bus.event_queue is not None
+	assert session.event_bus._on_idle is not None
+	assert skill_service.close_calls == 1
+
+
+async def test_agent_close_preserves_keep_alive_event_bus():
+	session = FakeBrowserSession(keep_alive=True)
+	event_queue = session.event_bus.event_queue
+	on_idle = session.event_bus._on_idle
+	skill_service = FakeSkillService()
+	agent = make_agent(session, skill_service)
+
+	await agent.close()
+
+	assert session.kill_calls == 0
+	assert session.event_bus.stop_calls == []
+	assert session.event_bus.event_queue is event_queue
+	assert session.event_bus._on_idle is on_idle
+	assert skill_service.close_calls == 1


### PR DESCRIPTION
## Summary
- keep `Agent.close()` from stopping the browser event bus when `keep_alive=True`
- preserve the event queue and idle callback so CDP WebSocket handlers remain attached for the next agent run
- add close-lifecycle tests for both keep-alive and non-keep-alive browser sessions

Fixes #4374.

## Test plan
- `python -m py_compile browser_use/agent/service.py tests/ci/test_agent_close.py`
- `python -m pytest tests/ci/test_agent_close.py -q`
- `python -m ruff check browser_use/agent/service.py tests/ci/test_agent_close.py --no-fix`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the browser event bus alive during `Agent.close()` when `keep_alive=True` by not stopping or clearing it, so CDP WebSocket handlers persist into the next run. Adds tests for both keep-alive and non-keep-alive close behavior.

- **Bug Fixes**
  - Keep-alive: do not call `event_bus.stop`; preserve `event_queue` and `_on_idle`.
  - Non-keep-alive: kill the browser session; `Agent.close()` does not call `event_bus.stop`.

<sup>Written for commit 067cd67187a950d214572b2786dd672e98c6eb37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

