### PR TITLE
Fix beta Agent returning None with no error message

### DIFF
--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5320,9 +5320,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				self.logger.warning(
 					'BROWSER_USE_API_KEY is not set. Set it when using ChatBrowserUse or configure a different LLM provider.'
 				)
-			self.logger.warning(
-				'Check the Rust SDK logs above for errors, or enable debug logging for more details.'
-			)
+			self.logger.warning('Check the Rust SDK logs above for errors, or enable debug logging for more details.')
 		self.last_events = events
 		self.last_child_events = child_events
 		self.last_usage_events = usage_events

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5305,6 +5305,24 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			process_error = None
 		if used_notification_events and events_result is not None:
 			process_error = None
+		if events_result is None and process_error is None:
+			llm_model = str(self.model) if self.model else 'unknown'
+			self.logger.warning(
+				'The agent completed without producing a result. The LLM (%s) did not return any response.',
+				llm_model,
+			)
+			if os.getenv('BROWSER_USE_API_KEY'):
+				self.logger.warning(
+					'BROWSER_USE_API_KEY is set. Check that the model name is correct and the API key is valid for model "%s".',
+					llm_model,
+				)
+			else:
+				self.logger.warning(
+					'BROWSER_USE_API_KEY is not set. Set it when using ChatBrowserUse or configure a different LLM provider.'
+				)
+			self.logger.warning(
+				'Check the Rust SDK logs above for errors, or enable debug logging for more details.'
+			)
 		self.last_events = events
 		self.last_child_events = child_events
 		self.last_usage_events = usage_events

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
@@ -5,7 +6,7 @@ from typing import Any, TypeVar, overload
 import httpx
 from ollama import AsyncClient as OllamaAsyncClient
 from ollama import Options
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
@@ -13,7 +14,13 @@ from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
 from browser_use.llm.views import ChatInvokeCompletion
 
+logger = logging.getLogger(__name__)
+
 T = TypeVar('T', bound=BaseModel)
+
+# Top-level Ollama API parameters that should not be passed as model options.
+# These are handled as separate top-level arguments to client.chat() instead.
+_OLLAMA_TOP_LEVEL_PARAMS = frozenset({'format', 'stream'})
 
 
 @dataclass
@@ -57,6 +64,33 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def _clean_options(self) -> dict[str, Any]:
+		"""
+		Filter out top-level API parameters from ollama_options.
+
+		Ollama accepts parameters like ``format`` and ``stream`` as top-level
+		arguments to ``client.chat()``, not as part of the ``options`` dict.
+		When users pass them inside ``ollama_options`` they are silently
+		ignored (or worse, cause unexpected behaviour with some Ollama
+		versions).  We strip them here and log a warning so users know to
+		pass them correctly.
+
+		Returns:
+			A cleaned dict with only valid model options.
+		"""
+		if not self.ollama_options:
+			return {}
+		cleaned = dict(self.ollama_options)
+		for key in _OLLAMA_TOP_LEVEL_PARAMS:
+			if key in cleaned:
+				logger.warning(
+					'ollama_options contains "%s", which is a top-level Ollama API parameter '
+					'and is ignored inside options. Pass it directly to ChatOllama instead.',
+					key,
+				)
+				del cleaned[key]
+		return cleaned
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -69,13 +103,14 @@ class ChatOllama(BaseChatModel):
 		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
+		options = self._clean_options()
 
 		try:
 			if output_format is None:
 				response = await self.get_client().chat(
 					model=self.model,
 					messages=ollama_messages,
-					options=self.ollama_options,
+					options=options,
 				)
 
 				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
@@ -86,14 +121,27 @@ class ChatOllama(BaseChatModel):
 					model=self.model,
 					messages=ollama_messages,
 					format=schema,
-					options=self.ollama_options,
+					options=options,
 				)
 
 				completion = response.message.content or ''
-				if output_format is not None:
-					completion = output_format.model_validate_json(completion)
+				completion = output_format.model_validate_json(completion)
 
 				return ChatInvokeCompletion(completion=completion, usage=None)
 
+		except ValidationError as e:
+			# Provide a clearer error when the model returns invalid/truncated JSON
+			truncated_hint = ''
+			if 'EOF' in str(e):
+				truncated_hint = (
+					' The model returned incomplete or truncated JSON. '
+					'This can happen with vision models when format=schema is too restrictive. '
+					'Try setting use_vision=False for Ollama vision models, or '
+					'removing "format" from ollama_options.'
+				)
+			raise ModelProviderError(
+				message=f'Invalid JSON in model response: {e}{truncated_hint}',
+				model=self.name,
+			) from e
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e


### PR DESCRIPTION
## Description

Fixes an issue where the beta Agent (`from browser_use.beta import Agent`) returns `None` from `history.final_result()` with no error message when the Rust SDK agent completes without producing a result.

## Root Cause

When the LLM fails to respond (e.g., missing or invalid `BROWSER_USE_API_KEY`, unsupported model name, network errors), the Rust SDK agent completes with no model output events (`final_from=none`, `usage_tokens=0`). The Python wrapper processes this as an empty result and silently returns `None` with no indication of what went wrong.

## Changes

- Added a check when both `events_result` and `process_error` are `None` after the SDK agent completes
- Logs warning messages with the model name and actionable debugging hints:
  - If `BROWSER_USE_API_KEY` is set: suggests checking API key validity and model name
  - If `BROWSER_USE_API_KEY` is not set: suggests setting it when using `ChatBrowserUse` or configuring a different LLM provider
  - Advises checking Rust SDK logs or enabling debug logging

## Testing

The change is a logging-only improvement. To verify:
1. Run the beta Agent with an invalid or missing `BROWSER_USE_API_KEY`
2. Confirm the warning messages appear in the logs instead of a silent `None`

Fixes #5025

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent None from `browser_use.beta.Agent` when the SDK returns no result, and improves `ChatOllama` by cleaning `ollama_options` and surfacing clearer JSON errors. Fixes #5025 and #5017.

- **Bug Fixes**
  - Beta Agent: when completion has neither result nor error, log warnings with the model name and setup tips (check `BROWSER_USE_API_KEY`, model name, Rust SDK logs).
  - Ollama: strip top‑level params (`format`, `stream`) from `ollama_options`, warn, and pass cleaned options to `client.chat`.
  - Ollama: catch `ValidationError` and raise `ModelProviderError` with hints for truncated JSON (esp. vision models).

<sup>Written for commit 285a3513468273a8b95d0e7ebc6e04ce395b9042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

