### PR TITLE
Fix CLI installer shadowing user Python by using wrapper scripts

### DIFF
--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5320,9 +5320,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				self.logger.warning(
 					'BROWSER_USE_API_KEY is not set. Set it when using ChatBrowserUse or configure a different LLM provider.'
 				)
-			self.logger.warning(
-				'Check the Rust SDK logs above for errors, or enable debug logging for more details.'
-			)
+			self.logger.warning('Check the Rust SDK logs above for errors, or enable debug logging for more details.')
 		self.last_events = events
 		self.last_child_events = child_events
 		self.last_usage_events = usage_events

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5305,6 +5305,24 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			process_error = None
 		if used_notification_events and events_result is not None:
 			process_error = None
+		if events_result is None and process_error is None:
+			llm_model = str(self.model) if self.model else 'unknown'
+			self.logger.warning(
+				'The agent completed without producing a result. The LLM (%s) did not return any response.',
+				llm_model,
+			)
+			if os.getenv('BROWSER_USE_API_KEY'):
+				self.logger.warning(
+					'BROWSER_USE_API_KEY is set. Check that the model name is correct and the API key is valid for model "%s".',
+					llm_model,
+				)
+			else:
+				self.logger.warning(
+					'BROWSER_USE_API_KEY is not set. Set it when using ChatBrowserUse or configure a different LLM provider.'
+				)
+			self.logger.warning(
+				'Check the Rust SDK logs above for errors, or enable debug logging for more details.'
+			)
 		self.last_events = events
 		self.last_child_events = child_events
 		self.last_usage_events = usage_events

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
@@ -5,7 +6,7 @@ from typing import Any, TypeVar, overload
 import httpx
 from ollama import AsyncClient as OllamaAsyncClient
 from ollama import Options
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
@@ -13,7 +14,13 @@ from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
 from browser_use.llm.views import ChatInvokeCompletion
 
+logger = logging.getLogger(__name__)
+
 T = TypeVar('T', bound=BaseModel)
+
+# Top-level Ollama API parameters that should not be passed as model options.
+# These are handled as separate top-level arguments to client.chat() instead.
+_OLLAMA_TOP_LEVEL_PARAMS = frozenset({'format', 'stream'})
 
 
 @dataclass
@@ -57,6 +64,33 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def _clean_options(self) -> dict[str, Any]:
+		"""
+		Filter out top-level API parameters from ollama_options.
+
+		Ollama accepts parameters like ``format`` and ``stream`` as top-level
+		arguments to ``client.chat()``, not as part of the ``options`` dict.
+		When users pass them inside ``ollama_options`` they are silently
+		ignored (or worse, cause unexpected behaviour with some Ollama
+		versions).  We strip them here and log a warning so users know to
+		pass them correctly.
+
+		Returns:
+			A cleaned dict with only valid model options.
+		"""
+		if not self.ollama_options:
+			return {}
+		cleaned = dict(self.ollama_options)
+		for key in _OLLAMA_TOP_LEVEL_PARAMS:
+			if key in cleaned:
+				logger.warning(
+					'ollama_options contains "%s", which is a top-level Ollama API parameter '
+					'and is ignored inside options. Pass it directly to ChatOllama instead.',
+					key,
+				)
+				del cleaned[key]
+		return cleaned
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -69,13 +103,14 @@ class ChatOllama(BaseChatModel):
 		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
+		options = self._clean_options()
 
 		try:
 			if output_format is None:
 				response = await self.get_client().chat(
 					model=self.model,
 					messages=ollama_messages,
-					options=self.ollama_options,
+					options=options,
 				)
 
 				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
@@ -86,14 +121,27 @@ class ChatOllama(BaseChatModel):
 					model=self.model,
 					messages=ollama_messages,
 					format=schema,
-					options=self.ollama_options,
+					options=options,
 				)
 
 				completion = response.message.content or ''
-				if output_format is not None:
-					completion = output_format.model_validate_json(completion)
+				completion = output_format.model_validate_json(completion)
 
 				return ChatInvokeCompletion(completion=completion, usage=None)
 
+		except ValidationError as e:
+			# Provide a clearer error when the model returns invalid/truncated JSON
+			truncated_hint = ''
+			if 'EOF' in str(e):
+				truncated_hint = (
+					' The model returned incomplete or truncated JSON. '
+					'This can happen with vision models when format=schema is too restrictive. '
+					'Try setting use_vision=False for Ollama vision models, or '
+					'removing "format" from ollama_options.'
+				)
+			raise ModelProviderError(
+				message=f'Invalid JSON in model response: {e}{truncated_hint}',
+				model=self.name,
+			) from e
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -444,7 +444,7 @@ configure_powershell_wrappers() {
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			{
 				echo '@echo off'
-				echo ""$(echo "$venv_bin/$cmd" | sed 's|/|\|g')" %*"
+				echo ""$(echo "$venv_bin/$cmd" | sed 's|/\\|g')" %*"
 			} > "$wrapper"
 			chmod +x "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -392,7 +392,7 @@ create_wrappers() {
 	local commands="browser-use bu browseruse browser browser-use-tui"
 
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
@@ -440,7 +440,7 @@ configure_powershell_wrappers() {
 	# Create .cmd wrappers for each CLI command
 	local commands="browser-use bu browseruse browser browser-use-tui"
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			{
 				echo '@echo off'

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -396,7 +396,7 @@ create_wrappers() {
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
-				exec "$venv_bin/$cmd" "$@"
+				exec "$venv_bin/$cmd" "\$@"
 			WRAPPER_EOF
 			chmod +x "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/$cmd"

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -375,62 +375,101 @@ install_profile_use() {
 # PATH configuration
 # =============================================================================
 
-configure_path() {
-	local shell_rc=""
-	local bin_path=$(get_venv_bin_dir)
-	local local_bin="$HOME/.local/bin"
+# =============================================================================
+# PATH configuration
+# =============================================================================
 
-	# Detect user's login shell (not the running shell, since this script
-	# is typically executed via "curl ... | bash" which always sets BASH_VERSION)
+# Create wrapper scripts in ~/.local/bin for CLI commands instead of
+# adding the entire virtualenv bin directory to PATH. This prevents the
+# venv's Python and other executables from shadowing the user's system Python.
+
+create_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
+
+	# CLI entry points from pyproject.toml
+	local commands="browser-use bu browseruse browser browser-use-tui"
+
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/$cmd"
+			cat > "$wrapper" <<- WRAPPER_EOF
+				#!/bin/sh
+				exec "$venv_bin/$cmd" "$@"
+			WRAPPER_EOF
+			chmod +x "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/$cmd"
+		fi
+	done
+}
+
+configure_path() {
+	local wrapper_dir="$HOME/.local/bin"
+	local shell_rc=""
+
+	# Detect user's login shell
 	case "$(basename "$SHELL")" in
 		zsh)  shell_rc="$HOME/.zshrc" ;;
 		bash) shell_rc="$HOME/.bashrc" ;;
 		*)    shell_rc="$HOME/.profile" ;;
 	esac
 
-	# Check if already in PATH (browser-use-env matches both /bin and /Scripts)
-	if grep -q "browser-use-env" "$shell_rc" 2>/dev/null; then
-		log_info "PATH already configured in $shell_rc"
-	else
-		# Add to shell config (includes ~/.local/bin for tools)
+	# Create wrapper scripts for each CLI command
+	create_wrappers
+
+	# Ensure ~/.local/bin is on PATH (standard location for user CLI tools)
+	if ! grep -q "\.local/bin" "$shell_rc" 2>/dev/null; then
 		echo "" >> "$shell_rc"
-		echo "# Browser-Use" >> "$shell_rc"
-		echo "export PATH=\"$bin_path:$local_bin:\$PATH\"" >> "$shell_rc"
-		log_success "Added to PATH in $shell_rc"
+		echo "# Browser-Use CLI wrappers" >> "$shell_rc"
+		echo "export PATH="$wrapper_dir:\$PATH"" >> "$shell_rc"
+		log_success "Added ~/.local/bin to PATH in $shell_rc"
 	fi
 
-	# On Windows, also configure PowerShell profile
+	# On Windows, also configure via registry
 	if [ "$PLATFORM" = "windows" ]; then
-		configure_powershell_path
+		configure_powershell_wrappers
 	fi
 }
 
-configure_powershell_path() {
-	# Use PowerShell to modify user PATH in registry (no execution policy needed)
-	# This persists across sessions without requiring profile script execution
+configure_powershell_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
 
-	local scripts_path='\\.browser-use-env\\Scripts'
-	local local_bin='\\.local\\bin'
+	# Create .cmd wrappers for each CLI command
+	local commands="browser-use bu browseruse browser browser-use-tui"
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/${cmd}.cmd"
+			{
+				echo '@echo off'
+				echo ""$(echo "$venv_bin/$cmd" | sed 's|/|\|g')" %*"
+			} > "$wrapper"
+			chmod +x "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
+		fi
+	done
 
-	# Check if already in user PATH
-	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '\r')
+	# Ensure wrapper dir is in user PATH via registry
+	local wrapper_win='\.localin'
+	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '
+')
 
-	if echo "$current_path" | grep -q "browser-use-env"; then
-		log_info "PATH already configured"
+	if echo "$current_path" | grep -q "\.local\bin"; then
+		log_info "Wrapper directory already in PATH"
 		return 0
 	fi
 
-	# Append to user PATH via registry (safe, no truncation, no execution policy needed)
-	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$scripts_path;' + \$env:USERPROFILE + '$local_bin', 'User')" 2>/dev/null
+	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$wrapper_win', 'User')" 2>/dev/null
 
 	if [ $? -eq 0 ]; then
-		log_success "Added to Windows PATH: %USERPROFILE%\\.browser-use-env\\Scripts"
+		log_success "Added to Windows PATH: %USERPROFILE%\.localin"
 	else
 		log_warn "Could not update PATH automatically. Add manually:"
-		log_warn "  \$env:PATH += \";\$env:USERPROFILE\\.browser-use-env\\Scripts\""
+		log_warn "  \$env:PATH += ";\$env:USERPROFILE\.localin""
 	fi
 }
-
 # =============================================================================
 # Validation
 # =============================================================================

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -411,7 +411,7 @@ configure_powershell_wrappers() {
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			(
 				echo '@echo off'
-				echo "\"$(echo "$venv_bin/$cmd" | sed 's|/|\|g')\" %*"
+				echo "\"$(echo "$venv_bin/$cmd" | sed 's|/\\|g')\" %*"
 			) > "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
 		fi

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -357,7 +357,7 @@ create_wrappers() {
 	local commands="browser-use bu browseruse browser browser-use-tui"
 
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
@@ -407,7 +407,7 @@ configure_powershell_wrappers() {
 	# Create .cmd wrappers for each CLI command
 	local commands="browser-use bu browseruse browser browser-use-tui"
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			(
 				echo '@echo off'

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -361,7 +361,7 @@ create_wrappers() {
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
-				exec "$venv_bin/$cmd" "$@"
+				exec "$venv_bin/$cmd" "\$@"
 			WRAPPER_EOF
 			chmod +x "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/$cmd"

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -340,10 +340,38 @@ install_profile_use() {
 # PATH configuration
 # =============================================================================
 
+# =============================================================================
+# PATH configuration
+# =============================================================================
+
+# Create wrapper scripts in ~/.local/bin for CLI commands instead of
+# adding the entire virtualenv bin directory to PATH. This prevents the
+# venv's Python and other executables from shadowing the user's system Python.
+
+create_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
+
+	# CLI entry points from pyproject.toml
+	local commands="browser-use bu browseruse browser browser-use-tui"
+
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/$cmd"
+			cat > "$wrapper" <<- WRAPPER_EOF
+				#!/bin/sh
+				exec "$venv_bin/$cmd" "$@"
+			WRAPPER_EOF
+			chmod +x "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/$cmd"
+		fi
+	done
+}
+
 configure_path() {
+	local wrapper_dir="$HOME/.local/bin"
 	local shell_rc=""
-	local bin_path=$(get_venv_bin_dir)
-	local local_bin="$HOME/.local/bin"
 
 	# Detect shell
 	if [ -n "$BASH_VERSION" ]; then
@@ -354,49 +382,59 @@ configure_path() {
 		shell_rc="$HOME/.profile"
 	fi
 
-	# Check if already in PATH (browser-use-env matches both /bin and /Scripts)
-	if grep -q "browser-use-env" "$shell_rc" 2>/dev/null; then
-		log_info "PATH already configured in $shell_rc"
-	else
-		# Add to shell config (includes ~/.local/bin for tools)
+	# Create wrapper scripts for each CLI command
+	create_wrappers
+
+	# Ensure ~/.local/bin is on PATH (standard location for user CLI tools)
+	if ! grep -q "\.local/bin" "$shell_rc" 2>/dev/null; then
 		echo "" >> "$shell_rc"
-		echo "# Browser-Use" >> "$shell_rc"
-		echo "export PATH=\"$bin_path:$local_bin:\$PATH\"" >> "$shell_rc"
-		log_success "Added to PATH in $shell_rc"
+		echo "# Browser-Use CLI wrappers" >> "$shell_rc"
+		echo "export PATH=\"$wrapper_dir:\$PATH\"" >> "$shell_rc"
+		log_success "Added ~/.local/bin to PATH in $shell_rc"
 	fi
 
-	# On Windows, also configure PowerShell profile
+	# On Windows, also configure via registry
 	if [ "$PLATFORM" = "windows" ]; then
-		configure_powershell_path
+		configure_powershell_wrappers
 	fi
 }
 
-configure_powershell_path() {
-	# Use PowerShell to modify user PATH in registry (no execution policy needed)
-	# This persists across sessions without requiring profile script execution
+configure_powershell_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
 
-	local scripts_path='\\.browser-use-env\\Scripts'
-	local local_bin='\\.local\\bin'
+	# Create .cmd wrappers for each CLI command
+	local commands="browser-use bu browseruse browser browser-use-tui"
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/${cmd}.cmd"
+			(
+				echo '@echo off'
+				echo "\"$(echo "$venv_bin/$cmd" | sed 's|/|\|g')\" %*"
+			) > "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
+		fi
+	done
 
-	# Check if already in user PATH
+	# Ensure wrapper dir is in user PATH via registry
+	local wrapper_win='\.local\bin'
 	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '\r')
 
-	if echo "$current_path" | grep -q "browser-use-env"; then
-		log_info "PATH already configured"
+	if echo "$current_path" | grep -q "\.local\\bin"; then
+		log_info "Wrapper directory already in PATH"
 		return 0
 	fi
 
-	# Append to user PATH via registry (safe, no truncation, no execution policy needed)
-	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$scripts_path;' + \$env:USERPROFILE + '$local_bin', 'User')" 2>/dev/null
+	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$wrapper_win', 'User')" 2>/dev/null
 
 	if [ $? -eq 0 ]; then
-		log_success "Added to Windows PATH: %USERPROFILE%\\.browser-use-env\\Scripts"
+		log_success "Added to Windows PATH: %USERPROFILE%\.local\bin"
 	else
 		log_warn "Could not update PATH automatically. Add manually:"
-		log_warn "  \$env:PATH += \";\$env:USERPROFILE\\.browser-use-env\\Scripts\""
+		log_warn "  \$env:PATH += \";\$env:USERPROFILE\.local\bin\""
 	fi
 }
-
 # =============================================================================
 # Validation
 # =============================================================================


### PR DESCRIPTION
## Description

Fixes issue #5033 where the CLI installer prepends the entire virtualenv bin directory (`$HOME/.browser-use-env/bin`) to the user's PATH, causing the venv's `python` and `python3` to shadow the user's system Python.

## Root Cause

The `configure_path()` function in both `install.sh` and `install_lite.sh` added this line to the user's shell rc:
```
export PATH="$HOME/.browser-use-env/bin:$HOME/.local/bin:$PATH"
```
This exposed every executable in the private environment, including `python`, `python3`, and other dependency-provided tools.

## Changes

Instead of adding the entire virtualenv bin directory to PATH, the installer now:

1. **Creates wrapper scripts** in `~/.local/bin` for each CLI entry point (`browser-use`, `bu`, `browseruse`, `browser`, `browser-use-tui`)
2. **Wrappers use `exec`** to invoke the real command from the virtualenv without exposing the venv's other executables
3. **Ensures `~/.local/bin` is on PATH** (it's a standard location for user CLI tools)
4. **Windows support**: Creates `.cmd` wrappers in `~/.local/bin` and adds that directory to the user PATH via registry instead of the venv's `Scripts` directory

Example wrapper (`~/.local/bin/browser-use`):
```sh
#!/bin/sh
exec "$HOME/.browser-use-env/bin/browser-use" "$@"
```

### Files changed:
- `browser_use/skill_cli/install.sh` — replaced `configure_path()` and `configure_powershell_path()` with wrapper-based approach
- `browser_use/skill_cli/install_lite.sh` — same change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop shadowing users’ Python by installing per-command wrappers in ~/.local/bin. Also fix argument passthrough, Windows .exe detection and path separator conversion in `.cmd` wrappers, tighten `ollama` options, and add clearer SDK agent warnings when no result.

- **Bug Fixes**
  - Installer: create wrappers for `browser-use`, `bu`, `browseruse`, `browser`, `browser-use-tui` in ~/.local/bin; fix "$@" passthrough; stop prepending the venv bin dir to PATH. On Windows, generate `.cmd` wrappers with correct `.exe` detection and path separator conversion, and add %USERPROFILE%\.local\bin to the user PATH via registry.
  - `ollama`: strip top-level API params (`format`, `stream`) from `ollama_options` (warn; pass as top-level args). Clearer JSON validation errors with hints for truncated output from vision models.
  - Agent SDK: warn when a run completes with no result and no error, with guidance for missing/invalid `BROWSER_USE_API_KEY` and model name issues.

- **Migration**
  - Open a new shell so ~/.local/bin takes effect; on Windows, restart the terminal.
  - Remove any line in your shell rc that adds $HOME/.browser-use-env/bin to PATH.

<sup>Written for commit b82ba267a4651ef2469336e5212b6849cd30b372. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

