### PR TITLE
Enhance README with Browser Use agent instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Python API -> Rust core -> Browser harness -> Web task done
 ```bash
 uv add "browser-use[core]"
 # or: pip install "browser-use[core]"
+browser
 ```
 
 The `[core]` extra installs the native Browser Use runtime for your platform.
@@ -72,6 +73,14 @@ BROWSER_USE_API_KEY=your-key
 ```
 
 **3. Run your first agent:**
+
+**Browser Use Terminal:** 
+```bash
+uv add "browser-use[core]"
+browser
+```
+
+**Python Script:**
 ```python
 from browser_use.beta import Agent, BrowserProfile, ChatBrowserUse
 # from browser_use.beta import ChatOpenAI  # ChatOpenAI(model='gpt-5.5')


### PR DESCRIPTION
Added instructions for running the Browser Use agent in the terminal and Python script.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added quick-start steps to the README for running the Browser Use agent from the terminal and in a Python script. Includes the `uv add "browser-use[core]"` install command, the `browser` CLI invocation, and a minimal Python example.

<sup>Written for commit bbb8a0ccc1098e191cc8874beb147e888256d83b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

