### PR TITLE
Reject MCP tool names that collide with existing actions

### DIFF
--- a/browser_use/mcp/client.py
+++ b/browser_use/mcp/client.py
@@ -226,7 +226,7 @@ class MCPClient:
 			await self.connect()
 
 		registry = tools.registry
-
+		pending_tools: list[tuple[str, types.Tool]] = []
 		for tool_name, tool in self._tools.items():
 			# Skip if not in filter
 			if tool_filter and tool_name not in tool_filter:
@@ -238,10 +238,27 @@ class MCPClient:
 			# Skip if already registered
 			if action_name in self._registered_actions:
 				continue
+			pending_tools.append((action_name, tool))
 
-			# Register the tool as an action
-			self._register_tool_as_action(registry, action_name, tool)
-			self._registered_actions.add(action_name)
+		collisions = sorted(action_name for action_name, _ in pending_tools if action_name in registry.registry.actions)
+		if collisions:
+			collision_names = ', '.join(collisions)
+			raise ValueError(
+				f'Action names already registered: {collision_names}. '
+				'Use an MCP tool prefix or filter to avoid overriding existing actions.'
+			)
+
+		registered_now: list[str] = []
+		try:
+			for action_name, tool in pending_tools:
+				self._register_tool_as_action(registry, action_name, tool)
+				self._registered_actions.add(action_name)
+				registered_now.append(action_name)
+		except Exception:
+			for action_name in registered_now:
+				registry.registry.actions.pop(action_name, None)
+				self._registered_actions.discard(action_name)
+			raise
 
 		logger.info(f"✅ Registered {len(self._registered_actions)} MCP tools from '{self.server_name}' as browser-use actions")
 
@@ -253,6 +270,12 @@ class MCPClient:
 			action_name: Name for the registered action
 			tool: MCP Tool object with schema information
 		"""
+		if action_name in registry.registry.actions:
+			raise ValueError(
+				f"Action name '{action_name}' is already registered. "
+				'Use an MCP tool prefix or filter to avoid overriding existing actions.'
+			)
+
 		# Parse tool parameters to create Pydantic model
 		param_fields = {}
 

--- a/browser_use/mcp/controller.py
+++ b/browser_use/mcp/controller.py
@@ -62,22 +62,26 @@ class MCPToolWrapper:
 		async with stdio_client(server_params) as (read, write):
 			async with ClientSession(read, write) as session:
 				self.session = session
+				previous_tools = self._tools
+				try:
+					# Initialize the connection
+					await session.initialize()
 
-				# Initialize the connection
-				await session.initialize()
+					# Discover available tools
+					tools_response = await session.list_tools()
+					self._tools = {tool.name: tool for tool in tools_response.tools}
 
-				# Discover available tools
-				tools_response = await session.list_tools()
-				self._tools = {tool.name: tool for tool in tools_response.tools}
+					logger.info(f'📦 Discovered {len(self._tools)} MCP tools: {list(self._tools.keys())}')
 
-				logger.info(f'📦 Discovered {len(self._tools)} MCP tools: {list(self._tools.keys())}')
+					self._register_discovered_tools()
 
-				# Register all discovered tools as actions
-				for tool_name, tool in self._tools.items():
-					self._register_tool_as_action(tool_name, tool)
-
-				# Keep session alive while tools are being used
-				await self._keep_session_alive()
+					# Keep session alive while tools are being used
+					await self._keep_session_alive()
+				except Exception:
+					self._tools = previous_tools
+					raise
+				finally:
+					self.session = None
 
 	async def _keep_session_alive(self):
 		"""Keep the MCP session alive."""
@@ -88,6 +92,30 @@ class MCPToolWrapper:
 		except asyncio.CancelledError:
 			pass
 
+	def _register_discovered_tools(self) -> None:
+		"""Register the discovered MCP tools as one atomic batch."""
+		pending_tools = [
+			(tool_name, tool) for tool_name, tool in self._tools.items() if tool_name not in self._registered_actions
+		]
+		collisions = sorted(tool_name for tool_name, _ in pending_tools if tool_name in self.registry.registry.actions)
+		if collisions:
+			collision_names = ', '.join(collisions)
+			raise ValueError(
+				f'Action names already registered: {collision_names}. '
+				'Use an MCP tool prefix or filter to avoid overriding existing actions.'
+			)
+
+		registered_now: list[str] = []
+		try:
+			for tool_name, tool in pending_tools:
+				self._register_tool_as_action(tool_name, tool)
+				registered_now.append(tool_name)
+		except Exception:
+			for tool_name in registered_now:
+				self.registry.registry.actions.pop(tool_name, None)
+				self._registered_actions.discard(tool_name)
+			raise
+
 	def _register_tool_as_action(self, tool_name: str, tool: Tool):
 		"""Register an MCP tool as a browser-use action.
 
@@ -97,6 +125,11 @@ class MCPToolWrapper:
 		"""
 		if tool_name in self._registered_actions:
 			return  # Already registered
+		if tool_name in self.registry.registry.actions:
+			raise ValueError(
+				f"Action name '{tool_name}' is already registered. "
+				'Use an MCP tool prefix or filter to avoid overriding existing actions.'
+			)
 
 		# Parse tool parameters to create Pydantic model
 		param_fields = {}

--- a/tests/ci/security/test_mcp_action_name_collision.py
+++ b/tests/ci/security/test_mcp_action_name_collision.py
@@ -1,0 +1,135 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from browser_use.agent.views import ActionResult
+from browser_use.mcp.client import MCPClient
+from browser_use.mcp.controller import MCPToolWrapper
+from browser_use.tools.registry.service import Registry
+
+
+def make_tool(name: str) -> Any:
+	return SimpleNamespace(name=name, description=f'External MCP {name}', inputSchema={})
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_cannot_override_existing_action_name() -> None:
+	registry = Registry()
+
+	@registry.action('Native click action')
+	async def click() -> ActionResult:
+		return ActionResult(extracted_content='native click')
+
+	client = MCPClient(server_name='external', command='python')
+
+	with pytest.raises(ValueError, match='already registered'):
+		client._register_tool_as_action(registry, 'click', make_tool('click'))
+
+	result = await registry.execute_action('click', {})
+	assert result.extracted_content == 'native click'
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_wrapper_cannot_override_existing_action_name() -> None:
+	registry = Registry()
+
+	@registry.action('Native click action')
+	async def click() -> ActionResult:
+		return ActionResult(extracted_content='native click')
+
+	wrapper = MCPToolWrapper(registry=registry, mcp_command='python')
+
+	with pytest.raises(ValueError, match='already registered'):
+		wrapper._register_tool_as_action('click', make_tool('click'))
+
+	result = await registry.execute_action('click', {})
+	assert result.extracted_content == 'native click'
+
+
+def test_mcp_tool_wrapper_preflights_collisions_before_registering() -> None:
+	registry = Registry()
+
+	@registry.action('Native click action')
+	async def click() -> ActionResult:
+		return ActionResult(extracted_content='native click')
+
+	wrapper = MCPToolWrapper(registry=registry, mcp_command='python')
+	wrapper._tools = {'new_tool': make_tool('new_tool'), 'click': make_tool('click')}
+
+	with pytest.raises(ValueError, match='already registered'):
+		wrapper._register_discovered_tools()
+
+	assert 'new_tool' not in registry.registry.actions
+	assert wrapper._registered_actions == set()
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_wrapper_restores_state_and_can_reconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+	from browser_use.mcp import controller as controller_module
+
+	registry = Registry()
+
+	@registry.action('Native click action')
+	async def click() -> ActionResult:
+		return ActionResult(extracted_content='native click')
+
+	tool_sets = [[make_tool('new_tool'), make_tool('click')], [make_tool('new_tool')]]
+	connection_count = 0
+
+	class StdioContext:
+		async def __aenter__(self) -> tuple[object, object]:
+			return object(), object()
+
+		async def __aexit__(self, *args: object) -> None:
+			return None
+
+	class FakeSession:
+		def __init__(self, *args: object) -> None:
+			pass
+
+		async def __aenter__(self) -> 'FakeSession':
+			return self
+
+		async def __aexit__(self, *args: object) -> None:
+			return None
+
+		async def initialize(self) -> None:
+			return None
+
+		async def list_tools(self) -> SimpleNamespace:
+			nonlocal connection_count
+			tools = tool_sets[connection_count]
+			connection_count += 1
+			return SimpleNamespace(tools=tools)
+
+	async def keep_session_alive() -> None:
+		return None
+
+	monkeypatch.setattr(controller_module, 'stdio_client', lambda params: StdioContext())
+	monkeypatch.setattr(controller_module, 'ClientSession', FakeSession)
+
+	wrapper = MCPToolWrapper(registry=registry, mcp_command='python')
+	monkeypatch.setattr(wrapper, '_keep_session_alive', keep_session_alive)
+
+	def register_tool_as_action(tool_name: str, tool: Any) -> None:
+		registry.registry.actions[tool_name] = tool
+		wrapper._registered_actions.add(tool_name)
+
+	monkeypatch.setattr(wrapper, '_register_tool_as_action', register_tool_as_action)
+
+	with pytest.raises(ValueError, match='already registered'):
+		await wrapper.connect()
+
+	assert wrapper.session is None
+	assert wrapper._tools == {}
+	assert 'new_tool' not in registry.registry.actions
+	assert wrapper._registered_actions == set()
+
+	await wrapper.connect()
+
+	assert connection_count == 2
+	assert wrapper.session is None
+	assert set(wrapper._tools) == {'new_tool'}
+	assert wrapper._registered_actions == {'new_tool'}
+	assert 'new_tool' in registry.registry.actions


### PR DESCRIPTION
## Summary

- Preflight the complete MCP tool batch before registering any action.
- Reject names already owned by the target registry in both MCP registration paths.
- Roll back actions registered during the current batch if a later registration fails.
- Restore `MCPToolWrapper` tool and session state after a failed connection so a later connection can retry cleanly.

## Details

MCP tools are exposed through the browser-use action registry. Registration previously happened one tool at a time, so detecting a collision partway through discovery could leave earlier MCP actions in the shared registry. The failed wrapper also retained its session reference, causing later `connect()` calls to return without reconnecting.

The registration paths now build and validate the full pending set before changing the registry. They also remove actions added by the current batch if an unexpected registration error occurs. The wrapper restores its prior discovered-tool state and always clears the session reference when the connection context exits.

## Tests

- `uv run pytest -q tests/ci/security/test_mcp_action_name_collision.py` (4 passed)
- `uv run pytest -q tests/ci/security/test_mcp_allowed_domains.py tests/ci/security/test_mcp_action_name_collision.py` (7 passed)
- `uv run pytest -q tests/ci/infrastructure/test_registry_core.py` (17 passed)
- `uv run pre-commit run --files browser_use/mcp/client.py browser_use/mcp/controller.py tests/ci/security/test_mcp_action_name_collision.py`
- `git diff --check`