### PR TITLE
fix: preserve empty accessibility names

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -848,7 +848,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -876,7 +876,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_ax_name_matching.py
+++ b/tests/ci/test_ax_name_matching.py
@@ -14,8 +14,59 @@ from unittest.mock import AsyncMock
 from browser_use.agent.service import Agent
 from browser_use.agent.views import ActionResult, AgentHistory, AgentHistoryList, RerunSummaryAction, StepMetadata
 from browser_use.browser.views import BrowserStateHistory
-from browser_use.dom.views import DOMInteractedElement, DOMRect, MatchLevel, NodeType
+from browser_use.dom.views import DOMInteractedElement, DOMRect, EnhancedAXNode, EnhancedDOMTreeNode, MatchLevel, NodeType
 from tests.ci.conftest import create_mock_llm
+
+
+def _make_ax_name_node(ax_name: str | None) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={'role': 'button'},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=EnhancedAXNode(
+			ax_node_id='ax-1',
+			ignored=False,
+			role='button',
+			name=ax_name,
+			description=None,
+			properties=None,
+			child_ids=None,
+		),
+		snapshot_node=None,
+	)
+
+
+def test_empty_ax_name_is_preserved_in_interacted_elements():
+	empty_name_node = _make_ax_name_node('')
+	missing_name_node = _make_ax_name_node(None)
+
+	empty_interacted = DOMInteractedElement.load_from_enhanced_dom_tree(empty_name_node)
+	missing_interacted = DOMInteractedElement.load_from_enhanced_dom_tree(missing_name_node)
+
+	assert empty_interacted.ax_name == ''
+	assert missing_interacted.ax_name is None
+
+
+def test_empty_ax_name_participates_in_element_hashes():
+	empty_name_node = _make_ax_name_node('')
+	missing_name_node = _make_ax_name_node(None)
+
+	assert hash(empty_name_node) != hash(missing_name_node)
+	assert empty_name_node.compute_stable_hash() != missing_name_node.compute_stable_hash()
 
 
 async def test_ax_name_matching_succeeds_when_hash_fails(httpserver):


### PR DESCRIPTION
Fixes #5041.

## Summary

- preserve AX node names when CDP reports the accessible name as an empty string
- include an explicit empty AX name in both regular and stable element hashes
- add a regression test that keeps `ax_name=""` distinct from a missing AX name

## To verify

- `uv run pytest tests\ci\test_ax_name_matching.py -q`
- `uv run python -m py_compile browser_use\dom\views.py tests\ci\test_ax_name_matching.py`
- `uv run ruff check browser_use\dom\views.py tests\ci\test_ax_name_matching.py`
- `uvx --python 3.11 pre-commit run --files browser_use\dom\views.py tests\ci\test_ax_name_matching.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves empty accessibility names from CDP and uses them in element hashing and interacted-element construction. Prevents collisions where ax_name="" was treated as missing, improving element matching accuracy.

- **Bug Fixes**
  - Treat empty `ax_node.name` as valid; include `ax_name=""` in both stable and runtime hashes and when building `DOMInteractedElement`.
  - Add regression tests for interacted elements and both hashes to keep empty vs missing AX names distinct.

<sup>Written for commit 04a8ec6f6e38c279ec8e5ace7691f2dd0d166385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

