### PR TITLE
fix: parse Groq tool call structured output

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -170,17 +170,27 @@ class ChatGroq(BaseChatModel):
 
 		if self.model in ToolCallingModels:
 			response = await self._invoke_with_tool_calling(groq_messages, output_format, schema)
+			message = response.choices[0].message
+			if not message.tool_calls:
+				raise ModelProviderError(
+					message='No tool calls in response',
+					status_code=500,
+					model=self.name,
+				)
+			raw_args = message.tool_calls[0].function.arguments
+			if isinstance(raw_args, str):
+				parsed_response = output_format.model_validate_json(raw_args)
+			else:
+				parsed_response = output_format.model_validate(raw_args)
 		else:
 			response = await self._invoke_with_json_schema(groq_messages, output_format, schema)
-
-		if not response.choices[0].message.content:
-			raise ModelProviderError(
-				message='No content in response',
-				status_code=500,
-				model=self.name,
-			)
-
-		parsed_response = output_format.model_validate_json(response.choices[0].message.content)
+			if not response.choices[0].message.content:
+				raise ModelProviderError(
+					message='No content in response',
+					status_code=500,
+					model=self.name,
+				)
+			parsed_response = output_format.model_validate_json(response.choices[0].message.content)
 		usage = self._get_usage(response)
 
 		return ChatInvokeCompletion(

--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -178,6 +178,12 @@ class ChatGroq(BaseChatModel):
 					model=self.name,
 				)
 			raw_args = message.tool_calls[0].function.arguments
+			if raw_args is None:
+				raise ModelProviderError(
+					message='No tool call arguments in response',
+					status_code=500,
+					model=self.name,
+				)
 			if isinstance(raw_args, str):
 				parsed_response = output_format.model_validate_json(raw_args)
 			else:

--- a/tests/ci/models/test_llm_groq.py
+++ b/tests/ci/models/test_llm_groq.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.groq.chat import ChatGroq
+
+
+class GroqStructuredAnswer(BaseModel):
+	answer: str
+
+
+@pytest.mark.asyncio
+async def test_groq_tool_calling_structured_output_reads_function_arguments(monkeypatch):
+	chat = ChatGroq(model='moonshotai/kimi-k2-instruct')
+
+	async def fake_tool_calling(groq_messages, output_format, schema):
+		return SimpleNamespace(
+			usage=None,
+			choices=[
+				SimpleNamespace(
+					message=SimpleNamespace(
+						content=None,
+						tool_calls=[
+							SimpleNamespace(function=SimpleNamespace(arguments='{"answer": "ok"}')),
+						],
+					)
+				)
+			],
+		)
+
+	monkeypatch.setattr(chat, '_invoke_with_tool_calling', fake_tool_calling)
+
+	result = await chat._invoke_structured_output([], GroqStructuredAnswer)
+
+	assert result.completion == GroqStructuredAnswer(answer='ok')
+	assert result.usage is None
+
+
+@pytest.mark.asyncio
+async def test_groq_tool_calling_structured_output_requires_tool_calls(monkeypatch):
+	chat = ChatGroq(model='moonshotai/kimi-k2-instruct')
+
+	async def fake_tool_calling(groq_messages, output_format, schema):
+		return SimpleNamespace(
+			usage=None,
+			choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[]))],
+		)
+
+	monkeypatch.setattr(chat, '_invoke_with_tool_calling', fake_tool_calling)
+
+	with pytest.raises(ModelProviderError, match='No tool calls in response'):
+		await chat._invoke_structured_output([], GroqStructuredAnswer)

--- a/tests/ci/models/test_llm_groq.py
+++ b/tests/ci/models/test_llm_groq.py
@@ -39,6 +39,33 @@ async def test_groq_tool_calling_structured_output_reads_function_arguments(monk
 
 
 @pytest.mark.asyncio
+async def test_groq_tool_calling_structured_output_accepts_dict_arguments(monkeypatch):
+	chat = ChatGroq(model='moonshotai/kimi-k2-instruct')
+
+	async def fake_tool_calling(groq_messages, output_format, schema):
+		return SimpleNamespace(
+			usage=None,
+			choices=[
+				SimpleNamespace(
+					message=SimpleNamespace(
+						content=None,
+						tool_calls=[
+							SimpleNamespace(function=SimpleNamespace(arguments={'answer': 'ok'})),
+						],
+					)
+				)
+			],
+		)
+
+	monkeypatch.setattr(chat, '_invoke_with_tool_calling', fake_tool_calling)
+
+	result = await chat._invoke_structured_output([], GroqStructuredAnswer)
+
+	assert result.completion == GroqStructuredAnswer(answer='ok')
+	assert result.usage is None
+
+
+@pytest.mark.asyncio
 async def test_groq_tool_calling_structured_output_requires_tool_calls(monkeypatch):
 	chat = ChatGroq(model='moonshotai/kimi-k2-instruct')
 
@@ -51,4 +78,29 @@ async def test_groq_tool_calling_structured_output_requires_tool_calls(monkeypat
 	monkeypatch.setattr(chat, '_invoke_with_tool_calling', fake_tool_calling)
 
 	with pytest.raises(ModelProviderError, match='No tool calls in response'):
+		await chat._invoke_structured_output([], GroqStructuredAnswer)
+
+
+@pytest.mark.asyncio
+async def test_groq_tool_calling_structured_output_requires_tool_call_arguments(monkeypatch):
+	chat = ChatGroq(model='moonshotai/kimi-k2-instruct')
+
+	async def fake_tool_calling(groq_messages, output_format, schema):
+		return SimpleNamespace(
+			usage=None,
+			choices=[
+				SimpleNamespace(
+					message=SimpleNamespace(
+						content=None,
+						tool_calls=[
+							SimpleNamespace(function=SimpleNamespace(arguments=None)),
+						],
+					)
+				)
+			],
+		)
+
+	monkeypatch.setattr(chat, '_invoke_with_tool_calling', fake_tool_calling)
+
+	with pytest.raises(ModelProviderError, match='No tool call arguments in response'):
 		await chat._invoke_structured_output([], GroqStructuredAnswer)


### PR DESCRIPTION
## Summary

- parse structured Groq responses from tool call function arguments when the tool-calling path is used
- keep the JSON-schema response path reading and validating message content
- add unit coverage for content-less tool-call responses and missing tool calls

Fixes #4945.

## Root cause

Tool-calling responses can return `message.content = None` while placing the structured payload in `message.tool_calls[0].function.arguments`. The structured-output path was validating `message.content` after both response paths, so valid tool-call responses were rejected as empty.

## Validation

- `uv run pytest tests/ci/models/test_llm_groq.py`
- `uv run ruff format --check browser_use/llm/groq/chat.py tests/ci/models/test_llm_groq.py`
- `uv run ruff check browser_use/llm/groq/chat.py tests/ci/models/test_llm_groq.py`
- `uv run pyright browser_use/llm/groq/chat.py tests/ci/models/test_llm_groq.py`
- `uv run pre-commit run --files browser_use/llm/groq/chat.py tests/ci/models/test_llm_groq.py`
- `git diff --check`
