### PR TITLE
Expose video recording path in agent history

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2687,6 +2687,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			# to match backend requirements for CREATE events to be fired when entities are created,
 			# not when they are completed
 
+			await self._finalize_video_recording_path()
+
 			# Emit UpdateAgentTaskEvent at the END of run() with final task state
 			self.eventbus.dispatch(UpdateAgentTaskEvent.from_agent(self))
 
@@ -3955,6 +3957,24 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 	@property
 	def message_manager(self) -> MessageManager:
 		return self._message_manager
+
+	async def _finalize_video_recording_path(self) -> None:
+		"""Finalize any run-scoped recording and expose its saved path on history."""
+		if self.browser_session is None or self.browser_session.browser_profile.keep_alive:
+			return
+
+		watchdog = getattr(self.browser_session, '_recording_watchdog', None)
+		if watchdog is None or not getattr(watchdog, 'is_recording', False):
+			return
+
+		try:
+			saved = await watchdog.stop_recording()
+		except Exception as e:
+			self.logger.warning(f'Error finalizing video recording: {e}')
+			return
+
+		if saved is not None:
+			self.history.video_recording_path = str(saved)
 
 	async def close(self):
 		"""Close all resources"""

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -597,6 +597,10 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	history: list[AgentHistory]
 	usage: UsageSummary | None = None
+	video_recording_path: str | None = Field(
+		default=None,
+		description='Path to the run-level video recording, if recording was enabled and finalized before the browser closed.',
+	)
 
 	_output_model_schema: type[AgentStructuredOutput] | None = None
 
@@ -668,9 +672,12 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def model_dump(self, **kwargs) -> dict[str, Any]:
 		"""Custom serialization that properly uses AgentHistory's model_dump"""
-		return {
+		data: dict[str, Any] = {
 			'history': [h.model_dump(**kwargs) for h in self.history],
 		}
+		if self.video_recording_path:
+			data['video_recording_path'] = self.video_recording_path
+		return data
 
 	@classmethod
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:

--- a/tests/ci/test_agent_video_recording_path.py
+++ b/tests/ci/test_agent_video_recording_path.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from browser_use.agent.service import Agent
+from browser_use.agent.views import AgentHistoryList, AgentOutput
+
+
+class RecordingWatchdogShouldNotBeCalled:
+	is_recording = True
+
+	async def stop_recording(self) -> Path:
+		raise AssertionError('stop_recording should not be called')
+
+
+def test_agent_history_list_serializes_video_recording_path():
+	history = AgentHistoryList(history=[], video_recording_path='/tmp/session.mp4')
+
+	data = history.model_dump()
+
+	assert data['video_recording_path'] == '/tmp/session.mp4'
+	assert AgentHistoryList.load_from_dict(data, AgentOutput).video_recording_path == '/tmp/session.mp4'
+
+
+def test_agent_history_list_omits_empty_video_recording_path():
+	assert AgentHistoryList(history=[]).model_dump() == {'history': []}
+
+
+@pytest.mark.asyncio
+async def test_finalize_video_recording_path_skips_missing_browser_session():
+	agent = cast(Any, object.__new__(Agent))
+	agent.history = AgentHistoryList(history=[])
+	agent.browser_session = None
+
+	await Agent._finalize_video_recording_path(agent)
+
+	assert agent.history.video_recording_path is None
+
+
+@pytest.mark.asyncio
+async def test_finalize_video_recording_path_updates_history():
+	class FakeWatchdog:
+		is_recording = True
+
+		async def stop_recording(self) -> Path:
+			return Path('/tmp/session.mp4')
+
+	agent = cast(Any, object.__new__(Agent))
+	agent.history = AgentHistoryList(history=[])
+	agent.browser_session = SimpleNamespace(
+		id='browser-session',
+		browser_profile=SimpleNamespace(keep_alive=False),
+		_recording_watchdog=FakeWatchdog(),
+	)
+
+	await Agent._finalize_video_recording_path(agent)
+
+	assert agent.history.video_recording_path == '/tmp/session.mp4'
+
+
+@pytest.mark.asyncio
+async def test_finalize_video_recording_path_skips_keep_alive_sessions():
+	agent = cast(Any, object.__new__(Agent))
+	agent.history = AgentHistoryList(history=[])
+	agent.browser_session = SimpleNamespace(
+		id='browser-session',
+		agent_focus_target_id=None,
+		browser_profile=SimpleNamespace(keep_alive=True),
+		_recording_watchdog=RecordingWatchdogShouldNotBeCalled(),
+	)
+
+	await Agent._finalize_video_recording_path(agent)
+
+	assert agent.history.video_recording_path is None
+
+
+@pytest.mark.asyncio
+async def test_finalize_video_recording_path_skips_missing_watchdog():
+	agent = cast(Any, object.__new__(Agent))
+	agent.history = AgentHistoryList(history=[])
+	agent.browser_session = SimpleNamespace(
+		id='browser-session',
+		agent_focus_target_id=None,
+		browser_profile=SimpleNamespace(keep_alive=False),
+	)
+
+	await Agent._finalize_video_recording_path(agent)
+
+	assert agent.history.video_recording_path is None
+
+
+@pytest.mark.asyncio
+async def test_finalize_video_recording_path_skips_inactive_watchdog():
+	class InactiveWatchdog:
+		is_recording = False
+
+		async def stop_recording(self) -> Path:
+			raise AssertionError('stop_recording should not be called')
+
+	agent = cast(Any, object.__new__(Agent))
+	agent.history = AgentHistoryList(history=[])
+	agent.browser_session = SimpleNamespace(
+		id='browser-session',
+		agent_focus_target_id=None,
+		browser_profile=SimpleNamespace(keep_alive=False),
+		_recording_watchdog=InactiveWatchdog(),
+	)
+
+	await Agent._finalize_video_recording_path(agent)
+
+	assert agent.history.video_recording_path is None
+
+
+@pytest.mark.asyncio
+async def test_finalize_video_recording_path_swallows_stop_errors():
+	class FailingWatchdog:
+		is_recording = True
+
+		async def stop_recording(self) -> Path:
+			raise RuntimeError('no encoder')
+
+	agent = cast(Any, object.__new__(Agent))
+	agent.history = AgentHistoryList(history=[])
+	agent.browser_session = SimpleNamespace(
+		id='browser-session',
+		agent_focus_target_id=None,
+		browser_profile=SimpleNamespace(keep_alive=False),
+		_recording_watchdog=FailingWatchdog(),
+	)
+
+	await Agent._finalize_video_recording_path(agent)
+
+	assert agent.history.video_recording_path is None


### PR DESCRIPTION
## Summary
- add an optional `video_recording_path` field to `AgentHistoryList`
- finalize active run-scoped recordings before agent teardown and store the saved path on the returned history
- cover serialization and cleanup edge cases for missing/inactive recorders, `keep_alive`, and recorder failures

Fixes #4623.

## Validation
- `uv run pytest -q tests/ci/test_agent_video_recording_path.py`
- `uv run pytest -q tests/ci/test_action_record.py` (skipped locally because the optional video extra is unavailable)
- `uv run ruff check browser_use/agent/views.py browser_use/agent/service.py tests/ci/test_agent_video_recording_path.py`
- `uv run ruff format --check browser_use/agent/views.py browser_use/agent/service.py tests/ci/test_agent_video_recording_path.py`
- `uv run pyright browser_use/agent/views.py browser_use/agent/service.py tests/ci/test_agent_video_recording_path.py`
- `uv run pre-commit run --files browser_use/agent/views.py browser_use/agent/service.py tests/ci/test_agent_video_recording_path.py`
