### PR TITLE
Fix image-only clickable DOM context

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -880,6 +880,52 @@ class DOMTreeSerializer:
 		return False
 
 	@staticmethod
+	def _get_child_image_context(node: SimplifiedNode) -> str:
+		"""Extract compact context from image descendants of an interactive element."""
+
+		image_context: list[str] = []
+
+		def normalize_src(src: str) -> str:
+			clean_src = src.strip()
+			if clean_src.lower().startswith('data:'):
+				return ''
+			path_without_query = clean_src.split('?', 1)[0].split('#', 1)[0].rstrip('/')
+			return path_without_query.rsplit('/', 1)[-1] or clean_src
+
+		def collect(current: SimplifiedNode) -> None:
+			if len(image_context) >= 3:
+				return
+
+			original_node = current.original_node
+			if original_node.node_type == NodeType.ELEMENT_NODE and original_node.tag_name == 'img':
+				attributes = original_node.attributes or {}
+				parts = []
+
+				for attr_name, output_name in (
+					('alt', 'image_alt'),
+					('title', 'image_title'),
+					('aria-label', 'image_label'),
+				):
+					attr_value = attributes.get(attr_name, '').strip()
+					if attr_value:
+						parts.append(f'{output_name}={cap_text_length(attr_value, 100)}')
+
+				src = normalize_src(attributes.get('src', ''))
+				if src:
+					parts.append(f'image_src={cap_text_length(src, 100)}')
+
+				if parts:
+					image_context.append(' '.join(parts))
+
+			for child in current.children:
+				collect(child)
+
+		for child in node.children:
+			collect(child)
+
+		return ' '.join(image_context)
+
+	@staticmethod
 	def serialize_tree(node: SimplifiedNode | None, include_attributes: list[str], depth: int = 0) -> str:
 		"""Serialize the optimized tree to string format."""
 		if not node:
@@ -949,6 +995,13 @@ class DOMTreeSerializer:
 				attributes_html_str = DOMTreeSerializer._build_attributes_string(
 					node.original_node, include_attributes, text_content
 				)
+				if node.is_interactive:
+					image_context = DOMTreeSerializer._get_child_image_context(node)
+					if image_context:
+						if attributes_html_str:
+							attributes_html_str += f' {image_context}'
+						else:
+							attributes_html_str = image_context
 
 				# Add compound component information to attributes if present
 				if node.original_node._compound_children:

--- a/tests/ci/test_image_only_dom_representation.py
+++ b/tests/ci/test_image_only_dom_representation.py
@@ -1,0 +1,80 @@
+from browser_use.dom.serializer.serializer import DOMTreeSerializer
+from browser_use.dom.views import (
+	DEFAULT_INCLUDE_ATTRIBUTES,
+	DOMRect,
+	EnhancedDOMTreeNode,
+	EnhancedSnapshotNode,
+	NodeType,
+	SimplifiedNode,
+)
+
+
+def _make_element_node(
+	backend_node_id: int,
+	tag_name: str,
+	attributes: dict[str, str],
+	x: float,
+	y: float,
+	width: float = 64,
+	height: float = 64,
+	parent: EnhancedDOMTreeNode | None = None,
+) -> EnhancedDOMTreeNode:
+	bounds = DOMRect(x=x, y=y, width=width, height=height)
+	return EnhancedDOMTreeNode(
+		node_id=backend_node_id,
+		backend_node_id=backend_node_id,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name=tag_name.upper(),
+		node_value='',
+		attributes=attributes,
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=bounds,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=parent,
+		children_nodes=None,
+		ax_node=None,
+		snapshot_node=EnhancedSnapshotNode(
+			is_clickable=tag_name in {'a', 'button'},
+			cursor_style='pointer' if tag_name in {'a', 'button'} else None,
+			bounds=bounds,
+			clientRects=bounds,
+			scrollRects=None,
+			computed_styles=None,
+			paint_order=None,
+			stacking_contexts=None,
+		),
+	)
+
+
+def test_image_only_interactive_parent_includes_child_image_context_in_llm_dom():
+	"""Image-only clickable cards should expose child image context so the LLM can tell options apart."""
+	link = _make_element_node(201, 'a', {'href': '/select-payment-method'}, x=10, y=10, width=80, height=80)
+	image = _make_element_node(
+		202,
+		'img',
+		{'src': 'https://cdn.example.test/logos/acme-bank-primary-card.png'},
+		x=18,
+		y=18,
+		width=64,
+		height=64,
+		parent=link,
+	)
+	link.children_nodes = [image]
+
+	llm_dom = DOMTreeSerializer.serialize_tree(
+		SimplifiedNode(
+			original_node=link,
+			children=[SimplifiedNode(original_node=image, children=[])],
+			is_interactive=True,
+		),
+		DEFAULT_INCLUDE_ATTRIBUTES,
+	)
+
+	assert '[201]<a' in llm_dom
+	assert 'acme-bank-primary-card.png' in llm_dom


### PR DESCRIPTION
## Summary

Fixes #4312 by preserving compact image context for image-only clickable elements.

When a clickable parent like `<a>` or `<button>` wraps only a logo/image, the DOM serializer currently emits the clickable parent but drops the non-interactive child `<img>` context. That leaves the LLM with several indistinguishable clickable options. This PR adds bounded child image context to the interactive element line, for example `image_src=acme-bank-primary-card.png`.

This complements #4315, which addressed overlapping highlight badges. This change fixes the text DOM representation path so the model has a semantic-ish anchor even when overlays are not enough.

## Implementation notes

- Extracts `alt`, `title`, `aria-label`, and a query-stripped `src` basename from image descendants of interactive elements.
- Ignores data URLs to avoid dumping large inline image payloads into the prompt.
- Limits extraction to 3 descendant images and caps values with existing `cap_text_length`.
- Keeps the context attached to the clickable parent, so the LLM can choose the actual click target.

## Tests

- `uv run pytest -q tests/ci/test_image_only_dom_representation.py::test_image_only_interactive_parent_includes_child_image_context_in_llm_dom` (red before fix, green after)
- `uv run pytest -q tests/ci/test_image_only_dom_representation.py tests/ci/security/test_sensitive_data.py::test_text_input_value_preserved tests/ci/security/test_sensitive_data.py::test_password_field_value_excluded_from_dom_snapshot`
- `uv run ruff check browser_use/dom/serializer/serializer.py tests/ci/test_image_only_dom_representation.py`
- `uv run ruff format --check browser_use/dom/serializer/serializer.py tests/ci/test_image_only_dom_representation.py`
- `uv run pyright browser_use/dom/serializer/serializer.py tests/ci/test_image_only_dom_representation.py`
- `uv run pre-commit run --files browser_use/dom/serializer/serializer.py tests/ci/test_image_only_dom_representation.py`

## Review

Local autoreview: clean, no blocking findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ambiguous DOM for image-only clickable elements by adding compact child image context to the interactive parent. This helps the model tell similar links/buttons apart (e.g., logo-only cards).

- **Bug Fixes**
  - Serialize image context from interactive descendants: `alt`, `title`, `aria-label`, and query-stripped `src` basename.
  - Ignore data URLs, limit to 3 images, and cap field lengths.
  - Attach the context to the clickable parent line for reliable target selection.
  - Added coverage in `tests/ci/test_image_only_dom_representation.py`.

<sup>Written for commit 23684a9e5757540dcf09fae06f630f28e58e7b87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

