### PR TITLE
fix: preserve remote keep-alive sessions on agent close

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3965,8 +3965,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					# Kill the browser session - this dispatches BrowserStopEvent,
 					# stops the EventBus with clear=True, and recreates a fresh EventBus
 					await self.browser_session.kill()
-				else:
-					# keep_alive=True sessions shouldn't keep the event loop alive after agent.run()
+				elif self.browser_session.is_local:
+					# Local keep_alive=True sessions shouldn't keep the event loop alive after agent.run().
+					# Remote keep-alive sessions keep their event bus running for reuse.
 					await self.browser_session.event_bus.stop(
 						clear=False,
 						timeout=_get_timeout('TIMEOUT_BrowserSessionEventBusStopOnAgentClose', 1.0),

--- a/tests/ci/test_agent_close_keep_alive.py
+++ b/tests/ci/test_agent_close_keep_alive.py
@@ -1,0 +1,56 @@
+"""Regression tests for Agent.close() keep-alive browser cleanup."""
+
+from typing import Any, cast
+
+from browser_use import Agent
+from browser_use.browser import BrowserProfile, BrowserSession
+
+
+def _make_session(*, keep_alive: bool, is_local: bool, cdp_url: str | None = None) -> tuple[BrowserSession, Any]:
+	session = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=keep_alive,
+			is_local=is_local,
+			cdp_url=cdp_url,
+		),
+		cdp_url=cdp_url,
+	)
+	event_bus = cast(Any, session.event_bus)
+	event_bus._on_idle = object()
+	return session, event_bus
+
+
+async def test_agent_close_preserves_remote_keep_alive_event_bus(mock_llm):
+	session, event_bus = _make_session(keep_alive=True, is_local=False, cdp_url='ws://browser.example/devtools/browser/1')
+	original_event_bus = session.event_bus
+	original_queue = event_bus.event_queue
+	original_on_idle = event_bus._on_idle
+	agent = Agent(task='keep remote browser alive', llm=mock_llm, browser_session=session)
+
+	await agent.close()
+
+	assert session.event_bus is original_event_bus
+	assert event_bus.event_queue is original_queue
+	assert event_bus._on_idle is original_on_idle
+
+
+async def test_agent_close_still_cleans_local_keep_alive_event_bus(mock_llm):
+	session, event_bus = _make_session(keep_alive=True, is_local=True)
+	agent = Agent(task='keep local browser alive', llm=mock_llm, browser_session=session)
+
+	await agent.close()
+
+	assert event_bus.event_queue is None
+	assert event_bus._on_idle is None
+
+
+async def test_agent_close_kills_non_keep_alive_browser_session(mock_llm):
+	session, event_bus = _make_session(keep_alive=False, is_local=False, cdp_url='ws://browser.example/devtools/browser/1')
+	original_event_bus = session.event_bus
+	agent = Agent(task='close browser session', llm=mock_llm, browser_session=session)
+
+	await agent.close()
+
+	assert session.event_bus is not original_event_bus


### PR DESCRIPTION
## Summary

Fixes #4374.

`Agent.close()` now leaves the event bus intact for remote `keep_alive=True` browser sessions instead of stopping it and clearing its queue/idle handler. Local keep-alive sessions keep the existing cleanup behavior, and non-keep-alive sessions still go through `BrowserSession.kill()`.

## Why

Remote CDP sessions use the WebSocket/event-bus path as the live connection to the browser. Clearing that event bus during `Agent.close()` can drop CDP handlers and force an avoidable reconnect cycle, which is the opposite of what `keep_alive=True` is meant to preserve.

## Validation

- `uv run pytest -vxs tests/ci/test_agent_close_keep_alive.py tests/ci/browser/test_session_start.py::TestBrowserSessionReusePatterns::test_sequential_agents_same_profile_same_browser tests/ci/test_beta_agent.py::test_beta_agent_close_kills_non_keep_alive_browser_session`
- `uv run pre-commit run --files browser_use/agent/service.py tests/ci/test_agent_close_keep_alive.py`
- `uv run ruff check browser_use/agent/service.py tests/ci/test_agent_close_keep_alive.py`
- `uv run ruff format --check browser_use/agent/service.py tests/ci/test_agent_close_keep_alive.py`
- `uv run pyright browser_use/agent/service.py tests/ci/test_agent_close_keep_alive.py`
- `git diff --check`
