### PR TITLE
fix(dom): scale clientRects/scrollRects by device_pixel_ratio in build_snapshot_lookup

### DIFF
--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -142,10 +142,10 @@ def build_snapshot_lookup(
 						client_rect_data = client_rects_data[layout_idx]
 						if client_rect_data and len(client_rect_data) >= 4:
 							client_rects = DOMRect(
-								x=client_rect_data[0],
-								y=client_rect_data[1],
-								width=client_rect_data[2],
-								height=client_rect_data[3],
+								x=client_rect_data[0] / device_pixel_ratio,
+								y=client_rect_data[1] / device_pixel_ratio,
+								width=client_rect_data[2] / device_pixel_ratio,
+								height=client_rect_data[3] / device_pixel_ratio,
 							)
 
 					# Extract scroll rects if available
@@ -154,10 +154,10 @@ def build_snapshot_lookup(
 						scroll_rect_data = scroll_rects_data[layout_idx]
 						if scroll_rect_data and len(scroll_rect_data) >= 4:
 							scroll_rects = DOMRect(
-								x=scroll_rect_data[0],
-								y=scroll_rect_data[1],
-								width=scroll_rect_data[2],
-								height=scroll_rect_data[3],
+								x=scroll_rect_data[0] / device_pixel_ratio,
+								y=scroll_rect_data[1] / device_pixel_ratio,
+								width=scroll_rect_data[2] / device_pixel_ratio,
+								height=scroll_rect_data[3] / device_pixel_ratio,
 							)
 
 					# Extract stacking contexts if available

--- a/tests/ci/browser/test_enhanced_snapshot.py
+++ b/tests/ci/browser/test_enhanced_snapshot.py
@@ -1,0 +1,47 @@
+"""Pure-function unit tests for build_snapshot_lookup coordinate scaling (no browser).
+
+build_snapshot_lookup() takes a raw CDP DOMSnapshot dict and returns enhanced
+nodes, so a synthetic snapshot lets us assert the device-pixel-ratio coordinate
+math directly without launching a browser.
+"""
+
+from browser_use.dom.enhanced_snapshot import build_snapshot_lookup
+
+
+def _single_node_snapshot() -> dict:
+	"""One backend node (id=1) with bounds/clientRects/scrollRects in device pixels."""
+	return {
+		'documents': [
+			{
+				'nodes': {'backendNodeId': [1]},
+				'layout': {
+					'nodeIndex': [0],
+					'bounds': [[100, 200, 50, 60]],
+					'clientRects': [[100, 200, 50, 60]],
+					'scrollRects': [[0, 0, 50, 300]],
+				},
+			}
+		],
+		'strings': [],
+	}
+
+
+def test_all_rects_scaled_to_css_pixels_at_dpr_2():
+	"""bounds, clientRects and scrollRects must all be divided by the DPR uniformly."""
+	lookup = build_snapshot_lookup(_single_node_snapshot(), device_pixel_ratio=2.0)
+	node = lookup[1]
+	assert node.bounds.x == 50.0
+	assert node.bounds.height == 30.0
+	assert node.clientRects.x == 50.0
+	assert node.clientRects.width == 25.0
+	assert node.scrollRects.height == 150.0
+	assert node.scrollRects.width == 25.0
+
+
+def test_dpr_1_is_identity():
+	"""At DPR=1 (Linux/CI default) all coordinates are unchanged."""
+	lookup = build_snapshot_lookup(_single_node_snapshot(), device_pixel_ratio=1.0)
+	node = lookup[1]
+	assert node.bounds.x == 100.0
+	assert node.clientRects.x == 100.0
+	assert node.scrollRects.height == 300.0


### PR DESCRIPTION
## Problem

`build_snapshot_lookup()` (browser_use/dom/enhanced_snapshot.py) divides `bounds`
by `device_pixel_ratio` to convert CDP **device** pixels to **CSS** pixels — that's
exactly what the existing intent comment says it does. But the immediately-following
`clientRects` and `scrollRects` are built straight from the same CDP layout snapshot
**without** that division, so they stay in raw device pixels.

Consumers in `browser_use/dom/service.py` then mix the three in CSS space:

- **pages_down hint**: `y_pos = bounds.y` (CSS) vs `viewport_height = clientRects.height` (device)
- **iframe intersection**: `viewport_right = clientRects.width` (device) vs `adjusted = current_bounds - scrollRects` (CSS − device)
- **total_frame_offset**: `-= scrollRects` (device) then `+= bounds` (CSS)

On high-DPI environments (Retina macOS `DPR=2`, Windows 150/200% scaling) this
corrupts scrolled-iframe DOM math, so the agent mis-reads what is on-screen inside
scrolled iframes. At `DPR=1` (Linux/CI) every form is identity, which is why it
stayed latent. Matches the high-DPI coordinate pain reported in #4571.

## Fix

Divide `clientRects` and `scrollRects` by `device_pixel_ratio` exactly like `bounds`,
so `build_snapshot_lookup` emits **all** coordinates uniformly in CSS pixels.

Adds a pure-function regression test (no browser/Playwright) that fails on current
`main` (`clientRects`/`scrollRects` come back unscaled at DPR=2) and passes after.

Complementary to #4655 (which hardens DPR *detection* in `service.py`): even with a
correct DPR value, `clientRects`/`scrollRects` stay unscaled until this lands. Different
file, no overlap.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale `clientRects` and `scrollRects` by `device_pixel_ratio` in `build_snapshot_lookup` so all rects (including `bounds`) are in CSS pixels. Fixes high-DPI coordinate mixups that broke scrolled-iframe math, with a pure-function regression test to lock it in.

<sup>Written for commit 07993f9717ef774493faed0b1e7c64d7ea4fdac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

