### PR TITLE
fix: preserve explicit empty accessibility names in DOMInteractedElement

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(


### PR DESCRIPTION
## Summary

This PR fixes an edge case in `DOMInteractedElement.load_from_enhanced_dom_tree` where an explicit empty accessibility name (`""`) is treated the same as `None` due to an implicit truthiness check.

## Changes

* Replaced:

  ```python
  if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
  ```

  with:

  ```python
  if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
  ```
* This preserves intentionally empty accessibility names while still correctly handling `None`.

## Related Issue

Fixes #5041.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves explicit empty accessibility names ("") when building `DOMInteractedElement` from an enhanced DOM tree by checking for `None` instead of truthiness. This prevents deliberate empty names from being overwritten as `None`.

<sup>Written for commit 727e06a014de1cb7c1ef5bbb12c465cbbaa1dba9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

