### PR TITLE
fix(utils): only strip leading scheme/www in _log_pretty_url

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -782,7 +782,11 @@ def _log_pretty_path(path: str | Path | None) -> str:
 
 def _log_pretty_url(s: str, max_len: int | None = 22) -> str:
 	"""Truncate/pretty-print a URL with a maximum length, removing the protocol and www. prefix"""
-	s = s.replace('https://', '').replace('http://', '').replace('www.', '')
+	# Only strip a leading scheme and a single leading "www." so that URLs whose
+	# path/query legitimately contain "http(s)://" or "www." are not mangled.
+	s = re.sub(r'^https?://', '', s)
+	if s.startswith('www.'):
+		s = s[len('www.') :]
 	if max_len is not None and len(s) > max_len:
 		return s[:max_len] + '…'
 	return s

--- a/tests/ci/infrastructure/test_log_pretty_url.py
+++ b/tests/ci/infrastructure/test_log_pretty_url.py
@@ -1,0 +1,35 @@
+"""Tests for the _log_pretty_url helper in browser_use.utils.
+
+The helper is documented to strip the protocol and a leading ``www.`` *prefix*
+only. Earlier it used ``str.replace`` which removed those substrings anywhere in
+the URL, mangling domains like ``awwww.com`` and URLs whose query/path contained
+``http(s)://`` or ``www.``.
+"""
+
+from browser_use.utils import _log_pretty_url
+
+
+def test_strips_leading_scheme_and_www():
+	assert _log_pretty_url('https://www.example.com', max_len=None) == 'example.com'
+	assert _log_pretty_url('http://example.com', max_len=None) == 'example.com'
+
+
+def test_does_not_strip_www_inside_domain():
+	# "awwww.com" contains the substring "www." but it is not a prefix.
+	assert _log_pretty_url('https://awwww.com', max_len=None) == 'awwww.com'
+
+
+def test_does_not_corrupt_embedded_scheme_in_query():
+	url = 'https://example.com/r?u=https://other.com'
+	assert _log_pretty_url(url, max_len=None) == 'example.com/r?u=https://other.com'
+
+
+def test_does_not_strip_www_inside_path():
+	url = 'https://site.com/www.assets/img'
+	assert _log_pretty_url(url, max_len=None) == 'site.com/www.assets/img'
+
+
+def test_truncation_still_applies():
+	long_url = 'https://example.com/' + 'a' * 100
+	out = _log_pretty_url(long_url, max_len=22)
+	assert out == 'example.com/' + 'a' * 10 + '…'


### PR DESCRIPTION
### What

`_log_pretty_url` is documented to *"remove the protocol and www. prefix"*, but it implemented this with `str.replace`:

```python
s = s.replace('https://', '').replace('http://', '').replace('www.', '')
```

`str.replace` removes every occurrence, not just the leading prefix, so the helper corrupts otherwise valid URLs:

- `https://awwww.com` → `awcom` (the substring `www.` inside the domain is stripped)
- `https://example.com/r?u=https://other.com` → `example.com/r?u=other.com` (embedded scheme in the query is dropped)
- `https://site.com/www.assets/img` → `site.com/assets/img` (`www.` inside the path is stripped)

This shows up in the tab-info debug logging in `browser/session.py`, making logged URLs misleading.

### Fix

Strip only a leading scheme and a single leading `www.`, matching the documented behavior:

```python
s = re.sub(r'^https?://', '', s)
if s.startswith('www.'):
    s = s[len('www.') :]
```

The rest of the URL (path, query, fragment) is left untouched.

### Verification

Added `tests/ci/infrastructure/test_log_pretty_url.py` covering prefix stripping, the three corruption cases above, and the existing truncation behavior.

```
$ uv run pytest tests/ci/infrastructure/test_log_pretty_url.py -p no:xdist -o addopts="" -q
5 passed
```

Before the fix the three "does not corrupt" cases fail; after the fix all 5 pass. `ruff check` and `ruff format --check` pass on the changed files.

> Note: drafted with AI assistance and verified by a human (RED/GREEN tests run locally).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix `_log_pretty_url` to only strip a leading `http(s)://` and a single leading `www.`, preventing mangled domains and embedded URLs in logs. Adds focused tests; truncation behavior is unchanged.

- **Bug Fixes**
  - Replaced global `str.replace` with `re.sub(r'^https?://', ...)` and a prefix check for `www.`.
  - Preserves path/query and embedded `https://`/`www.`.
  - Added tests in `tests/ci/infrastructure/test_log_pretty_url.py`.

<sup>Written for commit aaa6033cce96196faa92911675690736e7c54e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

