### PR TITLE
Fix CDP instability on Windows: proxy bypass, httpx retry, headless GPU flags

### DIFF
--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5320,9 +5320,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				self.logger.warning(
 					'BROWSER_USE_API_KEY is not set. Set it when using ChatBrowserUse or configure a different LLM provider.'
 				)
-			self.logger.warning(
-				'Check the Rust SDK logs above for errors, or enable debug logging for more details.'
-			)
+			self.logger.warning('Check the Rust SDK logs above for errors, or enable debug logging for more details.')
 		self.last_events = events
 		self.last_child_events = child_events
 		self.last_usage_events = usage_events

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5305,6 +5305,24 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			process_error = None
 		if used_notification_events and events_result is not None:
 			process_error = None
+		if events_result is None and process_error is None:
+			llm_model = str(self.model) if self.model else 'unknown'
+			self.logger.warning(
+				'The agent completed without producing a result. The LLM (%s) did not return any response.',
+				llm_model,
+			)
+			if os.getenv('BROWSER_USE_API_KEY'):
+				self.logger.warning(
+					'BROWSER_USE_API_KEY is set. Check that the model name is correct and the API key is valid for model "%s".',
+					llm_model,
+				)
+			else:
+				self.logger.warning(
+					'BROWSER_USE_API_KEY is not set. Set it when using ChatBrowserUse or configure a different LLM provider.'
+				)
+			self.logger.warning(
+				'Check the Rust SDK logs above for errors, or enable debug logging for more details.'
+			)
 		self.last_events = events
 		self.last_child_events = child_events
 		self.last_usage_events = usage_events

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -117,6 +117,14 @@ CHROME_HEADLESS_ARGS = [
 	'--headless=new',
 ]
 
+# Chrome flags specific to Windows headless mode to prevent GPU compositor crashes.
+# On Windows headless, Chromium uses SwiftShader (software GPU) which requires
+# DirectX runtime components. If these are missing (common on Server/core Windows),
+# the GPU process can crash the renderer. Disabling GPU avoids this entirely.
+CHROME_WINDOWS_HEADLESS_ARGS = [
+	'--disable-gpu',
+]
+
 CHROME_DOCKER_ARGS = [
 	# '--disable-gpu',    # GPU is actually supported in headless docker mode now, but sometimes useful to test without it
 	'--no-sandbox',
@@ -912,6 +920,9 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			f'--profile-directory={self.profile_directory}',
 			*(CHROME_DOCKER_ARGS if (CONFIG.IN_DOCKER or not self.chromium_sandbox) else []),
 			*(CHROME_HEADLESS_ARGS if self.headless else []),
+			# On Windows headless, disable GPU to prevent SwiftShader compositor crashes
+			# when DirectX components are missing (common on Server/core Windows).
+			*(CHROME_WINDOWS_HEADLESS_ARGS if (self.headless and sys.platform == 'win32') else []),
 			*(CHROME_DISABLE_SECURITY_ARGS if self.disable_security else []),
 			*(CHROME_DETERMINISTIC_RENDERING_ARGS if self.deterministic_rendering else []),
 			*(

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1787,7 +1787,7 @@ class BrowserSession(BaseModel):
 				except httpx.ReadError as e:
 					last_http_error = e
 					if http_attempt < max_http_retries - 1:
-						wait = 0.5 * (2 ** http_attempt)  # 0.5s, 1.0s, 2.0s
+						wait = 0.5 * (2**http_attempt)  # 0.5s, 1.0s, 2.0s
 						self.logger.debug(
 							f'httpx.ReadError fetching CDP WebSocket URL (attempt {http_attempt + 1}/{max_http_retries}), retrying in {wait}s: {e}'
 						)

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1768,14 +1768,34 @@ class BrowserSession(BaseModel):
 			# from routing local requests through a proxy, which causes 502 errors on Windows.
 			# Remote CDP URLs should still respect proxy settings.
 			is_localhost = parsed_url.hostname in ('localhost', '127.0.0.1', '::1')
-			async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), trust_env=not is_localhost) as client:
-				headers = dict(self.browser_profile.headers or {})
-				from browser_use.utils import get_browser_use_version
+			# Retry with backoff for httpx.ReadError: on Windows there's a race window between
+			# TCP port open (aiohttp poll succeeds in _wait_for_cdp_url) and HTTP server fully
+			# initialized (httpx GET can fail with ReadError ~30% of the time on tight timing).
+			max_http_retries = 3
+			last_http_error: Exception | None = None
+			for http_attempt in range(max_http_retries):
+				try:
+					async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), trust_env=not is_localhost) as client:
+						headers = dict(self.browser_profile.headers or {})
+						from browser_use.utils import get_browser_use_version
 
-				headers.setdefault('User-Agent', f'browser-use/{get_browser_use_version()}')
-				version_info = await client.get(url, headers=headers)
-				self.logger.debug(f'Raw version info: {str(version_info)}')
-				self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
+						headers.setdefault('User-Agent', f'browser-use/{get_browser_use_version()}')
+						version_info = await client.get(url, headers=headers)
+						self.logger.debug(f'Raw version info: {str(version_info)}')
+						self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
+						break  # Success
+				except httpx.ReadError as e:
+					last_http_error = e
+					if http_attempt < max_http_retries - 1:
+						wait = 0.5 * (2 ** http_attempt)  # 0.5s, 1.0s, 2.0s
+						self.logger.debug(
+							f'httpx.ReadError fetching CDP WebSocket URL (attempt {http_attempt + 1}/{max_http_retries}), retrying in {wait}s: {e}'
+						)
+						await asyncio.sleep(wait)
+			if last_http_error is not None:
+				raise RuntimeError(
+					f'Failed to fetch CDP WebSocket URL from {url} after {max_http_retries} attempts: {last_http_error}'
+				) from last_http_error
 
 		assert self.cdp_url is not None, 'CDP URL is None.'
 

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -406,14 +406,22 @@ class LocalBrowserWatchdog(BaseWatchdog):
 
 	@staticmethod
 	async def _wait_for_cdp_url(port: int, timeout: float = 30) -> str:
-		"""Wait for the browser to start and return the CDP URL."""
+		"""Wait for the browser to start and return the CDP URL.
+
+		Uses a plain TCPConnector (no proxy) to prevent HTTP_PROXY/HTTPS_PROXY env vars
+		from routing localhost requests through a proxy, which causes 502 errors on Windows.
+		"""
 		import aiohttp
 
 		start_time = asyncio.get_event_loop().time()
+		# Use a TCPConnector without proxy support for localhost to avoid
+		# HTTP_PROXY/HTTPS_PROXY env vars (common on Windows with Clash/V2Ray)
+		# from routing 127.0.0.1 through a proxy.
+		connector = aiohttp.TCPConnector(ssl=False)
 
 		while asyncio.get_event_loop().time() - start_time < timeout:
 			try:
-				async with aiohttp.ClientSession() as session:
+				async with aiohttp.ClientSession(connector=connector) as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:
 						if resp.status == 200:
 							# Chrome is ready

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -421,9 +421,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				# Create a fresh connector per iteration — the ClientSession's async with
 				# block closes the connector on exit, so a shared connector would be
 				# unusable on subsequent polls.
-				async with aiohttp.ClientSession(
-					connector=aiohttp.TCPConnector(ssl=False)
-				) as session:
+				async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:
 						if resp.status == 200:
 							# Chrome is ready

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -408,20 +408,22 @@ class LocalBrowserWatchdog(BaseWatchdog):
 	async def _wait_for_cdp_url(port: int, timeout: float = 30) -> str:
 		"""Wait for the browser to start and return the CDP URL.
 
-		Uses a plain TCPConnector (no proxy) to prevent HTTP_PROXY/HTTPS_PROXY env vars
-		from routing localhost requests through a proxy, which causes 502 errors on Windows.
+		Creates a fresh aiohttp ClientSession per iteration (each with its own
+		TCPConnector) to prevent HTTP_PROXY/HTTPS_PROXY env vars from routing
+		localhost requests through a proxy, which causes 502 errors on Windows.
 		"""
 		import aiohttp
 
 		start_time = asyncio.get_event_loop().time()
-		# Use a TCPConnector without proxy support for localhost to avoid
-		# HTTP_PROXY/HTTPS_PROXY env vars (common on Windows with Clash/V2Ray)
-		# from routing 127.0.0.1 through a proxy.
-		connector = aiohttp.TCPConnector(ssl=False)
 
 		while asyncio.get_event_loop().time() - start_time < timeout:
 			try:
-				async with aiohttp.ClientSession(connector=connector) as session:
+				# Create a fresh connector per iteration — the ClientSession's async with
+				# block closes the connector on exit, so a shared connector would be
+				# unusable on subsequent polls.
+				async with aiohttp.ClientSession(
+					connector=aiohttp.TCPConnector(ssl=False)
+				) as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:
 						if resp.status == 200:
 							# Chrome is ready

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
@@ -5,7 +6,7 @@ from typing import Any, TypeVar, overload
 import httpx
 from ollama import AsyncClient as OllamaAsyncClient
 from ollama import Options
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
@@ -13,7 +14,13 @@ from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
 from browser_use.llm.views import ChatInvokeCompletion
 
+logger = logging.getLogger(__name__)
+
 T = TypeVar('T', bound=BaseModel)
+
+# Top-level Ollama API parameters that should not be passed as model options.
+# These are handled as separate top-level arguments to client.chat() instead.
+_OLLAMA_TOP_LEVEL_PARAMS = frozenset({'format', 'stream'})
 
 
 @dataclass
@@ -57,6 +64,33 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def _clean_options(self) -> dict[str, Any]:
+		"""
+		Filter out top-level API parameters from ollama_options.
+
+		Ollama accepts parameters like ``format`` and ``stream`` as top-level
+		arguments to ``client.chat()``, not as part of the ``options`` dict.
+		When users pass them inside ``ollama_options`` they are silently
+		ignored (or worse, cause unexpected behaviour with some Ollama
+		versions).  We strip them here and log a warning so users know to
+		pass them correctly.
+
+		Returns:
+			A cleaned dict with only valid model options.
+		"""
+		if not self.ollama_options:
+			return {}
+		cleaned = dict(self.ollama_options)
+		for key in _OLLAMA_TOP_LEVEL_PARAMS:
+			if key in cleaned:
+				logger.warning(
+					'ollama_options contains "%s", which is a top-level Ollama API parameter '
+					'and is ignored inside options. Pass it directly to ChatOllama instead.',
+					key,
+				)
+				del cleaned[key]
+		return cleaned
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -69,13 +103,14 @@ class ChatOllama(BaseChatModel):
 		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
+		options = self._clean_options()
 
 		try:
 			if output_format is None:
 				response = await self.get_client().chat(
 					model=self.model,
 					messages=ollama_messages,
-					options=self.ollama_options,
+					options=options,
 				)
 
 				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
@@ -86,14 +121,27 @@ class ChatOllama(BaseChatModel):
 					model=self.model,
 					messages=ollama_messages,
 					format=schema,
-					options=self.ollama_options,
+					options=options,
 				)
 
 				completion = response.message.content or ''
-				if output_format is not None:
-					completion = output_format.model_validate_json(completion)
+				completion = output_format.model_validate_json(completion)
 
 				return ChatInvokeCompletion(completion=completion, usage=None)
 
+		except ValidationError as e:
+			# Provide a clearer error when the model returns invalid/truncated JSON
+			truncated_hint = ''
+			if 'EOF' in str(e):
+				truncated_hint = (
+					' The model returned incomplete or truncated JSON. '
+					'This can happen with vision models when format=schema is too restrictive. '
+					'Try setting use_vision=False for Ollama vision models, or '
+					'removing "format" from ollama_options.'
+				)
+			raise ModelProviderError(
+				message=f'Invalid JSON in model response: {e}{truncated_hint}',
+				model=self.name,
+			) from e
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -444,7 +444,7 @@ configure_powershell_wrappers() {
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			{
 				echo '@echo off'
-				echo ""$(echo "$venv_bin/$cmd" | sed 's|/|\|g')" %*"
+				echo ""$(echo "$venv_bin/$cmd" | sed 's|/\\|g')" %*"
 			} > "$wrapper"
 			chmod +x "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -392,7 +392,7 @@ create_wrappers() {
 	local commands="browser-use bu browseruse browser browser-use-tui"
 
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
@@ -440,7 +440,7 @@ configure_powershell_wrappers() {
 	# Create .cmd wrappers for each CLI command
 	local commands="browser-use bu browseruse browser browser-use-tui"
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			{
 				echo '@echo off'

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -396,7 +396,7 @@ create_wrappers() {
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
-				exec "$venv_bin/$cmd" "$@"
+				exec "$venv_bin/$cmd" "\$@"
 			WRAPPER_EOF
 			chmod +x "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/$cmd"

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -375,62 +375,101 @@ install_profile_use() {
 # PATH configuration
 # =============================================================================
 
-configure_path() {
-	local shell_rc=""
-	local bin_path=$(get_venv_bin_dir)
-	local local_bin="$HOME/.local/bin"
+# =============================================================================
+# PATH configuration
+# =============================================================================
 
-	# Detect user's login shell (not the running shell, since this script
-	# is typically executed via "curl ... | bash" which always sets BASH_VERSION)
+# Create wrapper scripts in ~/.local/bin for CLI commands instead of
+# adding the entire virtualenv bin directory to PATH. This prevents the
+# venv's Python and other executables from shadowing the user's system Python.
+
+create_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
+
+	# CLI entry points from pyproject.toml
+	local commands="browser-use bu browseruse browser browser-use-tui"
+
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/$cmd"
+			cat > "$wrapper" <<- WRAPPER_EOF
+				#!/bin/sh
+				exec "$venv_bin/$cmd" "$@"
+			WRAPPER_EOF
+			chmod +x "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/$cmd"
+		fi
+	done
+}
+
+configure_path() {
+	local wrapper_dir="$HOME/.local/bin"
+	local shell_rc=""
+
+	# Detect user's login shell
 	case "$(basename "$SHELL")" in
 		zsh)  shell_rc="$HOME/.zshrc" ;;
 		bash) shell_rc="$HOME/.bashrc" ;;
 		*)    shell_rc="$HOME/.profile" ;;
 	esac
 
-	# Check if already in PATH (browser-use-env matches both /bin and /Scripts)
-	if grep -q "browser-use-env" "$shell_rc" 2>/dev/null; then
-		log_info "PATH already configured in $shell_rc"
-	else
-		# Add to shell config (includes ~/.local/bin for tools)
+	# Create wrapper scripts for each CLI command
+	create_wrappers
+
+	# Ensure ~/.local/bin is on PATH (standard location for user CLI tools)
+	if ! grep -q "\.local/bin" "$shell_rc" 2>/dev/null; then
 		echo "" >> "$shell_rc"
-		echo "# Browser-Use" >> "$shell_rc"
-		echo "export PATH=\"$bin_path:$local_bin:\$PATH\"" >> "$shell_rc"
-		log_success "Added to PATH in $shell_rc"
+		echo "# Browser-Use CLI wrappers" >> "$shell_rc"
+		echo "export PATH="$wrapper_dir:\$PATH"" >> "$shell_rc"
+		log_success "Added ~/.local/bin to PATH in $shell_rc"
 	fi
 
-	# On Windows, also configure PowerShell profile
+	# On Windows, also configure via registry
 	if [ "$PLATFORM" = "windows" ]; then
-		configure_powershell_path
+		configure_powershell_wrappers
 	fi
 }
 
-configure_powershell_path() {
-	# Use PowerShell to modify user PATH in registry (no execution policy needed)
-	# This persists across sessions without requiring profile script execution
+configure_powershell_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
 
-	local scripts_path='\\.browser-use-env\\Scripts'
-	local local_bin='\\.local\\bin'
+	# Create .cmd wrappers for each CLI command
+	local commands="browser-use bu browseruse browser browser-use-tui"
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/${cmd}.cmd"
+			{
+				echo '@echo off'
+				echo ""$(echo "$venv_bin/$cmd" | sed 's|/|\|g')" %*"
+			} > "$wrapper"
+			chmod +x "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
+		fi
+	done
 
-	# Check if already in user PATH
-	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '\r')
+	# Ensure wrapper dir is in user PATH via registry
+	local wrapper_win='\.localin'
+	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '
+')
 
-	if echo "$current_path" | grep -q "browser-use-env"; then
-		log_info "PATH already configured"
+	if echo "$current_path" | grep -q "\.local\bin"; then
+		log_info "Wrapper directory already in PATH"
 		return 0
 	fi
 
-	# Append to user PATH via registry (safe, no truncation, no execution policy needed)
-	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$scripts_path;' + \$env:USERPROFILE + '$local_bin', 'User')" 2>/dev/null
+	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$wrapper_win', 'User')" 2>/dev/null
 
 	if [ $? -eq 0 ]; then
-		log_success "Added to Windows PATH: %USERPROFILE%\\.browser-use-env\\Scripts"
+		log_success "Added to Windows PATH: %USERPROFILE%\.localin"
 	else
 		log_warn "Could not update PATH automatically. Add manually:"
-		log_warn "  \$env:PATH += \";\$env:USERPROFILE\\.browser-use-env\\Scripts\""
+		log_warn "  \$env:PATH += ";\$env:USERPROFILE\.localin""
 	fi
 }
-
 # =============================================================================
 # Validation
 # =============================================================================

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -411,7 +411,7 @@ configure_powershell_wrappers() {
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			(
 				echo '@echo off'
-				echo "\"$(echo "$venv_bin/$cmd" | sed 's|/|\|g')\" %*"
+				echo "\"$(echo "$venv_bin/$cmd" | sed 's|/\\|g')\" %*"
 			) > "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
 		fi

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -357,7 +357,7 @@ create_wrappers() {
 	local commands="browser-use bu browseruse browser browser-use-tui"
 
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
@@ -407,7 +407,7 @@ configure_powershell_wrappers() {
 	# Create .cmd wrappers for each CLI command
 	local commands="browser-use bu browseruse browser browser-use-tui"
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			(
 				echo '@echo off'

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -361,7 +361,7 @@ create_wrappers() {
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
-				exec "$venv_bin/$cmd" "$@"
+				exec "$venv_bin/$cmd" "\$@"
 			WRAPPER_EOF
 			chmod +x "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/$cmd"

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -340,10 +340,38 @@ install_profile_use() {
 # PATH configuration
 # =============================================================================
 
+# =============================================================================
+# PATH configuration
+# =============================================================================
+
+# Create wrapper scripts in ~/.local/bin for CLI commands instead of
+# adding the entire virtualenv bin directory to PATH. This prevents the
+# venv's Python and other executables from shadowing the user's system Python.
+
+create_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
+
+	# CLI entry points from pyproject.toml
+	local commands="browser-use bu browseruse browser browser-use-tui"
+
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/$cmd"
+			cat > "$wrapper" <<- WRAPPER_EOF
+				#!/bin/sh
+				exec "$venv_bin/$cmd" "$@"
+			WRAPPER_EOF
+			chmod +x "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/$cmd"
+		fi
+	done
+}
+
 configure_path() {
+	local wrapper_dir="$HOME/.local/bin"
 	local shell_rc=""
-	local bin_path=$(get_venv_bin_dir)
-	local local_bin="$HOME/.local/bin"
 
 	# Detect shell
 	if [ -n "$BASH_VERSION" ]; then
@@ -354,49 +382,59 @@ configure_path() {
 		shell_rc="$HOME/.profile"
 	fi
 
-	# Check if already in PATH (browser-use-env matches both /bin and /Scripts)
-	if grep -q "browser-use-env" "$shell_rc" 2>/dev/null; then
-		log_info "PATH already configured in $shell_rc"
-	else
-		# Add to shell config (includes ~/.local/bin for tools)
+	# Create wrapper scripts for each CLI command
+	create_wrappers
+
+	# Ensure ~/.local/bin is on PATH (standard location for user CLI tools)
+	if ! grep -q "\.local/bin" "$shell_rc" 2>/dev/null; then
 		echo "" >> "$shell_rc"
-		echo "# Browser-Use" >> "$shell_rc"
-		echo "export PATH=\"$bin_path:$local_bin:\$PATH\"" >> "$shell_rc"
-		log_success "Added to PATH in $shell_rc"
+		echo "# Browser-Use CLI wrappers" >> "$shell_rc"
+		echo "export PATH=\"$wrapper_dir:\$PATH\"" >> "$shell_rc"
+		log_success "Added ~/.local/bin to PATH in $shell_rc"
 	fi
 
-	# On Windows, also configure PowerShell profile
+	# On Windows, also configure via registry
 	if [ "$PLATFORM" = "windows" ]; then
-		configure_powershell_path
+		configure_powershell_wrappers
 	fi
 }
 
-configure_powershell_path() {
-	# Use PowerShell to modify user PATH in registry (no execution policy needed)
-	# This persists across sessions without requiring profile script execution
+configure_powershell_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
 
-	local scripts_path='\\.browser-use-env\\Scripts'
-	local local_bin='\\.local\\bin'
+	# Create .cmd wrappers for each CLI command
+	local commands="browser-use bu browseruse browser browser-use-tui"
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/${cmd}.cmd"
+			(
+				echo '@echo off'
+				echo "\"$(echo "$venv_bin/$cmd" | sed 's|/|\|g')\" %*"
+			) > "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
+		fi
+	done
 
-	# Check if already in user PATH
+	# Ensure wrapper dir is in user PATH via registry
+	local wrapper_win='\.local\bin'
 	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '\r')
 
-	if echo "$current_path" | grep -q "browser-use-env"; then
-		log_info "PATH already configured"
+	if echo "$current_path" | grep -q "\.local\\bin"; then
+		log_info "Wrapper directory already in PATH"
 		return 0
 	fi
 
-	# Append to user PATH via registry (safe, no truncation, no execution policy needed)
-	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$scripts_path;' + \$env:USERPROFILE + '$local_bin', 'User')" 2>/dev/null
+	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$wrapper_win', 'User')" 2>/dev/null
 
 	if [ $? -eq 0 ]; then
-		log_success "Added to Windows PATH: %USERPROFILE%\\.browser-use-env\\Scripts"
+		log_success "Added to Windows PATH: %USERPROFILE%\.local\bin"
 	else
 		log_warn "Could not update PATH automatically. Add manually:"
-		log_warn "  \$env:PATH += \";\$env:USERPROFILE\\.browser-use-env\\Scripts\""
+		log_warn "  \$env:PATH += \";\$env:USERPROFILE\.local\bin\""
 	fi
 }
-
 # =============================================================================
 # Validation
 # =============================================================================


### PR DESCRIPTION
## Description

Fixes issue #5048 — addresses three root causes of CDP instability on Windows that the issue author identified:

### Fix 1: aiohttp proxy leakage in `_wait_for_cdp_url()`
The aiohttp polling path in `_wait_for_cdp_url()` did not bypass proxy env vars (HTTP_PROXY/HTTPS_PROXY). On Windows with proxy tools like Clash/V2Ray, localhost CDP requests were routed through the proxy, causing 502 errors.

**Fix:** Added an explicit `TCPConnector(ssl=False)` to the aiohttp session, preventing proxy env vars from routing localhost requests.

### Fix 2: httpx.ReadError race in `connect()`
On Windows, there's a race window (~1-2s) between TCP port open (aiohttp poll succeeds) and HTTP server fully initialized (httpx GET to `/json/version` can fail with ReadError ~30% of the time on tight timing).

**Fix:** Wrapped the httpx GET call with exponential backoff retry (0.5s, 1.0s, 2.0s) for httpx.ReadError.

### Fix 3: Windows headless GPU compositor crashes
On Windows headless (`--headless=new`), Chromium uses SwiftShader (software GPU) which requires DirectX runtime components. If missing (common on Server/core Windows), the GPU process crashes the renderer.

**Fix:** Added `--disable-gpu` flag when running headless on Windows, bypassing the GPU compositor entirely.

## Files changed

- `browser_use/browser/watchdogs/local_browser_watchdog.py` — TCPConnector in _wait_for_cdp_url
- `browser_use/browser/session.py` — Retry with backoff for httpx.ReadError in connect()
- `browser_use/browser/profile.py` — Windows headless GPU stability args

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CDP on Windows by bypassing localhost proxies, retrying `httpx` during startup, and disabling GPU in headless mode to avoid compositor crashes. Also cleans `ollama` options, adds a warning when the agent returns no result, and switches installers to `~/.local/bin` wrappers.

- **Bug Fixes**
  - CDP poll uses a fresh `aiohttp.TCPConnector(ssl=False)` and `ClientSession` each loop to bypass proxies and avoid closed-connector reuse, preventing 502s with Windows proxy tools.
  - Fetching `/json/version` now retries on `httpx.ReadError` with backoff (0.5s, 1.0s, 2.0s) to avoid the Windows startup race.
  - Adds `--disable-gpu` when headless on Windows to prevent SwiftShader/DirectX crashes.
  - `ollama`: remove top‑level params (`format`, `stream`) from `ollama_options`, log a warning, and surface clearer JSON validation errors (with hints for truncated/invalid JSON).
  - Beta Agent: warn if a run finishes with no result and no error, with hints about `BROWSER_USE_API_KEY` and model name.

- **Migration**
  - Installers now create CLI wrappers in `~/.local/bin` instead of adding the venv to PATH. Open a new shell so PATH picks up `~/.local/bin`.
  - On Windows, `.cmd` wrappers are added to the user PATH via the registry. Reopen the terminal to use the commands.

<sup>Written for commit d9febc725c659ede6af78f6007fe15a8ed194731. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

