### PR TITLE
docs: remove stray 'browser' line from install code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Python API -> Rust core -> Browser harness -> Web task done
 ```bash
 uv add "browser-use[core]"
 # or: pip install "browser-use[core]"
-browser
 ```
 
 The `[core]` extra installs the native Browser Use runtime for your platform.


### PR DESCRIPTION
## Why
In the "Human Quickstart" section (Step 1 – Install), the install code block 
contains a stray line `browser` right after the `pip install` comment. It is 
not part of the install command, so a new user copying this block would be 
confused about what `browser` is supposed to do at the install step.

## What
Remove the stray `browser` line from the Step 1 install code block in README.md.

Before:
```bash
uv add "browser-use[core]"
# or: pip install "browser-use[core]"
browser
```

After:
```bash
uv add "browser-use[core]"
# or: pip install "browser-use[core]"
```

## Notes
Docs-only change, single line removed. No code or behavior affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stray `browser` line from the Human Quickstart (Step 1 – Install) code block in README. This prevents copy-paste errors when installing `browser-use[core]` with `uv` or `pip`.

<sup>Written for commit 4e0040eaacfc0e17d7157c052c00683cebb8d0ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

