### PR TITLE
fix(llm): include cache-read tokens in Anthropic total_tokens

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -209,7 +209,9 @@ class ChatAnthropic(BaseChatModel):
 				response.usage.cache_read_input_tokens or 0
 			),  # Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
 			completion_tokens=response.usage.output_tokens,
-			total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+			total_tokens=response.usage.input_tokens
+			+ (response.usage.cache_read_input_tokens or 0)
+			+ response.usage.output_tokens,
 			prompt_cached_tokens=response.usage.cache_read_input_tokens,
 			prompt_cache_creation_tokens=response.usage.cache_creation_input_tokens,
 			prompt_cache_creation_5m_tokens=cache_creation_5m_tokens,

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -149,7 +149,9 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 				response.usage.cache_read_input_tokens or 0
 			),  # Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
 			completion_tokens=response.usage.output_tokens,
-			total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+			total_tokens=response.usage.input_tokens
+			+ (response.usage.cache_read_input_tokens or 0)
+			+ response.usage.output_tokens,
 			prompt_cached_tokens=response.usage.cache_read_input_tokens,
 			prompt_cache_creation_tokens=response.usage.cache_creation_input_tokens,
 			prompt_cache_creation_5m_tokens=cache_creation_5m_tokens,

--- a/tests/ci/models/test_anthropic_usage.py
+++ b/tests/ci/models/test_anthropic_usage.py
@@ -8,12 +8,13 @@ caching is active.
 """
 
 from types import SimpleNamespace
+from typing import Any
 
 from browser_use.llm.anthropic.chat import ChatAnthropic
 from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
 
 
-def _response(input_tokens: int, output_tokens: int, cache_read: int, cache_creation: int = 0):
+def _response(input_tokens: int, output_tokens: int, cache_read: int, cache_creation: int = 0) -> Any:
 	usage = SimpleNamespace(
 		input_tokens=input_tokens,
 		output_tokens=output_tokens,

--- a/tests/ci/models/test_anthropic_usage.py
+++ b/tests/ci/models/test_anthropic_usage.py
@@ -1,0 +1,50 @@
+"""Usage accounting for the Anthropic chat models.
+
+Anthropic reports cached prompt tokens in `cache_read_input_tokens`, which is
+*not* included in `input_tokens`. `_get_usage` already adds it to
+`prompt_tokens`, so `total_tokens` has to add it too or the invariant
+`total_tokens == prompt_tokens + completion_tokens` breaks whenever prompt
+caching is active.
+"""
+
+from types import SimpleNamespace
+
+from browser_use.llm.anthropic.chat import ChatAnthropic
+from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
+
+
+def _response(input_tokens: int, output_tokens: int, cache_read: int, cache_creation: int = 0):
+	usage = SimpleNamespace(
+		input_tokens=input_tokens,
+		output_tokens=output_tokens,
+		cache_read_input_tokens=cache_read,
+		cache_creation_input_tokens=cache_creation,
+		cache_creation=None,
+	)
+	return SimpleNamespace(usage=usage)
+
+
+def test_bedrock_total_includes_cache_read():
+	usage = ChatAnthropicBedrock()._get_usage(_response(input_tokens=500, output_tokens=200, cache_read=10_000))
+	assert usage is not None
+	assert usage.prompt_tokens == 10_500
+	assert usage.completion_tokens == 200
+	assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+	assert usage.total_tokens == 10_700
+
+
+def test_anthropic_total_includes_cache_read():
+	usage = ChatAnthropic(model='claude-sonnet-4-6')._get_usage(_response(input_tokens=500, output_tokens=200, cache_read=10_000))
+	assert usage is not None
+	assert usage.prompt_tokens == 10_500
+	assert usage.completion_tokens == 200
+	assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+	assert usage.total_tokens == 10_700
+
+
+def test_total_unchanged_without_cache():
+	for model in (ChatAnthropicBedrock(), ChatAnthropic(model='claude-sonnet-4-6')):
+		usage = model._get_usage(_response(input_tokens=500, output_tokens=200, cache_read=0))
+		assert usage is not None
+		assert usage.total_tokens == 700
+		assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens


### PR DESCRIPTION
### What

`_get_usage` computes `prompt_tokens` as `input_tokens + cache_read_input_tokens` (Anthropic reports cached prompt tokens separately, so they have to be added back), but `total_tokens` was left as just `input_tokens + output_tokens`. As soon as prompt caching kicks in, `total_tokens` is smaller than `prompt_tokens + completion_tokens`, which breaks anything downstream that assumes the totals add up (cost tracking, budget/limit checks).

Concrete example with a cached prompt: `input_tokens=500`, `cache_read_input_tokens=10000`, `output_tokens=200` gives `prompt_tokens=10500`, `completion_tokens=200`, but `total_tokens=700` instead of `10700`.

This affects both `ChatAnthropic` (`browser_use/llm/anthropic/chat.py`) and `ChatAnthropicBedrock` (`browser_use/llm/aws/chat_anthropic.py`), which share the same usage logic.

### Fix

Add the cache-read tokens to `total_tokens` so it mirrors the `prompt_tokens` formula and the invariant `total_tokens == prompt_tokens + completion_tokens` holds again. One line per file.

### Verifying

Added `tests/ci/models/test_anthropic_usage.py` covering both clients: the cached case (asserts the totals add up) and the no-cache case (asserts the number is unchanged).

```
uv run pytest tests/ci/models/test_anthropic_usage.py -q
```

The cached-case assertions fail on current `main` (700 != 10700) and pass with this change; the no-cache case stays at 700 both ways. `ruff check` / `ruff format` clean on the touched files.

Note: #4294 proposed the same one-liner for `chat.py` but went stale before it landed, and it never touched the Bedrock client. This covers both and adds a regression test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic usage accounting by adding cache-read prompt tokens to `total_tokens`, restoring `total_tokens == prompt_tokens + completion_tokens`. Applies to both Anthropic and Bedrock clients.

- **Bug Fixes**
  - Include `cache_read_input_tokens` in `total_tokens` in `browser_use/llm/anthropic/chat.py` and `browser_use/llm/aws/chat_anthropic.py`.
  - Add `tests/ci/models/test_anthropic_usage.py` for cached/no-cache cases and type the mock response helper for Pyright.

<sup>Written for commit aa4c71f881d218c9eb443ace54ede22ebe758b46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

