### PR TITLE
Harden search_page against model-supplied ReDoS patterns

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -298,6 +298,103 @@ try {
 """
 
 
+# Hardening for the model-controlled search_page regex (ReDoS guard).
+# The pattern below is compiled and executed by the browser's V8 RegExp engine,
+# which is backtracking-based and can exhibit catastrophic (exponential) runtime
+# for "nested quantifier" patterns such as (a+)+$ against long near-miss text.
+# We cap the pattern length and reject the nested-quantifier shapes before the
+# pattern ever reaches `new RegExp(...)`. These limits are intentionally generous
+# so legitimate searches keep working; they only block pathological inputs.
+_MAX_SEARCH_PATTERN_LENGTH = 1000
+
+
+def _has_unbounded_quantifier_after(pattern: str, i: int) -> bool:
+	"""True if position `i` is immediately followed by an unbounded quantifier (+, *, or {n,})."""
+	n = len(pattern)
+	if i >= n:
+		return False
+	if pattern[i] in '+*':
+		return True
+	if pattern[i] == '{':
+		close = pattern.find('}', i)
+		if close != -1:
+			inner = pattern[i + 1 : close]
+			# {n,} (no upper bound) is unbounded; {n}, {n,m} are bounded.
+			if ',' in inner and inner.split(',', 1)[1].strip() == '':
+				return True
+	return False
+
+
+def _has_nested_quantifier(pattern: str) -> bool:
+	"""Detect catastrophic-backtracking "evil regex" shapes in a regex pattern string.
+
+	Returns True when a group that itself contains an unbounded quantifier (or a nested
+	quantified group) is immediately followed by another unbounded quantifier — e.g.
+	(a+)+, (a*)*, (a+)*, (?:ab+)+, ((a)+)+, (([a-z]+)*)+. Handles arbitrary group nesting,
+	escaped metacharacters, and character classes so the check can't be trivially evaded.
+	This is a conservative linear scan, not a full regex parser; it is only used to reject
+	model-supplied patterns, so over-rejection of a pathological shape is acceptable.
+	"""
+	n = len(pattern)
+	stack: list[bool] = []  # per-open-group: does the group body contain unbounded repetition?
+	i = 0
+	in_class = False  # inside a [...] character class
+	while i < n:
+		c = pattern[i]
+		# Skip escaped characters (a backslash that is not itself escaped).
+		if c == '\\':
+			i += 2
+			continue
+		if in_class:
+			if c == ']':
+				in_class = False
+			i += 1
+			continue
+		if c == '[':
+			in_class = True
+			i += 1
+			continue
+		if c == '(':
+			stack.append(False)
+			i += 1
+			continue
+		if c == ')':
+			body_unbounded = stack.pop() if stack else False
+			group_quantified = _has_unbounded_quantifier_after(pattern, i + 1)
+			if body_unbounded and group_quantified:
+				return True
+			# A quantified group counts as unbounded repetition within its parent group.
+			if group_quantified and stack:
+				stack[-1] = True
+			i += 1
+			continue
+		if c in '+*' or (c == '{' and _has_unbounded_quantifier_after(pattern, i)):
+			if stack:
+				stack[-1] = True
+		i += 1
+	return False
+
+
+def _validate_search_pattern(pattern: str, regex: bool) -> None:
+	"""Reject model-supplied search patterns that could cause catastrophic regex backtracking.
+
+	Raises ValueError with a user-facing message when the pattern is unsafe. Literal
+	(non-regex) searches are only length-capped because they are escaped before being
+	compiled, so they cannot backtrack pathologically.
+	"""
+	if len(pattern) > _MAX_SEARCH_PATTERN_LENGTH:
+		raise ValueError(
+			f'search pattern too long ({len(pattern)} chars, max {_MAX_SEARCH_PATTERN_LENGTH}). '
+			'Use a shorter, more specific pattern.'
+		)
+	if regex and _has_nested_quantifier(pattern):
+		raise ValueError(
+			'search pattern rejected: nested quantifiers like (a+)+ or (a*)* can cause '
+			'catastrophic backtracking (ReDoS). Rewrite the pattern without a repeated group '
+			'inside another repetition, or set regex=false for a literal search.'
+		)
+
+
 def _build_search_page_js(
 	pattern: str,
 	regex: bool,
@@ -307,6 +404,7 @@ def _build_search_page_js(
 	max_results: int,
 ) -> str:
 	"""Build JS IIFE for search_page with safe parameter injection."""
+	_validate_search_pattern(pattern, regex)
 	params_js = (
 		f'var PATTERN = {json.dumps(pattern)};\n'
 		f'var IS_REGEX = {json.dumps(regex)};\n'
@@ -1276,14 +1374,17 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			param_model=SearchPageAction,
 		)
 		async def search_page(params: SearchPageAction, browser_session: BrowserSession):
-			js_code = _build_search_page_js(
-				pattern=params.pattern,
-				regex=params.regex,
-				case_sensitive=params.case_sensitive,
-				context_chars=params.context_chars,
-				css_scope=params.css_scope,
-				max_results=params.max_results,
-			)
+			try:
+				js_code = _build_search_page_js(
+					pattern=params.pattern,
+					regex=params.regex,
+					case_sensitive=params.case_sensitive,
+					context_chars=params.context_chars,
+					css_scope=params.css_scope,
+					max_results=params.max_results,
+				)
+			except ValueError as e:
+				return ActionResult(error=f'search_page: {e}')
 
 			cdp_session = await browser_session.get_or_create_cdp_session()
 			result = await cdp_session.cdp_client.send.Runtime.evaluate(

--- a/tests/ci/security/test_search_page_redos.py
+++ b/tests/ci/security/test_search_page_redos.py
@@ -1,0 +1,200 @@
+"""Regression tests for the search_page ReDoS hardening.
+
+The ``search_page`` browser action compiles a model-controlled pattern with
+``new RegExp(PATTERN, flags)`` inside the page's V8 engine and runs it over the
+concatenated page text. V8's RegExp engine is backtracking-based, so a
+"nested quantifier" pattern such as ``(a+)+$`` against long near-miss text can
+exhibit catastrophic (exponential) runtime and tie up the browser action.
+
+These tests pin the Python-side guard that rejects such patterns *before* they
+ever reach ``new RegExp(...)``. They are hermetic (no browser, no network) and
+the one test that actually exercises a backtracking engine is bounded by
+construction (tiny input lengths) so it can never hang the suite.
+
+The behavioural sink-level test (``test_build_rejects_poc_pattern``) depends only
+on ``_build_search_page_js``, which already exists upstream, so it *runs* against
+the unpatched code and fails there (the pattern is happily embedded into the
+generated JS), and passes once the guard is added.
+"""
+
+import re
+import time
+
+import pytest
+
+# _build_search_page_js exists in both the unpatched and patched trees, so this
+# import succeeds either way and lets the behavioural test execute on both.
+from browser_use.tools.service import _build_search_page_js
+
+# Catastrophic-backtracking "evil regex" shapes that must be rejected in regex mode.
+EVIL_PATTERNS = [
+	'(a+)+$',  # the PoC pattern
+	'(a*)*',
+	'(a+)*',
+	'(a*)+',
+	'(ab+)+',
+	'(?:a+)+',
+	'((a)+)+',  # arbitrary nesting
+	'(([a-z]+)*)+',
+	r'(\d+)+$',
+	'(a{2,})+',
+	'(a+){3,}',
+	'(.*)+',
+]
+
+# Legitimate patterns a model might reasonably emit; these must keep working.
+SAFE_PATTERNS = [
+	r'\d+\.\d+',
+	r'\$\d+\.\d{2}',
+	'support@example.com',
+	'a+',
+	'[a-z]+',
+	'(foo|bar)',
+	'(abc)+',
+	'(ab)+',
+	'a{2,5}',
+	r'[+*]+',  # quantifier chars only inside a character class — not nested
+	r'\(a+\)+',  # escaped parens are literal, not a group
+	'Widget A',
+]
+
+
+def _guard_helpers():
+	"""Import the guard helpers lazily so helper-specific tests skip cleanly on
+	an unpatched tree instead of erroring at collection time."""
+	try:
+		from browser_use.tools.service import (
+			_MAX_SEARCH_PATTERN_LENGTH,
+			_has_nested_quantifier,
+			_validate_search_pattern,
+		)
+	except ImportError:
+		pytest.skip('search_page ReDoS guard not present in this build')
+	return _validate_search_pattern, _has_nested_quantifier, _MAX_SEARCH_PATTERN_LENGTH
+
+
+class TestNestedQuantifierDetection:
+	"""Unit coverage for the nested-quantifier detector."""
+
+	@pytest.mark.parametrize('pattern', EVIL_PATTERNS)
+	def test_evil_patterns_flagged(self, pattern):
+		_, has_nested_quantifier, _ = _guard_helpers()
+		assert has_nested_quantifier(pattern) is True, f'expected {pattern!r} to be flagged'
+
+	@pytest.mark.parametrize('pattern', SAFE_PATTERNS)
+	def test_safe_patterns_not_flagged(self, pattern):
+		_, has_nested_quantifier, _ = _guard_helpers()
+		assert has_nested_quantifier(pattern) is False, f'{pattern!r} should not be flagged'
+
+
+class TestValidateSearchPattern:
+	"""The validator should raise on unsafe input and accept safe input."""
+
+	@pytest.mark.parametrize('pattern', EVIL_PATTERNS)
+	def test_evil_regex_rejected(self, pattern):
+		validate_search_pattern, _, _ = _guard_helpers()
+		with pytest.raises(ValueError):
+			validate_search_pattern(pattern, regex=True)
+
+	@pytest.mark.parametrize('pattern', SAFE_PATTERNS)
+	def test_safe_regex_accepted(self, pattern):
+		validate_search_pattern, _, _ = _guard_helpers()
+		validate_search_pattern(pattern, regex=True)  # should not raise
+
+	def test_literal_mode_ignores_nested_quantifier(self):
+		# In literal mode the pattern is escaped before compilation, so it cannot
+		# backtrack pathologically; the nested-quantifier rule must not fire.
+		validate_search_pattern, _, _ = _guard_helpers()
+		validate_search_pattern('(a+)+$', regex=False)
+
+	def test_pattern_length_cap(self):
+		validate_search_pattern, _, max_len = _guard_helpers()
+		too_long = 'a' * (max_len + 1)
+		with pytest.raises(ValueError):
+			validate_search_pattern(too_long, regex=False)
+		with pytest.raises(ValueError):
+			validate_search_pattern(too_long, regex=True)
+		# Exactly at the cap is allowed.
+		validate_search_pattern('a' * max_len, regex=False)
+
+
+class TestBuildSearchPageJsGuard:
+	"""The guard is enforced at the single chokepoint that feeds new RegExp(...).
+
+	These tests use only ``_build_search_page_js`` so they execute on both the
+	patched and unpatched trees — and fail on the unpatched tree.
+	"""
+
+	def test_build_rejects_poc_pattern(self):
+		# Unpatched: returns a JS string embedding the evil pattern (no raise) -> FAILS here.
+		# Patched: raises ValueError before any JS is built.
+		with pytest.raises(ValueError):
+			_build_search_page_js(
+				pattern='(a+)+$',
+				regex=True,
+				case_sensitive=True,
+				context_chars=150,
+				css_scope=None,
+				max_results=1,
+			)
+
+	def test_build_rejects_overlong_pattern(self):
+		with pytest.raises(ValueError):
+			_build_search_page_js(
+				pattern='a' * 5000,
+				regex=False,
+				case_sensitive=False,
+				context_chars=150,
+				css_scope=None,
+				max_results=25,
+			)
+
+	def test_build_allows_benign_regex(self):
+		js = _build_search_page_js(
+			pattern=r'\d+\.\d+',
+			regex=True,
+			case_sensitive=False,
+			context_chars=150,
+			css_scope=None,
+			max_results=25,
+		)
+		assert 'var PATTERN' in js
+		assert 'var IS_REGEX' in js  # template still intact
+
+
+def _match_time(pattern: str, subject: str) -> float:
+	"""Wall-clock seconds to attempt ``pattern`` against ``subject`` once."""
+	compiled = re.compile(pattern)
+	start = time.perf_counter()
+	compiled.search(subject)
+	return time.perf_counter() - start
+
+
+class TestEvilPatternActuallyBacktracks:
+	"""Demonstrate the threat is real, bounded by construction so it cannot hang.
+
+	We use small input lengths where the PoC pattern ``(a+)+$`` already exhibits
+	clear exponential growth in a backtracking engine (CPython ``re`` here stands
+	in for the browser's V8 RegExp engine — both backtrack). The largest match
+	attempted is ``n == 24`` (well under a second), keeping total runtime tiny.
+	"""
+
+	def test_poc_pattern_growth_is_super_linear(self):
+		# Near-miss subjects for /(a+)+$/: a run of 'a' that fails the final anchor.
+		# Each +2 in n should multiply the runtime, which a linear engine never would.
+		t_small = _match_time('(a+)+$', 'a' * 20 + '!')
+		t_large = _match_time('(a+)+$', 'a' * 24 + '!')
+
+		# A safe linear pattern over the same (larger) input is effectively free.
+		t_safe = _match_time('a+$', 'a' * 24 + '!')
+
+		# Generous thresholds: robust across machines while still proving the pathology.
+		assert t_large > t_small * 3, f'expected super-linear growth, got {t_small=} {t_large=}'
+		assert t_large > t_safe * 20, f'expected evil >> safe, got {t_large=} {t_safe=}'
+
+	def test_guard_blocks_the_catastrophic_pattern(self):
+		# The guard rejects exactly this pattern before it can ever be compiled into
+		# the page's RegExp engine, so the blow-up above can never actually run.
+		validate_search_pattern, _, _ = _guard_helpers()
+		with pytest.raises(ValueError):
+			validate_search_pattern('(a+)+$', regex=True)


### PR DESCRIPTION
The search_page browser action compiles a model-controlled pattern with `new RegExp(PATTERN, flags)` in the page's V8 engine and runs it over the concatenated page text. V8's RegExp engine is backtracking-based, so a nested-quantifier pattern such as `(a+)+$` against long near-miss text can exhibit catastrophic (exponential) runtime and tie up the browser action until the per-action timeout fires.

Add a Python-side guard at the single chokepoint that builds the search JS (`_build_search_page_js`):

- cap the pattern length (`_MAX_SEARCH_PATTERN_LENGTH = 1000`, generous for legitimate searches);
- reject catastrophic nested-quantifier shapes (`(a+)+`, `(a*)*`, `((a)+)+`, `(([a-z]+)*)+`, ...) when `regex=true`, via a conservative linear scanner that handles arbitrary group nesting, escaped metacharacters, and character classes. Literal (`regex=false`) searches are only length-capped because they are escaped before compilation and cannot backtrack pathologically.

The guard runs before the pattern ever reaches `new RegExp(...)`. When a pattern is rejected, `search_page` returns a clear `ActionResult(error=...)` so the agent can adjust, instead of stalling the browser. Public action schema and signatures are unchanged.

Adds tests/ci/security/test_search_page_redos.py.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects `search_page` from regex-based ReDoS by validating model-supplied patterns before they reach `new RegExp(...)`. Prevents catastrophic backtracking and returns a clear error instead of stalling the browser.

- **Bug Fixes**
  - Add Python-side guard in `_build_search_page_js` that runs before `new RegExp(...)`.
  - Cap pattern length at `_MAX_SEARCH_PATTERN_LENGTH = 1000`.
  - Reject nested-quantifier patterns in regex mode (e.g., `(a+)+`, `(a*)*`, `((a)+)+`) using a conservative scanner that handles nesting, escapes, and character classes.
  - Literal searches (`regex=false`) are only length-capped since they are escaped.
  - On rejection, return `ActionResult(error=...)`; no public API change. Added regression tests in `tests/ci/security/test_search_page_redos.py`.

<sup>Written for commit 7354a1c15c856f45745f053896bb3cf646b95182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

