### PR TITLE
fix: preserve empty accessibility names in DOMInteractedElement

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_ax_name_matching.py
+++ b/tests/ci/test_ax_name_matching.py
@@ -14,8 +14,44 @@ from unittest.mock import AsyncMock
 from browser_use.agent.service import Agent
 from browser_use.agent.views import ActionResult, AgentHistory, AgentHistoryList, RerunSummaryAction, StepMetadata
 from browser_use.browser.views import BrowserStateHistory
-from browser_use.dom.views import DOMInteractedElement, DOMRect, MatchLevel, NodeType
+from browser_use.dom.views import DOMInteractedElement, DOMRect, EnhancedAXNode, EnhancedDOMTreeNode, MatchLevel, NodeType
 from tests.ci.conftest import create_mock_llm
+
+
+def test_load_from_enhanced_dom_tree_preserves_empty_ax_name():
+	element = EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=EnhancedAXNode(
+			ax_node_id='ax-1',
+			ignored=False,
+			role='button',
+			name='',
+			description=None,
+			properties=None,
+			child_ids=None,
+		),
+		snapshot_node=None,
+	)
+
+	interacted_element = DOMInteractedElement.load_from_enhanced_dom_tree(element)
+
+	assert interacted_element.ax_name == ''
 
 
 async def test_ax_name_matching_succeeds_when_hash_fails(httpserver):


### PR DESCRIPTION
## Summary

This PR fixes an issue in `DOMInteractedElement.load_from_enhanced_dom_tree()` where explicitly empty accessibility names (`""`) were being treated as missing values.

Previously, the code used a truthiness check:

```python
if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
```

Because empty strings evaluate to `False` in Python, an accessibility name of `""` was incorrectly converted to `None`.

This change replaces the truthiness check with an explicit `None` check, preserving the distinction between:

* `None` → accessibility name is missing
* `""` → accessibility name exists but is intentionally empty

## Changes

* Replace the truthiness check with an explicit `is not None` check.
* Add a regression test to ensure empty accessibility names are preserved.

## Why

Empty accessibility names are valid in HTML/ARIA contexts. Preserving them avoids conflating two different states and ensures downstream DOM matching and interaction logic can correctly distinguish between missing and intentionally empty accessibility names.

Fixes #5041


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves empty accessibility names ("") when creating interacted elements instead of converting them to None. Fixes #5041.

- **Bug Fixes**
  - Replace truthiness check with an explicit None check in `DOMInteractedElement.load_from_enhanced_dom_tree`.
  - Add a regression test to ensure `ax_name == ""` is preserved.

<sup>Written for commit 475805ba2060791d7b0c6fa30155fab90eac7738. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

