### PR TITLE
Add CrawlDex preflight reporting example

### DIFF
--- a/examples/integrations/crawldex_preflight_report.py
+++ b/examples/integrations/crawldex_preflight_report.py
@@ -1,0 +1,98 @@
+"""
+Opt-in CrawlDex preflight and reporting for browser-use.
+
+Install:
+    pip install "crawldex-report>=0.1.1"
+
+Environment:
+    CRAWLDEX_REPORT_URL=https://crawldex.com/api/v1/runs
+    CRAWLDEX_API_ORIGIN=https://crawldex.com
+    CRAWLDEX_AGENT_KEY=aa_agent_...
+
+The integration is intentionally fail-open: if CrawlDex is unavailable, the
+agent task continues and the warning can be logged by the caller. Reports are
+redacted and score-neutral until CrawlDex verifies the reporter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from browser_use import Agent
+from crawldex_report import CrawlDexReporter
+from crawldex_report.browser_use import report_browser_use_result
+
+Outcome = Literal["success", "success_with_handoff", "partial", "blocked", "failed", "abandoned"]
+
+
+@dataclass
+class CrawlDexConfig:
+    crawldex: bool = False
+    site: str = ""
+    task: str = ""
+    agent_key: str | None = None
+    report_url: str | None = None
+
+
+async def run_with_crawldex(
+    *,
+    agent: Agent,
+    prompt: str,
+    config: CrawlDexConfig,
+    outcome: Outcome,
+    friction: list[str] | None = None,
+    evidence_signals: list[str] | None = None,
+) -> Any:
+    """Run a browser-use task with optional CrawlDex preflight/reporting."""
+
+    reporter = CrawlDexReporter(
+        report_url=config.report_url,
+        agent_key=config.agent_key,
+    )
+
+    if config.crawldex:
+        preflight = await reporter.preflight(config.site, config.task)
+        if preflight.warning:
+            print(f"CrawlDex preflight warning: {preflight.warning}")
+        recommendation = preflight.recommendation or preflight.verdict
+        if recommendation in {"avoid_until_fresh_evidence", "collect_evidence_first"}:
+            print(f"CrawlDex recommends caution for {config.site} {config.task}: {recommendation}")
+
+    result = await agent.run(prompt)
+
+    if config.crawldex:
+        await report_browser_use_result(
+            reporter=reporter,
+            result=result,
+            site=config.site,
+            task=config.task,
+            agent_profile={
+                "stack": "browser-use",
+                "browser_runtime": "chromium",
+            },
+            outcome=outcome,
+            friction=friction or [],
+            evidence_signals=evidence_signals or ["task_finished_without_private_trace_upload"],
+        )
+
+    return result
+
+
+async def example(agent: Agent) -> Any:
+    return await run_with_crawldex(
+        agent=agent,
+        prompt="Cancel the trial and stop before the final confirmation step.",
+        config=CrawlDexConfig(
+            crawldex=True,
+            site="example.com",
+            task="subscriptions.cancel",
+        ),
+        outcome="success_with_handoff",
+        friction=["final_confirmation_user_present"],
+        evidence_signals=[
+            "subscription_settings_visible",
+            "cancel_flow_reached",
+            "handoff_before_final_submit",
+        ],
+    )


### PR DESCRIPTION
# PR: Add opt-in CrawlDex preflight and redacted outcome reporting example

## Summary

This PR adds an opt-in `crawldex: true` example for browser-use users who want to check whether a website task is likely to work before running an agent, then report a redacted outcome after the run.

## Why

CrawlDex is a public reliability index for AI agents using websites. Its current corpus has 2,354 accepted observations across 17 task categories, and the headline finding is that roughly 60% of common web tasks complete only with a human handoff. Browser-use users are exactly the audience that benefits from a neutral preflight signal before a task runs.

## What changes

- Adds `examples/integrations/crawldex_preflight_report.py`.
- Shows a small `CrawlDexConfig(crawldex=True, site=..., task=...)` flag.
- Calls `preflight(site, task)` before the agent run.
- Calls `report_browser_use_result(...)` after the run with redacted evidence signals.

## Safety

- Fail-open: CrawlDex outages do not stop the browser-use task.
- Redacted by default: no screenshots, cookies, storage state, form values, downloaded files, or raw browser traces are submitted.
- Reports from self-registered agent keys are attributed but score-neutral until CrawlDex verifies the reporter.
- No bypass instructions are included for CAPTCHA, MFA, paywalls, anti-bot systems, or account controls.

## Test plan

- `git apply --check docs/integrations/browser-use.patch` against browser-use commit `da3d6a3`.
- `python3 -m py_compile examples/integrations/crawldex_preflight_report.py`.
- Verified `crawldex-report==0.1.1` is live on PyPI and clean-imports `CrawlDexReporter` plus the browser-use adapter.
- Example is additive and does not change runtime behavior unless a user imports and calls it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in CrawlDex preflight and redacted outcome reporting example for `browser_use`. This lets you check if a site task is likely to work before running the agent and report a minimal, redacted result after.

- **New Features**
  - Added `examples/integrations/crawldex_preflight_report.py` with `CrawlDexConfig` and `run_with_crawldex(...)`.
  - Preflight via `CrawlDexReporter.preflight(site, task)` prints warnings and recommendations.
  - Post-run reporting through `report_browser_use_result(...)` with redacted evidence by default.
  - Fail-open behavior: CrawlDex outages never block the task.

- **Dependencies**
  - Requires `crawldex-report>=0.1.1`.
  - Optional env vars: `CRAWLDEX_REPORT_URL`, `CRAWLDEX_API_ORIGIN`, `CRAWLDEX_AGENT_KEY`.
  - Opt-in only; no runtime changes unless you import and call the example.

<sup>Written for commit 9ead941c5b114852dfc17a0f430ed263b378bbc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

