### PR TITLE
fix(browser): ignore extension page targets

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -155,7 +155,7 @@ class SessionManager:
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
+			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
 				page_targets.append(target)
 		return page_targets
 

--- a/tests/ci/browser/test_session_manager.py
+++ b/tests/ci/browser/test_session_manager.py
@@ -1,0 +1,47 @@
+import logging
+from types import SimpleNamespace
+from typing import cast
+
+from browser_use.browser.session import BrowserSession, Target
+from browser_use.browser.session_manager import SessionManager
+
+
+def test_get_all_page_targets_excludes_chrome_extension_pages():
+	browser_session = cast(
+		BrowserSession,
+		SimpleNamespace(
+			logger=logging.getLogger('test_session_manager'),
+			agent_focus_target_id=None,
+		),
+	)
+	manager = SessionManager(browser_session)
+	manager._targets = {
+		'page-target': Target(
+			target_id='page-target',
+			target_type='page',
+			url='https://example.com',
+			title='Example',
+		),
+		'extension-side-panel': Target(
+			target_id='extension-side-panel',
+			target_type='page',
+			url='chrome-extension://abc123/side-panel.html',
+			title='Extension side panel',
+		),
+		'blank-tab': Target(
+			target_id='blank-tab',
+			target_type='tab',
+			url='about:blank',
+			title='New tab',
+		),
+		'worker-target': Target(
+			target_id='worker-target',
+			target_type='service_worker',
+			url='https://example.com/sw.js',
+			title='Worker',
+		),
+	}
+
+	target_ids = [target.target_id for target in manager.get_all_page_targets()]
+
+	assert target_ids == ['page-target', 'blank-tab']


### PR DESCRIPTION
## Summary
- Exclude `chrome-extension://` page/tab targets from `SessionManager.get_all_page_targets()`.
- Prevent extension side panels from being exposed as normal tabs or selected during focus recovery.
- Add a focused regression test for mixed page, extension, blank-tab, and worker targets.

Fixes #4133.

## Verification
- `uv run --no-sync pytest tests/ci/browser/test_session_manager.py`
- `uv run --no-sync ruff check browser_use/browser/session_manager.py tests/ci/browser/test_session_manager.py`
- `uv run --no-sync ruff format --check browser_use/browser/session_manager.py tests/ci/browser/test_session_manager.py`
- `uv run --no-sync pre-commit run --files browser_use/browser/session_manager.py tests/ci/browser/test_session_manager.py --show-diff-on-failure`

## Duplicate checks
I checked #4133 comments and found no assignee or claimed work. I also searched open and closed PRs for these related terms and found no matching fix: `4133`, `chrome-extension`, `Agent focus`, `get_all_page_targets`, `side panel`, `extension side panel`, and `extension focus target`.

## Notes
The change intentionally keeps the behavior narrow: it only filters extension page/tab targets, leaving ordinary `https://` pages and `about:blank` tabs untouched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignores `chrome-extension://` page/tab targets in the session manager so extension side panels no longer appear as normal tabs or get picked during focus recovery (fixes #4133). Adds a regression test that validates mixed page, extension, about:blank tab, and worker targets, ensuring only real pages and blank tabs are returned.

<sup>Written for commit dc81682aef5b3273c5147cdfd21b34e91f68a865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

