### PR TITLE
feat: add nimble as an API-backed search engine

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -75,6 +75,49 @@ Context = TypeVar('Context')
 T = TypeVar('T', bound=BaseModel)
 
 
+async def _search_nimble(query: str, *, max_results: int = 10) -> ActionResult:
+	"""Search the web via Nimble's API-backed search.
+
+	Unlike the browser-navigation engines (google/bing/duckduckgo), this returns
+	structured results directly in a single API call, with no page navigation —
+	a reliability upgrade over scraping a rendered results page. Requires the
+	optional ``nimble`` extra and a ``NIMBLE_API_KEY`` environment variable.
+	"""
+	try:
+		from nimble_python import AsyncNimble
+	except ImportError:
+		return ActionResult(
+			error="The 'nimble' search engine requires the nimble-python package. Install it with: pip install 'browser-use[nimble]'"
+		)
+
+	if not os.environ.get('NIMBLE_API_KEY'):
+		return ActionResult(error='NIMBLE_API_KEY environment variable not set')
+
+	try:
+		client = AsyncNimble(default_headers={'X-Client-Source': 'browser-use'})
+		response = await client.search(query=query, max_results=max_results, output_format='markdown')
+	except Exception as e:
+		logger.error(f'Failed to search Nimble: {e}')
+		return ActionResult(error=f'Failed to search Nimble for "{query}": {e}')
+
+	results = response.results or []
+	memory = f"Searched Nimble for '{query}' ({len(results)} results)"
+	if not results:
+		return ActionResult(extracted_content=memory, long_term_memory=memory)
+
+	lines = []
+	for result in results:
+		snippet = result.content or result.description or ''
+		lines.append(f'- {result.title}\n  {result.url}\n  {snippet}'.rstrip())
+	extracted = f"Search results for '{query}':\n" + '\n'.join(lines)
+	logger.info(f'🔍  {memory}')
+	return ActionResult(
+		extracted_content=extracted,
+		long_term_memory=memory,
+		include_extracted_content_only_once=True,
+	)
+
+
 # Global per-action timeout: last-resort guard against hung event handlers.
 # Individual CDP calls (Page.navigate etc.) have their own shorter timeouts,
 # but event-bus `await event` and `event_result()` calls have none — if a
@@ -440,6 +483,14 @@ class Tools(Generic[Context]):
 			terminates_sequence=True,
 		)
 		async def search(params: SearchAction, browser_session: BrowserSession):
+			# Nimble is an API-backed search engine: instead of navigating the
+			# browser to a search-results page and scraping it, it returns
+			# structured results in a single API call. Handle it before the
+			# browser-navigation engines below; google/bing/duckduckgo behavior
+			# is unchanged.
+			if params.engine.lower() == 'nimble':
+				return await _search_nimble(params.query)
+
 			import urllib.parse
 
 			# Encode query for URL safety
@@ -453,7 +504,9 @@ class Tools(Generic[Context]):
 			}
 
 			if params.engine.lower() not in search_engines:
-				return ActionResult(error=f'Unsupported search engine: {params.engine}. Options: duckduckgo, google, bing')
+				return ActionResult(
+					error=f'Unsupported search engine: {params.engine}. Options: duckduckgo, google, bing, nimble'
+				)
 
 			search_url = search_engines[params.engine.lower()]
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -94,8 +94,8 @@ async def _search_nimble(query: str, *, max_results: int = 10) -> ActionResult:
 		return ActionResult(error='NIMBLE_API_KEY environment variable not set')
 
 	try:
-		client = AsyncNimble(default_headers={'X-Client-Source': 'browser-use'})
-		response = await client.search(query=query, max_results=max_results, output_format='markdown')
+		async with AsyncNimble(default_headers={'X-Client-Source': 'browser-use'}) as client:
+			response = await client.search(query=query, max_results=max_results, output_format='markdown')
 	except Exception as e:
 		logger.error(f'Failed to search Nimble: {e}')
 		return ActionResult(error=f'Failed to search Nimble for "{query}": {e}')

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -49,7 +49,8 @@ class FindElementsAction(BaseModel):
 class SearchAction(BaseModel):
 	query: str
 	engine: str = Field(
-		default='duckduckgo', description='duckduckgo, google, bing (use duckduckgo by default because less captchas)'
+		default='duckduckgo',
+		description='duckduckgo, google, bing (use duckduckgo by default because less captchas), or nimble for an API-backed search that returns structured results without browser navigation',
 	)
 
 

--- a/examples/integrations/nimble/README.md
+++ b/examples/integrations/nimble/README.md
@@ -1,0 +1,41 @@
+# Nimble search engine
+
+Use [Nimble](https://nimbleway.com) as an API-backed search engine for Browser Use's
+built-in `search` action.
+
+## What & why
+
+The built-in `search` action navigates the browser to Google/Bing/DuckDuckGo and
+scrapes the rendered results page. With `engine="nimble"` it instead calls Nimble's
+search API and returns structured results (title, URL, snippet) in a single call — no
+page navigation, no CAPTCHA risk.
+
+Reach for it when you want clean, structured results without the agent browsing a
+SERP — for example research and extraction tasks where scraping Google is brittle. The
+browser-navigation engines (`duckduckgo`, the default, plus `google`/`bing`) stay
+available for when you actually want the agent to browse the results page.
+
+## Setup
+
+```bash
+uv pip install 'browser-use[nimble]'
+export NIMBLE_API_KEY='your-key'   # get a key from Nimble
+```
+
+If the `nimble` extra isn't installed or `NIMBLE_API_KEY` is unset, the engine returns a
+friendly error instead of raising.
+
+## Run
+
+From the repository root:
+
+```bash
+uv run python examples/integrations/nimble/nimble_search.py
+```
+
+## How it works
+
+The agent calls the normal `search` action with `engine="nimble"`; the action routes the
+query to Nimble's `/v1/search` and returns the results inline as the action's
+`extracted_content`. Nothing else in the agent loop changes. The API key is read from the
+environment only — no secrets are committed.

--- a/examples/integrations/nimble/nimble_search.py
+++ b/examples/integrations/nimble/nimble_search.py
@@ -1,0 +1,36 @@
+"""Use Nimble as an API-backed search engine inside Browser Use.
+
+The built-in `search` action normally navigates the browser to Google/Bing/
+DuckDuckGo and scrapes the rendered page. With `engine="nimble"` it calls Nimble's
+search API and returns structured results (title, URL, snippet) in one step — no
+navigation, no CAPTCHA risk — which is handy for research/extraction tasks.
+
+Setup:
+	uv pip install 'browser-use[nimble]'
+	export NIMBLE_API_KEY='your-key'    # get a key from Nimble
+
+Run from the repository root:
+	uv run python examples/integrations/nimble/nimble_search.py
+"""
+
+import asyncio
+import os
+
+from browser_use import Agent, ChatBrowserUse
+
+if not os.environ.get('NIMBLE_API_KEY'):
+	raise SystemExit('NIMBLE_API_KEY is not set — get a key from Nimble and export it before running.')
+
+
+async def main():
+	# Steer the built-in search action to Nimble's API-backed engine.
+	task = (
+		"Use the search action with engine='nimble' to find the latest browser-use "
+		'release notes, then summarize the top 3 results with their URLs.'
+	)
+	agent = Agent(task=task, llm=ChatBrowserUse())
+	await agent.run()
+
+
+if __name__ == '__main__':
+	asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ core = [
 ]
 aws = ["boto3==1.42.37"]
 oci = ["oci==2.166.0"]
+nimble = ["nimble-python>=0.16.0"]
 video = ["imageio[ffmpeg]==2.37.2", "numpy==2.4.1"]
 examples = [
     "agentmail==0.0.59",
@@ -229,6 +230,7 @@ dev-dependencies = [
     "pytest==9.0.2",
     "pytest-asyncio==1.3.0",
     "pytest-httpserver==1.1.3",
+    "nimble-python>=0.16.0",
     "fastapi==0.128.0",
     "inngest==0.5.15",
     "uvicorn==0.40.0",

--- a/tests/ci/test_nimble_search_provider.py
+++ b/tests/ci/test_nimble_search_provider.py
@@ -1,0 +1,171 @@
+"""Tests for the Nimble API-backed search engine on the native ``search`` action.
+
+Per the repo's testing rules these use real objects — a real ``AsyncNimble``
+client driven against a local ``pytest-httpserver`` — rather than mocks, and never
+hit a real remote URL. The client is pointed at the local server via the
+``NIMBLE_BASE_URL`` env var. ``nimble-python`` is the optional ``nimble`` extra; the
+module skips cleanly when it is not installed.
+
+The ``nimble_python``-not-installed branch (``service.py``: friendly install hint) is
+not exercised here on purpose — the module is skipped when the package is absent.
+"""
+
+import pytest
+
+pytest.importorskip('nimble_python')
+
+from browser_use import BrowserProfile, BrowserSession
+from browser_use.agent.views import ActionResult
+from browser_use.tools.service import Tools, _search_nimble
+
+
+def _search_payload() -> dict:
+	return {
+		'request_id': '00000000-0000-0000-0000-000000000000',
+		'total_results': 2,
+		'results': [
+			{
+				'title': 'Example One',
+				'url': 'https://example.com/one',
+				'content': 'First result content.',
+				'description': 'First description.',
+				'metadata': {'country': 'US', 'entity_type': 'organic', 'locale': 'en', 'position': 1},
+			},
+			{
+				'title': 'Example Two',
+				'url': 'https://example.com/two',
+				'content': 'Second result content.',
+				'description': 'Second description.',
+				'metadata': {'country': 'US', 'entity_type': 'organic', 'locale': 'en', 'position': 2},
+			},
+		],
+	}
+
+
+def _point_client_at(httpserver, monkeypatch) -> None:
+	"""Redirect the real AsyncNimble client at the local pytest-httpserver."""
+	monkeypatch.setenv('NIMBLE_API_KEY', 'test-key')
+	monkeypatch.setenv('NIMBLE_BASE_URL', httpserver.url_for('/').rstrip('/'))
+
+
+# Real registry + real (headless) browser, mirroring tests/ci/test_search_find.py.
+
+
+@pytest.fixture(scope='module')
+async def browser_session():
+	session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=True))
+	await session.start()
+	yield session
+	await session.kill()
+
+
+@pytest.fixture(scope='function')
+def tools():
+	return Tools()
+
+
+# --- Through the real registered `search` action (engine routing + side-effects) ---
+
+
+async def test_search_action_nimble_engine_returns_results_inline(tools, browser_session, httpserver, monkeypatch):
+	"""engine='nimble' on the real search action returns structured results inline,
+	without navigating the browser."""
+	httpserver.expect_request('/v1/search', method='POST').respond_with_json(_search_payload())
+	_point_client_at(httpserver, monkeypatch)
+
+	url_before = await browser_session.get_current_page_url()
+	result = await tools.search(query='browser use release notes', engine='nimble', browser_session=browser_session)
+
+	assert isinstance(result, ActionResult)
+	assert result.error is None
+	assert result.include_extracted_content_only_once is True
+	assert result.extracted_content is not None
+	assert 'Example One' in result.extracted_content
+	assert 'https://example.com/two' in result.extracted_content
+	assert '2 results' in (result.long_term_memory or '')
+
+	# The nimble path returns before any NavigateToUrlEvent, so the browser does not move.
+	assert await browser_session.get_current_page_url() == url_before
+
+	# The request really reached the API, carrying the tracking header.
+	request, _ = httpserver.log[-1]
+	assert request.headers.get('X-Client-Source') == 'browser-use'
+
+
+async def test_search_action_nimble_missing_key(tools, browser_session, monkeypatch):
+	"""Through the action: no key → friendly error, no API call, no navigation."""
+	monkeypatch.delenv('NIMBLE_API_KEY', raising=False)
+
+	url_before = await browser_session.get_current_page_url()
+	result = await tools.search(query='anything', engine='nimble', browser_session=browser_session)
+
+	assert result.error == 'NIMBLE_API_KEY environment variable not set'
+	assert result.extracted_content is None
+	assert await browser_session.get_current_page_url() == url_before
+
+
+async def test_search_action_unknown_engine_errors(tools, browser_session):
+	"""An unknown engine returns a clear ActionResult error, not a crash. nimble must
+	NOT fall into this branch."""
+	result = await tools.search(query='x', engine='altavista', browser_session=browser_session)
+
+	assert isinstance(result, ActionResult)
+	assert result.error is not None
+	assert 'Unsupported search engine' in result.error
+	assert 'altavista' in result.error
+
+
+# --- Registration (mirrors tests/ci/test_search_find.py TestRegistration) ---
+
+
+def test_search_action_registered(tools):
+	"""The search action (which now routes engine='nimble') is registered."""
+	assert 'search' in tools.registry.registry.actions
+
+
+def test_search_action_excludable():
+	"""Excluding 'search' removes the nimble entrypoint without breaking siblings."""
+	excluded = Tools(exclude_actions=['search'])
+	assert 'search' not in excluded.registry.registry.actions
+	assert 'navigate' in excluded.registry.registry.actions
+
+
+# --- Helper-level coverage of the nimble engine (no browser needed) ---
+
+
+async def test_nimble_search_returns_structured_results(httpserver, monkeypatch):
+	"""The nimble engine formats the API results into ActionResult.extracted_content."""
+	httpserver.expect_request('/v1/search', method='POST').respond_with_json(_search_payload())
+	_point_client_at(httpserver, monkeypatch)
+
+	result = await _search_nimble('browser use release notes')
+
+	assert isinstance(result, ActionResult)
+	assert result.error is None
+	assert result.include_extracted_content_only_once is True
+	assert result.extracted_content is not None
+	assert 'Example One' in result.extracted_content
+	assert 'https://example.com/two' in result.extracted_content
+	assert '2 results' in (result.long_term_memory or '')
+
+
+async def test_nimble_search_missing_key_returns_friendly_error(monkeypatch):
+	"""Without a key the engine returns a friendly error and never calls the API."""
+	monkeypatch.delenv('NIMBLE_API_KEY', raising=False)
+
+	result = await _search_nimble('anything')
+
+	assert result.error == 'NIMBLE_API_KEY environment variable not set'
+	assert result.extracted_content is None
+
+
+async def test_nimble_search_handles_empty_results(httpserver, monkeypatch):
+	"""An empty result set is reported without error."""
+	payload = {'request_id': '00000000-0000-0000-0000-000000000000', 'total_results': 0, 'results': []}
+	httpserver.expect_request('/v1/search', method='POST').respond_with_json(payload)
+	_point_client_at(httpserver, monkeypatch)
+
+	result = await _search_nimble('obscure query with no hits')
+
+	assert result.error is None
+	assert '0 results' in (result.extracted_content or '')


### PR DESCRIPTION
## What

Adds `nimble` as an API-backed engine for the built-in `search` action:

```python
# needs:  uv pip install 'browser-use[nimble]'   and   NIMBLE_API_KEY
search(query="...", engine="nimble")
```

The existing `google` / `bing` / `duckduckgo` engines navigate the browser to a results page and scrape the rendered HTML. `engine="nimble"` instead calls [Nimble](https://nimbleway.com)'s search API and returns structured results directly in the `ActionResult` — no navigation. The default engine is unchanged (`duckduckgo`); `nimble` is fully opt-in.

## Why

Scraping a live SERP is the flakiest part of an otherwise reliable run — captchas, bot blocks, and layout drift all hit the search step. An API-backed engine sidesteps that: one call, structured results, no page to render. It's opt-in and has zero impact on the base install. This mirrors the API-backed search pattern already shown in `examples/custom-functions/advanced_search.py` (Serper), but as a first-class option on the native action rather than a replacement of it.

## Changes

- `browser_use/tools/service.py` — new `_search_nimble()` helper; the `search` action dispatches to it when `engine == "nimble"` **before** the browser-navigation branch. The `google`/`bing`/`duckduckgo` path is untouched. The "unsupported engine" error message now lists `nimble` too.
- `browser_use/tools/views.py` — `SearchAction.engine`'s description mentions `nimble` (default still `duckduckgo`; field kept as a plain `str` so adding engines later doesn't break existing callers).
- `pyproject.toml` — optional `nimble` extra (`nimble-python>=0.16.0`). The import is lazy (inside the helper) and guarded by a `NIMBLE_API_KEY` check, so the base install and default behavior are unaffected.
- `tests/ci/test_nimble_search_provider.py` — real-object tests (a real `AsyncNimble` client driven against a local `pytest-httpserver`, no mocks, no real network).
- `examples/integrations/nimble/` — a short README + runnable example showing `engine="nimble"`, following `examples/integrations/README.md`.

## How it works

Results come back to the agent as the engine's `extracted_content` (one block per result):

```
Search results for '<query>':
- <title>
  <url>
  <snippet>
- <title>
  <url>
  <snippet>
...
```

If the `nimble` extra isn't installed, or `NIMBLE_API_KEY` is unset, the engine returns a friendly `ActionResult(error=...)` rather than raising. All calls send an `X-Client-Source: browser-use` header.

## Test plan

- [x] `uv run pytest tests/ci/test_nimble_search_provider.py` → **8 passed**. Real objects via `pytest-httpserver` (no mocks, no real network). Drives `engine="nimble"` through the registered `search` action with a real headless `browser_session` and asserts: structured results in `extracted_content`, the `X-Client-Source` header reaches the API, and the browser **does not navigate** (URL unchanged); plus missing-key, empty-results, unknown-engine, and registration/excludability. (The unchanged `google`/`bing`/`duckduckgo` path stays covered by the existing `test_search_action`.)
- [x] Co-run collection with `tests/ci/test_tools.py` + `tests/ci/test_search_find.py` → 48 collected, no collisions.
- [x] `uv run pyright` on the changed files → 0 errors.
- [x] `uv run ruff check` + `uv run ruff format --check` → clean; `codespell` clean.
- [x] Live smoke (real `NIMBLE_API_KEY`): `client.search('latest python release 2026')` returned 4 real, current results (e.g. Python 3.14.6, Jun 2026) — proving the live API path. Also verified end-to-end through a real `Agent` run that selects `engine="nimble"` and returns a cited answer.

## Scope / non-goals

- Search only (not Extract/Map/Crawl). Opt-in extra; no change to the default engine or the existing engines.
- Conservative defaults (`max_results=10`, `output_format="markdown"`); richer Nimble options can follow if useful.
- `nimble` is its own extra, not part of `[all]`.

## Security

`NIMBLE_API_KEY` is read from the environment only — never in code, tests, or logs. Tests use a dummy key against a local `pytest-httpserver` and never touch the network.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `nimble` as an opt-in API-backed engine for the built-in search action, returning structured results without browser navigation. The default stays duckduckgo; requires `browser-use[nimble]` and a `NIMBLE_API_KEY`.

- **New Features**
  - `engine="nimble"` routes to `_search_nimble()` which calls Nimble’s API and returns titles, URLs, and snippets in `ActionResult` (no page load; `include_extracted_content_only_once=True`).
  - Graceful errors if the `nimble-python` extra isn’t installed or `NIMBLE_API_KEY` is missing; sends `X-Client-Source: browser-use`.
  - Updated `SearchAction.engine` description; error for unknown engines now lists nimble. Added `examples/integrations/nimble/` and CI tests covering header, empty results, and no-navigation behavior.

- **Bug Fixes**
  - Close the `AsyncNimble` client with an async context manager to avoid leaking the underlying httpx connection pool.

<sup>Written for commit 8c63126b3a3faec53336596629010592e656d18c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

