### PR TITLE
fix(llm/openai): don't misclassify gpt-5-chat-latest as a reasoning model

### DIFF
--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -179,7 +179,7 @@ class ChatAzureOpenAI(ChatOpenAILike):
 				model_params['service_tier'] = self.service_tier
 
 			# Handle reasoning models
-			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+			if self._is_reasoning_model():
 				# For reasoning models, use reasoning parameter instead of reasoning_effort
 				model_params['reasoning'] = {'effort': self.reasoning_effort}
 				model_params.pop('temperature', None)

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -120,6 +120,28 @@ class ChatOpenAI(BaseChatModel):
 	def name(self) -> str:
 		return str(self.model)
 
+	def _is_reasoning_model(self) -> bool:
+		"""Whether ``self.model`` should be treated as a reasoning model.
+
+		Reasoning models receive ``reasoning_effort`` and have ``temperature``
+		dropped. Matching is substring-based so Azure deployment names that embed
+		a model id (e.g. ``prod-gpt-5``) still classify. Some chat-tuned
+		snapshots share a prefix with a reasoning model id but are regular chat
+		models that support sampling params (notably the ``gpt-5-chat`` family vs.
+		the ``gpt-5`` reasoning model), so they are excluded explicitly. The
+		exclusion markers are contiguous, so a reasoning deployment whose name
+		merely contains the word ``chat`` elsewhere (e.g. ``prod-chat-gpt-5``) is
+		unaffected.
+		"""
+		if not self.reasoning_models:
+			return False
+		model_lower = str(self.model).lower()
+		# Chat-tuned variants that collide with a reasoning-model prefix.
+		non_reasoning_markers = ('gpt-5-chat',)
+		if any(marker in model_lower for marker in non_reasoning_markers):
+			return False
+		return any(str(m).lower() in model_lower for m in self.reasoning_models)
+
 	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
 		if response.usage is not None:
 			# Note: completion_tokens already includes reasoning_tokens per OpenAI API docs.
@@ -186,7 +208,7 @@ class ChatOpenAI(BaseChatModel):
 			if self.service_tier is not None:
 				model_params['service_tier'] = self.service_tier
 
-			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+			if self._is_reasoning_model():
 				model_params['reasoning_effort'] = self.reasoning_effort
 				model_params.pop('temperature', None)
 				model_params.pop('frequency_penalty', None)

--- a/tests/ci/models/test_llm_openai.py
+++ b/tests/ci/models/test_llm_openai.py
@@ -13,3 +13,29 @@ async def test_openai_gpt_4_1_mini(httpserver):
 		extra_kwargs={},
 		httpserver=httpserver,
 	)
+
+
+def test_reasoning_model_classification():
+	"""gpt-5-chat-latest is a chat model, not a reasoning model, despite the gpt-5 prefix.
+
+	Regression: the reasoning-model gate used a plain substring match, so
+	``'gpt-5' in 'gpt-5-chat-latest'`` was true and the SDK silently dropped
+	``temperature`` (and added ``reasoning_effort``) for a model that supports
+	sampling params.
+	"""
+	# non-reasoning gpt-5-chat snapshots must NOT be treated as reasoning models
+	assert ChatOpenAI(model='gpt-5-chat-latest')._is_reasoning_model() is False
+	assert ChatOpenAI(model='gpt-5-chat')._is_reasoning_model() is False
+	# ...even when embedded in an Azure deployment name
+	assert ChatOpenAI(model='prod-gpt-5-chat-eastus')._is_reasoning_model() is False
+	# genuine reasoning models are still classified correctly
+	for model in ('gpt-5', 'gpt-5-mini', 'gpt-5-nano', 'o3', 'o3-mini', 'o1', 'o1-pro'):
+		assert ChatOpenAI(model=model)._is_reasoning_model() is True, model
+	# dated snapshots / known variants still match via substring
+	assert ChatOpenAI(model='gpt-5-2025-08-07')._is_reasoning_model() is True
+	assert ChatOpenAI(model='o1-preview')._is_reasoning_model() is True
+	# reasoning deployments whose name merely contains "chat" elsewhere stay reasoning
+	assert ChatOpenAI(model='prod-chat-gpt-5')._is_reasoning_model() is True
+	assert ChatOpenAI(model='team-chat-o3-mini')._is_reasoning_model() is True
+	# plain chat models are unaffected
+	assert ChatOpenAI(model='gpt-4o')._is_reasoning_model() is False


### PR DESCRIPTION
## Summary

`ChatOpenAI` (and `ChatAzureOpenAI`, which inherits it) decides whether to send `reasoning_effort` and drop `temperature` by checking whether any `reasoning_models` entry is a **substring** of the model name:

```python
if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
```

Because `gpt-5` is in that list, **`gpt-5-chat-latest`** matches it (`'gpt-5' in 'gpt-5-chat-latest'`), so the SDK silently drops `temperature` and adds `reasoning_effort` for a normal chat model that *does* support sampling params — yielding degraded sampling or a malformed request, with no error to diagnose.

## Fix

Extract a shared `ChatOpenAI._is_reasoning_model()` (inherited by `ChatOpenAILike` / `ChatAzureOpenAI`) used at both call sites. It keeps the substring match — intentional so Azure deployment names that embed a model id (e.g. `prod-gpt-5`) still classify — but excludes the `gpt-5-chat` family that collides with the `gpt-5` reasoning id.

The exclusion marker is contiguous (`gpt-5-chat`), so behaviour is precise:

| model / deployment | classified as |
|---|---|
| `gpt-5-chat-latest`, `gpt-5-chat`, `prod-gpt-5-chat-eastus` | chat (temperature kept) |
| `gpt-5`, `gpt-5-2025-08-07`, `o1-preview` | reasoning (unchanged) |
| `prod-chat-gpt-5`, `team-chat-o3-mini` | reasoning (unchanged — “chat” elsewhere in the name) |

Adds a pure-logic regression test (`test_reasoning_model_classification`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misclassification of `gpt-5-chat-latest` (and other `gpt-5-chat*`) as reasoning models so `temperature` is preserved and `reasoning_effort` isn’t sent incorrectly. Applies to `ChatOpenAI` and `ChatAzureOpenAI`; Azure deployment names that embed model IDs still classify correctly.

- **Bug Fixes**
  - Added `ChatOpenAI._is_reasoning_model()` that keeps substring matching but excludes the contiguous `gpt-5-chat` marker.
  - Switched both OpenAI and Azure code paths to use `_is_reasoning_model()` so only true reasoning models drop sampling params.
  - Added `test_reasoning_model_classification` to prevent regressions.

<sup>Written for commit 5baab801f340f6a04f2d3c8d7342e1ac0307e6db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

