### PR TITLE
fix(security): normalize trailing-dot FQDN host so it can't bypass domain filtering

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -202,6 +202,13 @@ class SecurityWatchdog(BaseWatchdog):
 
 		# Get the actual host (domain)
 		host = parsed.hostname
+		# Strip the trailing DNS-root dot: "evil.com." is the same origin as
+		# "evil.com" in every browser, but urlparse keeps the dot. Without this
+		# a one-character suffix bypasses prohibited_domains (and false-negatives
+		# allowed_domains). Done before the IP and domain checks so both the set
+		# fast-path and the glob slow-path are covered.
+		if host:
+			host = host.rstrip('.')
 		if not host:
 			return False
 

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -593,9 +593,7 @@ class TestTrailingDotHostNormalization:
 
 		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
 
-		browser_profile = BrowserProfile(
-			prohibited_domains={'evil.com', 'other.com'}, headless=True, user_data_dir=None
-		)
+		browser_profile = BrowserProfile(prohibited_domains={'evil.com', 'other.com'}, headless=True, user_data_dir=None)
 		browser_session = BrowserSession(browser_profile=browser_profile)
 		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=EventBus())
 

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -567,3 +567,52 @@ class TestDomainListOptimization:
 		# Should work correctly
 		assert watchdog._is_url_allowed('https://blocked0.com') is False
 		assert watchdog._is_url_allowed('https://example.com') is True
+
+
+class TestTrailingDotHostNormalization:
+	"""A trailing DNS-root dot ("evil.com.") resolves to the same origin as
+	"evil.com" in every browser, so it must not bypass domain filtering."""
+
+	def test_trailing_dot_does_not_bypass_prohibited_list(self):
+		"""Slow path (list): a trailing dot must not bypass a prohibited entry."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(prohibited_domains=['evil.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=EventBus())
+
+		assert watchdog._is_url_allowed('https://evil.com/') is False
+		assert watchdog._is_url_allowed('https://evil.com./') is False
+		assert watchdog._is_url_allowed('https://evil.com.../') is False
+
+	def test_trailing_dot_does_not_bypass_prohibited_set(self):
+		"""Fast path (set): a trailing dot must not bypass a prohibited entry."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(
+			prohibited_domains={'evil.com', 'other.com'}, headless=True, user_data_dir=None
+		)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=EventBus())
+
+		assert isinstance(browser_session.browser_profile.prohibited_domains, set)
+		assert watchdog._is_url_allowed('https://evil.com/') is False
+		assert watchdog._is_url_allowed('https://evil.com./') is False
+
+	def test_trailing_dot_still_matches_allowed_domains(self):
+		"""A trailing dot must not false-negative an allowed domain."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=EventBus())
+
+		assert watchdog._is_url_allowed('https://example.com/') is True
+		assert watchdog._is_url_allowed('https://example.com./') is True
+		assert watchdog._is_url_allowed('https://evil.com./') is False


### PR DESCRIPTION
`SecurityWatchdog._is_url_allowed` extracts `host = parsed.hostname` and matches it against `prohibited_domains` / `allowed_domains`, but `urlparse` keeps the trailing DNS-root dot. A trailing dot (`evil.com.`) is the **same origin** as `evil.com` in every browser, so:

- **`prohibited_domains` bypass**: `https://evil.com./` is **allowed** even though `evil.com` is in the blocklist (set fast-path: `'evil.com.' not in prohibited`; list path: `host.lower() != pattern`).
- **`allowed_domains` false-negative**: `https://example.com./` is **blocked** even though `example.com` is allowlisted.

The fix strips the trailing dot from `host` once, immediately after extraction and before the IP check and domain matching, so both the set fast-path and the list/glob slow-path are covered:

```python
host = parsed.hostname
if host:
    host = host.rstrip('.')
if not host:
    return False
```

`'.'` collapses to `''` and is rejected by the existing empty-host guard; IPv6 hosts have no trailing dot to strip. Added regression tests for the list path, the set fast-path, and the allowed-domain false-negative (all fail without the fix).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize trailing-dot FQDN hosts so domain filtering can’t be bypassed and allowlist checks don’t false-negative. We strip any trailing DNS-root dot(s) from `parsed.hostname` before IP and domain matching, add regression tests for prohibited lists/sets and allowed domains, and tidy the test file formatting.

<sup>Written for commit 7a74048c9653e7a0134e956cfc7798de2efb9599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

