### PR TITLE
Design doc: deterministic permission gating for browser actions (#5063)

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1052,6 +1052,23 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				except Exception as e:
 					self.logger.warning(f'Phase 0 captcha wait failed (non-fatal): {e}')
 
+				# Phase 0.5: Check for page crash recovery
+				# If the active tab crashed since the last step, SessionManager has
+				# already recovered focus to a new/existing tab.
+				# We auto-navigate to the previous URL and inform the LLM.
+				try:
+					recovered = await self.browser_session.check_and_recover_from_crash()
+					if recovered:
+						crash_msg = 'The previous page tab crashed and has been auto-recovered. The page has been reloaded.'
+						self.logger.warning(f'💥 {crash_msg}')
+						crash_result = ActionResult(long_term_memory=crash_msg)
+						if self.state.last_result:
+							self.state.last_result.append(crash_result)
+						else:
+							self.state.last_result = [crash_result]
+				except Exception as recovery_e:
+					self.logger.warning(f'Phase 0 crash recovery check failed (non-fatal): {recovery_e}')
+
 			# Phase 1: Prepare context and timing
 			browser_state_summary = await self._prepare_context(step_info)
 

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5320,9 +5320,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				self.logger.warning(
 					'BROWSER_USE_API_KEY is not set. Set it when using ChatBrowserUse or configure a different LLM provider.'
 				)
-			self.logger.warning(
-				'Check the Rust SDK logs above for errors, or enable debug logging for more details.'
-			)
+			self.logger.warning('Check the Rust SDK logs above for errors, or enable debug logging for more details.')
 		self.last_events = events
 		self.last_child_events = child_events
 		self.last_usage_events = usage_events

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5305,6 +5305,24 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			process_error = None
 		if used_notification_events and events_result is not None:
 			process_error = None
+		if events_result is None and process_error is None:
+			llm_model = str(self.model) if self.model else 'unknown'
+			self.logger.warning(
+				'The agent completed without producing a result. The LLM (%s) did not return any response.',
+				llm_model,
+			)
+			if os.getenv('BROWSER_USE_API_KEY'):
+				self.logger.warning(
+					'BROWSER_USE_API_KEY is set. Check that the model name is correct and the API key is valid for model "%s".',
+					llm_model,
+				)
+			else:
+				self.logger.warning(
+					'BROWSER_USE_API_KEY is not set. Set it when using ChatBrowserUse or configure a different LLM provider.'
+				)
+			self.logger.warning(
+				'Check the Rust SDK logs above for errors, or enable debug logging for more details.'
+			)
 		self.last_events = events
 		self.last_child_events = child_events
 		self.last_usage_events = usage_events

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -117,6 +117,14 @@ CHROME_HEADLESS_ARGS = [
 	'--headless=new',
 ]
 
+# Chrome flags specific to Windows headless mode to prevent GPU compositor crashes.
+# On Windows headless, Chromium uses SwiftShader (software GPU) which requires
+# DirectX runtime components. If these are missing (common on Server/core Windows),
+# the GPU process can crash the renderer. Disabling GPU avoids this entirely.
+CHROME_WINDOWS_HEADLESS_ARGS = [
+	'--disable-gpu',
+]
+
 CHROME_DOCKER_ARGS = [
 	# '--disable-gpu',    # GPU is actually supported in headless docker mode now, but sometimes useful to test without it
 	'--no-sandbox',
@@ -912,6 +920,9 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			f'--profile-directory={self.profile_directory}',
 			*(CHROME_DOCKER_ARGS if (CONFIG.IN_DOCKER or not self.chromium_sandbox) else []),
 			*(CHROME_HEADLESS_ARGS if self.headless else []),
+			# On Windows headless, disable GPU to prevent SwiftShader compositor crashes
+			# when DirectX components are missing (common on Server/core Windows).
+			*(CHROME_WINDOWS_HEADLESS_ARGS if (self.headless and sys.platform == 'win32') else []),
 			*(CHROME_DISABLE_SECURITY_ARGS if self.disable_security else []),
 			*(CHROME_DETERMINISTIC_RENDERING_ARGS if self.deterministic_rendering else []),
 			*(

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -16,6 +16,7 @@ from cdp_use import CDPClient
 from cdp_use.cdp.fetch import AuthRequiredEvent, RequestPausedEvent
 from cdp_use.cdp.network import Cookie
 from cdp_use.cdp.target import SessionID, TargetID
+from cdp_use.cdp.target.events import TargetCrashedEvent
 from cdp_use.cdp.target.commands import CreateTargetParameters
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 from uuid_extensions import uuid7str
@@ -1960,7 +1961,7 @@ class BrowserSession(BaseModel):
 
 	# region - ========== Page Crash Detection and Recovery ==========
 
-	def _on_target_crashed_cdp(self, event: dict, session_id: Any = None) -> None:
+	def _on_target_crashed_cdp(self, event: TargetCrashedEvent, session_id: SessionID | None = None) -> None:
 		"""Handle Target.targetCrashed CDP event.
 
 		Stores the crashed target info so check_and_recover_from_crash() can

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1787,7 +1787,7 @@ class BrowserSession(BaseModel):
 				except httpx.ReadError as e:
 					last_http_error = e
 					if http_attempt < max_http_retries - 1:
-						wait = 0.5 * (2 ** http_attempt)  # 0.5s, 1.0s, 2.0s
+						wait = 0.5 * (2**http_attempt)  # 0.5s, 1.0s, 2.0s
 						self.logger.debug(
 							f'httpx.ReadError fetching CDP WebSocket URL (attempt {http_attempt + 1}/{max_http_retries}), retrying in {wait}s: {e}'
 						)

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1792,6 +1792,7 @@ class BrowserSession(BaseModel):
 						version_info = await client.get(url, headers=headers)
 						self.logger.debug(f'Raw version info: {str(version_info)}')
 						self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
+						last_http_error = None  # Reset on success
 						break  # Success
 				except httpx.ReadError as e:
 					last_http_error = e
@@ -2027,7 +2028,10 @@ class BrowserSession(BaseModel):
 				self.logger.error(f'❌ Failed to auto-recover from page crash: {type(e).__name__}: {e}')
 				return False
 
-		return True
+		# No meaningful recovery possible (about:blank or unknown URL)
+		# Return False so callers know no reload was performed
+		self.logger.debug(f'⚠️ Page crash recovery skipped - previous URL was {old_url}')
+		return False
 
 	# endregion - ========== Page Crash Detection and Recovery ==========
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1768,14 +1768,34 @@ class BrowserSession(BaseModel):
 			# from routing local requests through a proxy, which causes 502 errors on Windows.
 			# Remote CDP URLs should still respect proxy settings.
 			is_localhost = parsed_url.hostname in ('localhost', '127.0.0.1', '::1')
-			async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), trust_env=not is_localhost) as client:
-				headers = dict(self.browser_profile.headers or {})
-				from browser_use.utils import get_browser_use_version
+			# Retry with backoff for httpx.ReadError: on Windows there's a race window between
+			# TCP port open (aiohttp poll succeeds in _wait_for_cdp_url) and HTTP server fully
+			# initialized (httpx GET can fail with ReadError ~30% of the time on tight timing).
+			max_http_retries = 3
+			last_http_error: Exception | None = None
+			for http_attempt in range(max_http_retries):
+				try:
+					async with httpx.AsyncClient(timeout=httpx.Timeout(30.0), trust_env=not is_localhost) as client:
+						headers = dict(self.browser_profile.headers or {})
+						from browser_use.utils import get_browser_use_version
 
-				headers.setdefault('User-Agent', f'browser-use/{get_browser_use_version()}')
-				version_info = await client.get(url, headers=headers)
-				self.logger.debug(f'Raw version info: {str(version_info)}')
-				self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
+						headers.setdefault('User-Agent', f'browser-use/{get_browser_use_version()}')
+						version_info = await client.get(url, headers=headers)
+						self.logger.debug(f'Raw version info: {str(version_info)}')
+						self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
+						break  # Success
+				except httpx.ReadError as e:
+					last_http_error = e
+					if http_attempt < max_http_retries - 1:
+						wait = 0.5 * (2 ** http_attempt)  # 0.5s, 1.0s, 2.0s
+						self.logger.debug(
+							f'httpx.ReadError fetching CDP WebSocket URL (attempt {http_attempt + 1}/{max_http_retries}), retrying in {wait}s: {e}'
+						)
+						await asyncio.sleep(wait)
+			if last_http_error is not None:
+				raise RuntimeError(
+					f'Failed to fetch CDP WebSocket URL from {url} after {max_http_retries} attempts: {last_http_error}'
+				) from last_http_error
 
 		assert self.cdp_url is not None, 'CDP URL is None.'
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -530,6 +530,10 @@ class BrowserSession(BaseModel):
 	# PUBLIC: SessionManager instance (OWNS all targets and sessions)
 	session_manager: Any = Field(default=None, exclude=True)  # SessionManager
 
+	# Page crash detection and auto-recovery
+	_crashed_target_ids: set = PrivateAttr(default_factory=set)
+	_crashed_target_url: str | None = PrivateAttr(default=None)
+
 	_cached_browser_state_summary: Any = PrivateAttr(default=None)
 	_cached_selector_map: dict[int, EnhancedDOMTreeNode] = PrivateAttr(default_factory=dict)
 	_downloaded_files: list[str] = PrivateAttr(default_factory=list)  # Track files downloaded during this session
@@ -632,6 +636,8 @@ class BrowserSession(BaseModel):
 		self._cached_browser_state_summary = None
 		self._cached_selector_map.clear()
 		self._downloaded_files.clear()
+		self._crashed_target_ids.clear()
+		self._crashed_target_url = None
 
 		self.agent_focus_target_id = None
 		if self.is_local:
@@ -663,6 +669,9 @@ class BrowserSession(BaseModel):
 		# Initialize reconnect event as set (no reconnection pending)
 		self._reconnect_event = asyncio.Event()
 		self._reconnect_event.set()
+		# Initialize crash tracking
+		self._crashed_target_ids = set()
+		self._crashed_target_url = None
 
 		# Check if handlers are already registered to prevent duplicates
 		from browser_use.browser.watchdog_base import BaseWatchdog
@@ -1886,6 +1895,17 @@ class BrowserSession(BaseModel):
 			# Enable proxy authentication handling if configured
 			await self._setup_proxy_auth()
 
+			# Register targetCrashed handler for page-level crash detection
+			# When a renderer process crashes (e.g., memory exhaustion, WebGL context loss),
+			# Chrome fires Target.targetCrashed before Target.detachedFromTarget.
+			# SessionManager handles detach/recovery; this handler tracks the crash info
+			# so check_and_recover_from_crash() can auto-reload the page afterwards.
+			if self._cdp_client_root:
+				try:
+					self._cdp_client_root.register.Target.targetCrashed(self._on_target_crashed_cdp)
+				except Exception as e:
+					self.logger.debug(f'Failed to register targetCrashed handler: {e}')
+
 			# Attach WS drop detection callback for auto-reconnection
 			self._intentional_stop = False
 			self._attach_ws_drop_callback()
@@ -1936,6 +1956,80 @@ class BrowserSession(BaseModel):
 			raise RuntimeError(f'Failed to establish CDP connection to browser: {e}') from e
 
 		return self
+
+	# region - ========== Page Crash Detection and Recovery ==========
+
+	def _on_target_crashed_cdp(self, event: dict, session_id: Any = None) -> None:
+		"""Handle Target.targetCrashed CDP event.
+
+		Stores the crashed target info so check_and_recover_from_crash() can
+		auto-reload the page on the next agent step.
+		Called synchronously by the CDP message handler.
+		"""
+		# cdp_use may deliver keys as either camelCase or snake_case; handle both
+		target_id = event.get('targetId') or event.get('target_id')
+		if not target_id:
+			return
+
+		self._crashed_target_ids.add(target_id)
+
+		# Only care if this is the agent's current focus target
+		if target_id == self.agent_focus_target_id:
+			target = self.session_manager.get_target(target_id) if self.session_manager else None
+			old_url = target.url if target else 'unknown'
+			self._crashed_target_url = old_url
+			self.logger.error(f'💥 Agent focus tab crashed! URL: {old_url} SessionManager will auto-recover focus...')
+
+	async def check_and_recover_from_crash(self) -> bool:
+		"""Check if agent focus was recovered from a page crash and auto-navigate.
+
+		After SessionManager recovers focus (creates new tab or switches to existing one),
+		navigate to the crashed page's previous URL to restore state.
+
+		Returns:
+			True if crash recovery was performed, False if no crash recovery needed.
+		"""
+		if not self._crashed_target_url:
+			return False
+
+		old_url = self._crashed_target_url
+		self._crashed_target_url = None  # Clear flag immediately to prevent re-trigger
+
+		# Wait up to 5 seconds for SessionManager to finish recovery
+		if not self.agent_focus_target_id:
+			start = time.time()
+			while time.time() - start < 5.0:
+				if self.agent_focus_target_id:
+					break
+				await asyncio.sleep(0.1)
+
+		if not self.agent_focus_target_id:
+			self.logger.error('❌ Cannot recover from crash - no agent focus target after recovery')
+			return False
+
+		# Only navigate if the recovered URL is a blank/new-tab page
+		target = self.session_manager.get_target(self.agent_focus_target_id) if self.session_manager else None
+		current_url = target.url if target else 'about:blank'
+
+		if not is_new_tab_page(current_url) and current_url != 'about:blank':
+			self.logger.info(
+				f'🔄 Page crash auto-recovery skipped - SessionManager already switched to existing tab: {current_url}'
+			)
+			return True
+
+		if old_url and old_url != 'about:blank' and old_url != 'unknown':
+			self.logger.info(f'🔄 Auto-recovering from page crash - navigating to previous URL: {old_url}')
+			try:
+				await self.navigate_to(old_url)
+				self.logger.info('✅ Page crash auto-recovery complete')
+				return True
+			except Exception as e:
+				self.logger.error(f'❌ Failed to auto-recover from page crash: {type(e).__name__}: {e}')
+				return False
+
+		return True
+
+	# endregion - ========== Page Crash Detection and Recovery ==========
 
 	async def _setup_proxy_auth(self) -> None:
 		"""Enable CDP Fetch auth handling for authenticated proxy, if credentials provided.

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -406,14 +406,22 @@ class LocalBrowserWatchdog(BaseWatchdog):
 
 	@staticmethod
 	async def _wait_for_cdp_url(port: int, timeout: float = 30) -> str:
-		"""Wait for the browser to start and return the CDP URL."""
+		"""Wait for the browser to start and return the CDP URL.
+
+		Uses a plain TCPConnector (no proxy) to prevent HTTP_PROXY/HTTPS_PROXY env vars
+		from routing localhost requests through a proxy, which causes 502 errors on Windows.
+		"""
 		import aiohttp
 
 		start_time = asyncio.get_event_loop().time()
+		# Use a TCPConnector without proxy support for localhost to avoid
+		# HTTP_PROXY/HTTPS_PROXY env vars (common on Windows with Clash/V2Ray)
+		# from routing 127.0.0.1 through a proxy.
+		connector = aiohttp.TCPConnector(ssl=False)
 
 		while asyncio.get_event_loop().time() - start_time < timeout:
 			try:
-				async with aiohttp.ClientSession() as session:
+				async with aiohttp.ClientSession(connector=connector) as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:
 						if resp.status == 200:
 							# Chrome is ready

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -421,9 +421,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				# Create a fresh connector per iteration — the ClientSession's async with
 				# block closes the connector on exit, so a shared connector would be
 				# unusable on subsequent polls.
-				async with aiohttp.ClientSession(
-					connector=aiohttp.TCPConnector(ssl=False)
-				) as session:
+				async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:
 						if resp.status == 200:
 							# Chrome is ready

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -408,20 +408,22 @@ class LocalBrowserWatchdog(BaseWatchdog):
 	async def _wait_for_cdp_url(port: int, timeout: float = 30) -> str:
 		"""Wait for the browser to start and return the CDP URL.
 
-		Uses a plain TCPConnector (no proxy) to prevent HTTP_PROXY/HTTPS_PROXY env vars
-		from routing localhost requests through a proxy, which causes 502 errors on Windows.
+		Creates a fresh aiohttp ClientSession per iteration (each with its own
+		TCPConnector) to prevent HTTP_PROXY/HTTPS_PROXY env vars from routing
+		localhost requests through a proxy, which causes 502 errors on Windows.
 		"""
 		import aiohttp
 
 		start_time = asyncio.get_event_loop().time()
-		# Use a TCPConnector without proxy support for localhost to avoid
-		# HTTP_PROXY/HTTPS_PROXY env vars (common on Windows with Clash/V2Ray)
-		# from routing 127.0.0.1 through a proxy.
-		connector = aiohttp.TCPConnector(ssl=False)
 
 		while asyncio.get_event_loop().time() - start_time < timeout:
 			try:
-				async with aiohttp.ClientSession(connector=connector) as session:
+				# Create a fresh connector per iteration — the ClientSession's async with
+				# block closes the connector on exit, so a shared connector would be
+				# unusable on subsequent polls.
+				async with aiohttp.ClientSession(
+					connector=aiohttp.TCPConnector(ssl=False)
+				) as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:
 						if resp.status == 200:
 							# Chrome is ready

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -41,6 +41,10 @@ class ChatOllama(BaseChatModel):
 	client_params: dict[str, Any] | None = None
 	ollama_options: Mapping[str, Any] | Options | None = None
 
+	# Top-level Ollama API parameters (forwarded as separate args to client.chat())
+	format: str | dict[str, Any] | None = None
+	stream: bool = False
+
 	# Static
 	@property
 	def provider(self) -> str:
@@ -72,8 +76,9 @@ class ChatOllama(BaseChatModel):
 		arguments to ``client.chat()``, not as part of the ``options`` dict.
 		When users pass them inside ``ollama_options`` they are silently
 		ignored (or worse, cause unexpected behaviour with some Ollama
-		versions).  We strip them here and log a warning so users know to
-		pass them correctly.
+		versions).  We strip them here — users who want these params should
+		set them as direct attributes on ``ChatOllama`` instead (which now
+		has ``format`` and ``stream`` fields that are forwarded correctly).
 
 		Returns:
 			A cleaned dict with only valid model options.
@@ -85,7 +90,8 @@ class ChatOllama(BaseChatModel):
 			if key in cleaned:
 				logger.warning(
 					'ollama_options contains "%s", which is a top-level Ollama API parameter '
-					'and is ignored inside options. Pass it directly to ChatOllama instead.',
+					'and is ignored inside options. Set ChatOllama.%s instead.',
+					key,
 					key,
 				)
 				del cleaned[key]
@@ -104,6 +110,12 @@ class ChatOllama(BaseChatModel):
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
 		options = self._clean_options()
+		# Forward top-level API params (format and stream) to client.chat()
+		chat_kwargs: dict[str, Any] = {}
+		if self.format is not None:
+			chat_kwargs['format'] = self.format
+		if self.stream:
+			chat_kwargs['stream'] = True
 
 		try:
 			if output_format is None:
@@ -111,16 +123,20 @@ class ChatOllama(BaseChatModel):
 					model=self.model,
 					messages=ollama_messages,
 					options=options,
+					**chat_kwargs,
 				)
 
 				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
 			else:
 				schema = output_format.model_json_schema()
+				# When output_format is provided, format is set to the schema
+				# but allow explicit ChatOllama.format to override
+				actual_format = chat_kwargs.get('format', schema)
 
 				response = await self.get_client().chat(
 					model=self.model,
 					messages=ollama_messages,
-					format=schema,
+					format=actual_format,
 					options=options,
 				)
 

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
@@ -5,7 +6,7 @@ from typing import Any, TypeVar, overload
 import httpx
 from ollama import AsyncClient as OllamaAsyncClient
 from ollama import Options
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
@@ -13,7 +14,13 @@ from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
 from browser_use.llm.views import ChatInvokeCompletion
 
+logger = logging.getLogger(__name__)
+
 T = TypeVar('T', bound=BaseModel)
+
+# Top-level Ollama API parameters that should not be passed as model options.
+# These are handled as separate top-level arguments to client.chat() instead.
+_OLLAMA_TOP_LEVEL_PARAMS = frozenset({'format', 'stream'})
 
 
 @dataclass
@@ -57,6 +64,33 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def _clean_options(self) -> dict[str, Any]:
+		"""
+		Filter out top-level API parameters from ollama_options.
+
+		Ollama accepts parameters like ``format`` and ``stream`` as top-level
+		arguments to ``client.chat()``, not as part of the ``options`` dict.
+		When users pass them inside ``ollama_options`` they are silently
+		ignored (or worse, cause unexpected behaviour with some Ollama
+		versions).  We strip them here and log a warning so users know to
+		pass them correctly.
+
+		Returns:
+			A cleaned dict with only valid model options.
+		"""
+		if not self.ollama_options:
+			return {}
+		cleaned = dict(self.ollama_options)
+		for key in _OLLAMA_TOP_LEVEL_PARAMS:
+			if key in cleaned:
+				logger.warning(
+					'ollama_options contains "%s", which is a top-level Ollama API parameter '
+					'and is ignored inside options. Pass it directly to ChatOllama instead.',
+					key,
+				)
+				del cleaned[key]
+		return cleaned
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -69,13 +103,14 @@ class ChatOllama(BaseChatModel):
 		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
+		options = self._clean_options()
 
 		try:
 			if output_format is None:
 				response = await self.get_client().chat(
 					model=self.model,
 					messages=ollama_messages,
-					options=self.ollama_options,
+					options=options,
 				)
 
 				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
@@ -86,14 +121,27 @@ class ChatOllama(BaseChatModel):
 					model=self.model,
 					messages=ollama_messages,
 					format=schema,
-					options=self.ollama_options,
+					options=options,
 				)
 
 				completion = response.message.content or ''
-				if output_format is not None:
-					completion = output_format.model_validate_json(completion)
+				completion = output_format.model_validate_json(completion)
 
 				return ChatInvokeCompletion(completion=completion, usage=None)
 
+		except ValidationError as e:
+			# Provide a clearer error when the model returns invalid/truncated JSON
+			truncated_hint = ''
+			if 'EOF' in str(e):
+				truncated_hint = (
+					' The model returned incomplete or truncated JSON. '
+					'This can happen with vision models when format=schema is too restrictive. '
+					'Try setting use_vision=False for Ollama vision models, or '
+					'removing "format" from ollama_options.'
+				)
+			raise ModelProviderError(
+				message=f'Invalid JSON in model response: {e}{truncated_hint}',
+				model=self.name,
+			) from e
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -105,6 +105,25 @@ class ChatOllama(BaseChatModel):
 	@overload
 	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T], **kwargs: Any) -> ChatInvokeCompletion[T]: ...
 
+	async def _extract_stream_content(self, response: Any) -> str:
+		"""Extract full content from a streaming Ollama response (async generator)."""
+		content_parts: list[str] = []
+		async for chunk in response:
+			if hasattr(chunk, 'message') and chunk.message and chunk.message.content:
+				content_parts.append(chunk.message.content)
+		return ''.join(content_parts)
+
+	async def _extract_content(self, response: Any) -> str:
+		"""Extract content from either a streaming (async generator) or non-streaming response.
+
+		Ollama's AsyncClient.chat() returns:
+		- A single ChatResponse when stream=False (default)
+		- An async generator yielding ChatResponse chunks when stream=True
+		"""
+		if self.stream:
+			return await self._extract_stream_content(response)
+		return response.message.content or ''
+
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
@@ -126,21 +145,25 @@ class ChatOllama(BaseChatModel):
 					**chat_kwargs,
 				)
 
-				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
+				completion = await self._extract_content(response)
+				return ChatInvokeCompletion(completion=completion, usage=None)
 			else:
 				schema = output_format.model_json_schema()
 				# When output_format is provided, format is set to the schema
 				# but allow explicit ChatOllama.format to override
 				actual_format = chat_kwargs.get('format', schema)
 
+				# Only forward stream kwarg to avoid passing format twice
+				stream_kwargs = {k: v for k, v in chat_kwargs.items() if k == 'stream'}
 				response = await self.get_client().chat(
 					model=self.model,
 					messages=ollama_messages,
 					format=actual_format,
 					options=options,
+					**stream_kwargs,
 				)
 
-				completion = response.message.content or ''
+				completion = await self._extract_content(response)
 				completion = output_format.model_validate_json(completion)
 
 				return ChatInvokeCompletion(completion=completion, usage=None)

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -444,7 +444,7 @@ configure_powershell_wrappers() {
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			{
 				echo '@echo off'
-				echo ""$(echo "$venv_bin/$cmd" | sed 's|/|\|g')" %*"
+				echo ""$(echo "$venv_bin/$cmd" | sed 's|/\\|g')" %*"
 			} > "$wrapper"
 			chmod +x "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -392,7 +392,7 @@ create_wrappers() {
 	local commands="browser-use bu browseruse browser browser-use-tui"
 
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
@@ -440,7 +440,7 @@ configure_powershell_wrappers() {
 	# Create .cmd wrappers for each CLI command
 	local commands="browser-use bu browseruse browser browser-use-tui"
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			{
 				echo '@echo off'

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -392,15 +392,21 @@ create_wrappers() {
 	local commands="browser-use bu browseruse browser browser-use-tui"
 
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
-			local wrapper="$wrapper_dir/$cmd"
-			cat > "$wrapper" <<- WRAPPER_EOF
-				#!/bin/sh
-				exec "$venv_bin/$cmd" "\$@"
-			WRAPPER_EOF
-			chmod +x "$wrapper"
-			log_success "Created wrapper: $wrapper_dir/$cmd"
+		local use_exe=""
+		if [ -x "$venv_bin/$cmd" ]; then
+			:  # exist without .exe suffix
+		elif [ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]; then
+			use_exe=".exe"
+		else
+			continue
 		fi
+		local wrapper="$wrapper_dir/$cmd"
+		cat > "$wrapper" <<- WRAPPER_EOF
+			#!/bin/sh
+			exec "$venv_bin/$cmd$use_exe" "\$@"
+		WRAPPER_EOF
+		chmod +x "$wrapper"
+		log_success "Created wrapper: $wrapper_dir/$cmd"
 	done
 }
 
@@ -440,15 +446,21 @@ configure_powershell_wrappers() {
 	# Create .cmd wrappers for each CLI command
 	local commands="browser-use bu browseruse browser browser-use-tui"
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
-			local wrapper="$wrapper_dir/${cmd}.cmd"
-			{
-				echo '@echo off'
-				echo ""$(echo "$venv_bin/$cmd" | sed 's|/\\|g')" %*"
-			} > "$wrapper"
-			chmod +x "$wrapper"
-			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
+		local use_exe=""
+		if [ -x "$venv_bin/$cmd" ]; then
+			:  # exist without .exe suffix
+		elif [ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]; then
+			use_exe=".exe"
+		else
+			continue
 		fi
+		local wrapper="$wrapper_dir/${cmd}.cmd"
+		{
+			echo '@echo off'
+			echo ""$(echo "$venv_bin/$cmd$use_exe" | sed 's|/\\|g')" %*"
+		} > "$wrapper"
+		chmod +x "$wrapper"
+		log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
 	done
 
 	# Ensure wrapper dir is in user PATH via registry
@@ -456,7 +468,8 @@ configure_powershell_wrappers() {
 	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '
 ')
 
-	if echo "$current_path" | grep -q "\.local\bin"; then
+	# Use grep -F (fixed-string) so that \b is treated literally, not as a regex word boundary
+	if echo "$current_path" | grep -qF "\.local\\bin"; then
 		log_info "Wrapper directory already in PATH"
 		return 0
 	fi

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -396,7 +396,7 @@ create_wrappers() {
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
-				exec "$venv_bin/$cmd" "$@"
+				exec "$venv_bin/$cmd" "\$@"
 			WRAPPER_EOF
 			chmod +x "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/$cmd"

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -375,62 +375,101 @@ install_profile_use() {
 # PATH configuration
 # =============================================================================
 
-configure_path() {
-	local shell_rc=""
-	local bin_path=$(get_venv_bin_dir)
-	local local_bin="$HOME/.local/bin"
+# =============================================================================
+# PATH configuration
+# =============================================================================
 
-	# Detect user's login shell (not the running shell, since this script
-	# is typically executed via "curl ... | bash" which always sets BASH_VERSION)
+# Create wrapper scripts in ~/.local/bin for CLI commands instead of
+# adding the entire virtualenv bin directory to PATH. This prevents the
+# venv's Python and other executables from shadowing the user's system Python.
+
+create_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
+
+	# CLI entry points from pyproject.toml
+	local commands="browser-use bu browseruse browser browser-use-tui"
+
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/$cmd"
+			cat > "$wrapper" <<- WRAPPER_EOF
+				#!/bin/sh
+				exec "$venv_bin/$cmd" "$@"
+			WRAPPER_EOF
+			chmod +x "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/$cmd"
+		fi
+	done
+}
+
+configure_path() {
+	local wrapper_dir="$HOME/.local/bin"
+	local shell_rc=""
+
+	# Detect user's login shell
 	case "$(basename "$SHELL")" in
 		zsh)  shell_rc="$HOME/.zshrc" ;;
 		bash) shell_rc="$HOME/.bashrc" ;;
 		*)    shell_rc="$HOME/.profile" ;;
 	esac
 
-	# Check if already in PATH (browser-use-env matches both /bin and /Scripts)
-	if grep -q "browser-use-env" "$shell_rc" 2>/dev/null; then
-		log_info "PATH already configured in $shell_rc"
-	else
-		# Add to shell config (includes ~/.local/bin for tools)
+	# Create wrapper scripts for each CLI command
+	create_wrappers
+
+	# Ensure ~/.local/bin is on PATH (standard location for user CLI tools)
+	if ! grep -q "\.local/bin" "$shell_rc" 2>/dev/null; then
 		echo "" >> "$shell_rc"
-		echo "# Browser-Use" >> "$shell_rc"
-		echo "export PATH=\"$bin_path:$local_bin:\$PATH\"" >> "$shell_rc"
-		log_success "Added to PATH in $shell_rc"
+		echo "# Browser-Use CLI wrappers" >> "$shell_rc"
+		echo "export PATH="$wrapper_dir:\$PATH"" >> "$shell_rc"
+		log_success "Added ~/.local/bin to PATH in $shell_rc"
 	fi
 
-	# On Windows, also configure PowerShell profile
+	# On Windows, also configure via registry
 	if [ "$PLATFORM" = "windows" ]; then
-		configure_powershell_path
+		configure_powershell_wrappers
 	fi
 }
 
-configure_powershell_path() {
-	# Use PowerShell to modify user PATH in registry (no execution policy needed)
-	# This persists across sessions without requiring profile script execution
+configure_powershell_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
 
-	local scripts_path='\\.browser-use-env\\Scripts'
-	local local_bin='\\.local\\bin'
+	# Create .cmd wrappers for each CLI command
+	local commands="browser-use bu browseruse browser browser-use-tui"
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/${cmd}.cmd"
+			{
+				echo '@echo off'
+				echo ""$(echo "$venv_bin/$cmd" | sed 's|/|\|g')" %*"
+			} > "$wrapper"
+			chmod +x "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
+		fi
+	done
 
-	# Check if already in user PATH
-	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '\r')
+	# Ensure wrapper dir is in user PATH via registry
+	local wrapper_win='\.localin'
+	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '
+')
 
-	if echo "$current_path" | grep -q "browser-use-env"; then
-		log_info "PATH already configured"
+	if echo "$current_path" | grep -q "\.local\bin"; then
+		log_info "Wrapper directory already in PATH"
 		return 0
 	fi
 
-	# Append to user PATH via registry (safe, no truncation, no execution policy needed)
-	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$scripts_path;' + \$env:USERPROFILE + '$local_bin', 'User')" 2>/dev/null
+	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$wrapper_win', 'User')" 2>/dev/null
 
 	if [ $? -eq 0 ]; then
-		log_success "Added to Windows PATH: %USERPROFILE%\\.browser-use-env\\Scripts"
+		log_success "Added to Windows PATH: %USERPROFILE%\.localin"
 	else
 		log_warn "Could not update PATH automatically. Add manually:"
-		log_warn "  \$env:PATH += \";\$env:USERPROFILE\\.browser-use-env\\Scripts\""
+		log_warn "  \$env:PATH += ";\$env:USERPROFILE\.localin""
 	fi
 }
-
 # =============================================================================
 # Validation
 # =============================================================================

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -411,7 +411,7 @@ configure_powershell_wrappers() {
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			(
 				echo '@echo off'
-				echo "\"$(echo "$venv_bin/$cmd" | sed 's|/|\|g')\" %*"
+				echo "\"$(echo "$venv_bin/$cmd" | sed 's|/\\|g')\" %*"
 			) > "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
 		fi

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -357,7 +357,7 @@ create_wrappers() {
 	local commands="browser-use bu browseruse browser browser-use-tui"
 
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
@@ -407,7 +407,7 @@ configure_powershell_wrappers() {
 	# Create .cmd wrappers for each CLI command
 	local commands="browser-use bu browseruse browser browser-use-tui"
 	for cmd in $commands; do
-		if [ -x "$venv_bin/$cmd" ]; then
+		if [ -x "$venv_bin/$cmd" ] || ([ "$PLATFORM" = "windows" ] && [ -x "$venv_bin/$cmd.exe" ]); then
 			local wrapper="$wrapper_dir/${cmd}.cmd"
 			(
 				echo '@echo off'

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -361,7 +361,7 @@ create_wrappers() {
 			local wrapper="$wrapper_dir/$cmd"
 			cat > "$wrapper" <<- WRAPPER_EOF
 				#!/bin/sh
-				exec "$venv_bin/$cmd" "$@"
+				exec "$venv_bin/$cmd" "\$@"
 			WRAPPER_EOF
 			chmod +x "$wrapper"
 			log_success "Created wrapper: $wrapper_dir/$cmd"

--- a/browser_use/skill_cli/install_lite.sh
+++ b/browser_use/skill_cli/install_lite.sh
@@ -340,10 +340,38 @@ install_profile_use() {
 # PATH configuration
 # =============================================================================
 
+# =============================================================================
+# PATH configuration
+# =============================================================================
+
+# Create wrapper scripts in ~/.local/bin for CLI commands instead of
+# adding the entire virtualenv bin directory to PATH. This prevents the
+# venv's Python and other executables from shadowing the user's system Python.
+
+create_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
+
+	# CLI entry points from pyproject.toml
+	local commands="browser-use bu browseruse browser browser-use-tui"
+
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/$cmd"
+			cat > "$wrapper" <<- WRAPPER_EOF
+				#!/bin/sh
+				exec "$venv_bin/$cmd" "$@"
+			WRAPPER_EOF
+			chmod +x "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/$cmd"
+		fi
+	done
+}
+
 configure_path() {
+	local wrapper_dir="$HOME/.local/bin"
 	local shell_rc=""
-	local bin_path=$(get_venv_bin_dir)
-	local local_bin="$HOME/.local/bin"
 
 	# Detect shell
 	if [ -n "$BASH_VERSION" ]; then
@@ -354,49 +382,59 @@ configure_path() {
 		shell_rc="$HOME/.profile"
 	fi
 
-	# Check if already in PATH (browser-use-env matches both /bin and /Scripts)
-	if grep -q "browser-use-env" "$shell_rc" 2>/dev/null; then
-		log_info "PATH already configured in $shell_rc"
-	else
-		# Add to shell config (includes ~/.local/bin for tools)
+	# Create wrapper scripts for each CLI command
+	create_wrappers
+
+	# Ensure ~/.local/bin is on PATH (standard location for user CLI tools)
+	if ! grep -q "\.local/bin" "$shell_rc" 2>/dev/null; then
 		echo "" >> "$shell_rc"
-		echo "# Browser-Use" >> "$shell_rc"
-		echo "export PATH=\"$bin_path:$local_bin:\$PATH\"" >> "$shell_rc"
-		log_success "Added to PATH in $shell_rc"
+		echo "# Browser-Use CLI wrappers" >> "$shell_rc"
+		echo "export PATH=\"$wrapper_dir:\$PATH\"" >> "$shell_rc"
+		log_success "Added ~/.local/bin to PATH in $shell_rc"
 	fi
 
-	# On Windows, also configure PowerShell profile
+	# On Windows, also configure via registry
 	if [ "$PLATFORM" = "windows" ]; then
-		configure_powershell_path
+		configure_powershell_wrappers
 	fi
 }
 
-configure_powershell_path() {
-	# Use PowerShell to modify user PATH in registry (no execution policy needed)
-	# This persists across sessions without requiring profile script execution
+configure_powershell_wrappers() {
+	local venv_bin=$(get_venv_bin_dir)
+	local wrapper_dir="$HOME/.local/bin"
+	mkdir -p "$wrapper_dir"
 
-	local scripts_path='\\.browser-use-env\\Scripts'
-	local local_bin='\\.local\\bin'
+	# Create .cmd wrappers for each CLI command
+	local commands="browser-use bu browseruse browser browser-use-tui"
+	for cmd in $commands; do
+		if [ -x "$venv_bin/$cmd" ]; then
+			local wrapper="$wrapper_dir/${cmd}.cmd"
+			(
+				echo '@echo off'
+				echo "\"$(echo "$venv_bin/$cmd" | sed 's|/|\|g')\" %*"
+			) > "$wrapper"
+			log_success "Created wrapper: $wrapper_dir/${cmd}.cmd"
+		fi
+	done
 
-	# Check if already in user PATH
+	# Ensure wrapper dir is in user PATH via registry
+	local wrapper_win='\.local\bin'
 	local current_path=$(powershell.exe -Command "[Environment]::GetEnvironmentVariable('Path', 'User')" 2>/dev/null | tr -d '\r')
 
-	if echo "$current_path" | grep -q "browser-use-env"; then
-		log_info "PATH already configured"
+	if echo "$current_path" | grep -q "\.local\\bin"; then
+		log_info "Wrapper directory already in PATH"
 		return 0
 	fi
 
-	# Append to user PATH via registry (safe, no truncation, no execution policy needed)
-	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$scripts_path;' + \$env:USERPROFILE + '$local_bin', 'User')" 2>/dev/null
+	powershell.exe -Command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + ';' + \$env:USERPROFILE + '$wrapper_win', 'User')" 2>/dev/null
 
 	if [ $? -eq 0 ]; then
-		log_success "Added to Windows PATH: %USERPROFILE%\\.browser-use-env\\Scripts"
+		log_success "Added to Windows PATH: %USERPROFILE%\.local\bin"
 	else
 		log_warn "Could not update PATH automatically. Add manually:"
-		log_warn "  \$env:PATH += \";\$env:USERPROFILE\\.browser-use-env\\Scripts\""
+		log_warn "  \$env:PATH += \";\$env:USERPROFILE\.local\bin\""
 	fi
 }
-
 # =============================================================================
 # Validation
 # =============================================================================

--- a/docs/design/permission-gating-2026-06-20.md
+++ b/docs/design/permission-gating-2026-06-20.md
@@ -1,0 +1,188 @@
+# Deterministic Permission Gating for Browser Actions
+
+**Date:** 2026-06-20
+**Author:** Adapted from proposal #5063
+**Status:** Draft for discussion
+
+## 1. Problem Statement
+
+browser-use agents control a real browser — they navigate, click, fill forms, and extract data. Currently, any agent with browser access can perform any browser action. There is no mechanism to say "the product scraper agent may GET pages but not POST forms" or "the QA agent may click buttons but not navigate to non-whitelisted domains."
+
+The `agchk` audit (#4739) flagged this: `capability_policy` at HIGH, noting that "Permission policy is not enforced on all dispatch paths."
+
+### Specific risks
+
+- **Domain escalation:** An agent tasked with scraping `example.com/docs` navigates to `example.com/admin`
+- **Action escalation:** An agent allowed to read page content instead submits forms or triggers downloads
+- **Data exfiltration:** An agent fills forms with sensitive data and submits to external endpoints
+- **Indirect prompt injection:** An agent navigates to a page with hidden instructions that redirect its behavior
+
+## 2. Existing Security Infrastructure
+
+Before designing new policy gating, we must understand what already exists:
+
+| Component | Location | What it does |
+|---|---|---|
+| `SecurityWatchdog` | `browser_use/browser/watchdogs/security_watchdog.py` | Filters allowed/prohibited domains before navigation |
+| `DomainFilter` | `browser_use/agent/security/domain_filter.py` | URL pattern matching against allow/deny lists |
+| `DownloadContainment` | `browser_use/agent/security/download_filename_sanitization.py` | Sanitizes downloaded filenames |
+| `IPBlocking` | `browser_use/agent/security/ip_blocking.py` | Blocks IP-based navigation |
+| `SensitiveDataFilter` | `browser_use/agent/security/sensitive_data.py` | Redacts sensitive data from LLM context |
+| `MCPAllowedDomains` | `browser_use/agent/security/mcp_allowed_domains.py` | Restricts MCP server domain access |
+| `message_compaction` | Agent config | Limits prompt growth |
+| `max_history_items` | Agent config | Limits token costs |
+
+**Key observation:** The domain-level checks exist (`allowed_domains`, `prohibited_domains`), but there is no action-level gating. The existing `SecurityWatchdog` only intercepts navigation — it doesn't gate `click`, `fill_form`, `submit`, `download`, or `execute_js`.
+
+## 3. Proposal: `BrowserPolicy` Configuration
+
+Add an optional `BrowserPolicy` model to the `Agent` constructor that evaluates **deterministically** before every browser action dispatch.
+
+### 3.1 Policy Model
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal
+
+
+class BrowserPolicy(BaseModel):
+    """Deterministic permission rules for browser actions.
+    
+    All checks are binary pass/fail — no LLM in the enforcement path.
+    Evaluation order: denied_actions → allowed_actions → require_approval_for.
+    """
+    
+    # Action namespace: actions match the agent's registered action names
+    # e.g. "navigate", "click_element", "input_text", "scroll_down",
+    #      "extract_content", "screenshot", "download_file", "execute_javascript"
+    
+    allowed_actions: list[str] | None = Field(
+        default=None,
+        description="If set, ONLY these actions are permitted. None = all actions allowed (subject to denied_actions).",
+    )
+    
+    denied_actions: list[str] = Field(
+        default_factory=list,
+        description="Actions that are ALWAYS rejected with a clear error message.",
+    )
+    
+    require_approval_for: list[str] = Field(
+        default_factory=list,
+        description="Actions that require human approval before execution. "
+                    "If no human is available (headless/CI), these actions are DENIED.",
+    )
+    
+    allowed_domains: list[str] | None = Field(
+        default=None,
+        description="Glob patterns for allowed navigation targets. "
+                    "Overrides BrowserSession.allowed_domains when set at the Agent level. "
+                    "None defers to BrowserSession's domain config.",
+    )
+    
+    max_consecutive_same_action: int = Field(
+        default=0, ge=0,
+        description="Max times the same action type can repeat consecutively before denial. "
+                    "0 = unlimited.",
+    )
+```
+
+### 3.2 Usage Example
+
+```python
+agent = Agent(
+    task="Scrape product pages on example.com",
+    browser_policy=BrowserPolicy(
+        allowed_actions=["navigate", "extract_content", "screenshot"],
+        denied_actions=["download_file", "execute_javascript"],
+        require_approval_for=["input_text", "click_element"],
+        allowed_domains=["example.com/products/*"],
+        max_consecutive_same_action=5,
+    ),
+)
+```
+
+### 3.3 Enforcement Point
+
+The single centralized enforcement point is in `Agent.step()`, right before dispatching the action:
+
+```python
+# In Agent.step(), before executing the chosen action:
+if self.browser_policy:
+    result = self.browser_policy.enforce(
+        action_name=action_name,
+        action_params=action_params,
+        history=self.history,
+    )
+    if result is not None:  # None = allowed
+        return result  # ActionResult with error or approval-requested
+```
+
+**Why centralized here?** All action dispatch flows through `step()`. This single point ensures no action bypasses the policy, avoids scattering checks across watchdog handlers, and makes the policy easy to audit.
+
+### 3.4 Integration with Existing Security
+
+| Existing check | Relationship |
+|---|---|
+| `allowed_domains` / `prohibited_domains` in `BrowserSession` | Kept as-is. When `BrowserPolicy.allowed_domains` is set, it supplements (not replaces) the session-level domains. Both must pass. |
+| `SecurityWatchdog` | Unchanged. It continues to handle domain-level filtering at navigation time. The policy layer adds action-level gating **before** navigation is even scheduled. |
+| `message_compaction` / `max_history_items` | Unchanged — these control prompt size, not agent capabilities. |
+
+### 3.5 Headless/CI Behavior
+
+When `require_approval_for` includes actions but no human is available to approve:
+- The action is **denied** with an `ActionResult` containing `error="Action requires human approval but no interactive session is available"`
+- The agent receives this as a tool error and will typically self-correct
+- This prevents agents from hanging indefinitely waiting for input
+
+The `Agent` detects interactive mode by checking `sys.stdin.isatty()` or an explicit `interactive: bool` flag.
+
+## 4. Implementation Plan
+
+### Phase 1: Model + Enforcement (est. 2-3 days)
+
+1. **Create `browser_use/agent/browser_policy.py`** — `BrowserPolicy` model with `enforce()` method
+2. **Add `browser_policy` field to `AgentSettings`** (in `agent/views.py`)
+3. **Integrate enforcement call in `Agent.step()`** — the single centralized dispatch point
+4. **Add tests** — unit tests for policy evaluation logic, integration test for step-level enforcement
+
+### Phase 2: Repo-level Default Policies (est. 1 day, optional)
+
+Support a `BROWSER_USE.yml` at the repo root that defines default policies for common agent types:
+
+```yaml
+# BROWSER_USE.yml
+policies:
+  scraper:
+    allowed_actions: [navigate, extract_content, screenshot]
+    denied_actions: [input_text, click_element, download_file, execute_javascript]
+  form_filler:
+    allowed_actions: [navigate, click_element, input_text, extract_content]
+    require_approval_for: [submit]
+```
+
+### Phase 3: Audit & Documentation (est. 1 day)
+
+1. Review all registered actions in the action registry to ensure complete coverage
+2. Write documentation with examples
+3. Add a `--dry-run` mode that logs what _would_ be denied without actually blocking
+
+## 5. Open Questions for Discussion
+
+1. **Per-action vs per-parameter granularity?** E.g., should we allow `navigate` but only to `example.com/*`? (Proposal: start with action-level, add parameter-level in a future iteration.)
+2. **Session-level or Agent-level?** Policy lives on the `Agent`, not `BrowserSession`, because different agents using the same browser may have different permissions. (Proposal: Agent-level, as shown above.)
+3. **Should `allowed_domains` at the policy level override or supplement the session-level domains?** (Proposal: supplement — both must pass. Users who want to bypass session domains can leave them unset.)
+4. **Should `require_approval_for` blocking be reported as a tool error or stop the agent entirely?** (Proposal: tool error — the agent re-plans naturally.)
+
+## 6. Non-Goals
+
+- **LLM-based policy evaluation** — all checks are deterministic, no LLM calls
+- **Realtime policy changes** — policy is set at agent creation and immutable for the agent's lifetime
+- **Per-user policy inheritance** — no RBAC or multi-tenant policy hierarchies
+- **Audit logging** — covered by the existing `History` system; no separate audit trail needed
+
+## 7. References
+
+- Issue #5063: Original proposal
+- Issue #4739: agchk audit (flagged `capability_policy` at HIGH)
+- `browser_use/agent/security/` directory — existing security modules
+- `browser_use/browser/watchdogs/security_watchdog.py` — existing domain filter


### PR DESCRIPTION
## Description

This is a design document for implementing deterministic permission gating for browser actions (originally proposed in #5063).

**Key decisions in this design:**

1. **Centralized enforcement** — single `BrowserPolicy.enforce()` call in `Agent.step()`, not scattered across action handlers
2. **No LLM in the enforcement path** — all checks are deterministic (binary pass/fail)
3. **Complements existing security** — the policy layer adds action-level gating **before** navigation is scheduled; existing `SecurityWatchdog`, domain filters, and `message_compaction` controls remain unchanged
4. **Headless-safe** — `require_approval_for` actions are DENIED (not hung) when no interactive session is available
5. **Agent-level, not session-level** — different agents using the same browser can have different policies
6. **Phased implementation** — Model + enforcement first, then optional repo-level config, then audit

**Open questions** are listed in section 5 for discussion.

This is a design-only PR. No code changes to the library itself.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a design doc for deterministic permission gating of browser actions and ships reliability improvements across browsing, LLM integration, and installation. Users get automatic tab crash recovery, safer Windows headless runs, clearer Ollama behavior, and CLI wrappers that avoid PATH shadowing.

- **New Features**
  - Auto-detect and recover crashed tabs; reloads the previous URL and informs the agent.
  - `ChatOllama`: supports `stream=True`, forwards `format`/`stream` correctly, and gives clearer JSON error messages.
  - Warn when the beta SDK agent completes with no result to surface LLM misconfig (e.g., `BROWSER_USE_API_KEY`).
  - Design doc outlines centralized, deterministic action gating in `Agent.step()`.

- **Bug Fixes**
  - Disable GPU in Windows headless to prevent SwiftShader compositor crashes.
  - More robust CDP connect: retries `json/version` fetch with backoff; avoid localhost proxy leakage and connector reuse in polling.
  - Installer now creates `~/.local/bin` wrappers for CLI commands instead of exporting the venv `bin`; adds Windows `.cmd` wrappers and PATH updates.

<sup>Written for commit 32f2ba159b312a2fa8725cc8af1fbdf3ed85cbd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

