### PR TITLE
fix(security): write storage_state.json session cookies with 0o600

### DIFF
--- a/browser_use/browser/watchdogs/storage_state_watchdog.py
+++ b/browser_use/browser/watchdogs/storage_state_watchdog.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -200,17 +201,47 @@ class StorageStateWatchdog(BaseWatchdog):
 					except Exception as e:
 						self.logger.error(f'[StorageStateWatchdog] Failed to merge with existing state: {e}')
 
-				# Write atomically
-				temp_path = json_path.with_suffix('.json.tmp')
-				temp_path.write_text(json.dumps(merged_state, indent=4, ensure_ascii=False), encoding='utf-8')
+				# Write atomically to a fresh owner-only temp file. mkstemp creates it
+				# with O_EXCL + 0o600, so the persisted session cookies / localStorage are
+				# never world-readable under the default umask — not even during the write
+				# or if the process crashes before the rename. Mirrors the project's own
+				# credential-file posture (skill_cli/config.py write_config, sync/auth.py,
+				# the daemon Unix socket all use 0o600).
+				fd, tmp_str = tempfile.mkstemp(dir=json_path.parent, prefix='.storage_state_', suffix='.json.tmp')
+				temp_path = Path(tmp_str)
+				try:
+					with os.fdopen(fd, 'w', encoding='utf-8') as f:
+						f.write(json.dumps(merged_state, indent=4, ensure_ascii=False))
+						f.flush()
+						os.fsync(f.fileno())
+					try:
+						temp_path.chmod(0o600)
+					except OSError:
+						pass
 
-				# Backup existing file
-				if json_path.exists():
+					# Lock down any cookie-bearing .json.bak left by a pre-fix version,
+					# regardless of whether the current file still exists.
 					backup_path = json_path.with_suffix('.json.bak')
-					json_path.replace(backup_path)
+					if backup_path.exists():
+						try:
+							backup_path.chmod(0o600)
+						except OSError:
+							pass
 
-				# Move temp to final
-				temp_path.replace(json_path)
+					# Rotate the current file to backup, restricting it first so the backup
+					# is never world-readable even if a later error aborts before the rename.
+					if json_path.exists():
+						try:
+							json_path.chmod(0o600)
+						except OSError:
+							pass
+						json_path.replace(backup_path)
+
+					# Move temp to final
+					temp_path.replace(json_path)
+				except BaseException:
+					temp_path.unlink(missing_ok=True)
+					raise
 
 				# Emit success event
 				self.event_bus.dispatch(

--- a/tests/ci/security/test_storage_state_perms.py
+++ b/tests/ci/security/test_storage_state_perms.py
@@ -1,0 +1,143 @@
+"""Tests for storage_state.json (session cookie) file permissions.
+
+StorageStateWatchdog persists authenticated session cookies + localStorage to
+storage_state.json. Under the default umask that file is world-readable (0o644),
+and the 30s autosave silently re-downgrades a user-pre-created 0o600 file on
+every write, so on a multi-user host a co-tenant can read live session cookies.
+The fix writes via tempfile.mkstemp (O_EXCL + 0o600 from creation) and restricts
+the .json.bak backup before its rename, mirroring the project's own
+credential-file posture (skill_cli/config.py write_config, sync/auth.py, the
+daemon Unix socket).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from browser_use.browser.watchdogs.storage_state_watchdog import StorageStateWatchdog
+
+skip_on_windows = pytest.mark.skipif(
+	sys.platform == 'win32',
+	reason='POSIX file-mode bits are not meaningful on Windows.',
+)
+
+_FAKE_STATE = {
+	'cookies': [{'name': 'session', 'value': 'secret-token', 'domain': 'example.com', 'path': '/'}],
+	'origins': [{'origin': 'https://example.com', 'localStorage': [{'name': 'k', 'value': 'v'}]}],
+}
+
+
+def _make_watchdog() -> StorageStateWatchdog:
+	"""Build a watchdog without a real browser via pydantic model_construct.
+
+	_save_storage_state only touches browser_session.get_or_create_cdp_session,
+	browser_session._cdp_get_storage_state, browser_session.logger and
+	event_bus.dispatch — all stubbed below.
+	"""
+
+	async def _get_or_create_cdp_session(target_id=None):
+		return True
+
+	async def _cdp_get_storage_state():
+		return json.loads(json.dumps(_FAKE_STATE))  # deep copy
+
+	browser_session = SimpleNamespace(
+		get_or_create_cdp_session=_get_or_create_cdp_session,
+		_cdp_get_storage_state=_cdp_get_storage_state,
+		logger=logging.getLogger('test-storage-state-perms'),
+	)
+	event_bus = SimpleNamespace(dispatch=lambda *a, **k: None)
+	return StorageStateWatchdog.model_construct(browser_session=browser_session, event_bus=event_bus)
+
+
+def _mode(path: Path) -> int:
+	return stat.S_IMODE(os.stat(path).st_mode)
+
+
+@skip_on_windows
+async def test_storage_state_written_0o600(tmp_path: Path) -> None:
+	"""A freshly written storage_state.json must be 0o600 (owner-only)."""
+	path = tmp_path / 'storage_state.json'
+
+	await _make_watchdog()._save_storage_state(path=str(path))
+
+	assert path.exists()
+	mode = _mode(path)
+	assert mode == 0o600, (
+		f'storage_state.json has mode {oct(mode)}, expected 0o600. Session cookies '
+		f'must not be world/group readable on multi-user hosts.'
+	)
+	# Sanity: we really are guarding a live secret.
+	assert 'secret-token' in path.read_text()
+
+
+@skip_on_windows
+async def test_storage_state_autosave_does_not_redowngrade(tmp_path: Path) -> None:
+	"""A pre-existing 0o644 file (and its .json.bak backup) end up 0o600 after save."""
+	path = tmp_path / 'storage_state.json'
+	# Simulate a stale world-readable file (external creation, or pre-fix autosave).
+	path.write_text(json.dumps({'cookies': [], 'origins': []}))
+	path.chmod(0o644)
+	assert _mode(path) == 0o644
+
+	await _make_watchdog()._save_storage_state(path=str(path))
+
+	assert _mode(path) == 0o600, 'autosave must not leave storage_state.json world-readable'
+	# The backup holds the previous cookie state, so it must be locked down too.
+	backup = path.with_suffix('.json.bak')
+	assert backup.exists()
+	assert _mode(backup) == 0o600, f'{backup.name} (contains cookies) must be 0o600, got {oct(_mode(backup))}'
+
+
+@skip_on_windows
+async def test_pre_existing_insecure_backup_locked_down_even_when_save_fails(
+	tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+	"""A 0o644 .json.bak left by a pre-fix version is restricted even if the save aborts."""
+	import pathlib
+
+	path = tmp_path / 'storage_state.json'
+	path.write_text(json.dumps({'cookies': [], 'origins': []}))
+	path.chmod(0o644)
+	backup = path.with_suffix('.json.bak')
+	backup.write_text(json.dumps({'cookies': [{'name': 'old', 'value': 'leak', 'domain': 'x', 'path': '/'}]}))
+	backup.chmod(0o644)
+
+	# Force the json -> .json.bak rename to fail, after the pre-rename chmods run.
+	real_replace = pathlib.Path.replace
+
+	def boom(self, target):
+		if str(target).endswith('.json.bak'):
+			raise OSError('forced backup-rename failure')
+		return real_replace(self, target)
+
+	monkeypatch.setattr(pathlib.Path, 'replace', boom)
+
+	# _save_storage_state swallows + logs the error, so this returns rather than raises.
+	await _make_watchdog()._save_storage_state(path=str(path))
+
+	# Despite the failed save, neither cookie-bearing file is left world-readable.
+	assert _mode(backup) == 0o600, f'pre-existing backup must be locked down, got {oct(_mode(backup))}'
+	assert _mode(path) == 0o600, f'current file must be locked down, got {oct(_mode(path))}'
+
+
+@skip_on_windows
+async def test_stale_backup_locked_down_when_current_file_missing(tmp_path: Path) -> None:
+	"""A lone stale 0o644 .json.bak (current file absent) is restricted on the next save."""
+	path = tmp_path / 'storage_state.json'  # intentionally does not exist
+	backup = path.with_suffix('.json.bak')
+	backup.write_text(json.dumps({'cookies': [{'name': 'old', 'value': 'leak', 'domain': 'x', 'path': '/'}]}))
+	backup.chmod(0o644)
+
+	await _make_watchdog()._save_storage_state(path=str(path))
+
+	assert path.exists() and _mode(path) == 0o600
+	assert _mode(backup) == 0o600, f'stale backup must be locked down even with no current file, got {oct(_mode(backup))}'


### PR DESCRIPTION
## What

`StorageStateWatchdog._save_storage_state()` persists authenticated session cookies and `localStorage` to `storage_state.json`. It wrote the file with `Path.write_text()` under the process umask, so the file (and its `.json.bak` backup) landed **world-readable (`0o644`)**, and the 30s autosave silently re-downgraded a user-pre-created `0o600` file on every write.

On a multi-user host any local co-tenant can then read live session cookies → session hijack. This is a self-consistency gap: the project already locks **less**-sensitive credential files to `0o600` with the same atomic tmp+rename pattern — `skill_cli/config.py:write_config`, `sync/auth.py`, and the daemon Unix socket (covered by `tests/ci/security/test_daemon_socket_perms.py`).

## Fix

Write through `tempfile.mkstemp`, which creates the temp file `O_EXCL` + `0o600`, so the cookies are never world-readable — not even during the write, or as a leftover temp if the process crashes before the rename. This mirrors `write_config`. The cookie-bearing `.json.bak` (the current one and any stale one left by a pre-fix version) is also restricted to `0o600` before rotation.

## Scope

Permissions only. The existing temp → backup → install rotation flow and its (pre-existing) crash-atomicity characteristics are intentionally left unchanged.

## Tests

`tests/ci/security/test_storage_state_perms.py` (no browser; mirrors the existing daemon-socket security test):

- a fresh write is `0o600`;
- an autosave over a `0o644` file leaves both `storage_state.json` and `.json.bak` at `0o600`;
- a pre-existing insecure backup is locked down even if the save aborts mid-way, and even when no current file exists.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Securely persist session cookies by writing storage_state.json with 0o600 and tightening permissions on its .json.bak backup. Prevents world-readable cookies on multi-user hosts and aligns with our existing credential file posture.

- **Bug Fixes**
  - Write via tempfile.mkstemp (O_EXCL) to create a 0o600 temp file, fsync, then atomic rename.
  - Lock down both storage_state.json and any .json.bak (including stale ones) to 0o600 before/after rotation; clean up temp on errors.
  - Preserve the existing temp → backup → install flow.
  - Add tests to ensure fresh writes, autosaves over 0o644, and stale backups all end up 0o600 (skipped on Windows).

<sup>Written for commit 3e6f3f1caf42e091a4db3da522e25735cc2aee89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

