### PR TITLE
fix(dom): don't mutate node.snapshot_node.bounds in is_element_visible_according_to_all_parents

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -275,6 +275,16 @@ class DomService:
 		if not current_bounds:
 			return False  # If there are no bounds, the element is not visible
 
+		# Work on a copy of the rect. The += / -= below shift bounds into each parent
+		# frame's coordinate space for the viewport intersection check, but
+		# node.snapshot_node.bounds is the node's shared, absolute-page-coordinate rect
+		# (set during construction at ~service.py:788). DOMRect is a mutable dataclass,
+		# so mutating this reference in place permanently corrupts the geometry that
+		# downstream consumers (paint-order occlusion, bbox containment) read on any
+		# scrolled or iframe page. Mirror the deliberate DOMRect copy in
+		# _construct_enhanced_node (~service.py:734, 'to get rid of the pointer references').
+		current_bounds = DOMRect(current_bounds.x, current_bounds.y, current_bounds.width, current_bounds.height)
+
 		# If threshold is None, skip all viewport-based filtering (only check CSS visibility)
 		if viewport_threshold is None:
 			return True

--- a/tests/ci/test_dom_visibility_bounds.py
+++ b/tests/ci/test_dom_visibility_bounds.py
@@ -1,0 +1,65 @@
+"""Regression test: the visibility predicate must not mutate the node's stored bounds.
+
+DomService.is_element_visible_according_to_all_parents() is a pure -> bool
+predicate, but it used to bind current_bounds directly to the shared, mutable
+node.snapshot_node.bounds (absolute page coordinates set at construction) and
+then apply iframe/scroll offsets in place. On any scrolled or iframe page that
+permanently corrupted the node's stored geometry, which downstream consumers
+(paint-order occlusion, bbox containment) then read as wrong rectangles. The fix
+computes on a DOMRect copy, mirroring the deliberate copy in
+_construct_enhanced_node.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from browser_use.dom.service import DomService
+from browser_use.dom.views import DOMRect, NodeType
+
+
+def _snap(*, bounds=None, scroll_rects=None, client_rects=None, computed_styles=None):
+	return SimpleNamespace(
+		bounds=bounds,
+		scrollRects=scroll_rects,
+		clientRects=client_rects,
+		computed_styles=computed_styles or {},
+	)
+
+
+def test_visibility_check_does_not_mutate_bounds_on_scrolled_page():
+	node_bounds = DOMRect(x=100.0, y=200.0, width=10.0, height=10.0)
+	node = SimpleNamespace(snapshot_node=_snap(bounds=node_bounds))
+	# Root HTML frame scrolled down 50px.
+	html_frame = SimpleNamespace(
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='HTML',
+		snapshot_node=_snap(
+			bounds=DOMRect(0.0, 0.0, 800.0, 600.0),
+			scroll_rects=DOMRect(0.0, 50.0, 800.0, 2000.0),
+			client_rects=DOMRect(0.0, 0.0, 800.0, 600.0),
+		),
+	)
+
+	visible = DomService.is_element_visible_according_to_all_parents(node, [html_frame])
+
+	assert visible is True
+	# Before the fix the scroll offset was applied in place, leaving y at 150.
+	assert (node_bounds.x, node_bounds.y) == (100.0, 200.0)
+	assert node.snapshot_node.bounds is node_bounds  # same object, untouched
+
+
+def test_visibility_check_does_not_mutate_bounds_inside_iframe():
+	node_bounds = DOMRect(x=10.0, y=20.0, width=10.0, height=10.0)
+	node = SimpleNamespace(snapshot_node=_snap(bounds=node_bounds))
+	# Element nested in an iframe offset by (300, 400).
+	iframe = SimpleNamespace(
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='IFRAME',
+		snapshot_node=_snap(bounds=DOMRect(300.0, 400.0, 200.0, 200.0)),
+	)
+
+	DomService.is_element_visible_according_to_all_parents(node, [iframe])
+
+	# Before the fix the iframe offset was added in place, leaving (310, 420).
+	assert (node_bounds.x, node_bounds.y) == (10.0, 20.0)

--- a/tests/ci/test_dom_visibility_bounds.py
+++ b/tests/ci/test_dom_visibility_bounds.py
@@ -13,9 +13,10 @@ _construct_enhanced_node.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import cast
 
 from browser_use.dom.service import DomService
-from browser_use.dom.views import DOMRect, NodeType
+from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, NodeType
 
 
 def _snap(*, bounds=None, scroll_rects=None, client_rects=None, computed_styles=None):
@@ -41,7 +42,11 @@ def test_visibility_check_does_not_mutate_bounds_on_scrolled_page():
 		),
 	)
 
-	visible = DomService.is_element_visible_according_to_all_parents(node, [html_frame])
+	# node/html_frame are SimpleNamespace duck-typed stand-ins for EnhancedDOMTreeNode
+	# (the predicate only reads .snapshot_node / .node_type / .node_name).
+	visible = DomService.is_element_visible_according_to_all_parents(
+		cast(EnhancedDOMTreeNode, node), cast(list[EnhancedDOMTreeNode], [html_frame])
+	)
 
 	assert visible is True
 	# Before the fix the scroll offset was applied in place, leaving y at 150.
@@ -59,7 +64,9 @@ def test_visibility_check_does_not_mutate_bounds_inside_iframe():
 		snapshot_node=_snap(bounds=DOMRect(300.0, 400.0, 200.0, 200.0)),
 	)
 
-	DomService.is_element_visible_according_to_all_parents(node, [iframe])
+	DomService.is_element_visible_according_to_all_parents(
+		cast(EnhancedDOMTreeNode, node), cast(list[EnhancedDOMTreeNode], [iframe])
+	)
 
 	# Before the fix the iframe offset was added in place, leaving (310, 420).
 	assert (node_bounds.x, node_bounds.y) == (10.0, 20.0)


### PR DESCRIPTION
## What

`DomService.is_element_visible_according_to_all_parents()` is a pure `-> bool` visibility predicate, but it binds `current_bounds` directly to the live `node.snapshot_node.bounds` (a mutable `DOMRect`) and then applies iframe-origin and scroll offsets to it **in place** (`+=` / `-=`).

`node.snapshot_node.bounds` is the node's stored, **absolute page-coordinate** rect — built during construction at `service.py:788-793` by adding the accumulated `total_frame_offset`. Mutating it here permanently corrupts that stored geometry on any **scrolled or iframe** page. The predicate runs once per node at construction (`service.py:893`) before serialization, so downstream consumers that read `snapshot_node.bounds` (paint-order occlusion filtering, bbox containment filtering — both default-on) then see wrong rectangles and can drop/keep the wrong elements in the DOM the agent sees.

## Fix

Compute the viewport transform on a `DOMRect` copy, mirroring the deliberate copy already in `_construct_enhanced_node` (`service.py:734`, *"to get rid of the pointer references"*). The boolean result is unchanged; only the destructive side effect on the shared rect is removed.

## Tests

`tests/ci/test_dom_visibility_bounds.py` (pure-function, no browser): assert the node's stored bounds are untouched after the predicate runs, on both a scrolled root frame and inside an offset iframe (before the fix, `y` / `x` were corrupted by the scroll / iframe offset).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the visibility check to stop mutating `snapshot_node.bounds`. We now compute on a `DOMRect` copy so geometry stays correct for scrolled pages and iframes.

- **Bug Fixes**
  - Apply iframe/scroll offsets to a copy in `DomService.is_element_visible_according_to_all_parents`, leaving the stored absolute bounds untouched.
  - Added regression tests for scrolled root frames and offset iframes; updated with `typing.cast` so CI type checks pass with no behavior change.

<sup>Written for commit 57c1923c23d4c36a39c95d279c5b3f844d581e2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

