### PR TITLE
fix: preserve empty accessibility name (ax_node.name) instead of dropping it

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3611,7 +3611,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				same_type_ax_names = [
 					(idx, elem.ax_node.name if elem.ax_node else None)
 					for idx, elem in selector_map.items()
-					if elem.node_name.lower() == hist_name and elem.ax_node and elem.ax_node.name
+					if elem.node_name.lower() == hist_name and elem.ax_node and elem.ax_node.name is not None
 				]
 				self.logger.debug(
 					f'AX_NAME match failed for <{hist_name.upper()}> ax_name="{hist_ax_name}". '

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -102,7 +102,7 @@ class DomService:
 				if is_interactive and is_hidden_by_threshold(subtree_root):
 					# Get element text/name
 					text = ''
-					if subtree_root.ax_node and subtree_root.ax_node.name:
+					if subtree_root.ax_node and subtree_root.ax_node.name is not None:
 						text = subtree_root.ax_node.name[:40]
 					elif subtree_root.attributes:
 						text = (

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -848,7 +848,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -876,7 +876,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_ax_name_matching.py
+++ b/tests/ci/test_ax_name_matching.py
@@ -556,3 +556,143 @@ def test_is_menu_item_element_returns_false_for_regular_element():
 	)
 
 	assert agent._is_menu_item_element(regular_element) is False
+
+
+# ─── Tests for empty ax_node.name preservation ────────────────────────────────
+
+
+def test_empty_ax_name_preserved_in_load_from_enhanced_dom_tree():
+	"""When ax_node.name is '' (empty string), load_from_enhanced_dom_tree
+	should preserve it as ax_name='' instead of dropping it to None.
+
+	Before the fix, `if .ax_node.name:` evaluated '' as falsy and dropped it.
+	"""
+	from browser_use.dom.views import EnhancedAXNode, EnhancedDOMTreeNode
+
+	# Build a minimal node with empty ax_node.name
+	ax_node = EnhancedAXNode(
+		ax_node_id='ax-1',
+		ignored=False,
+		role='button',
+		name='',  # empty string — the key test case
+		description=None,
+		properties=None,
+		child_ids=None,
+	)
+	node = EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={'type': 'submit'},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=None,
+	)
+
+	result = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+	assert result.ax_name == '', f'Expected empty string, got {result.ax_name!r}'
+
+
+def test_none_ax_name_preserved_in_load_from_enhanced_dom_tree():
+	"""When ax_node.name is None, load_from_enhanced_dom_tree should keep ax_name=None."""
+	from browser_use.dom.views import EnhancedAXNode, EnhancedDOMTreeNode
+
+	ax_node = EnhancedAXNode(
+		ax_node_id='ax-1',
+		ignored=False,
+		role='button',
+		name=None,  # explicitly absent
+		description=None,
+		properties=None,
+		child_ids=None,
+	)
+	node = EnhancedDOMTreeNode(
+		node_id=2,
+		backend_node_id=2,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={'type': 'submit'},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=None,
+	)
+
+	result = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+	assert result.ax_name is None, f'Expected None, got {result.ax_name!r}'
+
+
+def test_empty_vs_none_ax_name_produce_different_hashes():
+	"""Elements with empty ax_node.name vs no ax_node should hash differently.
+
+	An empty accessible name (explicitly set to '') is semantically different
+	from no accessible name at all (None), so they must not hash the same.
+	"""
+	from browser_use.dom.views import EnhancedAXNode, EnhancedDOMTreeNode
+
+	def _make_node(node_id: int, name: str | None) -> EnhancedDOMTreeNode:
+		return EnhancedDOMTreeNode(
+			node_id=node_id,
+			backend_node_id=node_id,
+			node_type=NodeType.ELEMENT_NODE,
+			node_name='INPUT',
+			node_value='',
+			attributes={'type': 'text'},
+			is_scrollable=None,
+			is_visible=True,
+			absolute_position=None,
+			target_id='target-1',
+			frame_id=None,
+			session_id=None,
+			content_document=None,
+			shadow_root_type=None,
+			shadow_roots=None,
+			parent_node=None,
+			children_nodes=None,
+			ax_node=EnhancedAXNode(
+				ax_node_id=f'ax-{node_id}',
+				ignored=False,
+				role='textbox',
+				name=name,
+				description=None,
+				properties=None,
+				child_ids=None,
+			),
+			snapshot_node=None,
+		)
+
+	node_empty = _make_node(1, '')  # explicitly empty
+	node_none = _make_node(2, None)  # no ax_node at all can't use this builder but we can set ax_node=None
+	node_none.ax_node = None
+
+	empty_hash = hash(node_empty)
+	none_hash = hash(node_none)
+
+	# Hashes must differ
+	assert empty_hash != none_hash, f'Empty name hash ({empty_hash}) should differ from None hash ({none_hash})'
+
+	# Both should produce deterministic hashes (not crash)
+	assert isinstance(empty_hash, int)
+	assert isinstance(none_hash, int)


### PR DESCRIPTION
## AI Assistance Disclosure
This contribution was developed with AI assistance (Claude / Anthropic Claude Code).

## Summary
When `ax_node.name` is an empty string (`''`), the truthiness check `if ax_node.name:` evaluates to `False`, causing valid empty accessibility names to be silently dropped. An empty name and an absent name (`None`) carry different semantic meaning in accessibility trees.

## Changes
Changed 5 instances of `if .ax_node.name:` to `if .ax_node.name is not None:` across 3 files:

- **browser_use/dom/views.py** — 3 occurrences in element hashing and `DOMInteractedElement.load_from_enhanced_dom_tree`
- **browser_use/dom/service.py** — 1 occurrence in hidden element text collection
- **browser_use/agent/service.py** — 1 occurrence in AX_NAME debug logging filter

## Verification Process
1. Forked → cloned to local sandbox
2. Created venv, installed deps (`uv sync`), ran existing test suite
3. Applied fix + wrote 3 targeted unit tests in `tests/ci/test_ax_name_matching.py`
4. Ran full ax_name test suite: **13/13 passed** (10 existing + 3 new)
5. Ruff format + lint: all checks passed

## Test Results
```
tests/ci/test_ax_name_matching.py::test_ax_name_matching_succeeds_when_hash_fails PASSED
tests/ci/test_ax_name_matching.py::test_ax_name_matching_requires_same_node_type PASSED
tests/ci/test_ax_name_matching.py::test_match_level_enum_includes_ax_name PASSED
tests/ci/test_ax_name_matching.py::test_ax_name_matching_before_attribute_matching PASSED
tests/ci/test_ax_name_matching.py::test_is_menu_opener_step_detects_aria_haspopup PASSED
tests/ci/test_ax_name_matching.py::test_is_menu_opener_step_detects_guidewire_toggle PASSED
tests/ci/test_ax_name_matching.py::test_is_menu_opener_step_returns_false_for_regular_element PASSED
tests/ci/test_ax_name_matching.py::test_is_menu_item_element_detects_role_menuitem PASSED
tests/ci/test_ax_name_matching.py::test_is_menu_item_element_detects_guidewire_class PASSED
tests/ci/test_ax_name_matching.py::test_is_menu_item_element_returns_false_for_regular_element PASSED
tests/ci/test_ax_name_matching.py::test_empty_ax_name_preserved_in_load_from_enhanced_dom_tree PASSED  [NEW]
tests/ci/test_ax_name_matching.py::test_none_ax_name_preserved_in_load_from_enhanced_dom_tree PASSED  [NEW]
tests/ci/test_ax_name_matching.py::test_empty_vs_none_ax_name_produce_different_hashes PASSED  [NEW]
```

## Cross-Validation
| Scenario | Before | After |
|----------|--------|-------|
| `ax_node.name = None` (no name) | skipped (correct) | skipped (correct) |
| `ax_node.name = ''` (empty name) | ❌ dropped as falsy | ✅ preserved |
| `ax_node.name = 'Submit'` (normal) | ✅ preserved | ✅ preserved |
| `ax_node = None` (no ax_node) | short-circuits (correct) | short-circuits (correct) |
| Empty vs None hash | identical (bug) | different (correct) |

Closes #5041