### PR TITLE
fix(llm/google): preserve first user message content/images when include_system_in_user=True

### DIFF
--- a/browser_use/llm/google/serializer.py
+++ b/browser_use/llm/google/serializer.py
@@ -76,43 +76,46 @@ class GoogleMessageSerializer:
 			# Initialize message parts
 			message_parts: list[Part] = []
 
+			# Build the content parts (text + images) once so both branches keep them
+			content_parts: list[Part] = []
+			if isinstance(message.content, str):
+				content_parts.append(Part.from_text(text=message.content))
+			elif message.content is not None:
+				# Handle Iterable of content parts
+				for part in message.content:
+					if part.type == 'text':
+						content_parts.append(Part.from_text(text=part.text))
+					elif part.type == 'refusal':
+						content_parts.append(Part.from_text(text=f'[Refusal] {part.refusal}'))
+					elif part.type == 'image_url':
+						# Handle images
+						url = part.image_url.url
+
+						# Format: data:image/jpeg;base64,<data>
+						header, data = url.split(',', 1)
+						# Decode base64 to bytes
+						image_bytes = base64.b64decode(data)
+
+						# Use the media_type from ImageURL, which correctly identifies the image format
+						mime_type = part.image_url.media_type
+
+						# Add image part
+						content_parts.append(Part.from_bytes(data=image_bytes, mime_type=mime_type))
+
 			# If this is the first user message and we have system parts, prepend them
 			if include_system_in_user and system_parts and role == 'user' and not formatted_messages:
 				system_text = '\n\n'.join(system_parts)
+				system_parts = []  # Clear after using
 				if isinstance(message.content, str):
+					# Fold the system text into the single text part
 					message_parts.append(Part.from_text(text=f'{system_text}\n\n{message.content}'))
 				else:
-					# Add system text as the first part
+					# Prepend the system text, then keep the user's actual content (text + images)
 					message_parts.append(Part.from_text(text=system_text))
-				system_parts = []  # Clear after using
+					message_parts.extend(content_parts)
 			else:
-				# Extract content and create parts normally
-				if isinstance(message.content, str):
-					# Regular text content
-					message_parts = [Part.from_text(text=message.content)]
-				elif message.content is not None:
-					# Handle Iterable of content parts
-					for part in message.content:
-						if part.type == 'text':
-							message_parts.append(Part.from_text(text=part.text))
-						elif part.type == 'refusal':
-							message_parts.append(Part.from_text(text=f'[Refusal] {part.refusal}'))
-						elif part.type == 'image_url':
-							# Handle images
-							url = part.image_url.url
-
-							# Format: data:image/jpeg;base64,<data>
-							header, data = url.split(',', 1)
-							# Decode base64 to bytes
-							image_bytes = base64.b64decode(data)
-
-							# Use the media_type from ImageURL, which correctly identifies the image format
-							mime_type = part.image_url.media_type
-
-							# Add image part
-							image_part = Part.from_bytes(data=image_bytes, mime_type=mime_type)
-
-							message_parts.append(image_part)
+				# Use the content parts as-is
+				message_parts = content_parts
 
 			# Create the Content object
 			if message_parts:

--- a/browser_use/llm/tests/test_gemini_image.py
+++ b/browser_use/llm/tests/test_gemini_image.py
@@ -2,8 +2,7 @@ import asyncio
 import base64
 import io
 import random
-
-from PIL import Image, ImageDraw, ImageFont
+from typing import cast
 
 from browser_use.llm.google.chat import ChatGoogle
 from browser_use.llm.google.serializer import GoogleMessageSerializer
@@ -15,6 +14,8 @@ from browser_use.llm.messages import (
 	SystemMessage,
 	UserMessage,
 )
+from google.genai.types import Content
+from PIL import Image, ImageDraw, ImageFont
 
 
 def create_random_text_image(text: str = 'hello world', width: int = 4000, height: int = 4000) -> str:
@@ -85,6 +86,46 @@ async def test_gemini_image_vision():
 	except Exception as e:
 		print(f'Error calling Gemini: {e}')
 		print(f'Error type: {type(e)}')
+
+
+def test_include_system_in_user_preserves_first_user_message_content():
+	"""Regression: include_system_in_user=True with list content must keep the user's text + images.
+
+	When the system message is folded into the first user message and that message has list
+	content, the serializer previously emitted only the system text and silently dropped the
+	user's own text and image parts (e.g. the screenshot the model reasons over on turn 1).
+	"""
+	image_data_url = create_random_text_image('preserve me', width=64, height=64)
+	messages: list[BaseMessage] = [
+		SystemMessage(content='SYSTEM_INSTRUCTION_TEXT'),
+		UserMessage(
+			content=[
+				ContentPartTextParam(text='USER_FIRST_TURN_TEXT'),
+				ContentPartImageParam(image_url=ImageURL(url=image_data_url)),
+			]
+		),
+	]
+
+	formatted_messages, system_message = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+
+	# System folded into the first user message -> no separate system instruction returned
+	assert system_message is None
+	formatted_list = cast(list[Content], formatted_messages)
+	assert len(formatted_list) == 1
+
+	parts = formatted_list[0].parts or []
+	texts = [p.text for p in parts if p.text is not None]
+	# System text is prepended ...
+	assert any('SYSTEM_INSTRUCTION_TEXT' in t for t in texts)
+	# ... and the user's own text is preserved (regression: previously dropped) ...
+	assert any('USER_FIRST_TURN_TEXT' in t for t in texts)
+	# ... and the image is preserved (regression: previously dropped).
+	image_parts = [p for p in parts if p.inline_data is not None]
+	assert len(image_parts) == 1
+	blob = image_parts[0].inline_data
+	assert blob is not None
+	assert blob.mime_type == 'image/png'
+	assert blob.data
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

`GoogleMessageSerializer.serialize_messages(..., include_system_in_user=True)` silently drops the **entire first user message** (its text *and* image parts) when that message's content is a list — it emits only the prepended system text.

In the first-user-message branch:

```python
if isinstance(message.content, str):
    message_parts.append(Part.from_text(text=f'{system_text}\n\n{message.content}'))  # str: content preserved
else:
    # Add system text as the first part
    message_parts.append(Part.from_text(text=system_text))   # list: ONLY system text — user text + images lost
```

For `str` content the user's text is concatenated in, but for **list** content the `else` arm appends only the system text and the normal content-iteration loop (text / refusal / image parts) is skipped, because the outer `if` already matched. Result: on a list-content first turn — e.g. a Gemma-3 / Gemma-3n run, which has no system role and so uses `include_system_in_user` to fold system text into the first user message — the user's actual prompt text and the page screenshot the agent reasons over are never sent. The model is effectively blind on turn 1.

This is the same bug an earlier external PR (#3513) flagged; that PR was auto-closed stale with no review, and the bug is still live on `main`.

## Fix

Build the message's content parts once, then have both arms preserve them: the system-prepend arm now appends the system text **and then** the user's content parts; the normal arm uses the content parts directly. The only behavioral change is that the list + `include_system_in_user` path now keeps the user's content — the `str` path, the `include_system_in_user=False` path, and image decoding are unchanged.

Adds a hermetic regression test (no network / no API key) asserting that with `include_system_in_user=True` and list content, the serialized first message contains the system text, the user's text, **and** the inline image — it fails on the old code.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Google serializer dropping the first user message’s text and images when include_system_in_user=True and the message content is a list. The system text is now prepended and the user’s content is preserved, preventing turn‑1 multimodal data loss.

- **Bug Fixes**
  - Build content parts once and reuse in both branches; prepend system text then append the user’s parts.
  - Preserve user text and images on the first turn; the list-content path no longer drops them.
  - Add a hermetic regression test for this case; other paths (str content, image decoding, include_system_in_user=False) are unchanged.

<sup>Written for commit 3f003c49fede8137dcdf16e205659eaf84f9d445. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

