### PR TITLE
fix(dom): use explicit None check for ax_node.name instead of truthiness

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3611,7 +3611,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				same_type_ax_names = [
 					(idx, elem.ax_node.name if elem.ax_node else None)
 					for idx, elem in selector_map.items()
-					if elem.node_name.lower() == hist_name and elem.ax_node and elem.ax_node.name
+					if elem.node_name.lower() == hist_name and elem.ax_node and elem.ax_node.name is not None
 				]
 				self.logger.debug(
 					f'AX_NAME match failed for <{hist_name.upper()}> ax_name="{hist_ax_name}". '

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -102,7 +102,7 @@ class DomService:
 				if is_interactive and is_hidden_by_threshold(subtree_root):
 					# Get element text/name
 					text = ''
-					if subtree_root.ax_node and subtree_root.ax_node.name:
+					if subtree_root.ax_node and subtree_root.ax_node.name is not None:
 						text = subtree_root.ax_node.name[:40]
 					elif subtree_root.attributes:
 						text = (

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -848,7 +848,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -876,7 +876,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(


### PR DESCRIPTION
## Changes

Replace truthiness checks (`if ax_node.name`) with explicit None checks (`if ax_node.name is not None`) so that empty accessibility names (`aria-label=''`) are not silently discarded.

## Problem

An empty string `""` is a valid accessibility name in HTML/ARIA, but Python evaluates `""` to `False`. The existing truthiness check silently drops elements with explicit empty accessibility names, causing:

- Missing `ax_name` in DOM element snapshots
- Incorrect element matching in accessibility-aware lookups  
- Lost accessibility context in agent decision-making

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `browser_use/dom/views.py` | 3 | `_hash`, `_repr`, `load_from_enhanced_dom_tree` |
| `browser_use/dom/service.py` | 1 | Accessibility tree text extraction |
| `browser_use/agent/service.py` | 1 | Element history matching |

## Fix

All 5 occurrences changed from:
```python
if obj.ax_node and obj.ax_node.name:
```
to:
```python
if obj.ax_node and obj.ax_node.name is not None:
```

Closes #5041

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use explicit None checks for `ax_node.name` so empty accessibility names (`aria-label=""`) are preserved. This fixes missing `ax_name` in snapshots and improves accessibility-aware element matching.

- **Bug Fixes**
  - Replaced truthiness checks with `is not None` in `browser_use/dom/views.py`, `browser_use/dom/service.py`, and `browser_use/agent/service.py`.
  - Empty accessibility names now persist in element hashes, serialization, hidden-element text extraction, and history matching; fixes #5041.

<sup>Written for commit ab166cc69c62335ef535f4032ac54ddceb21ee96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

