### PR TITLE
fix(security): require exact host match for full-URL allowed/prohibited_domains patterns

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -282,8 +282,19 @@ class SecurityWatchdog(BaseWatchdog):
 		else:
 			# Exact match
 			if '://' in pattern:
-				# Full URL pattern
-				if url.startswith(pattern):
+				# Full URL pattern (e.g. "https://example.com"). A bare url.startswith()
+				# lets prefix-collision and userinfo hosts bypass the domain-containment
+				# guarantee — e.g. "https://example.com" would wrongly match
+				# https://example.com.evil.com/, https://example.com@evil.com/ (real host
+				# evil.com), and https://example.computer.com/. Require the URL's real host
+				# to equal the pattern's host before honoring the prefix match.
+				from urllib.parse import urlparse
+
+				try:
+					pattern_host = urlparse(pattern).hostname
+				except ValueError:
+					return False
+				if host and pattern_host and host.lower() == pattern_host.lower() and url.startswith(pattern):
 					return True
 			else:
 				# Domain-only pattern (case-insensitive comparison)

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -26,6 +26,44 @@ class TestUrlAllowlistSecurity:
 		# Make sure legitimate auth credentials still work
 		assert watchdog._is_url_allowed('https://user:password@example.com') is True
 
+	def test_full_url_pattern_requires_exact_host(self):
+		"""A full-URL allowed_domains pattern (e.g. 'https://example.com') must match the
+		pattern's exact host. A bare url.startswith(pattern) let prefix-collision and
+		userinfo hosts bypass the domain-containment guarantee."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['https://example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		# Legitimate matches on the exact host (any path) still pass
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('https://example.com/') is True
+		assert watchdog._is_url_allowed('https://example.com/path?q=1') is True
+
+		# Bypass vectors that a bare startswith() wrongly allowed must be blocked
+		assert watchdog._is_url_allowed('https://example.com.evil.com/') is False  # subdomain suffix
+		assert watchdog._is_url_allowed('https://example.com@evil.com/') is False  # userinfo host spoof
+		assert watchdog._is_url_allowed('https://example.computer.com/') is False  # prefix collision
+
+		# Scheme still has to match (http pattern prefix not satisfied by https origin, vice versa)
+		assert watchdog._is_url_allowed('http://example.com') is False
+
+		# The same helper backs prohibited_domains: the exact host stays blocked, while a
+		# prefix-collision / userinfo host is a *different* host and must not be matched
+		# (old startswith over-blocked these legitimate hosts).
+		browser_profile = BrowserProfile(prohibited_domains=['https://example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+		assert watchdog._is_url_allowed('https://example.com') is False  # exact host stays blocked
+		assert watchdog._is_url_allowed('https://example.com/path') is False
+		assert watchdog._is_url_allowed('https://example.com.evil.com/') is True  # different host, not prohibited
+		assert watchdog._is_url_allowed('https://example.computer.com/') is True  # different host, not prohibited
+
 	def test_glob_pattern_matching(self):
 		"""Test that glob patterns in allowed_domains work correctly."""
 		from bubus import EventBus


### PR DESCRIPTION
## Problem

`allowed_domains` / `prohibited_domains` accept full-URL patterns — the field docs list `"https://example.com"` as a valid form. In `SecurityWatchdog._is_url_match`, the full-URL branch matched these with a bare prefix check:

```python
if '://' in pattern:
    # Full URL pattern
    if url.startswith(pattern):
        return True
```

`url.startswith(pattern)` has no host boundary, so a pattern like `https://example.com` silently matches attacker-controlled origins (all empirically reproduced via `urlparse`):

| URL | real host | wrongly matched? |
|---|---|---|
| `https://example.com.evil.com/` | `example.com.evil.com` | ✅ allowed (subdomain suffix) |
| `https://example.com@evil.com/` | `evil.com` | ✅ allowed (userinfo host spoof) |
| `https://example.computer.com/` | `example.computer.com` | ✅ allowed (prefix collision) |

A safety-sensitive deployment that locks an agent to a single trusted site via a full-URL `allowed_domains` entry is therefore silently exposed to unauthorized origins. For `prohibited_domains` the same prefix check over-matches the other way (over-blocking legitimate prefix-sharing hosts like `example.computer.com`).

The domain-only branch directly below already does the right thing (`host.lower() == pattern.lower()`); the full-URL branch just never got the same boundary.

## Fix

Require the URL's **real parsed host** to equal the pattern's host before honoring the prefix match:

```python
if '://' in pattern:
    pattern_host = urlparse(pattern).hostname
    if host and pattern_host and host.lower() == pattern_host.lower() and url.startswith(pattern):
        return True
```

`host` is the URL's real hostname (already parsed by `_is_url_allowed`, which extracts it via `urlparse` and rejects host-less URLs), so userinfo/subdomain/prefix-collision spoofs no longer satisfy the check. Everything else — scheme, port, path, and query prefix semantics — is left exactly as `url.startswith()` had it, so legitimate matches (`https://example.com`, `https://example.com/path`, port-bearing and path/query-prefixed patterns) are unaffected.

## Tests

Added to `TestUrlAllowlistSecurity` in `tests/ci/security/test_domain_filtering.py` (browser-free): the three bypass vectors are rejected and legitimate exact-host URLs still pass for `allowed_domains`, plus a `prohibited_domains` case asserting the exact host stays blocked while a prefix-collision host is no longer over-blocked.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require exact host match for full-URL patterns in `allowed_domains` and `prohibited_domains` to prevent spoofed hosts from slipping through. Keeps existing scheme/port/path/query prefix behavior.

- **Bug Fixes**
  - Parse the pattern’s host and require it to equal the URL’s real hostname before honoring the prefix check.
  - Blocks `https://example.com.evil.com/`, `https://example.com@evil.com/`, and `https://example.computer.com/`; avoids over-blocking different hosts in `prohibited_domains`.
  - Added tests in `tests/ci/security/test_domain_filtering.py` for allowed and prohibited cases.

<sup>Written for commit 72e62a866d442509927ac3ce0d9c04088cbb7676. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

