### PR TITLE
fix: commit input value by moving focus out of field (#5054)

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2085,9 +2085,9 @@ class DefaultActionWatchdog(BaseWatchdog):
 					// Input event - primary event for React controlled components
 					{ type: 'input', bubbles: true, cancelable: true },
 					// Change event - important for form validation and Vue v-model
-					{ type: 'change', bubbles: true, cancelable: true },
-					// Blur event - triggers validation in many frameworks
-					{ type: 'blur', bubbles: true, cancelable: true }
+					{ type: 'change', bubbles: true, cancelable: true }
+					// NOTE: blur is handled separately below via a real element.blur()
+					// (see issue #5054) — a dispatched Event('blur') does not move focus.
 				];
 
 				let success = true;
@@ -2145,6 +2145,30 @@ class DefaultActionWatchdog(BaseWatchdog):
 						setTimeout(() => element.dispatchEvent(vueEvent), 0);
 					} catch (e) {
 						console.warn('Vue reactivity trigger failed:', e);
+					}
+				}
+
+				// Commit the typed value by actually moving focus out of the field (issue #5054).
+				// A dispatched Event('blur') runs blur listeners but does NOT move focus, and is
+				// invisible to React's onBlur (React 17+ delegates onBlur to the native focusout
+				// event), so UIs that only commit/validate on real focus loss never see the value —
+				// the agent types, clicks Save, and the value is dropped. element.blur() fires the
+				// native blur + focusout and updates document.activeElement, which every major
+				// framework commits on.
+				// Skip autocomplete/combobox/contenteditable fields: removing focus there closes the
+				// suggestion dropdown before the agent can click an option (mirrors the
+				// autocomplete handling in input()).
+				const role = (element.getAttribute('role') || '').toLowerCase();
+				const ariaAutocomplete = (element.getAttribute('aria-autocomplete') || '').toLowerCase();
+				const isAutocompleteLike =
+					role === 'combobox' ||
+					(ariaAutocomplete !== '' && ariaAutocomplete !== 'none') ||
+					element.isContentEditable === true;
+				if (!isAutocompleteLike && typeof element.blur === 'function') {
+					try {
+						element.blur();
+					} catch (e) {
+						console.warn('element.blur() failed:', e);
 					}
 				}
 

--- a/tests/ci/interactions/test_input_blur_commit.py
+++ b/tests/ci/interactions/test_input_blur_commit.py
@@ -1,0 +1,173 @@
+"""Test that typing into a field commits the value by moving focus out (issue #5054).
+
+Many UIs only commit/validate a field's value on real focus loss. In particular,
+React 17+ implements `onBlur` on top of the native `focusout` event. A dispatched
+`Event('blur')` runs `addEventListener('blur')` handlers but does NOT move focus and
+does NOT produce `focusout`, so the framework never sees the value — the agent types,
+clicks Save, and the value is dropped.
+
+These tests assert:
+- A field that commits on `focusout` receives the typed value (the fix calls a real
+  `element.blur()`, which fires native blur + focusout).
+- After typing, focus actually leaves a plain field.
+- Autocomplete/combobox fields are NOT blurred, so their suggestion dropdown stays open
+  (the agent needs focus to click a suggestion).
+"""
+
+import asyncio
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from browser_use.agent.views import ActionResult
+from browser_use.browser import BrowserSession
+from browser_use.browser.profile import BrowserProfile
+from browser_use.tools.service import Tools
+
+
+@pytest.fixture(scope='session')
+def http_server():
+	"""Create and provide a test HTTP server with blur-commit test pages."""
+	server = HTTPServer()
+	server.start()
+
+	# Page 1: value only commits on focusout (mirrors React's onBlur, which listens on
+	# the native focusout event). A dispatched Event('blur') would not trigger this.
+	server.expect_request('/commit-on-blur').respond_with_data(
+		"""
+		<!DOCTYPE html>
+		<html>
+		<head><title>Commit On Blur Test</title></head>
+		<body>
+			<input id="field" type="text" />
+			<div id="committed">UNCOMMITTED</div>
+			<script>
+				const field = document.getElementById('field');
+				field.addEventListener('focusout', function () {
+					document.getElementById('committed').textContent = field.value;
+				});
+			</script>
+		</body>
+		</html>
+		""",
+		content_type='text/html',
+	)
+
+	# Page 2: combobox that records whether it ever lost focus.
+	server.expect_request('/combobox-keep-focus').respond_with_data(
+		"""
+		<!DOCTYPE html>
+		<html>
+		<head><title>Combobox Keep Focus Test</title></head>
+		<body>
+			<input id="combo" type="text" role="combobox"
+				aria-autocomplete="list" aria-controls="opts" aria-expanded="false" />
+			<ul id="opts" role="listbox" style="display:none;">
+				<li role="option">Option A</li>
+				<li role="option">Option B</li>
+			</ul>
+			<div id="lostfocus">no</div>
+			<script>
+				document.getElementById('combo').addEventListener('focusout', function () {
+					document.getElementById('lostfocus').textContent = 'yes';
+				});
+			</script>
+		</body>
+		</html>
+		""",
+		content_type='text/html',
+	)
+
+	yield server
+	server.stop()
+
+
+@pytest.fixture(scope='session')
+def base_url(http_server):
+	"""Return the base URL for the test HTTP server."""
+	return f'http://{http_server.host}:{http_server.port}'
+
+
+@pytest.fixture(scope='module')
+async def browser_session():
+	"""Create and provide a Browser instance for testing."""
+	browser_session = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=True,
+			chromium_sandbox=False,
+		)
+	)
+	await browser_session.start()
+	yield browser_session
+	await browser_session.kill()
+
+
+@pytest.fixture(scope='function')
+def tools():
+	"""Create and provide a Tools instance."""
+	return Tools()
+
+
+async def _read(browser_session: BrowserSession, expression: str) -> str:
+	"""Evaluate a JS expression in the page and return its value."""
+	cdp_session = await browser_session.get_or_create_cdp_session()
+	result = await cdp_session.cdp_client.send.Runtime.evaluate(
+		params={'expression': expression, 'returnByValue': True},
+		session_id=cdp_session.session_id,
+	)
+	return result.get('result', {}).get('value', '')
+
+
+class TestInputBlurCommit:
+	"""Typing should commit the value by moving focus out of the field (issue #5054)."""
+
+	async def test_value_committed_on_blur(self, tools: Tools, browser_session: BrowserSession, base_url: str):
+		"""A field that commits on focusout should receive the typed value after input()."""
+		await tools.navigate(url=f'{base_url}/commit-on-blur', new_tab=False, browser_session=browser_session)
+		await asyncio.sleep(0.3)
+		await browser_session.get_browser_state_summary()
+
+		idx = await browser_session.get_index_by_id('field')
+		assert idx is not None, 'Could not find input field'
+
+		result = await tools.input(index=idx, text='hello', browser_session=browser_session)
+		assert isinstance(result, ActionResult)
+		assert result.error is None, f'Input action failed: {result.error}'
+
+		committed = await _read(browser_session, "document.getElementById('committed').textContent")
+		assert committed == 'hello', (
+			f'Value was not committed on blur — got committed="{committed}". '
+			'The field never received a real focusout (issue #5054).'
+		)
+
+	async def test_plain_field_loses_focus_after_typing(self, tools: Tools, browser_session: BrowserSession, base_url: str):
+		"""After typing into a plain field, focus should no longer be on that field."""
+		await tools.navigate(url=f'{base_url}/commit-on-blur', new_tab=False, browser_session=browser_session)
+		await asyncio.sleep(0.3)
+		await browser_session.get_browser_state_summary()
+
+		idx = await browser_session.get_index_by_id('field')
+		assert idx is not None, 'Could not find input field'
+
+		await tools.input(index=idx, text='world', browser_session=browser_session)
+
+		active_id = await _read(browser_session, "(document.activeElement && document.activeElement.id) || ''")
+		assert active_id != 'field', 'Plain field should have lost focus after typing (real blur did not fire)'
+
+	async def test_autocomplete_field_keeps_focus(self, tools: Tools, browser_session: BrowserSession, base_url: str):
+		"""A combobox/autocomplete field must NOT be blurred, or its suggestion dropdown closes."""
+		await tools.navigate(url=f'{base_url}/combobox-keep-focus', new_tab=False, browser_session=browser_session)
+		await asyncio.sleep(0.3)
+		await browser_session.get_browser_state_summary()
+
+		idx = await browser_session.get_index_by_id('combo')
+		assert idx is not None, 'Could not find combobox input'
+
+		await tools.input(index=idx, text='ab', browser_session=browser_session)
+
+		lost_focus = await _read(browser_session, "document.getElementById('lostfocus').textContent")
+		active_id = await _read(browser_session, "(document.activeElement && document.activeElement.id) || ''")
+		assert lost_focus == 'no', 'Combobox should not be blurred (dropdown would close before the agent can pick)'
+		assert active_id == 'combo', f'Combobox should retain focus, but activeElement is "{active_id}"'


### PR DESCRIPTION
## Summary

Fixes #5054. After the agent types into a field, the value is now committed by actually moving focus out of the field (a real `element.blur()`), so UIs that only validate/commit on blur no longer lose the typed value when the agent's next action is a click (e.g. "Save").

Closes #5054

## Root cause

`DefaultActionWatchdog._trigger_framework_events()` (run after every text input) dispatched a **synthetic** blur event:

```js
element.focus();
const events = [ {input}, {change}, {blur} ];   // new Event('blur', {bubbles:true})
events.forEach(e => element.dispatchEvent(...));
```

Two problems:

1. **`new Event('blur')` does not move focus.** It runs `addEventListener('blur')` handlers but the element stays `document.activeElement`, so UIs that commit on *real* focus loss never commit.
2. **React's `onBlur` never fires.** React 17+ delegates events at the root and implements `onBlur` on top of the native **`focusout`** event. A dispatched `blur` event (bubbling or not) is not `focusout`, so React's handler is never invoked. This is the exact case in the issue: the agent types, clicks Save, and the value is dropped.

The function also called `element.focus()` immediately before the fake blur, which is contradictory.

## The fix

Replace the synthetic `blur` with a real `element.blur()`, which fires native `blur` + `focusout` and updates `document.activeElement` — what every major framework commits on. `input` and `change` are still dispatched as before.

The real blur is **skipped** for autocomplete-style fields (`role="combobox"`, non-empty `aria-autocomplete`, or `contenteditable`), because removing focus there closes the suggestion dropdown before the agent can click an option. This mirrors the existing autocomplete handling in `Tools.input()`.

## Test plan

New: `tests/ci/interactions/test_input_blur_commit.py` (3 cases, real browser + pytest-httpserver, no LLM):

- `test_value_committed_on_blur` — a field that commits on `focusout` (how React implements `onBlur`) receives the typed value after `input()`.
- `test_plain_field_loses_focus_after_typing` — focus actually leaves a plain field.
- `test_autocomplete_field_keeps_focus` — a `role="combobox"` field is **not** blurred and retains focus (dropdown stays open).

Red → green verification:

```
# reverting only the source fix (keeping the test):
FAILED test_value_committed_on_blur — committed="UNCOMMITTED" (value dropped)

# with the fix:
3 passed

# no regressions on the shared typing path:
13 passed  (new tests + tests/ci/interactions/test_autocomplete_interaction.py)
```

`ruff check`, `ruff format`, and `pyright` are all clean on the changed files.

## Notes / trade-offs

- A "type, then press Enter as a **separate** action" flow now types into a field that is no longer focused afterward. In-string newlines (`\n`, Enter *during* typing) are unaffected — this only touches Enter issued as its own subsequent step. Flagging in case maintainers want this gated behind a flag.
- Verified against a `focusout`-commit page (the mechanism React's `onBlur` uses), not against a bundled live React app.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Commits typed values by moving focus out of inputs after typing, fixing cases where UIs that commit on real blur (e.g., React `onBlur`/`focusout`) dropped the value when the next action was a click.

- **Bug Fixes**
  - Replace synthetic `Event('blur')` with real `element.blur()` to fire native `blur` and `focusout` and update `document.activeElement`.
  - Skip blurring for `role="combobox"`, non-empty `aria-autocomplete`, and `contenteditable` fields to keep dropdowns open.
  - Added tests to verify commit on `focusout`, focus loss for plain fields, and focus retention for autocomplete fields.

<sup>Written for commit 9f900edef18f51a5ea890ae16ef15990dd8399cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

