### PR TITLE
Bypass env proxies for local CDP polling

### DIFF
--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -413,7 +413,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 
 		while asyncio.get_event_loop().time() - start_time < timeout:
 			try:
-				async with aiohttp.ClientSession() as session:
+				async with aiohttp.ClientSession(trust_env=False) as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:
 						if resp.status == 200:
 							# Chrome is ready

--- a/tests/ci/browser/test_local_browser_watchdog.py
+++ b/tests/ci/browser/test_local_browser_watchdog.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import aiohttp
 import asyncio
+
+import aiohttp
 
 from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
 

--- a/tests/ci/browser/test_local_browser_watchdog.py
+++ b/tests/ci/browser/test_local_browser_watchdog.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import aiohttp
+import asyncio
+
+from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+
+def test_wait_for_cdp_url_bypasses_env_proxy_for_localhost(monkeypatch):
+	"""Local CDP readiness polling must not route 127.0.0.1 through env proxies."""
+	client_session_kwargs = []
+	requested_urls = []
+
+	class FakeResponse:
+		status = 200
+
+		async def __aenter__(self):
+			return self
+
+		async def __aexit__(self, exc_type, exc, tb):
+			return None
+
+	class FakeClientSession:
+		def __init__(self, **kwargs):
+			client_session_kwargs.append(kwargs)
+
+		async def __aenter__(self):
+			return self
+
+		async def __aexit__(self, exc_type, exc, tb):
+			return None
+
+		def get(self, url):
+			requested_urls.append(url)
+			return FakeResponse()
+
+	monkeypatch.setattr(aiohttp, 'ClientSession', FakeClientSession)
+
+	cdp_url = asyncio.run(LocalBrowserWatchdog._wait_for_cdp_url(9222, timeout=0.1))
+
+	assert cdp_url == 'http://127.0.0.1:9222/'
+	assert requested_urls == ['http://127.0.0.1:9222/json/version']
+	assert client_session_kwargs == [{'trust_env': False}]


### PR DESCRIPTION
Summary
- Disable environment proxy lookup for local aiohttp CDP readiness polling.
- Add regression coverage for the localhost polling path.

Tests
- python -m py_compile browser_use/browser/watchdogs/local_browser_watchdog.py tests/ci/browser/test_local_browser_watchdog.py
- Direct Python smoke: asserted LocalBrowserWatchdog._wait_for_cdp_url uses aiohttp.ClientSession(trust_env=False)
- Target pytest exits 139 locally even with PYTEST_DISABLE_PLUGIN_AUTOLOAD=1

Notes
- Fixes #5048.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass environment proxies during local CDP readiness polling by using `aiohttp.ClientSession(trust_env=False)` so readiness checks hit 127.0.0.1 directly. Adds a regression test for `LocalBrowserWatchdog._wait_for_cdp_url` that verifies the `/json/version` request to localhost with `trust_env=False`, and fixes the test import order.

<sup>Written for commit f8ffeb9a3ff18d8abdc8eb3709aa1344fc421efb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

