### PR TITLE
fix: preserve empty accessibility names

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -848,7 +848,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -876,7 +876,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_dom_interacted_element.py
+++ b/tests/ci/test_dom_interacted_element.py
@@ -1,0 +1,49 @@
+from browser_use.dom.views import DOMInteractedElement, EnhancedAXNode, EnhancedDOMTreeNode, NodeType
+
+
+def _make_enhanced_dom_node(*, ax_name: str | None) -> EnhancedDOMTreeNode:
+	ax_node = None
+	if ax_name is not None:
+		ax_node = EnhancedAXNode(
+			ax_node_id='ax-1',
+			ignored=False,
+			role='button',
+			name=ax_name,
+			description=None,
+			properties=None,
+			child_ids=None,
+		)
+
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={'aria-label': ax_name or ''},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=None,
+	)
+
+
+def test_load_from_enhanced_dom_tree_preserves_empty_ax_name():
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(_make_enhanced_dom_node(ax_name=''))
+
+	assert element.ax_name == ''
+
+
+def test_load_from_enhanced_dom_tree_keeps_missing_ax_name_none():
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(_make_enhanced_dom_node(ax_name=None))
+
+	assert element.ax_name is None

--- a/tests/ci/test_dom_interacted_element.py
+++ b/tests/ci/test_dom_interacted_element.py
@@ -47,3 +47,11 @@ def test_load_from_enhanced_dom_tree_keeps_missing_ax_name_none():
 	element = DOMInteractedElement.load_from_enhanced_dom_tree(_make_enhanced_dom_node(ax_name=None))
 
 	assert element.ax_name is None
+
+
+def test_empty_ax_name_changes_element_hashes():
+	node_with_empty_name = _make_enhanced_dom_node(ax_name='')
+	node_without_name = _make_enhanced_dom_node(ax_name=None)
+
+	assert hash(node_with_empty_name) != hash(node_without_name)
+	assert node_with_empty_name.compute_stable_hash() != node_without_name.compute_stable_hash()


### PR DESCRIPTION
## Summary
- Preserved ax_node.name whenever it is not None and added regression coverage for empty string vs missing accessibility names.

## Tests
- uv run ruff check browser_use/dom/views.py tests/ci/test_dom_interacted_element.py passed
- uv run ruff format --check browser_use/dom/views.py tests/ci/test_dom_interacted_element.py passed
- git diff --check passed
- python3 -m py_compile browser_use/dom/views.py tests/ci/test_dom_interacted_element.py passed
- uv run pytest tests/ci/test_dom_interacted_element.py blocked by local pytest startup segfault

## Notes
- Related issue: https://github.com/browser-use/browser-use/issues/5041

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DOM element mapping and hashing to preserve empty accessibility names, with regression tests. We keep an empty `ax_node.name` and include it in hashes, using `None` only when the name is missing.

- **Bug Fixes**
  - Preserve empty `ax_node.name` in `load_from_enhanced_dom_tree` and include it in `compute_stable_hash`/`__hash__` to distinguish empty vs missing.
  - Add CI tests to verify empty names are preserved and affect hashes.

<sup>Written for commit 863e99c14fe76395196a43da44d1738ae850a5be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

