### PR TITLE
Add EmpirioLabs OpenAI-compatible example

### DIFF
--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -274,5 +274,17 @@ llm = ChatOpenAI(model="deepseek/deepseek-r1", base_url="https://api.novita.ai/v
 ```
 **Env:** `NOVITA_API_KEY`
 
+### EmpirioLabs AI
+```python
+import os
+
+llm = ChatOpenAI(
+    model="qwen3-max",
+    api_key=os.getenv("EMPIRIOLABS_API_KEY"),
+    base_url="https://api.empiriolabs.ai/v1",
+)
+```
+**Env:** `EMPIRIOLABS_API_KEY` | [Available models](https://empiriolabs.ai/models)
+
 ### LangChain
 See example at [examples/models/langchain](https://github.com/browser-use/browser-use/tree/main/examples/models/langchain).

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -280,7 +280,7 @@ import os
 
 llm = ChatOpenAI(
     model="qwen3-max",
-    api_key=os.getenv("EMPIRIOLABS_API_KEY"),
+    api_key=os.environ["EMPIRIOLABS_API_KEY"],
     base_url="https://api.empiriolabs.ai/v1",
 )
 ```

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -276,5 +276,17 @@ llm = ChatOpenAI(model="deepseek/deepseek-r1", base_url="https://api.novita.ai/v
 ```
 **Env:** `NOVITA_API_KEY`
 
+### EmpirioLabs AI
+```python
+import os
+
+llm = ChatOpenAI(
+    model="qwen3-max",
+    api_key=os.getenv("EMPIRIOLABS_API_KEY"),
+    base_url="https://api.empiriolabs.ai/v1",
+)
+```
+**Env:** `EMPIRIOLABS_API_KEY` | [Available models](https://empiriolabs.ai/models)
+
 ### LangChain
 See example at [examples/models/langchain](https://github.com/browser-use/browser-use/tree/main/examples/models/langchain).

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -282,7 +282,7 @@ import os
 
 llm = ChatOpenAI(
     model="qwen3-max",
-    api_key=os.getenv("EMPIRIOLABS_API_KEY"),
+    api_key=os.environ["EMPIRIOLABS_API_KEY"],
     base_url="https://api.empiriolabs.ai/v1",
 )
 ```


### PR DESCRIPTION
Summary:
- add EmpirioLabs AI under OpenAI-compatible APIs
- show the base URL and API key env var for ChatOpenAI
- link the model catalog for available model IDs

Testing:
- Not run, docs-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an EmpirioLabs OpenAI-compatible example to the models reference so users can configure `ChatOpenAI` against https://api.empiriolabs.ai/v1. The snippet uses `api_key=os.environ["EMPIRIOLABS_API_KEY"]` with `model="qwen3-max"`, and the page notes the `EMPIRIOLABS_API_KEY` env var and links to the EmpirioLabs model catalog.

<sup>Written for commit f35370c7f3ab588c46c894ae15a2236e35cdc864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

