### PR TITLE
fix: case-insensitive sensitive_data redaction to prevent credential leaks

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -74,9 +74,16 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 
 
 def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
-	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
+	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks.
+
+	Matching is case-insensitive: a secret stored as 'MyPass123' is also redacted
+	when it appears as 'MYPASS123' or 'mypass123'. This matters because web pages
+	frequently transform displayed text (CSS text-transform, confirmation dialogs,
+	form echoes), and a case-sensitive match would let the credential through to
+	the LLM unredacted in those cases.
+	"""
 	for key, secret in sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True):
-		value = value.replace(secret, f'<secret>{key}</secret>')
+		value = re.sub(re.escape(secret), f'<secret>{key}</secret>', value, flags=re.IGNORECASE)
 	return value
 
 

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -257,6 +257,68 @@ def test_filter_sensitive_data(message_manager):
 	assert '<secret>email</secret>' in result.content
 
 
+def test_redact_sensitive_string_case_insensitive():
+	"""Sensitive data redaction must be case-insensitive.
+
+	A web page displaying a secret in a different case (CSS text-transform:
+	uppercase, confirmation dialogs, form echoes) must not defeat the redaction.
+	Before this fix, redact_sensitive_string used str.replace (case-sensitive),
+	so 'MyPass123' in a page rendered as 'MYPASS123' leaked to the LLM.
+	"""
+	from browser_use.utils import redact_sensitive_string
+
+	sensitive_values = {'password': 'TestValueAlpha9'}
+
+	# Exact match (baseline)
+	assert redact_sensitive_string('TestValueAlpha9', sensitive_values) == '<secret>password</secret>'
+
+	# Case variations that a webpage could produce (CSS text-transform etc.)
+	assert redact_sensitive_string('testvaluealpha9', sensitive_values) == '<secret>password</secret>'
+	assert redact_sensitive_string('TESTVALUEALPHA9', sensitive_values) == '<secret>password</secret>'
+	assert redact_sensitive_string('TeStVaLuEaLpHa9', sensitive_values) == '<secret>password</secret>'
+
+	# Embedded in larger text (realistic DOM content)
+	result = redact_sensitive_string('Password TESTVALUEALPHA9 set successfully', sensitive_values)
+	assert '<secret>password</secret>' in result
+	assert 'TestValueAlpha9' not in result.lower()
+	assert 'testvaluealpha9' not in result.lower()
+
+	# No false positives on similar-but-different text
+	assert redact_sensitive_string('TestValueBeta', sensitive_values) == 'TestValueBeta'
+
+
+def test_redact_sensitive_string_preserves_existing_ordering_fix():
+	"""The longest-match-first ordering (from #4660) must still work with case-insensitive matching."""
+	from browser_use.utils import redact_sensitive_string
+
+	# Two secrets where one is a substring of the other
+	sensitive_values = {'short': 'pass', 'long': 'password'}
+
+	# The longer secret must be matched first to avoid partial redaction
+	result = redact_sensitive_string('enter password here', sensitive_values)
+	assert '<secret>long</secret>' in result
+	assert '<secret>short</secret>word' not in result  # No partial match
+
+	# Case-insensitive variant
+	result = redact_sensitive_string('enter PASSWORD here', sensitive_values)
+	assert '<secret>long</secret>' in result
+
+
+def test_filter_sensitive_data_case_insensitive(message_manager):
+	"""Full pipeline test: a message containing a case-varied secret must be redacted.
+
+	Simulates a webpage with CSS text-transform:uppercase echoing the agent's
+	entered password in caps. Before the fix, this leaked the real credential.
+	"""
+	message_manager.sensitive_data = {'password': 'TestValueGamma9'}
+	# The page rendered the password in uppercase (CSS text-transform)
+	message = UserMessage(content='Confirmation: Password TESTVALUEGAMMA9 accepted')
+	result = message_manager._filter_sensitive_data(message)
+	assert '<secret>password</secret>' in result.content
+	assert 'TESTVALUEGAMMA9' not in result.content
+	assert 'testvaluegamma9' not in result.content.lower()
+
+
 def test_is_new_tab_page():
 	"""Test is_new_tab_page function"""
 	# Test about:blank


### PR DESCRIPTION
# fix: case-insensitive sensitive_data redaction to prevent credential leaks

## Summary

`redact_sensitive_string` used `str.replace` (case-sensitive exact match). A
web page displaying a secret in a different case — CSS `text-transform:
uppercase`, confirmation dialogs, form echoes — defeated the redaction,
leaking the real credential value to the LLM unredacted.

Fix: `re.sub(re.escape(secret), ..., flags=re.IGNORECASE)`. Closes the
case-bypass while preserving the existing longest-match-first ordering (#4660)
and introducing no new false positives beyond the pre-existing substring-match
behavior.

## The bypass

```python
# browser_use/utils.py (before)
def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
    for key, secret in sorted(..., key=lambda item: len(item[1]), reverse=True):
        value = value.replace(secret, f'<secret>{key}</secret>')  # case-sensitive
    return value
```

`str.replace` matches the secret exactly, including case. When a webpage
transforms the displayed text (extremely common via CSS), the case no longer
matches:

```python
from browser_use.utils import redact_sensitive_string

values = {'password': 'TestValueAlpha9'}

# Before fix: case variations leak
redact_sensitive_string('TESTVALUEALPHA9', values)     # → 'TESTVALUEALPHA9' (LEAKED)
redact_sensitive_string('testvaluealpha9', values)     # → 'testvaluealpha9' (LEAKED)

# After fix: all case variants redacted
redact_sensitive_string('TESTVALUEALPHA9', values)     # → '<secret>password</secret>'
redact_sensitive_string('testvaluealpha9', values)     # → '<secret>password</secret>'
```

### Realistic scenario

1. Agent types `TestValueAlpha9` into a form field (via `sensitive_data`)
2. Page displays a confirmation: `Password TESTVALUEALPHA9 set successfully`
   (CSS `text-transform: uppercase` is common for confirmation displays)
3. DOM extraction returns `TESTVALUEALPHA9` in the agent's message context
4. `_filter_sensitive_data` runs `str.replace('TestValueAlpha9', ...)` — but
   `TESTVALUEALPHA9 != TestValueAlpha9`, so the match fails
5. The real password value reaches the LLM unredacted

## The fix

```python
# after
def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
    for key, secret in sorted(..., key=lambda item: len(item[1]), reverse=True):
        value = re.sub(re.escape(secret), f'<secret>{key}</secret>', value, flags=re.IGNORECASE)
    return value
```

- `re.escape` ensures secrets containing regex metacharacters (`a+b`, `c*nt`)
  are matched literally (same safety as `str.replace`)
- `re.IGNORECASE` closes the case-bypass
- The longest-match-first ordering from #4660 is preserved (sorted before the
  loop, unchanged)

## Tests

3 tests added to `tests/ci/security/test_sensitive_data.py` (all 14 existing
tests pass unchanged):

- **`test_redact_sensitive_string_case_insensitive`**: exact, all-lowercase,
  all-uppercase, mixed-case, embedded-in-text, and no-false-positive cases
- **`test_redact_sensitive_string_preserves_existing_ordering_fix`**: confirms
  the #4660 longest-match-first ordering still works with case-insensitive
  matching (no regression of the substring-leak fix)
- **`test_filter_sensitive_data_case_insensitive`**: full-pipeline test
  simulating a webpage with CSS `text-transform:uppercase` echoing the
  password

```
$ python -m pytest tests/ci/security/test_sensitive_data.py -v
========================= 17 passed in 0.06s =========================
```

## Known limitation

Substring-based redaction (both before and after this fix) can match partial
words: a secret `main` matches `Maine`. This is pre-existing behavior of the
`str.replace`/`re.sub` substring approach — not introduced by this fix, which
only adds case-insensitivity. A word-boundary-aware redaction would be a
separate, larger change.

## Relationship to prior work

- #4660 (merged): fixed redaction ordering to prevent substring leaks between
  overlapping secrets (longest-match-first). This fix preserves that ordering.
- #4388 (merged): excluded password field values from DOM snapshots. This fix
  covers the case where a secret appears in non-password-field text (e.g.,
  confirmation messages, rendered content).
- #4907 (open): domain-scoped sensitive_data key name collision. Unrelated to
  case-sensitivity.
