### PR TITLE
Handle whitespace in variable pattern detection

### DIFF
--- a/browser_use/agent/variable_detector.py
+++ b/browser_use/agent/variable_detector.py
@@ -221,6 +221,7 @@ def _detect_from_value_pattern(value: str) -> tuple[str, str | None] | None:
 	- Name: Capitalized word(s), 2-30 chars, letters only
 	- Number: Pure digits, 1-9 chars
 	"""
+	value = value.strip()
 
 	# Email detection - most specific first
 	if '@' in value and '.' in value:

--- a/tests/ci/test_variable_detection.py
+++ b/tests/ci/test_variable_detection.py
@@ -63,6 +63,16 @@ def test_detect_email_from_pattern():
 	assert var_format == 'email'
 
 
+def test_detect_email_from_pattern_strips_surrounding_whitespace():
+	"""Test email detection via pattern matching ignores surrounding whitespace"""
+	result = _detect_from_value_pattern('  test@example.com  ')
+
+	assert result is not None
+	var_name, var_format = result
+	assert var_name == 'email'
+	assert var_format == 'email'
+
+
 def test_detect_phone_from_attributes():
 	"""Test phone detection via type='tel' attribute"""
 	attributes = {'type': 'tel', 'name': 'phone'}
@@ -384,6 +394,21 @@ def test_detect_variables_handles_missing_interacted_element():
 	# Should still detect via pattern matching
 	assert len(result) == 1
 	assert 'email' in result
+
+
+def test_detect_variables_strips_value_before_pattern_matching():
+	"""Test pattern matching still works when action values have surrounding whitespace"""
+	history = create_mock_history(
+		[
+			({'input': {'index': 1, 'text': '  test@example.com  '}}, None),
+		]
+	)
+
+	result = detect_variables_in_history(history)  # type: ignore[arg-type]
+
+	assert len(result) == 1
+	assert 'email' in result
+	assert result['email'].original_value == '  test@example.com  '
 
 
 def test_detect_variables_multiple_types():


### PR DESCRIPTION
## Summary
- Strip surrounding whitespace before fallback value-pattern detection
- Add coverage for whitespace-padded email values in direct pattern matching and agent history detection

## Why
When agent history lacks interacted element context, variable detection falls back to matching the action value itself. Values with leading or trailing whitespace, such as `  test@example.com `, were skipped by the email/date/name/number pattern checks even though the same trimmed value is valid. The detected variable keeps the original action value so substitution can still match the recorded history exactly.

## Validation
- `python -m pytest tests/ci/test_variable_detection.py -q`
- `python -m ruff check browser_use/agent/variable_detector.py tests/ci/test_variable_detection.py`
- `python -m ruff format --check browser_use/agent/variable_detector.py tests/ci/test_variable_detection.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trim surrounding whitespace before fallback value pattern detection so emails, dates, names, and numbers are detected even with leading/trailing spaces. Keeps the original untrimmed value for exact history substitution and adds tests for whitespace-padded emails and history detection.

<sup>Written for commit ddefc06704922be4513b83d7971c4c2bd42fe721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

