### PR TITLE
fix(tests): bump retired claude-sonnet-4-0 to claude-sonnet-4-6

### DIFF
--- a/tests/ci/models/test_llm_anthropic.py
+++ b/tests/ci/models/test_llm_anthropic.py
@@ -4,11 +4,11 @@ from browser_use.llm.anthropic.chat import ChatAnthropic
 from tests.ci.models.model_test_helper import run_model_button_click_test
 
 
-async def test_anthropic_claude_sonnet_4_0(httpserver):
-	"""Test Anthropic claude-sonnet-4-0 can click a button."""
+async def test_anthropic_claude_sonnet_4_6(httpserver):
+	"""Test Anthropic claude-sonnet-4-6 can click a button."""
 	await run_model_button_click_test(
 		model_class=ChatAnthropic,
-		model_name='claude-sonnet-4-0',
+		model_name='claude-sonnet-4-6',
 		api_key_env='ANTHROPIC_API_KEY',
 		extra_kwargs={},
 		httpserver=httpserver,


### PR DESCRIPTION
## What

The `models/test_llm_anthropic` CI job is failing on every branch (including unrelated PRs) with:

```
anthropic.NotFoundError: Error code: 404 - {'type': 'error', 'error':
{'type': 'not_found_error', 'message': 'model: claude-sonnet-4-0'}, ...}
```

`tests/ci/models/test_llm_anthropic.py::test_anthropic_claude_sonnet_4_0` runs a real agent loop against the live Anthropic API and pins the model id `claude-sonnet-4-0` (Claude Sonnet 4, `claude-sonnet-4-20250514`). Anthropic **retired Sonnet 4 on 2026-06-15**, so the request now 404s, the agent exhausts its retries without ever clicking the button, and the test fails its final assertion (`Button was not clicked`).

Example failing run: https://github.com/browser-use/browser-use/actions/runs/28216634342/job/83589007682

## How

Bump the test to the current GA Sonnet, `claude-sonnet-4-6` (Anthropic's drop-in replacement for the retired alias), and rename the test function to match.

## Notes / follow-up (not in this PR)

Other references to the retired `claude-sonnet-4-0` alias exist but don't make live API calls, so they don't break CI today:

- `browser_use/llm/models.py` — the `anthropic_claude_sonnet_4_0` factory entry still maps to the retired alias, so `get_llm_by_name('anthropic_claude_sonnet_4_0')` returns a model that 404s at runtime. Repointing vs. renaming that public key is a product decision, left out of this PR.
- `tests/ci/models/test_llm_model_factory.py`, `tests/ci/test_coordinate_clicking.py`, `tests/ci/test_beta_agent.py` — string/registry fixtures (no network).
- `examples/models/claude-4-sonnet.py`, `examples/features/fallback_model.py`, `AGENTS.md`, `skills/open-source/references/quickstart.md` — examples/docs.

More broadly, the live-API model tests pin retiring `*-4-0` aliases, so they break on Anthropic's retirement cadence; worth a follow-up to pin only current GA aliases or mark these tests non-blocking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace retired Anthropic model in the live API test from `claude-sonnet-4-0` to `claude-sonnet-4-6` to stop 404s and get the `models/test_llm_anthropic` job green again.

- **Bug Fixes**
  - Updated `tests/ci/models/test_llm_anthropic.py`: renamed test and set `model_name` to `claude-sonnet-4-6`.
  - Resolves 404 `not_found_error` after Sonnet 4 retirement (2026-06-15).

<sup>Written for commit e29cdeae0607bb6eaab9974d14b9881a706ce886. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

