### PR TITLE
fix(browser): tolerate stepping a torn-down event bus on warm-Lambda resume (ENG-5280)

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -104,27 +104,16 @@ class CDPSession(BaseModel):
 
 
 class ResilientEventBus(EventBus):
-	"""``EventBus`` whose ``step()``/``wait_until_idle()`` tolerate a torn-down bus.
+	"""EventBus whose step()/wait_until_idle() no-op on a torn-down bus instead of asserting.
 
-	On a warm-Lambda resume the V2 worker can reuse a ``keep_alive`` ``BrowserSession``
-	whose event bus was already stopped and had its async primitives (``event_queue`` /
-	``_on_idle``) nulled out by ``Agent.close()`` (done to release the event loop). In that
-	state bubus's ``EventBus.step()`` asserts ``EventBus._start() must be called before
-	step()``, which crashed the worker mid-run and dead-lettered the task (ENG-5280).
-
-	The nulling is deliberate — it lets the next ``dispatch()`` recreate a fresh queue and
-	``_start()`` the bus again — so instead of changing teardown we make ``step()`` and
-	``wait_until_idle()`` safe no-ops when the bus has not been started. A later
-	``dispatch()`` still restarts the bus as usual.
+	Agent.close() stops a keep_alive session's bus and nulls its async primitives to release
+	the event loop. On warm-Lambda resume the worker can step() it before a dispatch() restarts
+	it; stock bubus then asserts "_start() must be called before step()" (ENG-5280).
 	"""
 
 	def __init__(self, name: str | None = None, **kwargs: Any) -> None:
-		# bubus derives the default bus name from the class name, which would make session
-		# buses ``ResilientEventBus_*`` instead of ``EventBus_*``. Keep the original prefix so
-		# bus names stay stable for logging/identification (matches EventBus's own scheme).
-		if name is None:
-			name = f'EventBus_{uuid7str()[-8:]}'
-		super().__init__(name=name, **kwargs)
+		# Keep the EventBus_ name prefix (bubus would otherwise derive it from the class name).
+		super().__init__(name=name or f'EventBus_{uuid7str()[-8:]}', **kwargs)
 
 	async def step(
 		self,

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -118,6 +118,14 @@ class ResilientEventBus(EventBus):
 	``dispatch()`` still restarts the bus as usual.
 	"""
 
+	def __init__(self, name: str | None = None, **kwargs: Any) -> None:
+		# bubus derives the default bus name from the class name, which would make session
+		# buses ``ResilientEventBus_*`` instead of ``EventBus_*``. Keep the original prefix so
+		# bus names stay stable for logging/identification (matches EventBus's own scheme).
+		if name is None:
+			name = f'EventBus_{uuid7str()[-8:]}'
+		super().__init__(name=name, **kwargs)
+
 	async def step(
 		self,
 		event: 'BaseEvent[Any] | None' = None,

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse, urlunparse
 from uuid import UUID
 
 import httpx
-from bubus import EventBus
+from bubus import BaseEvent, EventBus
 from cdp_use import CDPClient
 from cdp_use.cdp.fetch import AuthRequiredEvent, RequestPausedEvent
 from cdp_use.cdp.network import Cookie
@@ -101,6 +101,37 @@ class CDPSession(BaseModel):
 	# Lifecycle monitoring (populated by SessionManager)
 	_lifecycle_events: Any = PrivateAttr(default=None)
 	_lifecycle_lock: Any = PrivateAttr(default=None)
+
+
+class ResilientEventBus(EventBus):
+	"""``EventBus`` whose ``step()``/``wait_until_idle()`` tolerate a torn-down bus.
+
+	On a warm-Lambda resume the V2 worker can reuse a ``keep_alive`` ``BrowserSession``
+	whose event bus was already stopped and had its async primitives (``event_queue`` /
+	``_on_idle``) nulled out by ``Agent.close()`` (done to release the event loop). In that
+	state bubus's ``EventBus.step()`` asserts ``EventBus._start() must be called before
+	step()``, which crashed the worker mid-run and dead-lettered the task (ENG-5280).
+
+	The nulling is deliberate — it lets the next ``dispatch()`` recreate a fresh queue and
+	``_start()`` the bus again — so instead of changing teardown we make ``step()`` and
+	``wait_until_idle()`` safe no-ops when the bus has not been started. A later
+	``dispatch()`` still restarts the bus as usual.
+	"""
+
+	async def step(
+		self,
+		event: 'BaseEvent[Any] | None' = None,
+		timeout: float | None = None,
+		wait_for_timeout: float = 0.1,
+	) -> 'BaseEvent[Any] | None':
+		if self._on_idle is None or self.event_queue is None:
+			return None
+		return await super().step(event, timeout, wait_for_timeout)
+
+	async def wait_until_idle(self, timeout: float | None = None) -> None:
+		if self._on_idle is None or self.event_queue is None:
+			return None
+		return await super().wait_until_idle(timeout)
 
 
 class BrowserSession(BaseModel):
@@ -518,7 +549,7 @@ class BrowserSession(BaseModel):
 		return self._demo_mode
 
 	# Main shared event bus for all browser session + all watchdogs
-	event_bus: EventBus = Field(default_factory=EventBus)
+	event_bus: EventBus = Field(default_factory=ResilientEventBus)
 
 	# Mutable public state - which target has agent focus
 	agent_focus_target_id: TargetID | None = None
@@ -713,7 +744,7 @@ class BrowserSession(BaseModel):
 		# Reset all state
 		await self.reset()
 		# Create fresh event bus
-		self.event_bus = EventBus()
+		self.event_bus = ResilientEventBus()
 
 	async def stop(self) -> None:
 		"""Stop the browser session without killing the browser process.
@@ -738,7 +769,7 @@ class BrowserSession(BaseModel):
 		# Reset all state
 		await self.reset()
 		# Create fresh event bus
-		self.event_bus = EventBus()
+		self.event_bus = ResilientEventBus()
 
 	async def close(self) -> None:
 		"""Alias for stop()."""

--- a/tests/ci/test_event_bus_resilience.py
+++ b/tests/ci/test_event_bus_resilience.py
@@ -1,13 +1,8 @@
 """Regression tests for ENG-5280: V2 worker crash on warm-Lambda resume.
 
-When a ``keep_alive`` ``BrowserSession`` is reused across warm Lambda invocations, its
-event bus is stopped and has its async primitives (``event_queue`` / ``_on_idle``) nulled
-out by ``Agent.close()`` to release the event loop. On resume the worker can ``step()`` the
-torn-down bus before any ``dispatch()`` restarts it. Stock ``bubus.EventBus.step()`` asserts
-``EventBus._start() must be called before step()`` in that state, crashing the run.
-
-``BrowserSession`` therefore uses ``ResilientEventBus``, whose ``step()`` / ``wait_until_idle()``
-are safe no-ops on a torn-down bus while a later ``dispatch()`` still restarts it.
+A reused keep_alive session bus is stopped and nulled by Agent.close(); on resume the worker
+can step() it before a dispatch() restarts it, which makes stock bubus assert. ResilientEventBus
+no-ops step()/wait_until_idle() in that state while still restarting on the next dispatch().
 """
 
 import asyncio

--- a/tests/ci/test_event_bus_resilience.py
+++ b/tests/ci/test_event_bus_resilience.py
@@ -1,0 +1,83 @@
+"""Regression tests for ENG-5280: V2 worker crash on warm-Lambda resume.
+
+When a ``keep_alive`` ``BrowserSession`` is reused across warm Lambda invocations, its
+event bus is stopped and has its async primitives (``event_queue`` / ``_on_idle``) nulled
+out by ``Agent.close()`` to release the event loop. On resume the worker can ``step()`` the
+torn-down bus before any ``dispatch()`` restarts it. Stock ``bubus.EventBus.step()`` asserts
+``EventBus._start() must be called before step()`` in that state, crashing the run.
+
+``BrowserSession`` therefore uses ``ResilientEventBus``, whose ``step()`` / ``wait_until_idle()``
+are safe no-ops on a torn-down bus while a later ``dispatch()`` still restarts it.
+"""
+
+import asyncio
+
+from bubus import BaseEvent, EventBus
+
+from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.browser.session import ResilientEventBus
+
+
+class ResiliencePingEvent(BaseEvent):
+	pass
+
+
+def _tear_down_like_agent_close(bus: EventBus) -> None:
+	"""Mimic the keep_alive teardown in Agent.close() that triggers ENG-5280."""
+	bus.event_queue = None
+	bus._on_idle = None
+
+
+def test_browser_session_uses_resilient_event_bus():
+	"""The session's default event bus must be the resilient subclass."""
+	session = BrowserSession(browser_profile=BrowserProfile(keep_alive=True))
+	assert isinstance(session.event_bus, ResilientEventBus)
+
+
+async def test_step_on_torn_down_bus_is_noop_not_assertion():
+	"""Stepping a stopped+nulled bus returns None instead of raising AssertionError."""
+	bus = ResilientEventBus(name='ResilientWarmResumeStep')
+	bus.dispatch(ResiliencePingEvent())
+	await asyncio.sleep(0.1)
+	await bus.stop(clear=False, timeout=1.0)
+	_tear_down_like_agent_close(bus)
+
+	# Warm-Lambda resume: worker steps the torn-down bus. Must not raise.
+	assert await bus.step() is None
+	assert await bus.wait_until_idle(timeout=0.1) is None
+
+
+async def test_torn_down_bus_still_restarts_on_dispatch():
+	"""A later dispatch() must recreate the queue and process events normally."""
+	processed: list[BaseEvent] = []
+	bus = ResilientEventBus(name='ResilientWarmResumeRestart')
+	bus.on('ResiliencePingEvent', lambda event: processed.append(event))
+
+	bus.dispatch(ResiliencePingEvent())
+	await asyncio.sleep(0.1)
+	await bus.stop(clear=False, timeout=1.0)
+	_tear_down_like_agent_close(bus)
+
+	# No-op step on the torn-down bus, then dispatch again -> bus restarts.
+	assert await bus.step() is None
+	processed.clear()
+	event = bus.dispatch(ResiliencePingEvent())
+	await asyncio.wait_for(event, timeout=2.0)
+	assert len(processed) == 1
+	await bus.stop(timeout=0.5)
+
+
+async def test_stock_event_bus_reproduces_the_crash():
+	"""Document the upstream bug the subclass guards against (stock bus still asserts)."""
+	bus = EventBus(name='StockWarmResume')
+	bus.dispatch(ResiliencePingEvent())
+	await asyncio.sleep(0.1)
+	await bus.stop(clear=False, timeout=1.0)
+	_tear_down_like_agent_close(bus)
+
+	try:
+		await bus.step()
+		raised = False
+	except AssertionError:
+		raised = True
+	assert raised, 'stock EventBus.step() should assert on a torn-down bus'

--- a/tests/ci/test_event_bus_resilience.py
+++ b/tests/ci/test_event_bus_resilience.py
@@ -34,6 +34,13 @@ def test_browser_session_uses_resilient_event_bus():
 	assert isinstance(session.event_bus, ResilientEventBus)
 
 
+def test_resilient_event_bus_keeps_event_bus_name_prefix():
+	"""The subclass must keep the ``EventBus_`` default name (not ``ResilientEventBus_``)."""
+	assert ResilientEventBus().name.startswith('EventBus_')
+	# Explicit names are still honored.
+	assert ResilientEventBus(name='EventBus_custom').name == 'EventBus_custom'
+
+
 async def test_step_on_torn_down_bus_is_noop_not_assertion():
 	"""Stepping a stopped+nulled bus returns None instead of raising AssertionError."""
 	bus = ResilientEventBus(name='ResilientWarmResumeStep')


### PR DESCRIPTION
## Problem

The V2 worker reuses a `keep_alive` `BrowserSession` across warm Lambda invocations. At the end of a run, `Agent.close()` stops the session's event bus and nulls out its async primitives (`event_queue` / `_on_idle`) to release the event loop (the "fix keep-alive hang" change).

On a warm resume, the worker can `step()` that bus *before* any `dispatch()` restarts it. In that torn-down state, stock `bubus` `EventBus.step()` hits:

```
AssertionError: EventBus._start() must be called before step()
```

The crash is deterministic (not transient), so retries don't recover and the task dead-letters after max receives — ~1,600+ occurrences over 2 days per the DLQ.

## Root cause

The nulling in `Agent.close()` is *load-bearing*: it's what lets the next `dispatch()` recreate a fresh queue and `_start()` the bus again (bubus `_start()` only recreates the queue when `event_queue is None`). So we can't simply stop nulling — but a nulled bus is exactly the state where `step()` / `wait_until_idle()` assert.

## Fix

Wrap the session's event bus in a small `ResilientEventBus(EventBus)` subclass whose `step()` and `wait_until_idle()` are **safe no-ops when the bus has not been started**, instead of asserting. Teardown is unchanged, so a later `dispatch()` still recreates the queue and restarts the bus normally.

This is the browser-use-level equivalent of the issue's suggested fix #1 ("patch bubus so `step()` tolerates a stopped/unstarted bus"), scoped to the bus that actually gets torn down.

## Verification

`tests/ci/test_event_bus_resilience.py`:
- the session's default `event_bus` is a `ResilientEventBus`
- `step()` / `wait_until_idle()` on a stopped + nulled bus return `None` (no `AssertionError`)
- a torn-down bus still restarts and processes events on the next `dispatch()`
- a stock `EventBus` still reproduces the original assertion (documents the upstream bug)

All 4 pass; `pyright` and `ruff` clean.

Fixes ENG-5280.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerate stepping a torn-down event bus on warm-Lambda resumes to prevent deterministic worker crashes and DLQs. The session now uses a resilient event bus that no-ops until the next `dispatch()` restarts it. Fixes ENG-5280.

- **Bug Fixes**
  - Added `ResilientEventBus(EventBus)` that makes `step()` and `wait_until_idle()` no-ops when `_on_idle` or `event_queue` is `None`.
  - Made `BrowserSession.event_bus` use `ResilientEventBus` by default and in `kill()`/`stop()`, and kept default bus names as `EventBus_*` (explicit names still honored).
  - Added `tests/ci/test_event_bus_resilience.py` to verify no-op behavior, restart on `dispatch()`, name prefix preservation, and to document the upstream `bubus.EventBus` assertion.
  - Tightened `ResilientEventBus` docstrings and comments (no behavior change).

<sup>Written for commit 5123e4fc087cfd05f6250c189ad1a1471965f9f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

