### PR TITLE
fix: use utf-8 for config file IO

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -278,7 +278,7 @@ def load_user_config() -> dict[str, Any]:
 	history_file = CONFIG.BROWSER_USE_CONFIG_DIR / 'command_history.json'
 	if history_file.exists():
 		try:
-			with open(history_file) as f:
+			with open(history_file, encoding='utf-8') as f:
 				config['command_history'] = json.load(f)
 		except (FileNotFoundError, json.JSONDecodeError):
 			config['command_history'] = []

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -1,6 +1,7 @@
 """Configuration system for browser-use with automatic migration support."""
 
 import json
+import locale
 import logging
 import os
 from datetime import datetime
@@ -311,6 +312,21 @@ def create_default_config() -> DBStyleConfigJSON:
 	return new_config
 
 
+def _load_config_json(config_path: Path) -> dict[str, Any]:
+	try:
+		with open(config_path, encoding='utf-8') as f:
+			return json.load(f)
+	except UnicodeDecodeError:
+		legacy_encoding = locale.getpreferredencoding(False)
+		logger.warning(
+			'Failed to decode %s as UTF-8, retrying with preferred locale encoding %s',
+			config_path,
+			legacy_encoding,
+		)
+		with open(config_path, encoding=legacy_encoding) as f:
+			return json.load(f)
+
+
 def load_and_migrate_config(config_path: Path) -> DBStyleConfigJSON:
 	"""Load config.json or create fresh one if old format detected."""
 	if not config_path.exists():
@@ -322,8 +338,7 @@ def load_and_migrate_config(config_path: Path) -> DBStyleConfigJSON:
 		return new_config
 
 	try:
-		with open(config_path, encoding='utf-8') as f:
-			data = json.load(f)
+		data = _load_config_json(config_path)
 
 		# Check if it's already in DB-style format
 		if all(key in data for key in ['browser_profile', 'llm', 'agent']) and all(

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -317,12 +317,12 @@ def load_and_migrate_config(config_path: Path) -> DBStyleConfigJSON:
 		# Create fresh config with defaults
 		config_path.parent.mkdir(parents=True, exist_ok=True)
 		new_config = create_default_config()
-		with open(config_path, 'w') as f:
+		with open(config_path, 'w', encoding='utf-8') as f:
 			json.dump(new_config.model_dump(), f, indent=2)
 		return new_config
 
 	try:
-		with open(config_path) as f:
+		with open(config_path, encoding='utf-8') as f:
 			data = json.load(f)
 
 		# Check if it's already in DB-style format
@@ -339,7 +339,7 @@ def load_and_migrate_config(config_path: Path) -> DBStyleConfigJSON:
 		new_config = create_default_config()
 
 		# Overwrite with new config
-		with open(config_path, 'w') as f:
+		with open(config_path, 'w', encoding='utf-8') as f:
 			json.dump(new_config.model_dump(), f, indent=2)
 
 		logger.debug(f'Created fresh config.json at {config_path}')
@@ -350,7 +350,7 @@ def load_and_migrate_config(config_path: Path) -> DBStyleConfigJSON:
 		# On any error, create fresh config
 		new_config = create_default_config()
 		try:
-			with open(config_path, 'w') as f:
+			with open(config_path, 'w', encoding='utf-8') as f:
 				json.dump(new_config.model_dump(), f, indent=2)
 		except Exception as write_error:
 			logger.error(f'Failed to write fresh config: {write_error}')

--- a/browser_use/sync/auth.py
+++ b/browser_use/sync/auth.py
@@ -59,7 +59,7 @@ class CloudAuthConfig(BaseModel):
 		config_path = CONFIG.BROWSER_USE_CONFIG_DIR / 'cloud_auth.json'
 		if config_path.exists():
 			try:
-				with open(config_path) as f:
+				with open(config_path, encoding='utf-8') as f:
 					data = json.load(f)
 				return cls.model_validate(data)
 			except Exception:
@@ -73,7 +73,7 @@ class CloudAuthConfig(BaseModel):
 		CONFIG.BROWSER_USE_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
 		config_path = CONFIG.BROWSER_USE_CONFIG_DIR / 'cloud_auth.json'
-		with open(config_path, 'w') as f:
+		with open(config_path, 'w', encoding='utf-8') as f:
 			json.dump(self.model_dump(mode='json'), f, indent=2, default=str)
 
 		# Set restrictive permissions (owner read/write only) for security

--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -100,12 +100,12 @@ class ProductTelemetry:
 		try:
 			if not os.path.exists(self.USER_ID_PATH):
 				os.makedirs(os.path.dirname(self.USER_ID_PATH), exist_ok=True)
-				with open(self.USER_ID_PATH, 'w') as f:
+				with open(self.USER_ID_PATH, 'w', encoding='utf-8') as f:
 					new_user_id = uuid7str()
 					f.write(new_user_id)
 				self._curr_user_id = new_user_id
 			else:
-				with open(self.USER_ID_PATH) as f:
+				with open(self.USER_ID_PATH, encoding='utf-8') as f:
 					self._curr_user_id = f.read()
 		except Exception:
 			self._curr_user_id = 'UNKNOWN_USER_ID'


### PR DESCRIPTION
## Problem

Several browser-use config and local state files are JSON/text files, but a few read/write paths still relied on Python's platform default encoding. On systems where the default encoding is not UTF-8, especially some Windows locales, this can make command history, cloud auth, telemetry device IDs, or migrated config files less portable than the UTF-8 writes already used elsewhere in the project.

## Before / after

Before:
- `config.json`, `command_history.json`, `cloud_auth.json`, and the telemetry device ID could be read or written with the platform default encoding in some paths.

After:
- Those text/JSON file paths consistently pass `encoding="utf-8"` for both reads and writes.
- Existing binary/image file handling is unchanged.

## Verification

- `python -m py_compile browser_use\config.py browser_use\cli.py browser_use\sync\auth.py browser_use\telemetry\service.py`
- `git diff --check`
- `uv run ruff check browser_use\config.py browser_use\cli.py browser_use\sync\auth.py browser_use\telemetry\service.py`
- `uv run pytest tests\ci\browser\test_cloud_browser.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes JSON/text config and local state files on UTF-8 and adds a safe fallback read using the system locale for legacy files. Prevents corrupted history/auth/telemetry on non-UTF-8 systems without breaking existing installs.

- **Bug Fixes**
  - Read/write `config.json`, `command_history.json`, `cloud_auth.json`, and the telemetry user ID with UTF-8.
  - On UTF-8 decode errors, retry reads with the OS preferred locale encoding (logs a warning) to handle legacy files.
  - All writes explicitly use UTF-8; binary/image file handling is unchanged.

<sup>Written for commit 281eecf13de14c496f789e65355746d6fc3a4522. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

