### PR TITLE
fix(deepseek): repair malformed tool call arguments

### DIFF
--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
 import httpx
+from json_repair import repair_json
 from openai import (
 	APIConnectionError,
 	APIError,
@@ -23,6 +24,21 @@ from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
+
+
+def _parse_tool_call_arguments(raw_args: str) -> Any:
+	try:
+		return json.loads(raw_args)
+	except json.JSONDecodeError:
+		repaired = repair_json(raw_args, return_objects=True)
+		if isinstance(repaired, dict):
+			return repaired
+		if isinstance(repaired, str):
+			try:
+				return json.loads(repaired)
+			except json.JSONDecodeError:
+				return {}
+		return {}
 
 
 @dataclass
@@ -166,7 +182,7 @@ class ChatDeepSeek(BaseChatModel):
 					raise ValueError('Expected tool_calls in response but got none')
 				raw_args = msg.tool_calls[0].function.arguments
 				if isinstance(raw_args, str):
-					parsed = json.loads(raw_args)
+					parsed = _parse_tool_call_arguments(raw_args)
 				else:
 					parsed = raw_args
 				# --------- Fix: only use model_validate when output_format is not None ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "google-genai==1.65.0",
+    "json-repair==0.61.0",
     "openai==2.16.0",
     "anthropic==0.76.0",
     "groq==1.0.0",

--- a/tests/ci/models/test_llm_deepseek.py
+++ b/tests/ci/models/test_llm_deepseek.py
@@ -1,0 +1,11 @@
+from browser_use.llm.deepseek.chat import _parse_tool_call_arguments
+
+
+def test_parse_tool_call_arguments_valid_json():
+	assert _parse_tool_call_arguments('{"action": "click", "index": 3}') == {'action': 'click', 'index': 3}
+
+
+def test_parse_tool_call_arguments_repairs_malformed_json():
+	parsed = _parse_tool_call_arguments('{"action": "click" "index": 3}')
+
+	assert parsed == {'action': 'click', 'index': 3}


### PR DESCRIPTION
## Summary
- add a DeepSeek tool-call argument parser that falls back to json-repair for malformed JSON
- add json-repair as a runtime dependency
- add unit coverage for valid and repairable tool-call arguments

## Testing
- Not run locally; this environment does not have the project's uv tool available.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DeepSeek tool-call parsing by repairing malformed JSON arguments to prevent crashes and missed tool calls. Adds a parser with a `json-repair` fallback and updates the chat path to use it.

- **Bug Fixes**
  - Add `_parse_tool_call_arguments` that tries `json.loads` then falls back to `json-repair`; returns `{}` if unrecoverable.
  - Use the parser when reading `function.arguments` in `ChatDeepSeek.ainvoke`.
  - Add tests for valid and repairable inputs.

- **Dependencies**
  - Add `json-repair==0.61.0`.

<sup>Written for commit b69bea0b0870af55413f137d74a620eebdd59169. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

