### PR TITLE
fix(dom): preserve empty accessibility names

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -848,7 +848,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -876,7 +876,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_dom_views.py
+++ b/tests/ci/test_dom_views.py
@@ -1,0 +1,55 @@
+from browser_use.dom.views import DOMInteractedElement, EnhancedAXNode, EnhancedDOMTreeNode, NodeType
+
+
+def _make_node(ax_name: str | None) -> EnhancedDOMTreeNode:
+	ax_node = (
+		EnhancedAXNode(
+			ax_node_id='ax-1',
+			ignored=False,
+			role='button',
+			name=ax_name,
+			description=None,
+			properties=None,
+			child_ids=None,
+		)
+		if ax_name is not None
+		else None
+	)
+
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={'id': 'empty-name-button'},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=None,
+	)
+
+
+def test_empty_accessibility_name_is_preserved() -> None:
+	node = _make_node('')
+
+	interacted = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+
+	assert interacted.ax_name == ''
+
+
+def test_empty_accessibility_name_affects_hashes() -> None:
+	node_without_ax_name = _make_node(None)
+	node_with_empty_ax_name = _make_node('')
+
+	assert hash(node_with_empty_ax_name) != hash(node_without_ax_name)
+	assert node_with_empty_ax_name.compute_stable_hash() != node_without_ax_name.compute_stable_hash()


### PR DESCRIPTION
Fixes #5041

## Summary

Preserve empty accessibility names instead of treating them as missing. Chrome's accessibility tree can legitimately provide an empty string name, and using truthiness checks caused that value to be dropped from element hashes and interacted element history.

## Tests

- python -m pytest tests\ci\test_dom_views.py -q
- python -m ruff check browser_use\dom\views.py tests\ci\test_dom_views.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve empty accessibility names (`ax_name`) so they’re treated as valid and included in element hashing and interacted element records, matching Chrome’s accessibility tree behavior.

- **Bug Fixes**
  - Use `is not None` checks to keep empty `ax_name` in `compute_stable_hash`, `__hash__`, and `load_from_enhanced_dom_tree`.
  - Add tests confirming empty `ax_name` is preserved and affects both `hash()` and `compute_stable_hash()` results.

<sup>Written for commit d3615433af9d1fad364cbd2bc9ba22c910dd39f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

