### PR TITLE
fix(beta): enable coordinate clicking for capable models in beta Agent (parity with stable)

### DIFF
--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -701,6 +701,15 @@ def _llm_timeout_for_model(llm: Any | None) -> int:
 	return 75
 
 
+def _supports_coordinate_clicking(llm: Any | None) -> bool:
+	"""Whether the model supports coordinate-based clicking (parity with the stable Agent)."""
+	model_name = str(getattr(llm, 'model', '') or '').lower()
+	return any(
+		pattern in model_name
+		for pattern in ('claude-sonnet-4', 'claude-opus-4', 'claude-fable-5', 'gemini-3-pro', 'browser-use/')
+	)
+
+
 def _resolve_default_llm(llm: BaseChatModel | None) -> BaseChatModel:
 	if llm is not None:
 		return llm
@@ -4344,6 +4353,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			use_vision,
 			display_files_in_done_text,
 		)
+		# Enable coordinate clicking for models that support it (parity with the stable Agent)
+		if _supports_coordinate_clicking(llm):
+			self.tools.set_coordinate_clicking(True)
 		if skills and skill_ids:
 			raise ValueError('Cannot specify both "skills" and "skill_ids" parameters. Use "skills" for the cleaner API.')
 		skill_ids = skills or skill_ids

--- a/tests/ci/test_coordinate_clicking.py
+++ b/tests/ci/test_coordinate_clicking.py
@@ -1,6 +1,6 @@
 """Tests for coordinate clicking feature.
 
-This feature allows certain models (Claude Sonnet 4, Claude Opus 4, Gemini 3 Pro, browser-use/* models)
+This feature allows certain models (Claude Sonnet 4, Claude Opus 4, Claude Fable 5, Gemini 3 Pro, browser-use/* models)
 to use coordinate-based clicking, while other models only get index-based clicking.
 """
 
@@ -122,6 +122,8 @@ class TestCoordinateClickingModelDetection:
 			('claude-opus-4-5-latest', True),
 			('claude-opus-4-0', True),
 			('claude-opus-4', True),
+			('claude-fable-5', True),
+			('claude-fable-5-preview', True),
 			('gemini-3-pro-preview', True),
 			('gemini-3-pro', True),
 			('browser-use/fast', True),
@@ -144,7 +146,7 @@ class TestCoordinateClickingModelDetection:
 		"""Test that the model detection patterns correctly identify coordinate-capable models."""
 		model_lower = model_name.lower()
 		supports_coords = any(
-			pattern in model_lower for pattern in ['claude-sonnet-4', 'claude-opus-4', 'gemini-3-pro', 'browser-use/']
+			pattern in model_lower for pattern in ['claude-sonnet-4', 'claude-opus-4', 'claude-fable-5', 'gemini-3-pro', 'browser-use/']
 		)
 		assert supports_coords == expected_coords, f'Model {model_name}: expected {expected_coords}, got {supports_coords}'
 
@@ -181,3 +183,37 @@ class TestCoordinateClickingWithPassedTools:
 		click_action = tools.registry.registry.actions.get('click')
 		assert click_action is not None
 		assert click_action.param_model == ClickElementAction
+
+
+class TestBetaAgentCoordinateClicking:
+	"""Test that the beta Agent's model detection enables coordinate clicking at parity with the stable Agent."""
+
+	@pytest.mark.parametrize(
+		'model_name,expected_coords',
+		[
+			# Coordinate-capable models (parity with stable Agent's enablement list)
+			('claude-sonnet-4-6', True),
+			('claude-sonnet-4', True),
+			('claude-opus-4-5', True),
+			('claude-opus-4', True),
+			('claude-fable-5', True),
+			('gemini-3-pro-preview', True),
+			('gemini-3-pro', True),
+			('browser-use/fast', True),
+			('anthropic/claude-sonnet-4-6', True),  # gateway-prefixed id
+			('CLAUDE-FABLE-5', True),  # case insensitive
+			# Models that should only get index-based clicking
+			('gpt-4o', False),
+			('claude-3-5-sonnet', False),
+			('gemini-1.5-pro', False),
+			(None, False),  # missing model id must not enable
+		],
+	)
+	def test_beta_supports_coordinate_clicking(self, model_name: str | None, expected_coords: bool):
+		from browser_use.beta.service import _supports_coordinate_clicking
+
+		class _StubLLM:
+			model = model_name
+
+		llm = None if model_name is None else _StubLLM()
+		assert _supports_coordinate_clicking(llm) is expected_coords


### PR DESCRIPTION
## What

Enable coordinate-based clicking for coordinate-capable models in the public **beta** `Agent` (`browser_use.beta.service.Agent`), at parity with the stable `Agent`.

## Why

The stable `Agent` upgrades coordinate-capable models to the more accurate coordinate clicking in `browser_use/agent/service.py`:

```python
# Enable coordinate clicking for models that support it
model_name = getattr(llm, 'model', '').lower()
supports_coordinate_clicking = any(
    pattern in model_name
    for pattern in ['claude-sonnet-4', 'claude-opus-4', 'claude-fable-5', 'gemini-3-pro', 'browser-use/']
)
if supports_coordinate_clicking:
    self.tools.set_coordinate_clicking(True)
```

The beta `Agent` never does this — `grep coordinate browser_use/beta/service.py` is empty. `Tools._coordinate_clicking_enabled` defaults to `False`, so `_register_click_action` registers the index-only `ClickElementActionIndexOnly`. The result: the beta / cloud-V2 path **silently falls back to index-only clicking** for exactly the models the stable path upgrades (Claude Sonnet 4 / Opus 4 / Fable 5 / Gemini 3 Pro / `browser-use/*`).

This is a missed surface from #5008 ("support claude fable 5"), which added `claude-fable-5` to the stable enablement list **and** edited `beta/service.py` in the same PR, but never wired coordinate enablement into beta. The same PR's `claude-fable-5` addition was also not propagated to the pattern list in `tests/ci/test_coordinate_clicking.py`.

## Change

- Add a small private helper `_supports_coordinate_clicking(llm)` to `beta/service.py` (next to the existing `_model_name` / `_llm_timeout_for_model` helpers) and call it right after `self.tools` is resolved, mirroring the stable enablement. The helper is the single source of truth for the pattern list (now including `claude-fable-5`).
- Add a parametrized regression test that exercises the production helper (no `Agent` construction, matching this file's existing test style), and backfill the missing `claude-fable-5` cases in `TestCoordinateClickingModelDetection`.

`llm` at the call site is the resolved llm (post `_resolve_default_llm`); `getattr(llm, 'model', '')` with `str(... or '')` keeps `llm=None` / missing `model` safe (no false enablement).

## Verification

Installed the package and constructed the beta `Agent` with a stub llm:

- before: `Agent(llm=<model='claude-sonnet-4-6'>).tools._coordinate_clicking_enabled` → `False` (bug)
- after: `True` for `claude-sonnet-4-6`, `claude-fable-5`, `claude-opus-4-5`, `gemini-3-pro-preview`, `browser-use/fast`, gateway-prefixed `anthropic/claude-sonnet-4-6`; `False` for `gpt-4o`

`tests/ci/test_coordinate_clicking.py` passes (49 tests).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables coordinate-based clicking in the beta `Agent` for coordinate-capable models (Claude Sonnet/Opus 4, Claude Fable 5, Gemini 3 Pro, and `browser-use/*`), matching the stable `Agent`. Fixes the beta path silently falling back to index-only clicks.

- **Bug Fixes**
  - Added `_supports_coordinate_clicking(llm)` in `browser_use/beta/service.py` and enabled `self.tools.set_coordinate_clicking(True)` during `Agent` init when patterns match.
  - Updated `tests/ci/test_coordinate_clicking.py` to cover `claude-fable-5` and added a regression test for the beta helper to ensure parity.

<sup>Written for commit 97cb82923a14f308c2b32cb47c2681852129a2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

