### PR TITLE
fix(browser): filter chrome helper targets

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1119,9 +1119,7 @@ class BrowserSession(BaseModel):
 				event.target_id = page_targets[-1].target_id
 			else:
 				# No pages open at all, create a new one (handles switching to it automatically)
-				assert self._cdp_client_root is not None, 'CDP client root not initialized - browser may not be connected yet'
-				new_target = await self._cdp_client_root.send.Target.createTarget(params={'url': 'about:blank'})
-				target_id = new_target['targetId']
+				target_id = await self._cdp_create_new_page(new_window=True)
 				# Don't await, these may circularly trigger SwitchTabEvent and could deadlock, dispatch to enqueue and return
 				self.event_bus.dispatch(TabCreatedEvent(url='about:blank', target_id=target_id))
 				self.event_bus.dispatch(AgentFocusChangedEvent(target_id=target_id, url='about:blank'))
@@ -1872,8 +1870,7 @@ class BrowserSession(BaseModel):
 
 			# Ensure we have at least one page
 			if not page_targets_from_manager:
-				new_target = await self._cdp_client_root.send.Target.createTarget(params={'url': 'about:blank'})
-				target_id = new_target['targetId']
+				target_id = await self._cdp_create_new_page(new_window=True)
 				self.logger.debug(f'📄 Created new blank page: {target_id}')
 			else:
 				target_id = page_targets_from_manager[0].target_id
@@ -2153,8 +2150,7 @@ class BrowserSession(BaseModel):
 				self.logger.debug(f'🔄 Agent focus set to fallback target {fallback_id[:8]}...')
 			else:
 				# No pages exist — create one
-				new_target = await self._cdp_client_root.send.Target.createTarget(params={'url': 'about:blank'})
-				target_id = new_target['targetId']
+				target_id = await self._cdp_create_new_page(new_window=True)
 				await self.get_or_create_cdp_session(target_id, focus=True)
 				self.logger.debug(f'🔄 Created new blank page during reconnect: {target_id[:8]}...')
 

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from cdp_use.cdp.target import AttachedToTargetEvent, DetachedFromTargetEvent, SessionID, TargetID
 
-from browser_use.utils import create_task_with_error_handling
+from browser_use.utils import create_task_with_error_handling, is_new_tab_page
 
 if TYPE_CHECKING:
 	from browser_use.browser.session import BrowserSession, CDPSession, Target
@@ -156,6 +156,9 @@ class SessionManager:
 		page_targets = []
 		for target in self._targets.values():
 			if target.target_type in ('page', 'tab'):
+				target_url = target.url or ''
+				if target_url.startswith('chrome://') and not is_new_tab_page(target_url):
+					continue
 				page_targets.append(target)
 		return page_targets
 
@@ -665,7 +668,7 @@ class SessionManager:
 			else:
 				# No pages exist - create a new one
 				self.logger.warning('[SessionManager] No tabs remain! Creating new tab for agent...')
-				new_target_id = await self.browser_session._cdp_create_new_page('about:blank')
+				new_target_id = await self.browser_session._cdp_create_new_page('about:blank', new_window=True)
 				self.logger.info(f'[SessionManager] Created new tab {new_target_id[:8]}... for agent')
 
 				# Dispatch TabCreatedEvent so watchdogs can initialize
@@ -711,7 +714,7 @@ class SessionManager:
 				f'[SessionManager] ❌ Failed to get session for {new_target_id[:8]}... after 2s, creating emergency fallback tab'
 			)
 
-			fallback_target_id = await self.browser_session._cdp_create_new_page('about:blank')
+			fallback_target_id = await self.browser_session._cdp_create_new_page('about:blank', new_window=True)
 			self.logger.warning(f'[SessionManager] Created emergency fallback tab {fallback_target_id[:8]}...')
 
 			# Try one more time with fallback

--- a/tests/ci/browser/test_session_manager_targets.py
+++ b/tests/ci/browser/test_session_manager_targets.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from browser_use.browser.events import SwitchTabEvent
+from browser_use.browser.session import BrowserSession
+from browser_use.browser.session_manager import SessionManager
+
+
+def _target(target_id: str, target_type: str, url: str):
+	return SimpleNamespace(target_id=target_id, target_type=target_type, url=url)
+
+
+def test_get_all_page_targets_filters_chrome_internal_helpers():
+	manager = SessionManager.__new__(SessionManager)
+	manager._targets = {
+		'page': _target('page', 'page', 'https://example.com'),
+		'blank': _target('blank', 'page', 'about:blank'),
+		'newtab': _target('newtab', 'page', 'chrome://newtab'),
+		'new-tab-page': _target('new-tab-page', 'tab', 'chrome://new-tab-page/'),
+		'omnibox-popup': _target('omnibox-popup', 'page', 'chrome://omnibox-popup'),
+		'settings': _target('settings', 'tab', 'chrome://settings'),
+		'worker': _target('worker', 'service_worker', 'https://example.com/worker.js'),
+	}
+
+	assert [target.target_id for target in manager.get_all_page_targets()] == [
+		'page',
+		'blank',
+		'newtab',
+		'new-tab-page',
+	]
+
+
+@pytest.mark.asyncio
+async def test_switch_tab_creates_new_window_when_no_targets():
+	session = BrowserSession()
+	session.agent_focus_target_id = 'existing-focus'
+	session.session_manager = MagicMock()
+	session.session_manager.get_all_page_targets.return_value = []
+
+	with (
+		patch.object(BrowserSession, '_cdp_create_new_page', new=AsyncMock(return_value='new-target')) as create_new_page,
+		patch.object(session.event_bus, 'dispatch') as dispatch,
+	):
+		target_id = await session.on_SwitchTabEvent(SwitchTabEvent(target_id=None))
+
+	assert target_id == 'new-target'
+	create_new_page.assert_awaited_once_with(new_window=True)
+	assert dispatch.call_count == 2


### PR DESCRIPTION
## Summary

- Filter `chrome://` helper targets such as `chrome://omnibox-popup` out of `SessionManager.get_all_page_targets()` while preserving `about:blank` and Chrome new-tab pages.
- Use `newWindow=True` when browser recovery/startup needs to create the first page after no page targets exist, avoiding a windowless orphan target.
- Add regression coverage for the target filter and the no-target switch-tab recovery path.

## Why

Some Chrome helpers are reported as `page`/`tab` CDP targets. When those targets are treated as agent pages, focus can attach to internal browser UI instead of a usable page.

Chrome can also create a target without a visible window when `Target.createTarget` is called after all pages/windows are gone. The no-page recovery paths should explicitly request a new window.

This is adjacent to the open `chrome-extension://` filtering PRs, but it handles `chrome://` helper pages and no-window first-page creation.

## Tests

- `python3 -m py_compile browser_use/browser/session_manager.py browser_use/browser/session.py tests/ci/browser/test_session_manager_targets.py`
- `uv run ruff format browser_use/browser/session_manager.py browser_use/browser/session.py tests/ci/browser/test_session_manager_targets.py`
- `uv run ruff check browser_use/browser/session_manager.py browser_use/browser/session.py tests/ci/browser/test_session_manager_targets.py`
- `uv run pytest -q tests/ci/browser/test_session_manager_targets.py tests/ci/browser/test_cdp_headers.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out Chrome `chrome://` helper targets and creates the first page in a new window during recovery. This prevents focusing internal browser UI and avoids windowless orphan targets.

- **Bug Fixes**
  - `SessionManager.get_all_page_targets()` now excludes `chrome://` helper pages (e.g., `chrome://omnibox-popup`, `chrome://settings`) while preserving `about:blank` and Chrome new-tab pages.
  - Recovery paths use `_cdp_create_new_page(..., new_window=True)` when no page targets exist (switch tab, reconnect, crash recovery) to ensure a visible window is created.

<sup>Written for commit b3b6f3e0da9ee8b30aedb7c5d8290af3b8649a5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

