### PR TITLE
fix(event-bus): add timeout to ResilientEventBus.stop() to prevent hangs

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -129,6 +129,22 @@ class ResilientEventBus(EventBus):
 		if self._on_idle is None or self.event_queue is None:
 			return None
 		return await super().wait_until_idle(timeout)
+	async def stop(self, clear: bool = True, timeout: float | None = None) -> None:
+		"""Stop the event bus with a timeout to prevent indefinite hangs.
+		
+		In serverless environments (Lambda, Cloud Run), a non-responsive shutdown blocks
+		the process from terminating gracefully, leading to cold-start timeouts.
+		"""
+		try:
+			# Use a default timeout of 30 seconds if not specified
+			shutdown_timeout = timeout if timeout is not None else 30.0
+			await asyncio.wait_for(super().stop(clear=clear, timeout=timeout), timeout=shutdown_timeout)
+		except asyncio.TimeoutError:
+			# Log warning but don't block process termination
+			logger.warning(
+				f'Event bus {self.name!r} stop() timed out after {shutdown_timeout}s, '
+				'proceeding with graceful degradation. The event loop may be in a bad state.'
+			)
 
 
 class BrowserSession(BaseModel):

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -138,7 +138,7 @@ class ResilientEventBus(EventBus):
 		try:
 			# Use a default timeout of 30 seconds if not specified
 			shutdown_timeout = timeout if timeout is not None else 30.0
-			await asyncio.wait_for(super().stop(clear=clear, timeout=timeout), timeout=shutdown_timeout)
+			await asyncio.wait_for(super().stop(clear=clear), timeout=shutdown_timeout)
 		except asyncio.TimeoutError:
 			# Log warning but don't block process termination
 			logger.warning(


### PR DESCRIPTION
## Problem
The event bus implementation in browser-use does not set a timeout on its internal `event.wait()` calls during shutdown. The shutdown path itself can block indefinitely if the asyncio event loop is in a bad state (e.g., during warm-Lambda cold-start transition).

**Issue:** Fixes #5097

## Solution
Override `stop()` in `ResilientEventBus` to wrap the parent's `stop()` with `asyncio.wait_for()` with a 30-second default timeout, handling `asyncio.TimeoutError` gracefully by logging a warning instead of blocking process termination.

## Impact
In serverless environments (Lambda, Cloud Run), this prevents cold-start timeouts and zombie instances caused by non-responsive `shutdown()` calls.

## Checklist
- [x] Code follows project style guidelines
- [x] Added/updated tests (if applicable)
- [x] All existing tests pass
- [x] Documentation updated (if needed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a timeout to `ResilientEventBus.stop()` to prevent shutdown hangs in serverless and other environments. Defaults to 30s, logs a warning on timeout, and fixes #5097.

- **Bug Fixes**
  - Wrap parent `stop()` in `asyncio.wait_for` with a 30s default; supports a `timeout` arg.
  - On timeout, log a warning and continue shutdown.
  - Do not pass a timeout to `super().stop()`; the outer `wait_for` enforces it.

<sup>Written for commit 906be330e8cb8bada1e32378d51c293e65189ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

