### PR TITLE
fix(security): block data:/blob: URL bypass when allowed_domains is configured

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -196,9 +196,14 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
+		# Allow data: and blob: URLs only when no domain restrictions are active
+		# (they have no hostname to validate, so they bypass domain checks)
 		if parsed.scheme in ['data', 'blob']:
-			return True
+			if (
+				not self.browser_session.browser_profile.allowed_domains
+				and not self.browser_session.browser_profile.prohibited_domains
+			):
+				return True
 
 		# Get the actual host (domain)
 		host = parsed.hostname


### PR DESCRIPTION
## Problem

`data:` and `blob:` URLs were unconditionally allowed before domain checks, bypassing `allowed_domains` and `prohibited_domains` restrictions. A malicious page could use `data:` URLs to execute scripts or render content outside the configured domain allowlist.

This is the same bypass class described in #5099 — `data:` and `blob:` were explicitly allowed at the top of `_is_url_allowed()` without checking whether domain restrictions are active.

## Fix

Only allow `data:` and `blob:` URLs when no domain restrictions are configured. When `allowed_domains` or `prohibited_domains` is set, these schemes fall through to the hostname check, which blocks them (they have no hostname to validate).

Schemes without hostnames (`javascript:`, `file:`, `about:`) were already blocked by the existing `if not host: return False` check. Non-http schemes with explicit `allowed_domains` entries (e.g., `chrome://version`) still work through pattern matching since they have hostnames.

## Test cases verified

| URL | allowed_domains | Before | After |
|-----|----------------|--------|-------|
| `data:text/html,...` | `['example.com']` | ✅ allowed (bypass) | ❌ blocked |
| `blob:xxx` | `['example.com']` | ✅ allowed (bypass) | ❌ blocked |
| `data:text/html,...` | none | ✅ allowed | ✅ allowed (unchanged) |
| `chrome://version` | `['chrome://version']` | ✅ allowed | ✅ allowed (unchanged) |
| `javascript:alert(1)` | `['example.com']` | ❌ blocked | ❌ blocked (unchanged) |
| `file:///etc/passwd` | `['example.com']` | ❌ blocked | ❌ blocked (unchanged) |
| `data:text/html,...` | prohibited only | ✅ allowed (bypass) | ❌ blocked |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a security bypass where `data:` and `blob:` URLs were allowed even when `allowed_domains` or `prohibited_domains` were set. These schemes are now only allowed when no domain restrictions are configured.

- **Bug Fixes**
  - `data:` and `blob:` now fall through to hostname checks and are blocked when domain rules exist.
  - No changes to other schemes: `javascript:`/`file:` remain blocked; explicit non-HTTP with hostnames (e.g., `chrome://version`) still work via pattern matching.

<sup>Written for commit 1789dec87f3e57918e54c7a531dbad597258a3eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

