### PR TITLE
Fix CDP page target selection

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1119,9 +1119,7 @@ class BrowserSession(BaseModel):
 				event.target_id = page_targets[-1].target_id
 			else:
 				# No pages open at all, create a new one (handles switching to it automatically)
-				assert self._cdp_client_root is not None, 'CDP client root not initialized - browser may not be connected yet'
-				new_target = await self._cdp_client_root.send.Target.createTarget(params={'url': 'about:blank'})
-				target_id = new_target['targetId']
+				target_id = await self._cdp_create_new_page('about:blank', new_window=True)
 				# Don't await, these may circularly trigger SwitchTabEvent and could deadlock, dispatch to enqueue and return
 				self.event_bus.dispatch(TabCreatedEvent(url='about:blank', target_id=target_id))
 				self.event_bus.dispatch(AgentFocusChangedEvent(target_id=target_id, url='about:blank'))
@@ -1872,8 +1870,7 @@ class BrowserSession(BaseModel):
 
 			# Ensure we have at least one page
 			if not page_targets_from_manager:
-				new_target = await self._cdp_client_root.send.Target.createTarget(params={'url': 'about:blank'})
-				target_id = new_target['targetId']
+				target_id = await self._cdp_create_new_page('about:blank', new_window=True)
 				self.logger.debug(f'📄 Created new blank page: {target_id}')
 			else:
 				target_id = page_targets_from_manager[0].target_id
@@ -2153,8 +2150,7 @@ class BrowserSession(BaseModel):
 				self.logger.debug(f'🔄 Agent focus set to fallback target {fallback_id[:8]}...')
 			else:
 				# No pages exist — create one
-				new_target = await self._cdp_client_root.send.Target.createTarget(params={'url': 'about:blank'})
-				target_id = new_target['targetId']
+				target_id = await self._cdp_create_new_page('about:blank', new_window=True)
 				await self.get_or_create_cdp_session(target_id, focus=True)
 				self.logger.debug(f'🔄 Created new blank page during reconnect: {target_id[:8]}...')
 

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from cdp_use.cdp.target import AttachedToTargetEvent, DetachedFromTargetEvent, SessionID, TargetID
 
-from browser_use.utils import create_task_with_error_handling
+from browser_use.utils import create_task_with_error_handling, is_new_tab_page
 
 if TYPE_CHECKING:
 	from browser_use.browser.session import BrowserSession, CDPSession, Target
@@ -155,8 +155,16 @@ class SessionManager:
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
-				page_targets.append(target)
+			if target.target_type not in ('page', 'tab'):
+				continue
+
+			# Chrome can expose helper UI surfaces, such as chrome://omnibox-popup/,
+			# as page-like CDP targets. They are not agent-controllable browser tabs.
+			url = target.url or ''
+			if url.startswith('chrome://') and not is_new_tab_page(url):
+				continue
+
+			page_targets.append(target)
 		return page_targets
 
 	async def validate_session(self, target_id: TargetID) -> bool:

--- a/tests/ci/browser/test_cdp_page_targets.py
+++ b/tests/ci/browser/test_cdp_page_targets.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from browser_use.browser.session import BrowserSession
+from browser_use.browser.session_manager import SessionManager
+
+
+def _target(target_id: str, target_type: str, url: str):
+	return SimpleNamespace(target_id=target_id, target_type=target_type, url=url)
+
+
+def test_get_all_page_targets_filters_chrome_helper_pages_but_keeps_new_tab_pages():
+	manager = SessionManager(SimpleNamespace(logger=MagicMock()))
+	manager._targets = {
+		'normal': _target('normal', 'page', 'https://example.com'),
+		'blank': _target('blank', 'page', 'about:blank'),
+		'newtab': _target('newtab', 'page', 'chrome://newtab/'),
+		'new-tab-page': _target('new-tab-page', 'tab', 'chrome://new-tab-page/'),
+		'omnibox': _target('omnibox', 'page', 'chrome://omnibox-popup/'),
+		'settings': _target('settings', 'tab', 'chrome://settings/'),
+		'iframe': _target('iframe', 'iframe', 'https://example.com/frame'),
+	}
+
+	page_target_ids = [target.target_id for target in manager.get_all_page_targets()]
+
+	assert page_target_ids == ['normal', 'blank', 'newtab', 'new-tab-page']
+
+
+@pytest.mark.asyncio
+async def test_cdp_create_new_page_can_request_new_window():
+	session = BrowserSession()
+	create_target = AsyncMock(return_value={'targetId': 'target-1'})
+	session._cdp_client_root = SimpleNamespace(
+		send=SimpleNamespace(Target=SimpleNamespace(createTarget=create_target)),
+	)
+
+	target_id = await session._cdp_create_new_page('about:blank', new_window=True)
+
+	assert target_id == 'target-1'
+	create_target.assert_awaited_once()
+	assert create_target.await_args.kwargs['params'] == {
+		'url': 'about:blank',
+		'background': False,
+		'newWindow': True,
+	}

--- a/tests/ci/browser/test_cdp_page_targets.py
+++ b/tests/ci/browser/test_cdp_page_targets.py
@@ -1,29 +1,38 @@
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from cdp_use import CDPClient
+from cdp_use.cdp.target import TargetID
 
-from browser_use.browser.session import BrowserSession
+from browser_use.browser.session import BrowserSession, Target
 from browser_use.browser.session_manager import SessionManager
 
 
-def _target(target_id: str, target_type: str, url: str):
-	return SimpleNamespace(target_id=target_id, target_type=target_type, url=url)
+def _target_id(target_id: str) -> TargetID:
+	return cast(TargetID, target_id)
+
+
+def _target(target_id: str, target_type: str, url: str) -> Target:
+	return Target(target_id=_target_id(target_id), target_type=target_type, url=url)
 
 
 def test_get_all_page_targets_filters_chrome_helper_pages_but_keeps_new_tab_pages():
-	manager = SessionManager(SimpleNamespace(logger=MagicMock()))
+	session = BrowserSession()
+	manager = SessionManager(session)
+	manager.logger = MagicMock()
 	manager._targets = {
-		'normal': _target('normal', 'page', 'https://example.com'),
-		'blank': _target('blank', 'page', 'about:blank'),
-		'newtab': _target('newtab', 'page', 'chrome://newtab/'),
-		'new-tab-page': _target('new-tab-page', 'tab', 'chrome://new-tab-page/'),
-		'omnibox': _target('omnibox', 'page', 'chrome://omnibox-popup/'),
-		'settings': _target('settings', 'tab', 'chrome://settings/'),
-		'iframe': _target('iframe', 'iframe', 'https://example.com/frame'),
+		_target_id('normal'): _target('normal', 'page', 'https://example.com'),
+		_target_id('blank'): _target('blank', 'page', 'about:blank'),
+		_target_id('newtab'): _target('newtab', 'page', 'chrome://newtab/'),
+		_target_id('new-tab-page'): _target('new-tab-page', 'tab', 'chrome://new-tab-page/'),
+		_target_id('omnibox'): _target('omnibox', 'page', 'chrome://omnibox-popup/'),
+		_target_id('settings'): _target('settings', 'tab', 'chrome://settings/'),
+		_target_id('iframe'): _target('iframe', 'iframe', 'https://example.com/frame'),
 	}
 
-	page_target_ids = [target.target_id for target in manager.get_all_page_targets()]
+	page_target_ids = [str(target.target_id) for target in manager.get_all_page_targets()]
 
 	assert page_target_ids == ['normal', 'blank', 'newtab', 'new-tab-page']
 
@@ -32,15 +41,18 @@ def test_get_all_page_targets_filters_chrome_helper_pages_but_keeps_new_tab_page
 async def test_cdp_create_new_page_can_request_new_window():
 	session = BrowserSession()
 	create_target = AsyncMock(return_value={'targetId': 'target-1'})
-	session._cdp_client_root = SimpleNamespace(
-		send=SimpleNamespace(Target=SimpleNamespace(createTarget=create_target)),
+	session._cdp_client_root = cast(
+		CDPClient,
+		SimpleNamespace(send=SimpleNamespace(Target=SimpleNamespace(createTarget=create_target))),
 	)
 
 	target_id = await session._cdp_create_new_page('about:blank', new_window=True)
 
 	assert target_id == 'target-1'
 	create_target.assert_awaited_once()
-	assert create_target.await_args.kwargs['params'] == {
+	await_args = create_target.await_args
+	assert await_args is not None
+	assert await_args.kwargs['params'] == {
 		'url': 'about:blank',
 		'background': False,
 		'newWindow': True,


### PR DESCRIPTION
## Summary
- Filter Chrome helper UI targets out of `SessionManager.get_all_page_targets()` while preserving real new-tab placeholder pages.
- Use `Target.createTarget` with `newWindow=True` for orphan/recovery `about:blank` pages so Chrome creates a visible window.
- Add focused unit coverage for both behaviors.

## Root Cause
Chrome can expose internal helper UI surfaces, such as `chrome://omnibox-popup/`, as page-like CDP targets. Returning those from `get_all_page_targets()` lets browser-use treat a non-agent-controllable Chrome UI surface as a normal tab. Separately, recovery paths that create an `about:blank` target after no pages exist need `newWindow=True`; otherwise Chrome can create a target without a visible browser window in no-default-window launches.

## Tests
- `uv run pytest tests/ci/browser/test_cdp_page_targets.py -q`
- `uv run pytest tests/ci/browser/test_cdp_page_targets.py tests/ci/browser/test_cdp_headers.py -q`
- `uv run ruff check browser_use/browser/session.py browser_use/browser/session_manager.py tests/ci/browser/test_cdp_page_targets.py`
- `uv run ruff format --check browser_use/browser/session.py browser_use/browser/session_manager.py tests/ci/browser/test_cdp_page_targets.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CDP page target selection so only real tabs are treated as pages, and guarantees recovery `about:blank` tabs open in a visible window. Consolidates page creation through `_cdp_create_new_page` and adds tests to prevent regressions.

- **Bug Fixes**
  - Filter out `chrome://` helper UI from `SessionManager.get_all_page_targets()`, while keeping real new-tab placeholders (`chrome://newtab/`, `chrome://new-tab-page/`, `about:blank`).
  - Route all recovery/new-tab creation through `_cdp_create_new_page('about:blank', new_window=True)` so Chrome opens a visible window when none exist; tests verify `newWindow=True` is passed.

<sup>Written for commit 8e11325efbef1890ad5d84863b4c7dea9ebfac0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

