### PR TITLE
fix(agent): compute step_interval as inter-step gap, not step duration

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1358,8 +1358,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 				if last_history_item.metadata:
 					previous_end_time = last_history_item.metadata.step_end_time
-					previous_start_time = last_history_item.metadata.step_start_time
-					step_interval = max(0, previous_end_time - previous_start_time)
+					step_interval = max(0, self.step_start_time - previous_end_time)
 			metadata = StepMetadata(
 				step_number=self.state.n_steps,
 				step_start_time=self.step_start_time,


### PR DESCRIPTION
## Problem

In `_finalize()`, `step_interval` is calculated as the previous step's **duration** (end - start), which includes LLM inference time:

```python
step_interval = max(0, previous_end_time - previous_start_time)
```

But `step_interval` is used by `rerun_history()` as the **replay delay** between steps:

```python
# Line 3143-3144
# Cap the saved interval to max_step_interval (saved interval includes LLM time)
step_delay = min(history_item.metadata.step_interval, max_step_interval)
```

The author's own comment acknowledges this: "saved interval includes LLM time." The `max_step_interval` cap (45s default) was added as a workaround to limit the excess delay.

## Fix

Calculate the actual inter-step gap — the time between the previous step ending and the current step starting:

```python
step_interval = max(0, self.step_start_time - previous_end_time)
```

This excludes LLM inference time, so replays only wait for the actual processing gap between steps.

## Test plan

- [ ] Existing tests pass: `pytest tests/`
- [ ] Run an agent with multiple steps, then `rerun_history()` — replay delays should be shorter and more accurate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compute `step_interval` as the gap between steps (current start − previous end) instead of the previous step’s duration. This removes LLM time from replays, so `rerun_history()` delays are shorter and accurate.

- **Bug Fixes**
  - In `_finalize()`, use `self.step_start_time - previous_end_time` for `step_interval`. This reduces unnecessary replay waiting and lessens reliance on the `max_step_interval` cap.

<sup>Written for commit 1deb8eb5f1b3ef8a42715ed8c08522b141f0cca8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

