### PR TITLE
fix(security): prevent subdomain/port/userinfo bypass in full URL pattern matching

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -315,10 +315,27 @@ class SecurityWatchdog(BaseWatchdog):
 					# Pattern has no explicit port but URL does — reject.
 					return False
 				# If the pattern specifies a path prefix, enforce it.
+				# Use boundary-aware comparison: the URL path must either
+				# equal the pattern path exactly, or start with it followed
+				# by '/' or '?' to prevent sibling-path overmatch
+				# (e.g., pattern '/api' must not match '/apiary').
+				# Also preserve query/fragment constraints from the pattern.
 				if pat_path:
-					url_path = _urlparse(url).path.rstrip('/')
-					if not url_path.startswith(pat_path):
+					url_parsed = _urlparse(url)
+					url_path = url_parsed.path.rstrip('/')
+					if url_path == pat_path:
+						pass  # exact path match
+					elif url_path.startswith(pat_path + '/'):
+						pass  # sub-path match
+					else:
 						return False
+					# If the pattern includes query params, enforce them.
+					if pat_parsed.query:
+						if url_parsed.query != pat_parsed.query:
+							return False
+					if pat_parsed.fragment:
+						if url_parsed.fragment != pat_parsed.fragment:
+							return False
 				return True
 			else:
 				# Domain-only pattern (case-insensitive comparison)

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -282,9 +282,44 @@ class SecurityWatchdog(BaseWatchdog):
 		else:
 			# Exact match
 			if '://' in pattern:
-				# Full URL pattern
-				if url.startswith(pattern):
-					return True
+				# Full URL pattern — parse both to avoid subdomain/port/userinfo bypass.
+				# url.startswith("https://example.com") would match
+				# "https://example.com.attacker.com" (subdomain bypass),
+				# "https://example.com:8080" (port bypass), and
+				# "https://example.com@attacker.com" (userinfo bypass).
+				from urllib.parse import urlparse as _urlparse
+
+				try:
+					pat_parsed = _urlparse(pattern)
+				except Exception:
+					return False
+				pat_host = (pat_parsed.hostname or '').lower()
+				pat_path = pat_parsed.path.rstrip('/')
+				pat_scheme = (pat_parsed.scheme or '').lower()
+
+				if scheme != pat_scheme or host.lower() != pat_host:
+					return False
+				# Port must also match — an explicit port in the URL that
+				# differs from the pattern's (implicit or explicit) port
+				# means the request targets a different service.
+				pat_port = pat_parsed.port  # None when not explicitly specified
+				url_parsed = _urlparse(url)
+				url_port = url_parsed.port
+				# If the pattern omits the port, the URL must also use the
+				# default port (i.e. have no explicit port).  If the pattern
+				# specifies a port, the URL must match exactly.
+				if pat_port is not None:
+					if url_port != pat_port:
+						return False
+				elif url_port is not None:
+					# Pattern has no explicit port but URL does — reject.
+					return False
+				# If the pattern specifies a path prefix, enforce it.
+				if pat_path:
+					url_path = _urlparse(url).path.rstrip('/')
+					if not url_path.startswith(pat_path):
+						return False
+				return True
 			else:
 				# Domain-only pattern (case-insensitive comparison)
 				if host.lower() == pattern.lower():


### PR DESCRIPTION
## Security Fix: URL Pattern Matching Bypass

`_is_url_match()` uses `url.startswith(pattern)` for full URL patterns (containing `://`), which allows three bypass vectors that affect both `allowed_domains` and `prohibited_domains` configurations.

### Vulnerability

When a user configures `allowed_domains=['https://example.com']`, the following URLs would be incorrectly allowed:

| Attack | URL | Why it matches |
|--------|-----|---------------|
| Subdomain bypass | `https://example.com.attacker.com/steal` | `startswith('https://example.com')` is True |
| Port bypass | `https://example.com:8080/admin` | `startswith('https://example.com')` is True |
| Userinfo bypass | `https://example.com@attacker.com/` | `startswith('https://example.com')` is True, but hostname is `attacker.com` |

The same issue affects `prohibited_domains` — a prohibited domain like `https://evil.com` would not block `https://evil.com.evil-cdn.net`.

### Fix

Replace `url.startswith(pattern)` with proper URL component comparison using `urlparse`:

1. Parse both the URL and the pattern
2. Compare scheme, hostname (case-insensitive), and port
3. If the pattern specifies a path prefix, enforce it with `startswith` on the path component only

### Changes
- `browser_use/browser/watchdogs/security_watchdog.py`: Replace `url.startswith(pattern)` with parsed URL component comparison in `_is_url_match()`

### Testing
Verified all attack vectors are blocked and legitimate URLs still work:
- `https://example.com.attacker.com/steal` → BLOCKED
- `https://example.com:8080/admin` → BLOCKED  
- `https://example.com@attacker.com/` → BLOCKED
- `https://example.com/page` → ALLOWED
- `https://example.com/api/v1` (with path prefix pattern) → ALLOWED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes full-URL pattern matching to stop subdomain, port, userinfo, and sibling-path bypasses in `allowed_domains` and `prohibited_domains`. We now parse URLs and compare scheme/hostname/port, reject explicit ports when the pattern omits them, enforce boundary-safe path prefixes, and require exact query/fragment matches.

<sup>Written for commit ae8546d867dae1481c2117f5f8045f7613a6fdec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

