### PR TITLE
agentic setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **Browser Use CLI 3.0 is here.** Give your coding agent a browser it can use reliably:
 
-```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```text
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 Or try the hosted agent in [Browser Use Cloud](https://cloud.browser-use.com?utm_source=github&utm_medium=readme&utm_campaign=cli_3_0_launch).
@@ -190,10 +190,10 @@ The CLI allows your agent to control the browser via Python, and it manages the 
 
 ### Agent Skill
 
-For Claude Code, Codex, and other agents, install the Browser Use skill:
+For Claude Code, Codex, and other agents, paste this setup prompt into your agent:
 
-```bash
-npx skills add https://github.com/browser-use/browser-use --skill browser-use
+```text
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
 ```
 
 <br/>

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -48,7 +48,7 @@ def _fake_browser_harness_tools(tmp_path: Path, skill_text: str) -> Path:
 def test_docs_install_browser_use_skill_from_package_alias():
 	readme = (ROOT / 'README.md').read_text(encoding='utf-8')
 
-	assert 'npx skills add https://github.com/browser-use/browser-use --skill browser-use' in readme
+	assert 'register the skill from `browser-use skill`' in readme
 	assert 'mkdir -p ~/.claude/skills/browser-use' not in readme
 	assert 'uv run --with "browser-use[browser-harness]" python -c' not in readme
 	assert 'from browser_use.skills import browser_use_skill_text' not in readme


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced the `npx skills add` command with a copy-paste agent setup prompt in the README, instructing users to install/upgrade `browser-use` via uv (Python 3.12), register via `browser-use skill`, and connect to the browser; both example blocks are now text instead of bash. Updated the CI doc test to assert the new wording.

<sup>Written for commit 66ad0c95b6b624e9b8e87e785f7aaaa2c27500a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

