### PR TITLE
fix(security): block non-HTTP schemes when domain restrictions are active

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -196,7 +196,16 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
+		# When domain restrictions are active, only allow http/https schemes
+		# (internal browser targets like about:blank are already handled above)
+		if (
+			self.browser_session.browser_profile.allowed_domains
+			or self.browser_session.browser_profile.prohibited_domains
+		):
+			if parsed.scheme not in ('http', 'https'):
+				return False
+
+		# Allow data: and blob: URLs when no domain restrictions are active
 		if parsed.scheme in ['data', 'blob']:
 			return True
 


### PR DESCRIPTION
## Problem

Issue #5099 identified that `javascript:`, `file://`, `chrome://`, and `about:` URLs bypass `allowed_domains` restrictions — the same class of bug as the `data:`/`blob:` bypass in #5101.

When `allowed_domains` is configured, a page can redirect the agent to:
- `javascript:alert(1)` — execute arbitrary JS
- `file:///etc/passwd` — read local files
- `chrome://settings` — access browser internals
- `about:srcdoc` — access iframe content

## Fix

When `allowed_domains` or `prohibited_domains` is configured, only allow `http`/`https` schemes:

```python
if (allowed_domains or prohibited_domains):
    if parsed.scheme not in ('http', 'https'):
        return False
```

Internal browser targets (`about:blank`, `chrome://newtab`) are already handled before this check. When no domain restrictions are active, all schemes remain allowed (existing behavior).

This also subsumes the `data:`/`blob:` fix from #5101 — those schemes are now blocked by the non-HTTP check when domain restrictions are active.

Fixes #5099

## Test plan

- [ ] Existing tests pass: `pytest tests/`
- [ ] Configure `allowed_domains`, navigate to `javascript:alert(1)` — should be blocked
- [ ] Configure `allowed_domains`, navigate to `file:///etc/passwd` — should be blocked
- [ ] No `allowed_domains` configured, navigate to `data:text/html,hello` — should still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block non-HTTP(S) URLs when domain restrictions are enabled to prevent bypassing `allowed_domains`/`prohibited_domains`. Fixes #5099.

- **Bug Fixes**
  - Only allow `http`/`https` when domain restrictions are configured.
  - Blocks navigation to `javascript:`, `file://`, `chrome://`, and `about:` under restrictions; internal targets (e.g., `about:blank`) are already handled.
  - Keeps previous behavior when no restrictions; `data:` and `blob:` remain allowed only in that case.

<sup>Written for commit ee47ff4a44bb8e7387c1b83dbe20f9c12d238f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

