### PR TITLE
fix(browser): use urlparse for same-domain check to avoid port mismatch

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1022,7 +1022,7 @@ class BrowserSession(BaseModel):
 			target = self.session_manager.get_target(target_id)
 			current_url = target.url
 			same_domain = (
-				url.split('/')[2] == current_url.split('/')[2]
+				urlparse(url).hostname == urlparse(current_url).hostname
 				if url.startswith('http') and current_url.startswith('http')
 				else False
 			)


### PR DESCRIPTION
## Problem

The same-domain check in `_navigate_and_wait()` uses `url.split('/')[2]` to extract the host, which includes the port:

```python
same_domain = url.split('/')[2] == current_url.split('/')[2]
```

For `https://example.com:443/foo`, `split('/')[2]` returns `'example.com:443'`.
For `https://example.com/bar`, `split('/')[2]` returns `'example.com'`.

Same-domain navigation with an explicit port is incorrectly classified as cross-domain, selecting the longer 8s timeout instead of 3s.

## Fix

Use `urlparse().hostname` for correct hostname comparison without port:

```python
same_domain = urlparse(url).hostname == urlparse(current_url).hostname
```

## Test plan

- [ ] Existing tests pass: `pytest tests/`
- [ ] Navigate from `https://example.com/page1` to `https://example.com:443/page2` — should use 3s timeout (same domain)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix same-domain detection in `_navigate_and_wait()` by comparing hostnames with `urlparse` instead of splitting URLs, so port differences don’t trigger the 8s cross-domain timeout. Same-site navigations (e.g., https://example.com → https://example.com:443) now use the 3s timeout.

<sup>Written for commit 8a0b82f70da7262c85e091caeab9900d0af05ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

