### PR TITLE
fix(browser): log response body instead of repr in version info debug

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1802,7 +1802,7 @@ class BrowserSession(BaseModel):
 
 				headers.setdefault('User-Agent', f'browser-use/{get_browser_use_version()}')
 				version_info = await client.get(url, headers=headers)
-				self.logger.debug(f'Raw version info: {str(version_info)}')
+				self.logger.debug(f'Raw version info: {version_info.text}')
 				self.browser_profile.cdp_url = version_info.json()['webSocketDebuggerUrl']
 
 		assert self.cdp_url is not None, 'CDP URL is None.'


### PR DESCRIPTION
## Problem

The debug log for browser version info prints \`str(version_info)\` which produces \`<Response [200]>\` — useless for debugging. The very next line calls \`version_info.json()\`, so the actual body is available.

## Fix

Use \`.text\` to log the actual response body:

\`\`\`python
self.logger.debug(f'Raw version info: {version_info.text}')
\`\`\`

## Test plan

- [ ] Existing tests pass: \`pytest tests/\`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Log the actual response body when fetching browser version info to make debug logs useful for troubleshooting. Replaces `str(version_info)` with `version_info.text` in `browser_use/browser/session.py`.

<sup>Written for commit 44d869eb08f6bfb47a297acd98702c010c75de74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

