### PR TITLE
Fix formatting and clarify setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-**Browser Use CLI 3.0 is here.** Give your coding agent a browser it can use reliably:
+**Browser Use CLI 3.0 is here.** Give your coding agent a browser it can use reliably.
+
+Paste this into Claude Code, Codex, etc:
 
 ```text
 Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
@@ -190,7 +192,7 @@ The CLI allows your agent to control the browser via Python, and it manages the 
 
 ### Agent Skill
 
-For Claude Code, Codex, and other agents, paste this setup prompt into your agent:
+For Claude Code, Codex, and other agents, paste this prompt into your agent:
 
 ```text
 Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.


### PR DESCRIPTION
Corrected formatting and improved clarity in instructions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed README formatting and clarified agent setup. Added a “Paste this into Claude Code, Codex, etc:” note above the prompt and renamed “setup prompt” to “prompt” for consistency.

<sup>Written for commit 1740bad08bd2ff7aadcffe64fa2346d207f858cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

