### PR TITLE
feat: make DOM tree-build CDP timeout configurable via BrowserProfile

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -674,6 +674,14 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		default=5,
 		description='Maximum depth for cross-origin iframe recursion (default: 5 levels deep).',
 	)
+	dom_build_timeout: float = Field(
+		default=10.0,
+		description='Seconds to wait for the parallel CDP calls that build the DOM tree (snapshot, DOM, accessibility, viewport) before retrying the ones that did not finish. Increase for slow remote/proxied browsers where a full getFullAXTree can exceed 10s, otherwise the build falls back to a minimal DOM state.',
+	)
+	dom_build_retry_timeout: float = Field(
+		default=2.0,
+		description='Seconds to wait on the retry pass for the DOM tree-build CDP calls that did not finish within dom_build_timeout.',
+	)
 
 	# --- Page load/wait timings ---
 

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -551,6 +551,8 @@ class DOMWatchdog(BaseWatchdog):
 					paint_order_filtering=self.browser_session.browser_profile.paint_order_filtering,
 					max_iframes=self.browser_session.browser_profile.max_iframes,
 					max_iframe_depth=self.browser_session.browser_profile.max_iframe_depth,
+					dom_build_timeout=self.browser_session.browser_profile.dom_build_timeout,
+					dom_build_retry_timeout=self.browser_session.browser_profile.dom_build_retry_timeout,
 				)
 
 			# Get serialized DOM tree using the service

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -52,6 +52,8 @@ class DomService:
 		max_iframes: int = 100,
 		max_iframe_depth: int = 5,
 		viewport_threshold: int | None = 1000,
+		dom_build_timeout: float = 10.0,
+		dom_build_retry_timeout: float = 2.0,
 	):
 		self.browser_session = browser_session
 		self.logger = logger or browser_session.logger
@@ -60,6 +62,8 @@ class DomService:
 		self.max_iframes = max_iframes
 		self.max_iframe_depth = max_iframe_depth
 		self.viewport_threshold = viewport_threshold
+		self.dom_build_timeout = dom_build_timeout
+		self.dom_build_retry_timeout = dom_build_retry_timeout
 
 	async def __aenter__(self):
 		return self
@@ -564,7 +568,7 @@ class DomService:
 		}
 
 		# Wait for all tasks with timeout
-		done, pending = await asyncio.wait(tasks.values(), timeout=10.0)
+		done, pending = await asyncio.wait(tasks.values(), timeout=self.dom_build_timeout)
 
 		# Retry any failed or timed out tasks
 		if pending:
@@ -589,7 +593,9 @@ class DomService:
 					tasks[key] = retry_map[task]()
 
 			# Wait again with shorter timeout
-			done2, pending2 = await asyncio.wait([t for t in tasks.values() if not t.done()], timeout=2.0)
+			done2, pending2 = await asyncio.wait(
+				[t for t in tasks.values() if not t.done()], timeout=self.dom_build_retry_timeout
+			)
 
 			if pending2:
 				for task in pending2:

--- a/tests/ci/test_dom_build_timeout.py
+++ b/tests/ci/test_dom_build_timeout.py
@@ -1,0 +1,66 @@
+"""Configurable DOM tree-build CDP timeout (dom_build_timeout / dom_build_retry_timeout).
+
+DomService._get_all_trees waits for the parallel CDP tree-build calls (snapshot,
+DOM, accessibility, viewport) with a budget that used to be hardcoded (10s, then a
+2s retry). On slow remote/proxied browsers a full getFullAXTree can exceed 10s, so
+the build fell back to a minimal DOM state with no way to raise the budget short of
+patching the source. These are now BrowserProfile fields threaded through
+DOMWatchdog into DomService.
+
+Defaults must preserve the old behavior; overrides must be stored on DomService and
+reach the asyncio.wait calls in _get_all_trees.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from browser_use import BrowserProfile
+from browser_use.browser.session import BrowserSession
+from browser_use.browser.watchdogs.dom_watchdog import DOMWatchdog
+from browser_use.dom.service import DomService
+
+
+def test_profile_defaults_preserve_legacy_budget():
+	"""Unset fields must keep the historical 10s + 2s budget (backward compatible)."""
+	profile = BrowserProfile()
+	assert profile.dom_build_timeout == 10.0
+	assert profile.dom_build_retry_timeout == 2.0
+
+
+def test_profile_accepts_overrides():
+	profile = BrowserProfile(dom_build_timeout=20.0, dom_build_retry_timeout=6.0)
+	assert profile.dom_build_timeout == 20.0
+	assert profile.dom_build_retry_timeout == 6.0
+
+
+def test_dom_service_stores_timeouts():
+	"""DomService keeps the default budget and honors explicit overrides."""
+	session = BrowserSession(browser_profile=BrowserProfile())
+
+	default = DomService(browser_session=session)
+	assert default.dom_build_timeout == 10.0
+	assert default.dom_build_retry_timeout == 2.0
+
+	configured = DomService(browser_session=session, dom_build_timeout=20.0, dom_build_retry_timeout=6.0)
+	assert configured.dom_build_timeout == 20.0
+	assert configured.dom_build_retry_timeout == 6.0
+
+
+def test_get_all_trees_uses_configured_timeouts_not_literals():
+	"""Regression guard: _get_all_trees must read the configured attributes and not
+	re-introduce the old hardcoded 10.0/2.0 literals. Exercising the full call path
+	needs a live CDP session, so we assert on the source of the two lines this
+	feature changed."""
+	source = inspect.getsource(DomService._get_all_trees)
+	assert 'timeout=self.dom_build_timeout' in source
+	assert 'timeout=self.dom_build_retry_timeout' in source
+	assert 'timeout=10.0' not in source
+	assert 'timeout=2.0' not in source
+
+
+def test_dom_watchdog_threads_profile_timeouts_into_dom_service():
+	"""Regression guard for the profile -> DOMWatchdog -> DomService wiring."""
+	source = inspect.getsource(DOMWatchdog._build_dom_tree_without_highlights)
+	assert 'dom_build_timeout=self.browser_session.browser_profile.dom_build_timeout' in source
+	assert 'dom_build_retry_timeout=self.browser_session.browser_profile.dom_build_retry_timeout' in source


### PR DESCRIPTION
## What this fixes

`DomService._get_all_trees` builds the DOM and accessibility tree by firing the CDP calls in parallel and waiting on them with a hardcoded budget: `asyncio.wait(..., timeout=10.0)` followed by a `2.0s` retry. Those two numbers aren't exposed anywhere — not on `BrowserProfile`, not through an env var, nothing.

That's fine for a local browser. But if you drive a remote/cloud browser over a proxy, a full `Accessibility.getFullAXTree` on a heavy page regularly takes longer than 10 seconds. When it does, the whole build times out, `DOMWatchdog` falls back to a minimal DOM state, and the agent is effectively blind for that step. The only way to raise the limit today is to patch the library source, which is exactly what I had to do before writing this PR.

## What it looks like in practice

Driving a remote cloud browser over a proxied connection, this happens on almost every heavy page:

```text
WARNING  [BrowserSession] CDP request snapshot timed out
WARNING  [BrowserSession] CDP request dom_tree timed out
WARNING  [BrowserSession] CDP request ax_tree timed out
WARNING  [BrowserSession] CDP request device_pixel_ratio timed out
ERROR    [BrowserSession] Failed to build DOM tree without highlights: CDP requests failed or timed out: snapshot, dom_tree, ax_tree, device_pixel_ratio
WARNING  [BrowserSession] DOMWatchdog.on_BrowserStateRequestEvent: DOM build failed: ... using minimal state
WARNING  [bubus] DOMWatchdog.on_BrowserStateRequestEvent() has been running for >15s on event. Possible slow processing or deadlock.
WARNING  [cdp_use.client] Received duplicate response for request 3237 - ignoring
WARNING  [cdp_use.client] Received duplicate response for request 3238 - ignoring
WARNING  [cdp_use.client] Received duplicate response for request 3239 - ignoring
```

Once the build fails and returns minimal state, the agent sees an empty page and burns the step on a wait/retry, often looping on the same page. This is the same failure path already reported in #3615 and #4579.

<details>
<summary>Full traceback</summary>

```text
ERROR    [BrowserSession] Exception in background task [build_dom_tree]: TimeoutError: CDP requests failed or timed out: snapshot, dom_tree, ax_tree, device_pixel_ratio
Traceback (most recent call last):
  File ".../browser_use/utils.py", line 450, in wrapper
    result = await func(*args, **kwargs)
  File ".../browser_use/observability.py", line 73, in async_wrapper
    return await func(*args, **kwargs)
  File ".../browser_use/browser/watchdogs/dom_watchdog.py", in _build_dom_tree_without_highlights
    self.current_dom_state, self.enhanced_dom_tree, timing_info = await self._dom_service.get_serialized_dom_tree(...)
  File ".../browser_use/dom/service.py", in get_serialized_dom_tree
    enhanced_dom_tree, dom_tree_timing = await self.get_dom_tree(...)
  File ".../browser_use/dom/service.py", in get_dom_tree
    trees = await self._get_all_trees(target_id)
  File ".../browser_use/dom/service.py", in _get_all_trees
    raise TimeoutError(f'CDP requests failed or timed out: {", ".join(failed)}')
TimeoutError: CDP requests failed or timed out: snapshot, dom_tree, ax_tree, device_pixel_ratio
```
</details>

## Root cause

The wait budget in `DomService._get_all_trees` is hardcoded:

```python
# Wait for all tasks with timeout
done, pending = await asyncio.wait(tasks.values(), timeout=10.0)   # hardcoded
...
# Wait again with shorter timeout
done2, pending2 = await asyncio.wait([...], timeout=2.0)           # hardcoded
```

10 seconds is reasonable for a local browser, but a `getFullAXTree` on a large, iframe-heavy page reached over a residential proxy or a remote cloud browser often needs more. There's already a knob for the per-request CDP timeout (`BROWSER_USE_CDP_TIMEOUT_S` in `_cdp_timeout.py`), but nothing for this DOM-build budget, so the only option is source patching.

## What I changed

Two new `BrowserProfile` fields, wired through `DOMWatchdog` into `DomService` the same way `max_iframes` and `cross_origin_iframes` already are:

```python
browser = Browser(
    cdp_url="...",                # remote / proxied browser
    dom_build_timeout=20.0,       # was hardcoded 10.0
    dom_build_retry_timeout=6.0,  # was hardcoded 2.0
)
```

The change is small (16 insertions, 2 deletions across 3 files):

- `browser/profile.py` — add `dom_build_timeout` (default `10.0`) and `dom_build_retry_timeout` (default `2.0`).
- `browser/watchdogs/dom_watchdog.py` — pass both from `browser_profile` into `DomService(...)`.
- `dom/service.py` — accept both in `__init__` and use `self.dom_build_timeout` / `self.dom_build_retry_timeout` in `_get_all_trees` instead of the literals.

## Numbers

In one session against a remote cloud browser over a proxy, `get_state` averaged 5.4s and peaked at 14.6s, and a couple of builds went past the 10+2s window and dropped to minimal state. Raising the budget to 20s/6s removed the collapses: max build time came down to 9.3s, with no more `ax_tree` timeouts, DOM build failures, or ">15s handler" warnings. Nothing else changed.

## Backward compatibility

Defaults stay at `10.0` and `2.0`, so behavior is identical unless you opt in.

## Tests

`tests/ci/test_dom_build_timeout.py` covers:

- defaults preserve the existing `10.0` / `2.0` budget,
- overrides are accepted on `BrowserProfile`,
- `DomService` stores the defaults and honors overrides,
- regression guards that `_get_all_trees` reads the configured attributes instead of the old literals, and that `DOMWatchdog` threads the profile values into `DomService`.

## Related

- #3615, #4579 — same `_get_all_trees` to `ax_tree` timeout to minimal-state path.
- #2029, #4491 — configurable-timeout requests for other layers (context setup, navigation); this covers the DOM-build gap.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the DOM tree-build CDP timeout configurable to avoid false timeouts on slow or remote browsers. Adds `dom_build_timeout` and `dom_build_retry_timeout` to `BrowserProfile` while keeping the old 10s/2s defaults.

- **New Features**
  - Added `BrowserProfile.dom_build_timeout` (default `10.0`) and `BrowserProfile.dom_build_retry_timeout` (default `2.0`).
  - `DOMWatchdog` now passes these values to `DomService`, which uses them in `_get_all_trees`.
  - Backward compatible: defaults preserve current behavior.

<sup>Written for commit a02958bc9daf5a0cbe75d903eba1a42c6d6fd438. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

