### PR TITLE
docs: add AgentCert Tripwire to community integrations

### DIFF
--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -28,3 +28,5 @@ Add entries in this format:
 ```markdown
 - [Project name](https://github.com/org/project) - One sentence about what it integrates with. Maintained by @github-handle.
 ```
+
+- [AgentCert Tripwire](https://github.com/Kakarottoooo/agentcert) - CI regression gate that runs a Browser Use agent under injected web faults (popups, button drift, decoy buttons, prompt-injection banners, slow network, HTTP failures) and grades runs deterministically with screenshots, traces, and JUnit output. Maintained by @Kakarottoooo.


### PR DESCRIPTION
# PR body: docs: add AgentCert Tripwire to community integrations

Adds AgentCert Tripwire to the community integrations list, following the
format requested in `examples/integrations/README.md`.

**What it is:** an Apache-2.0 CI harness that launches a controlled Chromium,
hands browser-use a CDP endpoint, injects one realistic web fault per run
(modal overlay, button-text drift, decoy button, disabled submit, layout
shift, prompt-injection banner, slow network, HTTP 503), and grades each run
with deterministic assertions. Output per run: HTML report, JUnit, screenshots,
DOM snapshots, and a step-level trace — so a browser-use regression shows up on
the PR that caused it (prompt change, model swap, target-site drift).

**Why it may be useful to browser-use users:** we published a reproducible
robustness matrix over the same task and fault suite for five agents, and
browser-use currently has the best score (8/9), adapting through faults that
crashed scripted Playwright agents:
https://kakarottoooo.github.io/agentcert/public-demo/real-agent-robustness/

The adapter used for that published run is ~80 lines and connects through
`BrowserProfile(cdp_url=...)`:
https://github.com/Kakarottoooo/agentcert/tree/main/examples/real-agents/browser-use

No code is vendored into this repository; this is a listing only, per the
integrations README guidance. Happy to also contribute a small runnable
`examples/integrations/agentcert-tripwire/` example (uv setup, no secrets,
`ChatBrowserUse()` default) if maintainers would find that useful.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds AgentCert Tripwire to the community integrations list as a CI regression gate that runs a Browser Use agent under injected web faults and outputs deterministic reports (screenshots, traces, JUnit).
Docs-only change to `examples/integrations/README.md`.

<sup>Written for commit 18e334eb7cfa9bb9990df5e40cacd15c14bbb698. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

