### PR TITLE
Guard browser event bus shutdown with timeout

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -104,7 +104,7 @@ class CDPSession(BaseModel):
 
 
 class ResilientEventBus(EventBus):
-	"""EventBus whose step()/wait_until_idle() no-op on a torn-down bus instead of asserting.
+	"""EventBus whose shutdown paths tolerate torn-down or unresponsive buses.
 
 	Agent.close() stops a keep_alive session's bus and nulls its async primitives to release
 	the event loop. On warm-Lambda resume the worker can step() it before a dispatch() restarts
@@ -129,6 +129,43 @@ class ResilientEventBus(EventBus):
 		if self._on_idle is None or self.event_queue is None:
 			return None
 		return await super().wait_until_idle(timeout)
+
+	async def stop(self, timeout: float | None = None, clear: bool = False) -> None:
+		if timeout is None or timeout <= 0:
+			await super().stop(timeout=timeout, clear=clear)
+			return
+
+		try:
+			watchdog_timeout = timeout + min(1.0, max(0.1, timeout * 0.1))
+			await asyncio.wait_for(super().stop(timeout=timeout, clear=clear), timeout=watchdog_timeout)
+		except TimeoutError:
+			logging.getLogger(__name__).warning('Timed out stopping %s after %.2fs; forcing shutdown', self, timeout)
+			self._force_shutdown(clear=clear)
+
+	def _force_shutdown(self, clear: bool) -> None:
+		self._is_running = False
+
+		if self.event_queue:
+			self.event_queue.shutdown()
+
+		if self._runloop_task and not self._runloop_task.done():
+			self._runloop_task.cancel()
+		self._runloop_task = None
+
+		if self._on_idle:
+			self._on_idle.set()
+
+		if clear:
+			self.event_history.clear()
+			self.handlers.clear()
+			if self in EventBus.all_instances:
+				EventBus.all_instances.discard(self)
+			try:
+				loop = asyncio.get_running_loop()
+				if hasattr(loop, '_eventbus_instances'):
+					loop._eventbus_instances.discard(self)
+			except RuntimeError:
+				pass
 
 
 class BrowserSession(BaseModel):

--- a/tests/ci/test_event_bus_resilience.py
+++ b/tests/ci/test_event_bus_resilience.py
@@ -69,6 +69,28 @@ async def test_torn_down_bus_still_restarts_on_dispatch():
 	await bus.stop(timeout=0.5)
 
 
+async def test_stop_forces_shutdown_when_idle_wait_hangs(monkeypatch):
+	"""Stopping the resilient bus must not hang if the idle wait never returns."""
+	bus = ResilientEventBus(name='ResilientWarmResumeStop')
+	bus.dispatch(ResiliencePingEvent())
+	await asyncio.sleep(0.1)
+
+	async def never_idle(timeout: float | None = None) -> None:
+		await asyncio.Event().wait()
+
+	monkeypatch.setattr(bus, 'wait_until_idle', never_idle)
+
+	started_at = asyncio.get_running_loop().time()
+	await bus.stop(clear=True, timeout=0.05)
+	elapsed = asyncio.get_running_loop().time() - started_at
+
+	assert elapsed < 0.5
+	assert bus._is_running is False
+	assert bus._runloop_task is None
+	assert bus.event_history == {}
+	assert bus.handlers == {}
+
+
 async def test_stock_event_bus_reproduces_the_crash():
 	"""Document the upstream bug the subclass guards against (stock bus still asserts)."""
 	bus = EventBus(name='StockWarmResume')


### PR DESCRIPTION
## Summary
- add a watchdog around `ResilientEventBus.stop()` so browser event bus shutdown cannot hang indefinitely
- force-shutdown the queue/runloop and clear references if the graceful stop path exceeds its timeout
- add a regression test for a hung idle wait during stop

Fixes #5097

## Tests
- `uv run pytest tests/ci/test_event_bus_resilience.py -q`
- `uv run ruff check browser_use/browser/session.py tests/ci/test_event_bus_resilience.py`
- `uv run ruff format --check browser_use/browser/session.py tests/ci/test_event_bus_resilience.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a watchdog timeout to `ResilientEventBus.stop()` so browser event bus shutdown can’t hang. If the graceful stop exceeds its deadline, we force-cleanup to prevent warm-resume lockups. Fixes #5097.

- **Bug Fixes**
  - Guard `stop()` with `asyncio.wait_for` using a small buffer over the caller timeout.
  - On timeout, force-shutdown: stop the queue, cancel the runloop, set idle, and (when `clear=True`) wipe handlers/history and remove instance references.
  - Add regression test to ensure shutdown completes quickly when `wait_until_idle` never returns.

<sup>Written for commit a53c09c0cf9811daa0fc57ce954f886615c81bcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

