### PR TITLE
Guard browser event bus shutdown with timeout

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -104,7 +104,7 @@ class CDPSession(BaseModel):
 
 
 class ResilientEventBus(EventBus):
-	"""EventBus whose step()/wait_until_idle() no-op on a torn-down bus instead of asserting.
+	"""EventBus whose shutdown paths tolerate torn-down or unresponsive buses.
 
 	Agent.close() stops a keep_alive session's bus and nulls its async primitives to release
 	the event loop. On warm-Lambda resume the worker can step() it before a dispatch() restarts
@@ -129,6 +129,44 @@ class ResilientEventBus(EventBus):
 		if self._on_idle is None or self.event_queue is None:
 			return None
 		return await super().wait_until_idle(timeout)
+
+	async def stop(self, timeout: float | None = None, clear: bool = False) -> None:
+		if timeout is None or timeout <= 0:
+			await super().stop(timeout=timeout, clear=clear)
+			return
+
+		try:
+			watchdog_timeout = timeout + min(1.0, max(0.1, timeout * 0.1))
+			await asyncio.wait_for(super().stop(timeout=timeout, clear=clear), timeout=watchdog_timeout)
+		except TimeoutError:
+			logging.getLogger(__name__).warning('Timed out stopping %s after %.2fs; forcing shutdown', self, timeout)
+			self._force_shutdown(clear=clear)
+
+	def _force_shutdown(self, clear: bool) -> None:
+		self._is_running = False
+
+		if self.event_queue:
+			self.event_queue.shutdown()
+
+		if self._runloop_task and not self._runloop_task.done():
+			self._runloop_task.cancel()
+		self._runloop_task = None
+
+		if self._on_idle:
+			self._on_idle.set()
+
+		if clear:
+			self.event_history.clear()
+			self.handlers.clear()
+			if self in EventBus.all_instances:
+				EventBus.all_instances.discard(self)
+			try:
+				loop = asyncio.get_running_loop()
+				eventbus_instances = getattr(loop, '_eventbus_instances', None)
+				if eventbus_instances is not None:
+					eventbus_instances.discard(self)
+			except RuntimeError:
+				pass
 
 
 class BrowserSession(BaseModel):

--- a/tests/ci/test_event_bus_resilience.py
+++ b/tests/ci/test_event_bus_resilience.py
@@ -69,6 +69,28 @@ async def test_torn_down_bus_still_restarts_on_dispatch():
 	await bus.stop(timeout=0.5)
 
 
+async def test_stop_forces_shutdown_when_idle_wait_hangs(monkeypatch):
+	"""Stopping the resilient bus must not hang if the idle wait never returns."""
+	bus = ResilientEventBus(name='ResilientWarmResumeStop')
+	bus.dispatch(ResiliencePingEvent())
+	await asyncio.sleep(0.1)
+
+	async def never_idle(timeout: float | None = None) -> None:
+		await asyncio.Event().wait()
+
+	monkeypatch.setattr(bus, 'wait_until_idle', never_idle)
+
+	started_at = asyncio.get_running_loop().time()
+	await bus.stop(clear=True, timeout=0.05)
+	elapsed = asyncio.get_running_loop().time() - started_at
+
+	assert elapsed < 0.5
+	assert bus._is_running is False
+	assert bus._runloop_task is None
+	assert bus.event_history == {}
+	assert bus.handlers == {}
+
+
 async def test_stock_event_bus_reproduces_the_crash():
 	"""Document the upstream bug the subclass guards against (stock bus still asserts)."""
 	bus = EventBus(name='StockWarmResume')


### PR DESCRIPTION
## Summary
- add a watchdog around `ResilientEventBus.stop()` so browser event bus shutdown cannot hang indefinitely
- force-shutdown the queue/runloop and clear references if the graceful stop path exceeds its timeout
- add a regression test for a hung idle wait during stop

Fixes #5097

## Tests
- `uv run pytest tests/ci/test_event_bus_resilience.py -q`
- `uv run pyright browser_use/browser/session.py`
- `uv run ruff check browser_use/browser/session.py tests/ci/test_event_bus_resilience.py`
- `uv run ruff format --check browser_use/browser/session.py tests/ci/test_event_bus_resilience.py`
- `uv run --no-sync pre-commit run --files browser_use/browser/session.py tests/ci/test_event_bus_resilience.py --show-diff-on-failure`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the browser event bus from hanging on shutdown by adding a timeout-guarded stop and a force-cleanup path. Ensures warm resumes and shutdowns don’t block and resources are released.

- **Bug Fixes**
  - Added a watchdog around `ResilientEventBus.stop(timeout=...)`; if the graceful stop exceeds the timeout, it force-shuts down the queue and runloop and optionally clears state.
  - Preserves previous behavior when `timeout` is None or <= 0.
  - Added a regression test that simulates a hung `wait_until_idle` and verifies stop completes quickly and cleans up.

<sup>Written for commit c9a55e9f99589367517252f58af9095b2c3aebdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

