### PR TITLE
fix(dom): preserve explicit empty accessibility names

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -848,7 +848,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -876,7 +876,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_dom_interacted_element.py
+++ b/tests/ci/test_dom_interacted_element.py
@@ -5,90 +5,90 @@ DOMInteractedElement.load_from_enhanced_dom_tree should preserve the empty strin
 instead of collapsing it to None.
 """
 
-import pytest
 
 from browser_use.dom.views import DOMInteractedElement, DOMRect, NodeType
 
 
 class FakeAXNode:
-    """A minimal fake AX node for testing."""
-    def __init__(self, name: str | None):
-        self.name = name
+	"""A minimal fake AX node for testing."""
+
+	def __init__(self, name: str | None):
+		self.name = name
 
 
 class FakeSnapshotNode:
-    """A minimal fake snapshot node."""
-    def __init__(self):
-        self.bounds = DOMRect(x=0, y=0, width=100, height=50)
+	"""A minimal fake snapshot node."""
+
+	def __init__(self):
+		self.bounds = DOMRect(x=0, y=0, width=100, height=50)
 
 
 class FakeEnhancedDOMTreeNode:
-    """A minimal fake EnhancedDOMTreeNode for testing load_from_enhanced_dom_tree."""
-    def __init__(self, ax_node: FakeAXNode | None, attributes: dict | None = None):
-        self.ax_node = ax_node
-        self.node_id = 1
-        self.backend_node_id = 1
-        self.frame_id = None
-        self.node_type = NodeType.ELEMENT_NODE
-        self.node_value = ''
-        self.node_name = 'DIV'
-        self.attributes = attributes or {}
-        self.snapshot_node = FakeSnapshotNode()
-        self.xpath = 'html/body/div[1]'
+	"""A minimal fake EnhancedDOMTreeNode for testing load_from_enhanced_dom_tree."""
 
-    def __hash__(self):
-        return 123456
+	def __init__(self, ax_node: FakeAXNode | None, attributes: dict | None = None):
+		self.ax_node = ax_node
+		self.node_id = 1
+		self.backend_node_id = 1
+		self.frame_id = None
+		self.node_type = NodeType.ELEMENT_NODE
+		self.node_value = ''
+		self.node_name = 'DIV'
+		self.attributes = attributes or {}
+		self.snapshot_node = FakeSnapshotNode()
+		self.xpath = 'html/body/div[1]'
 
-    def compute_stable_hash(self):
-        return 123456
+	def __hash__(self):
+		return 123456
+
+	def compute_stable_hash(self):
+		return 123456
 
 
 def test_ax_name_empty_string_preserved():
-    """ax_name="" should be preserved as empty string, not collapsed to None."""
-    fake_ax_node = FakeAXNode(name='')
-    fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
+	"""ax_name="" should be preserved as empty string, not collapsed to None."""
+	fake_ax_node = FakeAXNode(name='')
+	fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
 
-    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
 
-    assert element.ax_name == '', (
-        f'Empty ax_name should be preserved as "", not {element.ax_name!r}'
-    )
+	assert element.ax_name == '', f'Empty ax_name should be preserved as "", not {element.ax_name!r}'
 
 
 def test_ax_name_non_empty_string_preserved():
-    """ax_name="New Contact" should be preserved."""
-    fake_ax_node = FakeAXNode(name='New Contact')
-    fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
+	"""ax_name="New Contact" should be preserved."""
+	fake_ax_node = FakeAXNode(name='New Contact')
+	fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
 
-    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
 
-    assert element.ax_name == 'New Contact'
+	assert element.ax_name == 'New Contact'
 
 
 def test_ax_name_none_when_no_ax_node():
-    """ax_name should be None when ax_node is absent."""
-    fake_tree = FakeEnhancedDOMTreeNode(ax_node=None)
+	"""ax_name should be None when ax_node is absent."""
+	fake_tree = FakeEnhancedDOMTreeNode(ax_node=None)
 
-    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
 
-    assert element.ax_name is None
+	assert element.ax_name is None
 
 
 def test_ax_name_none_when_ax_node_name_is_none():
-    """ax_name should be None when ax_node.name is None."""
-    fake_ax_node = FakeAXNode(name=None)
-    fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
+	"""ax_name should be None when ax_node.name is None."""
+	fake_ax_node = FakeAXNode(name=None)
+	fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
 
-    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
 
-    assert element.ax_name is None
+	assert element.ax_name is None
 
 
 def test_ax_name_whitespace_string_preserved():
-    """ax_name=" " (whitespace) should be preserved as-is."""
-    fake_ax_node = FakeAXNode(name=' ')
-    fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
+	"""ax_name=" " (whitespace) should be preserved as-is."""
+	fake_ax_node = FakeAXNode(name=' ')
+	fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
 
-    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
 
-    assert element.ax_name == ' '
+	assert element.ax_name == ' '

--- a/tests/ci/test_dom_interacted_element.py
+++ b/tests/ci/test_dom_interacted_element.py
@@ -5,8 +5,9 @@ DOMInteractedElement.load_from_enhanced_dom_tree should preserve the empty strin
 instead of collapsing it to None.
 """
 
+from typing import cast
 
-from browser_use.dom.views import DOMInteractedElement, DOMRect, NodeType
+from browser_use.dom.views import DOMInteractedElement, DOMRect, EnhancedDOMTreeNode, NodeType
 
 
 class FakeAXNode:
@@ -50,7 +51,7 @@ def test_ax_name_empty_string_preserved():
 	fake_ax_node = FakeAXNode(name='')
 	fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
 
-	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(cast(EnhancedDOMTreeNode, fake_tree))
 
 	assert element.ax_name == '', f'Empty ax_name should be preserved as "", not {element.ax_name!r}'
 
@@ -60,7 +61,7 @@ def test_ax_name_non_empty_string_preserved():
 	fake_ax_node = FakeAXNode(name='New Contact')
 	fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
 
-	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(cast(EnhancedDOMTreeNode, fake_tree))
 
 	assert element.ax_name == 'New Contact'
 
@@ -69,7 +70,7 @@ def test_ax_name_none_when_no_ax_node():
 	"""ax_name should be None when ax_node is absent."""
 	fake_tree = FakeEnhancedDOMTreeNode(ax_node=None)
 
-	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(cast(EnhancedDOMTreeNode, fake_tree))
 
 	assert element.ax_name is None
 
@@ -79,7 +80,7 @@ def test_ax_name_none_when_ax_node_name_is_none():
 	fake_ax_node = FakeAXNode(name=None)
 	fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
 
-	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(cast(EnhancedDOMTreeNode, fake_tree))
 
 	assert element.ax_name is None
 
@@ -89,6 +90,6 @@ def test_ax_name_whitespace_string_preserved():
 	fake_ax_node = FakeAXNode(name=' ')
 	fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
 
-	element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(cast(EnhancedDOMTreeNode, fake_tree))
 
 	assert element.ax_name == ' '

--- a/tests/ci/test_dom_interacted_element.py
+++ b/tests/ci/test_dom_interacted_element.py
@@ -1,0 +1,94 @@
+"""Test for Issue #5041: Preserve explicit empty accessibility names.
+
+When an EnhancedDOMTreeNode has an ax_node with name="" (explicitly empty),
+DOMInteractedElement.load_from_enhanced_dom_tree should preserve the empty string
+instead of collapsing it to None.
+"""
+
+import pytest
+
+from browser_use.dom.views import DOMInteractedElement, DOMRect, NodeType
+
+
+class FakeAXNode:
+    """A minimal fake AX node for testing."""
+    def __init__(self, name: str | None):
+        self.name = name
+
+
+class FakeSnapshotNode:
+    """A minimal fake snapshot node."""
+    def __init__(self):
+        self.bounds = DOMRect(x=0, y=0, width=100, height=50)
+
+
+class FakeEnhancedDOMTreeNode:
+    """A minimal fake EnhancedDOMTreeNode for testing load_from_enhanced_dom_tree."""
+    def __init__(self, ax_node: FakeAXNode | None, attributes: dict | None = None):
+        self.ax_node = ax_node
+        self.node_id = 1
+        self.backend_node_id = 1
+        self.frame_id = None
+        self.node_type = NodeType.ELEMENT_NODE
+        self.node_value = ''
+        self.node_name = 'DIV'
+        self.attributes = attributes or {}
+        self.snapshot_node = FakeSnapshotNode()
+        self.xpath = 'html/body/div[1]'
+
+    def __hash__(self):
+        return 123456
+
+    def compute_stable_hash(self):
+        return 123456
+
+
+def test_ax_name_empty_string_preserved():
+    """ax_name="" should be preserved as empty string, not collapsed to None."""
+    fake_ax_node = FakeAXNode(name='')
+    fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
+
+    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+
+    assert element.ax_name == '', (
+        f'Empty ax_name should be preserved as "", not {element.ax_name!r}'
+    )
+
+
+def test_ax_name_non_empty_string_preserved():
+    """ax_name="New Contact" should be preserved."""
+    fake_ax_node = FakeAXNode(name='New Contact')
+    fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
+
+    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+
+    assert element.ax_name == 'New Contact'
+
+
+def test_ax_name_none_when_no_ax_node():
+    """ax_name should be None when ax_node is absent."""
+    fake_tree = FakeEnhancedDOMTreeNode(ax_node=None)
+
+    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+
+    assert element.ax_name is None
+
+
+def test_ax_name_none_when_ax_node_name_is_none():
+    """ax_name should be None when ax_node.name is None."""
+    fake_ax_node = FakeAXNode(name=None)
+    fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
+
+    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+
+    assert element.ax_name is None
+
+
+def test_ax_name_whitespace_string_preserved():
+    """ax_name=" " (whitespace) should be preserved as-is."""
+    fake_ax_node = FakeAXNode(name=' ')
+    fake_tree = FakeEnhancedDOMTreeNode(ax_node=fake_ax_node)
+
+    element = DOMInteractedElement.load_from_enhanced_dom_tree(fake_tree)
+
+    assert element.ax_name == ' '


### PR DESCRIPTION
In DOMInteractedElement.load_from_enhanced_dom_tree, the truthiness check  collapsed explicit empty strings ("") to None, conflating two distinct states: "attribute does not exist" vs "attribute exists but is intentionally empty".

Fixed by using explicit  check across all three locations in views.py where ax_node.name is accessed:
- __hash__ method (line 851)
- __str__ method (line 879)
- load_from_enhanced_dom_tree (line 1025)

Added regression tests covering empty string, whitespace, None, and missing ax_node scenarios.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves explicit empty accessibility names by not collapsing "" to `None` when loading or hashing DOM elements. Prevents mixing up missing vs intentionally empty names; addresses #5041.

- **Bug Fixes**
  - Use explicit `None` checks for `ax_node.name` in `compute_stable_hash`, `__hash__`, and `load_from_enhanced_dom_tree`.
  - Add regression tests for "", whitespace, `None`, and missing `ax_node`; fix ruff formatting and pyright type issues in tests (e.g., `typing.cast`, imports).

<sup>Written for commit fb2c2c222f0dbbdfe972f9076c490a46376e3580. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

