### PR TITLE
fix(dom): preserve empty accessibility names

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -848,7 +848,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -876,7 +876,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_ax_name_matching.py
+++ b/tests/ci/test_ax_name_matching.py
@@ -9,13 +9,54 @@ Also tests dropdown/menu re-opening behavior when menu items can't be found
 because the dropdown closed during the wait between steps.
 """
 
+from dataclasses import replace
 from unittest.mock import AsyncMock
 
 from browser_use.agent.service import Agent
 from browser_use.agent.views import ActionResult, AgentHistory, AgentHistoryList, RerunSummaryAction, StepMetadata
 from browser_use.browser.views import BrowserStateHistory
-from browser_use.dom.views import DOMInteractedElement, DOMRect, MatchLevel, NodeType
+from browser_use.dom.views import DOMInteractedElement, DOMRect, EnhancedAXNode, EnhancedDOMTreeNode, MatchLevel, NodeType
 from tests.ci.conftest import create_mock_llm
+
+
+def test_load_from_enhanced_dom_tree_preserves_empty_ax_name():
+	"""Explicitly empty accessibility names should not be collapsed to None."""
+	enhanced_node = EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=EnhancedAXNode(
+			ax_node_id='ax-1',
+			ignored=False,
+			role='button',
+			name='',
+			description=None,
+			properties=None,
+			child_ids=None,
+		),
+		snapshot_node=None,
+	)
+
+	element = DOMInteractedElement.load_from_enhanced_dom_tree(enhanced_node)
+	node_without_ax_name = replace(enhanced_node, ax_node=None)
+
+	assert element.ax_name == ''
+	assert hash(enhanced_node) != hash(node_without_ax_name)
+	assert enhanced_node.compute_stable_hash() != node_without_ax_name.compute_stable_hash()
 
 
 async def test_ax_name_matching_succeeds_when_hash_fails(httpserver):


### PR DESCRIPTION
## Summary
- preserve explicitly empty accessibility names when building DOMInteractedElement instances
- include empty accessibility names in element hash/stable hash calculations
- add regression coverage for an empty AX name vs a missing AX node

Fixes #5041

## Tests
- UV_CACHE_DIR=/private/tmp/uv-cache-browser-use uv run pytest -q tests/ci/test_ax_name_matching.py::test_load_from_enhanced_dom_tree_preserves_empty_ax_name
- UV_CACHE_DIR=/private/tmp/uv-cache-browser-use uv run pytest -q tests/ci/test_ax_name_matching.py::test_ax_name_matching_requires_same_node_type
- UV_CACHE_DIR=/private/tmp/uv-cache-browser-use uv run ruff check browser_use/dom/views.py tests/ci/test_ax_name_matching.py
- UV_CACHE_DIR=/private/tmp/uv-cache-browser-use uv run ruff format --check browser_use/dom/views.py tests/ci/test_ax_name_matching.py
- PATH=/private/tmp/uv-python-browser-use/cpython-3.11.15-macos-aarch64-none/bin:$PATH PRE_COMMIT_HOME=/private/tmp/pre-commit-browser-use UV_CACHE_DIR=/private/tmp/uv-cache-browser-use uv run pre-commit run --files browser_use/dom/views.py tests/ci/test_ax_name_matching.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves explicitly empty accessibility names ("") and includes them in hashing to prevent mismatches. Ensures empty names aren’t treated as missing AX nodes.

- **Bug Fixes**
  - Treat empty AX names as valid in `load_from_enhanced_dom_tree`.
  - Include empty AX names in `__hash__` and `compute_stable_hash`.
  - Add regression test verifying empty AX name is preserved and affects both hashes vs a missing AX node.

<sup>Written for commit eca2334d933844f24122a1aae3558732699cc866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

