### PR TITLE
fix(utils): prevent cascading redaction in redact_sensitive_string

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -74,10 +74,23 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 
 
 def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
-	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
-	for key, secret in sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True):
-		value = value.replace(secret, f'<secret>{key}</secret>')
-	return value
+	if not sensitive_values:
+		return value
+
+	# Create a lookup of secret -> key, keeping the first (longest) key for each secret
+	# Sorting by value length ensures that in the regex, the longest match is tried first
+	sorted_items = sorted(sensitive_values.items(), key=lambda x: len(x[1]), reverse=True)
+	lookup = {}
+	for k, v in sorted_items:
+		if v and v not in lookup:
+			lookup[v] = k
+
+	if not lookup:
+		return value
+
+	# Single-pass replacement using regex prevents cascading redaction
+	pattern = '|'.join(re.escape(s) for s in lookup)
+	return re.sub(pattern, lambda m: f'<secret>{lookup[m.group(0)]}</secret>', value)
 
 
 def _get_openai_bad_request_error() -> type | None:

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -74,23 +74,24 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 
 
 def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
+	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
 	if not sensitive_values:
 		return value
 
-	# Create a lookup of secret -> key, keeping the first (longest) key for each secret
-	# Sorting by value length ensures that in the regex, the longest match is tried first
+	# Sort by length descending to ensure longer matches take priority
 	sorted_items = sorted(sensitive_values.items(), key=lambda x: len(x[1]), reverse=True)
+
 	lookup = {}
 	for k, v in sorted_items:
 		if v and v not in lookup:
-			lookup[v] = k
+			lookup[v] = f'<secret>{k}</secret>'
 
 	if not lookup:
 		return value
 
-	# Single-pass replacement using regex prevents cascading redaction
-	pattern = '|'.join(re.escape(s) for s in lookup)
-	return re.sub(pattern, lambda m: f'<secret>{lookup[m.group(0)]}</secret>', value)
+	# Single-pass regex prevents cascading redaction of placeholder tags
+	pattern = re.compile('|'.join(re.escape(s) for s in lookup))
+	return pattern.sub(lambda m: lookup[m.group(0)], value)
 
 
 def _get_openai_bad_request_error() -> type | None:


### PR DESCRIPTION
The current redact_sensitive_string uses a str.replace loop, which causes "redaction inception" if a secret happens to be a substring of the <secret> tag itself (e.g., the word "secret").
This PR switches to a single-pass re.sub approach. This ensures we only process the string once—preventing cascading replacements—and correctly handles overlapping secrets by sorting them by length.

# Fixes
Issue #5135.

# Verification
Tested with the reproduction case provided in issue #5135:
``` Python
# Before fix:
'leaked <<secret>type</secret>>password</<secret>type</secret>> token'

# After fix:
'leaked <secret>password</secret> token'
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cascading redaction in redact_sensitive_string by switching to a single-pass regex that replaces longest matches first. Fixes #5135 and avoids corrupting <secret> tags when secrets overlap or contain "secret".

- **Bug Fixes**
  - Replaced iterative str.replace loop with a single re.sub using a pre-escaped combined pattern.
  - Sorted secrets by length, deduped by value, and skipped empty secrets.
  - Added early returns when no secrets or no valid patterns are present.

<sup>Written for commit 6dff3d3a424a4f22473ddc3eb6f9f27d1641f0c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

