### PR TITLE
Add arXiv browser integration example

### DIFF
--- a/examples/integrations/arxiv/README.md
+++ b/examples/integrations/arxiv/README.md
@@ -1,0 +1,32 @@
+# arXiv Integration
+
+This example shows a polite browser fallback for collecting structured arXiv search results with Browser Use.
+
+Use the official arXiv export API, OpenAlex, or Semantic Scholar first when possible. This browser workflow is useful when a research agent needs to verify arXiv result pages, collect PDF links, or recover metadata after an upstream API failure.
+
+## Setup
+
+Set your Browser Use API key:
+
+```sh
+export BROWSER_USE_API_KEY=your-key
+```
+
+## Run
+
+From the repository root:
+
+```sh
+uv run python examples/integrations/arxiv/arxiv_literature_browser.py "large language model interpretability" --limit 10
+```
+
+Use `--headed` while developing selectors or reviewing extraction behavior.
+
+## What it demonstrates
+
+- Restricting the browser to arXiv with `BrowserProfile(allowed_domains=["*.arxiv.org", "arxiv.org"])`
+- Returning structured paper metadata with a Pydantic output model
+- Treating browser automation as a fallback, not a replacement for official APIs
+- Stopping on CAPTCHA, login, bot-protection, or other access-control pages
+
+The example extracts title, authors, arXiv ID, abstract, URL, PDF URL, submitted date, and subjects.

--- a/examples/integrations/arxiv/arxiv_literature_browser.py
+++ b/examples/integrations/arxiv/arxiv_literature_browser.py
@@ -1,0 +1,106 @@
+"""Collect structured arXiv search results with Browser Use.
+
+This example is intended as an optional browser fallback after official
+metadata APIs have been tried. It keeps the browser restricted to arXiv and
+returns a structured Pydantic result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from urllib.parse import urlencode
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, Field
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from browser_use import Agent, BrowserProfile, ChatBrowserUse, Tools
+
+
+class ArxivPaper(BaseModel):
+	title: str
+	authors: list[str] = Field(default_factory=list)
+	arxiv_id: str = ''
+	abstract: str = ''
+	url: str = ''
+	pdf_url: str = ''
+	submitted: str = ''
+	subjects: list[str] = Field(default_factory=list)
+	notes: str = ''
+
+
+class ArxivSearchResult(BaseModel):
+	query: str
+	source_url: str
+	papers: list[ArxivPaper] = Field(default_factory=list)
+	blocked: bool = False
+	notes: str = ''
+
+
+def build_arxiv_search_url(query: str, limit: int) -> str:
+	size = min((25, 50, 100, 200), key=lambda value: abs(value - limit))
+	params = {
+		'query': query,
+		'searchtype': 'all',
+		'abstracts': 'show',
+		'order': '-announced_date_first',
+		'size': str(size),
+	}
+	return f'https://arxiv.org/search/?{urlencode(params)}'
+
+
+def parse_args() -> argparse.Namespace:
+	parser = argparse.ArgumentParser(description=__doc__)
+	parser.add_argument('query', help='arXiv search query.')
+	parser.add_argument('--limit', type=int, default=10, help='Number of papers to extract.')
+	parser.add_argument('--headed', action='store_true', help='Show the browser window.')
+	parser.add_argument('--max-steps', type=int, default=12)
+	return parser.parse_args()
+
+
+async def main() -> None:
+	load_dotenv()
+	args = parse_args()
+	limit = max(1, min(args.limit, 50))
+	source_url = build_arxiv_search_url(args.query, limit)
+
+	task = f"""
+Open this arXiv search URL and extract up to {limit} papers as JSON.
+
+URL: {source_url}
+
+Return exactly this schema: query, source_url, papers, blocked, notes.
+For each paper return title, authors, arxiv_id, abstract, url, pdf_url,
+submitted, subjects, and notes.
+
+Rules:
+- Stay on arxiv.org.
+- Prefer DOM text over screenshots.
+- Do not solve CAPTCHAs, bypass bot protection, or use login-only data.
+- If blocked, set blocked=true and explain the blocker in notes.
+""".strip()
+
+	tools = Tools(output_model=ArxivSearchResult)
+	browser_profile = BrowserProfile(
+		allowed_domains=['*.arxiv.org', 'arxiv.org'],
+		enable_default_extensions=False,
+		headless=not args.headed,
+	)
+	agent = Agent(task=task, llm=ChatBrowserUse(), tools=tools, browser_profile=browser_profile)
+
+	history = await agent.run(max_steps=args.max_steps)
+	raw_result = history.final_result()
+	if not raw_result:
+		raise SystemExit('No structured result returned.')
+
+	result = ArxivSearchResult.model_validate_json(raw_result)
+	print(json.dumps(result.model_dump(), ensure_ascii=False, indent=2))
+
+
+if __name__ == '__main__':
+	asyncio.run(main())


### PR DESCRIPTION
## Summary
- add an arXiv integration example for collecting structured literature search results
- restrict the browser to arxiv.org domains with BrowserProfile.allowed_domains
- document that official metadata APIs should be tried before browser fallback

## Validation
- python -m py_compile examples/integrations/arxiv/arxiv_literature_browser.py
- git diff --cached --check

## Notes
This is intentionally an example-only contribution. It does not add arXiv-specific behavior to browser-use core and does not attempt CAPTCHA solving, login bypass, or broad crawling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an arXiv browser integration example that collects structured search results using `browser_use`, restricted to arxiv.org. Intended as a polite fallback when official metadata APIs are unavailable.

- New Features
  - Example script to collect structured arXiv search results using `browser_use`.
  - Restricts browsing to arxiv.org via `BrowserProfile.allowed_domains`; headless by default with `--headed`.
  - Outputs a Pydantic `ArxivSearchResult` (title, authors, arXiv ID, abstract, URLs, submitted date, subjects).
  - Treated as a fallback; stops on CAPTCHA/login and sets `blocked=true` with notes; README includes quick run steps.

<sup>Written for commit 458e2595881f9b129e4786e83c5a04adf6c7a080. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

