### PR TITLE
fix(utils): single-pass regex in redact_sensitive_string to prevent placeholder cascade

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -74,10 +74,25 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 
 
 def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
-	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
-	for key, secret in sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True):
-		value = value.replace(secret, f'<secret>{key}</secret>')
-	return value
+	"""Replace sensitive values with placeholders in a single pass.
+
+	Sorts secrets longest-first so that longer secrets take priority over
+	shorter ones that are substrings of them. A single re.sub call ensures
+	that placeholders written for one secret are never re-scanned and
+	accidentally redacted by a shorter overlapping secret.
+	"""
+	if not sensitive_values:
+		return value
+
+	# Sort longest secret first so longer matches win over shorter substrings.
+	sorted_pairs = sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True)
+
+	# Build a mapping from secret text → placeholder for use in the sub callback.
+	replacement_map = {secret: f'<secret>{key}</secret>' for key, secret in sorted_pairs}
+
+	pattern = re.compile('|'.join(re.escape(secret) for _, secret in sorted_pairs))
+
+	return pattern.sub(lambda m: replacement_map[m.group(0)], value)
 
 
 def _get_openai_bad_request_error() -> type | None:


### PR DESCRIPTION
## Problem

`redact_sensitive_string` in `browser_use/utils.py` uses a sequential `str.replace` loop. If a shorter secret is a substring of a placeholder tag written by an earlier iteration, it gets re-replaced, corrupting the output.

Repro (from #5135):
```python
from browser_use.utils import redact_sensitive_string
print(redact_sensitive_string(
    'leaked supersecret token',
    {'password': 'supersecret', 'type': 'secret'}))
# Before: 'leaked <<secret>type</secret>>password</<secret>type</secret>> token'
# After:  'leaked <secret>password</secret> token'
```

The corruption reaches LLM message input via `agent/views.py` and `agent/message_manager/service.py`.

## Fix

Replace the loop with a **single `re.sub` call** over a pattern built from all secrets:

- Secrets still sorted longest-first → longer secrets take priority over shorter substrings.
- `re.sub` advances past each match position, so placeholders already written are never re-scanned.
- Empty `sensitive_values` short-circuits immediately.

## Testing

Verified the fix against the exact repro case from the issue, plus:
- Single secret replacement
- Longer secret wins over overlapping shorter secret
- Empty `sensitive_values` passthrough
- Multiple non-overlapping secrets

Closes #5135

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes placeholder cascade in `redact_sensitive_string` that corrupted output when secrets overlapped. Now uses a single-pass replacement. Fixes #5135.

- **Bug Fixes**
  - Longer secrets take priority over shorter substrings.
  - Placeholders are never re-scanned, preventing cascade.
  - No-op when `sensitive_values` is empty.

<sup>Written for commit 2751362274dbd18ff0c86aec05970800348e49e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

