### PR TITLE
fix(dom): preserve empty accessibility names

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3618,7 +3618,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Level 4: ax_name (accessible name) match - robust for dynamic SPAs with menus
 		# This uses the accessible name from the accessibility tree which is stable
 		# even when DOM structure changes (e.g., dynamically generated menu items)
-		if highlight_index is None and historical_element.ax_name:
+		if highlight_index is None and historical_element.ax_name is not None:
 			hist_name = historical_element.node_name.lower()
 			hist_ax_name = historical_element.ax_name
 			for idx, elem in selector_items:
@@ -3634,7 +3634,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				same_type_ax_names = [
 					(idx, elem.ax_node.name if elem.ax_node else None)
 					for idx, elem in selector_items
-					if elem.node_name.lower() == hist_name and elem.ax_node and elem.ax_node.name
+					if elem.node_name.lower() == hist_name and elem.ax_node and elem.ax_node.name is not None
 				]
 				self.logger.debug(
 					f'AX_NAME match failed for <{hist_name.upper()}> ax_name="{hist_ax_name}". '

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -850,7 +850,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -878,7 +878,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1024,7 +1024,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_ax_name_matching.py
+++ b/tests/ci/test_ax_name_matching.py
@@ -13,9 +13,63 @@ from unittest.mock import AsyncMock
 
 from browser_use.agent.service import Agent
 from browser_use.agent.views import ActionResult, AgentHistory, AgentHistoryList, RerunSummaryAction, StepMetadata
-from browser_use.browser.views import BrowserStateHistory
-from browser_use.dom.views import DOMInteractedElement, DOMRect, MatchLevel, NodeType
+from browser_use.browser.views import BrowserStateHistory, BrowserStateSummary
+from browser_use.dom.views import (
+	DOMInteractedElement,
+	DOMRect,
+	EnhancedAXNode,
+	EnhancedDOMTreeNode,
+	MatchLevel,
+	NodeType,
+	SerializedDOMState,
+)
 from tests.ci.conftest import create_mock_llm
+
+
+def create_test_dom_node(ax_name: str | None = None) -> EnhancedDOMTreeNode:
+	"""Create a minimal DOM node for ax_name matching tests."""
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={'class': 'dynamic-class-current'},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=[],
+		ax_node=EnhancedAXNode(
+			ax_node_id='ax-1',
+			ignored=False,
+			role='button',
+			name=ax_name,
+			description=None,
+			properties=None,
+			child_ids=None,
+		)
+		if ax_name is not None
+		else None,
+		snapshot_node=None,
+	)
+
+
+class DummyIndexAction:
+	def __init__(self, index: int):
+		self.index = index
+
+	def get_index(self) -> int:
+		return self.index
+
+	def set_index(self, index: int) -> None:
+		self.index = index
 
 
 async def test_ax_name_matching_succeeds_when_hash_fails(httpserver):
@@ -246,6 +300,52 @@ def test_match_level_enum_includes_ax_name():
 	assert hasattr(MatchLevel, 'AX_NAME')
 	assert MatchLevel.AX_NAME.value == 4
 	assert MatchLevel.ATTRIBUTE.value == 5  # AX_NAME comes before ATTRIBUTE
+
+
+def test_load_from_enhanced_dom_tree_preserves_empty_ax_name():
+	"""Test that an empty accessibility name is preserved instead of treated as missing."""
+	node = create_test_dom_node(ax_name='')
+
+	interacted_element = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+
+	assert interacted_element.ax_name == ''
+
+
+async def test_empty_ax_name_matching_succeeds_when_hash_fails():
+	"""Test that AX_NAME matching uses empty accessibility names when present."""
+	llm = create_mock_llm(actions=None)
+	agent = Agent(task='Test task', llm=llm)
+
+	historical_element = DOMInteractedElement(
+		node_id=9999,
+		backend_node_id=9999,
+		frame_id=None,
+		node_type=NodeType.ELEMENT_NODE,
+		node_value='',
+		node_name='BUTTON',
+		attributes={'class': 'dynamic-class-previous'},
+		x_path='html/body/div/button',
+		element_hash=111,
+		stable_hash=222,
+		bounds=DOMRect(x=0, y=0, width=100, height=50),
+		ax_name='',
+	)
+	current_node = create_test_dom_node(ax_name='')
+	browser_state = BrowserStateSummary(
+		dom_state=SerializedDOMState(_root=None, selector_map={7: current_node}),
+		url='http://test.com',
+		title='Test',
+		tabs=[],
+	)
+	action = DummyIndexAction(index=100)
+
+	try:
+		updated_action = await agent._update_action_indices(historical_element, action, browser_state)  # type: ignore[arg-type]
+
+		assert updated_action is action
+		assert action.index == 7
+	finally:
+		await agent.close()
 
 
 async def test_ax_name_matching_before_attribute_matching(httpserver):


### PR DESCRIPTION
**Problem**

Empty accessibility names from the AX tree are currently treated as missing values in a few DOM/history matching paths because the code checks them with truthiness. This means `""` is collapsed into the same behavior as `None`, so empty but present accessibility names are dropped from `DOMInteractedElement` and skipped during AX_NAME fallback matching.

**Solution**

Use explicit `is not None` checks for AX name handling. This preserves the distinction between a missing accessibility name and an empty accessibility name while keeping existing behavior unchanged for non-empty names.

**Changes**

- Preserve `ax_node.name == ""` when computing DOM element hashes and stable hashes.
- Preserve empty AX names when creating `DOMInteractedElement` from an enhanced DOM tree.
- Allow rerun AX_NAME fallback matching to run when `historical_element.ax_name == ""`.
- Add regression coverage for empty AX name serialization and fallback matching.

**Testing**

- `uv run pytest tests\ci\test_ax_name_matching.py -q -k "empty_ax_name or load_from_enhanced_dom_tree_preserves_empty_ax_name"`
- `uv run python -m py_compile browser_use\dom\views.py browser_use\agent\service.py tests\ci\test_ax_name_matching.py`

**Notes for Reviewer**

I intentionally kept this scoped to the DOM/history matching path mentioned in #5041. Other truthiness checks that only affect debug labels or menu heuristics were left unchanged to avoid broadening the behavior change.

Fixes #5041.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves empty accessibility names (ax_name == "") instead of treating them as missing, so AX_NAME fallback matching runs and element/stable hashes stay accurate. Fixes #5041.

- **Bug Fixes**
  - Use `is not None` checks for AX names in `browser_use/dom/views.py` (stable hash, `__hash__`, `load_from_enhanced_dom_tree`) and `browser_use/agent/service.py` (Level 4 AX_NAME matching).
  - Include empty AX names in hash computation and when creating `DOMInteractedElement` from enhanced DOM nodes.
  - Add tests for empty-name preservation and AX_NAME matching with empty names; update tests to use `BrowserStateSummary`, `EnhancedDOMTreeNode`, and `SerializedDOMState`.

<sup>Written for commit 61e4991fae8e84dd1e720606a72de135b206ca1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

