### PR TITLE
docs: clarify source checkout quickstart install

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ uv add browser-use
 # or: pip install browser-use
 ```
 
+> Cloned this repository instead of starting a new project? Run `uv sync --all-extras --dev` from the repo root; `uv add browser-use` is for projects that depend on the published package.
+
 **2. [Optional] Get your API key from [Browser Use Cloud](https://cloud.browser-use.com/new-api-key?utm_source=github&utm_medium=readme-quickstart-api-key):**
 ```
 # .env


### PR DESCRIPTION
## Summary

Fixes #5138.

- clarify that the README Human Quickstart `uv add browser-use` command is for projects that depend on the published package
- point contributors who are inside a cloned `browser-use` checkout to `uv sync --all-extras --dev` instead

## Validation

- reproduced uv's self-dependency failure with a temp `pyproject.toml` named `browser-use`
- `uvx pre-commit run --files README.md`
- `git diff --check`
- added-line secret scan: 0 findings
- CRLF scan: none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the README Quickstart install steps for cloned source checkouts, addressing #5138. Adds a note that contributors working from a cloned `browser-use` repo should run `uv sync --all-extras --dev` at the repo root; `uv add browser-use` is for downstream projects.

<sup>Written for commit 15b81dbb3b66fdae6bb36711a0b5660500b075e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

