### PR TITLE
fix(utils): preserve sensitive redaction priority

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -20,6 +20,7 @@ load_dotenv()
 
 # Pre-compiled regex for URL detection - used in URL shortening
 URL_PATTERN = re.compile(r'https?://[^\s<>"\']+|www\.[^\s<>"\']+|[^\s<>"\']+\.[a-z]{2,}(?:/[^\s<>"\']*)?', re.IGNORECASE)
+SECRET_PLACEHOLDER_PATTERN = re.compile(r'<secret>.*?</secret>', re.DOTALL)
 
 
 logger = logging.getLogger(__name__)
@@ -73,11 +74,52 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 	return sensitive_values
 
 
+def _span_overlaps_ranges(start: int, end: int, ranges: list[tuple[int, int]]) -> bool:
+	"""Return True when a span intersects any range in the provided list."""
+	return any(start < range_end and range_start < end for range_start, range_end in ranges)
+
+
 def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
-	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
-	for key, secret in sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True):
-		value = value.replace(secret, f'<secret>{key}</secret>')
-	return value
+	"""Replace sensitive values with placeholders selected from the original text.
+
+	Matches are prioritized by longest secret first, then by the order provided in
+	sensitive_values. The output is built once, so generated placeholder tags are
+	never scanned again by later replacements.
+	"""
+	protected_spans = [(match.start(), match.end()) for match in SECRET_PLACEHOLDER_PATTERN.finditer(value)]
+	candidates: list[tuple[int, int, int, int, str]] = []
+
+	for order, (key, secret) in enumerate(sensitive_values.items()):
+		if not secret:
+			continue
+
+		start = value.find(secret)
+		while start != -1:
+			end = start + len(secret)
+			if not _span_overlaps_ranges(start, end, protected_spans):
+				candidates.append((-len(secret), order, start, end, key))
+			start = value.find(secret, start + 1)
+
+	selected_spans: list[tuple[int, int, str]] = []
+	selected_ranges: list[tuple[int, int]] = []
+	for _, _, start, end, key in sorted(candidates):
+		if _span_overlaps_ranges(start, end, selected_ranges):
+			continue
+		selected_spans.append((start, end, key))
+		selected_ranges.append((start, end))
+
+	if not selected_spans:
+		return value
+
+	redacted_parts: list[str] = []
+	last_end = 0
+	for start, end, key in sorted(selected_spans):
+		redacted_parts.append(value[last_end:start])
+		redacted_parts.append(f'<secret>{key}</secret>')
+		last_end = end
+	redacted_parts.append(value[last_end:])
+
+	return ''.join(redacted_parts)
 
 
 def _get_openai_bad_request_error() -> type | None:

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -9,7 +9,7 @@ from browser_use.filesystem.file_system import FileSystem
 from browser_use.llm import SystemMessage, UserMessage
 from browser_use.llm.messages import ContentPartTextParam
 from browser_use.tools.registry.service import Registry
-from browser_use.utils import is_new_tab_page, match_url_with_domain_pattern
+from browser_use.utils import is_new_tab_page, match_url_with_domain_pattern, redact_sensitive_string
 
 
 class SensitiveParams(BaseModel):
@@ -213,6 +213,60 @@ def test_url_components():
 
 	# URLs with all components
 	assert match_url_with_domain_pattern('https://user:pass@example.com:8080/path?query=val#fragment', 'example.com') is True
+
+
+@pytest.mark.parametrize(
+	('value', 'sensitive_values', 'expected'),
+	[
+		(
+			'leaked supersecret token',
+			{'password': 'supersecret', 'type': 'secret'},
+			'leaked <secret>password</secret> token',
+		),
+		(
+			'supersecret secret',
+			{'password': 'supersecret', 'type': 'secret'},
+			'<secret>password</secret> <secret>type</secret>',
+		),
+		(
+			'abcde',
+			{'short': 'abc', 'long': 'bcde'},
+			'a<secret>long</secret>',
+		),
+		(
+			'token token',
+			{'first': 'token', 'second': 'token'},
+			'<secret>first</secret> <secret>first</secret>',
+		),
+		(
+			'abc',
+			{'empty': '', 'a': 'a'},
+			'<secret>a</secret>bc',
+		),
+		(
+			'literal a.b[c] value',
+			{'pattern': 'a.b[c]'},
+			'literal <secret>pattern</secret> value',
+		),
+		(
+			'<secret>password</secret> secret',
+			{'type': 'secret'},
+			'<secret>password</secret> <secret>type</secret>',
+		),
+	],
+)
+def test_redact_sensitive_string_uses_original_text_matches(value, sensitive_values, expected):
+	"""Sensitive redaction should not re-process placeholders while preserving match priority."""
+	assert redact_sensitive_string(value, sensitive_values) == expected
+
+
+def test_filter_sensitive_data_preserves_generated_placeholder_tags(message_manager):
+	"""The message filter should not let a later secret corrupt a generated placeholder tag."""
+	message_manager.sensitive_data = {'password': 'supersecret', 'type': 'secret'}
+
+	result = message_manager._filter_sensitive_data(UserMessage(content='leaked supersecret token'))
+
+	assert result.content == 'leaked <secret>password</secret> token'
 
 
 def test_filter_sensitive_data(message_manager):


### PR DESCRIPTION
## Summary
- Fix `redact_sensitive_string` by selecting non-overlapping redaction spans from the original input before emitting placeholders.
- Prevent generated and existing `<secret>...</secret>` placeholder tags from being reprocessed by later secrets.
- Preserve the existing longest-secret-first behavior for overlapping secrets and first-key behavior for duplicate secret values.
- Add regression tests for the reported cascade, overlap priority, duplicate values, empty values, literal special characters, and message filtering path.

Fixes #5135

## Why span-based
The reported bug happens because the current implementation mutates the output string repeatedly. Once a secret is replaced with `<secret>...</secret>`, a later shorter secret can match inside that generated placeholder markup.

A combined regex avoids that cascade, but regex replacement is still leftmost-first. That can change the current longest-secret-first behavior when overlapping secrets start at different positions:

```python
redact_sensitive_string(
    "abcde",
    {"short": "abc", "long": "bcde"},
)
```

The existing contract prefers the longer secret first and produces:

```text
a<secret>long</secret>
```

A leftmost regex replacement would redact `abc` first instead. This PR keeps the single-output-pass benefit while selecting spans by secret length and insertion order before emitting the final string.

## Tests
- `uv run pytest -q tests/ci/security/test_sensitive_data.py`
- `uv run pre-commit run --files browser_use/utils.py tests/ci/security/test_sensitive_data.py`