### PR TITLE
Add structured action evidence models

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -107,6 +107,181 @@ class PageFingerprint(BaseModel):
 		return PageFingerprint(url=url, element_count=element_count, text_hash=text_hash)
 
 
+ActionEvidenceOutcome = Literal['changed', 'no_change', 'navigation', 'failed', 'attention', 'unknown']
+ACTION_EVIDENCE_METADATA_KEY = 'action_evidence'
+NO_CHANGE_RECOVERY_HINT = (
+	'The action was dispatched and settled, but the page fingerprint did not change. '
+	'Consider re-observing the page, trying keyboard navigation, checking for overlays, '
+	'or choosing another element.'
+)
+
+
+class PageFingerprintDelta(BaseModel):
+	"""Fingerprint-level delta between two page observations."""
+
+	model_config = ConfigDict(frozen=True)
+
+	before: PageFingerprint | None = None
+	after: PageFingerprint | None = None
+	url_changed: bool = False
+	text_changed: bool = False
+	element_count_delta: int | None = None
+	observed_delta: list[str] = Field(default_factory=list)
+	missing_fingerprints: list[str] = Field(default_factory=list)
+
+	@classmethod
+	def between(
+		cls,
+		before: PageFingerprint | None,
+		after: PageFingerprint | None,
+	) -> PageFingerprintDelta:
+		"""Compare two page fingerprints and describe the bounded observable delta."""
+		missing_fingerprints: list[str] = []
+		if before is None:
+			missing_fingerprints.append('missing_before_fingerprint')
+		if after is None:
+			missing_fingerprints.append('missing_after_fingerprint')
+
+		if missing_fingerprints:
+			return cls(before=before, after=after, missing_fingerprints=missing_fingerprints)
+
+		assert before is not None
+		assert after is not None
+		url_changed = before.url != after.url
+		text_changed = before.text_hash != after.text_hash
+		element_count_delta = after.element_count - before.element_count
+
+		observed_delta: list[str] = []
+		if url_changed:
+			observed_delta.append('url_changed')
+		if text_changed:
+			observed_delta.append('text_changed')
+		if element_count_delta != 0:
+			observed_delta.append(f'element_count_delta:{element_count_delta:+d}')
+
+		return cls(
+			before=before,
+			after=after,
+			url_changed=url_changed,
+			text_changed=text_changed,
+			element_count_delta=element_count_delta,
+			observed_delta=observed_delta,
+		)
+
+	@property
+	def is_complete(self) -> bool:
+		"""Whether both before and after fingerprints were available."""
+		return not self.missing_fingerprints
+
+	@property
+	def has_changes(self) -> bool:
+		"""Whether the fingerprint delta contains any observable page change."""
+		return bool(self.url_changed or self.text_changed or self.element_count_delta not in (None, 0))
+
+
+def _default_recovery_hint(outcome: ActionEvidenceOutcome) -> str | None:
+	"""Return a bounded recovery hint for outcomes that need agent attention."""
+	if outcome == 'no_change':
+		return NO_CHANGE_RECOVERY_HINT
+	if outcome == 'failed':
+		return 'The action was not dispatched successfully. Inspect the error and retry only if the target is still valid.'
+	if outcome == 'attention':
+		return 'The action was dispatched, but settlement evidence is incomplete. Re-observe the page before repeating it.'
+	if outcome == 'unknown':
+		return 'The action evidence is incomplete. Re-observe the page before deciding whether to repeat the action.'
+	return None
+
+
+class ActionEvidence(BaseModel):
+	"""Structured receipt describing what a browser action appeared to do."""
+
+	action_id: str = Field(default_factory=uuid7str, min_length=1)
+	action_name: str = Field(min_length=1)
+	target_summary: str | None = None
+	dispatched: bool
+	settled: bool | None = None
+	outcome: ActionEvidenceOutcome = 'unknown'
+	before_fingerprint: PageFingerprint | None = None
+	after_fingerprint: PageFingerprint | None = None
+	observed_delta: list[str] = Field(default_factory=list)
+	blocking_signals: list[str] = Field(default_factory=list)
+	recovery_hint: str | None = None
+
+	@classmethod
+	def from_page_delta(
+		cls,
+		action_name: str,
+		before_fingerprint: PageFingerprint | None,
+		after_fingerprint: PageFingerprint | None,
+		*,
+		action_id: str | None = None,
+		target_summary: str | None = None,
+		dispatched: bool = True,
+		settled: bool | None = True,
+		outcome: ActionEvidenceOutcome | None = None,
+		blocking_signals: list[str] | None = None,
+		recovery_hint: str | None = None,
+	) -> ActionEvidence:
+		"""Build action evidence from before/after page fingerprints."""
+		delta = PageFingerprintDelta.between(before_fingerprint, after_fingerprint)
+		signals = list(blocking_signals or [])
+		signals.extend(delta.missing_fingerprints)
+
+		if settled is False and 'not_settled' not in signals:
+			signals.append('not_settled')
+
+		resolved_outcome = outcome or _infer_action_evidence_outcome(
+			dispatched=dispatched,
+			settled=settled,
+			delta=delta,
+		)
+		resolved_recovery_hint = recovery_hint if recovery_hint is not None else _default_recovery_hint(resolved_outcome)
+
+		model_kwargs: dict[str, Any] = {
+			'action_name': action_name,
+			'target_summary': target_summary,
+			'dispatched': dispatched,
+			'settled': settled,
+			'outcome': resolved_outcome,
+			'before_fingerprint': before_fingerprint,
+			'after_fingerprint': after_fingerprint,
+			'observed_delta': delta.observed_delta,
+			'blocking_signals': signals,
+			'recovery_hint': resolved_recovery_hint,
+		}
+		if action_id is not None:
+			model_kwargs['action_id'] = action_id
+
+		return cls(**model_kwargs)
+
+
+def _infer_action_evidence_outcome(
+	*,
+	dispatched: bool,
+	settled: bool | None,
+	delta: PageFingerprintDelta,
+) -> ActionEvidenceOutcome:
+	"""Infer an action outcome from dispatch, settlement, and fingerprint delta."""
+	if not dispatched:
+		return 'failed'
+	if settled is False:
+		return 'attention'
+	if not delta.is_complete:
+		return 'unknown'
+	if delta.url_changed:
+		return 'navigation'
+	if delta.has_changes:
+		return 'changed'
+	return 'no_change'
+
+
+def with_action_evidence_metadata(metadata: dict[str, Any] | None, evidence: ActionEvidence) -> dict[str, Any]:
+	"""Return metadata with serialized action evidence under the standard key."""
+	merged_metadata = dict(metadata or {})
+	merged_metadata[ACTION_EVIDENCE_METADATA_KEY] = evidence.model_dump(mode='json')
+	return merged_metadata
+
+
 def _normalize_action_for_hash(action_name: str, params: dict[str, Any]) -> str:
 	"""Normalize action parameters for similarity hashing.
 

--- a/tests/ci/test_action_evidence.py
+++ b/tests/ci/test_action_evidence.py
@@ -1,0 +1,195 @@
+import json
+
+from browser_use.agent.views import (
+	ACTION_EVIDENCE_METADATA_KEY,
+	ActionEvidence,
+	ActionResult,
+	PageFingerprint,
+	PageFingerprintDelta,
+	with_action_evidence_metadata,
+)
+
+
+def test_page_fingerprint_delta_detects_bounded_changes():
+	"""Fingerprint deltas expose URL, text, and element-count changes."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'hello world', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/next', 'goodbye world', 53)
+
+	delta = PageFingerprintDelta.between(before, after)
+
+	assert delta.is_complete is True
+	assert delta.has_changes is True
+	assert delta.url_changed is True
+	assert delta.text_changed is True
+	assert delta.element_count_delta == 3
+	assert delta.observed_delta == ['url_changed', 'text_changed', 'element_count_delta:+3']
+	assert delta.missing_fingerprints == []
+
+
+def test_page_fingerprint_delta_detects_no_change():
+	"""Identical fingerprints produce a complete empty delta."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'same content', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/start', 'same content', 50)
+
+	delta = PageFingerprintDelta.between(before, after)
+
+	assert delta.is_complete is True
+	assert delta.has_changes is False
+	assert delta.url_changed is False
+	assert delta.text_changed is False
+	assert delta.element_count_delta == 0
+	assert delta.observed_delta == []
+	assert delta.missing_fingerprints == []
+
+
+def test_page_fingerprint_delta_reports_missing_fingerprints():
+	"""Missing before/after fingerprints are explicit instead of silently treated as no-op."""
+	delta = PageFingerprintDelta.between(None, None)
+
+	assert delta.is_complete is False
+	assert delta.has_changes is False
+	assert delta.missing_fingerprints == ['missing_before_fingerprint', 'missing_after_fingerprint']
+
+
+def test_action_evidence_from_page_delta_marks_navigation():
+	"""URL changes are classified separately from in-page changes."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'hello world', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/next', 'hello world', 50)
+
+	evidence = ActionEvidence.from_page_delta(
+		action_id='action-1',
+		action_name='click',
+		target_summary='button: Next',
+		before_fingerprint=before,
+		after_fingerprint=after,
+	)
+
+	assert evidence.action_id == 'action-1'
+	assert evidence.action_name == 'click'
+	assert evidence.target_summary == 'button: Next'
+	assert evidence.dispatched is True
+	assert evidence.settled is True
+	assert evidence.outcome == 'navigation'
+	assert evidence.observed_delta == ['url_changed']
+	assert evidence.blocking_signals == []
+	assert evidence.recovery_hint is None
+
+
+def test_action_evidence_from_page_delta_marks_changed():
+	"""Text or element-count deltas are regular changed outcomes."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'old content', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/start', 'new content', 51)
+
+	evidence = ActionEvidence.from_page_delta(
+		action_id='action-2',
+		action_name='scroll',
+		before_fingerprint=before,
+		after_fingerprint=after,
+	)
+
+	assert evidence.outcome == 'changed'
+	assert evidence.observed_delta == ['text_changed', 'element_count_delta:+1']
+	assert evidence.recovery_hint is None
+
+
+def test_action_evidence_from_page_delta_marks_no_change_with_recovery_hint():
+	"""A dispatched, settled action with no page delta gets no-op recovery metadata."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'same content', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/start', 'same content', 50)
+
+	evidence = ActionEvidence.from_page_delta(
+		action_id='action-3',
+		action_name='click',
+		target_summary='button: Submit',
+		before_fingerprint=before,
+		after_fingerprint=after,
+	)
+
+	assert evidence.outcome == 'no_change'
+	assert evidence.observed_delta == []
+	assert evidence.blocking_signals == []
+	assert evidence.recovery_hint is not None
+	assert 'page fingerprint did not change' in evidence.recovery_hint
+	assert 'keyboard navigation' in evidence.recovery_hint
+
+
+def test_action_evidence_from_page_delta_marks_unsettled_action_attention():
+	"""Unsettled actions are attention outcomes even when fingerprints are available."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'same content', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/start', 'updated content', 50)
+
+	evidence = ActionEvidence.from_page_delta(
+		action_id='action-4',
+		action_name='input',
+		before_fingerprint=before,
+		after_fingerprint=after,
+		settled=False,
+	)
+
+	assert evidence.outcome == 'attention'
+	assert evidence.observed_delta == ['text_changed']
+	assert evidence.blocking_signals == ['not_settled']
+	assert evidence.recovery_hint is not None
+	assert 'settlement evidence is incomplete' in evidence.recovery_hint
+
+
+def test_action_evidence_from_page_delta_marks_failed_dispatch():
+	"""Failed dispatch is distinct from no-change after a successful dispatch."""
+	evidence = ActionEvidence.from_page_delta(
+		action_id='action-5',
+		action_name='click',
+		before_fingerprint=None,
+		after_fingerprint=None,
+		dispatched=False,
+		settled=None,
+	)
+
+	assert evidence.outcome == 'failed'
+	assert evidence.dispatched is False
+	assert evidence.settled is None
+	assert evidence.blocking_signals == ['missing_before_fingerprint', 'missing_after_fingerprint']
+	assert evidence.recovery_hint is not None
+	assert 'not dispatched successfully' in evidence.recovery_hint
+
+
+def test_action_evidence_from_page_delta_marks_unknown_when_fingerprints_missing():
+	"""Successful dispatch without complete before/after fingerprints remains unknown."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'same content', 50)
+
+	evidence = ActionEvidence.from_page_delta(
+		action_id='action-6',
+		action_name='click',
+		before_fingerprint=before,
+		after_fingerprint=None,
+	)
+
+	assert evidence.outcome == 'unknown'
+	assert evidence.observed_delta == []
+	assert evidence.blocking_signals == ['missing_after_fingerprint']
+	assert evidence.recovery_hint is not None
+	assert 'evidence is incomplete' in evidence.recovery_hint
+
+
+def test_action_evidence_metadata_merges_json_serializable_receipt():
+	"""Action evidence attaches under one stable metadata key without dropping existing metadata."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'same content', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/next', 'same content', 50)
+	evidence = ActionEvidence.from_page_delta(
+		action_id='action-7',
+		action_name='click',
+		before_fingerprint=before,
+		after_fingerprint=after,
+	)
+
+	metadata = with_action_evidence_metadata({'click_x': 10, 'click_y': 20}, evidence)
+	result = ActionResult(extracted_content='Clicked element 7', metadata=metadata)
+
+	assert result.metadata is not None
+	assert result.metadata['click_x'] == 10
+	assert result.metadata['click_y'] == 20
+	action_evidence = result.metadata[ACTION_EVIDENCE_METADATA_KEY]
+	assert action_evidence['action_id'] == 'action-7'
+	assert action_evidence['outcome'] == 'navigation'
+	assert action_evidence['before_fingerprint'] == before.model_dump(mode='json')
+	assert action_evidence['after_fingerprint'] == after.model_dump(mode='json')
+	json.dumps(result.metadata)


### PR DESCRIPTION
 Title:
  Add structured action evidence models

  Body:

  ## Summary
  Adds the first small slice for #5137: structured action evidence models and helpers for browser action receipts.

  This includes:
  - `ActionEvidence` for dispatch/settlement/outcome/recovery metadata
  - `PageFingerprintDelta` for URL/text/element-count deltas
  - `with_action_evidence_metadata()` for attaching evidence to `ActionResult.metadata`
  - focused tests for outcome inference and JSON-serializable metadata

  ## Tests
  - `uv run ruff check browser_use/agent/views.py tests/ci/test_action_evidence.py`
  - `uv run pytest tests/ci/test_action_evidence.py -q -s`

  Refs #5137

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured action evidence for browser actions and stores a JSON receipt on `ActionResult.metadata`. This is the first step for #5137 to infer outcomes and provide recovery hints.

- **New Features**
  - `ActionEvidence` to capture dispatch/settlement, before/after `PageFingerprint`, inferred outcome, observed deltas, blocking signals, and recovery hints.
  - `PageFingerprintDelta.between()` to detect URL/text/element-count changes, include markers like `url_changed`, `text_changed`, `element_count_delta:+N`, and report missing fingerprints.
  - `with_action_evidence_metadata()` to store serialized evidence under `ACTION_EVIDENCE_METADATA_KEY` on `ActionResult.metadata` without overwriting existing metadata.
  - Outcome inference: navigation on URL change; changed on other deltas; no_change with a default hint; attention if not settled; failed if not dispatched; unknown when fingerprints are incomplete. Blocking signals include missing fingerprints and `not_settled`.
  - Tests cover delta detection, outcome inference, blocking signals, and JSON-serializable metadata merging.

<sup>Written for commit fad655903b19ceaba2080fd35a4f491379566d9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

