### PR TITLE
Preserve BrowserError's structured memory through execute_action

### DIFF
--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -12,6 +12,7 @@ import pyotp
 from pydantic import BaseModel, Field, RootModel, create_model
 
 from browser_use.browser import BrowserSession
+from browser_use.browser.views import BrowserError
 from browser_use.filesystem.file_system import FileSystem
 from browser_use.llm.base import BaseChatModel
 from browser_use.observability import observe_debug
@@ -395,6 +396,11 @@ class Registry(Generic[Context]):
 			except Exception as e:
 				raise
 
+		except BrowserError:
+			# BrowserError carries structured short/long-term memory for the LLM
+			# (e.g. available dropdown options) — let Tools.act format it instead of
+			# flattening it into a generic RuntimeError string.
+			raise
 		except ValueError as e:
 			# Preserve ValueError messages from validation
 			if 'requires browser_session but none provided' in str(e) or 'requires page_extraction_llm but none provided' in str(

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -396,11 +396,15 @@ class Registry(Generic[Context]):
 			except Exception as e:
 				raise
 
-		except BrowserError:
-			# BrowserError carries structured short/long-term memory for the LLM
+		except BrowserError as e:
+			# BrowserError can carry structured short/long-term memory for the LLM
 			# (e.g. available dropdown options) — let Tools.act format it instead of
-			# flattening it into a generic RuntimeError string.
-			raise
+			# flattening it into a generic RuntimeError string. Only errors with
+			# long_term_memory bypass: handle_browser_error re-raises without it,
+			# which would escape Tools.act instead of returning an ActionResult.
+			if e.long_term_memory is not None:
+				raise
+			raise RuntimeError(f'Error executing action {action_name}: {str(e)}') from e
 		except ValueError as e:
 			# Preserve ValueError messages from validation
 			if 'requires browser_session but none provided' in str(e) or 'requires page_extraction_llm but none provided' in str(

--- a/tests/ci/test_browser_error_passthrough.py
+++ b/tests/ci/test_browser_error_passthrough.py
@@ -26,3 +26,21 @@ async def test_browser_error_memory_survives_execute_action():
 		f'structured long_term_memory lost: {result.error!r}'
 	)
 	assert result.extracted_content == 'Available options: alpha, beta, gamma'
+
+
+async def test_plain_browser_error_still_returns_recoverable_action_result():
+	"""A BrowserError without long_term_memory must not escape Tools.act as an
+	exception — it must still come back as a recoverable ActionResult (as it did
+	when the generic execute_action handler flattened it)."""
+	tools = Tools()
+
+	@tools.registry.action(description='Test action that raises a plain BrowserError')
+	async def raise_plain_error():
+		raise BrowserError(message='element with index 5 does not exist')
+
+	ActionModel = tools.registry.create_action_model()
+	action = ActionModel(**{'raise_plain_error': {}})
+
+	result = await tools.act(action, browser_session=None)  # type: ignore[arg-type] -- action doesn't touch the browser
+
+	assert result.error is not None and 'element with index 5 does not exist' in result.error

--- a/tests/ci/test_browser_error_passthrough.py
+++ b/tests/ci/test_browser_error_passthrough.py
@@ -1,0 +1,28 @@
+"""Regression test: BrowserError raised inside an action must reach Tools.act with its
+structured short/long-term memory intact, instead of being flattened into a generic
+'Error executing action ...' RuntimeError by execute_action's catch-all handler."""
+
+from browser_use.browser.views import BrowserError
+from browser_use.tools.service import Tools
+
+
+async def test_browser_error_memory_survives_execute_action():
+	tools = Tools()
+
+	@tools.registry.action(description='Test action that raises a structured BrowserError')
+	async def raise_structured_error():
+		raise BrowserError(
+			message='element is a select, not clickable',
+			short_term_memory='Available options: alpha, beta, gamma',
+			long_term_memory='Tried to click a dropdown; use select_dropdown instead',
+		)
+
+	ActionModel = tools.registry.create_action_model()
+	action = ActionModel(**{'raise_structured_error': {}})
+
+	result = await tools.act(action, browser_session=None)  # type: ignore[arg-type] -- action doesn't touch the browser
+
+	assert result.error == 'Tried to click a dropdown; use select_dropdown instead', (
+		f'structured long_term_memory lost: {result.error!r}'
+	)
+	assert result.extracted_content == 'Available options: alpha, beta, gamma'


### PR DESCRIPTION
## Problem

`Registry.execute_action`'s catch-all `except Exception` also caught `BrowserError`, flattening it into a generic `RuntimeError('Error executing action ...')`. That destroyed the structured `short_term_memory` / `long_term_memory` the error carries specifically to steer the LLM's next action — e.g. the list of available dropdown options when the agent clicks a `<select>`.

The `except BrowserError` branch in `Tools.act` (which formats those memories into an `ActionResult` via `handle_browser_error`) was dead code for any action that lets a `BrowserError` propagate through `execute_action` — `upload_file`, `dropdown_options` via `event_result(raise_if_any=True)`, extraction handler errors. The LLM got an opaque error string instead of actionable context, burning extra steps rediscovering what the error already knew.

## Fix

One `except BrowserError: raise` ahead of the generic handlers in `execute_action`, so `handle_browser_error` in `Tools.act` is the single formatting point again.

## Verification

- New regression test: a registered action raising `BrowserError(short_term_memory=..., long_term_memory=...)` must arrive in the `ActionResult` with `error` = long-term memory and `extracted_content` = short-term memory. Fails on the previous code with the flattened generic string.
- 17 tools/registry tests passing; pyright and ruff clean.

Part of a series of small fixes from an internal review (same batch as #5133, #5146).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves structured `BrowserError` memory through `Registry.execute_action` while keeping plain errors recoverable, so agents get context without breaking callers. `Tools.act` stays the single formatting point for structured errors.

- **Bug Fixes**
  - Re-raise `BrowserError` only when `long_term_memory` is present; otherwise, flatten to `RuntimeError` to preserve previous recoverable behavior.
  - Map `long_term_memory` -> `ActionResult.error` and `short_term_memory` -> `ActionResult.extracted_content` for structured errors.
  - Add tests for both structured and plain `BrowserError` paths to lock in behavior.

<sup>Written for commit 782535c34fe804eea209bdcf98f7099759aa6318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

