### PR TITLE
Detect LLM output truncation instead of failing with misleading parse errors

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1991,8 +1991,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# 402: Insufficient credits/payment required - fallback to different provider
 		# 429: Rate limit exceeded
 		# 500, 502, 503, 504: Server errors
-		# ModelOutputTruncatedError: the same request would truncate identically on
-		# this model, but a fallback with a different output cap can succeed
+		# ModelOutputTruncatedError: not retryable on the same model, but a fallback may have a higher cap
 		retryable_status_codes = {401, 402, 429, 500, 502, 503, 504}
 		is_retryable = isinstance(error, (ModelRateLimitError, ModelOutputTruncatedError)) or (
 			hasattr(error, 'status_code') and error.status_code in retryable_status_codes

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -25,7 +25,7 @@ from browser_use.agent.cloud_events import (
 )
 from browser_use.agent.message_manager.utils import save_conversation
 from browser_use.llm.base import BaseChatModel
-from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.exceptions import ModelOutputTruncatedError, ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage, ContentPartImageParam, ContentPartTextParam, UserMessage
 from browser_use.tokens.service import TokenCost
 
@@ -1991,8 +1991,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# 402: Insufficient credits/payment required - fallback to different provider
 		# 429: Rate limit exceeded
 		# 500, 502, 503, 504: Server errors
+		# ModelOutputTruncatedError: the same request would truncate identically on
+		# this model, but a fallback with a different output cap can succeed
 		retryable_status_codes = {401, 402, 429, 500, 502, 503, 504}
-		is_retryable = isinstance(error, ModelRateLimitError) or (
+		is_retryable = isinstance(error, (ModelRateLimitError, ModelOutputTruncatedError)) or (
 			hasattr(error, 'status_code') and error.status_code in retryable_status_codes
 		)
 

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -387,8 +387,6 @@ class ChatAnthropic(BaseChatModel):
 
 				usage = self._get_usage(response)
 
-				# A tool_use block cut off at max_tokens produces incomplete JSON that fails
-				# validation with a misleading parse error — surface the real cause instead.
 				if response.stop_reason == 'max_tokens':
 					raise ModelOutputTruncatedError(
 						message=(
@@ -450,8 +448,6 @@ class ChatAnthropic(BaseChatModel):
 		except APIStatusError as e:
 			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
 		except ModelProviderError:
-			# Already carries an accurate message and status code (e.g. max_tokens
-			# truncation) — don't re-wrap it with the generic 502.
-			raise
+			raise  # don't re-wrap with the generic 502
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -387,6 +387,18 @@ class ChatAnthropic(BaseChatModel):
 
 				usage = self._get_usage(response)
 
+				# A tool_use block cut off at max_tokens produces incomplete JSON that fails
+				# validation with a misleading parse error — surface the real cause instead.
+				if response.stop_reason == 'max_tokens':
+					raise ModelProviderError(
+						message=(
+							f'Model output was truncated at max_tokens={self.max_tokens}; the structured'
+							' output is incomplete. Increase max_tokens or request shorter output.'
+						),
+						status_code=400,
+						model=self.name,
+					)
+
 				# Extract the tool use block
 				for content_block in response.content:
 					if hasattr(content_block, 'type') and content_block.type == 'tool_use':
@@ -438,5 +450,9 @@ class ChatAnthropic(BaseChatModel):
 			raise ModelRateLimitError(message=e.message, model=self.name) from e
 		except APIStatusError as e:
 			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
+		except ModelProviderError:
+			# Already carries an accurate message and status code (e.g. max_tokens
+			# truncation) — don't re-wrap it with the generic 502.
+			raise
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 
 from browser_use.llm.anthropic.serializer import AnthropicMessageSerializer
 from browser_use.llm.base import BaseChatModel
-from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.exceptions import ModelOutputTruncatedError, ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
@@ -390,12 +390,11 @@ class ChatAnthropic(BaseChatModel):
 				# A tool_use block cut off at max_tokens produces incomplete JSON that fails
 				# validation with a misleading parse error — surface the real cause instead.
 				if response.stop_reason == 'max_tokens':
-					raise ModelProviderError(
+					raise ModelOutputTruncatedError(
 						message=(
 							f'Model output was truncated at max_tokens={self.max_tokens}; the structured'
 							' output is incomplete. Increase max_tokens or request shorter output.'
 						),
-						status_code=400,
 						model=self.name,
 					)
 

--- a/browser_use/llm/exceptions.py
+++ b/browser_use/llm/exceptions.py
@@ -30,12 +30,9 @@ class ModelRateLimitError(ModelProviderError):
 
 
 class ModelOutputTruncatedError(ModelProviderError):
-	"""Structured output was cut off at an output-token limit (finish_reason='length' /
-	stop_reason='max_tokens').
+	"""Output was cut off at an output-token limit (finish_reason='length' / stop_reason='max_tokens').
 
-	Retrying the same request would truncate identically (status 400 keeps it out of
-	same-provider retry loops), but switching to a fallback LLM with a different output
-	cap can succeed — the agent's fallback logic treats this as switchable.
+	Status 400 keeps it out of same-provider retry loops; the agent's fallback switch treats it as recoverable.
 	"""
 
 	def __init__(

--- a/browser_use/llm/exceptions.py
+++ b/browser_use/llm/exceptions.py
@@ -27,3 +27,20 @@ class ModelRateLimitError(ModelProviderError):
 		model: str | None = None,
 	):
 		super().__init__(message, status_code, model)
+
+
+class ModelOutputTruncatedError(ModelProviderError):
+	"""Structured output was cut off at an output-token limit (finish_reason='length' /
+	stop_reason='max_tokens').
+
+	Retrying the same request would truncate identically (status 400 keeps it out of
+	same-provider retry loops), but switching to a fallback LLM with a different output
+	cap can succeed — the agent's fallback logic treats this as switchable.
+	"""
+
+	def __init__(
+		self,
+		message: str,
+		model: str | None = None,
+	):
+		super().__init__(message, status_code=400, model=model)

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -14,7 +14,7 @@ from google.genai.types import MediaModality
 from pydantic import BaseModel
 
 from browser_use.llm.base import BaseChatModel
-from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.exceptions import ModelOutputTruncatedError, ModelProviderError
 from browser_use.llm.google.serializer import GoogleMessageSerializer
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
@@ -206,13 +206,12 @@ class ChatGoogle(BaseChatModel):
 				if self.max_output_tokens is not None
 				else "the model's output token limit"
 			)
-			raise ModelProviderError(
+			raise ModelOutputTruncatedError(
 				message=(
 					f'Model output was truncated at {cap};'
 					' the structured output is incomplete. Increase max_output_tokens or request'
 					' shorter output.'
 				),
-				status_code=400,
 				model=self.name,
 			)
 

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -194,11 +194,7 @@ class ChatGoogle(BaseChatModel):
 		return None
 
 	def _raise_if_output_truncated(self, response: types.GenerateContentResponse) -> None:
-		"""Structured output cut off at max_output_tokens produces incomplete JSON that
-		fails parsing with a misleading error — surface the real cause instead.
-
-		Uses status 400 (not in retryable_status_codes): retrying the same request
-		would truncate identically."""
+		"""Raise ModelOutputTruncatedError when the response hit an output-token limit."""
 		stop_reason = self._get_stop_reason(response)
 		if stop_reason and 'MAX_TOKENS' in stop_reason:
 			cap = (

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -201,9 +201,14 @@ class ChatGoogle(BaseChatModel):
 		would truncate identically."""
 		stop_reason = self._get_stop_reason(response)
 		if stop_reason and 'MAX_TOKENS' in stop_reason:
+			cap = (
+				f'max_output_tokens={self.max_output_tokens}'
+				if self.max_output_tokens is not None
+				else "the model's output token limit"
+			)
 			raise ModelProviderError(
 				message=(
-					f'Model output was truncated at max_output_tokens={self.max_output_tokens};'
+					f'Model output was truncated at {cap};'
 					' the structured output is incomplete. Increase max_output_tokens or request'
 					' shorter output.'
 				),

--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -193,6 +193,24 @@ class ChatGoogle(BaseChatModel):
 			return str(response.candidates[0].finish_reason) if hasattr(response.candidates[0], 'finish_reason') else None
 		return None
 
+	def _raise_if_output_truncated(self, response: types.GenerateContentResponse) -> None:
+		"""Structured output cut off at max_output_tokens produces incomplete JSON that
+		fails parsing with a misleading error — surface the real cause instead.
+
+		Uses status 400 (not in retryable_status_codes): retrying the same request
+		would truncate identically."""
+		stop_reason = self._get_stop_reason(response)
+		if stop_reason and 'MAX_TOKENS' in stop_reason:
+			raise ModelProviderError(
+				message=(
+					f'Model output was truncated at max_output_tokens={self.max_output_tokens};'
+					' the structured output is incomplete. Increase max_output_tokens or request'
+					' shorter output.'
+				),
+				status_code=400,
+				model=self.name,
+			)
+
 	def _get_usage(self, response: types.GenerateContentResponse) -> ChatInvokeUsage | None:
 		usage: ChatInvokeUsage | None = None
 
@@ -374,6 +392,7 @@ class ChatGoogle(BaseChatModel):
 						self.logger.debug(f'✅ Got structured response in {elapsed:.2f}s')
 
 						usage = self._get_usage(response)
+						self._raise_if_output_truncated(response)
 
 						# Handle case where response.parsed might be None
 						if response.parsed is None:
@@ -458,6 +477,7 @@ class ChatGoogle(BaseChatModel):
 						self.logger.debug(f'✅ Got fallback response in {elapsed:.2f}s')
 
 						usage = self._get_usage(response)
+						self._raise_if_output_truncated(response)
 
 						# Try to extract JSON from the text response
 						if response.text:

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -284,9 +284,14 @@ class ChatOpenAI(BaseChatModel):
 				# Output cut off at the completion cap produces incomplete JSON that fails
 				# validation with a misleading parse error — surface the real cause instead.
 				if choice.finish_reason == 'length':
+					cap = (
+						f'max_completion_tokens={self.max_completion_tokens}'
+						if self.max_completion_tokens is not None
+						else "the model's output token limit"
+					)
 					raise ModelProviderError(
 						message=(
-							f'Model output was truncated at max_completion_tokens={self.max_completion_tokens};'
+							f'Model output was truncated at {cap};'
 							' the structured output is incomplete. Increase max_completion_tokens or request'
 							' shorter output.'
 						),

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -281,6 +281,19 @@ class ChatOpenAI(BaseChatModel):
 
 				usage = self._get_usage(response)
 
+				# Output cut off at the completion cap produces incomplete JSON that fails
+				# validation with a misleading parse error — surface the real cause instead.
+				if choice.finish_reason == 'length':
+					raise ModelProviderError(
+						message=(
+							f'Model output was truncated at max_completion_tokens={self.max_completion_tokens};'
+							' the structured output is incomplete. Increase max_completion_tokens or request'
+							' shorter output.'
+						),
+						status_code=400,
+						model=self.name,
+					)
+
 				parsed = output_format.model_validate_json(choice.message.content)
 
 				return ChatInvokeCompletion(

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -12,7 +12,7 @@ from openai.types.shared_params.response_format_json_schema import JSONSchema, R
 from pydantic import BaseModel
 
 from browser_use.llm.base import BaseChatModel
-from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.exceptions import ModelOutputTruncatedError, ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.openai.serializer import OpenAIMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer
@@ -289,13 +289,12 @@ class ChatOpenAI(BaseChatModel):
 						if self.max_completion_tokens is not None
 						else "the model's output token limit"
 					)
-					raise ModelProviderError(
+					raise ModelOutputTruncatedError(
 						message=(
 							f'Model output was truncated at {cap};'
 							' the structured output is incomplete. Increase max_completion_tokens or request'
 							' shorter output.'
 						),
-						status_code=400,
 						model=self.name,
 					)
 

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -272,17 +272,11 @@ class ChatOpenAI(BaseChatModel):
 						model=self.name,
 					)
 
-				if choice.message.content is None:
-					raise ModelProviderError(
-						message='Failed to parse structured output from model response',
-						status_code=500,
-						model=self.name,
-					)
-
-				usage = self._get_usage(response)
-
 				# Output cut off at the completion cap produces incomplete JSON that fails
 				# validation with a misleading parse error — surface the real cause instead.
+				# Checked BEFORE the missing-content guard: reasoning models can spend the
+				# whole budget on hidden reasoning, returning finish_reason='length' with
+				# content=None, which must also read as truncation.
 				if choice.finish_reason == 'length':
 					cap = (
 						f'max_completion_tokens={self.max_completion_tokens}'
@@ -297,6 +291,15 @@ class ChatOpenAI(BaseChatModel):
 						),
 						model=self.name,
 					)
+
+				if choice.message.content is None:
+					raise ModelProviderError(
+						message='Failed to parse structured output from model response',
+						status_code=500,
+						model=self.name,
+					)
+
+				usage = self._get_usage(response)
 
 				parsed = output_format.model_validate_json(choice.message.content)
 

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -272,11 +272,8 @@ class ChatOpenAI(BaseChatModel):
 						model=self.name,
 					)
 
-				# Output cut off at the completion cap produces incomplete JSON that fails
-				# validation with a misleading parse error — surface the real cause instead.
-				# Checked BEFORE the missing-content guard: reasoning models can spend the
-				# whole budget on hidden reasoning, returning finish_reason='length' with
-				# content=None, which must also read as truncation.
+				# before the content-None guard: reasoning models can burn the whole budget
+				# on hidden reasoning, leaving finish_reason='length' with content=None
 				if choice.finish_reason == 'length':
 					cap = (
 						f'max_completion_tokens={self.max_completion_tokens}'

--- a/tests/ci/test_llm_output_truncation.py
+++ b/tests/ci/test_llm_output_truncation.py
@@ -63,3 +63,31 @@ async def test_openai_normal_structured_output_still_parses(httpserver):
 
 	result = await llm.ainvoke([UserMessage(content='answer briefly')], output_format=AnswerFormat)
 	assert result.completion.answer == 'complete answer'
+
+
+async def test_truncation_error_readable_when_cap_unset(httpserver):
+	"""With max_completion_tokens=None, the error must describe the limit without printing 'None'."""
+	httpserver.expect_request('/v1/chat/completions', method='POST').respond_with_json(
+		{
+			'id': 'chatcmpl-test',
+			'object': 'chat.completion',
+			'created': 0,
+			'model': 'gpt-4o',
+			'choices': [
+				{
+					'index': 0,
+					'message': {'role': 'assistant', 'content': '{"answer": "cut off mid'},
+					'finish_reason': 'length',
+				}
+			],
+			'usage': {'prompt_tokens': 10, 'completion_tokens': 16384, 'total_tokens': 16394},
+		}
+	)
+
+	llm = ChatOpenAI(model='gpt-4o', api_key='test-key', base_url=httpserver.url_for('/v1'), max_completion_tokens=None)
+
+	with pytest.raises(ModelProviderError) as exc_info:
+		await llm.ainvoke([UserMessage(content='answer at length')], output_format=AnswerFormat)
+
+	assert 'truncated' in str(exc_info.value)
+	assert 'None' not in str(exc_info.value), f'error message leaks None: {exc_info.value}'

--- a/tests/ci/test_llm_output_truncation.py
+++ b/tests/ci/test_llm_output_truncation.py
@@ -110,3 +110,32 @@ def test_truncation_error_triggers_fallback_llm_switch(tmp_path):
 	error = ModelOutputTruncatedError(message='Model output was truncated at max_completion_tokens=4096', model='gpt-4o')
 	assert agent._try_switch_to_fallback_llm(error) is True
 	assert agent._using_fallback_llm is True
+
+
+async def test_truncation_detected_when_content_is_null(httpserver):
+	"""Reasoning models can spend the whole completion budget on hidden reasoning:
+	finish_reason='length' with content=null. That must surface as truncation, not
+	the generic 'Failed to parse structured output'."""
+	httpserver.expect_request('/v1/chat/completions', method='POST').respond_with_json(
+		{
+			'id': 'chatcmpl-test',
+			'object': 'chat.completion',
+			'created': 0,
+			'model': 'o3',
+			'choices': [
+				{
+					'index': 0,
+					'message': {'role': 'assistant', 'content': None},
+					'finish_reason': 'length',
+				}
+			],
+			'usage': {'prompt_tokens': 10, 'completion_tokens': 4096, 'total_tokens': 4106},
+		}
+	)
+
+	llm = ChatOpenAI(model='o3', api_key='test-key', base_url=httpserver.url_for('/v1'))
+
+	with pytest.raises(ModelProviderError) as exc_info:
+		await llm.ainvoke([UserMessage(content='think hard')], output_format=AnswerFormat)
+
+	assert 'truncated' in str(exc_info.value), f'expected truncation signal, got: {exc_info.value}'

--- a/tests/ci/test_llm_output_truncation.py
+++ b/tests/ci/test_llm_output_truncation.py
@@ -1,0 +1,65 @@
+"""Regression test: structured output cut off at the completion-token cap must raise a
+clear truncation error, not a misleading JSON parse error ('Unterminated string...')."""
+
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.messages import UserMessage
+from browser_use.llm.openai.chat import ChatOpenAI
+
+
+class AnswerFormat(BaseModel):
+	answer: str
+
+
+async def test_openai_truncated_structured_output_raises_clear_error(httpserver):
+	"""finish_reason='length' with JSON cut mid-string must surface the token cap, not a parse error."""
+	httpserver.expect_request('/v1/chat/completions', method='POST').respond_with_json(
+		{
+			'id': 'chatcmpl-test',
+			'object': 'chat.completion',
+			'created': 0,
+			'model': 'gpt-4o',
+			'choices': [
+				{
+					'index': 0,
+					'message': {'role': 'assistant', 'content': '{"answer": "this output was cut off mid-sent'},
+					'finish_reason': 'length',
+				}
+			],
+			'usage': {'prompt_tokens': 10, 'completion_tokens': 4096, 'total_tokens': 4106},
+		}
+	)
+
+	llm = ChatOpenAI(model='gpt-4o', api_key='test-key', base_url=httpserver.url_for('/v1'))
+
+	with pytest.raises(ModelProviderError) as exc_info:
+		await llm.ainvoke([UserMessage(content='answer at length')], output_format=AnswerFormat)
+
+	assert 'truncated' in str(exc_info.value), f'expected a truncation error, got: {exc_info.value}'
+	assert 'max_completion_tokens' in str(exc_info.value)
+
+
+async def test_openai_normal_structured_output_still_parses(httpserver):
+	httpserver.expect_request('/v1/chat/completions', method='POST').respond_with_json(
+		{
+			'id': 'chatcmpl-test',
+			'object': 'chat.completion',
+			'created': 0,
+			'model': 'gpt-4o',
+			'choices': [
+				{
+					'index': 0,
+					'message': {'role': 'assistant', 'content': '{"answer": "complete answer"}'},
+					'finish_reason': 'stop',
+				}
+			],
+			'usage': {'prompt_tokens': 10, 'completion_tokens': 8, 'total_tokens': 18},
+		}
+	)
+
+	llm = ChatOpenAI(model='gpt-4o', api_key='test-key', base_url=httpserver.url_for('/v1'))
+
+	result = await llm.ainvoke([UserMessage(content='answer briefly')], output_format=AnswerFormat)
+	assert result.completion.answer == 'complete answer'

--- a/tests/ci/test_llm_output_truncation.py
+++ b/tests/ci/test_llm_output_truncation.py
@@ -91,3 +91,22 @@ async def test_truncation_error_readable_when_cap_unset(httpserver):
 
 	assert 'truncated' in str(exc_info.value)
 	assert 'None' not in str(exc_info.value), f'error message leaks None: {exc_info.value}'
+
+
+def test_truncation_error_triggers_fallback_llm_switch(tmp_path):
+	"""A truncation error must allow switching to a configured fallback LLM — a
+	fallback with a different output cap can succeed where the primary truncated."""
+	from browser_use.agent.service import Agent
+	from browser_use.llm.exceptions import ModelOutputTruncatedError
+	from tests.ci.conftest import create_mock_llm
+
+	agent = Agent(
+		task='test fallback on truncation',
+		llm=create_mock_llm(),
+		fallback_llm=create_mock_llm(),
+		file_system_path=str(tmp_path / 'agent-files'),
+	)
+
+	error = ModelOutputTruncatedError(message='Model output was truncated at max_completion_tokens=4096', model='gpt-4o')
+	assert agent._try_switch_to_fallback_llm(error) is True
+	assert agent._using_fallback_llm is True


### PR DESCRIPTION
## Problem

When structured output hits the completion-token cap, the JSON arrives cut mid-string. Nothing checked `finish_reason`/`stop_reason` anywhere (`grep stop_reason browser_use/agent/service.py` → no hits), so users saw either:

- an opaque `Unterminated string starting at...` / pydantic validation error, or
- **worse**: a valid-but-chopped answer, if truncation landed between JSON fields — silent partial answers.

With `ChatOpenAI`'s default `max_completion_tokens=4096`, this regularly hits long `done(text=...)` and `extract` outputs. The real cause was never surfaced.

## Fix

Each provider checks its truncation signal before parsing structured output and raises a clear error naming the cause and the knob:

- **OpenAI** (`finish_reason == 'length'`): raise `ModelProviderError('Model output was truncated at max_completion_tokens=N; ... increase max_completion_tokens or request shorter output')`
- **Anthropic** (`stop_reason == 'max_tokens'`): same, for the tool_use input path; plus an `except ModelProviderError: raise` guard so the new error isn't re-wrapped by the generic catch-all into a status-502 blob
- **Google** (`MAX_TOKENS` finish reason): shared `_raise_if_output_truncated()` helper applied to both the structured path and the fallback text path

Status code **400** is deliberate: it's not in any provider's retryable set (Google retries 429/5xx), and retrying an identical request would truncate identically.

## Verification

- Regression test drives the **real OpenAI SDK** against a local httpserver returning `finish_reason='length'` with JSON cut mid-string — asserts the error names the truncation and the parameter, not a parse failure (fails on previous code with the misleading validation error). A companion test confirms normal `finish_reason='stop'` responses still parse.
- 9 LLM tests passing; pyright and ruff clean.

Anthropic/Google paths are verified by type-checker and code-trace; their SDK transports don't point at a local httpserver as easily — follow-up welcome if there's an established fake for them.

Part of a series of small fixes from an internal review (#5133, #5146, #5147).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect and surface LLM output truncation instead of misleading JSON parse errors, and allow switching to a fallback LLM when truncation occurs. Also handles reasoning models that return `content=null` with a length-based finish reason.

- **Bug Fixes**
  - OpenAI: If `finish_reason == 'length'`, raise `ModelOutputTruncatedError` (400) before the missing-content guard; reference `max_completion_tokens` or say "the model's output token limit" when unset.
  - Anthropic: If `stop_reason == 'max_tokens'`, raise `ModelOutputTruncatedError`; add `except ModelProviderError: raise` so the clear error isn’t re-wrapped.
  - Google: Detect `MAX_TOKENS` in both structured and fallback paths via `_raise_if_output_truncated`; raise (400) referencing `max_output_tokens` or the generic phrase when unset.
  - Agent: Introduced `ModelOutputTruncatedError` (400). Provider retry loops skip it; the agent treats it as fallback-switchable so a higher-cap model can succeed.
  - Tests: Cover truncation vs normal parse, unset-cap message, `content=None` case, and that truncation triggers a fallback LLM switch.

- **Refactors**
  - Trimmed comments to essentials.

<sup>Written for commit 248f98f20813a4e13cf4d625ebeb0353eb7f6f17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

