### PR TITLE
shim for legacy CLI cmds

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -224,6 +224,67 @@ def _run_browser_harness() -> int | None:
 	return None
 
 
+# Subcommands and flags from the pre-3.0 CLI; maps to hint
+_LEGACY_HINTS: dict[str, str] = {
+	'open': 'new_tab("https://example.com")',
+	'state': 'print(page_info())',
+	'screenshot': 'print(capture_screenshot())',
+	'eval': 'print(js("document.title"))',
+	'cookies': 'print(cdp("Network.getCookies"))',
+	'python': '# the CLI runs Python directly now — pipe it on stdin as shown below',
+	'run': '# write the steps as Python using the pre-imported helpers shown below',
+	'connect': '# connecting is automatic — the default flow attaches to your running Chrome',
+	'close': '# restart the local daemon with `browser-use --reload`; stop cloud browsers with stop_remote_daemon(name)',
+	'sessions': '# named local sessions were removed — one default daemon; use BU_NAME=<name> for cloud daemons',
+	'profile': '# profiles now come from your real Chrome; see the profile-sync interaction skill',
+	'cloud': '# authenticate with `browser-use auth login`, then start_remote_daemon("<name>")',
+	'daemon': '# the daemon starts automatically on every call; restart it with `browser-use --reload`',
+	'record': '# session recording was removed; use capture_screenshot() per step',
+	'mcp': '# MCP server mode is now the --mcp flag: `browser-use --mcp`',
+	'--session': '# use BU_NAME=<name> as an env var for named cloud daemons; local runs use one default daemon',
+	'--headed': '# local control always attaches to your real, visible Chrome — no flag needed',
+	'--cdp-url': '# use the BU_CDP_URL=<url> env var instead of a flag',
+	'--profile': '# use your real Chrome profile; for cloud cookie sync see the profile-sync interaction skill',
+	'--json': '# output is whatever your Python prints — use print(json.dumps(...))',
+	'-c': "# pipe code on stdin instead: echo 'print(page_info())' | browser-use",
+	'--code': "# pipe code on stdin instead: echo 'print(page_info())' | browser-use",
+}
+
+
+def _legacy_command(args: list[str]) -> str | None:
+	if not args:
+		return None
+	first = args[0].split('=', 1)[0]
+	if first in _LEGACY_HINTS:
+		return first
+	return None
+
+
+def _legacy_migration_message(command: str) -> str:
+	hint = _LEGACY_HINTS[command]
+	if hint.startswith('#'):
+		replacement = f'  {hint.lstrip("# ")}\n\nExample:\n  browser-use <<\'PY\'\n  new_tab("https://example.com")\n  print(page_info())\n  PY'
+	else:
+		replacement = f"  browser-use <<'PY'\n  {hint}\n  PY"
+	return f"""The browser-use CLI changed in 3.0, and '{command}' was removed.
+
+The old preset subcommands are gone. To use the CLI, you write raw Python and 
+pipe it on stdin, and it runs in a persistent browser session. Browser management
+(daemon startup, Chrome/CDP attach, tabs, waiting) is handled for you.
+
+Replacement for '{command}':
+{replacement}
+
+Core helpers: new_tab(url), goto_url(url), page_info(), capture_screenshot(),
+  click_at_xy(x, y), js(code), cdp(method, ...), wait_for_load()
+
+Read the full interface now:   browser-use skill show
+Install the skill so you remember it in future sessions (also upgrades the CLI):
+                               browser-use skill install
+Skill reference:               https://github.com/browser-use/browser-use/blob/main/browser_use/skills/browser-use/SKILL.md
+Health check:                  browser-use --doctor"""
+
+
 def _read_harness_task(args: list[str]) -> str | None:
 	for flag in ('-c', '--code'):
 		if flag in args:
@@ -248,6 +309,9 @@ def _command_context(args: list[str]) -> tuple[str, str]:
 		return 'init', 'init'
 	if args and args[0] == 'skill':
 		return 'skill', 'skill'
+	legacy = _legacy_command(args)
+	if legacy is not None:
+		return 'browser_harness', f'legacy:{legacy}'
 	return 'browser_harness', args[0] if args else 'run'
 
 
@@ -265,6 +329,11 @@ def _dispatch(args: list[str]) -> tuple[int | None, str, str, str | None]:
 		from browser_use.skills.install import handle as handle_skill_command
 
 		return handle_skill_command(args[1:]), 'skill', 'skill', None
+
+	legacy = _legacy_command(args)
+	if legacy is not None:
+		print(_legacy_migration_message(legacy), file=sys.stderr)
+		return 2, 'browser_harness', f'legacy:{legacy}', None
 
 	task = _read_harness_task(args)
 	return _run_browser_harness(), 'browser_harness', args[0] if args else 'run', task


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a legacy command shim to the `browser-use` CLI that detects pre-3.0 subcommands/flags and prints a short migration guide with examples. It exits with code 2 and tags the run as `legacy:<cmd>` instead of running the harness.

- **New Features**
  - Detects common pre-3.0 commands and flags and maps them to clear hints.
  - Prints a structured migration message to stderr with stdin piping examples, core helpers, and doc links.
  - Exits with status 2 to signal misuse; avoids starting the browser harness.
  - Updates command context/dispatch to label events as `legacy:<cmd>` for easier tracking.

<sup>Written for commit b65642f8107260d38c717f4cb3ca974c7db83d18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

