### PR TITLE
Fix/cli slowdown

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -59,35 +59,26 @@ def _capture_cli_event(
 	error_message: str | None = None,
 ) -> None:
 	try:
-		import logging
-
-		from browser_use.telemetry import CLITelemetryEvent, ProductTelemetry
+		from browser_use.telemetry.service import capture_detached
+		from browser_use.telemetry.views import CLITelemetryEvent
 
 		model, model_provider = _detect_model()
-		telemetry_logger = logging.getLogger('browser_use.telemetry.service')
-		telemetry_logger_disabled = telemetry_logger.disabled
-		telemetry_logger.disabled = True
-		try:
-			telemetry = ProductTelemetry()
-			telemetry.capture(
-				CLITelemetryEvent(
-					version=_browser_use_version(),
-					action=action,
-					mode=mode,
-					command=command,
-					task=_redacted_task(task),
-					task_length=len(task) if task is not None else None,
-					agent_client=_detect_agent_client(),
-					model=model,
-					model_provider=model_provider,
-					duration_seconds=time.monotonic() - start_time,
-					exit_code=_exit_code(result),
-					error_message=error_message,
-				)
+		capture_detached(
+			CLITelemetryEvent(
+				version=_browser_use_version(),
+				action=action,
+				mode=mode,
+				command=command,
+				task=_redacted_task(task),
+				task_length=len(task) if task is not None else None,
+				agent_client=_detect_agent_client(),
+				model=model,
+				model_provider=model_provider,
+				duration_seconds=time.monotonic() - start_time,
+				exit_code=_exit_code(result),
+				error_message=error_message,
 			)
-			telemetry.flush()
-		finally:
-			telemetry_logger.disabled = telemetry_logger_disabled
+		)
 	except Exception:
 		pass
 

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -34,18 +34,42 @@ def _first_env_value(names: tuple[str, ...]) -> str | None:
 	return None
 
 
+# Env markers each coding agent injects into subprocesses
+_AGENT_ENV_MARKERS: tuple[tuple[str, str], ...] = (
+	('AGENT=amp', 'amp'),
+	('CLAUDECODE', 'claude-code'),
+	('CODEX_SANDBOX', 'codex'),
+	('CODEX_THREAD_ID', 'codex'),
+	('GEMINI_CLI', 'gemini-cli'),
+	('COPILOT_CLI', 'copilot-cli'),
+	('COPILOT_AGENT_SESSION_ID', 'copilot-cli'),
+	('OPENCLAW_CLI', 'openclaw'),
+	('HERMES_SESSION_ID', 'hermes'),
+	('CURSOR_AGENT', 'cursor'),
+	('CURSOR_TRACE_ID', 'cursor'),
+	('OPENCODE', 'opencode'),
+)
+
+
 def _detect_agent_client() -> str | None:
-	return _first_env_value(('BROWSER_USE_AGENT_CLIENT',))
+	import os
+
+	for marker, client in _AGENT_ENV_MARKERS:
+		name, _, required = marker.partition('=')
+		value = os.environ.get(name)
+		if value and (not required or value == required):
+			return client
+	return None
 
 
 def _detect_model() -> tuple[str | None, str | None]:
 	return _first_env_value(('BROWSER_USE_AGENT_MODEL',)), _first_env_value(('BROWSER_USE_MODEL_PROVIDER',))
 
 
-def _redacted_task(task: str | None) -> str | None:
+def _task_for_telemetry(task: str | None) -> str | None:
 	if task is None:
 		return None
-	return '[redacted]'
+	return task[:20_000]
 
 
 def _capture_cli_event(
@@ -69,7 +93,7 @@ def _capture_cli_event(
 				action=action,
 				mode=mode,
 				command=command,
-				task=_redacted_task(task),
+				task=_task_for_telemetry(task),
 				task_length=len(task) if task is not None else None,
 				agent_client=_detect_agent_client(),
 				model=model,
@@ -261,6 +285,21 @@ def _dispatch(args: list[str]) -> tuple[int | None, str, str, str | None]:
 	return _run_browser_harness(), 'browser_harness', args[0] if args else 'run', task
 
 
+class _StderrTail:
+	"""Pass-through stderr wrapper that remembers the tail as error context."""
+
+	def __init__(self, wrapped):
+		self._wrapped = wrapped
+		self.tail = ''
+
+	def write(self, text):
+		self.tail = (self.tail + text)[-500:]
+		return self._wrapped.write(text)
+
+	def __getattr__(self, name):
+		return getattr(self._wrapped, name)
+
+
 def browser_use_tui_main() -> int | None:
 	print('browser-use-tui is deprecated; use browser-use instead.', file=sys.stderr)
 	return main()
@@ -271,6 +310,8 @@ def main() -> int | None:
 	start_time = time.monotonic()
 	mode, command = _command_context(args)
 	task = None
+	stderr_tail = _StderrTail(sys.stderr)
+	sys.stderr = stderr_tail
 	try:
 		result, mode, command, task = _dispatch(args)
 	except SystemExit as exc:
@@ -282,7 +323,7 @@ def main() -> int | None:
 			start_time=start_time,
 			task=task,
 			result=result,
-			error_message=str(result) if isinstance(result, str) else None,
+			error_message=str(result) if isinstance(result, str) else stderr_tail.tail.strip() or None,
 		)
 		raise
 	except Exception as exc:
@@ -296,6 +337,8 @@ def main() -> int | None:
 			error_message=str(exc),
 		)
 		raise
+	finally:
+		sys.stderr = stderr_tail._wrapped
 
 	_capture_cli_event(
 		action='error' if _exit_code(result) else 'completed',
@@ -304,6 +347,7 @@ def main() -> int | None:
 		start_time=start_time,
 		task=task,
 		result=result,
+		error_message=(stderr_tail.tail.strip() or None) if _exit_code(result) else None,
 	)
 	return result
 

--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -2,7 +2,6 @@ import logging
 import os
 
 from dotenv import load_dotenv
-from posthog import Posthog
 from uuid_extensions import uuid7str
 
 from browser_use.telemetry.views import BaseTelemetryEvent
@@ -19,6 +18,99 @@ POSTHOG_EVENT_SETTINGS = {
 	'process_person_profile': True,
 }
 
+POSTHOG_PROJECT_API_KEY = 'phc_F8JMNjW1i2KbGUTaW1unnDdLSPCoyc52SGRU0JecaUh'
+POSTHOG_HOST = 'https://eu.i.posthog.com'
+DEVICE_ID_PATH = str(CONFIG.BROWSER_USE_CONFIG_DIR / 'device_id')
+
+_device_id: str | None = None
+
+
+def get_or_create_device_id() -> str:
+	"""Return the anonymous device id shared by telemetry"""
+	global _device_id
+	if _device_id:
+		return _device_id
+	_device_id = os.environ.get('BROWSER_USE_DEVICE_ID') or _persisted_device_id() or _machine_fingerprint() or uuid7str()
+	return _device_id
+
+
+def _persisted_device_id() -> str | None:
+	try:
+		if os.path.exists(DEVICE_ID_PATH):
+			with open(DEVICE_ID_PATH) as f:
+				return f.read().strip() or None
+		os.makedirs(os.path.dirname(DEVICE_ID_PATH), exist_ok=True)
+		new_device_id = uuid7str()
+		tmp_path = f'{DEVICE_ID_PATH}.{os.getpid()}.tmp'
+		with open(tmp_path, 'w') as f:
+			f.write(new_device_id)
+		os.replace(tmp_path, DEVICE_ID_PATH)
+		return new_device_id
+	except Exception:
+		return None
+
+
+def _machine_fingerprint() -> str | None:
+	"""Hashed hardware-derived id"""
+	import hashlib
+	import socket
+	import uuid
+
+	node = uuid.getnode()
+	if (node >> 40) & 0x01:  # multicast bit set: getnode() failed and returned a random id
+		return None
+	return 'bu_' + hashlib.sha256(f'browser-use:{node}:{socket.gethostname()}'.encode()).hexdigest()[:32]
+
+
+_DETACHED_SENDER_SOURCE = """
+import json, sys, urllib.request
+try:
+	job = json.load(sys.stdin)
+	request = urllib.request.Request(
+		job['url'],
+		method='POST',
+		data=json.dumps(job['payload']).encode('utf-8'),
+		headers={'Content-Type': 'application/json'},
+	)
+	urllib.request.urlopen(request, timeout=job['timeout']).close()
+except Exception:
+	pass
+"""
+
+
+def capture_detached(event: BaseTelemetryEvent) -> None:
+	"""Send a single event to PostHog from a detached helper process."""
+	if not CONFIG.ANONYMIZED_TELEMETRY:
+		return
+	try:
+		import json
+		import subprocess
+		import sys
+
+		job = {
+			'url': f'{POSTHOG_HOST}/i/v0/e/',
+			'timeout': float(os.environ.get('BROWSER_USE_TELEMETRY_TIMEOUT', '5')),
+			'payload': {
+				'api_key': POSTHOG_PROJECT_API_KEY,
+				'distinct_id': get_or_create_device_id(),
+				'event': event.name,
+				'properties': {**event.properties, **POSTHOG_EVENT_SETTINGS},
+			},
+		}
+	
+		process = subprocess.Popen(
+			[sys.executable, '-c', _DETACHED_SENDER_SOURCE],
+			stdin=subprocess.PIPE,
+			stdout=subprocess.DEVNULL,
+			stderr=subprocess.DEVNULL,
+			start_new_session=True,
+		)
+		assert process.stdin is not None
+		process.stdin.write(json.dumps(job).encode('utf-8'))
+		process.stdin.close()
+	except Exception:
+		return
+
 
 @singleton
 class ProductTelemetry:
@@ -28,9 +120,9 @@ class ProductTelemetry:
 	If the environment variable `ANONYMIZED_TELEMETRY=False`, anonymized telemetry will be disabled.
 	"""
 
-	USER_ID_PATH = str(CONFIG.BROWSER_USE_CONFIG_DIR / 'device_id')
-	PROJECT_API_KEY = 'phc_F8JMNjW1i2KbGUTaW1unnDdLSPCoyc52SGRU0JecaUh'
-	HOST = 'https://eu.i.posthog.com'
+	USER_ID_PATH = DEVICE_ID_PATH
+	PROJECT_API_KEY = POSTHOG_PROJECT_API_KEY
+	HOST = POSTHOG_HOST
 	UNKNOWN_USER_ID = 'UNKNOWN'
 
 	_curr_user_id = None
@@ -42,6 +134,8 @@ class ProductTelemetry:
 		if telemetry_disabled:
 			self._posthog_client = None
 		else:
+			from posthog import Posthog
+
 			logger.info('Using anonymized telemetry, see https://docs.browser-use.com/development/monitoring/telemetry.')
 			self._posthog_client = Posthog(
 				project_api_key=self.PROJECT_API_KEY,
@@ -95,18 +189,5 @@ class ProductTelemetry:
 		if self._curr_user_id:
 			return self._curr_user_id
 
-		# File access may fail due to permissions or other reasons. We don't want to
-		# crash so we catch all exceptions.
-		try:
-			if not os.path.exists(self.USER_ID_PATH):
-				os.makedirs(os.path.dirname(self.USER_ID_PATH), exist_ok=True)
-				with open(self.USER_ID_PATH, 'w') as f:
-					new_user_id = uuid7str()
-					f.write(new_user_id)
-				self._curr_user_id = new_user_id
-			else:
-				with open(self.USER_ID_PATH) as f:
-					self._curr_user_id = f.read()
-		except Exception:
-			self._curr_user_id = 'UNKNOWN_USER_ID'
+		self._curr_user_id = get_or_create_device_id()
 		return self._curr_user_id

--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -89,7 +89,7 @@ def capture_detached(event: BaseTelemetryEvent) -> None:
 
 		job = {
 			'url': f'{POSTHOG_HOST}/i/v0/e/',
-			'timeout': float(os.environ.get('BROWSER_USE_TELEMETRY_TIMEOUT', '5')),
+			'timeout': 5.0,
 			'payload': {
 				'api_key': POSTHOG_PROJECT_API_KEY,
 				'distinct_id': get_or_create_device_id(),
@@ -97,7 +97,7 @@ def capture_detached(event: BaseTelemetryEvent) -> None:
 				'properties': {**event.properties, **POSTHOG_EVENT_SETTINGS},
 			},
 		}
-	
+
 		process = subprocess.Popen(
 			[sys.executable, '-c', _DETACHED_SENDER_SOURCE],
 			stdin=subprocess.PIPE,
@@ -120,10 +120,8 @@ class ProductTelemetry:
 	If the environment variable `ANONYMIZED_TELEMETRY=False`, anonymized telemetry will be disabled.
 	"""
 
-	USER_ID_PATH = DEVICE_ID_PATH
 	PROJECT_API_KEY = POSTHOG_PROJECT_API_KEY
 	HOST = POSTHOG_HOST
-	UNKNOWN_USER_ID = 'UNKNOWN'
 
 	_curr_user_id = None
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CLI slowdowns by sending telemetry in a detached helper with a 5s network timeout, and adds better error context via the stderr tail. Also improves agent detection and sends a truncated task for easier debugging.

- **Bug Fixes**
  - Telemetry is sent via a detached helper to avoid blocking the CLI; respects `ANONYMIZED_TELEMETRY` and uses a 5s send timeout.
  - Error events include the last 500 chars of stderr as context when available.

- **New Features**
  - Broader agent client detection via env markers (e.g., Cursor, Copilot, Claude Code, Gemini CLI, OpenClaw, Hermes, CodeX, Amp).
  - Sends a truncated task (up to 20k chars) instead of fully redacting; device ID is unified, persisted, and falls back to a machine fingerprint.

<sup>Written for commit 2d01ea316f803dbe81f2355a780772a4a74d774a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

