### PR TITLE
Fix visibility check mutating shared snapshot bounds

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -269,11 +269,16 @@ class DomService:
 		except (ValueError, TypeError):
 			pass
 
-		# Start with the element's local bounds (in its own frame's coordinate system)
-		current_bounds = node.snapshot_node.bounds
-
-		if not current_bounds:
+		if not node.snapshot_node.bounds:
 			return False  # If there are no bounds, the element is not visible
+
+		# work on a copy: snapshot bounds are shared, in-place mutation corrupts other consumers
+		current_bounds = DOMRect(
+			x=node.snapshot_node.bounds.x,
+			y=node.snapshot_node.bounds.y,
+			width=node.snapshot_node.bounds.width,
+			height=node.snapshot_node.bounds.height,
+		)
 
 		# If threshold is None, skip all viewport-based filtering (only check CSS visibility)
 		if viewport_threshold is None:
@@ -283,6 +288,9 @@ class DomService:
 		Reverse iterate through the html frames (that can be either iframe or document -> if it's a document frame compare if the current bounds interest with it (taking scroll into account) otherwise move the current bounds by the iframe offset)
 		"""
 		for frame in reversed(html_frames):
+			# skip self: a frame node appears in its own frame chain and must not offset itself
+			if frame is node:
+				continue
 			if (
 				frame.node_type == NodeType.ELEMENT_NODE
 				and (frame.node_name.upper() == 'IFRAME' or frame.node_name.upper() == 'FRAME')

--- a/tests/ci/test_dom_visibility.py
+++ b/tests/ci/test_dom_visibility.py
@@ -76,15 +76,16 @@ class TestVisibilityDoesNotMutateBounds:
 
 	def test_visibility_check_is_idempotent(self):
 		"""Calling the check twice must return the same result (fails if bounds drift)."""
-		html = _make_html_frame(viewport_height=900, scroll_y=600)
-		# Element near the bottom edge of the threshold window: any bounds drift
-		# between calls flips the result.
-		element = _make_node('DIV', _make_snapshot(bounds=DOMRect(x=10, y=2400, width=100, height=50)))
+		html = _make_html_frame(viewport_height=900, scroll_y=1000)
+		# Element exactly inside the top threshold window: with in-place mutation
+		# the first check returns True, then the drifted second check returns False.
+		element = _make_node('DIV', _make_snapshot(bounds=DOMRect(x=10, y=0, width=100, height=50)))
 
 		first = DomService.is_element_visible_according_to_all_parents(element, [html], viewport_threshold=1000)
 		second = DomService.is_element_visible_according_to_all_parents(element, [html], viewport_threshold=1000)
 
-		assert first == second
+		assert first is True
+		assert second is True
 
 	def test_iframe_not_double_transformed_by_own_bounds(self):
 		"""An iframe checked against a frame chain containing itself must not have its

--- a/tests/ci/test_dom_visibility.py
+++ b/tests/ci/test_dom_visibility.py
@@ -1,0 +1,102 @@
+"""Tests for DomService.is_element_visible_according_to_all_parents.
+
+Regression tests for the in-place mutation of shared snapshot bounds: the
+visibility check must never modify node.snapshot_node.bounds, and a frame
+node must not be transformed by its own bounds when it appears in its own
+frame chain (as built by _construct_enhanced_node).
+"""
+
+from browser_use.dom.service import DomService
+from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, EnhancedSnapshotNode, NodeType
+
+
+def _make_snapshot(
+	bounds: DOMRect | None = None,
+	client_rects: DOMRect | None = None,
+	scroll_rects: DOMRect | None = None,
+) -> EnhancedSnapshotNode:
+	return EnhancedSnapshotNode(
+		is_clickable=None,
+		cursor_style=None,
+		bounds=bounds,
+		clientRects=client_rects,
+		scrollRects=scroll_rects,
+		computed_styles={},
+		paint_order=None,
+		stacking_contexts=None,
+	)
+
+
+def _make_node(node_name: str, snapshot_node: EnhancedSnapshotNode | None) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name=node_name,
+		node_value='',
+		attributes={},
+		is_scrollable=None,
+		is_visible=None,
+		absolute_position=None,
+		target_id='test-target',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=None,
+		snapshot_node=snapshot_node,
+	)
+
+
+def _make_html_frame(viewport_width: float = 1280, viewport_height: float = 900, scroll_y: float = 0) -> EnhancedDOMTreeNode:
+	return _make_node(
+		'HTML',
+		_make_snapshot(
+			bounds=DOMRect(x=0, y=0, width=viewport_width, height=viewport_height),
+			client_rects=DOMRect(x=0, y=0, width=viewport_width, height=viewport_height),
+			scroll_rects=DOMRect(x=0, y=scroll_y, width=viewport_width, height=5000),
+		),
+	)
+
+
+class TestVisibilityDoesNotMutateBounds:
+	def test_bounds_unchanged_after_visibility_check(self):
+		"""The check must not modify the shared snapshot bounds object."""
+		html = _make_html_frame(scroll_y=100)
+		element = _make_node('DIV', _make_snapshot(bounds=DOMRect(x=10, y=500, width=100, height=50)))
+
+		DomService.is_element_visible_according_to_all_parents(element, [html], viewport_threshold=1000)
+
+		assert element.snapshot_node is not None and element.snapshot_node.bounds is not None
+		assert element.snapshot_node.bounds.x == 10
+		assert element.snapshot_node.bounds.y == 500
+
+	def test_visibility_check_is_idempotent(self):
+		"""Calling the check twice must return the same result (fails if bounds drift)."""
+		html = _make_html_frame(viewport_height=900, scroll_y=600)
+		# Element near the bottom edge of the threshold window: any bounds drift
+		# between calls flips the result.
+		element = _make_node('DIV', _make_snapshot(bounds=DOMRect(x=10, y=2400, width=100, height=50)))
+
+		first = DomService.is_element_visible_according_to_all_parents(element, [html], viewport_threshold=1000)
+		second = DomService.is_element_visible_according_to_all_parents(element, [html], viewport_threshold=1000)
+
+		assert first == second
+
+	def test_iframe_not_double_transformed_by_own_bounds(self):
+		"""An iframe checked against a frame chain containing itself must not have its
+		coordinates doubled (y=1200 on a 900px viewport with threshold 1000 is visible;
+		doubled to 2400 it would not be)."""
+		html = _make_html_frame(viewport_height=900, scroll_y=0)
+		iframe = _make_node('IFRAME', _make_snapshot(bounds=DOMRect(x=0, y=1200, width=600, height=400)))
+
+		# _construct_enhanced_node appends the iframe to its own frame chain before
+		# computing its visibility — reproduce that here.
+		visible = DomService.is_element_visible_according_to_all_parents(iframe, [html, iframe], viewport_threshold=1000)
+
+		assert visible is True
+		assert iframe.snapshot_node is not None and iframe.snapshot_node.bounds is not None
+		assert iframe.snapshot_node.bounds.y == 1200


### PR DESCRIPTION
## Problem

`is_element_visible_according_to_all_parents` mutated `node.snapshot_node.bounds` **in place** while walking the frame chain (`dom/service.py:295-296, 333-334`):

1. Every checked node's bounds were permanently shifted by frame offsets and scroll, corrupting coordinates shared with `absolute_position` math, paint-order filtering, and iframe hidden-element counting. The check wasn't even idempotent — calling it twice on the same node could return different results.
2. A frame node appears in **its own** frame chain (`_construct_enhanced_node` appends it before computing its visibility), so an iframe's bounds got offset by themselves — coordinates doubled. An iframe at y=1200 on a 900px viewport (threshold 1000) became y=2400 → classified invisible → `should_process_iframe=False` → its entire content subtree silently dropped from extraction. A likely contributor to "elements missing from the DOM" reports and one of the reasons cross-origin iframe support has been flaky.

## Fix

Work on a copy of the bounds; skip `frame is node` in the chain walk. No behavioral change for correctly-classified elements.

## Verification

New unit tests (no browser needed) that fail on the previous code:
- bounds object unchanged after a visibility check
- the check is idempotent
- an iframe checked against a frame chain containing itself is not double-transformed (y=1200 stays visible)

Plus existing DOM serializer browser tests passing; pyright and ruff clean.

Part of a series of small fixes from an internal review (#5133, #5146, #5147, #5148).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a visibility bug that mutated shared bounds and double-offset iframes. We now copy bounds and skip self in the frame chain, restoring correct visibility and preventing dropped iframe content.

- **Bug Fixes**
  - Copy `snapshot_node.bounds` before transforms to avoid in-place mutations.
  - Skip `frame is node` when walking the frame chain to prevent double transforms.
  - Add tests for non-mutation and iframe visibility; strengthen the idempotency test to catch drift at threshold.

<sup>Written for commit 94ea8f60c8f528d5a8eca8996d97b5bf09b62bdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

