### PR TITLE
Fix occlusion check probing the wrong coordinate space in iframes

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -570,14 +570,11 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 	# ========== Implementation Methods ==========
 
-	async def _check_element_occlusion(self, backend_node_id: int, x: float, y: float, cdp_session) -> bool:
-		"""Check if an element is occluded by other elements at the given coordinates.
+	async def _check_element_occlusion(self, backend_node_id: int, cdp_session) -> bool:
+		"""Check if an element is occluded at its center point.
 
-		Args:
-			backend_node_id: The backend node ID of the target element
-			x: X coordinate to check
-			y: Y coordinate to check
-			cdp_session: CDP session to use
+		Runs in the element's own JS realm: elementFromPoint expects frame-local
+		coordinates, so the probe point is computed in-realm via getBoundingClientRect.
 
 		Returns:
 			True if element is occluded, False if clickable
@@ -612,7 +609,13 @@ class DefaultActionWatchdog(BaseWatchdog):
 						};
 
 
-						const elementAtPoint = document.elementFromPoint(arguments[0], arguments[1]);
+						// probe the center in frame-local coordinates (what elementFromPoint expects)
+						const rect = this.getBoundingClientRect();
+						const vw = window.innerWidth || document.documentElement.clientWidth;
+						const vh = window.innerHeight || document.documentElement.clientHeight;
+						const px = Math.max(0, Math.min(vw - 1, rect.x + rect.width / 2));
+						const py = Math.max(0, Math.min(vh - 1, rect.y + rect.height / 2));
+						const elementAtPoint = document.elementFromPoint(px, py);
 						if (!elementAtPoint) {
 							return { targetInfo: getElementInfo(this), isClickable: false };
 						}
@@ -668,7 +671,6 @@ class DefaultActionWatchdog(BaseWatchdog):
 						};
 					}
 					""",
-					'arguments': [{'value': x}, {'value': y}],
 					'returnByValue': True,
 				},
 				session_id=session_id,
@@ -872,7 +874,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 			center_y = max(0, min(viewport_height - 1, center_y))
 
 			# Check for occlusion before attempting CDP click
-			is_occluded = await self._check_element_occlusion(backend_node_id, center_x, center_y, cdp_session)
+			is_occluded = await self._check_element_occlusion(backend_node_id, cdp_session)
 
 			if is_occluded:
 				self.logger.debug('🚫 Element is occluded, falling back to JavaScript click')
@@ -1791,7 +1793,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 				center_y = coords.y + coords.height / 2
 
 				# Check for occlusion before using coordinates for focus
-				is_occluded = await self._check_element_occlusion(backend_node_id, center_x, center_y, cdp_session)
+				is_occluded = await self._check_element_occlusion(backend_node_id, cdp_session)
 
 				if is_occluded:
 					self.logger.debug('🚫 Input element is occluded, skipping coordinate-based focus')

--- a/tests/ci/browser/test_iframe_click_occlusion.py
+++ b/tests/ci/browser/test_iframe_click_occlusion.py
@@ -1,0 +1,97 @@
+"""Regression test: clicks on same-origin iframe elements must use real mouse events.
+
+The occlusion pre-check runs in the element's own JS realm, where elementFromPoint
+expects frame-local coordinates. Probing with top-viewport coordinates misclassifies
+every iframe element as occluded, downgrading the click to a JS this.click() fallback
+that fires no mousedown/mouseup. A real CDP mouse click fires mousedown — that is the
+observable this test asserts on.
+"""
+
+import asyncio
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+from browser_use.tools.service import Tools
+
+IFRAME_HTML = """
+<!DOCTYPE html>
+<html>
+<body style="margin: 0;">
+	<div style="height: 120px;">spacer inside iframe</div>
+	<button id="iframe-button"
+		onmousedown="parent.document.title = 'mousedown-received'"
+		onclick="if (parent.document.title !== 'mousedown-received') parent.document.title = 'click-only'">
+		Click me
+	</button>
+	<!-- Non-ancestor element occupying the spot where the button's TOP-VIEWPORT
+	     coordinates land inside this frame's local space. A wrong-realm probe hits
+	     this instead of the button and misclassifies the button as occluded. -->
+	<div id="decoy" style="height: 300px;">decoy content below the button</div>
+</body>
+</html>
+"""
+
+MAIN_HTML = """
+<!DOCTYPE html>
+<html>
+<head><title>initial</title></head>
+<body style="margin: 0;">
+	<div style="height: 250px;">tall header so top-viewport and frame-local coordinates diverge</div>
+	<iframe id="test-iframe" src="/iframe-content" style="width: 600px; height: 400px; border: 0;"></iframe>
+</body>
+</html>
+"""
+
+
+@pytest.fixture
+async def browser_session():
+	session = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=True,
+		)
+	)
+	await session.start()
+	yield session
+	await session.kill()
+
+
+async def test_same_origin_iframe_click_fires_real_mouse_events(httpserver, browser_session: BrowserSession):
+	"""Clicking a button inside a same-origin iframe must dispatch real mouse events."""
+	httpserver.expect_request('/main').respond_with_data(MAIN_HTML, content_type='text/html')
+	httpserver.expect_request('/iframe-content').respond_with_data(IFRAME_HTML, content_type='text/html')
+
+	await browser_session.navigate_to(httpserver.url_for('/main'))
+	await asyncio.sleep(1)
+
+	browser_state = await browser_session.get_browser_state_summary(
+		include_screenshot=False,
+		include_recent_events=False,
+	)
+	selector_map = browser_state.dom_state.selector_map
+
+	button_idx = None
+	for idx, element in selector_map.items():
+		if element.attributes and element.attributes.get('id') == 'iframe-button':
+			button_idx = idx
+			break
+	assert button_idx is not None, f'iframe button not found in selector map ({len(selector_map)} elements)'
+
+	tools = Tools()
+	result = await tools.click(index=button_idx, browser_session=browser_session)
+	assert result.error is None, f'click failed: {result.error}'
+
+	await asyncio.sleep(0.5)
+	cdp_session = await browser_session.get_or_create_cdp_session()
+	eval_result = await cdp_session.cdp_client.send.Runtime.evaluate(
+		params={'expression': 'document.title', 'returnByValue': True},
+		session_id=cdp_session.session_id,
+	)
+	title = eval_result['result'].get('value')
+	assert title == 'mousedown-received', (
+		f'expected a real mouse click (mousedown) on the iframe button, got title={title!r} — '
+		f"'click-only' means the click was downgraded to the JS this.click() fallback"
+	)


### PR DESCRIPTION
## Problem

`_check_element_occlusion` runs its JS via `callFunctionOn` on the element's objectId — i.e. **in the element's own realm**, where `document.elementFromPoint` expects coordinates local to that document. But it was handed **top-viewport coordinates** from CDP quads.

For any element inside an iframe, the probe hit the wrong point. Whenever that point landed on a non-ancestor element in the iframe's document, the click was misclassified as occluded and silently downgraded to the JS `this.click()` fallback — which fires only `click`, no `mousedown`/`mouseup`/hover, breaking widgets that need real mouse semantics (mousedown-driven menus, drag handles, some form controls). The agent was told the click succeeded either way.

## Fix

Compute the probe point in-realm from `this.getBoundingClientRect()` (frame-local by definition, correct at any nesting depth, top document included), clamped to the frame's own viewport — and drop the now-unused coordinate parameters. The Python-side quad center is still used for the actual mouse dispatch.

## Verification

Regression test with a discriminating observable: a button inside a same-origin iframe records `mousedown` via `parent.document.title` — only a real CDP mouse click fires it; JS `click()` cannot. A decoy element sits exactly where the wrong-realm probe lands (iframe offset 250px from page top, decoy below the button), so pre-fix the test deterministically fails with `title='click-only'` (the silent downgrade), post-fix it passes with real mouse events. 34 click/coordinate tests passing; pyright and ruff clean.

Part of a series of small fixes from an internal review (#5133, #5146, #5147, #5148, #5151).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes occlusion checks to use frame-local coordinates so iframe clicks use real mouse events instead of falling back to `this.click()`. This prevents false occlusion and restores `mousedown`/`mouseup` behavior.

- **Bug Fixes**
  - `_check_element_occlusion` now computes the probe point via `getBoundingClientRect()` in the element’s realm and clamps to the frame viewport.
  - Removed `x, y` params from `_check_element_occlusion`; CDP mouse dispatch still uses the quad center in the top document.
  - Added `tests/ci/browser/test_iframe_click_occlusion.py` to assert iframe buttons receive `mousedown` (detects previous `click`-only downgrade).

<sup>Written for commit 9c1effa3815ac8aaf623447aa51b7cc444a89095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

