### PR TITLE
fix(example): make news monitor file handling explicit

### DIFF
--- a/examples/apps/news-use/news_monitor.py
+++ b/examples/apps/news-use/news_monitor.py
@@ -8,8 +8,8 @@ import argparse
 import asyncio
 import hashlib
 import json
-import logging
 import locale
+import logging
 import os
 import time
 from datetime import datetime, timezone

--- a/examples/apps/news-use/news_monitor.py
+++ b/examples/apps/news-use/news_monitor.py
@@ -9,6 +9,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import locale
 import os
 import time
 from datetime import datetime, timezone
@@ -173,16 +174,30 @@ async def extract_latest_article(site_url: str, debug: bool = False) -> dict:
 # ---------------------------------------------------------
 
 
+def _load_articles(file_path: str) -> list | None:
+	"""Load saved articles, including files written with the system locale."""
+	encodings = ['utf-8', 'utf-8-sig', locale.getencoding(), 'cp1252']
+	for encoding in dict.fromkeys(encodings):
+		try:
+			with open(file_path, encoding=encoding) as f:
+				return json.load(f)
+		except UnicodeDecodeError:
+			continue
+		except Exception:
+			return []
+
+	logging.warning('Could not decode %s as UTF-8 or the system locale; keeping existing data untouched', file_path)
+	return None
+
+
 def load_seen_hashes(file_path: str = 'news_data.json') -> set:
 	"""Load already-saved article URL hashes from disk for dedup across restarts."""
 	if not os.path.exists(file_path):
 		return set()
-	try:
-		with open(file_path, encoding='utf-8') as f:
-			items = json.load(f)
-		return {entry['hash'] for entry in items if 'hash' in entry}
-	except Exception:
+	items = _load_articles(file_path)
+	if items is None:
 		return set()
+	return {entry['hash'] for entry in items if 'hash' in entry}
 
 
 def save_article(article: dict, file_path: str = 'news_data.json'):
@@ -195,11 +210,9 @@ def save_article(article: dict, file_path: str = 'news_data.json'):
 
 	existing = []
 	if os.path.exists(file_path):
-		try:
-			with open(file_path, encoding='utf-8') as f:
-				existing = json.load(f)
-		except Exception:
-			existing = []
+		existing = _load_articles(file_path)
+		if existing is None:
+			return
 
 	existing.append(payload)
 	# Keep last 100

--- a/examples/apps/news-use/news_monitor.py
+++ b/examples/apps/news-use/news_monitor.py
@@ -176,7 +176,7 @@ async def extract_latest_article(site_url: str, debug: bool = False) -> dict:
 
 def _load_articles(file_path: str) -> list | None:
 	"""Load saved articles, including files written with the system locale."""
-	encodings = ['utf-8', 'utf-8-sig', locale.getencoding(), 'cp1252']
+	encodings = ['utf-8-sig', 'utf-8', locale.getencoding(), 'cp1252']
 	for encoding in dict.fromkeys(encodings):
 		try:
 			with open(file_path, encoding=encoding) as f:

--- a/examples/apps/news-use/news_monitor.py
+++ b/examples/apps/news-use/news_monitor.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
 from dateutil import parser as dtparser
@@ -178,7 +178,7 @@ def load_seen_hashes(file_path: str = 'news_data.json') -> set:
 	if not os.path.exists(file_path):
 		return set()
 	try:
-		with open(file_path) as f:
+		with open(file_path, encoding='utf-8') as f:
 			items = json.load(f)
 		return {entry['hash'] for entry in items if 'hash' in entry}
 	except Exception:
@@ -196,7 +196,7 @@ def save_article(article: dict, file_path: str = 'news_data.json'):
 	existing = []
 	if os.path.exists(file_path):
 		try:
-			with open(file_path) as f:
+			with open(file_path, encoding='utf-8') as f:
 				existing = json.load(f)
 		except Exception:
 			existing = []
@@ -205,7 +205,7 @@ def save_article(article: dict, file_path: str = 'news_data.json'):
 	# Keep last 100
 	existing = existing[-100:]
 
-	with open(file_path, 'w') as f:
+	with open(file_path, 'w', encoding='utf-8') as f:
 		json.dump(existing, f, ensure_ascii=False, indent=2)
 
 
@@ -219,7 +219,7 @@ def _fmt(ts_raw: str) -> str:
 	try:
 		return dtparser.parse(ts_raw).strftime('%Y-%m-%d %H:%M:%S')
 	except Exception:
-		return datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+		return datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
 
 
 async def run_once(url: str, output_path: str, debug: bool):


### PR DESCRIPTION
## Summary
- read and write the news monitor JSON history with explicit UTF-8 encoding
- replace the fallback `datetime.utcnow()` timestamp with timezone-aware UTC

## Problem
The news monitor example writes JSON with `ensure_ascii=False`, but relies on the platform default encoding when reading and writing `news_data.json`. That can break or misread non-ASCII article titles on non-UTF-8 systems. Its timestamp fallback also uses naive UTC via `datetime.utcnow()`.

## Before / After
Before, the example used default text encoding for `news_data.json` and emitted a naive UTC fallback timestamp.

After, the JSON history is consistently handled as UTF-8 and the fallback timestamp is generated with `datetime.now(timezone.utc)`.

## Verification
- `python -m py_compile examples/apps/news-use/news_monitor.py`
- `uv run ruff check examples/apps/news-use/news_monitor.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the news monitor read and write `news_data.json` as UTF-8 and handle legacy encodings, including UTF‑8 BOM files. Uses timezone-aware UTC for fallback timestamps and avoids overwriting unreadable histories.

- **Bug Fixes**
  - Read existing files with a fallback chain (`utf-8-sig`, `utf-8`, system locale, `cp1252`) to support UTF‑8 BOM and legacy encodings; write with `encoding='utf-8'` and `ensure_ascii=False`; skip writes if the file can’t be decoded and log a warning.
  - Replace `datetime.utcnow()` with `datetime.now(timezone.utc)` for the fallback timestamp; fix import order.

<sup>Written for commit 58bde7aaeb5ab61253e38643cc1a8c1c11583a89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

