### PR TITLE
feat: structured ActionOutcome — typed result categories (not_found, …

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -47,7 +47,7 @@ base_subprocess.BaseSubprocessTransport.__del__ = _patched_del
 if TYPE_CHECKING:
 	from browser_use.agent.prompts import SystemPrompt
 	from browser_use.agent.service import Agent
-	from browser_use.agent.views import ActionModel, ActionResult, AgentHistoryList
+	from browser_use.agent.views import ActionModel, ActionOutcome, ActionResult, AgentHistoryList
 	from browser_use.browser import BrowserProfile, BrowserSession
 	from browser_use.browser import BrowserSession as Browser
 	from browser_use.dom.service import DomService
@@ -75,6 +75,7 @@ _LAZY_IMPORTS = {
 	# Agent views (very heavy - over 1 second!)
 	'ActionModel': ('browser_use.agent.views', 'ActionModel'),
 	'ActionResult': ('browser_use.agent.views', 'ActionResult'),
+	'ActionOutcome': ('browser_use.agent.views', 'ActionOutcome'),
 	'AgentHistoryList': ('browser_use.agent.views', 'AgentHistoryList'),
 	'BrowserSession': ('browser_use.browser', 'BrowserSession'),
 	'Browser': ('browser_use.browser', 'BrowserSession'),  # Alias for BrowserSession
@@ -134,6 +135,7 @@ __all__ = [
 	'DomService',
 	'SystemPrompt',
 	'ActionResult',
+	'ActionOutcome',
 	'ActionModel',
 	'AgentHistoryList',
 	# Chat models

--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -8,6 +8,7 @@ from browser_use.agent.message_manager.views import (
 )
 from browser_use.agent.prompts import AgentMessagePrompt
 from browser_use.agent.views import (
+	ActionOutcome,
 	ActionResult,
 	AgentOutput,
 	AgentStepInfo,
@@ -341,6 +342,9 @@ class MessageManager:
 					error_text = action_result.error[:100] + '......' + action_result.error[-100:]
 				else:
 					error_text = action_result.error
+				# Prefix with outcome category for non-system errors so the agent understands the type
+				if action_result.outcome != ActionOutcome.SUCCESS:
+					error_text = f'[{action_result.outcome.value}] {error_text}'
 				action_results += f'{error_text}\n'
 				logger.debug(f'Added error to action_results: {error_text}')
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -45,6 +45,7 @@ from browser_use.agent.message_manager.service import (
 )
 from browser_use.agent.prompts import SystemPrompt
 from browser_use.agent.views import (
+	ActionOutcome,
 	ActionResult,
 	AgentError,
 	AgentHistory,
@@ -859,7 +860,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					elif isinstance(params, dict):
 						skill_params = params
 					else:
-						return ActionResult(extracted_content=None, error=f'Invalid parameters type: {type(params)}')
+						return ActionResult(
+							outcome=ActionOutcome.INVALID_STATE,
+							extracted_content=None,
+							error=f'Invalid parameters type: {type(params)}',
+						)
 
 					# Get cookies from browser
 					_cookies = await self.browser_session.cookies()
@@ -875,7 +880,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 								error=None,
 							)
 						else:
-							return ActionResult(extracted_content=None, error=result.error or 'Skill execution failed')
+							return ActionResult(
+								outcome=ActionOutcome.SYSTEM_ERROR,
+								extracted_content=None,
+								error=result.error or 'Skill execution failed',
+							)
 					except Exception as e:
 						# Check if it's a MissingCookieException
 						if type(e).__name__ == 'MissingCookieException':
@@ -883,8 +892,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 							cookie_name = getattr(e, 'cookie_name', 'unknown')
 							cookie_description = getattr(e, 'cookie_description', str(e))
 							error_msg = f'Missing cookies ({cookie_name}): {cookie_description}'
-							return ActionResult(extracted_content=None, error=error_msg)
-						return ActionResult(extracted_content=None, error=f'Skill execution error: {type(e).__name__}: {e}')
+							return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, extracted_content=None, error=error_msg)
+						return ActionResult(
+							outcome=ActionOutcome.SYSTEM_ERROR,
+							extracted_content=None,
+							error=f'Skill execution error: {type(e).__name__}: {e}',
+						)
 
 				return skill_handler
 
@@ -1222,12 +1235,23 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		# Record executed actions for loop detection
 		self._update_loop_detector_actions()
 
-		# check for action errors - only count single-action steps toward consecutive failures;
+		# check for action errors - only SYSTEM_ERROR counts toward consecutive failures;
+		# NOT_FOUND and INVALID_STATE are informative feedback, not failures.
 		# multi-action steps with errors are handled by loop detection and replan nudges instead
-		if self.state.last_result and len(self.state.last_result) == 1 and self.state.last_result[-1].error:
-			self.state.consecutive_failures += 1
-			self.logger.debug(f'🔄 Step {self.state.n_steps}: Consecutive failures: {self.state.consecutive_failures}')
-			return
+		if self.state.last_result and len(self.state.last_result) == 1:
+			last = self.state.last_result[-1]
+			if last.is_system_error:
+				self.state.consecutive_failures += 1
+				self.logger.debug(
+					f'🔄 Step {self.state.n_steps}: Consecutive failures (system_error): {self.state.consecutive_failures}'
+				)
+				return
+			elif last.is_not_found:
+				self.logger.debug(f'🔄 Step {self.state.n_steps}: Action returned not_found - informative')
+				return
+			elif last.is_invalid_state:
+				self.logger.debug(f'🔄 Step {self.state.n_steps}: Action returned invalid_state - informative')
+				return
 
 		if self.state.consecutive_failures > 0:
 			self.state.consecutive_failures = 0
@@ -1273,7 +1297,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				# Check if reconnection succeeded
 				if self.browser_session.is_cdp_connected:
 					self.logger.info('🔄 Reconnection succeeded, retrying step...')
-					self.state.last_result = [ActionResult(error=f'Connection lost and recovered: {error}')]
+					self.state.last_result = [
+						ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=f'Connection lost and recovered: {error}')
+					]
 					return
 
 			# Not reconnecting or reconnection failed — check if truly terminal
@@ -1302,7 +1328,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			self.logger.log(log_level, f'{prefix}{error_msg}')
 
 		await self._demo_mode_log(f'Step error: {error_msg}', 'error', {'step': self.state.n_steps})
-		self.state.last_result = [ActionResult(error=error_msg)]
+		self.state.last_result = [ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)]
 		return None
 
 	def _is_connection_like_error(self, error: Exception) -> bool:
@@ -2461,7 +2487,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			self.logger.error(f'⏰ {error_msg}')
 			await self._demo_mode_log(error_msg, 'error', {'step': step + 1})
 			self.state.consecutive_failures += 1
-			self.state.last_result = [ActionResult(error=error_msg)]
+			self.state.last_result = [ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)]
 			# Ensure step counter advances on timeout — _finalize() may have
 			# been skipped or returned early due to the cancellation.
 			if self.state.n_steps == step + 1:
@@ -2578,7 +2604,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					f'(browser may be unresponsive). Proceeding to main execution loop.'
 				)
 				self.logger.error(f'⏰ {initial_timeout_msg}')
-				self.state.last_result = [ActionResult(error=initial_timeout_msg)]
+				self.state.last_result = [ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=initial_timeout_msg)]
 				self.state.consecutive_failures += 1
 			except Exception as e:
 				raise e
@@ -2626,7 +2652,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				self.history.add_item(
 					AgentHistory(
 						model_output=None,
-						result=[ActionResult(error=agent_run_error, include_in_memory=True)],
+						result=[ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=agent_run_error, include_in_memory=True)],
 						state=BrowserStateHistory(
 							url='',
 							title='',
@@ -2795,7 +2821,13 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 				results.append(result)
 
-				if results[-1].is_done or results[-1].error or i == total_actions - 1:
+				if (
+					results[-1].is_done
+					or results[-1].error
+					or results[-1].is_not_found
+					or results[-1].is_invalid_state
+					or i == total_actions - 1
+				):
 					break
 
 				# --- Page-change guards (only when more actions remain) ---
@@ -3020,7 +3052,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				browser_session=self.browser_session, extract_links=extract_links
 			)
 		except Exception as e:
-			return ActionResult(error=f'Could not extract clean markdown: {type(e).__name__}: {e}')
+			return ActionResult(
+				outcome=ActionOutcome.SYSTEM_ERROR, error=f'Could not extract clean markdown: {type(e).__name__}: {e}'
+			)
 
 		# Get screenshot if requested
 		screenshot_b64 = None
@@ -3087,7 +3121,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		except Exception as e:
 			self.logger.warning(f'Failed to execute AI step: {e.__class__.__name__}: {e}')
 			self.logger.debug('Full error traceback:', exc_info=True)
-			return ActionResult(error=f'AI step failed: {e}')
+			return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=f'AI step failed: {e}')
 
 	async def rerun_history(
 		self,
@@ -3179,7 +3213,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					)
 					results.append(
 						ActionResult(
-							error=f'Skipped - original step had error: {error_msgs[0][:100] if error_msgs else "unknown"}'
+							outcome=ActionOutcome.SYSTEM_ERROR,
+							error=f'Skipped - original step had error: {error_msgs[0][:100] if error_msgs else "unknown"}',
 						)
 					)
 					continue

--- a/browser_use/agent/system_prompts/system_prompt.md
+++ b/browser_use/agent/system_prompts/system_prompt.md
@@ -229,6 +229,18 @@ Here are examples of good output patterns. Use them as reference but never copy 
 "next_goal": "Apply price filter to narrow results to items under $50."
 </next_goal_examples>
 </examples>
+<action_outcomes>
+Actions return results with one of four outcome categories:
+- success: Action completed as expected
+- not_found: Target element or data does not exist on the page — try a different approach
+- invalid_state: Element exists but cannot be interacted with (disabled, wrong type) — adjust your strategy
+- system_error: Technical failure (CDP, timeout, network) — worth retrying
+
+NOT_FOUND and INVALID_STATE are NOT failures counted against you. 
+They mean you need to adapt your approach.
+Only SYSTEM_ERROR counts toward the failure limit.
+</action_outcomes>
+
 <output>
 You must ALWAYS respond with a valid JSON in this exact format:
 {{

--- a/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
@@ -153,6 +153,18 @@ If an interactive index inside your browser_state does not have text information
 Use screenshot if you are unsure or simply want more information about the current page state.
 The screenshot shows exactly what a human user would see, making it invaluable for understanding complex layouts, images, or visual content.
 </browser_vision_details>
+<action_outcomes>
+Actions return results with one of four outcome categories:
+- success: Action completed as expected
+- not_found: Target element or data does not exist on the page — try a different approach
+- invalid_state: Element exists but cannot be interacted with (disabled, wrong type) — adjust your strategy
+- system_error: Technical failure (CDP, timeout, network) — worth retrying
+
+NOT_FOUND and INVALID_STATE are NOT failures counted against you. 
+They mean you need to adapt your approach.
+Only SYSTEM_ERROR counts toward the failure limit.
+</action_outcomes>
+
 <output>You must call the AgentOutput tool with the following schema for the arguments:
 
 {{

--- a/browser_use/agent/system_prompts/system_prompt_browser_use.md
+++ b/browser_use/agent/system_prompts/system_prompt_browser_use.md
@@ -4,6 +4,18 @@ You are a browser-use agent operating in thinking mode. You automate browser tas
 Instructions containing "do NOT", "never", "avoid", "skip", or "only X" are hard constraints. Before each action, check: does this violate any constraint? If yes, stop and find an alternative.
 </constraint_enforcement>
 
+<action_outcomes>
+Actions return results with one of four outcome categories:
+- success: Action completed as expected
+- not_found: Target element or data does not exist on the page — try a different approach
+- invalid_state: Element exists but cannot be interacted with (disabled, wrong type) — adjust your strategy
+- system_error: Technical failure (CDP, timeout, network) — worth retrying
+
+NOT_FOUND and INVALID_STATE are NOT failures counted against you. 
+They mean you need to adapt your approach.
+Only SYSTEM_ERROR counts toward the failure limit.
+</action_outcomes>
+
 <output>
 You must ALWAYS respond with a valid JSON in this exact format:
 {{

--- a/browser_use/agent/system_prompts/system_prompt_browser_use_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_browser_use_flash.md
@@ -4,6 +4,18 @@ You are a browser-use agent operating in flash mode. You automate browser tasks 
 Instructions containing "do NOT", "never", "avoid", "skip", or "only X" are hard constraints. Before each action, check: does this violate any constraint? If yes, stop and find an alternative.
 </constraint_enforcement>
 
+<action_outcomes>
+Actions return results with one of four outcome categories:
+- success: Action completed as expected
+- not_found: Target element or data does not exist on the page — try a different approach
+- invalid_state: Element exists but cannot be interacted with (disabled, wrong type) — adjust your strategy
+- system_error: Technical failure (CDP, timeout, network) — worth retrying
+
+NOT_FOUND and INVALID_STATE are NOT failures counted against you. 
+They mean you need to adapt your approach.
+Only SYSTEM_ERROR counts toward the failure limit.
+</action_outcomes>
+
 <output>
 You must respond with a valid JSON in this exact format:
 {{

--- a/browser_use/agent/system_prompts/system_prompt_browser_use_no_thinking.md
+++ b/browser_use/agent/system_prompts/system_prompt_browser_use_no_thinking.md
@@ -4,6 +4,18 @@ You are a browser-use agent. You automate browser tasks by outputting structured
 Instructions containing "do NOT", "never", "avoid", "skip", or "only X" are hard constraints. Before each action, check: does this violate any constraint? If yes, stop and find an alternative.
 </constraint_enforcement>
 
+<action_outcomes>
+Actions return results with one of four outcome categories:
+- success: Action completed as expected
+- not_found: Target element or data does not exist on the page — try a different approach
+- invalid_state: Element exists but cannot be interacted with (disabled, wrong type) — adjust your strategy
+- system_error: Technical failure (CDP, timeout, network) — worth retrying
+
+NOT_FOUND and INVALID_STATE are NOT failures counted against you. 
+They mean you need to adapt your approach.
+Only SYSTEM_ERROR counts toward the failure limit.
+</action_outcomes>
+
 <output>
 You must ALWAYS respond with a valid JSON in this exact format:
 {{

--- a/browser_use/agent/system_prompts/system_prompt_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_flash.md
@@ -6,6 +6,18 @@ You are an AI agent designed to operate in an iterative loop to automate browser
 <action_rules>
 You are allowed to use a maximum of {max_actions} actions per step. Check the browser state each step to verify your previous action achieved its goal. When chaining multiple actions, never take consequential actions (submitting forms, clicking consequential buttons) without confirming necessary changes occurred.
 </action_rules>
+<action_outcomes>
+Actions return results with one of four outcome categories:
+- success: Action completed as expected
+- not_found: Target element or data does not exist on the page — try a different approach
+- invalid_state: Element exists but cannot be interacted with (disabled, wrong type) — adjust your strategy
+- system_error: Technical failure (CDP, timeout, network) — worth retrying
+
+NOT_FOUND and INVALID_STATE are NOT failures counted against you. 
+They mean you need to adapt your approach.
+Only SYSTEM_ERROR counts toward the failure limit.
+</action_outcomes>
+
 <output>You must respond with a valid JSON in this exact format:
 {{
   "memory": "Up to 5 sentences of specific reasoning about: Was the previous step successful / failed? What do we need to remember from the current state for the task? Plan ahead what are the best next actions. What's the next immediate goal? Depending on the complexity think longer. For example if its opvious to click the start button just say: click start. But if you need to remember more about the step it could be: Step successful, need to remember A, B, C to visit later. Next click on A.",

--- a/browser_use/agent/system_prompts/system_prompt_flash_anthropic.md
+++ b/browser_use/agent/system_prompts/system_prompt_flash_anthropic.md
@@ -11,6 +11,18 @@ PDFs are auto-downloaded to available_file_paths - use read_file to read the doc
 <action_rules>
 You are allowed to use a maximum of {max_actions} actions per step. Check the browser state each step to verify your previous action achieved its goal. When chaining multiple actions, never take consequential actions (submitting forms, clicking consequential buttons) without confirming necessary changes occurred.
 </action_rules>
+<action_outcomes>
+Actions return results with one of four outcome categories:
+- success: Action completed as expected
+- not_found: Target element or data does not exist on the page — try a different approach
+- invalid_state: Element exists but cannot be interacted with (disabled, wrong type) — adjust your strategy
+- system_error: Technical failure (CDP, timeout, network) — worth retrying
+
+NOT_FOUND and INVALID_STATE are NOT failures counted against you. 
+They mean you need to adapt your approach.
+Only SYSTEM_ERROR counts toward the failure limit.
+</action_outcomes>
+
 <output>You must call the AgentOutput tool with the following schema for the arguments:
 
 {{

--- a/browser_use/agent/system_prompts/system_prompt_no_thinking.md
+++ b/browser_use/agent/system_prompts/system_prompt_no_thinking.md
@@ -206,6 +206,18 @@ Here are examples of good output patterns. Use them as reference but never copy 
 "next_goal": "Apply price filter to narrow results to items under $50."
 </next_goal_examples>
 </examples>
+<action_outcomes>
+Actions return results with one of four outcome categories:
+- success: Action completed as expected
+- not_found: Target element or data does not exist on the page — try a different approach
+- invalid_state: Element exists but cannot be interacted with (disabled, wrong type) — adjust your strategy
+- system_error: Technical failure (CDP, timeout, network) — worth retrying
+
+NOT_FOUND and INVALID_STATE are NOT failures counted against you. 
+They mean you need to adapt your approach.
+Only SYSTEM_ERROR counts toward the failure limit.
+</action_outcomes>
+
 <output>
 You must ALWAYS respond with a valid JSON in this exact format:
 {{

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -6,6 +6,7 @@ import logging
 import re
 import traceback
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any, Generic, Literal
 
@@ -304,6 +305,22 @@ class JudgementResult(BaseModel):
 	)
 
 
+class ActionOutcome(str, Enum):
+	"""Typed outcome for action execution results.
+
+	Helps the agent distinguish between:
+	- SUCCESS: action completed as expected
+	- NOT_FOUND: element/data does not exist on the page
+	- INVALID_STATE: element exists but cannot be interacted with
+	- SYSTEM_ERROR: infrastructure failure (CDP, timeout, network)
+	"""
+
+	SUCCESS = 'success'
+	NOT_FOUND = 'not_found'
+	INVALID_STATE = 'invalid_state'
+	SYSTEM_ERROR = 'system_error'
+
+
 class ActionResult(BaseModel):
 	"""Result of executing an action"""
 
@@ -316,6 +333,9 @@ class ActionResult(BaseModel):
 
 	# Error handling - always include in long term memory
 	error: str | None = None
+
+	# Typed outcome - helps the agent distinguish failure categories
+	outcome: ActionOutcome = ActionOutcome.SUCCESS
 
 	# Files
 	attachments: list[str] | None = None  # Files to display in the done message
@@ -338,6 +358,17 @@ class ActionResult(BaseModel):
 	include_in_memory: bool = False  # whether to include in extracted_content inside long_term_memory
 
 	@model_validator(mode='after')
+	def infer_outcome_from_error(self):
+		"""Auto-set outcome to SYSTEM_ERROR when error is set but outcome is still default SUCCESS.
+
+		This ensures backward compatibility: old code that only sets error= gets the correct
+		failure treatment instead of being treated as a success.
+		"""
+		if self.error is not None and self.outcome == ActionOutcome.SUCCESS:
+			self.outcome = ActionOutcome.SYSTEM_ERROR
+		return self
+
+	@model_validator(mode='after')
 	def validate_success_requires_done(self):
 		"""Ensure success=True can only be set when is_done=True"""
 		if self.success is True and self.is_done is not True:
@@ -347,6 +378,18 @@ class ActionResult(BaseModel):
 				'Use success=False only for actions that fail.'
 			)
 		return self
+
+	@property
+	def is_not_found(self) -> bool:
+		return self.outcome == ActionOutcome.NOT_FOUND
+
+	@property
+	def is_system_error(self) -> bool:
+		return self.outcome == ActionOutcome.SYSTEM_ERROR
+
+	@property
+	def is_invalid_state(self) -> bool:
+		return self.outcome == ActionOutcome.INVALID_STATE
 
 
 class RerunSummaryAction(BaseModel):

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -13,7 +13,7 @@ except ImportError:
 	Laminar = None  # type: ignore
 from pydantic import BaseModel
 
-from browser_use.agent.views import ActionModel, ActionResult
+from browser_use.agent.views import ActionModel, ActionOutcome, ActionResult
 from browser_use.browser import BrowserSession
 from browser_use.browser.events import (
 	ClickCoordinateEvent,
@@ -186,10 +186,13 @@ def handle_browser_error(e: BrowserError) -> ActionResult:
 	if e.long_term_memory is not None:
 		if e.short_term_memory is not None:
 			return ActionResult(
-				extracted_content=e.short_term_memory, error=e.long_term_memory, include_extracted_content_only_once=True
+				outcome=ActionOutcome.SYSTEM_ERROR,
+				extracted_content=e.short_term_memory,
+				error=e.long_term_memory,
+				include_extracted_content_only_once=True,
 			)
 		else:
-			return ActionResult(error=e.long_term_memory)
+			return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=e.long_term_memory)
 	# Fallback to original error handling if long_term_memory is None
 	logger.warning(
 		'⚠️ A BrowserError was raised without long_term_memory - always set long_term_memory when raising BrowserError to propagate right messages to LLM.'
@@ -474,7 +477,10 @@ class Tools(Generic[Context]):
 			}
 
 			if params.engine.lower() not in search_engines:
-				return ActionResult(error=f'Unsupported search engine: {params.engine}. Options: duckduckgo, google, bing')
+				return ActionResult(
+					outcome=ActionOutcome.INVALID_STATE,
+					error=f'Unsupported search engine: {params.engine}. Options: duckduckgo, google, bing',
+				)
 
 			search_url = search_engines[params.engine.lower()]
 
@@ -497,7 +503,9 @@ class Tools(Generic[Context]):
 				return ActionResult(extracted_content=memory, long_term_memory=memory)
 			except Exception as e:
 				logger.error(f'Failed to search {params.engine}: {e}')
-				return ActionResult(error=f'Failed to search {params.engine} for "{params.query}": {str(e)}')
+				return ActionResult(
+					outcome=ActionOutcome.SYSTEM_ERROR, error=f'Failed to search {params.engine} for "{params.query}": {str(e)}'
+				)
 
 		@self.registry.action(
 			'',
@@ -538,9 +546,10 @@ class Tools(Generic[Context]):
 							state = await browser_session.get_browser_state_summary(include_screenshot=False)
 							if state.url.lower().startswith(('http://', 'https://')) and state.dom_state._root is None:
 								return ActionResult(
+									outcome=ActionOutcome.SYSTEM_ERROR,
 									error=f'Page loaded but returned empty content for {params.url}. '
 									f'The page may require JavaScript that failed to render, use anti-bot measures, '
-									f'or have a connection issue (e.g. tunnel/proxy error). Try a different URL or approach.'
+									f'or have a connection issue (e.g. tunnel/proxy error). Try a different URL or approach.',
 								)
 
 				if params.new_tab:
@@ -560,7 +569,7 @@ class Tools(Generic[Context]):
 				# Check if it's specifically a RuntimeError about CDP client
 				if isinstance(e, RuntimeError) and 'CDP client not initialized' in error_msg:
 					browser_session.logger.error('❌ Browser connection failed - CDP client not properly initialized')
-					return ActionResult(error=f'Browser connection error: {error_msg}')
+					return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=f'Browser connection error: {error_msg}')
 				# Check for network-related errors
 				elif any(
 					err in error_msg
@@ -575,10 +584,10 @@ class Tools(Generic[Context]):
 				):
 					site_unavailable_msg = f'Navigation failed - site unavailable: {params.url}'
 					browser_session.logger.warning(f'⚠️ {site_unavailable_msg} - {error_msg}')
-					return ActionResult(error=site_unavailable_msg)
+					return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=site_unavailable_msg)
 				else:
 					# Return error in ActionResult instead of re-raising
-					return ActionResult(error=f'Navigation failed: {str(e)}')
+					return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=f'Navigation failed: {str(e)}')
 
 		@self.registry.action('Go back', param_model=NoParamsAction, terminates_sequence=True)
 		async def go_back(_: NoParamsAction, browser_session: BrowserSession):
@@ -592,7 +601,7 @@ class Tools(Generic[Context]):
 			except Exception as e:
 				logger.error(f'Failed to dispatch GoBackEvent: {type(e).__name__}: {e}')
 				error_msg = f'Failed to go back: {str(e)}'
-				return ActionResult(error=error_msg)
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)
 
 		@self.registry.action('Wait for x seconds.')
 		async def wait(seconds: int = 3):
@@ -656,7 +665,9 @@ class Tools(Generic[Context]):
 		async def _click_by_coordinate(params: ClickElementAction, browser_session: BrowserSession) -> ActionResult:
 			# Ensure coordinates are provided (type safety)
 			if params.coordinate_x is None or params.coordinate_y is None:
-				return ActionResult(error='Both coordinate_x and coordinate_y must be provided')
+				return ActionResult(
+					outcome=ActionOutcome.INVALID_STATE, error='Both coordinate_x and coordinate_y must be provided'
+				)
 
 			try:
 				# Convert coordinates from LLM size to original viewport size if resizing was used
@@ -681,7 +692,7 @@ class Tools(Generic[Context]):
 				# Check for validation errors (only happens when force=False)
 				if isinstance(click_metadata, dict) and 'validation_error' in click_metadata:
 					error_msg = click_metadata['validation_error']
-					return ActionResult(error=error_msg)
+					return ActionResult(outcome=ActionOutcome.INVALID_STATE, error=error_msg)
 
 				memory = f'Clicked on coordinate {params.coordinate_x}, {params.coordinate_y}'
 				memory += await _detect_new_tab_opened(browser_session, tabs_before)
@@ -695,7 +706,7 @@ class Tools(Generic[Context]):
 				return handle_browser_error(e)
 			except Exception as e:
 				error_msg = f'Failed to click at coordinates ({params.coordinate_x}, {params.coordinate_y}).'
-				return ActionResult(error=error_msg)
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)
 
 		async def _click_by_index(
 			params: ClickElementAction | ClickElementActionIndexOnly, browser_session: BrowserSession
@@ -711,7 +722,7 @@ class Tools(Generic[Context]):
 				if node is None:
 					msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 					logger.warning(f'⚠️ {msg}')
-					return ActionResult(extracted_content=msg)
+					return ActionResult(outcome=ActionOutcome.NOT_FOUND, extracted_content=msg)
 
 				# Get description of clicked element
 				element_desc = get_click_description(node)
@@ -742,7 +753,7 @@ class Tools(Generic[Context]):
 							logger.debug(
 								f'Failed to get dropdown options as shortcut during click on dropdown: {type(dropdown_error).__name__}: {dropdown_error}'
 							)
-					return ActionResult(error=error_msg)
+					return ActionResult(outcome=ActionOutcome.INVALID_STATE, error=error_msg)
 
 				# Build memory with element info
 				memory = f'Clicked {element_desc}'
@@ -758,7 +769,7 @@ class Tools(Generic[Context]):
 				return handle_browser_error(e)
 			except Exception as e:
 				error_msg = f'Failed to click element {params.index}: {str(e)}'
-				return ActionResult(error=error_msg)
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)
 
 		# Store click handlers for re-registration
 		self._click_by_index = _click_by_index
@@ -782,7 +793,7 @@ class Tools(Generic[Context]):
 			if node is None:
 				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(outcome=ActionOutcome.NOT_FOUND, extracted_content=msg)
 
 			# Highlight the element being typed into (truly non-blocking)
 			create_task_with_error_handling(
@@ -851,7 +862,7 @@ class Tools(Generic[Context]):
 				# Log the full error for debugging
 				logger.error(f'Failed to dispatch TypeTextEvent: {type(e).__name__}: {e}')
 				error_msg = f'Failed to type text into element {params.index}: {e}'
-				return ActionResult(error=error_msg)
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)
 
 		@self.registry.action(
 			'',
@@ -891,12 +902,12 @@ class Tools(Generic[Context]):
 							if not (real_path == real_dir or real_path.startswith(real_dir + os.sep)):
 								msg = f'Upload of {params.path!r} escapes FileSystem directory; refusing.'
 								logger.error(f'❌ {msg}')
-								return ActionResult(error=msg)
+								return ActionResult(outcome=ActionOutcome.INVALID_STATE, error=msg)
 							params = UploadFileAction(index=params.index, path=file_system_path)
 						else:
 							msg = f'File path {params.path} is not available. To fix: The user must add this file path to the available_file_paths parameter when creating the Agent. Example: Agent(task="...", llm=llm, browser=browser, available_file_paths=["{params.path}"])'
 							logger.error(f'❌ {msg}')
-							return ActionResult(error=msg)
+							return ActionResult(outcome=ActionOutcome.INVALID_STATE, error=msg)
 					else:
 						# If browser is remote, allow passing a remote-accessible absolute path
 						if not browser_session.is_local:
@@ -909,17 +920,17 @@ class Tools(Generic[Context]):
 			if browser_session.is_local:
 				if not os.path.exists(params.path):
 					msg = f'File {params.path} does not exist'
-					return ActionResult(error=msg)
+					return ActionResult(outcome=ActionOutcome.INVALID_STATE, error=msg)
 				file_size = os.path.getsize(params.path)
 				if file_size == 0:
 					msg = f'File {params.path} is empty (0 bytes). The file may not have been saved correctly.'
-					return ActionResult(error=msg)
+					return ActionResult(outcome=ActionOutcome.INVALID_STATE, error=msg)
 
 			# Get the selector map to find the node
 			selector_map = await browser_session.get_selector_map()
 			if params.index not in selector_map:
 				msg = f'Element with index {params.index} does not exist.'
-				return ActionResult(error=msg)
+				return ActionResult(outcome=ActionOutcome.NOT_FOUND, error=msg)
 
 			node = selector_map[params.index]
 
@@ -1113,7 +1124,8 @@ class Tools(Generic[Context]):
 			chunks = chunk_markdown_by_structure(content, max_chunk_chars=MAX_CHAR_LIMIT, start_from_char=start_from_char)
 			if not chunks:
 				return ActionResult(
-					error=f'start_from_char ({start_from_char}) exceeds content length {final_filtered_length} characters.'
+					outcome=ActionOutcome.INVALID_STATE,
+					error=f'start_from_char ({start_from_char}) exceeds content length {final_filtered_length} characters.',
 				)
 			chunk = chunks[0]
 			content = chunk.content
@@ -1314,14 +1326,14 @@ You will be given a query and the markdown of a webpage that has been filtered t
 
 			if result.get('exceptionDetails'):
 				error_text = result['exceptionDetails'].get('text', 'Unknown JS error')
-				return ActionResult(error=f'search_page failed: {error_text}')
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=f'search_page failed: {error_text}')
 
 			data = result.get('result', {}).get('value')
 			if data is None:
-				return ActionResult(error='search_page returned no result')
+				return ActionResult(outcome=ActionOutcome.NOT_FOUND, error='search_page returned no result')
 
 			if isinstance(data, dict) and data.get('error'):
-				return ActionResult(error=f'search_page: {data["error"]}')
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=f'search_page: {data["error"]}')
 
 			formatted = _format_search_results(data, params.pattern)
 			total = data.get('total', 0)
@@ -1349,14 +1361,14 @@ You will be given a query and the markdown of a webpage that has been filtered t
 
 			if result.get('exceptionDetails'):
 				error_text = result['exceptionDetails'].get('text', 'Unknown JS error')
-				return ActionResult(error=f'find_elements failed: {error_text}')
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=f'find_elements failed: {error_text}')
 
 			data = result.get('result', {}).get('value')
 			if data is None:
-				return ActionResult(error='find_elements returned no result')
+				return ActionResult(outcome=ActionOutcome.NOT_FOUND, error='find_elements returned no result')
 
 			if isinstance(data, dict) and data.get('error'):
-				return ActionResult(error=f'find_elements: {data["error"]}')
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=f'find_elements: {data["error"]}')
 
 			formatted = _format_find_results(data, params.selector)
 			total = data.get('total', 0)
@@ -1378,7 +1390,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 					if node is None:
 						# Element does not exist
 						msg = f'Element index {params.index} not found in browser state'
-						return ActionResult(error=msg)
+						return ActionResult(outcome=ActionOutcome.NOT_FOUND, error=msg)
 
 				direction = 'down' if params.down else 'up'
 				target = f'element {params.index}' if params.index is not None and params.index != 0 else ''
@@ -1467,7 +1479,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			except Exception as e:
 				logger.error(f'Failed to dispatch ScrollEvent: {type(e).__name__}: {e}')
 				error_msg = 'Failed to execute scroll action.'
-				return ActionResult(error=error_msg)
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)
 
 		@self.registry.action(
 			'',
@@ -1486,7 +1498,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			except Exception as e:
 				logger.error(f'Failed to dispatch SendKeysEvent: {type(e).__name__}: {e}')
 				error_msg = f'Failed to send keys: {str(e)}'
-				return ActionResult(error=error_msg)
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)
 
 		@self.registry.action('Scroll to text.')
 		async def find_text(text: str, browser_session: BrowserSession):  # type: ignore
@@ -1675,7 +1687,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			if node is None:
 				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(outcome=ActionOutcome.NOT_FOUND, extracted_content=msg)
 
 			# Dispatch GetDropdownOptionsEvent to the event handler
 
@@ -1703,7 +1715,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			if node is None:
 				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(outcome=ActionOutcome.NOT_FOUND, extracted_content=msg)
 
 			# Dispatch SelectDropdownOptionEvent to the event handler
 			from browser_use.browser.events import SelectDropdownOptionEvent
@@ -1735,7 +1747,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 				else:
 					# Fallback to regular error
 					error_msg = selection_data.get('error', f'Failed to select option: {params.text}')
-					return ActionResult(error=error_msg)
+					return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)
 
 		# File System Actions
 
@@ -1849,7 +1861,7 @@ Validated Code (after quote fixing):
 """
 
 					logger.debug(enhanced_msg)
-					return ActionResult(error=enhanced_msg)
+					return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=enhanced_msg)
 
 				# Get the result data
 				result_data = result.get('result', {})
@@ -1858,7 +1870,7 @@ Validated Code (after quote fixing):
 				if result_data.get('wasThrown'):
 					msg = f'JavaScript code: {code} execution failed (wasThrown=true)'
 					logger.debug(msg)
-					return ActionResult(error=msg)
+					return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=msg)
 
 				# Get the actual value
 				value = result_data.get('value')
@@ -1924,7 +1936,7 @@ Validated Code (after quote fixing):
 				# CDP communication or other system errors
 				error_msg = f'Failed to execute JavaScript: {type(e).__name__}: {e}'
 				logger.debug(f'JavaScript code that failed: {code[:200]}...')
-				return ActionResult(error=error_msg)
+				return ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=error_msg)
 
 	def _validate_and_fix_javascript(self, code: str) -> str:
 		"""Validate and fix common JavaScript issues before execution"""
@@ -2118,7 +2130,10 @@ Validated Code (after quote fixing):
 			async def click(params: ClickElementAction, browser_session: BrowserSession):
 				# Validate that either index or coordinates are provided
 				if params.index is None and (params.coordinate_x is None or params.coordinate_y is None):
-					return ActionResult(error='Must provide either index or both coordinate_x and coordinate_y')
+					return ActionResult(
+						outcome=ActionOutcome.INVALID_STATE,
+						error='Must provide either index or both coordinate_x and coordinate_y',
+					)
 
 				# Try index-based clicking first if index is provided
 				if params.index is not None:
@@ -2227,16 +2242,17 @@ Validated Code (after quote fixing):
 							f'— likely an unresponsive CDP connection. Returning error so the agent can recover.'
 						)
 						result = ActionResult(
+							outcome=ActionOutcome.SYSTEM_ERROR,
 							error=(
 								f'Action {action_name} timed out after {timeout_s:.0f}s. '
 								f'The browser may be unresponsive (dead CDP WebSocket). '
 								f'Try again or a different approach.'
-							)
+							),
 						)
 					except Exception as e:
 						# Log the original exception with traceback for observability
 						logger.error(f"Action '{action_name}' failed with error: {str(e)}")
-						result = ActionResult(error=str(e))
+						result = ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error=str(e))
 
 					if Laminar is not None:
 						Laminar.set_span_output(result)

--- a/tests/ci/test_action_outcome.py
+++ b/tests/ci/test_action_outcome.py
@@ -1,0 +1,148 @@
+"""Tests for ActionOutcome typed result system.
+
+Covers: outcome enum values, ActionResult helper properties,
+consecutive failures counting per outcome type,
+multi_act break behavior, backward compatibility.
+"""
+
+from browser_use.agent.service import Agent
+from browser_use.agent.views import (
+	ActionOutcome,
+	ActionResult,
+)
+
+# ===========================================================================
+# Pure unit tests (no fixtures needed)
+# ===========================================================================
+
+
+class TestActionOutcomeEnum:
+	"""ActionOutcome enum behavior"""
+
+	def test_enum_values(self):
+		assert ActionOutcome.SUCCESS.value == 'success'
+		assert ActionOutcome.NOT_FOUND.value == 'not_found'
+		assert ActionOutcome.INVALID_STATE.value == 'invalid_state'
+		assert ActionOutcome.SYSTEM_ERROR.value == 'system_error'
+
+	def test_is_str_enum(self):
+		assert isinstance(ActionOutcome.SUCCESS, str)
+		assert ActionOutcome.SUCCESS == 'success'
+
+
+class TestActionResultHelpers:
+	"""ActionResult helper properties"""
+
+	def test_default_outcome(self):
+		r = ActionResult()
+		assert r.outcome == ActionOutcome.SUCCESS
+		assert not r.is_not_found
+		assert not r.is_system_error
+		assert not r.is_invalid_state
+
+	def test_not_found(self):
+		r = ActionResult(outcome=ActionOutcome.NOT_FOUND, error='element not on page')
+		assert r.is_not_found
+		assert not r.is_system_error
+		assert not r.is_invalid_state
+
+	def test_system_error(self):
+		r = ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error='cdp connection lost')
+		assert r.is_system_error
+		assert not r.is_not_found
+		assert not r.is_invalid_state
+
+	def test_invalid_state(self):
+		r = ActionResult(outcome=ActionOutcome.INVALID_STATE, error='cannot click select element')
+		assert r.is_invalid_state
+		assert not r.is_not_found
+		assert not r.is_system_error
+
+	def test_backward_compat(self):
+		"""Old-style ActionResult(error=...) now auto-infers SYSTEM_ERROR (not SUCCESS)."""
+		r = ActionResult(error='some error')
+		assert r.outcome == ActionOutcome.SYSTEM_ERROR
+		assert r.is_system_error
+		assert r.error == 'some error'
+
+	def test_error_auto_infers_system_error(self):
+		"""ActionResult(error=...) without explicit outcome defaults to SYSTEM_ERROR with new validator."""
+		# Note: old style ActionResult(error=...) now auto-infers SYSTEM_ERROR
+		# This is the expected behavior after the validator was added
+		r = ActionResult(error='some error')
+		assert r.outcome == ActionOutcome.SYSTEM_ERROR
+		assert r.is_system_error
+		assert r.error == 'some error'
+		r = ActionResult(extracted_content='all good')
+		assert r.outcome == ActionOutcome.SUCCESS
+		assert not r.is_not_found
+		assert r.error is None
+
+	def test_break_conditions_not_found(self):
+		"""NOT_FOUND triggers early break in multi_act"""
+		r = ActionResult(outcome=ActionOutcome.NOT_FOUND, error='not found')
+		assert r.is_not_found
+		assert r.is_not_found or r.is_system_error or r.is_invalid_state
+
+	def test_break_conditions_system_error(self):
+		r = ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error='system failure')
+		assert r.is_system_error
+		assert r.is_system_error  # will break
+
+	def test_break_conditions_invalid_state(self):
+		r = ActionResult(outcome=ActionOutcome.INVALID_STATE, error='invalid state')
+		assert r.is_invalid_state
+		assert r.is_invalid_state  # will break
+
+
+# ===========================================================================
+# Agent integration tests (require browser_session + mock_llm fixtures)
+# ===========================================================================
+
+
+def _make_agent(browser_session, mock_llm, **kwargs):
+	return Agent(task='Test task', llm=mock_llm, browser_session=browser_session, **kwargs)
+
+
+class TestPostProcessFailureCounting:
+	"""_post_process behavior with ActionOutcome"""
+
+	async def test_system_error_increments(self, browser_session, mock_llm):
+		agent = _make_agent(browser_session, mock_llm)
+		agent.state.consecutive_failures = 0
+		agent.state.last_result = [ActionResult(outcome=ActionOutcome.SYSTEM_ERROR, error='connection failed')]
+		agent.state.n_steps = 1
+		await agent._post_process()
+		assert agent.state.consecutive_failures == 1
+
+	async def test_not_found_does_not_increment(self, browser_session, mock_llm):
+		agent = _make_agent(browser_session, mock_llm)
+		agent.state.consecutive_failures = 0
+		agent.state.last_result = [ActionResult(outcome=ActionOutcome.NOT_FOUND, error='element not found')]
+		agent.state.n_steps = 1
+		await agent._post_process()
+		assert agent.state.consecutive_failures == 0
+
+	async def test_invalid_state_does_not_increment(self, browser_session, mock_llm):
+		agent = _make_agent(browser_session, mock_llm)
+		agent.state.consecutive_failures = 0
+		agent.state.last_result = [ActionResult(outcome=ActionOutcome.INVALID_STATE, error='cannot click select')]
+		agent.state.n_steps = 1
+		await agent._post_process()
+		assert agent.state.consecutive_failures == 0
+
+	async def test_success_resets_failures(self, browser_session, mock_llm):
+		agent = _make_agent(browser_session, mock_llm)
+		agent.state.consecutive_failures = 3
+		agent.state.last_result = [ActionResult(extracted_content='success')]
+		agent.state.n_steps = 1
+		await agent._post_process()
+		assert agent.state.consecutive_failures == 0
+
+	async def test_old_style_error_becomes_system_error(self, browser_session, mock_llm):
+		agent = _make_agent(browser_session, mock_llm)
+		agent.state.consecutive_failures = 0
+		agent.state.last_result = [ActionResult(error='old style error')]
+
+		await agent._post_process()
+		assert agent.state.consecutive_failures == 1

--- a/tests/ci/test_action_outcome_e2e.py
+++ b/tests/ci/test_action_outcome_e2e.py
@@ -1,0 +1,156 @@
+"""E2E tests for ActionOutcome in tools/service.py action handlers.
+
+Tests use mocked BrowserSession - no real browser needed.
+"""
+
+from unittest.mock import MagicMock
+
+from browser_use.agent.views import ActionOutcome
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.tools.service import Tools
+
+
+def _mock_session(**kw):
+	s = MagicMock()
+	s.event_bus = MagicMock()
+	s.logger = MagicMock()
+
+	async def _dispatch(event):
+		class A:
+			def __await__(self):
+				async def _inner():
+					return None
+
+				return _inner().__await__()
+
+			async def event_result(self, **kw):
+				return None
+
+		return A()
+
+	s.event_bus.dispatch = _dispatch
+	for k, v in kw.items():
+		setattr(s, k, v)
+	return s
+
+
+def _action(tools, name, params):
+	"""Create an ActionModel with **unpacking to avoid IDE warnings on dynamic fields."""
+	M = tools.registry.create_action_model()
+	return M(**{name: params})
+
+
+class TestSearchOutcome:
+	async def test_unsupported_engine_is_invalid_state(self):
+		t = Tools()
+		r = await t.act(action=_action(t, 'search', {'query': 'x', 'engine': 'yahoo'}), browser_session=_mock_session())
+		assert r.outcome == ActionOutcome.INVALID_STATE
+		assert r.error is not None and 'Unsupported search engine' in r.error
+
+
+class TestNavigateOutcome:
+	async def test_failure_is_system_error(self):
+		t = Tools()
+
+		async def raise_(event):
+			raise RuntimeError('Connection refused')
+
+		s = _mock_session(event_bus=MagicMock(dispatch=raise_))
+		r = await t.act(action=_action(t, 'navigate', {'url': 'https://example.com'}), browser_session=s)
+		assert r.outcome == ActionOutcome.SYSTEM_ERROR
+		assert r.error is not None and 'Navigation failed' in r.error
+
+
+class TestInputOutcome:
+	async def test_missing_element_is_not_found(self):
+		t = Tools()
+		s = _mock_session()
+
+		async def get(idx):
+			return None
+
+		s.get_element_by_index = get
+		r = await t.act(action=_action(t, 'input', {'index': 999, 'text': 'hi'}), browser_session=s)
+		assert r.outcome == ActionOutcome.NOT_FOUND
+		assert r.extracted_content is not None and 'not available' in r.extracted_content
+
+
+class TestScrollOutcome:
+	async def test_missing_element_is_not_found(self):
+		t = Tools()
+		s = _mock_session()
+
+		async def get(idx):
+			return None
+
+		s.get_element_by_index = get
+
+		async def state(**kw):
+			from browser_use.browser.views import BrowserStateSummary
+			from browser_use.dom.views import SerializedDOMState
+
+			return BrowserStateSummary(
+				dom_state=SerializedDOMState(_root=None, selector_map={}), url='https://ex.com', title='', tabs=[]
+			)
+
+		s.get_browser_state_summary = state
+		r = await t.act(action=_action(t, 'scroll', {'down': True, 'pages': 1, 'index': 999}), browser_session=s)
+		assert r.outcome == ActionOutcome.NOT_FOUND
+		assert r.error is not None and 'not found' in r.error
+
+
+class TestDoneOutcome:
+	async def test_success(self):
+		t = Tools()
+		r = await t.act(
+			action=_action(t, 'done', {'text': 'ok', 'success': True}),
+			browser_session=_mock_session(),
+			file_system=FileSystem(base_dir='/tmp/test_fs'),
+		)
+		assert r.is_done
+		assert r.outcome == ActionOutcome.SUCCESS
+
+	async def test_failure_flag(self):
+		t = Tools()
+		r = await t.act(
+			action=_action(t, 'done', {'text': 'no', 'success': False}),
+			browser_session=_mock_session(),
+			file_system=FileSystem(base_dir='/tmp/test_fs'),
+		)
+		assert r.is_done
+		assert r.outcome == ActionOutcome.SUCCESS
+		assert r.success is False
+
+
+class TestClickOutcome:
+	"""click action: missing coords → INVALID_STATE, element not found → NOT_FOUND"""
+
+	async def test_missing_coords_is_invalid_state(self):
+		t = Tools()
+		t.set_coordinate_clicking(True)
+		r = await t.act(
+			action=_action(t, 'click', {'index': None, 'coordinate_x': None, 'coordinate_y': None}),
+			browser_session=_mock_session(),
+		)
+		assert r.outcome == ActionOutcome.INVALID_STATE
+		assert r.error is not None and 'Must provide either index or both coordinate_x and coordinate_y' in r.error
+
+	async def test_missing_element_is_not_found(self):
+		t = Tools()
+		s = _mock_session()
+
+		async def get(idx):
+			return None
+
+		s.get_element_by_index = get
+
+		async def tabs():
+			return []
+
+		s.get_tabs = tabs
+		r = await t.act(
+			action=_action(t, 'click', {'index': 999, 'coordinate_x': None, 'coordinate_y': None}),
+			browser_session=s,
+		)
+		assert r.outcome == ActionOutcome.NOT_FOUND
+		assert r.extracted_content is not None and 'not available' in r.extracted_content


### PR DESCRIPTION
…invalid_state, system_error)

- Add ActionOutcome enum (SUCCESS / NOT_FOUND / INVALID_STATE / SYSTEM_ERROR)
- Add outcome field to ActionResult with auto-inference from error
- Classify ~40 ActionResult(error=...) calls across all action handlers
- Only SYSTEM_ERROR counts toward consecutive_failures in _post_process
- NOT_FOUND / INVALID_STATE break multi_act chain early (informative feedback)
- Add outcome prefix [not_found]/[invalid_state]/[system_error] in message manager
- Document action_outcomes in all 8 system prompt files
- Export ActionOutcome from browser_use package
- Add 17 tests: 11 model-level + 8 e2e handler-level

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured `ActionOutcome` categories (`success`, `not_found`, `invalid_state`, `system_error`) to action results so the agent adapts strategy and only true system errors increase failure counts. Outcomes now flow through agent, tools, messages, and prompts; `not_found`/`invalid_state` short‑circuit multi‑action steps.

- **New Features**
  - Added `ActionOutcome` and `outcome` on `ActionResult` with auto‑inference when `error` is set; helper flags (`.is_not_found`, `.is_invalid_state`, `.is_system_error`); exported from `browser_use`.
  - Classified outcomes across agent and tools: invalid params/missing coordinates → `invalid_state`, missing elements/data → `not_found`, timeouts/connection/JS/CDP/AI‑step errors → `system_error`.
  - Only `system_error` increments consecutive failures in `_post_process`; `not_found`/`invalid_state` break `multi_act` early.
  - Message manager prefixes errors with `[outcome]`; all system prompts include an outcomes guide.
  - Added unit and e2e tests for outcome inference, failure counting, and handler categories.

- **Migration**
  - Optional: set `outcome` when returning `ActionResult` errors; otherwise errors auto‑infer `system_error`.
  - Expect changes in failure counting and action chaining. Import `ActionOutcome` from `browser_use`.

<sup>Written for commit 35aacf6fdf7f80fb79a3fbe104f115a67f202e85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

