### PR TITLE
Add local skill service

### DIFF
--- a/browser_use/skills/README.md
+++ b/browser_use/skills/README.md
@@ -31,3 +31,20 @@ async def main():
 
 asyncio.run(main())
 ```
+
+## Local Skills
+
+Use `LocalSkillService` to load local `SKILL.md` files without a Browser Use API key.
+It scans a directory for `*/SKILL.md` files with YAML frontmatter containing
+`name` and `description`, then exposes each file as a no-argument skill action.
+
+```python
+from browser_use import Agent, ChatBrowserUse
+from browser_use.skills import LocalSkillService
+
+agent = Agent(
+    task='Use my local workflow',
+    llm=ChatBrowserUse(),
+    skill_service=LocalSkillService('./skills'),
+)
+```

--- a/browser_use/skills/README.md
+++ b/browser_use/skills/README.md
@@ -38,6 +38,9 @@ Use `LocalSkillService` to load local `SKILL.md` files without a Browser Use API
 It scans a directory for `*/SKILL.md` files with YAML frontmatter containing
 `name` and `description`, then exposes each file as a no-argument skill action.
 The agent still needs whichever credentials are required by the LLM you choose.
+Frontmatter supports plain scalars, YAML single-quoted scalars, and JSON-compatible
+double-quoted scalars. Full YAML block scalars and YAML-specific double-quoted
+escape sequences are rejected instead of being guessed.
 
 ```python
 from browser_use import Agent, ChatOpenAI

--- a/browser_use/skills/README.md
+++ b/browser_use/skills/README.md
@@ -34,17 +34,18 @@ asyncio.run(main())
 
 ## Local Skills
 
-Use `LocalSkillService` to load local `SKILL.md` files without a Browser Use API key.
+Use `LocalSkillService` to load local `SKILL.md` files without a Browser Use API key for the skill service.
 It scans a directory for `*/SKILL.md` files with YAML frontmatter containing
 `name` and `description`, then exposes each file as a no-argument skill action.
+The agent still needs whichever credentials are required by the LLM you choose.
 
 ```python
-from browser_use import Agent, ChatBrowserUse
+from browser_use import Agent, ChatOpenAI
 from browser_use.skills import LocalSkillService
 
 agent = Agent(
     task='Use my local workflow',
-    llm=ChatBrowserUse(),
+    llm=ChatOpenAI(model='gpt-4.1-mini'),
     skill_service=LocalSkillService('./skills'),
 )
 ```

--- a/browser_use/skills/__init__.py
+++ b/browser_use/skills/__init__.py
@@ -1,5 +1,6 @@
 from browser_use.skills.browser_use import skill_text as browser_use_skill_text
+from browser_use.skills.local import LocalSkillService
 from browser_use.skills.service import SkillService
 from browser_use.skills.views import MissingCookieException
 
-__all__ = ['SkillService', 'MissingCookieException', 'browser_use_skill_text']
+__all__ = ['SkillService', 'LocalSkillService', 'MissingCookieException', 'browser_use_skill_text']

--- a/browser_use/skills/local.py
+++ b/browser_use/skills/local.py
@@ -172,7 +172,7 @@ class LocalSkillService:
 			try:
 				parsed = json.loads(value)
 			except json.JSONDecodeError as e:
-				raise ValueError('invalid double-quoted scalar') from e
+				raise ValueError('invalid double-quoted scalar; use JSON-compatible escapes') from e
 			if isinstance(parsed, str):
 				return parsed
 			raise ValueError('quoted scalar must parse to a string')

--- a/browser_use/skills/local.py
+++ b/browser_use/skills/local.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import ast
+import json
 import logging
 from pathlib import Path
 from typing import Any, Literal
@@ -33,6 +33,7 @@ class _LocalSkillRecord(BaseModel):
 	model_config = ConfigDict(arbitrary_types_allowed=True)
 
 	skill: Skill
+	name: str
 	body: str
 	path: Path
 
@@ -54,7 +55,7 @@ class LocalSkillService:
 			skill_ids: Optional list of local skill IDs/names to load, or ['*'] for all.
 		"""
 		self.skills_path = Path(skills_path).expanduser()
-		self.skill_ids = skill_ids or ['*']
+		self.skill_ids = skill_ids if skill_ids is not None else ['*']
 		self._skills: dict[str, _LocalSkillRecord] = {}
 		self._initialized = False
 
@@ -74,13 +75,15 @@ class LocalSkillService:
 			try:
 				record = self._load_skill_file(skill_file)
 			except ValueError as e:
+				if self.skills_path.is_file():
+					raise ValueError(f'Invalid local skill {skill_file}: {e}') from e
 				logger.warning(f'Skipping invalid local skill {skill_file}: {e}')
 				continue
 
-			skill = record.skill
-			if not use_wildcard and skill.id not in requested_ids and skill.title not in requested_ids:
+			if not use_wildcard and requested_ids.isdisjoint(self._skill_aliases(record)):
 				continue
 
+			skill = record.skill
 			if skill.id in records:
 				existing_path = records[skill.id].path
 				raise ValueError(f'Duplicate local skill id "{skill.id}" in {existing_path} and {skill_file}')
@@ -88,8 +91,10 @@ class LocalSkillService:
 			records[skill.id] = record
 
 		if not use_wildcard:
-			found = set(records)
-			missing = requested_ids - found - {record.skill.title for record in records.values()}
+			found_aliases: set[str] = set()
+			for record in records.values():
+				found_aliases.update(self._skill_aliases(record))
+			missing = requested_ids - found_aliases
 			if missing:
 				logger.warning(f'Requested local skills not found: {missing}')
 
@@ -100,7 +105,7 @@ class LocalSkillService:
 	def _skill_files(self) -> list[Path]:
 		if self.skills_path.is_file():
 			return [self.skills_path]
-		return sorted(self.skills_path.rglob('SKILL.md'))
+		return sorted(self.skills_path.glob('*/SKILL.md'))
 
 	def _load_skill_file(self, skill_file: Path) -> _LocalSkillRecord:
 		metadata, body = self._parse_skill_file(skill_file)
@@ -114,9 +119,14 @@ class LocalSkillService:
 				parameters=[],
 				output_schema={},
 			),
+			name=metadata.name,
 			body=body,
 			path=skill_file,
 		)
+
+	@staticmethod
+	def _skill_aliases(record: _LocalSkillRecord) -> set[str]:
+		return {record.skill.id, record.skill.title, record.name}
 
 	@classmethod
 	def _parse_skill_file(cls, skill_file: Path) -> tuple[LocalSkillMetadata, str]:
@@ -147,13 +157,25 @@ class LocalSkillService:
 	@staticmethod
 	def _parse_frontmatter_scalar(value: str) -> str:
 		value = value.strip()
-		if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+		if value in {'|', '>'} or value.startswith('|') or value.startswith('>'):
+			raise ValueError('YAML block scalars are not supported in local skill frontmatter')
+		if not value:
+			return value
+
+		quote = value[0]
+		if quote in {'"', "'"}:
+			if len(value) < 2 or value[-1] != quote:
+				raise ValueError('unterminated quoted scalar')
+			if quote == "'":
+				return value[1:-1].replace("''", "'")
+
 			try:
-				parsed = ast.literal_eval(value)
-			except (SyntaxError, ValueError):
-				return value[1:-1]
+				parsed = json.loads(value)
+			except json.JSONDecodeError as e:
+				raise ValueError('invalid double-quoted scalar') from e
 			if isinstance(parsed, str):
 				return parsed
+			raise ValueError('quoted scalar must parse to a string')
 		return value
 
 	async def get_skill(self, skill_id: str) -> Skill | None:

--- a/browser_use/skills/local.py
+++ b/browser_use/skills/local.py
@@ -134,10 +134,17 @@ class LocalSkillService:
 		if not text.startswith('---\n'):
 			raise ValueError('missing YAML frontmatter')
 
-		try:
-			frontmatter, body = text.removeprefix('---\n').split('\n---\n', 1)
-		except ValueError as e:
-			raise ValueError('unterminated YAML frontmatter') from e
+		content = text.removeprefix('---\n')
+		delimiter_index = content.find('\n---')
+		if delimiter_index == -1:
+			raise ValueError('unterminated YAML frontmatter')
+
+		frontmatter = content[:delimiter_index]
+		body = content[delimiter_index + len('\n---') :]
+		if body.startswith('\n'):
+			body = body.removeprefix('\n')
+		elif body:
+			raise ValueError('unterminated YAML frontmatter')
 
 		data: dict[str, str] = {}
 		for raw_line in frontmatter.splitlines():

--- a/browser_use/skills/local.py
+++ b/browser_use/skills/local.py
@@ -1,0 +1,196 @@
+"""Local filesystem-backed skills service."""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from typing import Any, Literal
+
+from browser_use_sdk import ExecuteSkillResponse
+from cdp_use.cdp.network import Cookie
+from pydantic import BaseModel, ConfigDict, Field
+
+from browser_use.skills.views import Skill
+
+logger = logging.getLogger(__name__)
+
+
+class LocalSkillMetadata(BaseModel):
+	"""Metadata parsed from a local SKILL.md frontmatter block."""
+
+	model_config = ConfigDict(extra='ignore')
+
+	name: str = Field(min_length=1)
+	description: str = Field(min_length=1)
+	id: str | None = Field(default=None, min_length=1)
+	title: str | None = Field(default=None, min_length=1)
+
+
+class _LocalSkillRecord(BaseModel):
+	"""Cached local skill contents."""
+
+	model_config = ConfigDict(arbitrary_types_allowed=True)
+
+	skill: Skill
+	body: str
+	path: Path
+
+
+class LocalSkillService:
+	"""Load Markdown skills from the local filesystem.
+
+	The service implements the same async interface Agent expects from SkillService:
+	``get_all_skills()``, ``execute_skill()``, and ``close()``. Each local
+	``SKILL.md`` file becomes a no-argument skill action whose execution returns
+	the Markdown body as instructions for the agent.
+	"""
+
+	def __init__(self, skills_path: str | Path, skill_ids: list[str | Literal['*']] | None = None):
+		"""Initialize a local skill service.
+
+		Args:
+			skills_path: A directory containing */SKILL.md files, or a direct SKILL.md path.
+			skill_ids: Optional list of local skill IDs/names to load, or ['*'] for all.
+		"""
+		self.skills_path = Path(skills_path).expanduser()
+		self.skill_ids = skill_ids or ['*']
+		self._skills: dict[str, _LocalSkillRecord] = {}
+		self._initialized = False
+
+	async def async_init(self) -> None:
+		"""Load and cache all matching local skills."""
+		if self._initialized:
+			return
+
+		if not self.skills_path.exists():
+			raise FileNotFoundError(f'Local skills path does not exist: {self.skills_path}')
+
+		records: dict[str, _LocalSkillRecord] = {}
+		use_wildcard = '*' in self.skill_ids
+		requested_ids = {skill_id for skill_id in self.skill_ids if skill_id != '*'}
+
+		for skill_file in self._skill_files():
+			try:
+				record = self._load_skill_file(skill_file)
+			except ValueError as e:
+				logger.warning(f'Skipping invalid local skill {skill_file}: {e}')
+				continue
+
+			skill = record.skill
+			if not use_wildcard and skill.id not in requested_ids and skill.title not in requested_ids:
+				continue
+
+			if skill.id in records:
+				existing_path = records[skill.id].path
+				raise ValueError(f'Duplicate local skill id "{skill.id}" in {existing_path} and {skill_file}')
+
+			records[skill.id] = record
+
+		if not use_wildcard:
+			found = set(records)
+			missing = requested_ids - found - {record.skill.title for record in records.values()}
+			if missing:
+				logger.warning(f'Requested local skills not found: {missing}')
+
+		self._skills = records
+		self._initialized = True
+		logger.info(f'Loaded {len(self._skills)} local skill(s) from {self.skills_path}')
+
+	def _skill_files(self) -> list[Path]:
+		if self.skills_path.is_file():
+			return [self.skills_path]
+		return sorted(self.skills_path.rglob('SKILL.md'))
+
+	def _load_skill_file(self, skill_file: Path) -> _LocalSkillRecord:
+		metadata, body = self._parse_skill_file(skill_file)
+		skill_id = metadata.id or metadata.name
+		title = metadata.title or metadata.name
+		return _LocalSkillRecord(
+			skill=Skill(
+				id=skill_id,
+				title=title,
+				description=metadata.description,
+				parameters=[],
+				output_schema={},
+			),
+			body=body,
+			path=skill_file,
+		)
+
+	@classmethod
+	def _parse_skill_file(cls, skill_file: Path) -> tuple[LocalSkillMetadata, str]:
+		text = skill_file.read_text(encoding='utf-8').replace('\r\n', '\n')
+		if not text.startswith('---\n'):
+			raise ValueError('missing YAML frontmatter')
+
+		try:
+			frontmatter, body = text.removeprefix('---\n').split('\n---\n', 1)
+		except ValueError as e:
+			raise ValueError('unterminated YAML frontmatter') from e
+
+		data: dict[str, str] = {}
+		for raw_line in frontmatter.splitlines():
+			line = raw_line.strip()
+			if not line or line.startswith('#'):
+				continue
+			if ':' not in line:
+				continue
+
+			key, value = line.split(':', 1)
+			key = key.strip()
+			if key in LocalSkillMetadata.model_fields:
+				data[key] = cls._parse_frontmatter_scalar(value)
+
+		return LocalSkillMetadata.model_validate(data), body
+
+	@staticmethod
+	def _parse_frontmatter_scalar(value: str) -> str:
+		value = value.strip()
+		if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+			try:
+				parsed = ast.literal_eval(value)
+			except (SyntaxError, ValueError):
+				return value[1:-1]
+			if isinstance(parsed, str):
+				return parsed
+		return value
+
+	async def get_skill(self, skill_id: str) -> Skill | None:
+		"""Get a cached local skill by ID."""
+		if not self._initialized:
+			await self.async_init()
+
+		record = self._skills.get(skill_id)
+		return record.skill if record else None
+
+	async def get_all_skills(self) -> list[Skill]:
+		"""Get all loaded local skills."""
+		if not self._initialized:
+			await self.async_init()
+
+		return [record.skill for record in self._skills.values()]
+
+	async def execute_skill(
+		self, skill_id: str, parameters: dict[str, Any] | BaseModel, cookies: list[Cookie]
+	) -> ExecuteSkillResponse:
+		"""Return the Markdown body for a local skill."""
+		if not self._initialized:
+			await self.async_init()
+
+		record = self._skills.get(skill_id)
+		if record is None:
+			return ExecuteSkillResponse(
+				success=False,
+				result=None,
+				error=f'Local skill {skill_id} not found. Available skills: {list(self._skills.keys())}',
+				stderr=None,
+				latencyMs=0,
+			)
+
+		return ExecuteSkillResponse(success=True, result=record.body, error=None, stderr=None, latencyMs=0)
+
+	async def close(self) -> None:
+		"""Clear cached local skills."""
+		self._skills = {}
+		self._initialized = False

--- a/tests/ci/test_local_skill_service.py
+++ b/tests/ci/test_local_skill_service.py
@@ -110,6 +110,19 @@ async def test_local_skill_service_rejects_block_scalar_frontmatter_in_direct_fi
 		await service.get_all_skills()
 
 
+async def test_local_skill_service_accepts_frontmatter_closing_delimiter_at_eof(tmp_path):
+	skill_path = tmp_path / 'SKILL.md'
+	skill_path.write_text('---\nname: local\ndescription: Ends at frontmatter delimiter.\n---', encoding='utf-8')
+
+	service = LocalSkillService(skill_path)
+	skills = await service.get_all_skills()
+
+	assert [skill.id for skill in skills] == ['local']
+	result = await service.execute_skill('local', parameters={}, cookies=[])
+	assert result.success is True
+	assert result.result == ''
+
+
 async def test_local_skill_service_rejects_yaml_specific_double_quoted_escapes(tmp_path):
 	skill_path = tmp_path / 'SKILL.md'
 	skill_path.write_text('---\nname: local\ndescription: "Bad \\x41 escape"\n---\nBody', encoding='utf-8')

--- a/tests/ci/test_local_skill_service.py
+++ b/tests/ci/test_local_skill_service.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+
+import pytest
+
+from browser_use.agent.service import Agent
+from browser_use.skills import LocalSkillService
+from tests.ci.conftest import create_mock_llm
+
+
+def _write_skill(root: Path, directory: str, frontmatter: str, body: str) -> Path:
+	skill_dir = root / directory
+	skill_dir.mkdir(parents=True)
+	skill_path = skill_dir / 'SKILL.md'
+	skill_path.write_text(f'---\n{frontmatter}\n---\n{body}', encoding='utf-8')
+	return skill_path
+
+
+async def test_local_skill_service_loads_and_executes_markdown_skill(tmp_path):
+	_write_skill(
+		tmp_path,
+		'research',
+		'name: local-research\ntitle: "Local Research"\ndescription: "Load local research workflow instructions."',
+		'# Research\n\nUse the local workflow.',
+	)
+
+	service = LocalSkillService(tmp_path)
+	skills = await service.get_all_skills()
+
+	assert len(skills) == 1
+	assert skills[0].id == 'local-research'
+	assert skills[0].title == 'Local Research'
+	assert skills[0].description == 'Load local research workflow instructions.'
+	assert skills[0].parameters == []
+
+	result = await service.execute_skill('local-research', parameters={}, cookies=[])
+	assert result.success is True
+	assert result.result == '# Research\n\nUse the local workflow.'
+
+
+async def test_local_skill_service_filters_by_skill_id(tmp_path):
+	_write_skill(tmp_path, 'one', 'name: one\ndescription: First skill.', 'one body')
+	_write_skill(tmp_path, 'two', 'name: two\ndescription: Second skill.', 'two body')
+
+	service = LocalSkillService(tmp_path, skill_ids=['two'])
+	skills = await service.get_all_skills()
+
+	assert [skill.id for skill in skills] == ['two']
+
+
+async def test_local_skill_service_rejects_duplicate_skill_ids(tmp_path):
+	_write_skill(tmp_path, 'first', 'name: duplicate\ndescription: First skill.', 'first body')
+	_write_skill(tmp_path, 'second', 'name: duplicate\ndescription: Second skill.', 'second body')
+
+	service = LocalSkillService(tmp_path)
+
+	with pytest.raises(ValueError, match='Duplicate local skill id'):
+		await service.get_all_skills()
+
+
+async def test_agent_registers_local_skills_as_actions(tmp_path):
+	_write_skill(
+		tmp_path,
+		'workflow',
+		'name: local-workflow\ntitle: Local Workflow\ndescription: Load local workflow instructions before acting.',
+		'Follow these local instructions.',
+	)
+
+	service = LocalSkillService(tmp_path)
+	agent = Agent(task='Use the local workflow', llm=create_mock_llm(), skill_service=service)
+
+	await agent._register_skills_as_actions()
+
+	action = agent.tools.registry.registry.actions.get('local_workflow')
+	assert action is not None
+	assert action.description == 'Load local workflow instructions before acting. (Skill: "Local Workflow")'

--- a/tests/ci/test_local_skill_service.py
+++ b/tests/ci/test_local_skill_service.py
@@ -19,7 +19,7 @@ async def test_local_skill_service_loads_and_executes_markdown_skill(tmp_path):
 	_write_skill(
 		tmp_path,
 		'research',
-		'name: local-research\ntitle: "Local Research"\ndescription: "Load local research workflow instructions."',
+		"name: local-research\ntitle: \"Local Research\"\ndescription: 'Load Bob''s local workflow instructions.'",
 		'# Research\n\nUse the local workflow.',
 	)
 
@@ -29,7 +29,7 @@ async def test_local_skill_service_loads_and_executes_markdown_skill(tmp_path):
 	assert len(skills) == 1
 	assert skills[0].id == 'local-research'
 	assert skills[0].title == 'Local Research'
-	assert skills[0].description == 'Load local research workflow instructions.'
+	assert skills[0].description == "Load Bob's local workflow instructions."
 	assert skills[0].parameters == []
 
 	result = await service.execute_skill('local-research', parameters={}, cookies=[])
@@ -47,6 +47,39 @@ async def test_local_skill_service_filters_by_skill_id(tmp_path):
 	assert [skill.id for skill in skills] == ['two']
 
 
+async def test_local_skill_service_empty_skill_ids_loads_no_skills(tmp_path):
+	_write_skill(tmp_path, 'one', 'name: one\ndescription: First skill.', 'one body')
+
+	service = LocalSkillService(tmp_path, skill_ids=[])
+	skills = await service.get_all_skills()
+
+	assert skills == []
+
+
+async def test_local_skill_service_filters_by_frontmatter_name_when_id_and_title_exist(tmp_path):
+	_write_skill(
+		tmp_path,
+		'summarize',
+		'name: summarize\nid: local-summarizer\ntitle: Summarize text\ndescription: Summarize content.',
+		'summarize body',
+	)
+
+	service = LocalSkillService(tmp_path, skill_ids=['summarize'])
+	skills = await service.get_all_skills()
+
+	assert [skill.id for skill in skills] == ['local-summarizer']
+
+
+async def test_local_skill_service_only_scans_immediate_skill_directories(tmp_path):
+	_write_skill(tmp_path, 'top-level', 'name: top-level\ndescription: Top-level skill.', 'top-level body')
+	_write_skill(tmp_path, 'vendor/nested', 'name: nested\ndescription: Nested skill.', 'nested body')
+
+	service = LocalSkillService(tmp_path)
+	skills = await service.get_all_skills()
+
+	assert [skill.id for skill in skills] == ['top-level']
+
+
 async def test_local_skill_service_rejects_duplicate_skill_ids(tmp_path):
 	_write_skill(tmp_path, 'first', 'name: duplicate\ndescription: First skill.', 'first body')
 	_write_skill(tmp_path, 'second', 'name: duplicate\ndescription: Second skill.', 'second body')
@@ -54,6 +87,26 @@ async def test_local_skill_service_rejects_duplicate_skill_ids(tmp_path):
 	service = LocalSkillService(tmp_path)
 
 	with pytest.raises(ValueError, match='Duplicate local skill id'):
+		await service.get_all_skills()
+
+
+async def test_local_skill_service_raises_for_invalid_direct_file(tmp_path):
+	skill_path = tmp_path / 'SKILL.md'
+	skill_path.write_text('missing frontmatter', encoding='utf-8')
+
+	service = LocalSkillService(skill_path)
+
+	with pytest.raises(ValueError, match='Invalid local skill'):
+		await service.get_all_skills()
+
+
+async def test_local_skill_service_rejects_block_scalar_frontmatter_in_direct_file(tmp_path):
+	skill_path = tmp_path / 'SKILL.md'
+	skill_path.write_text('---\nname: local\ndescription: |\n  multiline\n---\nBody', encoding='utf-8')
+
+	service = LocalSkillService(skill_path)
+
+	with pytest.raises(ValueError, match='block scalars are not supported'):
 		await service.get_all_skills()
 
 

--- a/tests/ci/test_local_skill_service.py
+++ b/tests/ci/test_local_skill_service.py
@@ -110,6 +110,16 @@ async def test_local_skill_service_rejects_block_scalar_frontmatter_in_direct_fi
 		await service.get_all_skills()
 
 
+async def test_local_skill_service_rejects_yaml_specific_double_quoted_escapes(tmp_path):
+	skill_path = tmp_path / 'SKILL.md'
+	skill_path.write_text('---\nname: local\ndescription: "Bad \\x41 escape"\n---\nBody', encoding='utf-8')
+
+	service = LocalSkillService(skill_path)
+
+	with pytest.raises(ValueError, match='JSON-compatible escapes'):
+		await service.get_all_skills()
+
+
 async def test_agent_registers_local_skills_as_actions(tmp_path):
 	_write_skill(
 		tmp_path,


### PR DESCRIPTION
## Summary

Adds a filesystem-backed `LocalSkillService` for loading local `SKILL.md` files through the existing `skill_service=` integration point.

## Details

- scans a directory for `*/SKILL.md` files, or accepts a direct `SKILL.md` path
- parses scalar YAML frontmatter fields for `name`, `description`, optional `id`, and optional `title`
- exposes each local skill as a no-argument Browser Use skill action
- returns the Markdown body from `execute_skill()` so agents can load local instructions without a Browser Use API key
- documents basic local skill usage

Closes #4219.

## Validation

- `uv run --python 3.11 pytest tests/ci/test_local_skill_service.py -q`
- `uv run --python 3.11 pyright browser_use/skills/local.py tests/ci/test_local_skill_service.py`
- `uv run --python 3.11 pre-commit run --all-files`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a filesystem-backed `LocalSkillService` that loads local `SKILL.md` files and exposes them as no-argument skill actions so agents can run local instructions without a Browser Use API key. Fulfills #4219.

- New Features
  - Scans immediate `*/SKILL.md` under a directory or a direct `SKILL.md`; parses frontmatter (`name`, `description`, optional `id`, `title`) and registers each as a skill.
  - Supports frontmatter scalars: plain, YAML single-quoted, and JSON-compatible double-quoted; rejects YAML block scalars and YAML-specific double-quoted escapes (documented in README).
  - Supports `skill_ids` filtering by `id`/`name`/`title` (default `['*']` loads all) and rejects duplicate IDs.
  - Accepts frontmatter closing delimiter at EOF; allows empty skill bodies.
  - Returns the Markdown body from `execute_skill()`. Integrates via `skill_service=LocalSkillService(...)`, exported in `browser_use/skills/__init__.py`, with README usage.

<sup>Written for commit 82011e917c62e9c12448ba95bc6024469b8b7236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

