### PR TITLE
perf(dom): speed up paint-order filtering

### DIFF
--- a/browser_use/dom/serializer/paint_order.py
+++ b/browser_use/dom/serializer/paint_order.py
@@ -52,93 +52,80 @@ class RectUnionPure:
 	_MAX_RECTS = 5000
 
 	def __init__(self):
-		self._rects: list[Rect] = []
+		self._rects: list[tuple[float, float, float, float]] = []
 
-	# -----------------------------------------------------------------
-	def _split_diff(self, a: Rect, b: Rect) -> list[Rect]:
-		r"""
-		Return list of up to 4 rectangles = a \ b.
-		Assumes a intersects b.
-		"""
+	def _split_diff(
+		self,
+		ax1: float,
+		ay1: float,
+		ax2: float,
+		ay2: float,
+		bx1: float,
+		by1: float,
+		bx2: float,
+		by2: float,
+	) -> list[tuple[float, float, float, float]]:
 		parts = []
 
-		# Bottom slice
-		if a.y1 < b.y1:
-			parts.append(Rect(a.x1, a.y1, a.x2, b.y1))
-		# Top slice
-		if b.y2 < a.y2:
-			parts.append(Rect(a.x1, b.y2, a.x2, a.y2))
+		if ay1 < by1:
+			parts.append((ax1, ay1, ax2, by1))
+		if by2 < ay2:
+			parts.append((ax1, by2, ax2, ay2))
 
-		# Middle (vertical) strip: y overlap is [max(a.y1,b.y1), min(a.y2,b.y2)]
-		y_lo = max(a.y1, b.y1)
-		y_hi = min(a.y2, b.y2)
+		y_lo = max(ay1, by1)
+		y_hi = min(ay2, by2)
 
-		# Left slice
-		if a.x1 < b.x1:
-			parts.append(Rect(a.x1, y_lo, b.x1, y_hi))
-		# Right slice
-		if b.x2 < a.x2:
-			parts.append(Rect(b.x2, y_lo, a.x2, y_hi))
+		if ax1 < bx1:
+			parts.append((ax1, y_lo, bx1, y_hi))
+		if bx2 < ax2:
+			parts.append((bx2, y_lo, ax2, y_hi))
 
 		return parts
 
-	# -----------------------------------------------------------------
 	def contains(self, r: Rect) -> bool:
-		"""
-		True iff r is fully covered by the current union.
-		"""
+		# Keep the Rect-based API for compatibility with direct helper callers.
+		return self.contains_quad(r.x1, r.y1, r.x2, r.y2)
+
+	def contains_quad(self, rx1: float, ry1: float, rx2: float, ry2: float) -> bool:
 		if not self._rects:
 			return False
 
-		stack = [r]
-		for s in self._rects:
+		stack = [(rx1, ry1, rx2, ry2)]
+		for sx1, sy1, sx2, sy2 in self._rects:
 			new_stack = []
-			for piece in stack:
-				if s.contains(piece):
-					# piece completely gone
+			for px1, py1, px2, py2 in stack:
+				if sx1 <= px1 and sy1 <= py1 and sx2 >= px2 and sy2 >= py2:
 					continue
-				if piece.intersects(s):
-					new_stack.extend(self._split_diff(piece, s))
+				if not (px2 <= sx1 or sx2 <= px1 or py2 <= sy1 or sy2 <= py1):
+					new_stack.extend(self._split_diff(px1, py1, px2, py2, sx1, sy1, sx2, sy2))
 				else:
-					new_stack.append(piece)
-			if not new_stack:  # everything eaten – covered
+					new_stack.append((px1, py1, px2, py2))
+			if not new_stack:
 				return True
 			stack = new_stack
-		return False  # something survived
+		return False
 
-	# -----------------------------------------------------------------
 	def add(self, r: Rect) -> bool:
-		"""
-		Insert r unless it is already covered.
-		Returns True if the union grew.
-		"""
-		# Safety cap: stop accepting new rects to prevent exponential explosion
+		# Keep the Rect-based API for compatibility with direct helper callers.
+		return self.add_quad(r.x1, r.y1, r.x2, r.y2)
+
+	def add_quad(self, rx1: float, ry1: float, rx2: float, ry2: float) -> bool:
 		if len(self._rects) >= self._MAX_RECTS:
 			return False
 
-		if self.contains(r):
+		if self.contains_quad(rx1, ry1, rx2, ry2):
 			return False
 
-		pending = [r]
-		i = 0
-		while i < len(self._rects):
-			s = self._rects[i]
+		pending = [(rx1, ry1, rx2, ry2)]
+		for sx1, sy1, sx2, sy2 in self._rects:
 			new_pending = []
-			changed = False
-			for piece in pending:
-				if piece.intersects(s):
-					new_pending.extend(self._split_diff(piece, s))
-					changed = True
+			for px1, py1, px2, py2 in pending:
+				if not (px2 <= sx1 or sx2 <= px1 or py2 <= sy1 or sy2 <= py1):
+					new_pending.extend(self._split_diff(px1, py1, px2, py2, sx1, sy1, sx2, sy2))
 				else:
-					new_pending.append(piece)
+					new_pending.append((px1, py1, px2, py2))
 			pending = new_pending
-			if changed:
-				# s unchanged; proceed with next existing rectangle
-				i += 1
-			else:
-				i += 1
 
-		# Any left‑over pieces are new, non‑overlapping areas
 		self._rects.extend(pending)
 		return True
 
@@ -163,63 +150,71 @@ class PaintOrderRemover:
 		return str(original_node.session_id), None
 
 	def calculate_paint_order(self) -> None:
-		all_simplified_nodes_with_paint_order: list[SimplifiedNode] = []
+		nodes_info = []
+		stack = [self.root]
 
-		def collect_paint_order(node: SimplifiedNode) -> None:
-			if (
-				node.original_node.snapshot_node
-				and node.original_node.snapshot_node.paint_order is not None
-				and node.original_node.snapshot_node.bounds is not None
-			):
-				all_simplified_nodes_with_paint_order.append(node)
+		# Single-pass traversal to collect relevant nodes
+		while stack:
+			node = stack.pop()
+			if node.children:
+				for k in range(len(node.children) - 1, -1, -1):
+					stack.append(node.children[k])
 
-			for child in node.children:
-				collect_paint_order(child)
+			snap = node.original_node.snapshot_node
+			if snap and snap.paint_order is not None and snap.bounds:
+				# Match baseline blocker detection
+				is_blocker = True
+				styles = snap.computed_styles
+				if styles:
+					bg = styles.get('background-color', 'rgba(0, 0, 0, 0)')
+					if bg == 'rgba(0, 0, 0, 0)':
+						is_blocker = False
+					elif float(styles.get('opacity', '1')) < 0.8:
+						is_blocker = False
 
-		collect_paint_order(self.root)
-
-		grouped_by_paint_order: defaultdict[int, list[SimplifiedNode]] = defaultdict(list)
-
-		for node in all_simplified_nodes_with_paint_order:
-			if node.original_node.snapshot_node and node.original_node.snapshot_node.paint_order is not None:
-				grouped_by_paint_order[node.original_node.snapshot_node.paint_order].append(node)
-
-		rect_unions: defaultdict[tuple[str | None, str | None], RectUnionPure] = defaultdict(RectUnionPure)
-
-		for paint_order, nodes in sorted(grouped_by_paint_order.items(), key=lambda x: -x[0]):
-			rects_to_add: defaultdict[tuple[str | None, str | None], list[Rect]] = defaultdict(list)
-
-			for node in nodes:
-				if not node.original_node.snapshot_node or not node.original_node.snapshot_node.bounds:
-					continue  # shouldn't happen by how we filter them out in the first place
-
-				rect = Rect(
-					x1=node.original_node.snapshot_node.bounds.x,
-					y1=node.original_node.snapshot_node.bounds.y,
-					x2=node.original_node.snapshot_node.bounds.x + node.original_node.snapshot_node.bounds.width,
-					y2=node.original_node.snapshot_node.bounds.y + node.original_node.snapshot_node.bounds.height,
+				nodes_info.append(
+					{
+						'node': node,
+						'po': snap.paint_order,
+						'q': (
+							snap.bounds.x,
+							snap.bounds.y,
+							snap.bounds.x + snap.bounds.width,
+							snap.bounds.y + snap.bounds.height,
+						),
+						'is_blocker': is_blocker,
+						# Scope occlusion bookkeeping to the owning iframe document so
+						# rectangles from one document never occlude another's.
+						'context': self._document_context(node),
+					}
 				)
-				context = self._document_context(node)
 
-				if rect_unions[context].contains(rect):
-					node.ignored_by_paint_order = True
+		# Sort by paint order descending (highest paint order on top)
+		nodes_info.sort(key=lambda x: x['po'], reverse=True)
 
-				# don't add to the nodes if opacity is less then 0.95 or background-color is transparent
-				if (
-					node.original_node.snapshot_node.computed_styles
-					and node.original_node.snapshot_node.computed_styles.get('background-color', 'rgba(0, 0, 0, 0)')
-					== 'rgba(0, 0, 0, 0)'
-				) or (
-					node.original_node.snapshot_node.computed_styles
-					and float(node.original_node.snapshot_node.computed_styles.get('opacity', '1'))
-					< 0.8  # this is highly vibes based number
-				):
-					continue
+		# One disjoint-rectangle union per (session, iframe document) context.
+		rect_unions: defaultdict[tuple[str | None, str | None], RectUnionPure] = defaultdict(RectUnionPure)
+		i, n = 0, len(nodes_info)
 
-				rects_to_add[context].append(rect)
+		while i < n:
+			j = i
+			current_po = nodes_info[i]['po']
 
-			for context, rects in rects_to_add.items():
-				for rect in rects:
-					rect_unions[context].add(rect)
+			# 1. Check coverage for all nodes in the same paint_order group, each
+			#    against its own document's union.
+			while j < n and nodes_info[j]['po'] == current_po:
+				item = nodes_info[j]
+				if rect_unions[item['context']].contains_quad(*item['q']):
+					item['node'].ignored_by_paint_order = True
+				j += 1
+
+			# 2. Add blockers from this group to their document's union for
+			#    subsequent (lower) paint-order groups.
+			for k in range(i, j):
+				item = nodes_info[k]
+				if item['is_blocker']:
+					rect_unions[item['context']].add_quad(*item['q'])
+
+			i = j
 
 		return None

--- a/tests/ci/browser/test_paint_order_rect_union.py
+++ b/tests/ci/browser/test_paint_order_rect_union.py
@@ -1,0 +1,163 @@
+"""Focused coverage for the float-quad RectUnionPure and paint-order scoping.
+
+Guards the #5159 allocation optimization (tuple-backed union with
+contains_quad/add_quad) against behaviour drift: containment, partial overlap,
+split coverage, degenerate rectangles, add-order independence, the Rect/quad
+API parity, the safety cap, repeated invocation, and per-iframe-document
+scoping of occlusion.
+"""
+
+from browser_use.dom.serializer.paint_order import PaintOrderRemover, Rect, RectUnionPure
+from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, EnhancedSnapshotNode, NodeType, SimplifiedNode
+
+
+# --------------------------------------------------------------------------- #
+# RectUnionPure                                                               #
+# --------------------------------------------------------------------------- #
+def test_empty_union_contains_nothing():
+	u = RectUnionPure()
+	assert u.contains_quad(0, 0, 10, 10) is False
+	assert u.contains(Rect(0, 0, 10, 10)) is False
+
+
+def test_full_containment():
+	u = RectUnionPure()
+	assert u.add_quad(0, 0, 100, 100) is True
+	assert u.contains_quad(10, 10, 40, 40) is True
+	# an already-covered rectangle is not re-added
+	assert u.add_quad(10, 10, 40, 40) is False
+
+
+def test_partial_overlap_not_contained():
+	u = RectUnionPure()
+	u.add_quad(0, 0, 10, 10)
+	# extends past the covered region on x -> not fully covered
+	assert u.contains_quad(5, 5, 15, 8) is False
+
+
+def test_split_coverage_from_two_disjoint_rects():
+	u = RectUnionPure()
+	u.add_quad(0, 0, 10, 10)
+	u.add_quad(10, 0, 20, 10)  # adjacent, shares the x=10 edge
+	# the spanning rectangle is covered by the union of the two halves
+	assert u.contains_quad(0, 0, 20, 10) is True
+	assert u.contains_quad(2, 2, 18, 8) is True
+
+
+def test_degenerate_zero_area_rectangle():
+	u = RectUnionPure()
+	u.add_quad(0, 0, 10, 10)
+	# a zero-width probe fully inside the covered area is contained
+	assert u.contains_quad(5, 0, 5, 10) is True
+	# adding a degenerate rectangle does not crash and reports growth honestly
+	u2 = RectUnionPure()
+	assert u2.add_quad(3, 3, 3, 8) is True
+
+
+def test_add_order_independence():
+	rects = [(0, 0, 10, 10), (5, 5, 15, 15), (12, 0, 20, 8), (0, 12, 8, 20)]
+	probes = [
+		(1, 1, 4, 4),
+		(6, 6, 9, 9),
+		(13, 1, 19, 7),
+		(0, 5, 15, 10),  # covered only by combining the first two rectangles
+		(0, 0, 20, 20),
+	]
+	a = RectUnionPure()
+	for r in rects:
+		a.add_quad(*r)
+	b = RectUnionPure()
+	for r in reversed(rects):
+		b.add_quad(*r)
+	assert [a.contains_quad(*p) for p in probes] == [b.contains_quad(*p) for p in probes]
+
+
+def test_rect_api_matches_quad_api():
+	u_rect = RectUnionPure()
+	u_quad = RectUnionPure()
+	seq = [(0, 0, 10, 10), (5, 5, 20, 20), (30, 30, 40, 40), (5, 5, 20, 20)]
+	for x1, y1, x2, y2 in seq:
+		assert u_rect.add(Rect(x1, y1, x2, y2)) == u_quad.add_quad(x1, y1, x2, y2)
+		assert u_rect.contains(Rect(x1, y1, x2, y2)) == u_quad.contains_quad(x1, y1, x2, y2)
+
+
+def test_max_rects_cap_stops_growth():
+	u = RectUnionPure()
+	# pre-fill to the cap with disjoint dummy rects, then confirm add is refused
+	u._rects = [(float(i), 0.0, float(i) + 0.5, 1.0) for i in range(RectUnionPure._MAX_RECTS)]
+	assert len(u._rects) == RectUnionPure._MAX_RECTS
+	assert u.add_quad(10_000, 10_000, 10_010, 10_010) is False
+	assert len(u._rects) == RectUnionPure._MAX_RECTS
+
+
+# --------------------------------------------------------------------------- #
+# PaintOrderRemover                                                           #
+# --------------------------------------------------------------------------- #
+def _enh(tag, *, session_id, frame_id=None, parent=None, paint_order=None, bg='rgb(255, 255, 255)'):
+	bounds = DOMRect(x=0, y=0, width=100, height=30)
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name=tag.upper(),
+		node_value='',
+		attributes={},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=bounds,
+		target_id=f'target-{session_id}',
+		frame_id=frame_id,
+		session_id=session_id,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=parent,
+		children_nodes=[],
+		ax_node=None,
+		snapshot_node=EnhancedSnapshotNode(
+			is_clickable=None,
+			cursor_style='auto',
+			bounds=bounds,
+			clientRects=bounds,
+			scrollRects=None,
+			computed_styles={'display': 'block', 'visibility': 'visible', 'opacity': '1', 'background-color': bg},
+			paint_order=paint_order,
+			stacking_contexts=None,
+		),
+	)
+
+
+def _two_input_tree(card_parent, cvv_parent):
+	lower = _enh('input', session_id='wrapper', parent=card_parent, paint_order=1)
+	upper = _enh('input', session_id='wrapper', parent=cvv_parent, paint_order=2)
+	root = SimplifiedNode(
+		original_node=_enh('html', session_id='main'),
+		children=[SimplifiedNode(original_node=lower, children=[]), SimplifiedNode(original_node=upper, children=[])],
+	)
+	return root
+
+
+def test_scoping_isolated_between_iframe_documents():
+	card = _enh('iframe', session_id='wrapper', frame_id='card')
+	cvv = _enh('iframe', session_id='wrapper', frame_id='cvv')
+	root = _two_input_tree(card, cvv)
+	PaintOrderRemover(root).calculate_paint_order()
+	# different documents -> the higher-paint-order rect cannot occlude the other
+	assert root.children[0].ignored_by_paint_order is False
+	assert root.children[1].ignored_by_paint_order is False
+
+
+def test_occlusion_within_single_document():
+	root = _two_input_tree(None, None)  # both live in the main document
+	PaintOrderRemover(root).calculate_paint_order()
+	assert root.children[0].ignored_by_paint_order is True  # lower, occluded
+	assert root.children[1].ignored_by_paint_order is False  # upper blocker
+
+
+def test_repeated_invocation_is_idempotent():
+	root = _two_input_tree(None, None)
+	PaintOrderRemover(root).calculate_paint_order()
+	first = [c.ignored_by_paint_order for c in root.children]
+	PaintOrderRemover(root).calculate_paint_order()
+	second = [c.ignored_by_paint_order for c in root.children]
+	assert first == second == [True, False]


### PR DESCRIPTION
## Summary
- Use tuple-backed exact rectangle-union operations to reduce `Rect` allocations while preserving the existing split-based coverage semantics.
- Collect paint-order nodes in a single iterative traversal and process sorted paint-order groups directly.
- Preserve same-paint-order grouping plus transparent and low-opacity blocker behavior.

## Performance
Measured on upstream `origin/main` at `052787f9c` with a strict large-tree eval:

- Baseline: `98.70976815000176 ms`, `101.44010884687304 ms` medians over 9 samples.
- Candidate: `63.144379295408726 ms`, `61.90446997061372 ms` medians over 9 samples.

Supplementary autoresearch: [20-step public dashboard](https://dashboard.weco.ai/share/gqkLA02a75wKrVbjH41mE8VRxxEk7G-d).

## Validation
- `uvx ruff check --fix .` fails on 69 pre-existing `ASYNC240`/`ASYNC250` findings outside this patch.
- `uvx ruff check --fix browser_use/dom/serializer/paint_order.py`
- `uv run ruff check browser_use/dom/serializer/paint_order.py`
- `uv run ruff format --check browser_use/dom/serializer/paint_order.py`
- `uv run pytest tests/ci/test_dom_visibility.py -q`
- Strict large-tree evaluator, 9 samples, repeated twice
- Randomized equivalence harness: fixed cases=9, random paint-order trees=1500, `RectUnionPure.add/contains` sequences=1200
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up paint-order filtering by ~35–40% with fewer allocations and a single traversal. Preserves behavior, including per-iframe-document occlusion and the 5k union cap; aligns with #4587/#5151.

- **Refactors**
  - Tuple-backed float-quad union with `contains_quad`/`add_quad`; `Rect` API retained.
  - Single-pass collect + sort by `paint_order` desc. Per group: mark covered nodes, then add blockers (non-transparent bg and opacity ≥ 0.8). Occlusion is scoped per iframe document.
  - New focused tests cover containment/overlap, API parity, degenerate rects, add-order independence, per-iframe scoping, the 5k cap, and idempotence.

<sup>Written for commit e72c6ba676d85cb130d8b0374c31c4f30384add2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

