### PR TITLE
reduce CLI repetition

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,7 @@
 
 </br>
 
-**Browser Use CLI 3.0 is here.** Give your coding agent a browser it can use reliably.
-
-Paste this into Claude Code, Codex, etc:
-
-```text
-Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
-```
+**[Browser Use CLI 3.0 is here.](#-cli)** Give your coding agent a browser it can use reliably.
 
 🌤️ Want to skip the setup? Use our <b>[cloud](https://cloud.browser-use.com?utm_source=github&utm_medium=readme-skip-setup)</b> for faster, scalable, stealth-enabled browser automation!
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Condensed the README by removing the duplicated CLI setup snippet. The “Browser Use CLI 3.0 is here.” headline now links to the CLI section (`#-cli`) to centralize instructions and reduce clutter.

<sup>Written for commit 95050db6ee7bdbae9518fb79b3e5a884b42a359c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

