### PR TITLE
rename browser harness -> use except urls

### DIFF
--- a/browser_use/skills/browser_use.py
+++ b/browser_use/skills/browser_use.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from importlib import resources
 from pathlib import Path
 
@@ -40,11 +41,8 @@ def as_browser_use_skill(text: str) -> str:
 		)
 
 	body = body.replace('# browser-harness', '# Browser Use', 1).replace('# Browser Harness', '# Browser Use', 1)
-	body = body.replace('`browser-harness`', '`browser-use`')
-	body = body.replace('browser-harness <<', 'browser-use <<')
-	body = body.replace('browser-harness --', 'browser-use --')
-	body = body.replace('browser-harness auth', 'browser-use auth')
-	body = body.replace('browser-harness doctor', 'browser-use doctor')
+	# Rebrand every mention except repo URLs (github.com/browser-use/browser-harness/...)
+	body = re.sub(r'(?<!/)browser-harness', 'browser-use', body)
 	body = body.replace('Browser Harness', 'Browser Use')
 	frontmatter_text = '\n'.join(lines)
 	return f'---\n{frontmatter_text}\n---\n{body}'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed all non-URL mentions of "browser-harness" to "browser-use" in generated skill docs to prevent broken links and simplify the logic.

- **Refactors**
  - Replaced multiple targeted string replacements with a single regex that skips URL path segments (uses `re.sub(r'(?<!/)browser-harness', 'browser-use', body)`).

<sup>Written for commit 53b1316076b60ecde8d5e00decd0a3d2800e27c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

