### PR TITLE
fix(utils): prevent cascading redaction inside placeholders

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -75,8 +75,15 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 
 def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
 	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
+	placeholders: dict[str, str] = {}
 	for key, secret in sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True):
-		value = value.replace(secret, f'<secret>{key}</secret>')
+		if not secret:
+			continue
+		token = f'__REDACTED_{key}__'
+		placeholders[token] = f'<secret>{key}</secret>'
+		value = value.replace(secret, token)
+	for token, tag in placeholders.items():
+		value = value.replace(token, tag)
 	return value
 
 

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -9,7 +9,7 @@ from browser_use.filesystem.file_system import FileSystem
 from browser_use.llm import SystemMessage, UserMessage
 from browser_use.llm.messages import ContentPartTextParam
 from browser_use.tools.registry.service import Registry
-from browser_use.utils import is_new_tab_page, match_url_with_domain_pattern
+from browser_use.utils import is_new_tab_page, match_url_with_domain_pattern, redact_sensitive_string
 
 
 class SensitiveParams(BaseModel):
@@ -588,3 +588,11 @@ def test_password_field_without_type_attribute():
 	attrs_str = DOMTreeSerializer._build_attributes_string(node, list(DEFAULT_INCLUDE_ATTRIBUTES), '')
 
 	assert value in attrs_str, 'Input without type attribute should preserve its value'
+
+
+def test_redact_sensitive_string_does_not_cascade_into_placeholders():
+	result = redact_sensitive_string(
+		'leaked supersecret token',
+		{'password': 'supersecret', 'type': 'secret'},
+	)
+	assert result == 'leaked <secret>password</secret> token'


### PR DESCRIPTION
## Summary
- Two-phase redaction with temporary tokens
- Add regression test

Fixes #5135

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent cascading redaction in `redact_sensitive_string` by swapping secrets for temporary tokens, then mapping tokens to `<secret>{key}</secret>` so shorter secrets don’t re-match inside placeholders. Skip empty secrets and add a regression test verifying: "leaked <secret>password</secret> token".

<sup>Written for commit 3baf1fa2161c563b67fd46d7c99187d776884aec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

