### PR TITLE
improve CLI hint

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -294,8 +294,9 @@ Core helpers: new_tab(url), goto_url(url), page_info(), capture_screenshot(),
   click_at_xy(x, y), js(code), cdp(method, ...), wait_for_load()
 
 Read the full interface now:   browser-use skill show
-Install the skill so you remember it in future sessions (also upgrades the CLI):
+Install the CLI 3.0 skill (upgrades the CLI and replaces any pre-existing browser-use skill):
                                browser-use skill install
+Then load the freshly installed browser-use skill, and follow it to use the latest CLI.
 Skill reference:               https://github.com/browser-use/browser-use/blob/main/browser_use/skills/browser-use/SKILL.md
 Health check:                  browser-use --doctor"""
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies the CLI legacy migration hint so users can upgrade to CLI 3.0 without confusion. The message now instructs to run `browser-use skill install` to install the CLI 3.0 skill (replacing any existing browser-use skill) and to load the skill after installation.

<sup>Written for commit 55a56c31c46e31f4086fd7dfe58ad80fa3fa4f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

