### PR TITLE
remove telemetry

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -24,84 +24,35 @@ def _exit_code(result: int | str | None) -> int:
 	return 1
 
 
-def _first_env_value(names: tuple[str, ...]) -> str | None:
+def _set_harness_client_env() -> None:
 	import os
 
-	for name in names:
-		value = os.environ.get(name)
-		if value:
-			return value
-	return None
+	os.environ['BH_CLIENT'] = 'browser-use-cli'
+	os.environ['BH_CLIENT_VERSION'] = _browser_use_version()
 
 
-# Env markers each coding agent injects into subprocesses
-_AGENT_ENV_MARKERS: tuple[tuple[str, str], ...] = (
-	('AGENT=amp', 'amp'),
-	('CLAUDECODE', 'claude-code'),
-	('CODEX_SANDBOX', 'codex'),
-	('CODEX_THREAD_ID', 'codex'),
-	('GEMINI_CLI', 'gemini-cli'),
-	('COPILOT_CLI', 'copilot-cli'),
-	('COPILOT_AGENT_SESSION_ID', 'copilot-cli'),
-	('OPENCLAW_CLI', 'openclaw'),
-	('HERMES_SESSION_ID', 'hermes'),
-	('CURSOR_AGENT', 'cursor'),
-	('CURSOR_TRACE_ID', 'cursor'),
-	('OPENCODE', 'opencode'),
-)
-
-
-def _detect_agent_client() -> str | None:
-	import os
-
-	for marker, client in _AGENT_ENV_MARKERS:
-		name, _, required = marker.partition('=')
-		value = os.environ.get(name)
-		if value and (not required or value == required):
-			return client
-	return None
-
-
-def _detect_model() -> tuple[str | None, str | None]:
-	return _first_env_value(('BROWSER_USE_AGENT_MODEL',)), _first_env_value(('BROWSER_USE_MODEL_PROVIDER',))
-
-
-def _task_for_telemetry(task: str | None) -> str | None:
-	if task is None:
-		return None
-	return task[:20_000]
-
-
-def _capture_cli_event(
+def _capture_via_harness(
 	*,
-	action: str,
-	mode: str,
 	command: str,
 	start_time: float,
-	task: str | None = None,
 	result: int | str | None = None,
 	error_message: str | None = None,
 ) -> None:
-	try:
-		from browser_use.telemetry.service import capture_detached
-		from browser_use.telemetry.views import CLITelemetryEvent
 
-		model, model_provider = _detect_model()
-		capture_detached(
-			CLITelemetryEvent(
-				version=_browser_use_version(),
-				action=action,
-				mode=mode,
-				command=command,
-				task=_task_for_telemetry(task),
-				task_length=len(task) if task is not None else None,
-				agent_client=_detect_agent_client(),
-				model=model,
-				model_provider=model_provider,
-				duration_seconds=time.monotonic() - start_time,
-				exit_code=_exit_code(result),
-				error_message=error_message,
-			)
+	try:
+		from browser_harness import telemetry as harness_telemetry
+
+		capture_cli_event = getattr(harness_telemetry, 'capture_cli_event', None)
+		if capture_cli_event is None:
+			return
+		_set_harness_client_env()
+		code = _exit_code(result)
+		capture_cli_event(
+			action='error' if code else 'completed',
+			command=command,
+			duration_seconds=time.monotonic() - start_time,
+			exit_code=code,
+			error_message=error_message,
 		)
 	except Exception:
 		pass
@@ -219,13 +170,15 @@ def _patch_browser_harness_cli_text() -> None:
 	auth.run_auth_cli = run_auth_cli
 	telemetry.run_telemetry_cli = run_telemetry_cli
 
+_delegated_to_harness = False
+
 
 def _run_browser_harness() -> int | None:
-	import os
-
 	from browser_harness import run
 
-	os.environ['BH_CLIENT'] = 'browser-use-cli'
+	global _delegated_to_harness
+
+	_set_harness_client_env()
 	_patch_browser_harness_cli_text()
 	args = sys.argv[1:]
 	if args and args[0] == 'doctor' and args[1:]:
@@ -235,6 +188,7 @@ def _run_browser_harness() -> int | None:
 		if args[1:] != ['--fix-snap']:
 			print('usage: browser-use doctor [--fix-snap]', file=sys.stderr)
 			sys.exit(2)
+	_delegated_to_harness = True
 	run.main()
 	return None
 
@@ -300,58 +254,44 @@ Skill reference:               https://github.com/browser-use/browser-use/blob/m
 Health check:                  browser-use --doctor"""
 
 
-def _read_harness_task(args: list[str]) -> str | None:
-	for flag in ('-c', '--code'):
-		if flag in args:
-			index = args.index(flag)
-			if index + 1 < len(args):
-				return args[index + 1]
-	if args or sys.stdin.isatty():
-		return None
-	code = sys.stdin.read()
-	sys.stdin = StringIO(code)
-	return code
-
-
-def _command_context(args: list[str]) -> tuple[str, str]:
+def _command_name(args: list[str]) -> str:
 	if '--mcp' in args:
-		return 'mcp_server', 'mcp'
+		return 'mcp'
 	if args and args[0] == 'install':
-		return 'install', 'install'
+		return 'install'
 	if args and args[0] == 'init':
-		return 'init', 'init'
+		return 'init'
 	if '--template' in args or '-t' in args:
-		return 'init', 'init'
+		return 'init'
 	if args and args[0] == 'skill':
-		return 'skill', 'skill'
+		return 'skill'
 	legacy = _legacy_command(args)
 	if legacy is not None:
-		return 'browser_harness', f'legacy:{legacy}'
-	return 'browser_harness', args[0] if args else 'run'
+		return f'legacy:{legacy}'
+	return args[0] if args else 'run'
 
 
-def _dispatch(args: list[str]) -> tuple[int | None, str, str, str | None]:
+def _dispatch(args: list[str]) -> tuple[int | None, str]:
 	if '--mcp' in args:
 		_run_mcp_server()
-		return 0, 'mcp_server', 'mcp', None
+		return 0, 'mcp'
 	if args and args[0] == 'install':
-		return _run_install_command(args[1:]), 'install', 'install', None
+		return _run_install_command(args[1:]), 'install'
 	if args and args[0] == 'init':
-		return _run_init_command(args[1:]), 'init', 'init', None
+		return _run_init_command(args[1:]), 'init'
 	if '--template' in args or '-t' in args:
-		return _run_init_command(args), 'init', 'init', None
+		return _run_init_command(args), 'init'
 	if args and args[0] == 'skill':
 		from browser_use.skills.install import handle as handle_skill_command
 
-		return handle_skill_command(args[1:]), 'skill', 'skill', None
+		return handle_skill_command(args[1:]), 'skill'
 
 	legacy = _legacy_command(args)
 	if legacy is not None:
 		print(_legacy_migration_message(legacy), file=sys.stderr)
-		return 2, 'browser_harness', f'legacy:{legacy}', None
+		return 2, f'legacy:{legacy}'
 
-	task = _read_harness_task(args)
-	return _run_browser_harness(), 'browser_harness', args[0] if args else 'run', task
+	return _run_browser_harness(), args[0] if args else 'run'
 
 
 class _StderrTail:
@@ -377,47 +317,35 @@ def browser_use_tui_main() -> int | None:
 def main() -> int | None:
 	args = sys.argv[1:]
 	start_time = time.monotonic()
-	mode, command = _command_context(args)
-	task = None
+	command = _command_name(args)
 	stderr_tail = _StderrTail(sys.stderr)
 	sys.stderr = stderr_tail
 	try:
-		result, mode, command, task = _dispatch(args)
+		result, command = _dispatch(args)
 	except SystemExit as exc:
 		result = exc.code
-		_capture_cli_event(
-			action='error' if _exit_code(result) else 'completed',
-			mode=mode,
-			command=command,
-			start_time=start_time,
-			task=task,
-			result=result,
-			error_message=str(result) if isinstance(result, str) else stderr_tail.tail.strip() or None,
-		)
+		if not _delegated_to_harness:
+			_capture_via_harness(
+				command=command,
+				start_time=start_time,
+				result=result,
+				error_message=str(result) if isinstance(result, str) else stderr_tail.tail.strip() or None,
+			)
 		raise
 	except Exception as exc:
-		_capture_cli_event(
-			action='error',
-			mode=mode,
-			command=command,
-			start_time=start_time,
-			task=task,
-			result=1,
-			error_message=str(exc),
-		)
+		if not _delegated_to_harness:
+			_capture_via_harness(command=command, start_time=start_time, result=1, error_message=str(exc))
 		raise
 	finally:
 		sys.stderr = stderr_tail._wrapped
 
-	_capture_cli_event(
-		action='error' if _exit_code(result) else 'completed',
-		mode=mode,
-		command=command,
-		start_time=start_time,
-		task=task,
-		result=result,
-		error_message=(stderr_tail.tail.strip() or None) if _exit_code(result) else None,
-	)
+	if not _delegated_to_harness:
+		_capture_via_harness(
+			command=command,
+			start_time=start_time,
+			result=result,
+			error_message=(stderr_tail.tail.strip() or None) if _exit_code(result) else None,
+		)
 	return result
 
 

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -38,7 +38,6 @@ def _capture_via_harness(
 	result: int | str | None = None,
 	error_message: str | None = None,
 ) -> None:
-
 	try:
 		from browser_harness import telemetry as harness_telemetry
 
@@ -169,6 +168,7 @@ def _patch_browser_harness_cli_text() -> None:
 
 	auth.run_auth_cli = run_auth_cli
 	telemetry.run_telemetry_cli = run_telemetry_cli
+
 
 _delegated_to_harness = False
 
@@ -315,6 +315,9 @@ def browser_use_tui_main() -> int | None:
 
 
 def main() -> int | None:
+	global _delegated_to_harness
+
+	_delegated_to_harness = False
 	args = sys.argv[1:]
 	start_time = time.monotonic()
 	command = _command_name(args)

--- a/browser_use/telemetry/__init__.py
+++ b/browser_use/telemetry/__init__.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 	from browser_use.telemetry.service import ProductTelemetry
 	from browser_use.telemetry.views import (
 		BaseTelemetryEvent,
-		CLITelemetryEvent,
 		MCPClientTelemetryEvent,
 		MCPServerTelemetryEvent,
 	)
@@ -18,7 +17,6 @@ if TYPE_CHECKING:
 _LAZY_IMPORTS = {
 	'ProductTelemetry': ('browser_use.telemetry.service', 'ProductTelemetry'),
 	'BaseTelemetryEvent': ('browser_use.telemetry.views', 'BaseTelemetryEvent'),
-	'CLITelemetryEvent': ('browser_use.telemetry.views', 'CLITelemetryEvent'),
 	'MCPClientTelemetryEvent': ('browser_use.telemetry.views', 'MCPClientTelemetryEvent'),
 	'MCPServerTelemetryEvent': ('browser_use.telemetry.views', 'MCPServerTelemetryEvent'),
 }
@@ -45,7 +43,6 @@ def __getattr__(name: str):
 __all__ = [
 	'BaseTelemetryEvent',
 	'ProductTelemetry',
-	'CLITelemetryEvent',
 	'MCPClientTelemetryEvent',
 	'MCPServerTelemetryEvent',
 ]

--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -62,56 +62,6 @@ def _machine_fingerprint() -> str | None:
 	return 'bu_' + hashlib.sha256(f'browser-use:{node}:{socket.gethostname()}'.encode()).hexdigest()[:32]
 
 
-_DETACHED_SENDER_SOURCE = """
-import json, sys, urllib.request
-try:
-	job = json.load(sys.stdin)
-	request = urllib.request.Request(
-		job['url'],
-		method='POST',
-		data=json.dumps(job['payload']).encode('utf-8'),
-		headers={'Content-Type': 'application/json'},
-	)
-	urllib.request.urlopen(request, timeout=job['timeout']).close()
-except Exception:
-	pass
-"""
-
-
-def capture_detached(event: BaseTelemetryEvent) -> None:
-	"""Send a single event to PostHog from a detached helper process."""
-	if not CONFIG.ANONYMIZED_TELEMETRY:
-		return
-	try:
-		import json
-		import subprocess
-		import sys
-
-		job = {
-			'url': f'{POSTHOG_HOST}/i/v0/e/',
-			'timeout': 5.0,
-			'payload': {
-				'api_key': POSTHOG_PROJECT_API_KEY,
-				'distinct_id': get_or_create_device_id(),
-				'event': event.name,
-				'properties': {**event.properties, **POSTHOG_EVENT_SETTINGS},
-			},
-		}
-
-		process = subprocess.Popen(
-			[sys.executable, '-c', _DETACHED_SENDER_SOURCE],
-			stdin=subprocess.PIPE,
-			stdout=subprocess.DEVNULL,
-			stderr=subprocess.DEVNULL,
-			start_new_session=True,
-		)
-		assert process.stdin is not None
-		process.stdin.write(json.dumps(job).encode('utf-8'))
-		process.stdin.close()
-	except Exception:
-		return
-
-
 @singleton
 class ProductTelemetry:
 	"""

--- a/browser_use/telemetry/views.py
+++ b/browser_use/telemetry/views.py
@@ -86,23 +86,3 @@ class MCPServerTelemetryEvent(BaseTelemetryEvent):
 	parent_process_cmdline: str | None = None
 
 	name: str = 'mcp_server_event'
-
-
-@dataclass
-class CLITelemetryEvent(BaseTelemetryEvent):
-	"""Telemetry event for CLI usage"""
-
-	version: str
-	action: str  # 'completed', 'error'
-	mode: str  # 'browser_harness', 'install', 'init', 'skill', 'mcp_server'
-	command: str | None = None
-	task: str | None = None
-	task_length: int | None = None
-	agent_client: str | None = None
-	model: str | None = None
-	model_provider: str | None = None
-	duration_seconds: float | None = None
-	exit_code: int | None = None
-	error_message: str | None = None
-
-	name: str = 'cli_event'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed in-repo telemetry and delegated CLI event reporting to `browser_harness` for unified, simpler telemetry. No user-facing behavior changes; events report via Harness when available.

- **Refactors**
  - Removed PostHog sender and `CLITelemetryEvent`; cleaned up exports and dead code in `telemetry/*`.
  - Added `_capture_via_harness` that calls `browser_harness.telemetry.capture_cli_event` if present, and `_set_harness_client_env` to set `BH_CLIENT`/`BH_CLIENT_VERSION`.
  - Added `_delegated_to_harness` to prevent double-reporting; only capture when not delegated.
  - Simplified CLI telemetry context by dropping agent/model detection, task parsing, and mode tracking; kept only command name.

- **Migration**
  - If you imported `browser_use.telemetry.CLITelemetryEvent` or `capture_detached`, switch to `browser_harness.telemetry.capture_cli_event`.

<sup>Written for commit d1af39626e3f3e8e72619814cee73567bc64a055. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

