### PR TITLE
chore: add .gitguardian.yaml to ignore public PostHog telemetry key

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,8 @@
+version: 2
+# This file configures GitGuardian (ggshield) to ignore intentional secrets.
+# The PostHog Project API Key is public by design for telemetry ingestion.
+
+secret:
+  ignored_matches:
+    - name: "PostHog Public Telemetry Key"
+      match: "phc_F8JMNjW1i2KbGUTaW1unnDdLSPCoyc52SGRU0JecaUh"

--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -139,3 +139,6 @@ class ProductTelemetry:
 
 		self._curr_user_id = get_or_create_device_id()
 		return self._curr_user_id
+
+
+# Test Comment, Will be removed next commit

--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -139,6 +139,3 @@ class ProductTelemetry:
 
 		self._curr_user_id = get_or_create_device_id()
 		return self._curr_user_id
-
-
-# Test Comment, Will be removed next commit


### PR DESCRIPTION
### **PR Description**
Adding `.gitguardian.yaml` to stop GitGuardian from flagging the public PostHog telemetry key as a secret.

### Why:
- **Stop the noise:** Prevents GitGuardian from "screaming" whenever someone updates a branch or works on files containing the key.
- **Better for contributors:** No more false-positive alerts during reverse merges or branch updates.
- **Maintainable:** Uses plain text instead of a SHA so it's clear what’s being ignored and why.

The PostHog key is public by design for telemetry ingestion, so this just cleans up the workflow for everyone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.gitguardian.yaml` to configure `ggshield` to ignore the public PostHog telemetry key so it isn’t flagged as a secret. Configuration only; no functional changes.

<sup>Written for commit b9466bbd9166fb1a7885fdd04f2791ff6c85499c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

