### PR TITLE
fix(beta): fail invalid structured terminal results

### DIFF
--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -1760,7 +1760,7 @@ def _structured_result_text(
 		except (ValidationError, ValueError):
 			continue
 		return candidate
-	return result
+	return None
 
 
 def _failure_from_events(events: list[dict[str, Any]]) -> str | None:
@@ -3987,8 +3987,12 @@ def _history_from_events(
 	process_error: str | None,
 ) -> AgentHistoryList[AgentStructuredOutput]:
 	events = _events_after_terminal_rollbacks(_events_after_terminal_compaction(events))
-	final_result = _structured_result_text(_result_from_events(events), output_model_schema)
+	raw_result = _result_from_events(events)
+	final_result = _structured_result_text(raw_result, output_model_schema)
 	failure = process_error or _failure_from_events(events)
+	if final_result is None and raw_result is not None and output_model_schema is not None and failure is None:
+		schema_name = getattr(output_model_schema, '__name__', 'output_model_schema')
+		failure = f'Rust terminal final result did not match output schema {schema_name}.'
 	if final_result is None and failure is not None:
 		final_result = _structured_result_text(_last_streamed_assistant_text_from_events(events), output_model_schema)
 	if final_result is None and failure is None:

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -2385,6 +2385,26 @@ def test_rust_history_extracts_fenced_structured_output():
 	assert history.structured_output.answer == 'ok'
 
 
+def test_rust_history_rejects_invalid_structured_output_done():
+	from browser_use.beta.service import _history_from_events
+
+	class Answer(BaseModel):
+		answer: str
+
+	history = _history_from_events(
+		[{'event_type': 'session.done', 'payload': {'result': 'Result files:\n- final_answer.json'}}],
+		model='gpt-test',
+		started=1.0,
+		finished=2.0,
+		output_model_schema=Answer,
+		process_error=None,
+	)
+
+	assert history.final_result() is None
+	assert history.is_done() is False
+	assert history.errors() == ['Rust terminal final result did not match output schema Answer.']
+
+
 def test_rust_history_reconstructs_terminal_agent_completed_result():
 	from browser_use.beta.service import _history_from_events
 


### PR DESCRIPTION
## Summary
- stop accepting non-validating terminal `session.done` prose as a successful structured final result
- mark invalid structured terminal results as an explicit history error instead of `is_done=True`
- add a regression test for prose/file-pointer results with `output_model_schema`

Fixes #5129

## Tests
- PYTHONDONTWRITEBYTECODE=1 UV_CACHE_DIR=/private/tmp/uv-cache-browser-use uv run --frozen pytest tests/ci/test_beta_agent.py::test_rust_history_rejects_invalid_structured_output_done -q
- PYTHONDONTWRITEBYTECODE=1 UV_CACHE_DIR=/private/tmp/uv-cache-browser-use uv run --frozen pytest tests/ci/test_beta_agent.py::test_rust_history_supports_structured_output tests/ci/test_beta_agent.py::test_rust_history_extracts_fenced_structured_output tests/ci/test_beta_agent.py::test_rust_history_marks_missing_terminal_result_as_error -q
- UV_CACHE_DIR=/private/tmp/uv-cache-browser-use uv run --frozen ruff check browser_use/beta/service.py tests/ci/test_beta_agent.py
- UV_CACHE_DIR=/private/tmp/uv-cache-browser-use uv run --frozen ruff format --check browser_use/beta/service.py tests/ci/test_beta_agent.py
- PYTHONPYCACHEPREFIX=/private/tmp/browser-use-pycache python3 -m py_compile browser_use/beta/service.py tests/ci/test_beta_agent.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop treating invalid `session.done` results as successful structured output. If the final result doesn’t match `output_model_schema`, we now surface a clear history error and keep the run incomplete.

- **Bug Fixes**
  - `_structured_result_text` returns `None` on schema validation failure (no prose fallback).
  - `_history_from_events` sets an explicit error only when a terminal result exists and a schema is provided; the message includes the schema name and `is_done` stays False. If there’s an error, we still try parsing the last streamed assistant text for a valid structured result.
  - Added a regression test to reject invalid terminal results with `output_model_schema` and verify the error text.

<sup>Written for commit 5ca785b0f52e66eafe35b5cbaaf29508040f4164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

