### PR TITLE
fix(dom): clamp final chunk char_end to len(content) for trailing newline

### DIFF
--- a/browser_use/dom/markdown_extractor.py
+++ b/browser_use/dom/markdown_extractor.py
@@ -378,8 +378,9 @@ def _parse_atomic_blocks(content: str) -> list[_AtomicBlock]:
 		)
 		offset = para_end
 
-	# Fix last block char_end: content may not end with \n
-	if blocks and content and not content.endswith('\n'):
+	# Fix last block char_end: the parser counts +1 per line for the newline it
+	# split on, so content ending in \n (or a final blank line) overshoots len(content).
+	if blocks and content and blocks[-1].char_end > len(content):
 		blocks[-1] = _AtomicBlock(
 			block_type=blocks[-1].block_type,
 			lines=blocks[-1].lines,

--- a/tests/ci/test_markdown_chunking.py
+++ b/tests/ci/test_markdown_chunking.py
@@ -43,6 +43,21 @@ class TestChunkMarkdownBasic:
 		# Last chunk ends at content length
 		assert chunks[-1].char_offset_end == len(content)
 
+	def test_last_chunk_offset_equals_len_for_trailing_newline(self):
+		"""Content ending in a newline must report char_offset_end == len(content).
+
+		Regression: the parser adds +1 per line for the newline it split on, so a
+		trailing \\n overshot the final offset by one. That offset feeds next_start_char
+		for pagination, and chunk_markdown_by_structure returns [] for start_from_char
+		>= len(content), so newline-terminated markdown silently broke continuation.
+		"""
+		for content in ['# Header\n\nParagraph one.\n\n# Header 2\n\nParagraph two.\n', 'Hello\n', 'Hello\n\nWorld\n']:
+			chunks = chunk_markdown_by_structure(content, max_chunk_chars=20)
+			assert chunks[-1].char_offset_end == len(content), (
+				f'Expected last chunk to end at {len(content)}, got {chunks[-1].char_offset_end} '
+				f'for content {content!r}'
+			)
+
 
 class TestChunkMarkdownHeaders:
 	"""Header boundary splitting."""

--- a/tests/ci/test_markdown_chunking.py
+++ b/tests/ci/test_markdown_chunking.py
@@ -54,8 +54,7 @@ class TestChunkMarkdownBasic:
 		for content in ['# Header\n\nParagraph one.\n\n# Header 2\n\nParagraph two.\n', 'Hello\n', 'Hello\n\nWorld\n']:
 			chunks = chunk_markdown_by_structure(content, max_chunk_chars=20)
 			assert chunks[-1].char_offset_end == len(content), (
-				f'Expected last chunk to end at {len(content)}, got {chunks[-1].char_offset_end} '
-				f'for content {content!r}'
+				f'Expected last chunk to end at {len(content)}, got {chunks[-1].char_offset_end} for content {content!r}'
 			)
 
 


### PR DESCRIPTION
## Summary
The last-block offset clamp in `_parse_atomic_blocks` only fired when content did *not* end with `\n`. For newline-terminated markdown (the common case from markdownify/serializers), the final chunk's `char_offset_end` overshot `len(content)` by 1.

## Impact
That offset feeds `char_offset_end` → `next_start_char` for pagination in the `extract_structured_data` tool. `chunk_markdown_by_structure` early-returns `[]` whenever `start_from_char >= len(content)`, so any newline-terminated markdown silently broke continuation — the agent could never read past the first chunk.

## Fix
Clamp the final block's `char_end` to `len(content)` whenever it overshoots, regardless of trailing newline.

## Test
Added `test_last_chunk_offset_equals_len_for_trailing_newline` to `tests/ci/test_markdown_chunking.py`. FAILS before (`got 54 for len 53`), PASSES after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an off-by-one in the final chunk offset when content ends with a newline or blank line. Ensures pagination continues past the first chunk in structured extraction.

- **Bug Fixes**
  - Clamp final block `char_end` to `len(content)` whenever it overshoots, including trailing newline or a final blank line.
  - Add regression test `test_last_chunk_offset_equals_len_for_trailing_newline`; reformat tests for `ruff` 0.12.10.

<sup>Written for commit 9d6f0b43e12bf6a467533e39b9efc579ef18dbdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

