### PR TITLE
Restructure README quickstart: CLI and Python library paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ---
 
 <div align="center">
-<a href="#demos"><img src="https://media.browser-use.tools/badges/demos" alt="Demos"></a>
+<a href="#what-can-browser-use-do"><img src="https://media.browser-use.tools/badges/demos" alt="Demos"></a>
 <img width="16" height="1" alt="">
 <a href="https://docs.browser-use.com"><img src="https://media.browser-use.tools/badges/docs" alt="Docs"></a>
 <img width="16" height="1" alt="">
@@ -38,24 +38,50 @@
 
 </br>
 
+# What can Browser Use do?
+
+Browser Use lets an AI agent use a web browser the same way you do — it opens pages, clicks buttons, types, and fills in forms. You describe the task, and it completes it. For example, you can have it:
+
+
+### 📋 Fill Forms
+#### Task: "Fill in this job application with my resume and information."
+![Job Application Demo](https://github.com/user-attachments/assets/57865ee6-6004-49d5-b2c2-6dff39ec2ba9)
+[Example code ↗](https://github.com/browser-use/browser-use/blob/main/examples/use-cases/apply_to_job.py)
+
+
+### 🍎 Shop for Groceries
+#### Task: "Put this list of items into my instacart."
+
+https://github.com/user-attachments/assets/a6813fa7-4a7c-40a6-b4aa-382bf88b1850
+
+[Example code ↗](https://github.com/browser-use/browser-use/blob/main/examples/use-cases/buy_groceries.py)
+
+
+### 💻 Be Your Personal Assistant
+#### Task: "Help me find parts for a custom PC."
+
+https://github.com/user-attachments/assets/ac34f75c-057a-43ef-ad06-5b2c9d42bf06
+
+[Example code ↗](https://github.com/browser-use/browser-use/blob/main/examples/use-cases/pcpartpicker.py)
+
+
+<br/>
+
 # Quickstart
 
-There are two ways to use Browser Use:
-
-- **[CLI](#cli-let-your-coding-agent-use-the-web)**: let your coding agent (Claude Code, Codex, Cursor, etc.) do work for you on the web
-- **[Python library](#python-library-the-easiest-way-to-automate-the-web)**: automate the web from your own code, with any LLM
-
-## CLI: let your coding agent use the web
-
-**Browser Use CLI 3.0 is here.** Paste this prompt into your coding agent, and it sets everything up itself:
+If you want to use Browser Use in your agent (Claude Code, Codex, Cursor, Hermes, OpenClaw, etc.), paste this prompt, and it sets everything up itself:
 
 ```text
-Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, run `browser-use skill install` to register the skill, and connect it to my browser. If setup or connection fails, follow https://github.com/browser-use/browser-harness/blob/main/install.md.
 ```
 
-The CLI allows your agent to control the browser by writing Python, and it manages the browser in the background.
+Then tell your agent what you want done.
 
-## Python library: the easiest way to automate the web
+<br/>
+
+# Python library: the easiest way to automate the web
+
+Want to automate the web at scale, from your own code, and with any LLM? Use the Python library:
 
 **1. Install Browser Use (Python >= 3.11):**
 
@@ -94,40 +120,13 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-**Don't want to write the code yourself?** Give your coding agent our docs ([llms-full.txt](https://docs.browser-use.com/llms-full.txt)) and a task, and it writes the script for you:
+**Don't want to write the code yourself?** Give your coding agent our docs ([llms-full.txt](https://docs.browser-use.com/llms-full.txt)), and it writes the script for you:
 
 ```text
 Use Browser Use to find the top Hacker News story. Follow https://docs.browser-use.com/llms-full.txt, use ChatBrowserUse(), and show me the final result.
 ```
 
 Check out the [library docs](https://docs.browser-use.com/open-source/introduction) and the [cloud docs](https://docs.cloud.browser-use.com?utm_source=github&utm_medium=readme-cloud-docs) for more!
-
-<br/>
-
-# Demos
-
-
-### 📋 Form-Filling
-#### Task = "Fill in this job application with my resume and information."
-![Job Application Demo](https://github.com/user-attachments/assets/57865ee6-6004-49d5-b2c2-6dff39ec2ba9)
-[Example code ↗](https://github.com/browser-use/browser-use/blob/main/examples/use-cases/apply_to_job.py)
-
-
-### 🍎 Grocery-Shopping
-#### Task = "Put this list of items into my instacart."
-
-https://github.com/user-attachments/assets/a6813fa7-4a7c-40a6-b4aa-382bf88b1850
-
-[Example code ↗](https://github.com/browser-use/browser-use/blob/main/examples/use-cases/buy_groceries.py)
-
-
-### 💻 Personal-Assistant.
-#### Task = "Help me find parts for a custom PC."
-
-https://github.com/user-attachments/assets/ac34f75c-057a-43ef-ad06-5b2c9d42bf06
-
-[Example code ↗](https://github.com/browser-use/browser-use/blob/main/examples/use-cases/pcpartpicker.py)
-
 
 <br/>
 
@@ -160,6 +159,22 @@ We benchmark Browser Use across 100 real-world browser tasks. Full benchmark is 
 <br/>
 
 # FAQ
+
+<details>
+<summary><b>Should I use the CLI vs. the Python library?</b></summary>
+
+**Use the CLI** if you already have an agent (Claude Code, Codex, Cursor, Hermes, OpenClaw, etc.) that you want to complete browser tasks for you. The agent installs the skill once (see [Quickstart](#quickstart)) and can then control the browser. Examples:
+- "Upload this video to YouTube"
+- "Compare these three laptops and give me a table with prices"
+- "Fill in this job application with my resume"
+
+**Use the Python library** when you are building software that automates the web. Examples:
+- Run many tasks on a schedule or in parallel (scraping, monitoring, QA)
+- Embed a browser agent into your own product
+- Custom tools, custom system prompts, structured output, fine-grained browser control
+
+Rule of thumb: one-off tasks through an agent → CLI. Repeatable automation in code → Python library.
+</details>
 
 <details>
 <summary><b>What's the best model to use?</b></summary>

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
 
 There are two ways to use Browser Use:
 
-- **[CLI](#cli-give-your-coding-agent-a-browser)**: give your coding agent (Claude Code, Codex, Cursor, etc.) a browser it can use
-- **[Python library](#python-library-build-your-own-browser-agents)**: build browser agents in your own code and with any LLM
+- **[CLI](#cli-let-your-coding-agent-use-the-web)**: let your coding agent (Claude Code, Codex, Cursor, etc.) do work for you on the web
+- **[Python library](#python-library-the-easiest-way-to-automate-the-web)**: automate the web from your own code, with any LLM
 
-## CLI: give your coding agent a browser
+## CLI: let your coding agent use the web
 
 **Browser Use CLI 3.0 is here.** Paste this prompt into your coding agent, and it sets everything up itself:
 
@@ -55,16 +55,7 @@ Install or upgrade browser-use to the latest stable version with uv using Python
 
 The CLI allows your agent to control the browser by writing Python, and it manages the browser in the background.
 
-```bash
-browser-use <<'PY'
-new_tab("https://example.com")
-print(page_info())
-PY
-```
-
-The CLI is powered by [Browser Harness](https://github.com/browser-use/browser-harness), and it applies what we learned about [agent harnesses](https://browser-use.com/posts/bitter-lesson-agent-harnesses): the latest models do best when you give them freedom, rather than abstracting away complexity. We provide your agents with a direct, dependable surface for acting in the browser.
-
-## Python library: build your own browser agents
+## Python library: the easiest way to automate the web
 
 **1. Install Browser Use (Python >= 3.11):**
 
@@ -113,30 +104,6 @@ Check out the [library docs](https://docs.browser-use.com/open-source/introducti
 
 <br/>
 
-# Open Source vs Cloud
-
-<picture>
-  <source media="(prefers-color-scheme: light)" srcset="static/accuracy_by_model_light.png">
-  <source media="(prefers-color-scheme: dark)" srcset="static/accuracy_by_model_dark.png">
-  <img alt="BU Bench V1 - LLM Success Rates" src="static/accuracy_by_model_light.png" width="100%">
-</picture>
-
-We benchmark Browser Use across 100 real-world browser tasks. Full benchmark is open source: **[browser-use/benchmark](https://github.com/browser-use/benchmark)**.
-
-**Use the Open-Source Agent**
-- You need [custom tools](https://docs.browser-use.com/customize/tools/basics) or deep code-level integration
-- We recommend pairing with our [cloud browsers](https://docs.browser-use.com/open-source/customize/browser/remote) for leading stealth, proxy rotation, and scaling
-- Or self-host the open-source agent fully on your own machines
-
-**Use the [Fully-Hosted Cloud Agent](https://cloud.browser-use.com?utm_source=github&utm_medium=readme-hosted-agent) (recommended)**
-- Much more powerful agent for complex tasks (see plot above)
-- Easiest way to start and scale
-- Best stealth with proxy rotation and captcha solving
-- 1000+ integrations (Gmail, Slack, Notion, and more)
-- Persistent filesystem and memory
-
-<br/>
-
 # Demos
 
 
@@ -161,6 +128,30 @@ https://github.com/user-attachments/assets/ac34f75c-057a-43ef-ad06-5b2c9d42bf06
 
 [Example code ↗](https://github.com/browser-use/browser-use/blob/main/examples/use-cases/pcpartpicker.py)
 
+
+<br/>
+
+# Open Source vs Cloud
+
+<picture>
+  <source media="(prefers-color-scheme: light)" srcset="static/accuracy_by_model_light.png">
+  <source media="(prefers-color-scheme: dark)" srcset="static/accuracy_by_model_dark.png">
+  <img alt="BU Bench V1 - LLM Success Rates" src="static/accuracy_by_model_light.png" width="100%">
+</picture>
+
+We benchmark Browser Use across 100 real-world browser tasks. Full benchmark is open source: **[browser-use/benchmark](https://github.com/browser-use/benchmark)**.
+
+**Use the Open-Source Agent**
+- You need [custom tools](https://docs.browser-use.com/customize/tools/basics) or deep code-level integration
+- We recommend pairing with our [cloud browsers](https://docs.browser-use.com/open-source/customize/browser/remote) for leading stealth, proxy rotation, and scaling
+- Or self-host the open-source agent fully on your own machines
+
+**Use the [Fully-Hosted Cloud Agent](https://cloud.browser-use.com?utm_source=github&utm_medium=readme-hosted-agent) (recommended)**
+- Much more powerful agent for complex tasks (see plot above)
+- Easiest way to start and scale
+- Best stealth with proxy rotation and captcha solving
+- 1000+ integrations (Gmail, Slack, Notion, and more)
+- Persistent filesystem and memory
 
 <br/>
 

--- a/README.md
+++ b/README.md
@@ -120,12 +120,6 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-**Don't want to write the code yourself?** Give your coding agent our docs ([llms-full.txt](https://docs.browser-use.com/llms-full.txt)), and it writes the script for you:
-
-```text
-Use Browser Use to find the top Hacker News story. Follow https://docs.browser-use.com/llms-full.txt, use ChatBrowserUse(), and show me the final result.
-```
-
 Check out the [library docs](https://docs.browser-use.com/open-source/introduction) and the [cloud docs](https://docs.cloud.browser-use.com?utm_source=github&utm_medium=readme-cloud-docs) for more!
 
 <br/>
@@ -140,10 +134,12 @@ Check out the [library docs](https://docs.browser-use.com/open-source/introducti
 
 We benchmark Browser Use across 100 real-world browser tasks. Full benchmark is open source: **[browser-use/benchmark](https://github.com/browser-use/benchmark)**.
 
+Browser Use is also **#1 on the [Odysseys leaderboard](https://odysseysbench.com/leaderboard)** with an 87.4% average, ahead of computer-use agents from OpenAI, Anthropic, Google, and Microsoft. Odysseys measures the agent's performance on 200 long-horizon web tasks.
+
 **Use the Open-Source Agent**
-- You need [custom tools](https://docs.browser-use.com/customize/tools/basics) or deep code-level integration
-- We recommend pairing with our [cloud browsers](https://docs.browser-use.com/open-source/customize/browser/remote) for leading stealth, proxy rotation, and scaling
-- Or self-host the open-source agent fully on your own machines
+- Free, and runs on your own machine
+- Deep code-level integration and control: pick your LLM, customize the agent's behavior
+- We recommend pairing it with our [cloud browsers](https://docs.browser-use.com/open-source/customize/browser/remote) for leading stealth, proxy rotation, and scaling
 
 **Use the [Fully-Hosted Cloud Agent](https://cloud.browser-use.com?utm_source=github&utm_medium=readme-hosted-agent) (recommended)**
 - Much more powerful agent for complex tasks (see plot above)

--- a/README.md
+++ b/README.md
@@ -38,22 +38,44 @@
 
 </br>
 
-**[Browser Use CLI 3.0 is here.](#-cli)** Give your coding agent a browser it can use reliably.
+# Quickstart
 
-🌤️ Want to skip the setup? Use our <b>[cloud](https://cloud.browser-use.com?utm_source=github&utm_medium=readme-skip-setup)</b> for faster, scalable, stealth-enabled browser automation!
+There are two ways to use Browser Use:
 
-🤖 Give our docs to your coding agent: [llms-full.txt](https://docs.browser-use.com/llms-full.txt)
+- **[CLI](#cli-give-your-coding-agent-a-browser)**: give your coding agent (Claude Code, Codex, Cursor, etc.) a browser it can use
+- **[Python library](#python-library-build-your-own-browser-agents)**: build browser agents in your own code and with any LLM
 
-# 👋 Human Quickstart
+## CLI: give your coding agent a browser
 
-**1. Install Browser Use (Python>=3.11):**
+**Browser Use CLI 3.0 is here.** Paste this prompt into your coding agent, and it sets everything up itself:
+
+```text
+Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
+```
+
+The CLI allows your agent to control the browser by writing Python, and it manages the browser in the background.
+
+```bash
+browser-use <<'PY'
+new_tab("https://example.com")
+print(page_info())
+PY
+```
+
+The CLI is powered by [Browser Harness](https://github.com/browser-use/browser-harness), and it applies what we learned about [agent harnesses](https://browser-use.com/posts/bitter-lesson-agent-harnesses): the latest models do best when you give them freedom, rather than abstracting away complexity. We provide your agents with a direct, dependable surface for acting in the browser.
+
+## Python library: build your own browser agents
+
+**1. Install Browser Use (Python >= 3.11):**
+
 ```bash
 uv add browser-use
 # or: pip install browser-use
 ```
 
-**2. [Optional] Get your API key from [Browser Use Cloud](https://cloud.browser-use.com/new-api-key?utm_source=github&utm_medium=readme-quickstart-api-key):**
-```
+**2. Add your LLM API key to `.env`**. Get one from [Browser Use Cloud](https://cloud.browser-use.com/new-api-key?utm_source=github&utm_medium=readme-quickstart-api-key), or bring your own provider key:
+
+```bash
 # .env
 BROWSER_USE_API_KEY=your-key
 # GOOGLE_API_KEY=your-key
@@ -62,11 +84,10 @@ BROWSER_USE_API_KEY=your-key
 
 **3. Run your first agent:**
 
-**Python Script:**
 ```python
 import asyncio
 
-from browser_use import Agent, BrowserProfile, ChatBrowserUse
+from browser_use import Agent, ChatBrowserUse
 
 async def main():
     agent = Agent(
@@ -74,12 +95,18 @@ async def main():
         llm=ChatBrowserUse(model='openai/gpt-5.5'),
         # llm=ChatBrowserUse(model='bu-2-0'),  # Browser Use's optimized model
         # llm=ChatOpenAI(model='gpt-5.5'),
-        # llm=ChatAnthropic(model='claude-opus-4-8'),  # Sonnet also works well.
+        # llm=ChatAnthropic(model='claude-opus-4-8'),  # Sonnet also works well
     )
     history = await agent.run()
 
 if __name__ == "__main__":
     asyncio.run(main())
+```
+
+**Don't want to write the code yourself?** Give your coding agent our docs ([llms-full.txt](https://docs.browser-use.com/llms-full.txt)) and a task, and it writes the script for you:
+
+```text
+Use Browser Use to find the top Hacker News story. Follow https://docs.browser-use.com/llms-full.txt, use ChatBrowserUse(), and show me the final result.
 ```
 
 Check out the [library docs](https://docs.browser-use.com/open-source/introduction) and the [cloud docs](https://docs.cloud.browser-use.com?utm_source=github&utm_medium=readme-cloud-docs) for more!
@@ -134,29 +161,6 @@ https://github.com/user-attachments/assets/ac34f75c-057a-43ef-ad06-5b2c9d42bf06
 
 [Example code ↗](https://github.com/browser-use/browser-use/blob/main/examples/use-cases/pcpartpicker.py)
 
-
-<br/>
-
-# 💻 CLI
-
-**Browser Use CLI 3.0** lets your agents do work for you online with our highest accuracy yet. It is powered by [Browser Harness](https://github.com/browser-use/browser-harness), and it applies what we learned about [agent harnesses](https://browser-use.com/posts/bitter-lesson-agent-harnesses) and [agent frameworks](https://browser-use.com/posts/bitter-lesson-agent-frameworks): the latest models do best when you give them freedom, rather than abstracting away complexity. We provide your agents with a direct, dependable surface for acting in the browser.
-
-```bash
-browser-use <<'PY'
-new_tab("https://example.com")
-print(page_info())
-PY
-```
-
-The CLI allows your agent to control the browser via Python, and it manages the browser in the background.
-
-### Agent Skill
-
-For Claude Code, Codex, and other agents, paste this prompt into your agent:
-
-```text
-Install or upgrade browser-use to the latest stable version with uv using Python 3.12, register the skill from `browser-use skill`, and connect it to my browser. Follow https://github.com/browser-use/browser-use if setup or connection fails.
-```
 
 <br/>
 
@@ -264,6 +268,22 @@ For production use cases, use our [Browser Use Cloud API](https://cloud.browser-
 - Stealth browser fingerprinting
 - High-performance parallel execution
 </details>
+
+<br/>
+
+## Citation
+
+If you use Browser Use in your research or project, please cite:
+
+```bibtex
+@software{browser_use2024,
+  author = {Müller, Magnus and Žunič, Gregor},
+  title = {Browser Use: Enable AI to control your browser},
+  year = {2024},
+  publisher = {GitHub},
+  url = {https://github.com/browser-use/browser-use}
+}
+```
 
 <br/>
 

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -48,7 +48,7 @@ def _fake_browser_harness_tools(tmp_path: Path, skill_text: str) -> Path:
 def test_docs_install_browser_use_skill_from_package_alias():
 	readme = (ROOT / 'README.md').read_text(encoding='utf-8')
 
-	assert 'register the skill from `browser-use skill`' in readme
+	assert 'run `browser-use skill install` to register the skill' in readme
 	assert 'mkdir -p ~/.claude/skills/browser-use' not in readme
 	assert 'uv run --with "browser-use[browser-harness]" python -c' not in readme
 	assert 'from browser_use.skills import browser_use_skill_text' not in readme


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restructures the README into a simpler Quickstart for agent setup and a clear Python library path to speed up onboarding. Moves demos into a “What can Browser Use do?” section and adds an FAQ on when to use CLI vs library; updates benchmarks.

- **Refactors**
  - Consolidates intros into two paths: Quickstart (CLI skill) and Python library.
  - Quickstart: paste-in prompt uses Python 3.12, says run `browser-use skill install`, and links to the `browser-harness` install guide; removes the old CLI section and code example.
  - Python library: Python >= 3.11, clarify `.env` API key setup, remove `BrowserProfile` import, and show `uv add `browser-use``.
  - Move demos to the new “What can Browser Use do?” section at the top.
  - Add Odysseys leaderboard note to the benchmarks and include a Citation section.
  - Tests: update CI to look for “run `browser-use skill install` to register the skill”.

<sup>Written for commit 50bf4b222c0782157f54801aab187b985f05fbe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



