### PR TITLE
Pin init template integrity checks

### DIFF
--- a/browser_use/init_cmd.py
+++ b/browser_use/init_cmd.py
@@ -5,6 +5,7 @@ This module provides a minimal command-line interface for generating
 browser-use templates without requiring heavy TUI dependencies.
 """
 
+import hashlib
 import json
 import shutil
 import sys
@@ -26,10 +27,93 @@ console = Console()
 
 # GitHub template repository URL (for runtime fetching)
 TEMPLATE_REPO_URL = 'https://raw.githubusercontent.com/browser-use/template-library/main'
+TEMPLATE_MANIFEST_PATH = 'templates.json'
+TEMPLATE_FILE_SHA256 = {
+	'advanced_template.py': '4ad638db292622cc3701bd16cfe9476c6dc68c4e4da28be5d40849859c627d38',
+	'agentmail/.env.example.template': '7fbaafba3d522ff61e80f27adb8ff2ae89b3198c4c9199eb50ecbf42a423044a',
+	'agentmail/README.md': 'c3101e8b1ed8e8f2a5232afcd2c65d76aaf4f4de13645d1c370d8fad5179de1b',
+	'agentmail/email_tools.py': '08b379f4ffe312b556f6d736bd0f4101139dfbcd772154f080c0f117fd9b2120',
+	'agentmail/main.py': 'c5ff42dd869dfac8bdec73137362c9e84148a6f669255ac9b28c1cd1417b5fb2',
+	'agentmail/pyproject.toml.template': 'bfcd4476dc338ea6b418b738757b38bea10d472c6da08a9c87269c9103aaaab6',
+	'all-openai-jobs/.env.example.template': 'c09793f4dbb692e3d8165ae051946fc4e1222af59560ac90c696c0571ecd5cda',
+	'all-openai-jobs/README.md': '02ca20ecd9b3500688422c9b393b31a54b7ee1985c076b64fa4040b179d96ea0',
+	'all-openai-jobs/main.py': 'd41d84d2e888e0dd96bae467dc32d2f6fd13065ba26358f73e3d4d2d56c17e60',
+	'all-openai-jobs/pyproject.toml.template': '1df1aad8a5b5f52fecbb3fadde389a8a498c712293676d87bb574ce0177de764',
+	'default_template.py': '2786b926196dcb8cf4e9a37a6fa830a623bcc8c35329bcdac022d36a05897574',
+	'gitignore.template': '7f6197bf9efce61a901f7c836d5b854fd3f3a687f5c4b60aa2c01eb13a2ab137',
+	'job-application/.env.example.template': '478b582a07375698ed7c6a681a69766a376351c9c77f39a2e75aeeef485eab20',
+	'job-application/README.md': '633e15fa2c3e12cf0893edcce85f5fbe8a8922af42c9e0c05a006ad08b6d4f68',
+	'job-application/applicant_data.json': '8ea669ad2a4ed52db8676cd3db2a8f3556a9bd8726d122750b1a04de7f563bc0',
+	'job-application/example_resume.pdf': '95ebebe9489f467d5ecaa989f0d6e601364547c08bc57a02fb0c2fe816388a18',
+	'job-application/main.py': 'b0460ac996e4a376b94b093bc908750d7a2a4b6e71c394d5bead927169d6dfdc',
+	'job-application/pyproject.toml.template': 'fb248454a3ef90e4416028a9461bc7142cb3886a0b309b29e483987338196c11',
+	'llm-arena/.env.example.template': 'e0ab1c2baef61dd1a08a77cea359fa5c5340128b9014b3b3936cdbee5b195494',
+	'llm-arena/README.md': '713e8fdb275c66c9df70e68fcecd7ed139db555f2a077b3bb22c979da2b51348',
+	'llm-arena/main.py': '11f6e751ee0409a56702eae46ac47d489343a8861406f9d4ff4ee1d028c86739',
+	'llm-arena/pyproject.toml.template': '8f30bf5a09965988b627a055c7b7948ea8b54e92a04745068bac10884a83044d',
+	'sandbox/.env.example.template': 'e357d28d032c155996c1dc2e2f51d0d6d2b807c91398dc195f2f9c0e83878a2b',
+	'sandbox/README.md': '29a25f42945a4968763b2e79ec58153c6ac28510bfd5129663d82fa42e71d7b0',
+	'sandbox/main.py': '562c96d64f23a81c8cc33e0299d174c2bd65b023fd11d348a71c8a33a543980b',
+	'sandbox/pyproject.toml.template': 'e0da0a8c62d01a5926350e62bb6315e802aa29573690afff5bad9d260d4339ce',
+	'scheduler/.env.example.template': 'dc5ce4d2a309d69952abf7c32d868566ecf26a0ba98a1fdeb31dc92a4bdade1b',
+	'scheduler/README.md': '639cf80ba353422c9671a7745bb2868ce3ec7ff5f71e5e12d480ad8917b5697c',
+	'scheduler/agents/gmail.py': '10a49bd97eed085bed56c280047c55a7b0502676ffc2a371aa3eefedd375110e',
+	'scheduler/agents/x.py': 'c9fdcb87a50c6a46c77beea77b898b541025bc0f91bad7c0a896aab35ba088eb',
+	'scheduler/main.py': '45a46a63f98acbc9e8fca7bf94a65b735ffcb4d67f435bc1777115eb9f996e10',
+	'scheduler/pyproject.toml.template': '29701de70d88d24324089cbbe2df63dc9e793db758a2ab02de1ee4edf074f622',
+	'shopping/.env.example.template': '8c732e83970c6b0637ecf47025afcf122580f430063925b9217d56885d933ece',
+	'shopping/README.md': '49d0609f7b2d46dd7f1e122760932f16a3f71325bbef2c1f5fbf885225be8ce5',
+	'shopping/launch_chrome_debug.py': 'a985b6c0c255575455a78999428c60904648151c7093f6287eb03c57fbdf74f9',
+	'shopping/main.py': '1e256552217f770d81d5f0f976111a82d8563bb4fede5f5618e05aa820fec7e0',
+	'shopping/pyproject.toml.template': 'cd86c1fed589d8148ac1cc0148a8900dcd48498b5f50efc46900e764fffe7dff',
+	'slack/.env.example.template': '70cc178f9e12ad4723d2e1425dc352fb60b9d435404560716f30ca992dbf8f3c',
+	'slack/README.md': 'f752cc79d0e2d85e7aba350864bfb4be41538d3ff34bf02004cf0dd699c543eb',
+	'slack/app/main.py': 'fcbabbff8899a520aed014fad155bf8b5a91266c39d60ca855c993a64e0b6d10',
+	'slack/app/service.py': 'a6974f20b90390442eec38571d1e22f91c5bb7ecb63ef34d194785b83cd70e60',
+	'slack/pyproject.toml.template': 'a32ef287248627f2c1a5ab76adeaeaa4a3436e3586191bf25fe6dc6c777f9435',
+	TEMPLATE_MANIFEST_PATH: '31043ff5109a4d8498cd005bb38aca8c5a4e6d2e4968b946fd33442ec32c1eb2',
+	'tools_template.py': '5b3850bbd1e10f62d56199ba03070526b658e1eafa67a73e25e52f041ce8a778',
+}
+
+
+class TemplateIntegrityError(RuntimeError):
+	"""Raised when a downloaded init template does not match its pinned checksum."""
+
 
 # Export for backward compatibility with cli.py
 # Templates are fetched at runtime via _get_template_list()
 INIT_TEMPLATES: dict[str, Any] = {}
+
+
+def _verify_template_bytes(file_path: str, content: bytes) -> None:
+	"""Verify a downloaded template artifact against its pinned SHA-256."""
+	expected_hash = TEMPLATE_FILE_SHA256.get(file_path)
+	if expected_hash is None:
+		raise TemplateIntegrityError(f'No pinned checksum for template artifact: {file_path}')
+
+	actual_hash = hashlib.sha256(content).hexdigest()
+	if actual_hash != expected_hash:
+		raise TemplateIntegrityError(
+			f'Template integrity check failed for {file_path}: expected sha256:{expected_hash}, got sha256:{actual_hash}'
+		)
+
+
+def _validate_template_manifest(templates: dict[str, Any]) -> None:
+	"""Ensure every manifest-referenced template artifact has a pinned checksum."""
+	for template_name, metadata in templates.items():
+		if not isinstance(metadata, dict):
+			raise TemplateIntegrityError(f'Invalid template manifest entry for {template_name}')
+
+		template_file = metadata.get('file')
+		if not isinstance(template_file, str) or template_file not in TEMPLATE_FILE_SHA256:
+			raise TemplateIntegrityError(f'Template {template_name} references an unpinned file: {template_file}')
+
+		for file_spec in metadata.get('files', []):
+			if not isinstance(file_spec, dict):
+				raise TemplateIntegrityError(f'Template {template_name} has an invalid file specification')
+			source_path = file_spec.get('source')
+			if not isinstance(source_path, str) or source_path not in TEMPLATE_FILE_SHA256:
+				raise TemplateIntegrityError(f'Template {template_name} references an unpinned file: {source_path}')
 
 
 def _fetch_template_list() -> dict[str, Any] | None:
@@ -39,11 +123,16 @@ def _fetch_template_list() -> dict[str, Any] | None:
 	Returns template dict if successful, None if failed.
 	"""
 	try:
-		url = f'{TEMPLATE_REPO_URL}/templates.json'
+		url = f'{TEMPLATE_REPO_URL}/{TEMPLATE_MANIFEST_PATH}'
 		with request.urlopen(url, timeout=5) as response:
-			data = response.read().decode('utf-8')
-			return json.loads(data)
-	except (URLError, TimeoutError, json.JSONDecodeError, Exception):
+			data = response.read()
+			_verify_template_bytes(TEMPLATE_MANIFEST_PATH, data)
+			templates = json.loads(data.decode('utf-8'))
+			if not isinstance(templates, dict):
+				raise TemplateIntegrityError('Template manifest must be a JSON object')
+			_validate_template_manifest(templates)
+			return templates
+	except (URLError, TimeoutError, json.JSONDecodeError):
 		return None
 
 
@@ -68,8 +157,10 @@ def _fetch_from_github(file_path: str) -> str | None:
 	try:
 		url = f'{TEMPLATE_REPO_URL}/{file_path}'
 		with request.urlopen(url, timeout=5) as response:
-			return response.read().decode('utf-8')
-	except (URLError, TimeoutError, Exception):
+			content = response.read()
+			_verify_template_bytes(file_path, content)
+			return content.decode('utf-8')
+	except (URLError, TimeoutError):
 		return None
 
 
@@ -82,8 +173,10 @@ def _fetch_binary_from_github(file_path: str) -> bytes | None:
 	try:
 		url = f'{TEMPLATE_REPO_URL}/{file_path}'
 		with request.urlopen(url, timeout=5) as response:
-			return response.read()
-	except (URLError, TimeoutError, Exception):
+			content = response.read()
+			_verify_template_bytes(file_path, content)
+			return content
+	except (URLError, TimeoutError):
 		return None
 
 
@@ -247,6 +340,9 @@ def main(
 	try:
 		INIT_TEMPLATES = _get_template_list()
 	except FileNotFoundError as e:
+		console.print(f'[red]✗[/red] {e}')
+		sys.exit(1)
+	except TemplateIntegrityError as e:
 		console.print(f'[red]✗[/red] {e}')
 		sys.exit(1)
 

--- a/tests/ci/test_init_cmd_integrity.py
+++ b/tests/ci/test_init_cmd_integrity.py
@@ -1,0 +1,68 @@
+import hashlib
+
+import pytest
+
+from browser_use import init_cmd
+
+
+class FakeResponse:
+	def __init__(self, content: bytes):
+		self.content = content
+
+	def __enter__(self):
+		return self
+
+	def __exit__(self, *_args):
+		return None
+
+	def read(self):
+		return self.content
+
+
+def fake_urlopen(content: bytes):
+	def _urlopen(_url: str, timeout: int):
+		assert timeout == 5
+		return FakeResponse(content)
+
+	return _urlopen
+
+
+def test_template_manifest_hash_mismatch_is_blocked(monkeypatch):
+	manifest = b'{"default": {"file": "default_template.py", "description": "tampered"}}'
+	monkeypatch.setattr(init_cmd.request, 'urlopen', fake_urlopen(manifest))
+
+	with pytest.raises(init_cmd.TemplateIntegrityError, match='Template integrity check failed'):
+		init_cmd._fetch_template_list()
+
+
+def test_template_manifest_rejects_unpinned_file_reference(monkeypatch):
+	manifest = b'{"default": {"file": "evil.py", "description": "tampered"}}'
+	monkeypatch.setitem(init_cmd.TEMPLATE_FILE_SHA256, init_cmd.TEMPLATE_MANIFEST_PATH, hashlib.sha256(manifest).hexdigest())
+	monkeypatch.setattr(init_cmd.request, 'urlopen', fake_urlopen(manifest))
+
+	with pytest.raises(init_cmd.TemplateIntegrityError, match='references an unpinned file'):
+		init_cmd._fetch_template_list()
+
+
+def test_template_file_hash_mismatch_is_blocked(monkeypatch):
+	monkeypatch.setitem(init_cmd.TEMPLATE_FILE_SHA256, 'default_template.py', '0' * 64)
+	monkeypatch.setattr(init_cmd.request, 'urlopen', fake_urlopen(b'print("tampered")'))
+
+	with pytest.raises(init_cmd.TemplateIntegrityError, match='Template integrity check failed'):
+		init_cmd._fetch_from_github('default_template.py')
+
+
+def test_verified_template_file_is_returned(monkeypatch):
+	content = b'print("hello")'
+	monkeypatch.setitem(init_cmd.TEMPLATE_FILE_SHA256, 'default_template.py', hashlib.sha256(content).hexdigest())
+	monkeypatch.setattr(init_cmd.request, 'urlopen', fake_urlopen(content))
+
+	assert init_cmd._fetch_from_github('default_template.py') == 'print("hello")'
+
+
+def test_verified_binary_template_file_is_returned(monkeypatch):
+	content = b'%PDF-1.4 fake resume'
+	monkeypatch.setitem(init_cmd.TEMPLATE_FILE_SHA256, 'job-application/example_resume.pdf', hashlib.sha256(content).hexdigest())
+	monkeypatch.setattr(init_cmd.request, 'urlopen', fake_urlopen(content))
+
+	assert init_cmd._fetch_binary_from_github('job-application/example_resume.pdf') == content


### PR DESCRIPTION
## Summary
- pin SHA-256 checksums for the remote init template manifest and every referenced template artifact
- verify downloaded template bytes before parsing or writing them to disk
- fail closed on tampered manifests, unpinned files, and checksum mismatches with a clear integrity error

Fixes #4721.

## Validation
- `uv run pytest tests/ci/test_init_cmd_integrity.py -q`
- `uv run ruff check browser_use/init_cmd.py tests/ci/test_init_cmd_integrity.py`
- `uv run ruff format --check browser_use/init_cmd.py tests/ci/test_init_cmd_integrity.py`
- `uv run python -m browser_use.init_cmd --list`
- `tmpdir=$(mktemp -d) && cd "$tmpdir" && uv run --project /Users/AdityaWork/IgniteTechProjects/BrowserUse/browser-use python -m browser_use.init_cmd --template default --force && test -s default/main.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SHA-256 pinning and runtime integrity checks for the init template manifest and all template files. Downloads are verified before parsing or writing, and the CLI fails with a clear integrity error on mismatches, unpinned files, or invalid manifests.

- **New Features**
  - Pinned checksums for `templates.json` and every template artifact.
  - Validates manifest structure (must be a JSON object) and rejects unpinned file references (including `files` entries).
  - Verifies bytes in `_fetch_template_list`, `_fetch_from_github`, and `_fetch_binary_from_github`; raises `TemplateIntegrityError` on mismatch.
  - CLI catches integrity failures, prints a clear error, and exits; tests cover mismatches, unpinned refs, and verified fetches.

<sup>Written for commit 4e6931a01de60b593b2b1a96a0aa0b27068b56fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

