### PR TITLE
Add MiniMax chat provider

### DIFF
--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
 	from browser_use.llm.mistral.chat import ChatMistral
+	from browser_use.llm.minimax.chat import ChatMiniMax
 	from browser_use.llm.oci_raw.chat import ChatOCIRaw
 	from browser_use.llm.ollama.chat import ChatOllama
 	from browser_use.llm.openai.chat import ChatOpenAI
@@ -89,6 +90,7 @@ _LAZY_IMPORTS = {
 	'ChatGoogle': ('browser_use.llm.google.chat', 'ChatGoogle'),
 	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
 	'ChatMistral': ('browser_use.llm.mistral.chat', 'ChatMistral'),
+	'ChatMiniMax': ('browser_use.llm.minimax.chat', 'ChatMiniMax'),
 	'ChatOCIRaw': ('browser_use.llm.oci_raw.chat', 'ChatOCIRaw'),
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
@@ -152,6 +154,7 @@ __all__ = [
 	'ChatAWSBedrock',
 	'ChatGroq',
 	'ChatMistral',
+	'ChatMiniMax',
 	'ChatAzureOpenAI',
 	'ChatOCIRaw',
 	'ChatOllama',

--- a/browser_use/llm/minimax/__init__.py
+++ b/browser_use/llm/minimax/__init__.py
@@ -1,0 +1,3 @@
+from browser_use.llm.minimax.chat import ChatMiniMax
+
+__all__ = ['ChatMiniMax']

--- a/browser_use/llm/minimax/chat.py
+++ b/browser_use/llm/minimax/chat.py
@@ -1,0 +1,29 @@
+import os
+from dataclasses import dataclass
+
+import httpx
+
+from browser_use.llm.openai.chat import ChatOpenAI
+
+
+@dataclass
+class ChatMiniMax(ChatOpenAI):
+	"""
+	MiniMax chat model using MiniMax's OpenAI-compatible API.
+
+	MiniMax-M3 supports the existing OpenAI-style multimodal message format used by
+	Browser Use for screenshots and target/sample images.
+	"""
+
+	model: str = 'MiniMax-M3'
+	api_key: str | None = None
+	base_url: str | httpx.URL | None = 'https://api.minimax.io/v1'
+	max_completion_tokens: int | None = 4096
+
+	def __post_init__(self) -> None:
+		if self.api_key is None:
+			self.api_key = os.getenv('MINIMAX_API_KEY')
+
+	@property
+	def provider(self) -> str:
+		return 'minimax'

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -18,6 +18,7 @@ from browser_use.llm.azure.chat import ChatAzureOpenAI
 from browser_use.llm.browser_use.chat import ChatBrowserUse
 from browser_use.llm.cerebras.chat import ChatCerebras
 from browser_use.llm.google.chat import ChatGoogle
+from browser_use.llm.minimax.chat import ChatMiniMax
 from browser_use.llm.mistral.chat import ChatMistral
 from browser_use.llm.openai.chat import ChatOpenAI
 
@@ -222,8 +223,14 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('BROWSER_USE_API_KEY')
 		return ChatBrowserUse(model=model, api_key=api_key)
 
+	# MiniMax Models
+	elif provider == 'minimax':
+		api_key = os.getenv('MINIMAX_API_KEY')
+		base_url = os.getenv('MINIMAX_BASE_URL', 'https://api.minimax.io/v1')
+		return ChatMiniMax(model=model, api_key=api_key, base_url=base_url)
+
 	else:
-		available_providers = ['openai', 'azure', 'google', 'anthropic', 'mistral', 'oci', 'cerebras', 'bu']
+		available_providers = ['openai', 'azure', 'google', 'anthropic', 'mistral', 'oci', 'cerebras', 'bu', 'minimax']
 		raise ValueError(f"Unknown provider: '{provider}'. Available providers: {', '.join(available_providers)}")
 
 
@@ -247,6 +254,8 @@ def __getattr__(name: str) -> 'BaseChatModel':
 		return ChatOCIRaw  # type: ignore
 	elif name == 'ChatCerebras':
 		return ChatCerebras  # type: ignore
+	elif name == 'ChatMiniMax':
+		return ChatMiniMax  # type: ignore
 	elif name == 'ChatBrowserUse':
 		return ChatBrowserUse  # type: ignore
 


### PR DESCRIPTION
Reason: add target image capability using existing tool/provider pattern.

## Summary
- Adds a `ChatMiniMax` provider backed by the existing OpenAI-compatible chat implementation.
- Registers MiniMax in lazy LLM exports and `get_llm_by_name` using `MINIMAX_API_KEY` and optional `MINIMAX_BASE_URL`.
- Defaults to MiniMax-M3 and the MiniMax OpenAI-compatible base URL so existing screenshot/sample image content parts can flow through unchanged.

## Test plan
- `python3 -m py_compile browser_use/llm/minimax/chat.py browser_use/llm/models.py browser_use/llm/__init__.py`
- Secret scan over tracked diff
- Import smoke test attempted but local environment lacks `python-dotenv` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ChatMiniMax` via the OpenAI-compatible chat path, so MiniMax-M3 can process screenshots and target/sample images without changing the message format.

- **New Features**
  - Introduced `ChatMiniMax` (defaults: model `MiniMax-M3`, base URL https://api.minimax.io/v1, max completion tokens 4096).
  - Registered in lazy exports and `get_llm_by_name` (use provider `minimax`).
  - Reads `MINIMAX_API_KEY` and optional `MINIMAX_BASE_URL`.

<sup>Written for commit f19fdc580811b1acff6ab2ffe237aa79dd46869b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

