### PR TITLE
fix(llm/google): handle non-data image URLs in serializer

### DIFF
--- a/browser_use/llm/google/serializer.py
+++ b/browser_use/llm/google/serializer.py
@@ -101,16 +101,18 @@ class GoogleMessageSerializer:
 							# Handle images
 							url = part.image_url.url
 
-							# Format: data:image/jpeg;base64,<data>
-							header, data = url.split(',', 1)
-							# Decode base64 to bytes
-							image_bytes = base64.b64decode(data)
-
 							# Use the media_type from ImageURL, which correctly identifies the image format
 							mime_type = part.image_url.media_type
 
-							# Add image part
-							image_part = Part.from_bytes(data=image_bytes, mime_type=mime_type)
+							if url.startswith('data:'):
+								# Format: data:image/jpeg;base64,<data>
+								_, data = url.split(',', 1)
+								# Decode base64 to bytes
+								image_bytes = base64.b64decode(data)
+								image_part = Part.from_bytes(data=image_bytes, mime_type=mime_type)
+							else:
+								# Remote image URL - pass it through instead of trying to base64-decode it
+								image_part = Part.from_uri(file_uri=url, mime_type=mime_type)
 
 							message_parts.append(image_part)
 

--- a/tests/ci/models/test_llm_google.py
+++ b/tests/ci/models/test_llm_google.py
@@ -69,3 +69,45 @@ def test_x_goog_api_client_header_with_dict_http_options():
 	assert http_opts.get('timeout') == 45
 	assert http_opts.get('headers', {}).get('another-header') == 'another-value'
 	assert http_opts.get('headers', {}).get('x-goog-api-client', '').startswith('browser-use/')
+
+
+def test_serializer_decodes_data_url_image():
+	"""Test that base64 data URL images are decoded into inline bytes."""
+	import base64
+
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import ContentPartImageParam, ContentPartTextParam, ImageURL, UserMessage
+
+	raw_bytes = b'fake-png-bytes'
+	data_url = 'data:image/png;base64,' + base64.b64encode(raw_bytes).decode()
+	message = UserMessage(
+		content=[
+			ContentPartTextParam(text='What is in this image?'),
+			ContentPartImageParam(image_url=ImageURL(url=data_url, media_type='image/png')),
+		]
+	)
+
+	contents, _ = GoogleMessageSerializer.serialize_messages([message])
+	parts = contents[0].parts
+
+	assert parts[0].text == 'What is in this image?'
+	assert parts[1].inline_data is not None
+	assert parts[1].inline_data.data == raw_bytes
+	assert parts[1].inline_data.mime_type == 'image/png'
+
+
+def test_serializer_passes_through_remote_image_url():
+	"""Test that a plain https image URL is passed through instead of being base64-decoded."""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import ContentPartImageParam, ImageURL, UserMessage
+
+	url = 'https://example.com/images/photo.png'
+	message = UserMessage(content=[ContentPartImageParam(image_url=ImageURL(url=url, media_type='image/png'))])
+
+	# Used to raise ValueError because the serializer assumed every image URL is a data: URL
+	contents, _ = GoogleMessageSerializer.serialize_messages([message])
+	part = contents[0].parts[0]
+
+	assert part.file_data is not None
+	assert part.file_data.file_uri == url
+	assert part.file_data.mime_type == 'image/png'


### PR DESCRIPTION
**Problem**

Passing a `UserMessage` with a remote image URL to `ChatGoogle` crashes during serialization:

```python
UserMessage(content=[ContentPartImageParam(image_url=ImageURL(url='https://example.com/photo.png'))])
# ValueError: not enough values to unpack (expected 2, got 1)
```

The serializer assumes every `image_url` part is a base64 `data:` URL and unconditionally does `url.split(',', 1)` + base64 decode. The anthropic, aws and ollama serializers all branch on `url.startswith('data:')` and pass remote URLs through; the google one was the only one that didn't.

**Fix**

Branch on `data:` like the other serializers: keep the base64 path for data URLs, build the part with `Part.from_uri` for remote URLs. Added unit tests for both paths in `tests/ci/models/test_llm_google.py`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the Google LLM serializer when a `UserMessage` includes a remote image URL. Non-data image URLs are now passed through; data URLs are still base64-decoded.

- **Bug Fixes**
  - Branch on URL scheme: `data:` -> `Part.from_bytes`, http/https -> `Part.from_uri`.
  - Preserve `mime_type` from `ImageURL`.
  - Added unit tests for both paths in `tests/ci/models/test_llm_google.py`.

<sup>Written for commit 029918c92ebfd3e6b93e2e43a663461bb91920ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

