### PR TITLE
fix: export documented LLM chat models

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -53,8 +53,12 @@ if TYPE_CHECKING:
 	from browser_use.dom.service import DomService
 	from browser_use.llm import models
 	from browser_use.llm.anthropic.chat import ChatAnthropic
+	from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
+	from browser_use.llm.aws.chat_bedrock import ChatAWSBedrock
 	from browser_use.llm.azure.chat import ChatAzureOpenAI
 	from browser_use.llm.browser_use.chat import ChatBrowserUse
+	from browser_use.llm.cerebras.chat import ChatCerebras
+	from browser_use.llm.deepseek.chat import ChatDeepSeek
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
 	from browser_use.llm.litellm.chat import ChatLiteLLM
@@ -62,6 +66,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.oci_raw.chat import ChatOCIRaw
 	from browser_use.llm.ollama.chat import ChatOllama
 	from browser_use.llm.openai.chat import ChatOpenAI
+	from browser_use.llm.openrouter.chat import ChatOpenRouter
 	from browser_use.llm.vercel.chat import ChatVercel
 	from browser_use.sandbox import sandbox
 	from browser_use.tools.service import Controller, Tools
@@ -88,13 +93,18 @@ _LAZY_IMPORTS = {
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
 	'ChatGoogle': ('browser_use.llm.google.chat', 'ChatGoogle'),
 	'ChatAnthropic': ('browser_use.llm.anthropic.chat', 'ChatAnthropic'),
+	'ChatAnthropicBedrock': ('browser_use.llm.aws.chat_anthropic', 'ChatAnthropicBedrock'),
+	'ChatAWSBedrock': ('browser_use.llm.aws.chat_bedrock', 'ChatAWSBedrock'),
 	'ChatBrowserUse': ('browser_use.llm.browser_use.chat', 'ChatBrowserUse'),
+	'ChatCerebras': ('browser_use.llm.cerebras.chat', 'ChatCerebras'),
+	'ChatDeepSeek': ('browser_use.llm.deepseek.chat', 'ChatDeepSeek'),
 	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
 	'ChatLiteLLM': ('browser_use.llm.litellm.chat', 'ChatLiteLLM'),
 	'ChatMistral': ('browser_use.llm.mistral.chat', 'ChatMistral'),
 	'ChatAzureOpenAI': ('browser_use.llm.azure.chat', 'ChatAzureOpenAI'),
 	'ChatOCIRaw': ('browser_use.llm.oci_raw.chat', 'ChatOCIRaw'),
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
+	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
 	# LLM models module
 	'models': ('browser_use.llm.models', None),
@@ -140,13 +150,18 @@ __all__ = [
 	'ChatOpenAI',
 	'ChatGoogle',
 	'ChatAnthropic',
+	'ChatAnthropicBedrock',
+	'ChatAWSBedrock',
 	'ChatBrowserUse',
+	'ChatCerebras',
+	'ChatDeepSeek',
 	'ChatGroq',
 	'ChatLiteLLM',
 	'ChatMistral',
 	'ChatAzureOpenAI',
 	'ChatOCIRaw',
 	'ChatOllama',
+	'ChatOpenRouter',
 	'ChatVercel',
 	'Tools',
 	'Controller',


### PR DESCRIPTION
## Summary
- Export documented LLM chat model classes from the top-level `browser_use` package
- Adds missing lazy exports for OpenRouter, DeepSeek, Cerebras, and AWS Bedrock chat models
- Keeps the supported-models examples like `from browser_use import ChatOpenRouter` working as documented

Fixes #4755

## Test Plan
- `python3 -m py_compile browser_use/__init__.py`
- Structural export check for `ChatOpenRouter`, `ChatDeepSeek`, `ChatCerebras`, `ChatAWSBedrock`, and `ChatAnthropicBedrock`

Note: Full import verification was blocked in this minimal environment because repository dependencies are not installed (`psutil` missing before package setup).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export missing chat model classes at the top level of `browser_use` to match the docs and prevent import errors. Restores imports like `from browser_use import ChatOpenRouter`.

- **Bug Fixes**
  - Added lazy exports for `ChatOpenRouter`, `ChatDeepSeek`, `ChatCerebras`, `ChatAWSBedrock`, `ChatAnthropicBedrock`.
  - Updated lazy export map and `__all__` so `from browser_use import ...` works as documented.
  - Fixes #4755.

<sup>Written for commit 8ec5a9e03004e891441d45f0bbc6a9dbd676e1c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

