### PR TITLE
Expose recorded video paths in history

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2502,6 +2502,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		agent_run_error: str | None = None  # Initialize error tracking variable
 		self._force_exit_telemetry_logged = False  # ADDED: Flag for custom telemetry on force exit
 		should_delay_close = False
+		recorded_video_paths_start_index = len(self.browser_session.recorded_video_paths)
 
 		# Set up the  signal handler with callbacks specific to this agent
 		from browser_use.utils import SignalHandler
@@ -2714,6 +2715,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			await self.eventbus.stop(clear=True, timeout=_get_timeout('TIMEOUT_AgentEventBusStop', 3.0))
 
 			await self.close()
+			self._sync_recorded_video_paths(recorded_video_paths_start_index)
 
 	@observe_debug(ignore_input=True, ignore_output=True)
 	@time_execution_async('--multi_act')
@@ -4049,6 +4051,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		import asyncio
 
 		return asyncio.run(self.run(max_steps=max_steps, on_step_start=on_step_start, on_step_end=on_step_end))
+
+	def _sync_recorded_video_paths(self, start_index: int) -> None:
+		"""Append video recordings finalized during this run to the returned history."""
+		self.history.recordings.extend(self.browser_session.recorded_video_paths[start_index:])
 
 	def detect_variables(self) -> dict[str, DetectedVariable]:
 		"""Detect reusable variables in agent history"""

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -597,6 +597,7 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	history: list[AgentHistory]
 	usage: UsageSummary | None = None
+	recordings: list[str] = Field(default_factory=list)
 
 	_output_model_schema: type[AgentStructuredOutput] | None = None
 
@@ -668,9 +669,12 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def model_dump(self, **kwargs) -> dict[str, Any]:
 		"""Custom serialization that properly uses AgentHistory's model_dump"""
-		return {
+		data: dict[str, Any] = {
 			'history': [h.model_dump(**kwargs) for h in self.history],
 		}
+		if self.recordings:
+			data['recordings'] = self.recordings.copy()
+		return data
 
 	@classmethod
 	def load_from_dict(cls, data: dict[str, Any], output_model: type[AgentOutput]) -> AgentHistoryList:
@@ -782,6 +786,14 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 				return [h.state.screenshot_path if h.state.screenshot_path is not None else None for h in self.history[-n_last:]]
 			else:
 				return [h.state.screenshot_path for h in self.history[-n_last:] if h.state.screenshot_path is not None]
+
+	def recorded_video_paths(self) -> list[str]:
+		"""Get all video recording paths captured for this history."""
+		return self.recordings.copy()
+
+	def video_paths(self) -> list[str]:
+		"""Alias for recorded_video_paths()."""
+		return self.recorded_video_paths()
 
 	def screenshots(self, n_last: int | None = None, return_none_if_not_screenshot: bool = True) -> list[str | None]:
 		"""Get all screenshots from history as base64 strings"""

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -561,6 +561,7 @@ class BrowserSession(BaseModel):
 	_cached_browser_state_summary: Any = PrivateAttr(default=None)
 	_cached_selector_map: dict[int, EnhancedDOMTreeNode] = PrivateAttr(default_factory=dict)
 	_downloaded_files: list[str] = PrivateAttr(default_factory=list)  # Track files downloaded during this session
+	_recorded_video_paths: list[str] = PrivateAttr(default_factory=list)  # Track videos recorded during this session
 	_closed_popup_messages: list[str] = PrivateAttr(default_factory=list)  # Store messages from auto-closed JavaScript dialogs
 
 	# Watchdogs
@@ -1264,6 +1265,15 @@ class BrowserSession(BaseModel):
 				self.logger.warning(f'FileDownloadedEvent has no path: {event}')
 			else:
 				self.logger.debug(f'File already tracked: {event.path}')
+
+	def _track_recorded_video(self, path: str | Path) -> None:
+		"""Track a finalized video recording path for this session."""
+		path_str = str(path)
+		if path_str not in self._recorded_video_paths:
+			self._recorded_video_paths.append(path_str)
+			self.logger.info(
+				f'📹 Tracked video recording: {path_str} ({len(self._recorded_video_paths)} total recordings in session)'
+			)
 
 	def _cloud_session_id_from_cdp_url(self) -> str | None:
 		"""Derive cloud browser session ID from a Browser Use CDP URL."""
@@ -3325,6 +3335,11 @@ class BrowserSession(BaseModel):
 			list[str]: List of absolute file paths to downloaded files in this session
 		"""
 		return self._downloaded_files.copy()
+
+	@property
+	def recorded_video_paths(self) -> list[str]:
+		"""Get list of video recordings finalized during this browser session."""
+		return self._recorded_video_paths.copy()
 
 	# endregion - ========== Helper Methods ==========
 

--- a/browser_use/browser/watchdogs/recording_watchdog.py
+++ b/browser_use/browser/watchdogs/recording_watchdog.py
@@ -115,6 +115,10 @@ class RecordingWatchdog(BaseWatchdog):
 		output_path = recorder.output_path
 		loop = asyncio.get_event_loop()
 		await loop.run_in_executor(None, recorder.stop_and_save)
+		if output_path.exists() and output_path.stat().st_size > 0:
+			self.browser_session._track_recorded_video(output_path)
+		else:
+			self.logger.warning(f'Video recording was not saved, skipping path tracking: {output_path}')
 		return output_path
 
 	@property

--- a/tests/ci/test_action_record.py
+++ b/tests/ci/test_action_record.py
@@ -20,6 +20,7 @@ try:
 except ImportError:
 	IMAGEIO_AVAILABLE = False
 
+from browser_use import Agent, AgentHistoryList
 from browser_use.browser.events import NavigateToUrlEvent
 from browser_use.browser.profile import BrowserProfile
 from browser_use.browser.session import BrowserSession
@@ -79,6 +80,7 @@ async def test_start_stop_recording_produces_video(browser_session: BrowserSessi
 	final = await watchdog.stop_recording()
 	assert final == out_path
 	assert not watchdog.is_recording
+	assert browser_session.recorded_video_paths == [str(out_path)]
 	assert out_path.exists(), 'recording stop should leave a file on disk'
 	assert out_path.stat().st_size > 0, 'recorded video must be non-empty'
 
@@ -107,6 +109,28 @@ async def test_stop_without_start_returns_none(browser_session: BrowserSession):
 	watchdog = browser_session._recording_watchdog
 	assert watchdog is not None
 	assert await watchdog.stop_recording() is None
+
+
+async def test_failed_recording_finalize_does_not_track_path(
+	browser_session: BrowserSession, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+	watchdog = browser_session._recording_watchdog
+	assert watchdog is not None
+
+	out_path = tmp_path / 'missing.mp4'
+	await watchdog.start_recording(out_path)
+	assert watchdog._recorder is not None
+
+	def fake_stop_and_save() -> None:
+		if out_path.exists():
+			out_path.unlink()
+
+	monkeypatch.setattr(watchdog._recorder, 'stop_and_save', fake_stop_and_save)
+
+	final = await watchdog.stop_recording()
+
+	assert final == out_path
+	assert browser_session.recorded_video_paths == []
 
 
 async def test_on_browser_connected_degrades_gracefully_when_recording_fails(
@@ -150,3 +174,45 @@ async def test_profile_record_video_dir_still_works(page_url: str, tmp_path: Pat
 	videos = list(tmp_path.glob('*.mp4'))
 	assert videos, f'expected at least one recorded mp4 in {tmp_path}'
 	assert videos[0].stat().st_size > 0
+	assert session.recorded_video_paths == [str(videos[0])]
+
+
+async def test_agent_history_exposes_recorded_video_paths(mock_llm, tmp_path: Path):
+	session = BrowserSession(
+		browser_profile=BrowserProfile(headless=True, record_video_dir=tmp_path),
+	)
+	agent = Agent(
+		task='Finish immediately.',
+		llm=mock_llm,
+		browser_session=session,
+		use_judge=False,
+	)
+
+	history: AgentHistoryList = await agent.run(max_steps=1)
+
+	video_paths = history.recorded_video_paths()
+	assert video_paths == history.video_paths()
+	assert len(video_paths) == 1
+	assert video_paths[0].endswith('.mp4')
+	assert Path(video_paths[0]).exists()
+	assert Path(video_paths[0]).stat().st_size > 0
+
+
+def test_agent_history_recording_sync_appends_new_paths(mock_llm):
+	session = BrowserSession(
+		browser_profile=BrowserProfile(headless=True),
+	)
+	agent = Agent(
+		task='Finish immediately.',
+		llm=mock_llm,
+		browser_session=session,
+		use_judge=False,
+	)
+	session._track_recorded_video('/tmp/first.mp4')
+	agent.history.recordings = ['/tmp/first.mp4']
+	start_index = len(session.recorded_video_paths)
+
+	session._track_recorded_video('/tmp/second.mp4')
+	agent._sync_recorded_video_paths(start_index)
+
+	assert agent.history.recorded_video_paths() == ['/tmp/first.mp4', '/tmp/second.mp4']

--- a/tests/ci/test_sandbox_structured_output.py
+++ b/tests/ci/test_sandbox_structured_output.py
@@ -27,6 +27,14 @@ class NestedModel(BaseModel):
 	total_count: int
 
 
+def test_agent_history_list_exposes_recorded_video_paths():
+	history = AgentHistoryList(history=[], recordings=['recordings/session.mp4'])
+
+	assert history.recorded_video_paths() == ['recordings/session.mp4']
+	assert history.video_paths() == ['recordings/session.mp4']
+	assert history.model_dump()['recordings'] == ['recordings/session.mp4']
+
+
 class TestGetStructuredOutput:
 	"""Tests for AgentHistoryList.get_structured_output method"""
 


### PR DESCRIPTION
Fixes #4623.

## Why

Users can configure `BrowserProfile(record_video_dir=...)` and browser-use will save session recordings, but the returned `AgentHistoryList` does not expose the generated video paths. This makes it hard to programmatically attach recordings to logs, reports, dashboards, or debugging workflows after `agent.run()` completes.

## Summary

- Track finalized video recording paths on `BrowserSession`
- Expose recorded videos on `AgentHistoryList` via:
  - `recorded_video_paths()`
  - `video_paths()`
- Sync recordings from the browser session into the returned history after `Agent.run()` cleanup
- Add coverage for direct recording, profile-driven recording, and agent history access

## Demo / Screenshots

No UI change. Screenshot/gif is not applicable for this API-level change.

The behavior is covered by tests that generate real `.mp4` recordings locally and assert the paths are exposed through history.

## Tests

```bash
uv run pytest tests/ci/test_sandbox_structured_output.py::test_agent_history_list_exposes_recorded_video_paths tests/ci/test_action_record.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose recorded video file paths in `AgentHistoryList` so callers can attach recordings to logs and reports after `agent.run()`. Fixes #4623.

- **New Features**
  - Add `BrowserSession.recorded_video_paths` and track only finalized, non-empty files via the recording watchdog.
  - Expose recordings on `AgentHistoryList.recordings` with `recorded_video_paths()` and `video_paths()`, and include them in `model_dump`.
  - Sync only videos recorded during this `Agent.run()` to the returned history, including on force-exit.

<sup>Written for commit 477d61c5dd8c8bc3a60545d892486b62b6104509. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

