### PR TITLE
Thread action context through agent tools

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -142,7 +142,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		browser: Browser | None = None,  # Alias for browser_session
 		tools: Tools[Context] | None = None,
 		controller: Tools[Context] | None = None,  # Alias for tools
-		context: Context | None = None,
 		# Skills integration
 		skill_ids: list[str | Literal['*']] | None = None,
 		skills: list[str | Literal['*']] | None = None,  # Alias for skill_ids
@@ -210,6 +209,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_clickable_elements_length: int = 40000,
 		_url_shortening_limit: int = 25,
 		enable_signal_handler: bool = True,
+		context: Context | None = None,
 		**kwargs,
 	):
 		# Validate llm_screenshot_size

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -142,6 +142,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		browser: Browser | None = None,  # Alias for browser_session
 		tools: Tools[Context] | None = None,
 		controller: Tools[Context] | None = None,  # Alias for tools
+		context: Context | None = None,
 		# Skills integration
 		skill_ids: list[str | Literal['*']] | None = None,
 		skills: list[str | Literal['*']] | None = None,  # Alias for skill_ids
@@ -307,6 +308,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		# Initialize available file paths as direct attribute
 		self.available_file_paths = available_file_paths
+		self.context = context
 
 		# Set up tools first (needed to detect output_model_schema)
 		if tools is not None:
@@ -316,7 +318,15 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		else:
 			# Exclude screenshot tool when use_vision is not auto
 			exclude_actions = ['screenshot'] if use_vision != 'auto' else []
-			self.tools = Tools(exclude_actions=exclude_actions, display_files_in_done_text=display_files_in_done_text)
+			self.tools = Tools(
+				exclude_actions=exclude_actions,
+				display_files_in_done_text=display_files_in_done_text,
+				context=context,
+			)
+
+		if context is not None:
+			self.tools.context = context
+			self.tools.registry.context = context
 
 		# Enforce screenshot exclusion when use_vision != 'auto', even if user passed custom tools
 		if use_vision != 'auto':
@@ -2777,6 +2787,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					sensitive_data=self.sensitive_data,
 					available_file_paths=self.available_file_paths,
 					extraction_schema=self.extraction_schema,
+					context=self.context,
 				)
 
 				if result.error:

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -4242,7 +4242,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		browser: BrowserSession | None = None,
 		tools: Tools[Context] | None = None,
 		controller: Tools[Context] | None = None,
-		context: Context | None = None,
 		skill_ids: list[str | Literal['*']] | None = None,
 		skills: list[str | Literal['*']] | None = None,
 		skill_service: Any | None = None,
@@ -4298,6 +4297,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_clickable_elements_length: int = 40000,
 		_url_shortening_limit: int = 25,
 		enable_signal_handler: bool = True,
+		context: Context | None = None,
 		**kwargs,
 	):
 		if llm_screenshot_size is not None:

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -4102,11 +4102,18 @@ def _resolve_tools(
 	output_model_schema: type[BaseModel] | None,
 	use_vision: bool | Literal['auto'],
 	display_files_in_done_text: bool,
+	context: Any | None = None,
 ) -> Any:
 	resolved_tools = tools if tools is not None else controller
 	if resolved_tools is None:
 		exclude_actions = ['screenshot'] if use_vision is False else []
-		resolved_tools = Tools(exclude_actions=exclude_actions, display_files_in_done_text=display_files_in_done_text)
+		resolved_tools = Tools(
+			exclude_actions=exclude_actions, display_files_in_done_text=display_files_in_done_text, context=context
+		)
+	elif context is not None and hasattr(resolved_tools, 'context') and hasattr(resolved_tools, 'registry'):
+		resolved_tools.context = context
+		if hasattr(resolved_tools.registry, 'context'):
+			resolved_tools.registry.context = context
 	if output_model_schema is not None and hasattr(resolved_tools, 'use_structured_output_action'):
 		resolved_tools.use_structured_output_action(output_model_schema)
 	return resolved_tools
@@ -4235,6 +4242,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		browser: BrowserSession | None = None,
 		tools: Tools[Context] | None = None,
 		controller: Tools[Context] | None = None,
+		context: Context | None = None,
 		skill_ids: list[str | Literal['*']] | None = None,
 		skills: list[str | Literal['*']] | None = None,
 		skill_service: Any | None = None,
@@ -4324,6 +4332,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self.task_id = self.id
 		self.llm = llm
 		self.judge_llm = judge_llm
+		self.context = context
 		self.browser_session, self._browser_profile = _default_browser_session(
 			self.id,
 			browser_profile,
@@ -4343,6 +4352,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			output_model_schema,
 			use_vision,
 			display_files_in_done_text,
+			context,
 		)
 		if skills and skill_ids:
 			raise ValueError('Cannot specify both "skills" and "skill_ids" parameters. Use "skills" for the cleaner API.')

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -33,9 +33,10 @@ logger = logging.getLogger(__name__)
 class Registry(Generic[Context]):
 	"""Service for registering and managing actions"""
 
-	def __init__(self, exclude_actions: list[str] | None = None):
+	def __init__(self, exclude_actions: list[str] | None = None, context: Context | None = None):
 		self.registry = ActionRegistry()
 		self.telemetry = ProductTelemetry()
+		self.context = context
 		# Create a new list to avoid mutable default argument issues
 		self.exclude_actions = list(exclude_actions) if exclude_actions is not None else []
 
@@ -338,6 +339,7 @@ class Registry(Generic[Context]):
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		available_file_paths: list[str] | None = None,
 		extraction_schema: dict | None = None,
+		context: Context | None = None,
 	) -> Any:
 		"""Execute a registered action with simplified parameter handling"""
 		if action_name not in self.registry.actions:
@@ -366,6 +368,7 @@ class Registry(Generic[Context]):
 
 			# Build special context dict
 			special_context = {
+				'context': self.context if context is None else context,
 				'browser_session': browser_session,
 				'page_extraction_llm': page_extraction_llm,
 				'available_file_paths': available_file_paths,

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -444,8 +444,10 @@ class Tools(Generic[Context]):
 		exclude_actions: list[str] | None = None,
 		output_model: type[T] | None = None,
 		display_files_in_done_text: bool = True,
+		context: Context | None = None,
 	):
-		self.registry = Registry[Context](exclude_actions if exclude_actions is not None else [])
+		self.context = context
+		self.registry = Registry[Context](exclude_actions if exclude_actions is not None else [], context=context)
 		self.display_files_in_done_text = display_files_in_done_text
 		self._output_model: type[BaseModel] | None = output_model
 		self._coordinate_clicking_enabled: bool = False
@@ -2171,6 +2173,7 @@ Validated Code (after quote fixing):
 		file_system: FileSystem | None = None,
 		extraction_schema: dict | None = None,
 		action_timeout: float | None = None,
+		context: Context | None = None,
 	) -> ActionResult:
 		"""Execute an action.
 
@@ -2213,6 +2216,7 @@ Validated Code (after quote fixing):
 								sensitive_data=sensitive_data,
 								available_file_paths=available_file_paths,
 								extraction_schema=extraction_schema,
+								context=self.context if context is None else context,
 							),
 							timeout=timeout_s,
 						)

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -2281,6 +2281,7 @@ Validated Code (after quote fixing):
 					'available_file_paths',
 					'sensitive_data',
 					'extraction_schema',
+					'context',
 				}
 
 				# Extract action params (params for the action itself)

--- a/tests/ci/test_action_context.py
+++ b/tests/ci/test_action_context.py
@@ -50,6 +50,22 @@ async def test_tools_act_threads_context_to_registered_actions():
 	assert result.extracted_content == 'act-context'
 
 
+async def test_tools_direct_action_helper_threads_context():
+	tools = Tools[RuntimeContext](context=RuntimeContext('tools-context'))
+
+	@tools.registry.action('Read runtime context through direct helper')
+	async def read_context(context: RuntimeContext):
+		return ActionResult(extracted_content=context.value)
+
+	result = await tools.read_context()
+
+	assert result.extracted_content == 'tools-context'
+
+	result = await tools.read_context(context=RuntimeContext('helper-context'))
+
+	assert result.extracted_content == 'helper-context'
+
+
 def test_agent_threads_context_to_default_tools():
 	context = RuntimeContext('agent-context')
 

--- a/tests/ci/test_action_context.py
+++ b/tests/ci/test_action_context.py
@@ -1,0 +1,72 @@
+from dataclasses import dataclass
+
+from browser_use.agent.service import Agent
+from browser_use.agent.views import ActionResult
+from browser_use.tools.registry.service import Registry
+from browser_use.tools.service import Tools
+from tests.ci.conftest import create_mock_llm
+
+
+@dataclass
+class RuntimeContext:
+	value: str
+
+
+async def test_registry_injects_constructor_context_and_allows_per_call_override():
+	registry = Registry[RuntimeContext](context=RuntimeContext('registry-context'))
+
+	@registry.action('Read runtime context')
+	async def read_context(context: RuntimeContext):
+		return ActionResult(extracted_content=context.value)
+
+	result = await registry.execute_action('read_context', {})
+
+	assert result.extracted_content == 'registry-context'
+
+	result = await registry.execute_action('read_context', {}, context=RuntimeContext('override-context'))
+
+	assert result.extracted_content == 'override-context'
+
+
+async def test_tools_act_threads_context_to_registered_actions():
+	tools = Tools[RuntimeContext](context=RuntimeContext('tools-context'))
+
+	@tools.registry.action('Read runtime context through tools')
+	async def read_context(context: RuntimeContext):
+		return ActionResult(extracted_content=context.value)
+
+	ActionModel = tools.registry.create_action_model(include_actions=['read_context'])
+
+	result = await tools.act(ActionModel(**{'read_context': {}}), browser_session=None)  # type: ignore[arg-type]
+
+	assert result.extracted_content == 'tools-context'
+
+	result = await tools.act(
+		ActionModel(**{'read_context': {}}),
+		browser_session=None,  # type: ignore[arg-type]
+		context=RuntimeContext('act-context'),
+	)
+
+	assert result.extracted_content == 'act-context'
+
+
+def test_agent_threads_context_to_default_tools():
+	context = RuntimeContext('agent-context')
+
+	agent = Agent(task='Use context.', llm=create_mock_llm(), context=context)
+
+	assert agent.context is context
+	assert agent.tools.context is context
+	assert agent.tools.registry.context is context
+
+
+def test_agent_threads_context_to_custom_tools():
+	initial_context = RuntimeContext('initial-context')
+	context = RuntimeContext('agent-context')
+	tools = Tools[RuntimeContext](context=initial_context)
+
+	agent = Agent(task='Use custom tools context.', llm=create_mock_llm(), tools=tools, context=context)
+
+	assert agent.tools is tools
+	assert tools.context is context
+	assert tools.registry.context is context


### PR DESCRIPTION
## Summary

- Add `context` to `Agent`, `Tools`, and `Registry` so the `Context` type parameter is backed by runtime plumbing.
- Pass context into registered actions through the existing special-parameter injection path, with per-call overrides for `Tools.act()` and `Registry.execute_action()`.
- Keep beta Agent constructor/signature parity and add regression coverage for default tools, custom tools, and action execution.

Fixes #5188

## Validation

- `uv run pytest tests/ci/test_action_context.py tests/ci/test_beta_agent.py::test_beta_agent_constructor_signature_matches_browser_use_order tests/ci/test_beta_agent.py::test_beta_agent_constructor_type_hints_match_browser_use_core_params -q`
- `uv run pytest tests/ci/test_beta_agent.py::test_beta_agent_runtime_signatures_match_browser_use_callable_surface -q`
- `uv run ruff check browser_use/tools/registry/service.py browser_use/tools/service.py browser_use/agent/service.py browser_use/beta/service.py tests/ci/test_action_context.py`
- `uv run ruff format --check browser_use/tools/registry/service.py browser_use/tools/service.py browser_use/agent/service.py browser_use/beta/service.py tests/ci/test_action_context.py`
- `uv run pyright browser_use/tools/registry/service.py browser_use/tools/service.py browser_use/agent/service.py browser_use/beta/service.py tests/ci/test_action_context.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads a typed runtime context through `Agent`, `Tools`, and `Registry` so actions can access it at execution time, with optional per-call overrides. Fixes #5188.

- New Features
  - Added `context` to `Agent` (and beta Agent), `Tools`, and `Registry`; stored on instances and threaded to actions.
  - Injected `context` into registered actions via special-parameter path; per-call overrides supported in `Tools.act()`, `Registry.execute_action()`, and generated tool helper methods.
  - Default tools inherit the `Agent` context; when custom tools/controllers are provided, their `context` and `registry.context` are set to the `Agent` context (including beta resolve path).
  - Added tests for registry injection/override, `Tools.act()` overrides, direct helper overrides, and agent default/custom tools propagation.

<sup>Written for commit f50a331056f6eebb62d06e5c2d72e64837bf97f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

