### PR TITLE
Pin browser-harness to 0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "markdownify==1.2.2",
     "python-docx==1.2.0",
     "browser-use-sdk==3.4.2",
-    "browser-harness==0.1.4",
+    "browser-harness==0.1.5",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
Ship browser-harness 0.1.5 (Windows reliability, robust telemetry, cloud-browser suggestion) with the upcoming browser-use 0.13.4 release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `browser-harness` to 0.1.5 to ship Windows reliability fixes, more robust telemetry, and cloud-browser suggestion support alongside `browser-use` 0.13.4.

- **Dependencies**
  - Bump `browser-harness` from 0.1.4 to 0.1.5 in `pyproject.toml`.

<sup>Written for commit e3616da919990169aba688d8e471c74ddbfdcae0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

