### PR TITLE
fix(browser): fan out lifecycle events and release HAR listeners on reset

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -6,6 +6,7 @@ events, ensuring the session pool always reflects the current browser state.
 
 import asyncio
 from collections import deque
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 from cdp_use.cdp.target import AttachedToTargetEvent, DetachedFromTargetEvent, SessionID, TargetID
@@ -51,6 +52,7 @@ class SessionManager:
 		# CDP method, so per-session handler registrations would replace each other and
 		# leave every tab but the most recently attached one without lifecycle events.
 		self._lifecycle_events: dict[TargetID, deque[dict[str, Any]]] = {}
+		self._lifecycle_event_listeners: set[Callable[[Any, Any], None]] = set()
 
 		self._lock = asyncio.Lock()
 		self._recovery_lock = asyncio.Lock()
@@ -113,18 +115,18 @@ class SessionManager:
 			# ONE global handler for all targets: route by session_id -> target_id.
 			# Registering per-session closures instead would clobber each other in
 			# cdp-use's single-slot registry (one handler per CDP method).
-			if not session_id:
-				return
-			target_id = self.get_target_id_from_session_id(session_id)
-			if not target_id:
-				return
-			self.get_lifecycle_events(target_id).append(
-				{
-					'name': event.get('name', 'unknown'),
-					'loaderId': event.get('loaderId'),
-					'timestamp': asyncio.get_event_loop().time(),
-				}
-			)
+			if session_id:
+				target_id = self.get_target_id_from_session_id(session_id)
+				if target_id:
+					self.get_lifecycle_events(target_id).append(
+						{
+							'name': event.get('name', 'unknown'),
+							'frameId': event.get('frameId'),
+							'loaderId': event.get('loaderId'),
+							'timestamp': asyncio.get_event_loop().time(),
+						}
+					)
+			self._notify_lifecycle_event_listeners(event, session_id)
 
 		cdp_client.register.Target.attachedToTarget(on_attached)
 		cdp_client.register.Target.detachedFromTarget(on_detached)
@@ -143,6 +145,21 @@ class SessionManager:
 			events = deque(maxlen=50)
 			self._lifecycle_events[target_id] = events
 		return events
+
+	def add_lifecycle_event_listener(self, listener: Callable[[Any, Any], None]) -> None:
+		"""Subscribe to the shared Page.lifecycleEvent stream without replacing the global handler."""
+		self._lifecycle_event_listeners.add(listener)
+
+	def remove_lifecycle_event_listener(self, listener: Callable[[Any, Any], None]) -> None:
+		"""Unsubscribe a listener previously registered with add_lifecycle_event_listener."""
+		self._lifecycle_event_listeners.discard(listener)
+
+	def _notify_lifecycle_event_listeners(self, event: Any, session_id: SessionID | None = None) -> None:
+		for listener in tuple(self._lifecycle_event_listeners):
+			try:
+				listener(event, session_id)
+			except Exception as e:
+				self.logger.debug(f'[SessionManager] Page.lifecycleEvent listener failed: {type(e).__name__}: {e}')
 
 	def _get_session_for_target(self, target_id: TargetID) -> 'CDPSession | None':
 		"""Internal: Get ANY valid session for a target (picks first available).

--- a/browser_use/browser/watchdogs/har_recording_watchdog.py
+++ b/browser_use/browser/watchdogs/har_recording_watchdog.py
@@ -150,6 +150,8 @@ class HarRecordingWatchdog(BaseWatchdog):
 	def __init__(self, *args, **kwargs) -> None:
 		super().__init__(*args, **kwargs)
 		self._enabled: bool = False
+		self._lifecycle_listener_registered: bool = False
+		self._lifecycle_event_listener = self._on_lifecycle_event
 		self._entries: dict[str, _HarEntryBuilder] = {}
 		self._top_level_pages: dict[
 			str, dict
@@ -188,25 +190,37 @@ class HarRecordingWatchdog(BaseWatchdog):
 			cdp.Network.dataReceived(self._on_data_received)
 			cdp.Network.loadingFinished(self._on_loading_finished)
 			cdp.Network.loadingFailed(self._on_loading_failed)
-			cdp.Page.lifecycleEvent(self._on_lifecycle_event)
+			self.browser_session.session_manager.add_lifecycle_event_listener(self._lifecycle_event_listener)
+			self._lifecycle_listener_registered = True
 			cdp.Page.frameNavigated(self._on_frame_navigated)
 
 			self._enabled = True
 			self.logger.info(f'📊 Starting HAR recording to {self._har_path}')
 		except Exception as e:
+			self._remove_lifecycle_event_listener()
 			self.logger.warning(f'Failed to enable HAR recording: {e}')
 			self._enabled = False
 
 	async def on_BrowserStopEvent(self, event: BrowserStopEvent) -> None:
 		if not self._enabled:
+			self._remove_lifecycle_event_listener()
 			return
 		try:
 			await self._write_har()
 			self.logger.info(f'📊 HAR file saved: {self._har_path}')
 		except Exception as e:
 			self.logger.warning(f'Failed to write HAR: {e}')
+		finally:
+			self._remove_lifecycle_event_listener()
 
 	# =============== CDP Event Handlers (sync) ==================
+	def _remove_lifecycle_event_listener(self) -> None:
+		if not self._lifecycle_listener_registered:
+			return
+		if self.browser_session.session_manager is not None:
+			self.browser_session.session_manager.remove_lifecycle_event_listener(self._lifecycle_event_listener)
+		self._lifecycle_listener_registered = False
+
 	def _on_request_will_be_sent(self, params: RequestWillBeSentEvent, session_id: str | None) -> None:
 		try:
 			req = params.get('request', {}) if hasattr(params, 'get') else getattr(params, 'request', {})

--- a/browser_use/browser/watchdogs/har_recording_watchdog.py
+++ b/browser_use/browser/watchdogs/har_recording_watchdog.py
@@ -13,7 +13,7 @@ import json
 from dataclasses import dataclass, field
 from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from bubus import BaseEvent
 from cdp_use.cdp.network.events import (
@@ -27,6 +27,9 @@ from cdp_use.cdp.page.events import FrameNavigatedEvent, LifecycleEventEvent
 
 from browser_use.browser.events import BrowserConnectedEvent, BrowserStopEvent
 from browser_use.browser.watchdog_base import BaseWatchdog
+
+if TYPE_CHECKING:
+	from browser_use.browser.session_manager import SessionManager
 
 
 @dataclass
@@ -150,7 +153,7 @@ class HarRecordingWatchdog(BaseWatchdog):
 	def __init__(self, *args, **kwargs) -> None:
 		super().__init__(*args, **kwargs)
 		self._enabled: bool = False
-		self._lifecycle_listener_registered: bool = False
+		self._lifecycle_event_manager: SessionManager | None = None
 		self._lifecycle_event_listener = self._on_lifecycle_event
 		self._entries: dict[str, _HarEntryBuilder] = {}
 		self._top_level_pages: dict[
@@ -190,8 +193,10 @@ class HarRecordingWatchdog(BaseWatchdog):
 			cdp.Network.dataReceived(self._on_data_received)
 			cdp.Network.loadingFinished(self._on_loading_finished)
 			cdp.Network.loadingFailed(self._on_loading_failed)
-			self.browser_session.session_manager.add_lifecycle_event_listener(self._lifecycle_event_listener)
-			self._lifecycle_listener_registered = True
+			self._remove_lifecycle_event_listener()
+			manager = self.browser_session.session_manager
+			manager.add_lifecycle_event_listener(self._lifecycle_event_listener)
+			self._lifecycle_event_manager = manager
 			cdp.Page.frameNavigated(self._on_frame_navigated)
 
 			self._enabled = True
@@ -215,11 +220,10 @@ class HarRecordingWatchdog(BaseWatchdog):
 
 	# =============== CDP Event Handlers (sync) ==================
 	def _remove_lifecycle_event_listener(self) -> None:
-		if not self._lifecycle_listener_registered:
-			return
-		if self.browser_session.session_manager is not None:
-			self.browser_session.session_manager.remove_lifecycle_event_listener(self._lifecycle_event_listener)
-		self._lifecycle_listener_registered = False
+		# BrowserSession may reset its manager before the watchdog receives stop.
+		if self._lifecycle_event_manager is not None:
+			self._lifecycle_event_manager.remove_lifecycle_event_listener(self._lifecycle_event_listener)
+			self._lifecycle_event_manager = None
 
 	def _on_request_will_be_sent(self, params: RequestWillBeSentEvent, session_id: str | None) -> None:
 		try:

--- a/tests/ci/browser/test_navigation_readiness.py
+++ b/tests/ci/browser/test_navigation_readiness.py
@@ -47,6 +47,55 @@ async def test_navigation_detects_readiness_without_burning_timeout(httpserver, 
 	)
 
 
+async def test_har_recording_does_not_clobber_navigation_readiness(httpserver, tmp_path):
+	"""HAR recording must consume lifecycle events without replacing SessionManager's readiness handler."""
+	session = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=True,
+			record_har_path=tmp_path / 'session.har',
+		)
+	)
+	await session.start()
+	har_watchdog = None
+	try:
+		httpserver.expect_request('/fast-har').respond_with_data(SIMPLE_HTML, content_type='text/html')
+
+		start = time.monotonic()
+		await session.navigate_to(httpserver.url_for('/fast-har'))
+		elapsed = time.monotonic() - start
+
+		har_watchdog = getattr(session, '_har_recording_watchdog', None)
+		assert har_watchdog is not None
+		target_id = session.agent_focus_target_id
+		assert target_id is not None
+		lifecycle_event = next(
+			event
+			for event in reversed(session.session_manager.get_lifecycle_events(target_id))
+			if event.get('frameId') and event.get('name') in {'DOMContentLoaded', 'load'}
+		)
+		frame_id = lifecycle_event['frameId']
+		har_watchdog._top_level_pages[frame_id] = {
+			'url': httpserver.url_for('/fast-har'),
+			'title': 'fast page',
+			'startedDateTime': None,
+			'monotonic_start': 10.0,
+			'onContentLoad': -1,
+			'onLoad': -1,
+		}
+		session.session_manager._notify_lifecycle_event_listeners({**lifecycle_event, 'timestamp': 10.125})
+		timing_key = 'onContentLoad' if lifecycle_event['name'] == 'DOMContentLoaded' else 'onLoad'
+		assert har_watchdog._top_level_pages[frame_id][timing_key] == 125
+	finally:
+		await session.kill()
+
+	assert elapsed < FAST_NAVIGATION_BOUND_S, (
+		f'HAR-enabled navigation took {elapsed:.2f}s — HAR clobbered lifecycle readiness monitoring'
+	)
+	assert har_watchdog._lifecycle_listener_registered is False
+
+
 async def test_first_tab_navigation_still_works_after_second_tab_opens(httpserver, browser_session: BrowserSession):
 	"""Opening a new tab must not disable lifecycle monitoring on existing tabs.
 

--- a/tests/ci/browser/test_navigation_readiness.py
+++ b/tests/ci/browser/test_navigation_readiness.py
@@ -12,12 +12,16 @@ handler registered once on the root CDP client.
 
 import asyncio
 import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from browser_use.browser.events import NavigateToUrlEvent
+from browser_use.browser.events import BrowserConnectedEvent, BrowserStopEvent, NavigateToUrlEvent
 from browser_use.browser.profile import BrowserProfile
 from browser_use.browser.session import BrowserSession
+from browser_use.browser.session_manager import SessionManager
+from browser_use.browser.watchdogs.har_recording_watchdog import HarRecordingWatchdog
 
 SIMPLE_HTML = '<html><head><title>fast page</title></head><body>hello</body></html>'
 
@@ -58,6 +62,7 @@ async def test_har_recording_does_not_clobber_navigation_readiness(httpserver, t
 		)
 	)
 	await session.start()
+	manager = session.session_manager
 	har_watchdog = None
 	try:
 		httpserver.expect_request('/fast-har').respond_with_data(SIMPLE_HTML, content_type='text/html')
@@ -93,7 +98,7 @@ async def test_har_recording_does_not_clobber_navigation_readiness(httpserver, t
 	assert elapsed < FAST_NAVIGATION_BOUND_S, (
 		f'HAR-enabled navigation took {elapsed:.2f}s — HAR clobbered lifecycle readiness monitoring'
 	)
-	assert har_watchdog._lifecycle_listener_registered is False
+	assert har_watchdog._lifecycle_event_listener not in manager._lifecycle_event_listeners
 
 
 async def test_first_tab_navigation_still_works_after_second_tab_opens(httpserver, browser_session: BrowserSession):
@@ -186,3 +191,29 @@ async def test_same_document_navigation_completes_immediately(httpserver, browse
 
 	assert elapsed < FAST_NAVIGATION_BOUND_S, f'same-document navigation took {elapsed:.2f}s — burned the readiness timeout'
 	assert status is None, f'same-document navigation reported a bogus timeout: {status!r}'
+
+
+@pytest.mark.parametrize('replace_manager', [False, True])
+async def test_har_unregisters_from_original_manager_after_reset(tmp_path, monkeypatch, replace_manager):
+	"""A forced reset must not strand the HAR listener on the old manager."""
+	session = BrowserSession(browser_profile=BrowserProfile(record_har_path=tmp_path / 'reset.har'))
+	manager = session.session_manager = SessionManager(session)
+	client = Mock()
+	client.send.Network.enable = AsyncMock()
+	client.send.Page.enable = AsyncMock()
+	client.send.Browser.getVersion = AsyncMock(return_value={})
+	session._cdp_client_root = client
+	monkeypatch.setattr(
+		BrowserSession,
+		'get_or_create_cdp_session',
+		AsyncMock(return_value=SimpleNamespace(cdp_client=client, session_id='test-session')),
+	)
+	watchdog = HarRecordingWatchdog(event_bus=session.event_bus, browser_session=session)
+	await watchdog.on_BrowserConnectedEvent(BrowserConnectedEvent(cdp_url='ws://localhost:9222'))
+	assert watchdog._on_lifecycle_event in manager._lifecycle_event_listeners
+	await manager.clear()
+	session.session_manager = SessionManager(session) if replace_manager else None
+	await watchdog.on_BrowserStopEvent(BrowserStopEvent())
+	assert not manager._lifecycle_event_listeners
+	# Repeated teardown is harmless even after the registration owner is released.
+	await watchdog.on_BrowserStopEvent(BrowserStopEvent())

--- a/tests/ci/infrastructure/test_registry_core.py
+++ b/tests/ci/infrastructure/test_registry_core.py
@@ -9,7 +9,6 @@ Tests cover:
 5. Registry execution edge cases
 """
 
-import asyncio
 import logging
 
 import pytest
@@ -103,13 +102,12 @@ async def browser_session(base_url):
 			keep_alive=True,
 		)
 	)
-	await browser_session.start()
-	from browser_use.browser.events import NavigateToUrlEvent
-
-	browser_session.event_bus.dispatch(NavigateToUrlEvent(url=f'{base_url}/test'))
-	await asyncio.sleep(0.5)  # Wait for navigation
-	yield browser_session
-	await browser_session.kill()
+	try:
+		await browser_session.start()
+		await browser_session.navigate_to(f'{base_url}/test')
+		yield browser_session
+	finally:
+		await browser_session.kill()
 
 
 class TestActionRegistryParameterPatterns:


### PR DESCRIPTION
HAR recording registered `Page.lifecycleEvent` directly, replacing the single CDP callback used for navigation readiness. With recording enabled, fast navigations could therefore wait for the readiness timeout.

Keep SessionManager as the sole lifecycle-event registration owner and fan events out to HAR after updating navigation state. HAR retains the exact manager used for registration, so teardown removes the listener even when BrowserSession has already cleared or replaced its manager. This addresses the forced-shutdown review finding and avoids a separate registration boolean drifting from actual state.

Rebased on current main. The navigation regression checks readiness, HAR timing delivery, and actual listener removal; a focused regression covers manager reset and replacement plus repeated teardown.

Validation:
- `TIMEOUT_BrowserStartEvent=120 TIMEOUT_BrowserLaunchEvent=120 ANONYMIZED_TELEMETRY=false uv run pytest tests/ci/browser/test_navigation_readiness.py -q` — 8 passed. Startup allowances accommodate local Chrome launch; navigation timing assertions are unchanged.
- The owner-reset regression fails against the previous PR implementation at the retained-listener assertion.
- All applicable pre-commit hooks, including Pyright, and `git diff --check` passed.
