### PR TITLE
fix(example): read scheduled messages as utf-8

### DIFF
--- a/examples/apps/msg-use/scheduler.py
+++ b/examples/apps/msg-use/scheduler.py
@@ -50,7 +50,7 @@ async def parse_messages():
 
 	import aiofiles
 
-	async with aiofiles.open(messages_file) as f:
+	async with aiofiles.open(messages_file, encoding='utf-8') as f:
 		content = await f.read()
 
 	llm = ChatGoogle(model='gemini-2.0-flash-exp', temperature=0.1, api_key=GOOGLE_API_KEY)


### PR DESCRIPTION
## Summary
- Reads the WhatsApp scheduler example's `messages.txt` file with explicit UTF-8 encoding.

## Problem
The scheduler example currently relies on the platform default encoding when reading `messages.txt`. On Windows or other non-UTF-8 locales, multilingual contact names or message text can raise `UnicodeDecodeError` or be decoded incorrectly before the LLM parses the schedule.

## Before / after
Before: `aiofiles.open(messages_file)` used the process locale.

After: `aiofiles.open(messages_file, encoding="utf-8")` makes the example deterministic across platforms and matches the text-file behavior expected for project examples.

## Verification
- `python -m py_compile examples/apps/msg-use/scheduler.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force UTF-8 when opening `messages.txt` in the WhatsApp scheduler example. Prevents `UnicodeDecodeError` and garbled characters on non-UTF-8 locales, ensuring consistent parsing across platforms.

<sup>Written for commit 88f9354cf68e67f9faa72d2a9db43fef74bc3042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

