### PR TITLE
fix(dom): keep "more options" indicator for <select> with >4 options

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -970,7 +970,10 @@ class DOMTreeSerializer:
 						if 'options_count' in child_info and child_info['options_count'] is not None:
 							parts.append(f'count={child_info["options_count"]}')
 						if 'first_options' in child_info and child_info['first_options']:
-							options_str = '|'.join(child_info['first_options'][:4])  # Limit to 4 options
+							# first_options holds up to 4 option labels plus an optional trailing
+							# "... N more options..." indicator (see _extract_select_options), so keep
+							# up to 5 entries — slicing to 4 here would drop that indicator.
+							options_str = '|'.join(child_info['first_options'][:5])
 							parts.append(f'options={options_str}')
 						if 'format_hint' in child_info and child_info['format_hint']:
 							parts.append(f'format={child_info["format_hint"]}')

--- a/tests/ci/test_select_options_serialization.py
+++ b/tests/ci/test_select_options_serialization.py
@@ -1,0 +1,79 @@
+"""Regression tests for <select> option serialization in the DOM serializer.
+
+`_extract_select_options` builds `first_options` as up to 4 option labels *plus* a
+trailing "... N more options..." indicator when a select has more than 4 options.
+`DOMTreeSerializer.serialize_tree` used to slice that list to 4 entries, which silently
+dropped the indicator — the LLM was told `count=N` but shown only 4 option labels with
+no signal that more options existed. These tests pin the intended behaviour.
+"""
+
+from browser_use.dom.serializer.serializer import DOMTreeSerializer
+from browser_use.dom.views import EnhancedDOMTreeNode, NodeType, SimplifiedNode
+
+
+def _make_select_node(first_options: list[str], options_count: int) -> SimplifiedNode:
+	"""Build a minimal interactive <select> node carrying compound-component info."""
+	select = EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=42,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='SELECT',
+		node_value='',
+		attributes={},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='test-target',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=None,
+		snapshot_node=None,
+	)
+	select._compound_children = [
+		{
+			'name': 'Choose a fruit',
+			'role': 'combobox',
+			'valuemin': None,
+			'valuemax': None,
+			'valuenow': None,
+			'options_count': options_count,
+			'first_options': first_options,
+			'format_hint': None,
+		}
+	]
+	return SimplifiedNode(original_node=select, children=[], should_display=True, is_interactive=True)
+
+
+def test_more_options_indicator_is_preserved():
+	"""A select with more than 4 options must keep the '... N more options...' indicator."""
+	node = _make_select_node(
+		first_options=['Apple', 'Banana', 'Cherry', 'Date', '... 2 more options...'],
+		options_count=6,
+	)
+
+	out = DOMTreeSerializer.serialize_tree(node, ['id'])
+
+	assert 'count=6' in out
+	# All four visible labels are present...
+	for label in ('Apple', 'Banana', 'Cherry', 'Date'):
+		assert label in out
+	# ...and crucially the "more options" indicator is not dropped.
+	assert '... 2 more options...' in out
+
+
+def test_all_options_shown_when_four_or_fewer():
+	"""A select with <= 4 options renders every label and adds no indicator."""
+	node = _make_select_node(
+		first_options=['Yes', 'No', 'Maybe'],
+		options_count=3,
+	)
+
+	out = DOMTreeSerializer.serialize_tree(node, ['id'])
+
+	assert 'options=Yes|No|Maybe' in out
+	assert 'more options' not in out


### PR DESCRIPTION
Fixes #5195

### What

`DOMTreeSerializer._extract_select_options` builds `first_options` as up to **4 option labels plus** a trailing `"... N more options..."` indicator when a `<select>` has more than 4 options. `serialize_tree` then joined `first_options[:4]`, which slices off exactly that 5th element — so the indicator was always dropped.

### Impact

For any `<select>` with more than 4 options, the serialized DOM handed to the model looked like:

```
<select ... compound_components=(...,count=6,options=Apple|Banana|Cherry|Date) />
```

The model is told `count=6` but only sees 4 labels, with no hint that more options exist — the very signal `_extract_select_options` goes out of its way to add. That can make the agent treat a dropdown as fully enumerated when it isn't.

### Fix

Slice to `[:5]` so the four labels **and** the indicator survive:

```
<select ... compound_components=(...,count=6,options=Apple|Banana|Cherry|Date|... 2 more options...) />
```

One-line change in the consumer; the producer already caps the list at 4 labels + 1 indicator, so `[:5]` can never over-emit.

### Testing

- Added `tests/ci/test_select_options_serialization.py` with two regression tests: the indicator is preserved for a 6-option select, and all labels are shown with no indicator for a 3-option select. Confirmed they fail on the old `[:4]` and pass on `[:5]`.
- Verified end-to-end against a real headless Chromium rendering a 6-option `<select>`: the serialized output now includes `... 2 more options...`.
- `uv run ruff check` and `uv run pyright` pass on the changed files.

---

@laithrw would appreciate a look when you get a chance — small, self-contained serializer fix with a regression test. Happy to adjust anything.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the "... N more options..." indicator in serialized <select> elements with more than 4 options so the model knows additional choices exist.

- **Bug Fixes**
  - Updated `serialize_tree` to join `first_options[:5]` so four labels plus the indicator are kept.
  - Added regression tests to confirm the indicator appears for 6-option selects and is absent when ≤4 options.

<sup>Written for commit d658a9f4d5ec244c8ada86e554d09b738e728cf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

