### PR TITLE
fix(config): treat empty boolean env vars as unset instead of True

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -10,7 +10,7 @@ from typing import Any
 from uuid import uuid4
 
 import psutil
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -44,6 +44,27 @@ def is_running_in_docker() -> bool:
 	return False
 
 
+_TRUTHY_ENV_VALUES = frozenset({'true', '1', 'yes', 'y', 'on', 't'})
+
+
+def _env_bool(name: str, default: bool) -> bool:
+	"""Parse a boolean environment variable.
+
+	An unset or empty/whitespace-only value falls back to ``default`` — an empty
+	env var (e.g. a bare ``ANONYMIZED_TELEMETRY=`` in a ``.env`` file) is treated as
+	"not set", matching pydantic-settings/dotenv conventions. Any other value is
+	truthy only if it is one of the common affirmative spellings.
+
+	This replaces the previous ``os.getenv(...).lower()[:1] in 'ty1'`` check, under
+	which an empty string evaluated to ``True`` (``'' in 'ty1'`` is ``True``) and any
+	value starting with t/y/1 (e.g. ``'yesterday'``) counted as truthy.
+	"""
+	raw = os.getenv(name)
+	if raw is None or not raw.strip():
+		return default
+	return raw.strip().lower() in _TRUTHY_ENV_VALUES
+
+
 class OldConfig:
 	"""Original lazy-loading configuration class for environment variables."""
 
@@ -56,11 +77,11 @@ class OldConfig:
 
 	@property
 	def ANONYMIZED_TELEMETRY(self) -> bool:
-		return os.getenv('ANONYMIZED_TELEMETRY', 'true').lower()[:1] in 'ty1'
+		return _env_bool('ANONYMIZED_TELEMETRY', True)
 
 	@property
 	def BROWSER_USE_CLOUD_SYNC(self) -> bool:
-		return os.getenv('BROWSER_USE_CLOUD_SYNC', str(self.ANONYMIZED_TELEMETRY)).lower()[:1] in 'ty1'
+		return _env_bool('BROWSER_USE_CLOUD_SYNC', self.ANONYMIZED_TELEMETRY)
 
 	@property
 	def BROWSER_USE_CLOUD_API_URL(self) -> str:
@@ -164,7 +185,7 @@ class OldConfig:
 
 	@property
 	def SKIP_LLM_API_KEY_VERIFICATION(self) -> bool:
-		return os.getenv('SKIP_LLM_API_KEY_VERIFICATION', 'false').lower()[:1] in 'ty1'
+		return _env_bool('SKIP_LLM_API_KEY_VERIFICATION', False)
 
 	@property
 	def DEFAULT_LLM(self) -> str:
@@ -173,15 +194,15 @@ class OldConfig:
 	# Runtime hints
 	@property
 	def IN_DOCKER(self) -> bool:
-		return os.getenv('IN_DOCKER', 'false').lower()[:1] in 'ty1' or is_running_in_docker()
+		return _env_bool('IN_DOCKER', False) or is_running_in_docker()
 
 	@property
 	def IS_IN_EVALS(self) -> bool:
-		return os.getenv('IS_IN_EVALS', 'false').lower()[:1] in 'ty1'
+		return _env_bool('IS_IN_EVALS', False)
 
 	@property
 	def BROWSER_USE_VERSION_CHECK(self) -> bool:
-		return os.getenv('BROWSER_USE_VERSION_CHECK', 'true').lower()[:1] in 'ty1'
+		return _env_bool('BROWSER_USE_VERSION_CHECK', True)
 
 	@property
 	def WIN_FONT_DIR(self) -> str:
@@ -192,6 +213,20 @@ class FlatEnvConfig(BaseSettings):
 	"""All environment variables in a flat namespace."""
 
 	model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8', case_sensitive=True, extra='allow')
+
+	@model_validator(mode='before')
+	@classmethod
+	def _treat_empty_env_as_unset(cls, data: Any) -> Any:
+		"""Drop empty-string env values so field defaults apply.
+
+		pydantic rejects ``''`` for ``bool`` fields, so a bare ``ANONYMIZED_TELEMETRY=``
+		(or any empty boolean var) in the environment would otherwise raise a
+		ValidationError and make ``import browser_use`` fail outright. Treating empty
+		as "unset" also keeps this consistent with OldConfig's ``_env_bool`` handling.
+		"""
+		if isinstance(data, dict):
+			return {k: v for k, v in data.items() if not (isinstance(v, str) and not v.strip())}
+		return data
 
 	# Logging and telemetry
 	BROWSER_USE_LOGGING_LEVEL: str = Field(default='info')

--- a/tests/ci/test_config_bool_env.py
+++ b/tests/ci/test_config_bool_env.py
@@ -1,0 +1,51 @@
+"""Tests for boolean environment-variable parsing in browser_use.config.
+
+Two bugs are pinned here:
+
+1. `OldConfig` used `os.getenv(...).lower()[:1] in 'ty1'`. Because `'' in 'ty1'`
+   is True, an empty value flipped the flag on — e.g. `SKIP_LLM_API_KEY_VERIFICATION=`
+   silently skipped API-key verification. The substring test was also too loose
+   (any value starting with t/y/1, such as `yesterday`, counted as True).
+
+2. `FlatEnvConfig` (pydantic-settings) rejects `''` for a `bool` field, so a bare
+   `ANONYMIZED_TELEMETRY=` in the environment made `import browser_use` raise a
+   ValidationError and the whole library unimportable.
+"""
+
+from browser_use.config import FlatEnvConfig, OldConfig
+
+
+def test_empty_bool_env_falls_back_to_default(monkeypatch):
+	# default False -> empty stays False (previously became True)
+	monkeypatch.setenv('SKIP_LLM_API_KEY_VERIFICATION', '')
+	assert OldConfig().SKIP_LLM_API_KEY_VERIFICATION is False
+
+	monkeypatch.setenv('IS_IN_EVALS', '   ')  # whitespace-only counts as empty
+	assert OldConfig().IS_IN_EVALS is False
+
+	# default True -> empty stays True (treated as "unset")
+	monkeypatch.setenv('ANONYMIZED_TELEMETRY', '')
+	assert OldConfig().ANONYMIZED_TELEMETRY is True
+
+
+def test_loose_values_are_not_truthy(monkeypatch):
+	# Values that merely start with t/y/1 must not count as True anymore.
+	for value in ('yesterday', 'trap', 'nope', 'false', '0', 'no', 'off'):
+		monkeypatch.setenv('SKIP_LLM_API_KEY_VERIFICATION', value)
+		assert OldConfig().SKIP_LLM_API_KEY_VERIFICATION is False, value
+
+
+def test_affirmative_values_are_truthy(monkeypatch):
+	for value in ('true', 'True', '1', 'yes', 'y', 'on', 't', '  TRUE  '):
+		monkeypatch.setenv('SKIP_LLM_API_KEY_VERIFICATION', value)
+		assert OldConfig().SKIP_LLM_API_KEY_VERIFICATION is True, value
+
+
+def test_flat_env_config_does_not_crash_on_empty_bool(monkeypatch):
+	# Regression: a bare `ANONYMIZED_TELEMETRY=` used to raise ValidationError here,
+	# which is what broke `import browser_use`.
+	monkeypatch.setenv('ANONYMIZED_TELEMETRY', '')
+	monkeypatch.setenv('BROWSER_USE_VERSION_CHECK', '  ')
+	cfg = FlatEnvConfig()
+	assert cfg.ANONYMIZED_TELEMETRY is True  # default applied
+	assert cfg.BROWSER_USE_VERSION_CHECK is True


### PR DESCRIPTION
### What

Boolean environment variables were parsed with `os.getenv(...).lower()[:1] in 'ty1'` in `OldConfig`. That substring test has two problems:

- **`'' in 'ty1'` is `True`.** A bare `ANONYMIZED_TELEMETRY=` or `SKIP_LLM_API_KEY_VERIFICATION=` (common in `.env`/docker-compose) evaluated to **`True`** — the latter *silently skipping LLM API-key verification*.
- **It's too loose.** Any value whose first character is t/y/1 counted as `True`, so `SKIP_LLM_API_KEY_VERIFICATION=yesterday` → skip.

Separately, `FlatEnvConfig` (pydantic-settings) rejects `''` for a `bool` field, so a bare `ANONYMIZED_TELEMETRY=` in the environment raised a `ValidationError` — making **`import browser_use` fail outright**:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for FlatEnvConfig
ANONYMIZED_TELEMETRY
  Input should be a valid boolean, unable to interpret input [input_value='', input_type=str]
```

### Fix

- Add an `_env_bool(name, default)` helper: unset **or empty/whitespace** → `default` (treated as "unset", matching pydantic-settings/dotenv conventions); otherwise truthy only for the common affirmative spellings (`true/1/yes/y/on/t`). All `OldConfig` boolean properties now use it.
- Add a `model_validator(mode='before')` on `FlatEnvConfig` that drops empty-string env values so field defaults apply (prevents the import crash and keeps behaviour consistent with `_env_bool`).

### Testing

- New `tests/ci/test_config_bool_env.py`: empty → default; loose values (`yesterday`, `trap`, …) → False; affirmatives → True; and `FlatEnvConfig()` no longer crashes on empty bool env vars.
- `ruff check` and `pyright` pass on the changed files; `import browser_use` verified working.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix boolean env var parsing to treat empty values as unset and tighten truthy checks. Prevents accidental True flags (e.g., `SKIP_LLM_API_KEY_VERIFICATION=`) and stops `FlatEnvConfig` import errors from empty booleans.

- **Bug Fixes**
  - Added `_env_bool(name, default)` and used it across `OldConfig`; empty/whitespace → default, truthy only for `true/1/yes/y/on/t` (case/space tolerant).
  - Added `@model_validator(mode='before')` to `FlatEnvConfig` to drop empty-string env values so defaults apply, avoiding ValidationError on import.
  - Added `tests/ci/test_config_bool_env.py` to cover empty, loose (e.g., "yesterday"), and affirmative values.

<sup>Written for commit f3c0fd58d11b90fe191e58f77a8673ec084448fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

