### PR TITLE
fix(mcp): correct enum param types and per-registry tool dedup

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -10,7 +10,7 @@ from typing import Any
 from uuid import uuid4
 
 import psutil
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -44,6 +44,27 @@ def is_running_in_docker() -> bool:
 	return False
 
 
+_TRUTHY_ENV_VALUES = frozenset({'true', '1', 'yes', 'y', 'on', 't'})
+
+
+def _env_bool(name: str, default: bool) -> bool:
+	"""Parse a boolean environment variable.
+
+	An unset or empty/whitespace-only value falls back to ``default`` — an empty
+	env var (e.g. a bare ``ANONYMIZED_TELEMETRY=`` in a ``.env`` file) is treated as
+	"not set", matching pydantic-settings/dotenv conventions. Any other value is
+	truthy only if it is one of the common affirmative spellings.
+
+	This replaces the previous ``os.getenv(...).lower()[:1] in 'ty1'`` check, under
+	which an empty string evaluated to ``True`` (``'' in 'ty1'`` is ``True``) and any
+	value starting with t/y/1 (e.g. ``'yesterday'``) counted as truthy.
+	"""
+	raw = os.getenv(name)
+	if raw is None or not raw.strip():
+		return default
+	return raw.strip().lower() in _TRUTHY_ENV_VALUES
+
+
 class OldConfig:
 	"""Original lazy-loading configuration class for environment variables."""
 
@@ -56,11 +77,11 @@ class OldConfig:
 
 	@property
 	def ANONYMIZED_TELEMETRY(self) -> bool:
-		return os.getenv('ANONYMIZED_TELEMETRY', 'true').lower()[:1] in 'ty1'
+		return _env_bool('ANONYMIZED_TELEMETRY', True)
 
 	@property
 	def BROWSER_USE_CLOUD_SYNC(self) -> bool:
-		return os.getenv('BROWSER_USE_CLOUD_SYNC', str(self.ANONYMIZED_TELEMETRY)).lower()[:1] in 'ty1'
+		return _env_bool('BROWSER_USE_CLOUD_SYNC', self.ANONYMIZED_TELEMETRY)
 
 	@property
 	def BROWSER_USE_CLOUD_API_URL(self) -> str:
@@ -164,7 +185,7 @@ class OldConfig:
 
 	@property
 	def SKIP_LLM_API_KEY_VERIFICATION(self) -> bool:
-		return os.getenv('SKIP_LLM_API_KEY_VERIFICATION', 'false').lower()[:1] in 'ty1'
+		return _env_bool('SKIP_LLM_API_KEY_VERIFICATION', False)
 
 	@property
 	def DEFAULT_LLM(self) -> str:
@@ -173,15 +194,15 @@ class OldConfig:
 	# Runtime hints
 	@property
 	def IN_DOCKER(self) -> bool:
-		return os.getenv('IN_DOCKER', 'false').lower()[:1] in 'ty1' or is_running_in_docker()
+		return _env_bool('IN_DOCKER', False) or is_running_in_docker()
 
 	@property
 	def IS_IN_EVALS(self) -> bool:
-		return os.getenv('IS_IN_EVALS', 'false').lower()[:1] in 'ty1'
+		return _env_bool('IS_IN_EVALS', False)
 
 	@property
 	def BROWSER_USE_VERSION_CHECK(self) -> bool:
-		return os.getenv('BROWSER_USE_VERSION_CHECK', 'true').lower()[:1] in 'ty1'
+		return _env_bool('BROWSER_USE_VERSION_CHECK', True)
 
 	@property
 	def WIN_FONT_DIR(self) -> str:
@@ -192,6 +213,20 @@ class FlatEnvConfig(BaseSettings):
 	"""All environment variables in a flat namespace."""
 
 	model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8', case_sensitive=True, extra='allow')
+
+	@model_validator(mode='before')
+	@classmethod
+	def _treat_empty_env_as_unset(cls, data: Any) -> Any:
+		"""Drop empty-string env values so field defaults apply.
+
+		pydantic rejects ``''`` for ``bool`` fields, so a bare ``ANONYMIZED_TELEMETRY=``
+		(or any empty boolean var) in the environment would otherwise raise a
+		ValidationError and make ``import browser_use`` fail outright. Treating empty
+		as "unset" also keeps this consistent with OldConfig's ``_env_bool`` handling.
+		"""
+		if isinstance(data, dict):
+			return {k: v for k, v in data.items() if not (isinstance(v, str) and not v.strip())}
+		return data
 
 	# Logging and telemetry
 	BROWSER_USE_LOGGING_LEVEL: str = Field(default='info')

--- a/browser_use/mcp/client.py
+++ b/browser_use/mcp/client.py
@@ -226,6 +226,7 @@ class MCPClient:
 			await self.connect()
 
 		registry = tools.registry
+		registered_count = 0
 
 		for tool_name, tool in self._tools.items():
 			# Skip if not in filter
@@ -235,15 +236,19 @@ class MCPClient:
 			# Apply prefix if specified
 			action_name = f'{prefix}{tool_name}' if prefix else tool_name
 
-			# Skip if already registered
-			if action_name in self._registered_actions:
+			# Skip if this target registry already has an action with this name.
+			# Dedup must be per-registry, not client-global: keying off a
+			# client-wide `_registered_actions` set meant registering the same
+			# client to a second Tools instance silently registered nothing.
+			if action_name in registry.registry.actions:
 				continue
 
 			# Register the tool as an action
 			self._register_tool_as_action(registry, action_name, tool)
 			self._registered_actions.add(action_name)
+			registered_count += 1
 
-		logger.info(f"✅ Registered {len(self._registered_actions)} MCP tools from '{self.server_name}' as browser-use actions")
+		logger.info(f"✅ Registered {registered_count} MCP tools from '{self.server_name}' as browser-use actions")
 
 	def _register_tool_as_action(self, registry: Registry, action_name: str, tool: Any) -> None:
 		"""Register a single MCP tool as a browser-use action.
@@ -468,9 +473,13 @@ class MCPClient:
 			'null': type(None),
 		}
 
-		# Handle enums (they're still strings)
+		# Handle enums: use the enum's declared JSON Schema type rather than
+		# assuming string. Integer/number enums (e.g. {"type": "integer",
+		# "enum": [1, 2, 3]}) are valid, and forcing them to `str` makes the
+		# parameter un-callable (the model rejects an int, and the LLM is told
+		# to send a string). Fall back to `str` only when no type is declared.
 		if 'enum' in schema:
-			return str
+			return type_mapping.get(json_type, str)
 
 		# Handle objects with nested properties
 		if json_type == 'object':

--- a/tests/ci/test_config_bool_env.py
+++ b/tests/ci/test_config_bool_env.py
@@ -1,0 +1,51 @@
+"""Tests for boolean environment-variable parsing in browser_use.config.
+
+Two bugs are pinned here:
+
+1. `OldConfig` used `os.getenv(...).lower()[:1] in 'ty1'`. Because `'' in 'ty1'`
+   is True, an empty value flipped the flag on — e.g. `SKIP_LLM_API_KEY_VERIFICATION=`
+   silently skipped API-key verification. The substring test was also too loose
+   (any value starting with t/y/1, such as `yesterday`, counted as True).
+
+2. `FlatEnvConfig` (pydantic-settings) rejects `''` for a `bool` field, so a bare
+   `ANONYMIZED_TELEMETRY=` in the environment made `import browser_use` raise a
+   ValidationError and the whole library unimportable.
+"""
+
+from browser_use.config import FlatEnvConfig, OldConfig
+
+
+def test_empty_bool_env_falls_back_to_default(monkeypatch):
+	# default False -> empty stays False (previously became True)
+	monkeypatch.setenv('SKIP_LLM_API_KEY_VERIFICATION', '')
+	assert OldConfig().SKIP_LLM_API_KEY_VERIFICATION is False
+
+	monkeypatch.setenv('IS_IN_EVALS', '   ')  # whitespace-only counts as empty
+	assert OldConfig().IS_IN_EVALS is False
+
+	# default True -> empty stays True (treated as "unset")
+	monkeypatch.setenv('ANONYMIZED_TELEMETRY', '')
+	assert OldConfig().ANONYMIZED_TELEMETRY is True
+
+
+def test_loose_values_are_not_truthy(monkeypatch):
+	# Values that merely start with t/y/1 must not count as True anymore.
+	for value in ('yesterday', 'trap', 'nope', 'false', '0', 'no', 'off'):
+		monkeypatch.setenv('SKIP_LLM_API_KEY_VERIFICATION', value)
+		assert OldConfig().SKIP_LLM_API_KEY_VERIFICATION is False, value
+
+
+def test_affirmative_values_are_truthy(monkeypatch):
+	for value in ('true', 'True', '1', 'yes', 'y', 'on', 't', '  TRUE  '):
+		monkeypatch.setenv('SKIP_LLM_API_KEY_VERIFICATION', value)
+		assert OldConfig().SKIP_LLM_API_KEY_VERIFICATION is True, value
+
+
+def test_flat_env_config_does_not_crash_on_empty_bool(monkeypatch):
+	# Regression: a bare `ANONYMIZED_TELEMETRY=` used to raise ValidationError here,
+	# which is what broke `import browser_use`.
+	monkeypatch.setenv('ANONYMIZED_TELEMETRY', '')
+	monkeypatch.setenv('BROWSER_USE_VERSION_CHECK', '  ')
+	cfg = FlatEnvConfig()
+	assert cfg.ANONYMIZED_TELEMETRY is True  # default applied
+	assert cfg.BROWSER_USE_VERSION_CHECK is True

--- a/tests/ci/test_mcp_client_registration.py
+++ b/tests/ci/test_mcp_client_registration.py
@@ -1,0 +1,92 @@
+"""Regression tests for MCPClient tool registration.
+
+Two bugs are pinned here:
+
+1. `_json_schema_to_python_type` returned `str` for any schema containing `enum`,
+   so integer/number enums (e.g. {"type": "integer", "enum": [1, 2, 3]}) produced
+   a `str` param field — the model rejected an int and the LLM was told to send a
+   string, making such MCP tools effectively uncallable.
+
+2. `register_to_tools` deduplicated against a client-global `_registered_actions`
+   set, so registering the same connected client to a second `Tools` instance
+   skipped every tool and registered nothing (while still logging success).
+"""
+
+from mcp.types import Tool as MCPTool
+
+from browser_use.mcp.client import MCPClient
+from browser_use.tools.service import Tools
+
+
+def _make_client(tools: dict[str, MCPTool]) -> MCPClient:
+	"""A connected-looking MCPClient backed by real Tool objects (no live server)."""
+	client = MCPClient.__new__(MCPClient)
+	client.server_name = 'test-server'
+	client._connected = True
+	client._registered_actions = set()
+	client._tools = tools
+	return client
+
+
+async def test_integer_enum_param_keeps_int_type():
+	client = _make_client(
+		{
+			'pick': MCPTool(
+				name='pick',
+				description='pick a number',
+				inputSchema={
+					'type': 'object',
+					'properties': {'count': {'type': 'integer', 'enum': [1, 2, 3]}},
+					'required': ['count'],
+				},
+			)
+		}
+	)
+	tools = Tools()
+	await client.register_to_tools(tools)
+
+	param_model = tools.registry.registry.actions['pick'].param_model
+	assert param_model is not None
+	# An integer must be accepted (previously raised ValidationError because the
+	# field was typed as str).
+	assert param_model(count=2).model_dump() == {'count': 2}
+
+
+async def test_register_to_two_tools_instances():
+	client = _make_client(
+		{
+			'foo': MCPTool(
+				name='foo',
+				description='foo tool',
+				inputSchema={'type': 'object', 'properties': {'x': {'type': 'string'}}},
+			)
+		}
+	)
+	tools_a = Tools()
+	tools_b = Tools()
+
+	await client.register_to_tools(tools_a)
+	await client.register_to_tools(tools_b)
+
+	assert 'foo' in tools_a.registry.registry.actions
+	# Previously this registry got nothing because the client-global dedup set
+	# already contained 'foo' from the first call.
+	assert 'foo' in tools_b.registry.registry.actions
+
+
+async def test_re_register_same_tools_is_idempotent():
+	client = _make_client(
+		{
+			'foo': MCPTool(
+				name='foo',
+				description='foo tool',
+				inputSchema={'type': 'object', 'properties': {'x': {'type': 'string'}}},
+			)
+		}
+	)
+	tools = Tools()
+	await client.register_to_tools(tools)
+	# Registering the same client to the same registry again must not raise
+	# (per-registry dedup skips the already-present action).
+	await client.register_to_tools(tools)
+	assert 'foo' in tools.registry.registry.actions


### PR DESCRIPTION
Two independent bugs in `MCPClient` tool registration (`browser_use/mcp/client.py`).

### 1. Integer/number enum params are forced to `str`

`_json_schema_to_python_type` returned `str` for **any** schema containing `enum`:

```python
if 'enum' in schema:
    return str
```

But JSON Schema enums aren't always strings — `{"type": "integer", "enum": [1, 2, 3]}` is valid. The generated Pydantic param field became `str`, so the model rejected an integer and the LLM was instructed to send a string. Any MCP tool exposing an int/number enum was effectively uncallable.

**Fix:** map the enum to its declared type, falling back to `str` only when no `type` is present:
```python
if 'enum' in schema:
    return type_mapping.get(json_type, str)
```

### 2. Registering one client to a second `Tools` registers nothing

`register_to_tools` deduplicated against the **client-global** `_registered_actions` set:

```python
if action_name in self._registered_actions:
    continue
```

So calling `register_to_tools(tools_a)` then `register_to_tools(tools_b)` on the same connected client skipped every tool the second time — `tools_b` got **zero** actions, while the log still said "✅ Registered N MCP tools". This bites multi-agent / multiple-`Tools` setups sharing one client.

**Fix:** dedup per-target-registry (`action_name in registry.registry.actions`) and log the count registered in *this* call. Re-registering the same client to the same registry stays idempotent.

### Testing

New `tests/ci/test_mcp_client_registration.py` (real `mcp.types.Tool` + real `Tools`/registry, no live server):
- integer-enum param accepts an int,
- the same client registers into two separate `Tools` instances,
- re-registering into the same registry is idempotent.

`ruff check` and `pyright` pass; existing `test_mcp_allowed_domains.py` still green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP tool registration so enum params keep their numeric types and actions dedupe per target registry; also corrects boolean env var parsing to treat empty values as unset and prevent import errors.

- **Bug Fixes**
  - `MCPClient`: `_json_schema_to_python_type` now maps `enum` to its declared JSON Schema type (integer/number enums accept ints). `register_to_tools` dedupes against the target `Tools` registry and logs the count for this call; re-registering to the same registry is idempotent.
  - `browser_use.config`: `_env_bool` treats empty/whitespace as unset and only standard truthy values (`true`, `1`, `yes`, `y`, `on`, `t`) evaluate to True; `FlatEnvConfig` drops empty env values via a `model_validator` to avoid `ValidationError` on bare booleans (e.g., `ANONYMIZED_TELEMETRY=`). Added regression tests for both areas.

<sup>Written for commit 6fc8b3b63db8facc697802cb4a663151dff5265c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

