### PR TITLE
fix(filesystem): stop CSV field corruption and force UTF-8 text I/O

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -110,12 +110,12 @@ class BaseFile(BaseModel, ABC):
 
 	def sync_to_disk_sync(self, path: Path) -> None:
 		file_path = path / self.full_name
-		file_path.write_text(self.content)
+		file_path.write_text(self.content, encoding='utf-8')
 
 	async def sync_to_disk(self, path: Path) -> None:
 		file_path = path / self.full_name
 		with ThreadPoolExecutor() as executor:
-			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content))
+			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content, encoding='utf-8'))
 
 	async def write(self, content: str, path: Path) -> None:
 		self.write_file_content(content)
@@ -191,11 +191,16 @@ class CsvFile(BaseFile):
 			return raw
 
 		# Detect double-escaped LLM tool call output: if the content has no real
-		# newlines but contains literal \n sequences, the entire string is likely
-		# double-escaped JSON. Unescape \" → " first, then \n → newline.
+		# newlines but contains literal \n sequences, the string *may* be
+		# double-escaped JSON. Only accept the un-escape if it actually yields a
+		# consistent multi-column table; otherwise the backslash-n was literal
+		# field data (e.g. a Windows path like C:\new or a regex) and unescaping
+		# it would corrupt the field by splitting it across rows.
 		if '\n' not in stripped and '\\n' in stripped:
-			stripped = stripped.replace('\\"', '"')
-			stripped = stripped.replace('\\n', '\n')
+			candidate = stripped.replace('\\"', '"').replace('\\n', '\n')
+			candidate_rows = [row for row in csv.reader(io.StringIO(candidate)) if row]
+			if len(candidate_rows) > 1 and len({len(row) for row in candidate_rows}) == 1 and len(candidate_rows[0]) > 1:
+				stripped = candidate
 
 		reader = csv.reader(io.StringIO(stripped))
 		rows: list[list[str]] = []
@@ -530,7 +535,7 @@ class FileSystem:
 				if extension in text_extensions:
 					import anyio
 
-					async with await anyio.open_file(full_filename, 'r') as f:
+					async with await anyio.open_file(full_filename, 'r', encoding='utf-8') as f:
 						content = await f.read()
 						result['message'] = f'Read from file {full_filename}.\n<content>\n{content}\n</content>'
 						return result

--- a/tests/ci/test_filesystem_csv_and_encoding.py
+++ b/tests/ci/test_filesystem_csv_and_encoding.py
@@ -1,0 +1,58 @@
+"""Regression tests for FileSystem CSV normalization and text encoding.
+
+Bugs pinned here:
+
+1. `CsvFile._normalize_csv` treated any single-line content containing a literal
+   `\\n` as double-escaped JSON and turned it into a real newline. That corrupted
+   ordinary fields such as Windows paths (`C:\\new`) or regexes by splitting one
+   field across rows. The un-escape is now only applied when it yields a
+   consistent multi-column table.
+
+2. Text files were written/read without an explicit encoding, so on a non-UTF-8
+   locale (e.g. Windows cp1252) non-ASCII content (CJK, emoji) failed to encode
+   and was lost. All text I/O now uses `encoding='utf-8'`.
+"""
+
+import csv
+import io
+import tempfile
+
+from browser_use.filesystem.file_system import CsvFile, FileSystem
+
+
+def _rows(content: str) -> list[list[str]]:
+	return list(csv.reader(io.StringIO(content)))
+
+
+def test_csv_field_with_backslash_n_is_not_split():
+	f = CsvFile(name='paths')
+	f.write_file_content('col1,col2')
+	f.append_file_content('tool,C:\\new')  # field value is  C:\new
+	assert _rows(f.content) == [['col1', 'col2'], ['tool', 'C:\\new']]
+
+
+def test_csv_single_column_backslash_n_is_preserved():
+	f = CsvFile(name='paths')
+	f.write_file_content('C:\\new')
+	assert f.content == 'C:\\new'
+
+
+def test_csv_double_escaped_table_is_still_unescaped():
+	# The intended feature: a genuinely double-escaped rectangular table (no real
+	# newlines, literal \n as row separators) is still expanded into rows.
+	f = CsvFile(name='data')
+	f.write_file_content('a,b\\nc,d\\ne,f')
+	assert _rows(f.content) == [['a', 'b'], ['c', 'd'], ['e', 'f']]
+
+
+async def test_non_ascii_text_persists_as_utf8():
+	# Contract test: content is stored as UTF-8 regardless of locale. On a
+	# non-UTF-8 default (Windows cp1252) this used to error and write 0 bytes.
+	fs = FileSystem(tempfile.mkdtemp(), create_default_files=False)
+	content = '你好世界 😀 café'
+
+	result = await fs.write_file('notes.md', content)
+	assert 'Error' not in result
+
+	on_disk = fs.get_dir() / 'notes.md'
+	assert on_disk.read_bytes().decode('utf-8') == content


### PR DESCRIPTION
Two data-integrity bugs in `browser_use/filesystem/file_system.py`.

### 1. CSV normalization corrupts fields containing `\n`

`CsvFile._normalize_csv` unescaped **any** single-line content that contained a literal `\n`:

```python
if '\n' not in stripped and '\n' in stripped:
    stripped = stripped.replace('\\"', '"')
    stripped = stripped.replace('\n', '\n')
```

The intent was to repair double-escaped JSON output, but the trigger fires on ordinary field data too. A Windows path `C:\new`, a regex, or any backslash-`n` gets its `\n` turned into a real newline, **splitting one field across two rows**. This hits the very common single-row write/append path:

```python
csv.write_file_content("col1,col2")
csv.append_file_content("tool,C:\new")   # -> [['col1','col2'], ['tool','C:'], ['ew']]  (corrupted)
```

**Fix:** only accept the un-escape when it produces a *consistent multi-column table* (more than one row, all rows the same width, width > 1). Genuine double-escaped tables still expand; literal `\n` field data is left intact.

### 2. Text files written/read without UTF-8 → non-ASCII lost on Windows

`write_text`/`open_file` were called with no `encoding`, so they used the locale default — `cp1252` on Windows. Writing non-ASCII content (CJK, emoji) raised `'charmap' codec can't encode…` and left a **0-byte file** — silent data loss, even though the library explicitly supports such content (e.g. CJK filenames). All text I/O now passes `encoding='utf-8'`.

### Testing

New `tests/ci/test_filesystem_csv_and_encoding.py`:
- a `C:\new` field (with and without a second column) round-trips intact,
- a genuinely double-escaped `a,b\nc,d\ne,f` table still expands to rows,
- non-ASCII (`你好世界 😀 café`) persists and reads back as UTF-8.

All 123 existing filesystem tests still pass; `ruff` and `pyright` clean. (The UTF-8 failure is only observable on a non-UTF-8 locale such as Windows — verified there — but the fix and contract test are portable.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CSV field corruption from literal backslash-n values and forces UTF-8 for all text I/O to prevent non-ASCII data loss on Windows.

- **Bug Fixes**
  - CSV normalization only unescapes when the result is a consistent, equal-width, multi-row table; literals like `C:\new` stay as one field.
  - All text reads/writes now pass `encoding='utf-8'` (sync, async, and `anyio.open_file`), preventing cp1252 errors and 0-byte files.
  - Added regression tests for backslash-n fields, genuine double-escaped tables, and non-ASCII round-trips.

<sup>Written for commit 78bd9c1b204453059aa43003d717247bdf741925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

