### PR TITLE
Add MiniMax image generation tool example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ token.json
 temp-profile-*
 
 screenshot.png
+examples/integrations/minimax/output/
 
 # *.md
 

--- a/examples/integrations/minimax/README.md
+++ b/examples/integrations/minimax/README.md
@@ -1,0 +1,33 @@
+# MiniMax image generation
+
+This example registers MiniMax text-to-image generation as a Browser Use tool. The agent gathers visual requirements in the browser, calls the tool, and saves the generated image locally.
+
+## Setup
+
+Install the repository dependencies and export both API keys:
+
+```bash
+uv sync
+export BROWSER_USE_API_KEY='your-browser-use-api-key'
+export MINIMAX_API_KEY='your-minimax-api-key'
+```
+
+The example uses the global API by default. To use the API in China, set the image API base URL:
+
+```bash
+export MINIMAX_IMAGE_BASE_URL='https://api.minimaxi.com/v1'
+```
+
+`MINIMAX_IMAGE_BASE_URL` must be an API base URL ending in `/v1`; the example appends `/image_generation` when it sends a request.
+
+## Run
+
+From the repository root:
+
+```bash
+uv run python examples/integrations/minimax/image_generation.py
+```
+
+Generated images are written to `examples/integrations/minimax/output/`.
+
+See the [global image generation guide](https://platform.minimax.io/docs/guides/image-generation) or the [China image generation guide](https://platform.minimaxi.com/docs/guides/image-generation) for API details.

--- a/examples/integrations/minimax/image_generation.py
+++ b/examples/integrations/minimax/image_generation.py
@@ -1,0 +1,142 @@
+import asyncio
+import base64
+import binascii
+import os
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel, Field
+
+from browser_use import ActionResult, Agent, ChatBrowserUse, Tools
+
+MINIMAX_IMAGE_BASE_URL = 'https://api.minimax.io/v1'
+MINIMAX_IMAGE_MODEL = 'image-01'
+
+AspectRatio = Literal['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9']
+
+
+class GenerateImageParams(BaseModel):
+	prompt: str = Field(min_length=1, max_length=1500, description='A detailed description of the image to generate.')
+	aspect_ratio: AspectRatio = Field(default='1:1', description='The aspect ratio of the generated image.')
+
+
+class MiniMaxImageGenerationError(RuntimeError):
+	pass
+
+
+def build_image_generation_url(base_url: str) -> str:
+	base_url = base_url.rstrip('/')
+	if not base_url:
+		raise ValueError('MINIMAX_IMAGE_BASE_URL cannot be empty')
+	if base_url.endswith('/image_generation'):
+		raise ValueError('MINIMAX_IMAGE_BASE_URL must be the API base URL, not the image generation endpoint')
+	if not base_url.endswith('/v1'):
+		raise ValueError('MINIMAX_IMAGE_BASE_URL must end in /v1')
+	return f'{base_url}/image_generation'
+
+
+def parse_image_response(payload: object) -> bytes:
+	if not isinstance(payload, dict):
+		raise MiniMaxImageGenerationError('Image generation returned an invalid response')
+
+	base_resp = payload.get('base_resp')
+	if isinstance(base_resp, dict):
+		status_code = base_resp.get('status_code')
+		if status_code not in (None, 0):
+			status_msg = base_resp.get('status_msg') or 'unknown API error'
+			raise MiniMaxImageGenerationError(f'Image generation failed ({status_code}): {status_msg}')
+
+	data = payload.get('data')
+	images = data.get('image_base64') if isinstance(data, dict) else None
+	if not isinstance(images, list) or not images or not isinstance(images[0], str):
+		raise MiniMaxImageGenerationError('Image generation response did not contain image data')
+
+	try:
+		return base64.b64decode(images[0], validate=True)
+	except (binascii.Error, ValueError) as exc:
+		raise MiniMaxImageGenerationError('Image generation returned invalid base64 data') from exc
+
+
+async def generate_image_bytes(
+	params: GenerateImageParams,
+	*,
+	api_key: str,
+	base_url: str = MINIMAX_IMAGE_BASE_URL,
+	client: httpx.AsyncClient | None = None,
+) -> bytes:
+	request_client = client or httpx.AsyncClient(timeout=httpx.Timeout(120.0))
+	close_client = client is None
+
+	try:
+		response = await request_client.post(
+			build_image_generation_url(base_url),
+			headers={'Authorization': f'Bearer {api_key}'},
+			json={
+				'model': MINIMAX_IMAGE_MODEL,
+				'prompt': params.prompt,
+				'aspect_ratio': params.aspect_ratio,
+				'response_format': 'base64',
+				'n': 1,
+			},
+		)
+		try:
+			response.raise_for_status()
+		except httpx.HTTPStatusError as exc:
+			raise MiniMaxImageGenerationError(f'Image generation request failed with HTTP {response.status_code}') from exc
+
+		try:
+			payload = response.json()
+		except ValueError as exc:
+			raise MiniMaxImageGenerationError('Image generation returned invalid JSON') from exc
+		return parse_image_response(payload)
+	finally:
+		if close_client:
+			await request_client.aclose()
+
+
+tools = Tools()
+
+
+@tools.action(
+	'Generate an image from a text prompt and save it locally. Use this after gathering the visual requirements.',
+	param_model=GenerateImageParams,
+)
+async def generate_image(params: GenerateImageParams) -> ActionResult:
+	api_key = os.getenv('MINIMAX_API_KEY')
+	if not api_key:
+		return ActionResult(error='MINIMAX_API_KEY is not set')
+
+	base_url = os.getenv('MINIMAX_IMAGE_BASE_URL', MINIMAX_IMAGE_BASE_URL)
+	output_dir = Path(__file__).parent / 'output'
+	output_path = output_dir / f'{uuid4().hex}.jpeg'
+
+	try:
+		image = await generate_image_bytes(params, api_key=api_key, base_url=base_url)
+		await asyncio.to_thread(output_dir.mkdir, parents=True, exist_ok=True)
+		await asyncio.to_thread(output_path.write_bytes, image)
+	except (MiniMaxImageGenerationError, httpx.HTTPError, OSError, ValueError) as exc:
+		return ActionResult(error=f'Image generation failed: {exc}')
+
+	message = f'Generated image saved to {output_path}'
+	return ActionResult(extracted_content=message, long_term_memory=message)
+
+
+async def main() -> None:
+	if not os.getenv('MINIMAX_API_KEY'):
+		raise ValueError('MINIMAX_API_KEY is not set')
+
+	agent = Agent(
+		task=(
+			'Visit https://browser-use.com, identify the primary visual theme, and then call generate_image once '
+			'to create a square editorial illustration inspired by that theme.'
+		),
+		llm=ChatBrowserUse(),
+		tools=tools,
+	)
+	await agent.run()
+
+
+if __name__ == '__main__':
+	asyncio.run(main())

--- a/examples/integrations/minimax/image_generation.py
+++ b/examples/integrations/minimax/image_generation.py
@@ -120,7 +120,7 @@ async def generate_image(params: GenerateImageParams) -> ActionResult:
 		return ActionResult(error=f'Image generation failed: {exc}')
 
 	message = f'Generated image saved to {output_path}'
-	return ActionResult(extracted_content=message, long_term_memory=message)
+	return ActionResult(extracted_content=message, long_term_memory=message, attachments=[str(output_path)])
 
 
 async def main() -> None:

--- a/examples/integrations/minimax/image_generation.py
+++ b/examples/integrations/minimax/image_generation.py
@@ -49,7 +49,7 @@ def parse_image_response(payload: object) -> bytes:
 			raise MiniMaxImageGenerationError(f'Image generation failed ({status_code}): {status_msg}')
 
 	data = payload.get('data')
-	images = data.get('image_base64') if isinstance(data, dict) else None
+	images = data.get('image_urls') if isinstance(data, dict) else None
 	if not isinstance(images, list) or not images or not isinstance(images[0], str):
 		raise MiniMaxImageGenerationError('Image generation response did not contain image data')
 

--- a/tests/ci/test_minimax_image_generation.py
+++ b/tests/ci/test_minimax_image_generation.py
@@ -1,0 +1,86 @@
+import base64
+import json
+
+import httpx
+import pytest
+
+from examples.integrations.minimax.image_generation import (
+	GenerateImageParams,
+	MiniMaxImageGenerationError,
+	build_image_generation_url,
+	generate_image_bytes,
+)
+
+
+@pytest.mark.parametrize(
+	('base_url', 'expected'),
+	[
+		('https://api.minimax.io/v1', 'https://api.minimax.io/v1/image_generation'),
+		('https://api.minimax.io/v1/', 'https://api.minimax.io/v1/image_generation'),
+		('https://api.minimaxi.com/v1', 'https://api.minimaxi.com/v1/image_generation'),
+	],
+)
+def test_build_image_generation_url(base_url: str, expected: str) -> None:
+	assert build_image_generation_url(base_url) == expected
+
+
+def test_build_image_generation_url_rejects_full_endpoint() -> None:
+	with pytest.raises(ValueError, match='API base URL'):
+		build_image_generation_url('https://api.minimax.io/v1/image_generation')
+
+
+def test_build_image_generation_url_requires_versioned_base() -> None:
+	with pytest.raises(ValueError, match='end in /v1'):
+		build_image_generation_url('https://api.minimax.io')
+
+
+async def test_generate_image_bytes_uses_official_request_shape() -> None:
+	image = b'test-image'
+
+	def handler(request: httpx.Request) -> httpx.Response:
+		assert str(request.url) == 'https://api.minimaxi.com/v1/image_generation'
+		assert request.headers['Authorization'] == 'Bearer test-key'
+		assert request.headers['Content-Type'] == 'application/json'
+		assert json.loads(request.content) == {
+			'model': 'image-01',
+			'prompt': 'A precise test image',
+			'aspect_ratio': '16:9',
+			'response_format': 'base64',
+			'n': 1,
+		}
+		return httpx.Response(
+			200,
+			json={
+				'data': {'image_base64': [base64.b64encode(image).decode()]},
+				'base_resp': {'status_code': 0, 'status_msg': 'success'},
+			},
+		)
+
+	async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+		result = await generate_image_bytes(
+			GenerateImageParams(prompt='A precise test image', aspect_ratio='16:9'),
+			api_key='test-key',
+			base_url='https://api.minimaxi.com/v1',
+			client=client,
+		)
+
+	assert result == image
+
+
+async def test_generate_image_bytes_surfaces_api_errors() -> None:
+	def handler(request: httpx.Request) -> httpx.Response:
+		return httpx.Response(
+			200,
+			json={
+				'data': {},
+				'base_resp': {'status_code': 2013, 'status_msg': 'Invalid input parameters'},
+			},
+		)
+
+	async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+		with pytest.raises(MiniMaxImageGenerationError, match='2013'):
+			await generate_image_bytes(
+				GenerateImageParams(prompt='A precise test image'),
+				api_key='test-key',
+				client=client,
+			)

--- a/tests/ci/test_minimax_image_generation.py
+++ b/tests/ci/test_minimax_image_generation.py
@@ -1,9 +1,12 @@
 import base64
 import json
+from pathlib import Path
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 
+from examples.integrations.minimax import image_generation
 from examples.integrations.minimax.image_generation import (
 	GenerateImageParams,
 	MiniMaxImageGenerationError,
@@ -65,6 +68,25 @@ async def test_generate_image_bytes_uses_official_request_shape() -> None:
 		)
 
 	assert result == image
+
+
+async def test_generate_image_returns_saved_file_as_attachment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+	image = b'test-image'
+	generate = AsyncMock(return_value=image)
+	monkeypatch.setattr(image_generation, 'generate_image_bytes', generate)
+	monkeypatch.setattr(image_generation, '__file__', str(tmp_path / 'image_generation.py'))
+	monkeypatch.setenv('MINIMAX_API_KEY', 'test-key')
+	monkeypatch.delenv('MINIMAX_IMAGE_BASE_URL', raising=False)
+
+	result = await image_generation.generate_image(params=GenerateImageParams(prompt='A precise test image'))
+
+	generate.assert_awaited_once()
+	assert result.attachments is not None
+	assert len(result.attachments) == 1
+	output_path = Path(result.attachments[0])
+	assert output_path.parent == tmp_path / 'output'
+	assert output_path.read_bytes() == image
+	assert result.extracted_content == f'Generated image saved to {output_path}'
 
 
 async def test_generate_image_bytes_surfaces_api_errors() -> None:

--- a/tests/ci/test_minimax_image_generation.py
+++ b/tests/ci/test_minimax_image_generation.py
@@ -54,7 +54,7 @@ async def test_generate_image_bytes_uses_official_request_shape() -> None:
 		return httpx.Response(
 			200,
 			json={
-				'data': {'image_base64': [base64.b64encode(image).decode()]},
+				'data': {'image_urls': [base64.b64encode(image).decode()]},
 				'base_resp': {'status_code': 0, 'status_msg': 'success'},
 			},
 		)


### PR DESCRIPTION
Reason: add MiniMax image capability using the existing integration tool pattern.

## Summary
- Add a runnable Browser Use integration that registers MiniMax image generation as an agent tool and returns the saved image as an attachment.
- Use the official `image-01` request and base64 response format with validated API errors.
- Support the global API by default and the China API through `MINIMAX_IMAGE_BASE_URL`.
- Document setup, execution, output location, and both regional API bases.

## Testing
- `uv run --no-sync pytest -q tests/ci/test_minimax_image_generation.py`
- `uv run --no-sync pre-commit run --files .gitignore examples/integrations/minimax/README.md examples/integrations/minimax/image_generation.py tests/ci/test_minimax_image_generation.py --show-diff-on-failure`
- `uv run --no-sync pyright`
- `uv run --no-sync ruff check --no-fix --select PLE`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a runnable MiniMax text‑to‑image tool for Browser Use agents. It calls the official `image-01` API, saves images locally, and returns the saved file as an attachment.

- **New Features**
  - Example at `examples/integrations/minimax/image_generation.py` registers a `generate_image` tool; writes JPEGs to `examples/integrations/minimax/output/` and includes the file path in `ActionResult.attachments`.
  - Sends the official request shape (`model: image-01`, base64), fixes response parsing to read `data.image_urls` and surface `base_resp` errors; strict URL builder supports global and China API bases.
  - Uses `MINIMAX_API_KEY` and optional `MINIMAX_IMAGE_BASE_URL`; README covers setup and running; tests cover request shape, error handling, URL builder, and attachment behavior; `.gitignore` ignores the output folder.

<sup>Written for commit 809662ad00100ecc31a8fb5d70e51849afcffb18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

