### PR TITLE
fix(tokens): new_prompt_tokens should count uncached prompt tokens

### DIFF
--- a/browser_use/tokens/service.py
+++ b/browser_use/tokens/service.py
@@ -244,7 +244,9 @@ class TokenCost:
 			)
 
 		return TokenCostCalculated(
-			new_prompt_tokens=usage.prompt_tokens,
+			# "new" == uncached prompt tokens; this must match new_prompt_cost below,
+			# which is priced on uncached_prompt_tokens (prompt_tokens includes cached).
+			new_prompt_tokens=uncached_prompt_tokens,
 			new_prompt_cost=uncached_prompt_tokens * (data.input_cost_per_token or 0) * pricing_multiplier,
 			# Cached tokens
 			prompt_read_cached_tokens=usage.prompt_cached_tokens,

--- a/tests/ci/test_token_cost_new_prompt_tokens.py
+++ b/tests/ci/test_token_cost_new_prompt_tokens.py
@@ -1,0 +1,54 @@
+"""Regression test for TokenCost.calculate_cost token accounting.
+
+`new_prompt_tokens` is paired with `new_prompt_cost`, which is priced on the
+*uncached* prompt tokens (`prompt_tokens - prompt_cached_tokens`). The field was
+assigned the full `prompt_tokens` total (which includes cached tokens), so the
+reported token count and its cost described different quantities.
+"""
+
+import pytest
+
+from browser_use.llm.views import ChatInvokeUsage
+from browser_use.tokens.service import TokenCost
+from browser_use.tokens.views import ModelPricing
+
+
+def _pricing() -> ModelPricing:
+	return ModelPricing(
+		model='test-model',
+		input_cost_per_token=1e-6,
+		output_cost_per_token=2e-6,
+		cache_read_input_token_cost=1e-7,
+		cache_creation_input_token_cost=None,
+		max_tokens=None,
+		max_input_tokens=None,
+		max_output_tokens=None,
+	)
+
+
+async def test_new_prompt_tokens_excludes_cached(monkeypatch: pytest.MonkeyPatch):
+	tc = TokenCost(include_cost=True)
+
+	async def fake_get_model_pricing(model_name: str) -> ModelPricing:
+		return _pricing()
+
+	monkeypatch.setattr(tc, 'get_model_pricing', fake_get_model_pricing)
+
+	usage = ChatInvokeUsage(
+		prompt_tokens=1000,
+		prompt_cached_tokens=400,
+		prompt_cache_creation_tokens=None,
+		prompt_image_tokens=None,
+		completion_tokens=100,
+		total_tokens=1100,
+	)
+
+	cost = await tc.calculate_cost('test-model', usage)
+	assert cost is not None
+
+	# 1000 total - 400 cached = 600 uncached ("new") tokens
+	assert cost.new_prompt_tokens == 600
+	# Cost is priced on the same 600 tokens.
+	assert cost.new_prompt_cost == pytest.approx(600 * 1e-6)
+	# Cached tokens are reported separately and unchanged.
+	assert cost.prompt_read_cached_tokens == 400


### PR DESCRIPTION
### What

`TokenCostCalculated.new_prompt_tokens` was assigned `usage.prompt_tokens` — the **full** prompt total, which per `ChatInvokeUsage` includes cached tokens. But its paired `new_prompt_cost` is computed from `uncached_prompt_tokens` (`prompt_tokens - prompt_cached_tokens`):

```python
uncached_prompt_tokens = usage.prompt_tokens - (usage.prompt_cached_tokens or 0)
...
new_prompt_tokens=usage.prompt_tokens,   # total, incl. cached
new_prompt_cost=uncached_prompt_tokens * (data.input_cost_per_token or 0) * pricing_multiplier,
```

So the reported "new" token count and the "new" cost describe different quantities. Everywhere else in the file the "new" tokens are computed as `prompt_tokens - cached` (e.g. `_build_input_tokens_display`), and the cached tokens are reported separately — so the count double-counts the cached portion.

### Fix

Assign `new_prompt_tokens = uncached_prompt_tokens` so the count matches its cost. Dollar totals are unaffected (they already use `new_prompt_cost`); this corrects the token breakdown.

### Testing

New `tests/ci/test_token_cost_new_prompt_tokens.py`: with `prompt_tokens=1000`, `prompt_cached_tokens=400`, `new_prompt_tokens` is `600` (not `1000`), priced on 600, with 400 still reported under `prompt_read_cached_tokens`. `ruff`/`pyright` clean; existing token-cost tests still pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes token accounting by setting `new_prompt_tokens` to uncached prompt tokens so it matches `new_prompt_cost`. This corrects the “new” token count in the breakdown; total dollar cost is unchanged.

- **Bug Fixes**
  - Set `new_prompt_tokens = prompt_tokens - prompt_cached_tokens` in `calculate_cost`.
  - Added a regression test: with 1000 total and 400 cached, `new_prompt_tokens` is 600, cost priced on 600, and 400 reported as `prompt_read_cached_tokens`.

<sup>Written for commit 536d201f7525de340531a692693e31cee4c5a940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

