### PR TITLE
fix(registry): do not expose domain-restricted actions on an empty URL

### DIFF
--- a/browser_use/tools/registry/views.py
+++ b/browser_use/tools/registry/views.py
@@ -106,8 +106,16 @@ class ActionRegistry(BaseModel):
 			True if the URL's domain matches the pattern, False otherwise
 		"""
 
-		if domains is None or not url:
+		# Actions with no domain restriction are always available.
+		if domains is None:
 			return True
+
+		# A domain-restricted action must NOT be exposed when the URL is unknown/
+		# empty. Returning True here failed open: an empty page_url (e.g. a fresh
+		# about:blank target whose url is '') made every restricted action match,
+		# unlike the page_url is None path which correctly hides them.
+		if not url:
+			return False
 
 		# Use the centralized URL matching logic from utils
 		from browser_use.utils import match_url_with_domain_pattern

--- a/tests/ci/test_registry_empty_url_domain_filter.py
+++ b/tests/ci/test_registry_empty_url_domain_filter.py
@@ -1,0 +1,54 @@
+"""Regression test for domain-restricted action filtering on an unknown URL.
+
+`ActionRegistry._match_domains` returned True when the URL was empty (`not url`),
+so a domain-restricted action was exposed on a blank/unknown page URL — even
+though the `page_url is None` path correctly hides such actions. An empty
+`page_url` is reachable (e.g. a freshly created about:blank target whose
+`target.url` is ''), so this failed open for a security-relevant filter.
+"""
+
+from browser_use.tools.registry.service import Registry
+from browser_use.tools.registry.views import ActionRegistry
+
+
+def test_match_domains_fails_closed_on_empty_url():
+	# Unrestricted action: always available.
+	assert ActionRegistry._match_domains(None, '') is True
+	assert ActionRegistry._match_domains(None, 'https://anything.com') is True
+
+	# Domain-restricted action: hidden when the URL is unknown/empty...
+	assert ActionRegistry._match_domains(['*.admin.example.com'], '') is False
+	# ...matched only against a real, matching URL.
+	assert ActionRegistry._match_domains(['*.admin.example.com'], 'https://panel.admin.example.com') is True
+	assert ActionRegistry._match_domains(['*.admin.example.com'], 'https://evil.com') is False
+
+
+def _registry_with_admin_action() -> Registry:
+	registry = Registry()
+
+	@registry.action('admin only', domains=['*.admin.example.com'])
+	def admin_action():
+		pass
+
+	return registry
+
+
+def test_domain_restricted_action_hidden_on_empty_url():
+	registry = _registry_with_admin_action()
+
+	# None (system prompt): restricted action excluded.
+	assert 'admin_action' not in registry.get_prompt_description(page_url=None)
+	# Empty URL: also excluded now (previously exposed).
+	assert 'admin_action' not in registry.get_prompt_description(page_url='')
+	# Matching URL: available.
+	assert 'admin_action' in registry.get_prompt_description(page_url='https://panel.admin.example.com')
+
+
+def test_create_action_model_excludes_restricted_action_on_empty_url():
+	registry = _registry_with_admin_action()
+
+	empty_url_model = registry.create_action_model(page_url='')
+	assert 'admin_action' not in empty_url_model.model_fields
+
+	matching_model = registry.create_action_model(page_url='https://panel.admin.example.com')
+	assert 'admin_action' in matching_model.model_fields


### PR DESCRIPTION
### What

`ActionRegistry._match_domains` short-circuited to `True` whenever the URL was falsy:

```python
if domains is None or not url:
    return True
```

`domains is None` (unrestricted action) → available is correct. But `not url` meant an **empty** `page_url` made **every** domain-restricted action match. That's inconsistent with the `page_url is None` path, which only includes actions with no domain filter (fails closed). So the same "no real URL" condition gave opposite results:

- `page_url is None` → restricted actions hidden ✅
- `page_url == ''` → restricted actions **exposed** ❌

An empty `page_url` is reachable: `get_current_page_url()` returns `target.url`, which is `''` for a freshly created about:blank target before navigation commits. So a domain-scoped (e.g. admin-only) action could be offered on an unknown context.

### Fix

Only `domains is None` short-circuits to available. A domain-restricted action with an unknown/empty URL now fails **closed** (returns `False`), matching the `page_url is None` behaviour.

### Testing

New `tests/ci/test_registry_empty_url_domain_filter.py`:
- `_match_domains` directly (unrestricted always available; restricted hidden on `''`, matched only on a real matching URL),
- `get_prompt_description` and `create_action_model` both exclude a `domains=['*.admin.example.com']` action when `page_url=''` and include it on a matching URL.

All 24 existing domain-filtering tests still pass; `ruff`/`pyright` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop exposing domain-restricted actions when the current URL is empty by making `ActionRegistry._match_domains` return False for empty URLs. Only unrestricted actions (`domains is None`) short-circuit to available; regression tests verify filtering in `_match_domains`, `get_prompt_description`, and `create_action_model`.

<sup>Written for commit dcf8e018457e793fdcc2174685ab3bcb394d9ac8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

