### PR TITLE
fix(agent): give each MessageManager its own state (mutable default arg)

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -109,7 +109,7 @@ class MessageManager:
 		task: str,
 		system_message: SystemMessage,
 		file_system: FileSystem,
-		state: MessageManagerState = MessageManagerState(),
+		state: MessageManagerState | None = None,
 		use_thinking: bool = True,
 		include_attributes: list[str] | None = None,
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
@@ -122,7 +122,10 @@ class MessageManager:
 		max_clickable_elements_length: int = 40000,
 	):
 		self.task = task
-		self.state = state
+		# A fresh state per instance: a mutable default (MessageManagerState()) would be
+		# evaluated once at definition time and shared across every MessageManager created
+		# without an explicit state, cross-contaminating their history.
+		self.state = state if state is not None else MessageManagerState()
 		self.system_prompt = system_message
 		self.file_system = file_system
 		self.sensitive_data_description = ''

--- a/tests/ci/test_message_manager_state_isolation.py
+++ b/tests/ci/test_message_manager_state_isolation.py
@@ -1,0 +1,52 @@
+"""Regression test for MessageManager state isolation.
+
+MessageManager.__init__ used a mutable default argument `state=MessageManagerState()`,
+which is evaluated once at definition time and therefore shared by every MessageManager
+created without an explicit state. History (`agent_history_items`, etc.) then leaked
+across otherwise-independent instances.
+"""
+
+import tempfile
+
+from browser_use.agent.message_manager.service import MessageManager
+from browser_use.agent.views import MessageManagerState
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.llm import SystemMessage
+
+
+def _make_manager(task: str) -> MessageManager:
+	return MessageManager(
+		task=task,
+		system_message=SystemMessage(content='system'),
+		file_system=FileSystem(tempfile.mkdtemp()),
+	)
+
+
+def test_managers_get_independent_state():
+	mm1 = _make_manager('task one')
+	mm2 = _make_manager('task two')
+
+	assert mm1.state is not mm2.state
+	assert mm1.state.agent_history_items is not mm2.state.agent_history_items
+
+
+def test_mutating_one_manager_does_not_affect_another():
+	mm1 = _make_manager('task one')
+	mm2 = _make_manager('task two')
+
+	mm1.add_new_task('do X only in agent 1')
+
+	leaked = any('do X only in agent 1' in (item.system_message or '') for item in mm2.state.agent_history_items)
+	assert not leaked
+	assert '<follow_up_user_request>' not in mm2.task
+
+
+def test_explicit_state_is_used_as_is():
+	shared = MessageManagerState()
+	mm = MessageManager(
+		task='task',
+		system_message=SystemMessage(content='system'),
+		file_system=FileSystem(tempfile.mkdtemp()),
+		state=shared,
+	)
+	assert mm.state is shared


### PR DESCRIPTION
### What

`MessageManager.__init__` used a **mutable default argument**:

```python
def __init__(self, task, system_message, file_system,
             state: MessageManagerState = MessageManagerState(), ...):
    ...
    self.state = state
```

The default `MessageManagerState()` is evaluated **once at function-definition time**, so every `MessageManager` created without an explicit `state` shares the *same* `MessageManagerState` instance — including its `agent_history_items`, `history`, etc. Appends via `add_new_task` / history updates on one manager then leak into every other.

```python
mm1 = MessageManager(task='a', system_message=..., file_system=...)
mm2 = MessageManager(task='b', system_message=..., file_system=...)
mm1.state is mm2.state            # True  (should be False)
mm1.add_new_task('only for mm1')  # also appears in mm2.state
```

The main `Agent` path always passes `self.state.message_manager_state`, so it's shielded — but `MessageManager` is a public class and any direct construction is affected.

### Fix

Default `state` to `None` and construct a fresh `MessageManagerState()` per instance. An explicitly passed `state` is still used as-is (shared state remains opt-in).

### Testing

New `tests/ci/test_message_manager_state_isolation.py`: two managers get independent state; mutating one doesn't affect the other; an explicitly passed state is used as-is. Verified the isolation tests fail on the old code. `ruff`/`pyright` clean; existing message-manager tests still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure each `MessageManager` gets its own `MessageManagerState` to prevent cross-instance history leaks. Add tests for isolation and explicit state sharing.

- **Bug Fixes**
  - Replaced `state=MessageManagerState()` with `state=None`, creating a fresh `MessageManagerState()` per instance.
  - Kept opt-in sharing when a `state` is explicitly passed; added regression tests to verify isolation and explicit sharing.

<sup>Written for commit 69b9fc6128c6ba0d8035dab65a595f8bd5ab8d72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

