### PR TITLE
Tidy implementation detail in browser-use (#5188)

### DIFF
--- a/browser_use/actor/playground/playground.py
+++ b/browser_use/actor/playground/playground.py
@@ -56,12 +56,12 @@ async def main():
 			// Find all article links on the page
 			const links = Array.from(document.querySelectorAll('a[href*="/wiki/"]:not([href*=":"])'))
 				.filter(link => !link.href.includes('Main_Page') && !link.href.includes('Special:'));
-			
+
 			return {
 				total: links.length,
 				sample: links.slice(0, 3).map(link => ({
 					href: link.href,
-					text: link.textContent.trim() 
+					text: link.textContent.trim()
 				}))
 			};
 		}"""

--- a/browser_use/agent/judge.py
+++ b/browser_use/agent/judge.py
@@ -110,8 +110,8 @@ The ground truth takes ABSOLUTE precedence over all other evaluation criteria. I
 **PRIMARY EVALUATION CRITERIA (in order of importance):**
 1. **Task Satisfaction (Most Important)**: Did the agent accomplish what the user asked for? Break down the task into the key criteria and evaluate if the agent all of them. Focus on user intent and final outcome.
 2. **Output Quality**: Is the final result in the correct format and complete? Does it match exactly what was requested?
-3. **Tool Effectiveness**: Did the browser interactions work as expected? Were tools used appropriately? How many % of the tools failed? 
-4. **Agent Reasoning**: Quality of decision-making, planning, and problem-solving throughout the trajectory. 
+3. **Tool Effectiveness**: Did the browser interactions work as expected? Were tools used appropriately? How many % of the tools failed?
+4. **Agent Reasoning**: Quality of decision-making, planning, and problem-solving throughout the trajectory.
 5. **Browser Handling**: Navigation stability, error recovery, and technical execution. If the browser crashes, does not load or a captcha blocks the task, the score must be very low.
 
 **VERDICT GUIDELINES:**
@@ -133,7 +133,7 @@ The ground truth takes ABSOLUTE precedence over all other evaluation criteria. I
 - If the agent is unable to complete the task because no login information was provided and it is truly needed to complete the task: false
 
 **FAILURE CONDITIONS (automatically set verdict to false):**
-- Blocked by captcha or missing authentication 
+- Blocked by captcha or missing authentication
 - Output format completely wrong or missing
 - Infinite loops or severe technical failures
 - Critical user requirements ignored
@@ -171,7 +171,7 @@ Set `reached_captcha` to true if:
 - **screenshot is not entire content** - The agent has the entire DOM content, but the screenshot is only part of the content. If the agent extracts information from the page, but you do not see it in the screenshot, you can assume this information is there.
 - **Penalize poor tool usage** - Wrong tools, inefficient approaches, ignoring available information.
 - **current date/time is {current_date}** - content with recent dates is real, not fabricated.
-- **IMPORTANT**: be very picky about the user's request - Have very high standard for the agent completing the task exactly to the user's request. 
+- **IMPORTANT**: be very picky about the user's request - Have very high standard for the agent completing the task exactly to the user's request.
 - **IMPORTANT**: be initially doubtful of the agent's self reported success, be sure to verify that its methods are valid and fulfill the user's desires to a tee.
 
 </evaluation_framework>

--- a/browser_use/browser/watchdogs/aboutblank_watchdog.py
+++ b/browser_use/browser/watchdogs/aboutblank_watchdog.py
@@ -146,7 +146,7 @@ class AboutBlankWatchdog(BaseWatchdog):
 						return; // Already running, don't add another
 					}}
 					window.__dvdAnimationRunning = true;
-					
+
 					// Ensure document.body exists before proceeding
 					if (!document.body) {{
 						// Try again after DOM is ready
@@ -156,7 +156,7 @@ class AboutBlankWatchdog(BaseWatchdog):
 						}}
 						return;
 					}}
-					
+
 					const animated_title = `Starting agent ${{browser_session_label}}...`;
 					if (document.title === animated_title) {{
 						return;      // already run on this tab, dont run again

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2810,7 +2810,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 				const role = element.getAttribute('role');
 				const ariaControls = element.getAttribute('aria-controls');
 				const ariaExpanded = element.getAttribute('aria-expanded');
-				
+
 				if (role === 'combobox' && ariaControls) {
 					return {
 						isCombobox: true,
@@ -3069,18 +3069,18 @@ class DefaultActionWatchdog(BaseWatchdog):
 			expand_script = """
 			function() {
 				const element = this;
-				
+
 				// Dispatch focus event properly
 				const focusEvent = new FocusEvent('focus', { bubbles: true, cancelable: true });
 				element.dispatchEvent(focusEvent);
-				
+
 				// Also call native focus
 				element.focus();
-				
+
 				// Dispatch focusin event (bubbles, unlike focus)
 				const focusInEvent = new FocusEvent('focusin', { bubbles: true, cancelable: true });
 				element.dispatchEvent(focusInEvent);
-				
+
 				// For some comboboxes, a click is needed
 				const clickEvent = new MouseEvent('click', {
 					bubbles: true,
@@ -3088,7 +3088,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 					view: window
 				});
 				element.dispatchEvent(clickEvent);
-				
+
 				// Some comboboxes respond to mousedown
 				const mousedownEvent = new MouseEvent('mousedown', {
 					bubbles: true,
@@ -3096,7 +3096,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 					view: window
 				});
 				element.dispatchEvent(mousedownEvent);
-				
+
 				return {
 					success: true,
 					ariaExpanded: element.getAttribute('aria-expanded')
@@ -3117,21 +3117,21 @@ class DefaultActionWatchdog(BaseWatchdog):
 		extract_options_script = """
 		function(ariaControlsId) {
 			const combobox = this;
-			
+
 			// Find the listbox element referenced by aria-controls
 			const listbox = document.getElementById(ariaControlsId);
-			
+
 			if (!listbox) {
 				return {
 					error: `Could not find listbox element with id "${ariaControlsId}" referenced by aria-controls`,
 					ariaControlsId: ariaControlsId
 				};
 			}
-			
+
 			// Find all option elements in the listbox
 			const optionElements = listbox.querySelectorAll('[role="option"]');
 			const options = [];
-			
+
 			optionElements.forEach((item, idx) => {
 				const text = item.textContent ? item.textContent.trim() : '';
 				if (text) {
@@ -3143,7 +3143,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 					});
 				}
 			});
-			
+
 			// If no options with role="option", try other common patterns
 			if (options.length === 0) {
 				// Try li elements inside
@@ -3160,7 +3160,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 					}
 				});
 			}
-			
+
 			return {
 				type: 'aria-combobox',
 				options: options,


### PR DESCRIPTION
I addressed this issue with a small, targeted fix and kept scope limited to the reported area.

Related to #5188.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tidied implementation details by removing stray whitespace and normalizing formatting in embedded JS and prompt strings across `browser_use/browser/watchdogs`, `browser_use/agent/judge.py`, and `browser_use/actor/playground/playground.py`. Keeps formatting consistent and reduces noise in diffs; related to #5188.

<sup>Written for commit a5bce30b9cb2a825624da7cbc64bb06768f44f62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

