### PR TITLE
feat(llm): add Requesty provider

### DIFF
--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.ollama.chat import ChatOllama
 	from browser_use.llm.openai.chat import ChatOpenAI
 	from browser_use.llm.openrouter.chat import ChatOpenRouter
+	from browser_use.llm.requesty.chat import ChatRequesty
 	from browser_use.llm.vercel.chat import ChatVercel
 
 	# Type stubs for model instances - enables IDE autocomplete
@@ -93,6 +94,7 @@ _LAZY_IMPORTS = {
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
 	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
+	'ChatRequesty': ('browser_use.llm.requesty.chat', 'ChatRequesty'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
 }
 
@@ -156,6 +158,7 @@ __all__ = [
 	'ChatOCIRaw',
 	'ChatOllama',
 	'ChatOpenRouter',
+	'ChatRequesty',
 	'ChatVercel',
 	'ChatCerebras',
 ]

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.openai.chat import ChatOpenAI
 	from browser_use.llm.openrouter.chat import ChatOpenRouter
 	from browser_use.llm.orcarouter.chat import ChatOrcaRouter
+	from browser_use.llm.requesty.chat import ChatRequesty
 	from browser_use.llm.vercel.chat import ChatVercel
 
 	# Type stubs for model instances - enables IDE autocomplete
@@ -95,6 +96,7 @@ _LAZY_IMPORTS = {
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
 	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatOrcaRouter': ('browser_use.llm.orcarouter.chat', 'ChatOrcaRouter'),
+	'ChatRequesty': ('browser_use.llm.requesty.chat', 'ChatRequesty'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
 }
 
@@ -159,6 +161,7 @@ __all__ = [
 	'ChatOllama',
 	'ChatOpenRouter',
 	'ChatOrcaRouter',
+	'ChatRequesty',
 	'ChatVercel',
 	'ChatCerebras',
 ]

--- a/browser_use/llm/requesty/__init__.py
+++ b/browser_use/llm/requesty/__init__.py
@@ -1,0 +1,3 @@
+from browser_use.llm.requesty.chat import ChatRequesty
+
+__all__ = ['ChatRequesty']

--- a/browser_use/llm/requesty/chat.py
+++ b/browser_use/llm/requesty/chat.py
@@ -1,0 +1,216 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, TypeVar, overload
+
+import httpx
+from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
+from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.shared_params.response_format_json_schema import (
+	JSONSchema,
+	ResponseFormatJSONSchema,
+)
+from pydantic import BaseModel
+
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.requesty.serializer import RequestyMessageSerializer
+from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
+
+T = TypeVar('T', bound=BaseModel)
+
+
+@dataclass
+class ChatRequesty(BaseChatModel):
+	"""
+	A wrapper around Requesty's chat API, which provides access to various LLM models
+	through a unified OpenAI-compatible interface.
+
+	This class implements the BaseChatModel protocol for Requesty's API.
+	"""
+
+	# Model configuration
+	model: str
+
+	# Model params
+	temperature: float | None = None
+	top_p: float | None = None
+	seed: int | None = None
+
+	# Client initialization parameters
+	api_key: str | None = None
+	http_referer: str | None = None  # Requesty analytics header for tracking
+	x_title: str | None = None  # Requesty analytics header for tracking
+	base_url: str | httpx.URL = 'https://router.requesty.ai/v1'
+	timeout: float | httpx.Timeout | None = None
+	max_retries: int = 10
+	default_headers: Mapping[str, str] | None = None
+	default_query: Mapping[str, object] | None = None
+	http_client: httpx.AsyncClient | None = None
+	_strict_response_validation: bool = False
+	extra_body: dict[str, Any] | None = None
+
+	# Static
+	@property
+	def provider(self) -> str:
+		return 'requesty'
+
+	def _get_client_params(self) -> dict[str, Any]:
+		"""Prepare client parameters dictionary."""
+		# Define base client params
+		base_params = {
+			'api_key': self.api_key,
+			'base_url': self.base_url,
+			'timeout': self.timeout,
+			'max_retries': self.max_retries,
+			'default_headers': self.default_headers,
+			'default_query': self.default_query,
+			'_strict_response_validation': self._strict_response_validation,
+			'top_p': self.top_p,
+			'seed': self.seed,
+		}
+
+		# Create client_params dict with non-None values
+		client_params = {k: v for k, v in base_params.items() if v is not None}
+
+		# Add http_client if provided
+		if self.http_client is not None:
+			client_params['http_client'] = self.http_client
+
+		return client_params
+
+	def get_client(self) -> AsyncOpenAI:
+		"""
+		Returns an AsyncOpenAI client configured for Requesty.
+
+		Returns:
+		    AsyncOpenAI: An instance of the AsyncOpenAI client with Requesty base URL.
+		"""
+		if not hasattr(self, '_client'):
+			client_params = self._get_client_params()
+			self._client = AsyncOpenAI(**client_params)
+		return self._client
+
+	@property
+	def name(self) -> str:
+		return str(self.model)
+
+	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
+		"""Extract usage information from the Requesty response."""
+		if response.usage is None:
+			return None
+
+		prompt_details = getattr(response.usage, 'prompt_tokens_details', None)
+		cached_tokens = prompt_details.cached_tokens if prompt_details else None
+
+		return ChatInvokeUsage(
+			prompt_tokens=response.usage.prompt_tokens,
+			prompt_cached_tokens=cached_tokens,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+			# Completion
+			completion_tokens=response.usage.completion_tokens,
+			total_tokens=response.usage.total_tokens,
+		)
+
+	@overload
+	async def ainvoke(
+		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[str]: ...
+
+	@overload
+	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T], **kwargs: Any) -> ChatInvokeCompletion[T]: ...
+
+	async def ainvoke(
+		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		"""
+		Invoke the model with the given messages through Requesty.
+
+		Args:
+		    messages: List of chat messages
+		    output_format: Optional Pydantic model class for structured output
+
+		Returns:
+		    Either a string response or an instance of output_format
+		"""
+		requesty_messages = RequestyMessageSerializer.serialize_messages(messages)
+
+		# Set up extra headers for Requesty
+		extra_headers = {}
+		if self.http_referer:
+			extra_headers['HTTP-Referer'] = self.http_referer
+		if self.x_title:
+			extra_headers['X-Title'] = self.x_title
+
+		try:
+			if output_format is None:
+				# Return string response
+				response = await self.get_client().chat.completions.create(
+					model=self.model,
+					messages=requesty_messages,
+					temperature=self.temperature,
+					top_p=self.top_p,
+					seed=self.seed,
+					extra_headers=extra_headers,
+					**(self.extra_body or {}),
+				)
+
+				usage = self._get_usage(response)
+				return ChatInvokeCompletion(
+					completion=response.choices[0].message.content or '',
+					usage=usage,
+				)
+
+			else:
+				# Create a JSON schema for structured output
+				schema = SchemaOptimizer.create_optimized_json_schema(output_format)
+
+				response_format_schema: JSONSchema = {
+					'name': 'agent_output',
+					'strict': True,
+					'schema': schema,
+				}
+
+				# Return structured response
+				response = await self.get_client().chat.completions.create(
+					model=self.model,
+					messages=requesty_messages,
+					temperature=self.temperature,
+					top_p=self.top_p,
+					seed=self.seed,
+					response_format=ResponseFormatJSONSchema(
+						json_schema=response_format_schema,
+						type='json_schema',
+					),
+					extra_headers=extra_headers,
+					**(self.extra_body or {}),
+				)
+
+				if response.choices[0].message.content is None:
+					raise ModelProviderError(
+						message='Failed to parse structured output from model response',
+						status_code=500,
+						model=self.name,
+					)
+				usage = self._get_usage(response)
+
+				parsed = output_format.model_validate_json(response.choices[0].message.content)
+
+				return ChatInvokeCompletion(
+					completion=parsed,
+					usage=usage,
+				)
+
+		except RateLimitError as e:
+			raise ModelRateLimitError(message=e.message, model=self.name) from e
+
+		except APIConnectionError as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e
+
+		except APIStatusError as e:
+			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
+
+		except Exception as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/requesty/chat.py
+++ b/browser_use/llm/requesty/chat.py
@@ -1,5 +1,6 @@
+import os
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, TypeVar, overload
 
 import httpx
@@ -39,7 +40,7 @@ class ChatRequesty(BaseChatModel):
 	seed: int | None = None
 
 	# Client initialization parameters
-	api_key: str | None = None
+	api_key: str | None = field(default=None, repr=False)  # hidden from repr to avoid leaking the credential
 	http_referer: str | None = None  # Requesty analytics header for tracking
 	x_title: str | None = None  # Requesty analytics header for tracking
 	base_url: str | httpx.URL = 'https://router.requesty.ai/v1'
@@ -58,9 +59,14 @@ class ChatRequesty(BaseChatModel):
 
 	def _get_client_params(self) -> dict[str, Any]:
 		"""Prepare client parameters dictionary."""
+		# Resolve the API key from the Requesty-specific env var so we never
+		# silently fall through to OPENAI_API_KEY (which the AsyncOpenAI client
+		# would otherwise pick up and send to Requesty's base URL).
+		api_key = self.api_key or os.getenv('REQUESTY_API_KEY')
+
 		# Define base client params
 		base_params = {
-			'api_key': self.api_key,
+			'api_key': api_key,
 			'base_url': self.base_url,
 			'timeout': self.timeout,
 			'max_retries': self.max_retries,
@@ -154,7 +160,7 @@ class ChatRequesty(BaseChatModel):
 					top_p=self.top_p,
 					seed=self.seed,
 					extra_headers=extra_headers,
-					**(self.extra_body or {}),
+					extra_body=self.extra_body,
 				)
 
 				usage = self._get_usage(response)
@@ -185,7 +191,7 @@ class ChatRequesty(BaseChatModel):
 						type='json_schema',
 					),
 					extra_headers=extra_headers,
-					**(self.extra_body or {}),
+					extra_body=self.extra_body,
 				)
 
 				if response.choices[0].message.content is None:
@@ -211,6 +217,11 @@ class ChatRequesty(BaseChatModel):
 
 		except APIStatusError as e:
 			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
+
+		except ModelProviderError:
+			# Re-raise errors we intentionally raised (e.g. structured-output parsing
+			# failures) so their deliberate status_code is preserved.
+			raise
 
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/requesty/chat.py
+++ b/browser_use/llm/requesty/chat.py
@@ -1,5 +1,6 @@
+import os
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, TypeVar, overload
 
 import httpx
@@ -39,7 +40,7 @@ class ChatRequesty(BaseChatModel):
 	seed: int | None = None
 
 	# Client initialization parameters
-	api_key: str | None = None
+	api_key: str | None = field(default=None, repr=False)  # hidden from repr to avoid leaking the credential
 	http_referer: str | None = None  # Requesty analytics header for tracking
 	x_title: str | None = None  # Requesty analytics header for tracking
 	base_url: str | httpx.URL = 'https://router.requesty.ai/v1'
@@ -58,17 +59,26 @@ class ChatRequesty(BaseChatModel):
 
 	def _get_client_params(self) -> dict[str, Any]:
 		"""Prepare client parameters dictionary."""
+		# Resolve the API key from the Requesty-specific env var so we never
+		# silently fall through to OPENAI_API_KEY (which the AsyncOpenAI client
+		# would otherwise pick up and send to Requesty's base URL).
+		api_key = self.api_key or os.getenv('REQUESTY_API_KEY')
+		if not api_key:
+			raise ModelProviderError(
+				message='Missing Requesty API key. Set REQUESTY_API_KEY or pass api_key.',
+				status_code=401,
+				model=self.name,
+			)
+
 		# Define base client params
 		base_params = {
-			'api_key': self.api_key,
+			'api_key': api_key,
 			'base_url': self.base_url,
 			'timeout': self.timeout,
 			'max_retries': self.max_retries,
 			'default_headers': self.default_headers,
 			'default_query': self.default_query,
 			'_strict_response_validation': self._strict_response_validation,
-			'top_p': self.top_p,
-			'seed': self.seed,
 		}
 
 		# Create client_params dict with non-None values
@@ -154,7 +164,7 @@ class ChatRequesty(BaseChatModel):
 					top_p=self.top_p,
 					seed=self.seed,
 					extra_headers=extra_headers,
-					**(self.extra_body or {}),
+					extra_body=self.extra_body,
 				)
 
 				usage = self._get_usage(response)
@@ -185,7 +195,7 @@ class ChatRequesty(BaseChatModel):
 						type='json_schema',
 					),
 					extra_headers=extra_headers,
-					**(self.extra_body or {}),
+					extra_body=self.extra_body,
 				)
 
 				if response.choices[0].message.content is None:
@@ -211,6 +221,11 @@ class ChatRequesty(BaseChatModel):
 
 		except APIStatusError as e:
 			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
+
+		except ModelProviderError:
+			# Re-raise errors we intentionally raised (e.g. structured-output parsing
+			# failures) so their deliberate status_code is preserved.
+			raise
 
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/requesty/serializer.py
+++ b/browser_use/llm/requesty/serializer.py
@@ -1,0 +1,26 @@
+from openai.types.chat import ChatCompletionMessageParam
+
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.openai.serializer import OpenAIMessageSerializer
+
+
+class RequestyMessageSerializer:
+	"""
+	Serializer for converting between custom message types and Requesty message formats.
+
+	Requesty uses the OpenAI-compatible API, so we can reuse the OpenAI serializer.
+	"""
+
+	@staticmethod
+	def serialize_messages(messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
+		"""
+		Serialize a list of browser_use messages to Requesty-compatible messages.
+
+		Args:
+		    messages: List of browser_use messages
+
+		Returns:
+		    List of Requesty-compatible messages (identical to OpenAI format)
+		"""
+		# Requesty uses the same message format as OpenAI
+		return OpenAIMessageSerializer.serialize_messages(messages)

--- a/examples/models/requesty.py
+++ b/examples/models/requesty.py
@@ -1,0 +1,33 @@
+"""
+Simple try of the agent.
+
+@dev You need to add REQUESTY_API_KEY to your environment variables.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from browser_use import Agent
+from browser_use.llm.requesty.chat import ChatRequesty
+
+load_dotenv()
+
+# Requesty uses provider/model naming, same as OpenRouter.
+llm = ChatRequesty(
+	model='openai/gpt-4o-mini',
+	api_key=os.getenv('REQUESTY_API_KEY'),
+)
+agent = Agent(
+	task='Find the number of stars of the browser-use repo',
+	llm=llm,
+	use_vision=False,
+)
+
+
+async def main():
+	await agent.run(max_steps=10)
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds a dedicated `Requesty` LLM provider, mirroring the existing OpenRouter provider (`browser_use/llm/openrouter/`). Requesty is an OpenAI-compatible LLM gateway/router, so the implementation reuses the OpenAI serializer and the `AsyncOpenAI` client, with a fixed base URL and its own env var.

## Changes

- `browser_use/llm/requesty/chat.py`: `ChatRequesty`, a dataclass `BaseChatModel` implementation. Same structure as `ChatOpenRouter`:
  - base URL `https://router.requesty.ai/v1`, API key via `REQUESTY_API_KEY`
  - `provider` returns `"requesty"`
  - `provider/model` naming (e.g. `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`), same convention as OpenRouter
  - optional analytics headers `HTTP-Referer` and `X-Title`
  - supports string and structured (JSON-schema) output, usage extraction
- `browser_use/llm/requesty/serializer.py`: `RequestyMessageSerializer`, delegates to `OpenAIMessageSerializer` (OpenAI-compatible wire format)
- `browser_use/llm/requesty/__init__.py`: exports `ChatRequesty`
- `browser_use/llm/__init__.py`: registers `ChatRequesty` in the lazy-import map, `TYPE_CHECKING` stubs, and `__all__`, exactly like `ChatOpenRouter`
- `examples/models/requesty.py`: example mirroring `examples/models/openrouter.py`

## Notes

- No pricing module was added. OpenRouter's pricing helper (`browser_use/tokens/openrouter_pricing.py`) parses OpenRouter's `/api/v1/models` schema (`pricing.prompt`/`completion` strings, `context_length`, `top_provider`). Requesty's `/v1/models` uses a different shape (`context_window`, `supports_*` booleans, flat per-token prices), so a faithful port would need its own mapper; left out of this PR to keep it focused. Happy to add it as a follow-up if desired.
- No committed provider list / docs file references OpenRouter in the repo, so there was nothing to update there.

## Testing

- `ruff check` and `ruff format --check` pass on the new/changed files.
- `pyright` reports 0 errors on `browser_use/llm/requesty/` and the example.
- Existing `tests/ci/test_openrouter_token_cost.py` still passes (5 passed).
- Live-tested end to end through `ChatRequesty.ainvoke()` against the Requesty router with a real key: a `gpt-4o-mini` chat completion returned the expected content and parsed usage.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `Requesty` LLM provider that mirrors OpenRouter and enables OpenAI-compatible chat via Requesty’s router. Uses `AsyncOpenAI` with base URL `https://router.requesty.ai/v1` and `REQUESTY_API_KEY`.

- **Bug Fixes**
  - Resolve API key from `REQUESTY_API_KEY` only (prevents accidental `OPENAI_API_KEY` use).
  - Pass through `extra_body` to Requesty requests.
  - Improve error mapping: `RateLimitError` -> `ModelRateLimitError`; preserve status codes for `APIStatusError`; better generic error propagation.

- **Migration**
  - Set `REQUESTY_API_KEY` in the environment.
  - Use `ChatRequesty(model='openai/gpt-4o-mini')` and pass it to your `Agent`.

<sup>Written for commit 0e71d9e92b849affbca1f05f14b1c80dd88fc52a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


