### PR TITLE
examples: add DaoXE OpenAI-compatible gateway example

### DIFF
--- a/examples/models/daoxe.py
+++ b/examples/models/daoxe.py
@@ -1,0 +1,42 @@
+"""
+Use DaoXE as an OpenAI-compatible LLM gateway with browser-use.
+
+@dev Set DAOXE_API_KEY in your environment.
+     Copy an exact model ID from your DaoXE account catalog (GET /v1/models).
+     DaoXE is a multi-model multi-protocol gateway (OpenAI Chat Completions /
+     Responses + Anthropic Messages for other clients). Not available in mainland China.
+     Community example from a DaoXE maintainer: https://github.com/seven7763/DaoXE-AI
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from browser_use import Agent, ChatOpenAI
+
+load_dotenv()
+
+api_key = os.getenv('DAOXE_API_KEY', '')
+if not api_key:
+	raise ValueError('DAOXE_API_KEY is not set')
+
+# Prefer a live model ID from your DaoXE account; do not hardcode third-party names.
+model_id = os.getenv('DAOXE_MODEL_ID', 'YOUR_DAOXE_MODEL_ID')
+
+
+async def run_search():
+	agent = Agent(
+		task='Find the number of stars of the browser-use repo on GitHub',
+		llm=ChatOpenAI(
+			base_url='https://daoxe.com/v1',
+			model=model_id,
+			api_key=api_key,
+		),
+		use_vision=False,
+	)
+	await agent.run(max_steps=10)
+
+
+if __name__ == '__main__':
+	asyncio.run(run_search())


### PR DESCRIPTION
## Summary
Adds `examples/models/daoxe.py` showing how to run browser-use against [DaoXE](https://daoxe.com) via `ChatOpenAI` + OpenAI-compatible `base_url`.

## Why
Same pattern as existing `openrouter.py` / `novita.py` / `modelscope_example.py` gateway examples.

## Notes
- Community example from a DaoXE maintainer (disclosed in the file header).
- Base URL: `https://daoxe.com/v1`
- Model ID from env / account catalog (`DAOXE_MODEL_ID`) — no hardcoded vendor model list.
- Not available in mainland China (noted in header).

## Test plan
- [ ] `python examples/models/daoxe.py` with `DAOXE_API_KEY` + a live model ID (optional billed smoke)
- [ ] Example imports match public `browser_use.Agent` / `ChatOpenAI` API

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `examples/models/daoxe.py` to run `browser_use` with DaoXE via OpenAI‑compatible `ChatOpenAI` using a custom `base_url`. Lets you use a DaoXE model with env-configured API key and model ID.

- **New Features**
  - Configure with `DAOXE_API_KEY` and `DAOXE_MODEL_ID`; connects to `https://daoxe.com/v1` via `base_url`.
  - Runs an `Agent` task (max 10 steps, vision off) and fails fast if `DAOXE_API_KEY` is missing; notes DaoXE isn’t available in mainland China.

<sup>Written for commit 2dd511adaaa94421da3155bc0eea01196949055b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

