### PR TITLE
fix(dom): preserve empty accessibility names in ax_node.name checks

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -112,7 +112,7 @@ class DomService:
 				if is_interactive and is_hidden_by_threshold(subtree_root):
 					# Get element text/name
 					text = ''
-					if subtree_root.ax_node and subtree_root.ax_node.name:
+					if subtree_root.ax_node and subtree_root.ax_node.name is not None:
 						text = subtree_root.ax_node.name[:40]
 					elif subtree_root.attributes:
 						text = (

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -850,7 +850,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -878,7 +878,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1024,7 +1024,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_empty_ax_name.py
+++ b/tests/ci/test_empty_ax_name.py
@@ -1,0 +1,56 @@
+"""Tests for empty accessibility name preservation (#5041).
+
+Verifies that ax_node.name="" (explicitly empty ARIA name) is preserved
+as "" rather than collapsed to None by implicit truthiness checks.
+"""
+
+from unittest.mock import MagicMock
+
+from browser_use.dom.views import DOMInteractedElement, EnhancedDOMTreeNode
+
+
+class TestEmptyAxNamePreserved:
+	"""ax_node.name="" should be preserved, not conflated with None."""
+
+	def _make_tree_node(self, ax_name):
+		"""Build a minimal EnhancedDOMTreeNode with a given ax_node.name."""
+		node = MagicMock(spec=EnhancedDOMTreeNode)
+		node.node_id = 1
+		node.backend_node_id = 100
+		node.frame_id = 'frame1'
+		node.node_type = 1
+		node.node_value = None
+		node.node_name = 'button'
+		node.attributes = {'id': 'btn1'}
+		node.parent = None
+		node.children = []
+		node.is_visible = True
+		node.highlight_index = 1
+		node.bounds = None
+
+		if ax_name is None:
+			node.ax_node = None
+		else:
+			ax_node = MagicMock()
+			ax_node.name = ax_name
+			node.ax_node = ax_node
+
+		return node
+
+	def test_empty_string_ax_name_preserved(self):
+		"""aria-label='' should result in ax_name='' not None."""
+		tree_node = self._make_tree_node('')
+		elem = DOMInteractedElement.load_from_enhanced_dom_tree(tree_node)
+		assert elem.ax_name == '', f'Expected empty string, got {elem.ax_name!r}'
+
+	def test_none_ax_node_gives_none(self):
+		"""No ax_node at all should result in ax_name=None."""
+		tree_node = self._make_tree_node(None)
+		elem = DOMInteractedElement.load_from_enhanced_dom_tree(tree_node)
+		assert elem.ax_name is None
+
+	def test_nonempty_ax_name_preserved(self):
+		"""Normal non-empty ax_name should work as before."""
+		tree_node = self._make_tree_node('Submit')
+		elem = DOMInteractedElement.load_from_enhanced_dom_tree(tree_node)
+		assert elem.ax_name == 'Submit'


### PR DESCRIPTION
## Summary

Fixes the implicit truthiness check on `ax_node.name` that treats `""` as `False`, conflating "attribute does not exist" (`None`) with "attribute exists but is intentionally empty" (`""`). Elements with `aria-label=""` are valid in HTML/ARIA and should be preserved.

Closes #5041

## Root cause

`if self.ax_node and self.ax_node.name:` evaluates to `False` when `name` is `""`. This causes `ax_name` to be set to `None` instead of `""` in `load_from_enhanced_dom_tree`, and omits the empty name from element hashes in `element_hash()` and `__hash__()`.

## Fix

Changed all 4 `ax_node.name` truthiness checks to explicit `is not None` comparisons:
- `browser_use/dom/views.py` (3 sites: `element_hash`, `__hash__`, `load_from_enhanced_dom_tree`)
- `browser_use/dom/service.py` (1 site: hidden element text extraction)

## Tests

3 new tests in `tests/ci/test_empty_ax_name.py`:
- Empty string ax_name preserved as `""`
- Missing ax_node gives `None`
- Non-empty ax_name works as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves empty accessibility names (`ax_node.name == ""`) instead of treating them as missing. Fixes stable hashing and hidden-text extraction for elements with `aria-label=""`.

- **Bug Fixes**
  - Replaced truthiness checks with `is not None` for `ax_node.name` in `browser_use/dom/views.py` (`compute_stable_hash`, `__hash__`, `load_from_enhanced_dom_tree`) and `browser_use/dom/service.py` (`collect_hidden_elements`).
  - Added tests to confirm: empty string is preserved, missing `ax_node` yields `None`, and non-empty names behave as before.

<sup>Written for commit aba8bf908e7c1dae242673aaf971b555cb1a7d19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

