### PR TITLE
fix(dom): preserve 'N more options' indicator in select serialization

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -970,7 +970,7 @@ class DOMTreeSerializer:
 						if 'options_count' in child_info and child_info['options_count'] is not None:
 							parts.append(f'count={child_info["options_count"]}')
 						if 'first_options' in child_info and child_info['first_options']:
-							options_str = '|'.join(child_info['first_options'][:4])  # Limit to 4 options
+							options_str = '|'.join(child_info['first_options'][:5])  # Limit to 4 options + indicator
 							parts.append(f'options={options_str}')
 						if 'format_hint' in child_info and child_info['format_hint']:
 							parts.append(f'format={child_info["format_hint"]}')

--- a/tests/ci/test_select_options_indicator.py
+++ b/tests/ci/test_select_options_indicator.py
@@ -1,0 +1,143 @@
+"""
+Test that the '... N more options...' indicator is preserved for <select> elements with >4 options.
+
+This test verifies that:
+1. A select with <=4 options serializes all of them (no indicator).
+2. A select with >4 options includes the '... N more options...' indicator.
+
+Regression test for issue #5195: the indicator was being dropped by a [:4] slice
+in serialize_tree that should have been [:5].
+
+Usage:
+	uv run pytest tests/ci/test_select_options_indicator.py -v -s
+"""
+
+from browser_use.dom.serializer.serializer import DOMTreeSerializer
+from browser_use.dom.views import EnhancedDOMTreeNode, NodeType
+
+
+def _make_node(
+	tag_name: str,
+	node_type: NodeType = NodeType.ELEMENT_NODE,
+	node_value: str = '',
+	attributes: dict | None = None,
+	children: list | None = None,
+) -> EnhancedDOMTreeNode:
+	"""Helper to build a minimal EnhancedDOMTreeNode for testing."""
+	node = EnhancedDOMTreeNode(
+		node_id=0,
+		backend_node_id=0,
+		node_type=node_type,
+		node_name=tag_name,
+		node_value=node_value,
+		attributes=attributes or {},
+		is_scrollable=None,
+		is_visible=None,
+		absolute_position=None,
+		target_id='',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=children or [],
+		ax_node=None,
+		snapshot_node=None,
+	)
+	return node
+
+
+def _make_option(text: str, value: str = '') -> EnhancedDOMTreeNode:
+	"""Build an <option> node with a text child."""
+	text_node = _make_node(
+		tag_name='#text',
+		node_type=NodeType.TEXT_NODE,
+		node_value=text,
+	)
+	option_node = _make_node(
+		tag_name='option',
+		attributes={'value': value} if value else {},
+		children=[text_node],
+	)
+	return option_node
+
+
+def _make_select(option_labels: list[str]) -> EnhancedDOMTreeNode:
+	"""Build a <select> node with the given option labels."""
+	options = [_make_option(label, value=label) for label in option_labels]
+	return _make_node(tag_name='select', children=options)
+
+
+class TestSelectOptionsIndicator:
+	"""Tests for _extract_select_options and the serialize_tree slice."""
+
+	def _get_serializer(self, select_node: EnhancedDOMTreeNode) -> DOMTreeSerializer:
+		"""Create a DOMTreeSerializer with a dummy root node."""
+		root = _make_node(
+			tag_name='html',
+			node_type=NodeType.DOCUMENT_NODE,
+			children=[select_node],
+		)
+		return DOMTreeSerializer(root)
+
+	def test_select_with_4_or_fewer_options_no_indicator(self):
+		"""A <select> with <=4 options should serialize all labels, no indicator."""
+		labels = ['Apple', 'Banana', 'Cherry', 'Date']
+		select_node = _make_select(labels)
+		serializer = self._get_serializer(select_node)
+
+		result = serializer._extract_select_options(select_node)
+
+		assert result is not None
+		assert result['count'] == 4
+		assert result['first_options'] == ['Apple', 'Banana', 'Cherry', 'Date']
+
+	def test_select_with_more_than_4_options_has_indicator(self):
+		"""A <select> with >4 options should include '... N more options...' indicator."""
+		labels = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry', 'Fig']
+		select_node = _make_select(labels)
+		serializer = self._get_serializer(select_node)
+
+		result = serializer._extract_select_options(select_node)
+
+		assert result is not None
+		assert result['count'] == 6
+		assert len(result['first_options']) == 5  # 4 options + 1 indicator
+		assert result['first_options'][:4] == ['Apple', 'Banana', 'Cherry', 'Date']
+		assert result['first_options'][4] == '... 2 more options...'
+
+	def test_serialize_tree_preserves_indicator_in_options_str(self):
+		"""The [:5] slice in serialize_tree must include the indicator element."""
+		# Simulate what serialize_tree does with child_info['first_options']
+		first_options_with_indicator = [
+			'Apple',
+			'Banana',
+			'Cherry',
+			'Date',
+			'... 2 more options...',
+		]
+
+		# This is the fixed line from serialize_tree ([:5] instead of [:4])
+		options_str = '|'.join(first_options_with_indicator[:5])
+
+		assert '... 2 more options...' in options_str
+		assert options_str == 'Apple|Banana|Cherry|Date|... 2 more options...'
+
+	def test_serialize_tree_slice_would_drop_indicator_with_old_limit(self):
+		"""Verify that [:4] would drop the indicator (documenting the bug)."""
+		first_options_with_indicator = [
+			'Apple',
+			'Banana',
+			'Cherry',
+			'Date',
+			'... 2 more options...',
+		]
+
+		# Old buggy behaviour: [:4] drops the indicator
+		old_options_str = '|'.join(first_options_with_indicator[:4])
+		assert '... 2 more options...' not in old_options_str
+
+		# New fixed behaviour: [:5] keeps the indicator
+		new_options_str = '|'.join(first_options_with_indicator[:5])
+		assert '... 2 more options...' in new_options_str


### PR DESCRIPTION
## Summary

Fixes the `<select>` DOM serializer dropping the "... N more options..." indicator for selects with more than 4 options.

Closes #5195

## Root cause

`_extract_select_options` builds `first_options` as up to 4 option labels plus a trailing `"... N more options..."` indicator (5 elements total for >4 options). But `serialize_tree` sliced with `[:4]`, dropping the 5th indicator element.

The model saw `count=6` but only 4 labels with no signal that more options existed.

## Fix

Changed `[:4]` to `[:5]` in `serialize_tree` (line 973 of `serializer.py`) so the indicator is preserved.

**Before:** `options=Apple|Banana|Cherry|Date`
**After:** `options=Apple|Banana|Cherry|Date|... 2 more options...`

## Tests

4 new tests in `tests/ci/test_select_options_indicator.py`:
- Select with <=4 options serializes all without indicator
- Select with >4 options includes the indicator
- serialize_tree preserves indicator in joined string
- Documents that old [:4] bug drops the indicator

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes <select> serialization to preserve the "... N more options..." indicator for lists with >4 options by slicing `first_options` with `[:5]` in `serialize_tree` instead of `[:4]` (closes #5195). Adds tests for <=4 and >4 options and asserts the serialized `options=` string includes the indicator.

<sup>Written for commit fac94e5351f6f59a371ead63fe72530f8317d195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

