### PR TITLE
fix(security): block non-HTTP scheme bypasses when domain restrictions active

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -196,26 +196,37 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
-		if parsed.scheme in ['data', 'blob']:
-			return True
+		# Check if domain restrictions are active
+		has_domain_restrictions = bool(
+			self.browser_session.browser_profile.allowed_domains or self.browser_session.browser_profile.prohibited_domains
+		)
+
+		# When domain restrictions are active, only allow http and https schemes
+		# This prevents bypasses via javascript:, file://, chrome://, data:, blob:, etc.
+		if has_domain_restrictions and parsed.scheme not in ['http', 'https']:
+			return False
 
 		# Get the actual host (domain)
 		host = parsed.hostname
-		if not host:
+
+		# Reject URLs with no hostname (invalid URLs like 'not-a-url', or
+		# schemeless garbage).  data: and blob: legitimately have no host
+		# but are already handled by the scheme check above when domain
+		# restrictions are active, and should pass through when they are not.
+		if not host and parsed.scheme not in ('data', 'blob', 'file'):
 			return False
 
 		# Check if IP addresses should be blocked (before domain checks)
-		if self.browser_session.browser_profile.block_ip_addresses:
+		if host and self.browser_session.browser_profile.block_ip_addresses:
 			if self._is_ip_address(host):
 				return False
 
-		# If no allowed_domains specified, allow all URLs
-		if (
-			not self.browser_session.browser_profile.allowed_domains
-			and not self.browser_session.browser_profile.prohibited_domains
-		):
+		# If no domain restrictions specified, allow all URLs
+		if not has_domain_restrictions:
 			return True
+
+		if not host:
+			return False
 
 		# Check allowed domains (fast path for sets, slow path for lists with patterns)
 		if self.browser_session.browser_profile.allowed_domains:

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -81,11 +81,12 @@ class TestUrlAllowlistSecurity:
 		assert watchdog._is_url_allowed('chrome://google.com') is False
 		assert watchdog._is_url_allowed('chrome://abc.google.com') is False
 
-		# Test browser internal URLs
+		# Non-http/https schemes are blocked when domain restrictions are active
 		assert watchdog._is_url_allowed('chrome://settings') is False
-		assert watchdog._is_url_allowed('chrome://version') is True
+		assert watchdog._is_url_allowed('chrome://version') is False
 		assert watchdog._is_url_allowed('chrome-extension://version/') is False
-		assert watchdog._is_url_allowed('brave://anything/') is True
+		assert watchdog._is_url_allowed('brave://anything/') is False
+		# Internal browser targets are always allowed
 		assert watchdog._is_url_allowed('about:blank') is True
 		assert watchdog._is_url_allowed('chrome://new-tab-page/') is True
 		assert watchdog._is_url_allowed('chrome://new-tab-page') is True
@@ -335,8 +336,8 @@ class TestUrlProhibitlistSecurity:
 		# Allow other domains
 		assert watchdog._is_url_allowed('https://notexample.com') is True
 
-		# Wildcard with domain-only should not apply to non-http(s)
-		assert watchdog._is_url_allowed('chrome://abc.example.com') is True
+		# Non-http/https schemes are blocked when domain restrictions (prohibited_domains) are active
+		assert watchdog._is_url_allowed('chrome://abc.example.com') is False
 
 	def test_full_url_prohibited_patterns(self):
 		"""Full URL patterns block only matching scheme/host/prefix."""
@@ -354,9 +355,9 @@ class TestUrlProhibitlistSecurity:
 		assert watchdog._is_url_allowed('https://wiki.org') is False
 		assert watchdog._is_url_allowed('https://wiki.org/path') is False
 
-		# Internal URL prefix blocking
+		# Non-http/https schemes are all blocked when domain restrictions are active
 		assert watchdog._is_url_allowed('brave://anything/') is False
-		assert watchdog._is_url_allowed('chrome://settings') is True
+		assert watchdog._is_url_allowed('chrome://settings') is False
 
 	def test_internal_urls_allowed_even_when_prohibited(self):
 		"""Internal new-tab/blank URLs are always allowed regardless of prohibited list."""

--- a/tests/ci/security/test_scheme_bypass.py
+++ b/tests/ci/security/test_scheme_bypass.py
@@ -1,0 +1,116 @@
+from browser_use.browser import BrowserProfile, BrowserSession
+
+
+class TestSchemeBypass:
+	"""Tests that non-http/https URL schemes cannot bypass domain restrictions."""
+
+	def _make_watchdog(self, allowed_domains=None, prohibited_domains=None):
+		"""Helper to create a SecurityWatchdog with given domain restrictions."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(
+			allowed_domains=allowed_domains,
+			prohibited_domains=prohibited_domains,
+			headless=True,
+			user_data_dir=None,
+		)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		return SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+	def test_javascript_urls_blocked_with_allowed_domains(self):
+		"""javascript: URLs are blocked when allowed_domains is set."""
+		watchdog = self._make_watchdog(allowed_domains=['example.com'])
+
+		assert watchdog._is_url_allowed('javascript:alert(1)') is False
+		assert watchdog._is_url_allowed('javascript:void(0)') is False
+		assert watchdog._is_url_allowed('javascript:document.cookie') is False
+
+	def test_file_urls_blocked_with_allowed_domains(self):
+		"""file:// URLs are blocked when allowed_domains is set."""
+		watchdog = self._make_watchdog(allowed_domains=['example.com'])
+
+		assert watchdog._is_url_allowed('file:///etc/passwd') is False
+		assert watchdog._is_url_allowed('file:///home/user/.ssh/id_rsa') is False
+		assert watchdog._is_url_allowed('file://localhost/etc/passwd') is False
+
+	def test_chrome_urls_blocked_except_allowlisted(self):
+		"""chrome:// URLs (except the hardcoded internal targets) are blocked."""
+		watchdog = self._make_watchdog(allowed_domains=['example.com'])
+
+		# Non-allowlisted chrome:// URLs should be blocked
+		assert watchdog._is_url_allowed('chrome://settings') is False
+		assert watchdog._is_url_allowed('chrome://flags') is False
+		assert watchdog._is_url_allowed('chrome://version') is False
+		assert watchdog._is_url_allowed('chrome-extension://abc/popup.html') is False
+
+		# Hardcoded internal targets are always allowed
+		assert watchdog._is_url_allowed('chrome://new-tab-page/') is True
+		assert watchdog._is_url_allowed('chrome://new-tab-page') is True
+		assert watchdog._is_url_allowed('chrome://newtab/') is True
+		assert watchdog._is_url_allowed('about:blank') is True
+
+	def test_other_dangerous_schemes_blocked(self):
+		"""Other potentially dangerous schemes are blocked when domain restrictions are active."""
+		watchdog = self._make_watchdog(allowed_domains=['example.com'])
+
+		assert watchdog._is_url_allowed('data:text/html,<script>alert(1)</script>') is False
+		assert watchdog._is_url_allowed('blob:https://example.com/uuid') is False
+		assert watchdog._is_url_allowed('about:config') is False
+		assert watchdog._is_url_allowed('brave://settings') is False
+
+	def test_http_https_urls_work_normally(self):
+		"""http/https URLs still work normally with domain restrictions."""
+		watchdog = self._make_watchdog(allowed_domains=['example.com'])
+
+		# Allowed domain works with both schemes
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('http://example.com') is True
+		assert watchdog._is_url_allowed('https://example.com/path/page') is True
+		assert watchdog._is_url_allowed('https://www.example.com') is True
+
+		# Non-allowed domain is still blocked
+		assert watchdog._is_url_allowed('https://evil.com') is False
+		assert watchdog._is_url_allowed('http://evil.com') is False
+
+	def test_all_schemes_allowed_without_domain_restrictions(self):
+		"""All schemes are allowed when no domain restrictions are configured."""
+		watchdog = self._make_watchdog()
+
+		# http/https
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('http://example.com') is True
+
+		# Internal browser targets
+		assert watchdog._is_url_allowed('about:blank') is True
+		assert watchdog._is_url_allowed('chrome://new-tab-page/') is True
+
+		# data: and blob: URLs
+		assert watchdog._is_url_allowed('data:text/html,hello') is True
+		assert watchdog._is_url_allowed('blob:https://example.com/uuid') is True
+
+		# file:// URLs
+		assert watchdog._is_url_allowed('file:///tmp/test.html') is True
+
+	def test_schemes_blocked_with_prohibited_domains(self):
+		"""Non-http/https schemes are also blocked when prohibited_domains is set."""
+		watchdog = self._make_watchdog(prohibited_domains=['evil.com'])
+
+		# Non-http/https schemes are blocked
+		assert watchdog._is_url_allowed('javascript:alert(1)') is False
+		assert watchdog._is_url_allowed('file:///etc/passwd') is False
+		assert watchdog._is_url_allowed('chrome://settings') is False
+		assert watchdog._is_url_allowed('data:text/html,test') is False
+
+		# http/https still work (non-prohibited domains)
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('http://example.com') is True
+
+		# Prohibited domain is blocked
+		assert watchdog._is_url_allowed('https://evil.com') is False
+
+		# Internal browser targets are still allowed
+		assert watchdog._is_url_allowed('about:blank') is True
+		assert watchdog._is_url_allowed('chrome://new-tab-page/') is True


### PR DESCRIPTION
## Summary

Extends the `allowed_domains`/`prohibited_domains` security boundary to block non-HTTP scheme bypasses. PR #4850 fixed `data:` and `blob:` URLs, but `javascript:`, `file://`, `chrome://`, `chrome-extension://`, and `about:` URLs still bypassed domain restrictions.

Closes #5099

## Root cause

`_is_url_allowed()` explicitly allowed `data:` and `blob:` schemes through, and had no check for other non-HTTP schemes. A malicious page could redirect the agent via `javascript:`, read local files via `file://`, or access internal browser state via `chrome://`.

## Fix

Replaced the `data:`/`blob:` scheme allowlist with an HTTP(S)-only check when domain restrictions are active:
- Internal browser targets (`about:blank`, `chrome://new-tab-page/`, etc.) remain allowlisted at the top
- Non-http/https schemes are blocked when `allowed_domains` or `prohibited_domains` is configured
- When no domain restrictions are set, all schemes are still permitted (preserves existing behavior)

## Tests

7 new tests in `tests/ci/security/test_scheme_bypass.py`:
- `javascript:` URLs blocked with allowed_domains
- `file://` URLs blocked with allowed_domains
- `chrome://` URLs blocked (except allowlisted internals)
- Other dangerous schemes (`data:`, `blob:`, `about:`, `brave:`) blocked
- http/https URLs work normally
- All schemes allowed without domain restrictions
- Scheme blocking works with prohibited_domains

Updated 4 existing assertions in `test_domain_filtering.py` that expected non-http schemes to pass when domain restrictions were active.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks non-HTTP schemes when domain restrictions are active, enforcing http/https-only navigation. Internal targets like `about:blank` and new-tab pages remain allowed; behavior is unchanged when no restrictions are set.

- **Bug Fixes**
  - Replaced the `data:`/`blob:` allowlist with an HTTP(S)-only gate in `_is_url_allowed()` when `allowed_domains` or `prohibited_domains` is set.
  - Blocks `javascript:`, `file://`, `chrome://`, `chrome-extension://`, `about:`, `data:`, `blob:`, and `brave://`; continues to allow `about:blank`, `chrome://new-tab-page/`, and `chrome://newtab/`.
  - Added `tests/ci/security/test_scheme_bypass.py` (7 tests) and updated `tests/ci/security/test_domain_filtering.py` to reflect the new rules, including confirming that all schemes are allowed when no domain restrictions are configured.

<sup>Written for commit b92b37ab5d3e188f6fc3f6ad8bc05c6f99ea5d70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

