### PR TITLE
Add action evidence model

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -92,6 +92,9 @@ class AgentSettings(BaseModel):
 	max_clickable_elements_length: int = 40000  # Max characters for clickable elements in prompt
 
 
+PageDeltaField = Literal['url', 'element_count', 'text']
+
+
 class PageFingerprint(BaseModel):
 	"""Lightweight fingerprint of the browser page state."""
 
@@ -105,6 +108,32 @@ class PageFingerprint(BaseModel):
 	def from_browser_state(url: str, dom_text: str, element_count: int) -> PageFingerprint:
 		text_hash = hashlib.sha256(dom_text.encode('utf-8', errors='replace')).hexdigest()[:16]
 		return PageFingerprint(url=url, element_count=element_count, text_hash=text_hash)
+
+
+def page_fingerprint_delta(before: PageFingerprint, after: PageFingerprint) -> list[PageDeltaField]:
+	"""Return the browser page fields that changed between two fingerprints."""
+	changes: list[PageDeltaField] = []
+	if before.url != after.url:
+		changes.append('url')
+	if before.element_count != after.element_count:
+		changes.append('element_count')
+	if before.text_hash != after.text_hash:
+		changes.append('text')
+	return changes
+
+
+class ActionEvidence(BaseModel):
+	"""Structured evidence about whether an action changed the observed page state."""
+
+	changed: bool
+	changes: list[PageDeltaField] = Field(default_factory=list)
+	before: PageFingerprint | None = None
+	after: PageFingerprint | None = None
+
+	@staticmethod
+	def from_page_fingerprints(before: PageFingerprint, after: PageFingerprint) -> ActionEvidence:
+		changes = page_fingerprint_delta(before, after)
+		return ActionEvidence(changed=bool(changes), changes=changes, before=before, after=after)
 
 
 def _normalize_action_for_hash(action_name: str, params: dict[str, Any]) -> str:
@@ -333,6 +362,9 @@ class ActionResult(BaseModel):
 
 	# Metadata for observability (e.g., click coordinates)
 	metadata: dict | None = None
+
+	# Structured evidence about observed state changes caused by the action
+	evidence: ActionEvidence | None = None
 
 	# Deprecated
 	include_in_memory: bool = False  # whether to include in extracted_content inside long_term_memory

--- a/tests/ci/test_action_loop_detection.py
+++ b/tests/ci/test_action_loop_detection.py
@@ -2,9 +2,12 @@
 
 from browser_use.agent.service import Agent
 from browser_use.agent.views import (
+	ActionEvidence,
 	ActionLoopDetector,
+	ActionResult,
 	PageFingerprint,
 	compute_action_hash,
+	page_fingerprint_delta,
 )
 from browser_use.llm.messages import UserMessage
 from tests.ci.conftest import create_mock_llm
@@ -334,6 +337,53 @@ def test_page_fingerprint_different_element_count_not_equal():
 	fp1 = PageFingerprint.from_browser_state('https://example.com', 'hello world', 50)
 	fp2 = PageFingerprint.from_browser_state('https://example.com', 'hello world', 51)
 	assert fp1 != fp2
+
+
+def test_page_fingerprint_delta_reports_changed_fields():
+	"""Page fingerprint deltas report the specific fields that changed."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'hello world', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/done', 'goodbye world', 51)
+
+	assert page_fingerprint_delta(before, after) == ['url', 'element_count', 'text']
+
+
+def test_action_evidence_from_page_fingerprints_marks_changed():
+	"""ActionEvidence captures before/after fingerprints and changed fields."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'hello world', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/done', 'hello world', 50)
+
+	evidence = ActionEvidence.from_page_fingerprints(before, after)
+
+	assert evidence.changed is True
+	assert evidence.changes == ['url']
+	assert evidence.before == before
+	assert evidence.after == after
+
+
+def test_action_evidence_from_page_fingerprints_marks_unchanged():
+	"""ActionEvidence marks unchanged pages when fingerprints match."""
+	before = PageFingerprint.from_browser_state('https://example.com', 'hello world', 50)
+	after = PageFingerprint.from_browser_state('https://example.com', 'hello world', 50)
+
+	evidence = ActionEvidence.from_page_fingerprints(before, after)
+
+	assert evidence.changed is False
+	assert evidence.changes == []
+
+
+def test_action_result_serializes_action_evidence():
+	"""ActionResult accepts structured evidence without affecting existing metadata."""
+	before = PageFingerprint.from_browser_state('https://example.com', 'before', 10)
+	after = PageFingerprint.from_browser_state('https://example.com', 'after', 10)
+	evidence = ActionEvidence.from_page_fingerprints(before, after)
+
+	result = ActionResult(metadata={'click_x': 1}, evidence=evidence)
+	data = result.model_dump()
+
+	assert data['metadata'] == {'click_x': 1}
+	assert data['evidence']['changed'] is True
+	assert data['evidence']['changes'] == ['text']
+	assert data['evidence']['before']['url'] == 'https://example.com'
 
 
 # ─── Agent integration tests ─────────────────────────────────────────────────


### PR DESCRIPTION
# PR Draft: Add action evidence model

## Branch

`add-action-evidence-model`

## Title

Add action evidence model

## Body

## Summary

Adds the first small building block requested in #5137 for typed action outcome evidence:

- introduces `ActionEvidence` for structured before/after page-change evidence
- adds `page_fingerprint_delta()` to report which page fingerprint fields changed
- exposes optional `ActionResult.evidence` without changing existing action execution behavior
- adds regression coverage for changed/unchanged page evidence and serialization

This intentionally keeps the PR scoped to the schema/helper foundation. Follow-up PRs can populate `ActionResult.evidence` from concrete actions such as click/input/navigation.

Fixes part of #5137.

## Tests

- `.venv/bin/python -m pytest tests/ci/test_action_loop_detection.py`
- `UV_CACHE_DIR=/private/tmp/browser-use-uv-cache /Users/zyb/.local/bin/uv run --no-sync pyright`
- `.venv/bin/pre-commit run --files browser_use/agent/views.py tests/ci/test_action_loop_detection.py --show-diff-on-failure`

## Local Push Commands

Remote `main` was observed at `c9206829c1cefb049cec7335abd764da6d43a11c`, but this environment could not `git fetch` because DNS/network access was blocked. Before pushing, run:

```bash
cd /Users/zyb/Documents/Codex/2026-07-09/browser-agent/work/browser-use
git fetch origin main
git rebase origin/main
git push fork add-action-evidence-model
```

Then open:

```bash
https://github.com/browser-use/browser-use/compare/main...lisa0314:browser-use:add-action-evidence-model?expand=1
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add structured action outcome evidence with `ActionEvidence` and a `page_fingerprint_delta()` helper, and expose optional `ActionResult.evidence`. This sets the schema foundation for typed action evidence requested in #5137 without changing current behavior.

- **New Features**
  - Added `ActionEvidence` with before/after `PageFingerprint`, `changed`, and `changes`.
  - Added `page_fingerprint_delta(before, after)` to list changed fields.
  - Added optional `ActionResult.evidence`.
  - Added tests for deltas, unchanged/changed cases, and serialization.

<sup>Written for commit c94ef2a54f05990de4df43253477a7e4722206dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

