### PR TITLE
Add action evidence model

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -92,6 +92,9 @@ class AgentSettings(BaseModel):
 	max_clickable_elements_length: int = 40000  # Max characters for clickable elements in prompt
 
 
+PageDeltaField = Literal['url', 'element_count', 'text']
+
+
 class PageFingerprint(BaseModel):
 	"""Lightweight fingerprint of the browser page state."""
 
@@ -105,6 +108,32 @@ class PageFingerprint(BaseModel):
 	def from_browser_state(url: str, dom_text: str, element_count: int) -> PageFingerprint:
 		text_hash = hashlib.sha256(dom_text.encode('utf-8', errors='replace')).hexdigest()[:16]
 		return PageFingerprint(url=url, element_count=element_count, text_hash=text_hash)
+
+
+def page_fingerprint_delta(before: PageFingerprint, after: PageFingerprint) -> list[PageDeltaField]:
+	"""Return the browser page fields that changed between two fingerprints."""
+	changes: list[PageDeltaField] = []
+	if before.url != after.url:
+		changes.append('url')
+	if before.element_count != after.element_count:
+		changes.append('element_count')
+	if before.text_hash != after.text_hash:
+		changes.append('text')
+	return changes
+
+
+class ActionEvidence(BaseModel):
+	"""Structured evidence about whether an action changed the observed page state."""
+
+	changed: bool
+	changes: list[PageDeltaField] = Field(default_factory=list)
+	before: PageFingerprint | None = None
+	after: PageFingerprint | None = None
+
+	@staticmethod
+	def from_page_fingerprints(before: PageFingerprint, after: PageFingerprint) -> ActionEvidence:
+		changes = page_fingerprint_delta(before, after)
+		return ActionEvidence(changed=bool(changes), changes=changes, before=before, after=after)
 
 
 def _normalize_action_for_hash(action_name: str, params: dict[str, Any]) -> str:
@@ -333,6 +362,9 @@ class ActionResult(BaseModel):
 
 	# Metadata for observability (e.g., click coordinates)
 	metadata: dict | None = None
+
+	# Structured evidence about observed state changes caused by the action
+	evidence: ActionEvidence | None = None
 
 	# Deprecated
 	include_in_memory: bool = False  # whether to include in extracted_content inside long_term_memory

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -130,6 +130,12 @@ class ActionEvidence(BaseModel):
 	before: PageFingerprint | None = None
 	after: PageFingerprint | None = None
 
+	@model_validator(mode='after')
+	def validate_changed_matches_changes(self) -> ActionEvidence:
+		if self.changed != bool(self.changes):
+			raise ValueError('changed must match whether changes contains any page deltas')
+		return self
+
 	@staticmethod
 	def from_page_fingerprints(before: PageFingerprint, after: PageFingerprint) -> ActionEvidence:
 		changes = page_fingerprint_delta(before, after)

--- a/tests/ci/test_action_loop_detection.py
+++ b/tests/ci/test_action_loop_detection.py
@@ -2,9 +2,12 @@
 
 from browser_use.agent.service import Agent
 from browser_use.agent.views import (
+	ActionEvidence,
 	ActionLoopDetector,
+	ActionResult,
 	PageFingerprint,
 	compute_action_hash,
+	page_fingerprint_delta,
 )
 from browser_use.llm.messages import UserMessage
 from tests.ci.conftest import create_mock_llm
@@ -334,6 +337,53 @@ def test_page_fingerprint_different_element_count_not_equal():
 	fp1 = PageFingerprint.from_browser_state('https://example.com', 'hello world', 50)
 	fp2 = PageFingerprint.from_browser_state('https://example.com', 'hello world', 51)
 	assert fp1 != fp2
+
+
+def test_page_fingerprint_delta_reports_changed_fields():
+	"""Page fingerprint deltas report the specific fields that changed."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'hello world', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/done', 'goodbye world', 51)
+
+	assert page_fingerprint_delta(before, after) == ['url', 'element_count', 'text']
+
+
+def test_action_evidence_from_page_fingerprints_marks_changed():
+	"""ActionEvidence captures before/after fingerprints and changed fields."""
+	before = PageFingerprint.from_browser_state('https://example.com/start', 'hello world', 50)
+	after = PageFingerprint.from_browser_state('https://example.com/done', 'hello world', 50)
+
+	evidence = ActionEvidence.from_page_fingerprints(before, after)
+
+	assert evidence.changed is True
+	assert evidence.changes == ['url']
+	assert evidence.before == before
+	assert evidence.after == after
+
+
+def test_action_evidence_from_page_fingerprints_marks_unchanged():
+	"""ActionEvidence marks unchanged pages when fingerprints match."""
+	before = PageFingerprint.from_browser_state('https://example.com', 'hello world', 50)
+	after = PageFingerprint.from_browser_state('https://example.com', 'hello world', 50)
+
+	evidence = ActionEvidence.from_page_fingerprints(before, after)
+
+	assert evidence.changed is False
+	assert evidence.changes == []
+
+
+def test_action_result_serializes_action_evidence():
+	"""ActionResult accepts structured evidence without affecting existing metadata."""
+	before = PageFingerprint.from_browser_state('https://example.com', 'before', 10)
+	after = PageFingerprint.from_browser_state('https://example.com', 'after', 10)
+	evidence = ActionEvidence.from_page_fingerprints(before, after)
+
+	result = ActionResult(metadata={'click_x': 1}, evidence=evidence)
+	data = result.model_dump()
+
+	assert data['metadata'] == {'click_x': 1}
+	assert data['evidence']['changed'] is True
+	assert data['evidence']['changes'] == ['text']
+	assert data['evidence']['before']['url'] == 'https://example.com'
 
 
 # ─── Agent integration tests ─────────────────────────────────────────────────

--- a/tests/ci/test_action_loop_detection.py
+++ b/tests/ci/test_action_loop_detection.py
@@ -1,5 +1,7 @@
 """Tests for action loop detection — behavioral cycle breaking (PR #4)."""
 
+import pytest
+
 from browser_use.agent.service import Agent
 from browser_use.agent.views import (
 	ActionEvidence,
@@ -369,6 +371,15 @@ def test_action_evidence_from_page_fingerprints_marks_unchanged():
 
 	assert evidence.changed is False
 	assert evidence.changes == []
+
+
+def test_action_evidence_rejects_inconsistent_change_state():
+	"""ActionEvidence cannot carry contradictory change state."""
+	with pytest.raises(ValueError, match='changed must match whether changes contains any page deltas'):
+		ActionEvidence(changed=False, changes=['url'])
+
+	with pytest.raises(ValueError, match='changed must match whether changes contains any page deltas'):
+		ActionEvidence(changed=True, changes=[])
 
 
 def test_action_result_serializes_action_evidence():


### PR DESCRIPTION
## Summary

This PR adds a small, typed foundation for recording whether an action changed the observed page state.

- Adds `ActionEvidence`, a structured model for before/after page-change evidence.
- Adds `page_fingerprint_delta()` to report which `PageFingerprint` fields changed.
- Adds optional `ActionResult.evidence` so future action implementations can attach evidence without changing the existing metadata path.
- Adds unit coverage for changed/unchanged evidence creation and serialization through `ActionResult`.

## Motivation

Issue #5137 proposes making action outcomes easier to inspect and reason about. The current `ActionResult.metadata` field is useful for ad-hoc observability data, but it does not provide a typed place for page-change evidence.

This PR intentionally keeps the first step narrow: it introduces the model and helper needed to represent that evidence, without changing the current action execution flow. Follow-up PRs can populate `ActionResult.evidence` from concrete actions such as click, input, and navigation.

Refs #5137.

## Testing

- `.venv/bin/python -m pytest tests/ci/test_action_loop_detection.py`
- `UV_CACHE_DIR=/private/tmp/browser-use-uv-cache /Users/zyb/.local/bin/uv run --no-sync pyright`
- `.venv/bin/pre-commit run --all-files --show-diff-on-failure`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `ActionEvidence` and `page_fingerprint_delta()` to capture whether an action changed the observed page state. Add `ActionResult.evidence` and enforce that `changed` matches the provided deltas, without affecting existing `metadata` (addresses #5137).

- **New Features**
  - Add `ActionEvidence` with `from_page_fingerprints()` for before/after evidence and a validator that enforces `changed` matches `changes`.
  - Add `page_fingerprint_delta()` to report changed `PageFingerprint` fields (`url`, `element_count`, `text`).
  - Add `ActionResult.evidence` to carry evidence alongside `metadata`; tests cover deltas, evidence creation/validation, and serialization.

<sup>Written for commit fb6085bfb9f5a00e23c205b2b3f7a80bea36b25a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

