### PR TITLE
Preserve empty accessibility names in load_from_enhanced_dom_tree

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -75,9 +75,30 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 
 def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
 	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
-	for key, secret in sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True):
-		value = value.replace(secret, f'<secret>{key}</secret>')
-	return value
+	sensitive_values_sorted = sorted(
+		((key, secret) for key, secret in sensitive_values.items() if secret),
+		key=lambda item: len(item[1]),
+		reverse=True,
+	)
+	if not sensitive_values_sorted:
+		return value
+
+	pattern_parts = []
+	group_name_map: dict[str, str] = {}
+	for index, (key, secret) in enumerate(sensitive_values_sorted):
+		group_name = f's{index}'  # placeholder for regex group names
+		pattern_parts.append(f'(?P<{group_name}>{re.escape(secret)})')
+		group_name_map[group_name] = key
+
+	pattern = re.compile('|'.join(pattern_parts))
+
+	def replace_match(match: re.Match[str]) -> str:
+		group_name = match.lastgroup
+		if not group_name:
+			return match.group(0)
+		return f'<secret>{group_name_map[group_name]}</secret>'
+
+	return pattern.sub(replace_match, value)
 
 
 def _get_openai_bad_request_error() -> type | None:

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -83,22 +83,30 @@ def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str
 	if not sensitive_values_sorted:
 		return value
 
-	pattern_parts = []
-	group_name_map: dict[str, str] = {}
-	for index, (key, secret) in enumerate(sensitive_values_sorted):
-		group_name = f's{index}'  # placeholder for regex group names
-		pattern_parts.append(f'(?P<{group_name}>{re.escape(secret)})')
-		group_name_map[group_name] = key
+	matches: list[tuple[int, int, str]] = []
+	occupied: list[tuple[int, int]] = []
 
-	pattern = re.compile('|'.join(pattern_parts))
+	for key, secret in sensitive_values_sorted:
+		for match in re.finditer(re.escape(secret), value):
+			start, end = match.span()
+			overlaps_existing = any(start < o_end and o_start < end for o_start, o_end in occupied)
+			if not overlaps_existing:
+				matches.append((start, end, key))
+				occupied.append((start, end))
 
-	def replace_match(match: re.Match[str]) -> str:
-		group_name = match.lastgroup
-		if not group_name:
-			return match.group(0)
-		return f'<secret>{group_name_map[group_name]}</secret>'
+	if not matches:
+		return value
 
-	return pattern.sub(replace_match, value)
+	matches.sort(key=lambda item: item[0])
+	parts = []
+	last_index = 0
+	for start, end, key in matches:
+		parts.append(value[last_index:start])
+		parts.append(f'<secret>{key}</secret>')
+		last_index = end
+	parts.append(value[last_index:])
+
+	return ''.join(parts)
 
 
 def _get_openai_bad_request_error() -> type | None:

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -84,15 +84,16 @@ def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str
 		return value
 
 	matches: list[tuple[int, int, str]] = []
-	occupied: list[tuple[int, int]] = []
+	# A byte per input character keeps overlap checks bounded by the candidate
+	# match rather than by every previously found match.
+	occupied = bytearray(len(value))
 
 	for key, secret in sensitive_values_sorted:
 		for match in re.finditer(re.escape(secret), value):
 			start, end = match.span()
-			overlaps_existing = any(start < o_end and o_start < end for o_start, o_end in occupied)
-			if not overlaps_existing:
+			if not any(occupied[start:end]):
 				matches.append((start, end, key))
-				occupied.append((start, end))
+				occupied[start:end] = b'\x01' * (end - start)
 
 	if not matches:
 		return value

--- a/tests/ci/test_ax_name_matching.py
+++ b/tests/ci/test_ax_name_matching.py
@@ -14,7 +14,14 @@ from unittest.mock import AsyncMock
 from browser_use.agent.service import Agent
 from browser_use.agent.views import ActionResult, AgentHistory, AgentHistoryList, RerunSummaryAction, StepMetadata
 from browser_use.browser.views import BrowserStateHistory
-from browser_use.dom.views import DOMInteractedElement, DOMRect, MatchLevel, NodeType
+from browser_use.dom.views import (
+	DOMInteractedElement,
+	DOMRect,
+	EnhancedAXNode,
+	EnhancedDOMTreeNode,
+	MatchLevel,
+	NodeType,
+)
 from tests.ci.conftest import create_mock_llm
 
 
@@ -556,3 +563,41 @@ def test_is_menu_item_element_returns_false_for_regular_element():
 	)
 
 	assert agent._is_menu_item_element(regular_element) is False
+
+
+def test_load_from_enhanced_dom_tree_preserves_empty_ax_name():
+	"""Test that an explicit empty accessibility name is preserved as empty string."""
+	ax_node = EnhancedAXNode(
+		ax_node_id='ax-1',
+		ignored=False,
+		role='generic',
+		name='',
+		description=None,
+		properties=None,
+		child_ids=None,
+	)
+	enhanced_tree = EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='DIV',
+		node_value='',
+		attributes={},
+		is_scrollable=None,
+		is_visible=None,
+		absolute_position=None,
+		target_id='test-target',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=None,
+	)
+
+	interacted = DOMInteractedElement.load_from_enhanced_dom_tree(enhanced_tree)
+
+	assert interacted.ax_name == ''

--- a/tests/ci/test_utils.py
+++ b/tests/ci/test_utils.py
@@ -20,3 +20,13 @@ def test_redact_sensitive_string_preserves_shorter_matches():
 
 	# `sec` shouldn't corrupt already-redacted `<secret>outer</secret>` fragments
 	assert redact_sensitive_string(value, sensitive_values) == 'open nested <secret>outer</secret> <secret>outer</secret> code'
+
+
+def test_redact_sensitive_string_prefers_longer_overlapping_secret():
+	value = 'abcde'
+	sensitive_values = {
+		'short': 'abc',
+		'long': 'bcde',
+	}
+
+	assert redact_sensitive_string(value, sensitive_values) == 'a<secret>long</secret>'

--- a/tests/ci/test_utils.py
+++ b/tests/ci/test_utils.py
@@ -1,0 +1,22 @@
+from browser_use.utils import redact_sensitive_string
+
+
+def test_redact_sensitive_string_preserves_empty_string_value():
+	value = 'leaked supersecret token'
+	sensitive_values = {
+		'password': 'supersecret',
+		'type': 'secret',
+	}
+
+	assert redact_sensitive_string(value, sensitive_values) == 'leaked <secret>password</secret> token'
+
+
+def test_redact_sensitive_string_preserves_shorter_matches():
+	value = 'open nested secret secret code'
+	sensitive_values = {
+		'outer': 'secret',
+		'inner': 'sec',
+	}
+
+	# `sec` shouldn't corrupt already-redacted `<secret>outer</secret>` fragments
+	assert redact_sensitive_string(value, sensitive_values) == 'open nested <secret>outer</secret> <secret>outer</secret> code'

--- a/tests/ci/test_utils.py
+++ b/tests/ci/test_utils.py
@@ -1,7 +1,7 @@
 from browser_use.utils import redact_sensitive_string
 
 
-def test_redact_sensitive_string_preserves_empty_string_value():
+def test_redact_sensitive_string_prefers_longer_match_over_substring():
 	value = 'leaked supersecret token'
 	sensitive_values = {
 		'password': 'supersecret',
@@ -9,6 +9,13 @@ def test_redact_sensitive_string_preserves_empty_string_value():
 	}
 
 	assert redact_sensitive_string(value, sensitive_values) == 'leaked <secret>password</secret> token'
+
+
+def test_redact_sensitive_string_ignores_empty_secret_values():
+	value = 'safe value'
+	sensitive_values = {'empty': ''}
+
+	assert redact_sensitive_string(value, sensitive_values) == value
 
 
 def test_redact_sensitive_string_preserves_shorter_matches():


### PR DESCRIPTION
Supersedes #5207 after restoring the source branch. Preserves explicit empty accessibility names and adds focused regression coverage for DOM loading and sensitive-string redaction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves explicit empty accessibility names when loading `DOMInteractedElement` and rewrites `redact_sensitive_string` to use longest-first, non-overlapping redaction to avoid cascades and partial leaks.

- **Bug Fixes**
  - DOM: Treat `ax_node.name == ''` as a valid value in `load_from_enhanced_dom_tree` so empty accessibility names are kept.
  - Utils: Reimplemented `redact_sensitive_string` to select longest, non-overlapping matches in one pass and skip empty secrets, preventing partial overlaps and cascade effects.

<sup>Written for commit ed1371118017eedced2cb6f3f31684f513437c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

