### PR TITLE
docs(examples): add browser-use-proxyhat to community integrations

### DIFF
--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -28,3 +28,5 @@ Add entries in this format:
 ```markdown
 - [Project name](https://github.com/org/project) - One sentence about what it integrates with. Maintained by @github-handle.
 ```
+
+- [browser-use-proxyhat](https://github.com/ProxyHatCom/browser-use-proxyhat) - Routes browser-use agents through ProxyHat residential proxies via the `proxy=` BrowserSession option, with sticky per-session IPs and geo-targeting. Maintained by @ProxyHatCom.


### PR DESCRIPTION
Adds `browser-use-proxyhat` to the Community integrations list in `examples/integrations/README.md`. It's a published PyPI package that plugs a residential proxy provider into any browser-use agent through the existing `proxy=` BrowserSession option — no fork, no boilerplate. Listed as a pointer per the guidelines (not vendored).

Disclosure: I maintain ProxyHat; the integration itself is open source (MIT) at ProxyHatCom/browser-use-proxyhat.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `browser-use-proxyhat` to the community integrations list. This links to a PyPI package that routes `browser-use` agents through ProxyHat residential proxies via the `proxy=` BrowserSession option, with sticky session IPs and geo-targeting.

<sup>Written for commit 8920900618d14f17a8843b463691d577c65668e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

