### PR TITLE
fix(browser): prevent stale sessions during target attach/detach races

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -46,6 +46,12 @@ class SessionManager:
 		# Reverse mapping: session -> target it belongs to
 		self._session_to_target: dict[SessionID, TargetID] = {}
 
+		# Event callbacks schedule attach/detach work as separate tasks. Track only
+		# in-flight attaches so a detach received before its attach task runs can
+		# cancel registration without retaining arbitrary unknown session IDs.
+		self._pending_attach_session_ids: set[SessionID] = set()
+		self._detached_pending_attach_session_ids: set[SessionID] = set()
+
 		# Page lifecycle events per target, fed by ONE global Page.lifecycleEvent handler
 		# registered in start_monitoring(). cdp-use's event registry is single-slot per
 		# CDP method, so per-session handler registrations would replace each other and
@@ -80,6 +86,8 @@ class SessionManager:
 
 		# Register synchronous event handlers (CDP requirement)
 		def on_attached(event: AttachedToTargetEvent, session_id: SessionID | None = None):
+			attached_session_id = event['sessionId']
+			self._pending_attach_session_ids.add(attached_session_id)
 			# _handle_target_attached() handles:
 			# - setAutoAttach for children
 			# - Create CDPSession
@@ -93,8 +101,12 @@ class SessionManager:
 			)
 
 		def on_detached(event: DetachedFromTargetEvent, session_id: SessionID | None = None):
+			detached_session_id = event['sessionId']
+			attach_was_pending = detached_session_id in self._pending_attach_session_ids
+			if attach_was_pending:
+				self._detached_pending_attach_session_ids.add(detached_session_id)
 			create_task_with_error_handling(
-				self._handle_target_detached(event),
+				self._handle_target_detached(event, attach_was_pending=attach_was_pending),
 				name='handle_target_detached',
 				logger_instance=self.logger,
 				suppress_exceptions=True,
@@ -213,6 +225,8 @@ class SessionManager:
 			self._sessions.clear()
 			self._target_sessions.clear()
 			self._session_to_target.clear()
+			self._pending_attach_session_ids.clear()
+			self._detached_pending_attach_session_ids.clear()
 
 		self.logger.info('[SessionManager] Cleared all owned data (targets, sessions, mappings)')
 
@@ -410,6 +424,7 @@ class SessionManager:
 		target_type = event['targetInfo']['type']
 		target_info = event['targetInfo']
 		waiting_for_debugger = event.get('waitingForDebugger', False)
+		self._pending_attach_session_ids.add(session_id)
 
 		self.logger.debug(
 			f'[SessionManager] Target attached: {target_id[:8]}... (session={session_id[:8]}..., '
@@ -418,25 +433,33 @@ class SessionManager:
 
 		# Defensive check: browser may be shutting down and _cdp_client_root could be None
 		if self.browser_session._cdp_client_root is None:
+			self._pending_attach_session_ids.discard(session_id)
+			self._detached_pending_attach_session_ids.discard(session_id)
 			self.logger.debug(
 				f'[SessionManager] Skipping target attach for {target_id[:8]}... - browser shutting down (no CDP client)'
 			)
 			return
 
-		# Enable auto-attach for this session's children (do this FIRST, outside lock)
-		try:
-			await self.browser_session._cdp_client_root.send.Target.setAutoAttach(
-				params={'autoAttach': True, 'waitForDebuggerOnStart': False, 'flatten': True}, session_id=session_id
-			)
-		except Exception as e:
-			error_str = str(e)
-			# Expected for short-lived targets (workers, temp iframes) that detach before this executes
-			if '-32001' not in error_str and 'Session with given id not found' not in error_str:
-				self.logger.debug(f'[SessionManager] Auto-attach failed for {target_type}: {e}')
+		from browser_use.browser.session import CDPSession, Target
 
-		from browser_use.browser.session import Target
+		assert self.browser_session._cdp_client_root is not None, 'Root CDP client required'
+		cdp_session = CDPSession(
+			cdp_client=self.browser_session._cdp_client_root,
+			target_id=target_id,
+			session_id=session_id,
+		)
 
 		async with self._lock:
+			self._pending_attach_session_ids.discard(session_id)
+			if session_id in self._detached_pending_attach_session_ids:
+				self._detached_pending_attach_session_ids.discard(session_id)
+				self.logger.debug(f'[SessionManager] Ignoring late attach for detached session {session_id[:8]}...')
+				return
+
+			if session_id in self._sessions:
+				self.logger.debug(f'[SessionManager] Ignoring duplicate attach for session {session_id[:8]}...')
+				return
+
 			# Track this session for the target
 			if target_id not in self._target_sessions:
 				self._target_sessions[target_id] = set()
@@ -461,19 +484,25 @@ class SessionManager:
 				existing_target.url = target_info.get('url', existing_target.url)
 				existing_target.title = target_info.get('title', existing_target.title)
 
-		# Create CDPSession (communication channel)
-		from browser_use.browser.session import CDPSession
+			# Publish the session and every mapping atomically before the first CDP
+			# await, so a concurrent detach can remove a complete state entry.
+			self._sessions[session_id] = cdp_session
 
-		assert self.browser_session._cdp_client_root is not None, 'Root CDP client required'
+		# Enable auto-attach for this session's children after registration.
+		try:
+			await self.browser_session._cdp_client_root.send.Target.setAutoAttach(
+				params={'autoAttach': True, 'waitForDebuggerOnStart': False, 'flatten': True}, session_id=session_id
+			)
+		except Exception as e:
+			error_str = str(e)
+			# Expected for short-lived targets (workers, temp iframes) that detach before this executes
+			if '-32001' not in error_str and 'Session with given id not found' not in error_str:
+				self.logger.debug(f'[SessionManager] Auto-attach failed for {target_type}: {e}')
 
-		cdp_session = CDPSession(
-			cdp_client=self.browser_session._cdp_client_root,
-			target_id=target_id,
-			session_id=session_id,
-		)
-
-		# Add to sessions dict
-		self._sessions[session_id] = cdp_session
+		# The target may detach while setAutoAttach is in flight.
+		if self._sessions.get(session_id) is not cdp_session:
+			self.logger.debug(f'[SessionManager] Session {session_id[:8]}... detached during initialization')
+			return
 
 		# If proxy auth is configured, enable Fetch auth handling on this session
 		# Avoids overwriting Target.attachedToTarget handlers elsewhere
@@ -527,7 +556,7 @@ class SessionManager:
 				target.title = target_info.get('title', target.title)
 				target.url = target_info.get('url', target.url)
 
-	async def _handle_target_detached(self, event: DetachedFromTargetEvent) -> None:
+	async def _handle_target_detached(self, event: DetachedFromTargetEvent, *, attach_was_pending: bool = False) -> None:
 		"""Handle Target.detachedFromTarget event.
 
 		Called automatically by Chrome when a target/session is destroyed.
@@ -536,20 +565,27 @@ class SessionManager:
 		session_id = event['sessionId']
 		target_id = event.get('targetId')  # May be empty
 
-		# If targetId not in event, look it up via session mapping
-		if not target_id:
-			async with self._lock:
-				target_id = self._session_to_target.get(session_id)
-
-		if not target_id:
-			self.logger.warning(f'[SessionManager] Session detached but target unknown (session={session_id[:8]}...)')
-			return
-
 		agent_focus_lost = False
 		target_fully_removed = False
 		target_type = None
 
 		async with self._lock:
+			mapped_target_id = self._session_to_target.get(session_id)
+			if mapped_target_id is None and session_id not in self._sessions:
+				is_attach_pending = session_id in self._pending_attach_session_ids
+				if is_attach_pending:
+					self._detached_pending_attach_session_ids.add(session_id)
+				if attach_was_pending or is_attach_pending:
+					self.logger.debug(f'[SessionManager] Detach arrived before attach registration (session={session_id[:8]}...)')
+				else:
+					self.logger.warning(f'[SessionManager] Session detached but target unknown (session={session_id[:8]}...)')
+				return
+
+			target_id = target_id or mapped_target_id
+			if not target_id:
+				self.logger.warning(f'[SessionManager] Session detached but target unknown (session={session_id[:8]}...)')
+				return
+
 			# Remove this session from target's session set
 			if target_id in self._target_sessions:
 				self._target_sessions[target_id].discard(session_id)

--- a/tests/ci/browser/test_session_manager.py
+++ b/tests/ci/browser/test_session_manager.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Coroutine
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+from cdp_use import CDPClient
+from cdp_use.cdp.target import AttachedToTargetEvent, DetachedFromTargetEvent
+
+import browser_use.browser.session_manager as session_manager_module
+from browser_use.browser import BrowserSession
+from browser_use.browser.session_manager import SessionManager
+
+
+def _attached_event() -> AttachedToTargetEvent:
+	return cast(
+		AttachedToTargetEvent,
+		{
+			'sessionId': 'session-id',
+			'targetInfo': {
+				'targetId': 'iframe-target-id',
+				'type': 'iframe',
+				'url': 'https://iframe.example',
+				'title': 'Iframe',
+			},
+			'waitingForDebugger': False,
+		},
+	)
+
+
+def _detached_event() -> DetachedFromTargetEvent:
+	return cast(DetachedFromTargetEvent, {'sessionId': 'session-id'})
+
+
+async def test_detach_during_auto_attach_does_not_leave_stale_session() -> None:
+	set_auto_attach_started = asyncio.Event()
+	release_set_auto_attach = asyncio.Event()
+
+	async def block_set_auto_attach(*args: Any, **kwargs: Any) -> None:
+		del args, kwargs
+		set_auto_attach_started.set()
+		await release_set_auto_attach.wait()
+
+	root_client = CDPClient('ws://unused')
+	root_client.send.Target.setAutoAttach = AsyncMock(side_effect=block_set_auto_attach)
+	browser_session = BrowserSession()
+	browser_session._cdp_client_root = root_client
+	manager = SessionManager(browser_session)
+
+	attach_task = asyncio.create_task(manager._handle_target_attached(_attached_event()))
+	await set_auto_attach_started.wait()
+
+	await manager._handle_target_detached(_detached_event())
+	release_set_auto_attach.set()
+	await attach_task
+
+	assert manager.get_session('session-id') is None
+	assert manager.get_target('iframe-target-id') is None
+	assert manager.get_target_id_from_session_id('session-id') is None
+	assert manager.get_target_sessions_mapping() == {}
+
+
+async def test_detach_event_cancels_attach_before_attach_task_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+	scheduled_tasks: list[asyncio.Task[Any]] = []
+
+	def capture_task(
+		coro: Coroutine[Any, Any, Any],
+		*,
+		name: str | None = None,
+		logger_instance: logging.Logger | None = None,
+		suppress_exceptions: bool = False,
+	) -> asyncio.Task[Any]:
+		del logger_instance, suppress_exceptions
+		task = asyncio.create_task(coro, name=name)
+		scheduled_tasks.append(task)
+		return task
+
+	monkeypatch.setattr(session_manager_module, 'create_task_with_error_handling', capture_task)
+
+	root_client = CDPClient('ws://unused')
+	root_client.send.Target.setDiscoverTargets = AsyncMock()
+	root_client.send.Target.setAutoAttach = AsyncMock()
+	browser_session = BrowserSession()
+	browser_session._cdp_client_root = root_client
+	manager = SessionManager(browser_session)
+	monkeypatch.setattr(manager, '_initialize_existing_targets', AsyncMock())
+	await manager.start_monitoring()
+
+	await root_client.emit_event('Target.attachedToTarget', _attached_event())
+	await root_client.emit_event('Target.detachedFromTarget', _detached_event())
+	await asyncio.gather(*scheduled_tasks)
+
+	assert manager.get_session('session-id') is None
+	assert manager.get_target('iframe-target-id') is None
+	assert manager.get_target_id_from_session_id('session-id') is None
+	assert manager.get_target_sessions_mapping() == {}
+	root_client.send.Target.setAutoAttach.assert_not_awaited()


### PR DESCRIPTION
## Summary

- track target attaches from callback scheduling through session registration
- let a detach cancel an attach that has not registered yet
- publish target/session mappings atomically before the first CDP await
- stop post-attach initialization when the session detached while `Target.setAutoAttach` was in flight

## Problem

`Target.attachedToTarget` and `Target.detachedFromTarget` callbacks schedule independent async tasks. Previously, `_handle_target_attached()` awaited `Target.setAutoAttach` before registering the session and its target mappings.

This creates two race windows:

```text
attached callback -> attach task waits in Target.setAutoAttach
                       detached task finds no session mapping and returns
                   attach task resumes and registers a dead session
```

and:

```text
attached callback schedules attach task
detached callback schedules detach task
detached task runs before the attach task has registered anything
```

In either case, a short-lived target can leave stale session, target, and mapping state in `SessionManager`.

## Fix

The event callbacks now track attaches as pending as soon as they are observed. A detach received during that window records cancellation even if the attach task has not started.

The attach handler publishes the session, target, and both mappings under the existing lock before awaiting CDP. The detach handler can therefore remove a complete state entry while `Target.setAutoAttach` is in flight. When that await finishes, the attach handler verifies that its exact session is still registered before continuing initialization.

The pending state is limited to observed in-flight attaches and is cleared during manager cleanup.

## Regression coverage

The new tests deterministically cover both race windows:

1. detach while `Target.setAutoAttach` is blocked
2. detach callback before the scheduled attach task runs

On unmodified `main`, the first test logs `Session detached but target unknown` and fails because the dead `CDPSession` remains registered. Both tests pass with this change.

Validation:

```text
uv run pytest -n 0 tests/ci/browser/test_session_manager.py
2 passed

uv run pytest -n 0 tests/ci/browser/test_session_manager.py tests/ci/browser/test_session_start.py tests/ci/browser/test_cross_origin_click.py tests/ci/browser/test_true_cross_origin_click.py tests/ci/browser/test_tabs.py
18 passed

uv run pyright
0 errors, 0 warnings, 0 informations

uv run pre-commit run --files browser_use/browser/session_manager.py tests/ci/browser/test_session_manager.py
All hooks passed
```

## Scope

This fixes stale lifecycle state caused by attach/detach scheduling races. It does not change frame traversal or event timeout behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race between target attach/detach in the session manager to prevent stale sessions and mappings. Short-lived targets no longer leave dead `CDPSession` entries when `Target.setAutoAttach` is slow or a detach arrives first.

- **Bug Fixes**
  - Track pending attaches from the event and cancel them if a detach arrives first.
  - Publish `CDPSession`, target, and both mappings under lock before any CDP await; ignore late or duplicate attaches and verify the session still exists after `Target.setAutoAttach`.
  - Detach handler detects pending/early detaches, removes state while auto-attach is in flight, and avoids “unknown target” warnings for expected races.
  - Clear pending tracking on cleanup; add deterministic tests covering both race windows, including ensuring auto-attach is not called for canceled attaches.

<sup>Written for commit 81d6a630553aa47dde8ff6487d12d3f87adcfdb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

