### PR TITLE
docs(telemetry): document what AgentTelemetryEvent actually sends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,9 @@ BROWSER_USE_INFO_LOG_FILE=info.log
 CDP_LOGGING_LEVEL=WARNING
 
 # Telemetry and Analytics
-# Enable/disable anonymous telemetry
+# Enable/disable telemetry. The identifier is anonymous, but the event content includes
+# the task prompt, visited URLs, action history, and final result, see
+# browser_use/telemetry/views.py:AgentTelemetryEvent for the exact fields sent to PostHog.
 ANONYMIZED_TELEMETRY=true
 
 # Browser Use Cloud Configuration

--- a/browser_use/telemetry/views.py
+++ b/browser_use/telemetry/views.py
@@ -23,6 +23,17 @@ class BaseTelemetryEvent(ABC):
 
 @dataclass
 class AgentTelemetryEvent(BaseTelemetryEvent):
+	"""Telemetry event sent for each agent run when ANONYMIZED_TELEMETRY is enabled (the default).
+
+	The *identifier* PostHog associates with events is anonymous, but the *content* of this
+	event is a fairly complete transcript of the run: the full task prompt (``task``), every
+	URL visited (``urls_visited``), the actions taken including any text typed into pages
+	(``action_history``), and the data the agent read off the page (``final_result_response``).
+	If you run this against internal tools, authenticated dashboards, or with sensitive
+	business context in the prompt, that content leaves your machine by default. Disable with
+	``ANONYMIZED_TELEMETRY=false`` if that's not acceptable for your use case.
+	"""
+
 	# start details
 	task: str
 	model: str


### PR DESCRIPTION
## Summary

Fixes #5216. The telemetry docs describe the default-on collection as "anonymous usage data," which reads as counters/version strings. Checked `AgentTelemetryEvent` (`browser_use/telemetry/views.py`) directly: the *identifier* is anonymous, but the *content* is close to a full run transcript — `task` (the full prompt), `urls_visited`, `action_history` (including typed text), and `final_result_response`. Someone running this against internal tools, an authenticated dashboard, or with business context in the prompt has no way to learn that from the docs page alone.

## Why this PR doesn't touch the docs page directly

The actual telemetry docs page (`docs.browser-use.com/development/monitoring/telemetry`) lives in `browser-use/docs`, which is archived (read-only, no new PRs). So this adds the disclosure at the source instead of a page I can't submit to:

- A docstring on `AgentTelemetryEvent` listing exactly what's collected and why it matters, in the same file the original issue reporter had to read to find this out.
- A more specific `.env.example` comment pointing at that docstring, instead of the current one-line "anonymous telemetry" description.

No behavior change, this is disclosure only. If the docs site migrates somewhere reachable via PR later, the wording here is meant to be copy-pastable into that page's "what is collected" section, which is what the issue originally asked for.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents exactly what `AgentTelemetryEvent` sends (task prompt, visited URLs, action history incl. typed text, final result) and updates `.env.example` to point to that docstring and show how to disable via `ANONYMIZED_TELEMETRY=false`. Telemetry remains default-on and identifier-only anonymous; disclosure only, no behavior change (fixes #5216).

<sup>Written for commit 554a51898452511cc697b5cb5075fca8617b0d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

