### PR TITLE
Fix DOMTreeSerializer leaking paint-order-occluded text to the LLM

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -1047,10 +1047,12 @@ class DOMTreeSerializer:
 				formatted_text.append(f'{depth_str}Shadow End')
 
 		elif node.original_node.node_type == NodeType.TEXT_NODE:
-			# Include visible text
+			# Include visible text that isn't fully covered by another element
+			# painted on top of it (e.g. text underneath an open modal/dropdown).
 			is_visible = node.original_node.snapshot_node and node.original_node.is_visible
 			if (
 				is_visible
+				and not node.ignored_by_paint_order
 				and node.original_node.node_value
 				and node.original_node.node_value.strip()
 				and len(node.original_node.node_value.strip()) > 1

--- a/tests/ci/test_dom_paint_order_serialization.py
+++ b/tests/ci/test_dom_paint_order_serialization.py
@@ -1,0 +1,81 @@
+"""Regression test for DOMTreeSerializer leaking paint-order-occluded text.
+
+PaintOrderRemover.calculate_paint_order() correctly computes which nodes are
+fully covered by another element painted on top of them (e.g. content
+underneath an open modal/dropdown) and marks them `ignored_by_paint_order`.
+DOMTreeSerializer.serialize_tree() must respect that flag for TEXT_NODEs, or
+covered text still ends up in the DOM string sent to the LLM every step.
+"""
+
+from browser_use.dom.serializer.paint_order import PaintOrderRemover
+from browser_use.dom.serializer.serializer import DOMTreeSerializer
+from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, EnhancedSnapshotNode, NodeType, SimplifiedNode
+
+
+def _make_snapshot(paint_order: int, bounds: DOMRect) -> EnhancedSnapshotNode:
+	return EnhancedSnapshotNode(
+		is_clickable=None,
+		cursor_style=None,
+		bounds=bounds,
+		clientRects=None,
+		scrollRects=None,
+		computed_styles={},
+		paint_order=paint_order,
+		stacking_contexts=None,
+	)
+
+
+def _make_node(node_type: NodeType, node_value: str, snapshot_node: EnhancedSnapshotNode | None) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=node_type,
+		node_name='#text' if node_type == NodeType.TEXT_NODE else 'DIV',
+		node_value=node_value,
+		attributes={},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='test-target',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=None,
+		snapshot_node=snapshot_node,
+	)
+
+
+class TestPaintOrderTextExclusion:
+	def test_text_fully_covered_by_another_element_is_not_serialized(self):
+		"""Two text nodes at identical bounds: the lower paint-order one is fully
+		covered by the higher paint-order one and must be excluded from the
+		LLM-facing DOM string, even though both are individually `is_visible`."""
+		bounds = DOMRect(x=0, y=0, width=100, height=20)
+		hidden_node = _make_node(NodeType.TEXT_NODE, 'HIDDEN BEHIND MODAL', _make_snapshot(paint_order=1, bounds=bounds))
+		top_node = _make_node(NodeType.TEXT_NODE, 'TOP LAYER TEXT', _make_snapshot(paint_order=2, bounds=bounds))
+
+		hidden_simplified = SimplifiedNode(original_node=hidden_node, children=[])
+		top_simplified = SimplifiedNode(original_node=top_node, children=[])
+
+		# should_display=False on the wrapper so serialize_tree skips the element
+		# line itself and just recurses straight into the two text-node children.
+		wrapper = SimplifiedNode(
+			original_node=_make_node(NodeType.ELEMENT_NODE, '', None),
+			children=[hidden_simplified, top_simplified],
+			should_display=False,
+		)
+
+		PaintOrderRemover(wrapper).calculate_paint_order()
+
+		# Sanity check: paint-order calculation itself flagged the covered node.
+		assert hidden_simplified.ignored_by_paint_order is True
+		assert top_simplified.ignored_by_paint_order is False
+
+		output = DOMTreeSerializer.serialize_tree(wrapper, [])
+
+		assert 'TOP LAYER TEXT' in output
+		assert 'HIDDEN BEHIND MODAL' not in output


### PR DESCRIPTION
## Problem

`PaintOrderRemover.calculate_paint_order()` (`browser_use/dom/serializer/paint_order.py`) correctly computes, for every node with layout paint-order and bounds info, whether it is fully covered by another node painted on top of it (e.g. text underneath an open modal, an off-canvas menu, a tab panel that's present-but-hidden via overlapping z-index rather than `display:none`, a tooltip, etc). It records the result on `SimplifiedNode.ignored_by_paint_order`.

That flag was only ever consulted in one place: `_assign_interactive_indices_and_mark_new_nodes()`, which uses it to avoid handing out a clickable index for a covered button. But `DOMTreeSerializer.serialize_tree()` — the function that actually renders the tree into the text string sent to the LLM every step (via `SerializedDOMState.llm_representation()`, called from `agent/prompts.py`, `agent/service.py`, `actor/page.py`, `browser/session.py`) — never checked it for `TEXT_NODE`s. Text nodes were gated only by their own CSS `is_visible` (opacity/display/viewport), which stays `True` even when the element is completely covered by something else painted on top.

**Concrete failure scenario**: a page has two overlapping text blocks at the same screen position — e.g. content sitting underneath an open modal, where the modal covers it via z-index/position rather than `display:none`. Both text nodes are individually `is_visible=True` (they're not `display:none` and are inside the viewport), but `PaintOrderRemover` correctly marks the underneath one `ignored_by_paint_order=True`. Before this fix, `serialize_tree()` printed *both* lines of text into the LLM's DOM snapshot, even though only the top one is actually visible on screen — misleading the model into "reading" page content that isn't really there, on any page using overlap-based hide/show (modals, dropdowns, carousels, tab panels).

## Fix

Check `node.ignored_by_paint_order` alongside `is_visible` in the `TEXT_NODE` branch of `serialize_tree()`, matching the same acceptance check already used for interactive-index assignment.

## Testing

- Added `tests/ci/test_dom_paint_order_serialization.py`, which constructs two overlapping `EnhancedDOMTreeNode` TEXT_NODEs directly (no browser needed, following the existing `tests/ci/test_dom_visibility.py` pattern), runs the real `PaintOrderRemover` against them, and asserts the covered text is excluded from `DOMTreeSerializer.serialize_tree()`'s output while the covering text is still included.
- Confirmed red→green: reverting only `serializer.py` reproduces the exact leak (`assert 'HIDDEN BEHIND MODAL' not in ...` fails, both lines present); reapplying passes.
- Full fast test suite (`tests/ci/` minus files that construct a live `BrowserSession`): 493 passed, 7 skipped (unrelated, need provider API keys) — matches pre-change baseline.
- `ruff check`, `ruff format --check`, `pyright`: all clean.
- xref: checked open PRs touching `paint_order`/`ignored_by_paint_order`/`serialize_tree` — #5159 ("perf(dom): speed up paint-order filtering") only touches `paint_order.py`'s computation logic, not `serializer.py`'s consumption of the flag at the TEXT_NODE site, so this is complementary, not a duplicate.

## AI-Generated disclosure

Found via an AI-assisted code review pass (Claude Code) over `browser_use/dom/`. I personally traced `ignored_by_paint_order`'s single existing call site, confirmed the gap at the TEXT_NODE branch, reproduced the leak with a standalone construction (no live browser needed), verified the fix, and ran the fast test suite plus lint/format/typecheck before submitting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents text hidden behind overlays from reaching the LLM by skipping paint‑order‑occluded `TEXT_NODE`s in the DOM snapshot. The snapshot now matches on-screen content for modals, dropdowns, and tab panels.

- **Bug Fixes**
  - In `DOMTreeSerializer.serialize_tree()`, include `TEXT_NODE`s only when `is_visible` and not `ignored_by_paint_order`.
  - Align with interactive-index logic to avoid leaking covered content.
  - Add `tests/ci/test_dom_paint_order_serialization.py` to verify covered text is excluded and top-layer text remains.

<sup>Written for commit 561387adccb74df2fdc8060d25dd4a51f1d7713b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

