### PR TITLE
feat: accept bu-qa-1 model alias in ChatBrowserUse

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -60,6 +60,7 @@ class ChatBrowserUse(BaseChatModel):
 			model: Model name to use. Options:
 				- 'bu-2-0' or 'bu-latest': Default model (latest premium)
 				- 'bu-1-0': Previous generation model
+				- 'bu-qa-1': Website QA model (tests a site and scores functionality/aesthetics)
 				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
 				- Provider-prefixed ids resolved by the gateway, e.g. 'anthropic/claude-sonnet-4-6',
 				  'openai/gpt-5.5', 'google/gemini-3-pro'.
@@ -72,7 +73,7 @@ class ChatBrowserUse(BaseChatModel):
 		"""
 		# Accept 'bu-*' aliases and any provider-prefixed id; the gateway resolves the
 		# latter (anthropic/*, openai/*, google/*, browser-use/*), so we don't enumerate them.
-		bu_aliases = ['bu-latest', 'bu-1-0', 'bu-2-0']
+		bu_aliases = ['bu-latest', 'bu-1-0', 'bu-2-0', 'bu-qa-1']
 		is_valid = model in bu_aliases or '/' in model
 		if not is_valid:
 			raise ValueError(

--- a/tests/ci/models/test_llm_browseruse.py
+++ b/tests/ci/models/test_llm_browseruse.py
@@ -31,7 +31,7 @@ def test_default_model_is_bu_2_0():
 	assert chat.provider == 'browser-use'
 
 
-@pytest.mark.parametrize('alias', ['bu-1-0', 'bu-2-0'])
+@pytest.mark.parametrize('alias', ['bu-1-0', 'bu-2-0', 'bu-qa-1'])
 def test_bu_aliases_are_accepted(alias):
 	chat = ChatBrowserUse(model=alias, api_key=TEST_API_KEY)
 	assert chat.model == alias


### PR DESCRIPTION
## Summary

Adds `bu-qa-1` to the accepted `bu-*` alias list in `ChatBrowserUse`. The gateway already serves this model (browser-use/cloud#4945 — website QA agent that tests a site and scores functionality/aesthetics 0-2), but the client rejected it at construction:

```
ValueError: Invalid model: 'bu-qa-1'. Use a 'bu-*' alias (bu-latest, bu-1-0, bu-2-0) ...
```

Changes:
- `bu_aliases` list: add `'bu-qa-1'`
- docstring: document the alias
- test: extend the existing alias parametrize with `bu-qa-1`

## Usage

```python
agent = Agent(
    task='https://example-site.com\nSpec: landing page with working signup form',
    llm=ChatBrowserUse(model='bu-qa-1'),
    output_model_schema=WebsiteQAResult,  # recommended: reasoning + functionality/aesthetics ints, see cloud#4945
)
```

## Testing

- `tests/ci/models/test_llm_browseruse.py`: 20 passed, 1 skipped
- Verified end-to-end against the staging gateway: agent tested quotes.toscrape.com and returned a validated result (functionality=2, aesthetics=1)
- Note: `bin/lint.sh` pyright failures (`browser_harness` imports in cli.py) are pre-existing on main and unrelated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the `bu-qa-1` Website QA model in `ChatBrowserUse`, removing construction-time “Invalid model” errors when using this gateway-served alias.

- **New Features**
  - Add `bu-qa-1` to accepted `bu-*` aliases.
  - Document the alias in `ChatBrowserUse` docstring.
  - Update tests to include `bu-qa-1`.

<sup>Written for commit 4b1cc6375aa74511e0e621e9104cdb00e16c5bdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

