### PR TITLE
Fix Mouse.scroll() silently redirecting an explicit x=0/y=0 to viewport center

### DIFF
--- a/browser_use/actor/mouse.py
+++ b/browser_use/actor/mouse.py
@@ -9,6 +9,17 @@ if TYPE_CHECKING:
 	from browser_use.browser.session import BrowserSession
 
 
+def _resolve_scroll_anchor(x: int | None, y: int | None, viewport_width: float, viewport_height: float) -> tuple[float, float]:
+	"""Resolve the (x, y) point a scroll event should be dispatched at.
+
+	An explicit 0 must be honored as "left/top edge", not treated as "unset".
+	Only a genuinely missing (None) coordinate falls back to the viewport center.
+	"""
+	scroll_x = x if x is not None else viewport_width / 2
+	scroll_y = y if y is not None else viewport_height / 2
+	return scroll_x, scroll_y
+
+
 class Mouse:
 	"""Mouse operations for a target."""
 
@@ -82,27 +93,29 @@ class Mouse:
 		params: 'DispatchMouseEventParameters' = {'type': 'mouseMoved', 'x': x, 'y': y}
 		await self._client.send.Input.dispatchMouseEvent(params, session_id=self._session_id)
 
-	async def scroll(self, x: int = 0, y: int = 0, delta_x: int | None = None, delta_y: int | None = None) -> None:
+	async def scroll(
+		self, x: int | None = None, y: int | None = None, delta_x: int | None = None, delta_y: int | None = None
+	) -> None:
 		"""Scroll the page using robust CDP methods."""
 		if not self._session_id:
 			raise RuntimeError('Session ID is required for scroll operations')
 
-		# Method 1: Try mouse wheel event (most reliable)
+		# Get viewport dimensions (used to resolve x/y when the caller doesn't specify a coordinate)
 		try:
-			# Get viewport dimensions
 			layout_metrics = await self._client.send.Page.getLayoutMetrics(session_id=self._session_id)
 			viewport_width = layout_metrics['layoutViewport']['clientWidth']
 			viewport_height = layout_metrics['layoutViewport']['clientHeight']
+		except Exception:
+			viewport_width = viewport_height = 0
 
-			# Use provided coordinates or center of viewport
-			scroll_x = x if x > 0 else viewport_width / 2
-			scroll_y = y if y > 0 else viewport_height / 2
+		scroll_x, scroll_y = _resolve_scroll_anchor(x, y, viewport_width, viewport_height)
 
-			# Calculate scroll deltas (positive = down/right)
-			scroll_delta_x = delta_x or 0
-			scroll_delta_y = delta_y or 0
+		# Calculate scroll deltas (positive = down/right)
+		scroll_delta_x = delta_x or 0
+		scroll_delta_y = delta_y or 0
 
-			# Dispatch mouse wheel event
+		# Method 1: Try mouse wheel event (most reliable)
+		try:
 			await self._client.send.Input.dispatchMouseEvent(
 				params={
 					'type': 'mouseWheel',
@@ -120,7 +133,12 @@ class Mouse:
 
 		# Method 2: Fallback to synthesizeScrollGesture
 		try:
-			params: 'SynthesizeScrollGestureParameters' = {'x': x, 'y': y, 'xDistance': delta_x or 0, 'yDistance': delta_y or 0}
+			params: 'SynthesizeScrollGestureParameters' = {
+				'x': scroll_x,
+				'y': scroll_y,
+				'xDistance': delta_x or 0,
+				'yDistance': delta_y or 0,
+			}
 			await self._client.send.Input.synthesizeScrollGesture(
 				params,
 				session_id=self._session_id,

--- a/tests/ci/test_actor_mouse_scroll_anchor.py
+++ b/tests/ci/test_actor_mouse_scroll_anchor.py
@@ -1,0 +1,27 @@
+"""Test Mouse.scroll's anchor-point resolution honors explicit x=0/y=0 (see actor/mouse.py)."""
+
+from browser_use.actor.mouse import _resolve_scroll_anchor
+
+
+def test_explicit_zero_x_is_honored_as_left_edge():
+	scroll_x, scroll_y = _resolve_scroll_anchor(x=0, y=100, viewport_width=1000, viewport_height=800)
+	assert scroll_x == 0
+	assert scroll_y == 100
+
+
+def test_explicit_zero_y_is_honored_as_top_edge():
+	scroll_x, scroll_y = _resolve_scroll_anchor(x=100, y=0, viewport_width=1000, viewport_height=800)
+	assert scroll_x == 100
+	assert scroll_y == 0
+
+
+def test_both_unset_falls_back_to_viewport_center():
+	scroll_x, scroll_y = _resolve_scroll_anchor(x=None, y=None, viewport_width=1000, viewport_height=800)
+	assert scroll_x == 500
+	assert scroll_y == 400
+
+
+def test_positive_coordinates_are_passed_through():
+	scroll_x, scroll_y = _resolve_scroll_anchor(x=42, y=99, viewport_width=1000, viewport_height=800)
+	assert scroll_x == 42
+	assert scroll_y == 99


### PR DESCRIPTION
## Bug

`Mouse.scroll()` (`browser_use/actor/mouse.py`) resolves the scroll anchor
point with:

```python
scroll_x = x if x > 0 else viewport_width / 2
scroll_y = y if y > 0 else viewport_height / 2
```

`x`/`y` default to `0`, and `0 > 0` is `False` — so an explicitly-passed
`x=0` (left edge) or `y=0` (top edge) is treated identically to "not
provided" and silently redirected to the viewport center. No error, no
warning, just a wrong CDP event anchor point.

`page.mouse` is a public property on the `Page` actor
(`browser_use/actor/page.py`), so this is reachable by any caller of the
public API, not just internal code. The one in-repo call site
(`browser_use/actor/playground/playground.py:123`,
`mouse.scroll(x=0, y=100, delta_y=500)`) was itself silently hitting this
bug — the wheel event fired at horizontal-center instead of `x=0`.

## Fix

- Changed `x`/`y` to `int | None = None` so "unset" and "explicitly 0" are
  distinguishable, and only fall back to viewport center when the value is
  `None`.
- Extracted the resolution logic into a small pure `_resolve_scroll_anchor()`
  helper, unit-tested directly (no browser/mocking needed — it's plain
  arithmetic).
- Moved the viewport-metrics fetch + anchor resolution above both CDP
  methods (mouse wheel event, then `synthesizeScrollGesture` fallback) so
  both consistently use the same resolved anchor. Previously the
  `synthesizeScrollGesture` fallback used the raw, un-centered `x`/`y` args
  directly — a second instance of the same class of bug once `x`/`y` became
  `None`-able.

## Testing

Added `tests/ci/test_actor_mouse_scroll_anchor.py`:
- explicit `x=0` is honored (not redirected to center)
- explicit `y=0` is honored
- both unset → falls back to viewport center (unchanged default behavior)
- normal positive coordinates pass through unchanged

`ruff check`/`ruff format`/`pyright` all clean.

## Note on overlap

Open PR #4941 also touches `browser_use/actor/mouse.py` (a formatting pass
that keeps this exact buggy line unchanged, plus unrelated `move()` smoothing
work), so there's a textual overlap on this file. It doesn't fix this bug,
so this PR should be non-redundant either way — happy to rebase if #4941
merges first.

## Disclosure

Implemented with Claude Code (Anthropic), reviewed and submitted by me.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Mouse.scroll redirecting explicit x=0/y=0 to the viewport center. Now 0 anchors at the left/top edge; center is used only when x/y are unset.

- **Bug Fixes**
  - Changed `x`/`y` to `int | None` and fall back to center only when `None`.
  - Added `_resolve_scroll_anchor()` and unit tests for zero, unset, and positive coords.
  - Unified anchor resolution for both `Input.dispatchMouseEvent` and `Input.synthesizeScrollGesture`.

<sup>Written for commit 312bcf947de73e88464d3d7d4e385af6251becd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

