### PR TITLE
Fix ChatAnthropicBedrock.ainvoke() IndexError on an empty response.content list

### DIFF
--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -183,13 +183,17 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 
 				usage = self._get_usage(response)
 
-				# Extract text from the first content block
-				first_content = response.content[0]
-				if isinstance(first_content, TextBlock):
-					response_text = first_content.text
+				# Extract text from the first content block. Bedrock can return an
+				# empty content list for certain stop-reason edge cases.
+				if response.content:
+					first_content = response.content[0]
+					if isinstance(first_content, TextBlock):
+						response_text = first_content.text
+					else:
+						# If it's not a text block, convert to string
+						response_text = str(first_content)
 				else:
-					# If it's not a text block, convert to string
-					response_text = str(first_content)
+					response_text = ''
 
 				return ChatInvokeCompletion(
 					completion=response_text,

--- a/tests/ci/models/test_chat_anthropic_bedrock_empty_content.py
+++ b/tests/ci/models/test_chat_anthropic_bedrock_empty_content.py
@@ -1,0 +1,34 @@
+"""Test ChatAnthropicBedrock handles an empty response.content list without crashing."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from anthropic.types import Message, Usage
+
+from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
+from browser_use.llm.messages import UserMessage
+
+
+def _empty_content_message() -> Message:
+	return Message(
+		id='msg_test',
+		content=[],
+		model='anthropic.claude-3-5-sonnet-20240620-v1:0',
+		role='assistant',
+		stop_reason='end_turn',
+		stop_sequence=None,
+		type='message',
+		usage=Usage(input_tokens=5, output_tokens=0),
+	)
+
+
+async def test_ainvoke_handles_empty_content_list(monkeypatch: pytest.MonkeyPatch) -> None:
+	llm = ChatAnthropicBedrock(aws_region='us-east-1', aws_access_key='x', aws_secret_key='y')
+
+	fake_client = AsyncMock()
+	fake_client.messages.create = AsyncMock(return_value=_empty_content_message())
+	monkeypatch.setattr(llm, 'get_client', lambda: fake_client)
+
+	result = await llm.ainvoke([UserMessage(content='hi')])
+
+	assert result.completion == ''


### PR DESCRIPTION
## Bug

`ChatAnthropicBedrock.ainvoke()` unconditionally indexes
`response.content[0]` to extract the reply text. Bedrock can legitimately
return an empty `content` list for certain stop-reason edge cases (e.g. the
turn ends before any content block is produced) — when that happens, this
raises `IndexError`, which the surrounding `try/except` re-raises as an
opaque `ModelProviderError`, crashing the caller instead of returning empty
text.

The sibling direct-Anthropic implementation
(`browser_use/llm/anthropic/chat.py`'s `_extract_content_blocks`) already
guards this exact case:

```python
elif response.content:
    completion = str(response.content[0])
else:
    completion = ''
```

— strong evidence this is a real, previously-encountered scenario for the
underlying Claude message API, just missing from the Bedrock-transport
variant of the same contract.

## Fix

Mirror the sibling's guard: only index into `response.content` when it's
non-empty, otherwise fall back to an empty string.

## Testing

Added `tests/ci/models/test_chat_anthropic_bedrock_empty_content.py`, which
constructs a real `anthropic.types.Message` with `content=[]` (no mocking
of the SDK's own types — only the network-boundary client, per this repo's
"mock only the LLM" testing convention from CLAUDE.md) and confirms
`ainvoke()` returns an empty completion instead of raising.

Confirmed red→green: reverting only the source change reproduces
`ModelProviderError: list index out of range`; reapplying passes.

`ruff check` / `ruff format --check` / `pyright`: clean.

## Note on overlap

Open PR #5053 also touches `browser_use/llm/aws/chat_anthropic.py`, but a
different function entirely (`_get_usage`'s `total_tokens` calculation,
~line 152) — no overlap with this change (`ainvoke`'s content extraction,
~line 187).

## Disclosure

Implemented with Claude Code (Anthropic), reviewed and submitted by me.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an IndexError in `ChatAnthropicBedrock.ainvoke()` when Bedrock returns an empty `response.content` by safely handling empty lists and returning an empty completion. Adds a regression test for the empty-content case.

<sup>Written for commit 8b56f3c7597c424545ff5305c1eb7923d0307cd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

