### PR TITLE
fix(llm): read structured output from tool calls for Groq tool-calling models

### DIFF
--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -170,23 +170,45 @@ class ChatGroq(BaseChatModel):
 
 		if self.model in ToolCallingModels:
 			response = await self._invoke_with_tool_calling(groq_messages, output_format, schema)
+			parsed_response = self._parse_tool_call_output(response, output_format)
 		else:
 			response = await self._invoke_with_json_schema(groq_messages, output_format, schema)
 
-		if not response.choices[0].message.content:
-			raise ModelProviderError(
-				message='No content in response',
-				status_code=500,
-				model=self.name,
-			)
+			if not response.choices[0].message.content:
+				raise ModelProviderError(
+					message='No content in response',
+					status_code=500,
+					model=self.name,
+				)
 
-		parsed_response = output_format.model_validate_json(response.choices[0].message.content)
+			parsed_response = output_format.model_validate_json(response.choices[0].message.content)
+
 		usage = self._get_usage(response)
 
 		return ChatInvokeCompletion(
 			completion=parsed_response,
 			usage=usage,
 		)
+
+	def _parse_tool_call_output(self, response: ChatCompletion, output_format: type[T]) -> T:
+		"""Extract the structured payload returned by the tool-calling path.
+
+		`_invoke_with_tool_calling` sends tool_choice='required', so the model returns the payload as
+		tool-call arguments and leaves `message.content` empty.
+		"""
+		message = response.choices[0].message
+
+		if not message.tool_calls:
+			raise ModelProviderError(
+				message='No tool calls in response',
+				status_code=500,
+				model=self.name,
+			)
+
+		arguments = message.tool_calls[0].function.arguments
+		if isinstance(arguments, str):
+			return output_format.model_validate_json(arguments)
+		return output_format.model_validate(arguments)
 
 	async def _invoke_with_tool_calling(self, groq_messages, output_format: type[T], schema) -> ChatCompletion:
 		"""Handle structured output using tool calling."""

--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -145,6 +145,10 @@ class ChatGroq(BaseChatModel):
 
 		except APIError as e:
 			raise ModelProviderError(message=e.message, model=self.name) from e
+		except ModelProviderError:
+			# errors we raised ourselves (e.g. from structured-output parsing) already carry the right
+			# status code and message, so let them through instead of re-wrapping with the default status
+			raise
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e
 

--- a/tests/ci/models/test_llm_groq.py
+++ b/tests/ci/models/test_llm_groq.py
@@ -1,0 +1,92 @@
+"""Tests for the ChatGroq structured-output paths."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from groq.types.chat import ChatCompletion, ChatCompletionMessage, ChatCompletionMessageToolCall
+from groq.types.chat.chat_completion import Choice
+from groq.types.chat.chat_completion_message_tool_call import Function
+from pydantic import BaseModel
+
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.groq.chat import ChatGroq, ToolCallingModels
+from browser_use.llm.messages import UserMessage
+
+# A syntactically-valid key so the constructor doesn't bail before we reach the
+# code under test. These unit tests never hit the network.
+TEST_API_KEY = 'test-key-not-real'
+
+TOOL_CALLING_MODEL = ToolCallingModels[0]
+
+
+class Answer(BaseModel):
+	answer: str
+
+
+def _completion(model: str, *, content: str | None, tool_arguments: str | None) -> ChatCompletion:
+	"""Build a Groq ChatCompletion with either message content or tool-call arguments."""
+	tool_calls = None
+	if tool_arguments is not None:
+		tool_calls = [
+			ChatCompletionMessageToolCall(
+				id='call_1',
+				type='function',
+				function=Function(name='Answer', arguments=tool_arguments),
+			)
+		]
+
+	message = ChatCompletionMessage(role='assistant', content=content, tool_calls=tool_calls)
+	return ChatCompletion(
+		id='chatcmpl-test',
+		choices=[Choice(finish_reason='tool_calls' if tool_calls else 'stop', index=0, message=message)],
+		created=0,
+		model=model,
+		object='chat.completion',
+	)
+
+
+async def _ainvoke(llm: ChatGroq, response: ChatCompletion):
+	create = AsyncMock(return_value=response)
+	with patch.object(type(llm.get_client().chat.completions), 'create', create):
+		return await llm.ainvoke([UserMessage(content='question')], Answer)
+
+
+async def test_tool_calling_model_parses_arguments():
+	"""Tool-calling models return the payload in tool_calls with content=None (see #4945)."""
+	llm = ChatGroq(model=TOOL_CALLING_MODEL, api_key=TEST_API_KEY)
+	response = _completion(TOOL_CALLING_MODEL, content=None, tool_arguments='{"answer": "42"}')
+
+	result = await _ainvoke(llm, response)
+
+	assert result.completion == Answer(answer='42')
+
+
+async def test_tool_calling_model_without_tool_calls_raises():
+	"""An empty tool-call list is a provider error, not an unpacking crash."""
+	llm = ChatGroq(model=TOOL_CALLING_MODEL, api_key=TEST_API_KEY)
+	response = _completion(TOOL_CALLING_MODEL, content=None, tool_arguments=None)
+
+	with pytest.raises(ModelProviderError, match='No tool calls in response'):
+		await _ainvoke(llm, response)
+
+
+async def test_json_schema_model_parses_content():
+	"""Models outside ToolCallingModels still read the payload from message content."""
+	model = 'llama-3.3-70b-versatile'
+	assert model not in ToolCallingModels
+	llm = ChatGroq(model=model, api_key=TEST_API_KEY)
+	response = _completion(model, content='{"answer": "42"}', tool_arguments=None)
+
+	result = await _ainvoke(llm, response)
+
+	assert result.completion == Answer(answer='42')
+
+
+async def test_json_schema_model_without_content_raises():
+	"""The content guard still applies on the JSON-schema path."""
+	model = 'llama-3.3-70b-versatile'
+	llm = ChatGroq(model=model, api_key=TEST_API_KEY)
+	response = _completion(model, content=None, tool_arguments=None)
+
+	with pytest.raises(ModelProviderError, match='No content in response'):
+		await _ainvoke(llm, response)

--- a/tests/ci/models/test_llm_groq.py
+++ b/tests/ci/models/test_llm_groq.py
@@ -66,8 +66,12 @@ async def test_tool_calling_model_without_tool_calls_raises():
 	llm = ChatGroq(model=TOOL_CALLING_MODEL, api_key=TEST_API_KEY)
 	response = _completion(TOOL_CALLING_MODEL, content=None, tool_arguments=None)
 
-	with pytest.raises(ModelProviderError, match='No tool calls in response'):
+	with pytest.raises(ModelProviderError, match='No tool calls in response') as exc_info:
 		await _ainvoke(llm, response)
+
+	# the status code we set must survive `ainvoke`'s outer error handling rather than being
+	# re-wrapped with the default provider status
+	assert exc_info.value.status_code == 500
 
 
 async def test_json_schema_model_parses_content():


### PR DESCRIPTION
Fixes #4945.

### Problem

`ChatGroq._invoke_structured_output` picks one of two paths, but then reads the result from only one of them:

```python
if self.model in ToolCallingModels:
    response = await self._invoke_with_tool_calling(groq_messages, output_format, schema)
else:
    response = await self._invoke_with_json_schema(groq_messages, output_format, schema)

if not response.choices[0].message.content:
    raise ModelProviderError(message='No content in response', ...)
```

`_invoke_with_tool_calling` sends `tool_choice='required'`, so Groq returns the structured payload in `tool_calls[0].function.arguments` and leaves `message.content` empty. The content guard therefore fires on a perfectly valid response, and **every** model in `ToolCallingModels` (currently `moonshotai/kimi-k2-instruct`) fails structured output 100% of the time:

```
browser_use.llm.exceptions.ModelProviderError: No content in response
```

Since `ainvoke(messages, OutputModel)` is how the agent gets its structured output, these models are unusable with `ChatGroq` rather than merely degraded.

### Change

Parse the payload from the tool call on the tool-calling branch, and keep the content guard on the JSON-schema branch where it still applies. This mirrors what the deepseek provider already does for its tool-calling path (`browser_use/llm/deepseek/chat.py`): check `tool_calls`, then read `tool_calls[0].function.arguments`. An empty `tool_calls` list now reports `'No tool calls in response'` instead of falling through to content that is never populated.

The JSON-schema path is untouched, so models outside `ToolCallingModels` behave exactly as before.

### Testing

Added `tests/ci/models/test_llm_groq.py` (there were no `ChatGroq` tests). These are offline unit tests using a fake API key and a faked Groq client — the LLM is the one thing `CLAUDE.md` allows mocking, and no network is touched:

- `test_tool_calling_model_parses_arguments` — the reported scenario: `content=None`, payload in `tool_calls`. **Fails on `main`** with the exact reported `ModelProviderError: No content in response`; passes with this change.
- `test_tool_calling_model_without_tool_calls_raises` — empty `tool_calls` gives a clear provider error. **Fails on `main`.**
- `test_json_schema_model_parses_content` / `test_json_schema_model_without_content_raises` — backward-compatibility guards for the non-tool-calling path; these pass both with and without the change.

Results:
- `pytest tests/ci/models/test_llm_groq.py` — 4 passed (2 of them fail without the source change).
- `pytest tests/ci/models/` — 46 passed, 7 skipped, unchanged from `main`.
- `ruff check` clean on both files. I deliberately did **not** run `ruff format` on `chat.py`: it already reports as unformatted on `main`, so formatting it would pull unrelated reformatting into this diff — happy to include it if you'd prefer.
- `pyright browser_use/llm/groq/chat.py` reports the same 9 pre-existing errors as `main` (all unresolved `groq` imports in my local env, on lines this PR doesn't touch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes structured output for Groq tool-calling models in `ChatGroq` by reading tool call arguments and preserving provider error codes. Restores functionality for `ToolCallingModels` and stops false "No content in response" errors.

- **Bug Fixes**
  - Tool-calling path: parse `tool_calls[0].function.arguments`; keep the content check only on the JSON-schema path; raise a clear error when no tool calls are returned.
  - Preserve `ModelProviderError` status and message in `ainvoke` (do not re-wrap).
  - Add offline unit tests for both paths and error propagation.

<sup>Written for commit 0a59008f6abca2d940382edd7f49a3c09ac9d212. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

