### PR TITLE
fix(mcp): annotate read-only browser tools

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -277,6 +277,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_get_state',
 					description='Get the current state of the page including all interactive elements',
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 					inputSchema={
 						'type': 'object',
 						'properties': {
@@ -307,6 +308,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_get_html',
 					description='Get the raw HTML of the current page or a specific element by CSS selector',
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 					inputSchema={
 						'type': 'object',
 						'properties': {
@@ -320,6 +322,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_screenshot',
 					description='Take a screenshot of the current page. Returns viewport metadata as text and the screenshot as an image.',
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 					inputSchema={
 						'type': 'object',
 						'properties': {
@@ -353,7 +356,10 @@ class BrowserUseServer:
 				),
 				# Tab management
 				types.Tool(
-					name='browser_list_tabs', description='List all open tabs', inputSchema={'type': 'object', 'properties': {}}
+					name='browser_list_tabs',
+					description='List all open tabs',
+					annotations=types.ToolAnnotations(readOnlyHint=True),
+					inputSchema={'type': 'object', 'properties': {}},
 				),
 				types.Tool(
 					name='browser_switch_tab',
@@ -423,6 +429,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_list_sessions',
 					description='List all active browser sessions with their details and last activity time',
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 					inputSchema={'type': 'object', 'properties': {}},
 				),
 				types.Tool(

--- a/tests/ci/security/test_mcp_allowed_domains.py
+++ b/tests/ci/security/test_mcp_allowed_domains.py
@@ -13,6 +13,7 @@ preserved when the client omits the argument.
 from typing import Any
 
 import pytest
+from mcp import types
 
 from browser_use.mcp.server import BrowserUseServer
 
@@ -39,6 +40,24 @@ async def test_dispatch_passes_none_when_allowed_domains_omitted(server: Browser
 		f'got {captured["allowed_domains"]!r} which would disable SecurityWatchdog '
 		f'when passed as BrowserProfile(allowed_domains=...).'
 	)
+
+
+async def test_read_only_tools_advertise_mcp_annotations(server: BrowserUseServer) -> None:
+	"""Read-only tools can run without an approval prompt in compatible MCP clients."""
+	await server.server.request_handlers[types.ListToolsRequest](None)
+
+	read_only_tool_names = {
+		'browser_get_state',
+		'browser_get_html',
+		'browser_screenshot',
+		'browser_list_tabs',
+		'browser_list_sessions',
+	}
+
+	for tool_name in read_only_tool_names:
+		tool = server.server._tool_cache[tool_name]
+		assert tool.annotations is not None
+		assert tool.annotations.readOnlyHint is True
 
 
 async def test_dispatch_forwards_explicit_list(server: BrowserUseServer) -> None:


### PR DESCRIPTION
## Summary

- add standard MCP `readOnlyHint` annotations to browser inspection and session-listing tools
- cover the advertised annotations with a regression test for the tool catalogue

## Why

MCP clients can use the annotations to distinguish browser inspection from navigation or other state-changing operations. This lets compatible clients run the read-only tools without treating them as browser mutations.

Closes #5239.

## Testing

- `uv run pytest tests/ci/security/test_mcp_allowed_domains.py -q`
- `uv run ruff check browser_use/mcp/server.py tests/ci/security/test_mcp_allowed_domains.py`
- `uv run ruff format --check browser_use/mcp/server.py tests/ci/security/test_mcp_allowed_domains.py`
- `uv run pre-commit run --files browser_use/mcp/server.py tests/ci/security/test_mcp_allowed_domains.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP `readOnlyHint` to read-only browser tools so clients can run them without treating them as mutations, plus a regression test to ensure the hints are advertised.

- **Bug Fixes**
  - Annotated `browser_get_state`, `browser_get_html`, `browser_screenshot`, `browser_list_tabs`, `browser_list_sessions` with `readOnlyHint: true`.
  - Added a test to verify these tools expose `readOnlyHint` in the tool catalogue.

<sup>Written for commit a6d3a92ad5946e2ebf00c6491719b840f4d24dd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

