### PR TITLE
Release 0.13.6 with Browser Harness 0.1.6

### DIFF
--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -93,6 +93,35 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.
 
+## Recordings and Videos
+
+Fresh installs do not record. Users can enable local background traces:
+
+```bash
+browser-use recordings enable
+browser-use recordings disable
+browser-use recordings
+```
+
+`BH_RECORD=1` or `BH_RECORD=0` overrides the preference for one process. Any
+natural nudge to “record,” “show,” “demo,” or “make a video” opts in that task;
+significant work alone does not.
+
+Before browser work, call `start_recording(name, title=...)`, retain its exact
+returned directory, and call `stop_recording()` after verifying the result.
+Never replace that path with `recordings --latest`. For a request made after
+the task, use:
+
+```bash
+browser-use recordings --latest
+```
+
+Use it only if timestamps and pages match; otherwise say the work was not
+captured. Never reenact a completed task. For a video, follow
+[make-video.md](https://github.com/browser-use/browser-harness/blob/main/interaction-skills/make-video.md).
+If sub-agents are available, they may handle post-production from the exact
+recording path while the main agent returns the task result.
+
 ## Interaction Skills
 
 If you get stuck on a browser mechanic, check https://github.com/browser-use/browser-harness/tree/main/interaction-skills.
@@ -105,6 +134,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 - drag-and-drop.md
 - dropdowns.md
 - iframes.md
+- make-video.md
 - network-requests.md
 - print-as-pdf.md
 - profile-sync.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.13.5"
+version = "0.13.6"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [
@@ -46,7 +46,7 @@ dependencies = [
     "markdownify==1.2.2",
     "python-docx==1.2.0",
     "browser-use-sdk==3.4.2",
-    "browser-harness==0.1.5",
+    "browser-harness==0.1.6",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -93,6 +93,35 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.
 
+## Recordings and Videos
+
+Fresh installs do not record. Users can enable local background traces:
+
+```bash
+browser-use recordings enable
+browser-use recordings disable
+browser-use recordings
+```
+
+`BH_RECORD=1` or `BH_RECORD=0` overrides the preference for one process. Any
+natural nudge to “record,” “show,” “demo,” or “make a video” opts in that task;
+significant work alone does not.
+
+Before browser work, call `start_recording(name, title=...)`, retain its exact
+returned directory, and call `stop_recording()` after verifying the result.
+Never replace that path with `recordings --latest`. For a request made after
+the task, use:
+
+```bash
+browser-use recordings --latest
+```
+
+Use it only if timestamps and pages match; otherwise say the work was not
+captured. Never reenact a completed task. For a video, follow
+[make-video.md](https://github.com/browser-use/browser-harness/blob/main/interaction-skills/make-video.md).
+If sub-agents are available, they may handle post-production from the exact
+recording path while the main agent returns the task result.
+
 ## Interaction Skills
 
 If you get stuck on a browser mechanic, check https://github.com/browser-use/browser-harness/tree/main/interaction-skills.
@@ -105,6 +134,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 - drag-and-drop.md
 - dropdowns.md
 - iframes.md
+- make-video.md
 - network-requests.md
 - print-as-pdf.md
 - profile-sync.md


### PR DESCRIPTION
## Summary

- bump `browser-use` from `0.13.5` to `0.13.6`
- pin `browser-harness==0.1.6`
- sync both Browser Use skill copies from Browser Harness `main`, adding the recordings and video workflow

## Validation

- `uv run --frozen pre-commit run --files pyproject.toml skills/browser-use/SKILL.md browser_use/skills/browser-use/SKILL.md`
- `uv run --frozen python scripts/sync_browser_harness_skill.py --check`
- built the wheel and verified its metadata requires `browser-harness==0.1.6`
- verified the packaged skill contains the recordings/video instructions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `browser-use` 0.13.6 and pin `browser-harness` 0.1.6. Adds recordings and video workflow guidance to the Browser Use skill so users can opt into local traces and create videos.

- **Dependencies**
  - Bump `browser-use` to `0.13.6`.
  - Pin `browser-harness` to `0.1.6`.

- **New Features**
  - Synced both Browser Use skill docs from `browser-harness` `main`.
  - Added recordings/video workflow: CLI enable/disable, `BH_RECORD` override, `start_recording`/`stop_recording`, and safe use of `recordings --latest`.
  - Included `make-video.md` in Interaction Skills.

<sup>Written for commit 169ebee82e29931c003917affa344c0dc84ed3f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

