### PR TITLE
fix(mcp): mark read-only MCP tools with readOnlyHint annotations

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -287,6 +287,7 @@ class BrowserUseServer:
 							}
 						},
 					},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_extract_content',
@@ -316,6 +317,7 @@ class BrowserUseServer:
 							},
 						},
 					},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_screenshot',
@@ -330,6 +332,7 @@ class BrowserUseServer:
 							},
 						},
 					},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_scroll',
@@ -353,7 +356,10 @@ class BrowserUseServer:
 				),
 				# Tab management
 				types.Tool(
-					name='browser_list_tabs', description='List all open tabs', inputSchema={'type': 'object', 'properties': {}}
+					name='browser_list_tabs',
+					description='List all open tabs',
+					inputSchema={'type': 'object', 'properties': {}},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_switch_tab',
@@ -424,6 +430,7 @@ class BrowserUseServer:
 					name='browser_list_sessions',
 					description='List all active browser sessions with their details and last activity time',
 					inputSchema={'type': 'object', 'properties': {}},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_close_session',

--- a/tests/ci/test_mcp_tool_annotations.py
+++ b/tests/ci/test_mcp_tool_annotations.py
@@ -1,0 +1,75 @@
+"""Tests for MCP tool annotations on the `browser-use --mcp` surface (#5239).
+
+The MCP tool catalogue used to ship without any `annotations`, so clients that
+gate tool execution on MCP hints (e.g. Codex CLI with `approval_policy=never`)
+auto-cancelled even clearly read-only calls like `browser_get_state`.
+
+Read-only tools must advertise `readOnlyHint=True`; every state-changing tool
+must NOT advertise it. `browser_extract_content` is deliberately excluded from
+the read-only set: it dispatches the `extract` action through `Tools.act()`
+with a FileSystem handle and can write extraction artifacts.
+"""
+
+import mcp.types as types
+import pytest
+
+from browser_use.mcp.server import BrowserUseServer
+
+# Tools whose handlers only read state (see BrowserUseServer._get_browser_state,
+# _get_html, _screenshot, _list_tabs, _list_sessions). Everything else mutates
+# browser/session state and must never carry readOnlyHint=True.
+EXPECTED_READ_ONLY_TOOLS = frozenset(
+	{
+		'browser_get_state',
+		'browser_get_html',
+		'browser_screenshot',
+		'browser_list_tabs',
+		'browser_list_sessions',
+	}
+)
+
+
+@pytest.fixture
+def server() -> BrowserUseServer:
+	return BrowserUseServer()
+
+
+def _is_read_only(tool: types.Tool) -> bool:
+	return tool.annotations is not None and tool.annotations.readOnlyHint is True
+
+
+async def _list_tools(server: BrowserUseServer) -> list[types.Tool]:
+	handler = server.server.request_handlers[types.ListToolsRequest]
+	result = await handler(types.ListToolsRequest(method='tools/list'))
+	assert isinstance(result, types.ServerResult), f'expected ServerResult, got {type(result).__name__}'
+	list_result = result.root
+	assert isinstance(list_result, types.ListToolsResult), f'expected ListToolsResult, got {type(list_result).__name__}'
+	assert len(list_result.tools) > 0, 'tools/list returned an empty catalogue'
+	return list_result.tools
+
+
+async def test_read_only_tools_advertise_read_only_hint(server: BrowserUseServer) -> None:
+	"""Every genuinely read-only tool must carry annotations.readOnlyHint=True."""
+	tools = await _list_tools(server)
+	by_name = {tool.name: tool for tool in tools}
+
+	missing_tools = EXPECTED_READ_ONLY_TOOLS - by_name.keys()
+	assert not missing_tools, f'expected read-only tools missing from tools/list: {sorted(missing_tools)}'
+
+	unannotated = sorted(name for name in EXPECTED_READ_ONLY_TOOLS if not _is_read_only(by_name[name]))
+	assert not unannotated, (
+		f'read-only tools missing readOnlyHint=True: {unannotated}. '
+		f'Clients that gate on MCP annotations (e.g. Codex approval_policy=never) cancel unannotated calls.'
+	)
+
+
+async def test_mutating_tools_never_advertise_read_only_hint(server: BrowserUseServer) -> None:
+	"""No state-changing tool may claim to be read-only.
+
+	A new tool that carries readOnlyHint=True must be consciously added to
+	EXPECTED_READ_ONLY_TOOLS after checking its handler really only reads.
+	"""
+	tools = await _list_tools(server)
+
+	mislabeled = sorted(tool.name for tool in tools if tool.name not in EXPECTED_READ_ONLY_TOOLS and _is_read_only(tool))
+	assert not mislabeled, f'state-changing tools wrongly advertise readOnlyHint=True: {mislabeled}'


### PR DESCRIPTION
Closes #5239.

## Why

The `browser-use --mcp` tool catalogue ships without any MCP annotations, so clients that gate execution on hints treat every tool as potentially destructive. As reported in #5239, Codex CLI with `approval_policy=never` auto-cancels even `browser_get_state`, which makes the server unusable in non-interactive runs.

## What

Adds `annotations=types.ToolAnnotations(readOnlyHint=True)` to the five tools whose handlers only read state: `browser_get_state`, `browser_get_html`, `browser_screenshot`, `browser_list_tabs`, `browser_list_sessions`. I read each handler in `browser_use/mcp/server.py` before annotating it.

Two deliberate choices, happy to adjust if you see them differently:
- `browser_extract_content` stays unannotated. It dispatches the `extract` action through `Tools.act()` with a FileSystem handle and can write extraction artifacts, so it is not provably read-only.
- A cold-start call to an annotated tool still lazy-launches the browser session via `_execute_tool`. I kept the hint since that is idempotent bootstrapping rather than a mutation of the page being inspected, and it matches what the reporter validated with their proxy experiment. The one exception is `browser_list_sessions`, which never launches anything.

The scope here is only the `--mcp` surface from the issue. The newer `--cli-mcp` surface was left alone on purpose since that code is being actively reworked.

## Demo

Regression test fails on main's catalogue and passes with the fix:

```
$ git stash -- browser_use/mcp/server.py    # main's tool catalogue
$ uv run pytest -q tests/ci/test_mcp_tool_annotations.py
FAILED tests/ci/test_mcp_tool_annotations.py::test_read_only_tools_advertise_read_only_hint
$ git stash pop
$ uv run pytest -q tests/ci/test_mcp_tool_annotations.py
2 passed
```

`tools/list` after the fix advertises exactly these as read-only:

```
readOnly: ['browser_get_html', 'browser_get_state', 'browser_list_sessions', 'browser_list_tabs', 'browser_screenshot']
```

The new test pins the set in both directions: read-only tools must advertise the hint, and no state-changing tool may ever carry it.

## Checks

Ran locally: `uv run pre-commit run --all-files`, `uv run pyright` (0 errors), `uv run pytest tests/ci/test_mcp_tool_annotations.py tests/ci/security/test_mcp_allowed_domains.py` (5 passed).

---

quick note: I'm a college freshman trying my best to contribute for the greater good :) I worked through this with Claude Code (we read each tool handler together to decide the read-only set, and I ran the lint, type check and test gates locally). apologies in advance if anything looks off, if there are mistakes I would genuinely love to learn from them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks read-only MCP tools with `annotations.readOnlyHint=True` so hint-gated clients (e.g., Codex CLI with `approval_policy=never`) don’t auto-cancel safe calls. Fixes #5239 and adds a regression test to pin the read-only set.

- **Bug Fixes**
  - Annotated: `browser_get_state`, `browser_get_html`, `browser_screenshot`, `browser_list_tabs`, `browser_list_sessions`.
  - Left `browser_extract_content` unannotated (can write artifacts via `extract`).
  - Added `tests/ci/test_mcp_tool_annotations.py` to ensure read-only tools advertise the hint and mutating tools never do.
  - Scope limited to `--mcp`; `--cli-mcp` unchanged.

<sup>Written for commit d05aa1cfbcf9c61487b17b8db36432fdb389b5bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

