### PR TITLE
New files from Fly.io Launch

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,23 @@
+# fly.toml app configuration file generated for browser-use-wmywxg on 2026-07-17T21:01:53Z
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'browser-use-wmywxg'
+primary_region = 'ams'
+
+[build]
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '1gb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 2048

--- a/fly.toml
+++ b/fly.toml
@@ -1,9 +1,9 @@
-# fly.toml app configuration file generated for browser-use-wmywxg on 2026-07-17T21:01:53Z
+# fly.toml app configuration file generated for browser-use-s3zaza on 2026-07-18T06:15:00Z
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'browser-use-wmywxg'
+app = 'browser-use-s3zaza'
 primary_region = 'ams'
 
 [build]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Fly.io deployment config via `fly.toml`. Sets app `browser-use-s3zaza` in `ams`, HTTP service on port 8080 with HTTPS enforced, auto start/stop (0 min machines), process `app`, and a shared VM (1 vCPU, 2GB).

<sup>Written for commit 74a986bd4a505599c47cc8610bd34a19e8ad9e27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

