### PR TITLE
fix: preserve empty accessibility names by using explicit None check

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -848,7 +848,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -876,7 +876,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1022,7 +1022,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(


### PR DESCRIPTION
Fixes #5041

## Problem
The implicit truthiness check `if ax_node.name:` treats empty strings as falsy, causing explicitly empty accessibility names (e.g., `aria-label=""`) to be lost as `None`.

This conflates two distinct states:
- `None` = attribute does not exist
- `""` = attribute exists but is intentionally empty

## Fix
Changed 3 locations in `browser_use/dom/views.py` from:
```python
if self.ax_node and self.ax_node.name:
```
to:
```python
if self.ax_node and self.ax_node.name is not None:
```

## Impact
- Preserves explicit empty accessibility names for downstream DOM matching
- Affects `compute_stable_hash()`, `__hash__()`, and `DOMInteractedElement.load_from_enhanced_dom_tree()`
- No breaking changes — only affects edge case where name is explicitly empty string

## Testing
- All existing tests pass
- Verified fix handles `None`, `""`, and non-empty string correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves intentionally empty accessibility names by replacing truthiness checks with explicit None checks for `ax_node.name`. This keeps `""` (e.g., `aria-label=""`) distinct from `None`, fixing edge cases in hashing and DOM loading.

- **Bug Fixes**
  - Switched `if ... name:` to `if ... name is not None` in `browser_use/dom/views.py`.
  - Affects `compute_stable_hash()`, `__hash__()`, and `DOMInteractedElement.load_from_enhanced_dom_tree()`.
  - Ensures empty `ax_name` is preserved; no breaking changes.

<sup>Written for commit 2942cbbc78a56ed7f74d67cde8bc828f965c75e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

