### PR TITLE
Include tab context in CLI page_info state

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -7,6 +7,7 @@ import time
 from contextlib import redirect_stderr, redirect_stdout
 from importlib.metadata import PackageNotFoundError, version
 from io import StringIO
+from typing import Any
 
 
 def _browser_use_version() -> str:
@@ -131,6 +132,68 @@ def _as_browser_use_cli_text(text: str) -> str:
 	return text.replace('Browser Harness', 'Browser Use').replace('browser-harness', 'browser-use')
 
 
+def _infer_current_tab(page_info: dict[str, Any], tabs: list[dict[str, Any]]) -> dict[str, Any] | None:
+	url = page_info.get('url')
+	title = page_info.get('title')
+	if not url and not title:
+		return None
+
+	for tab in tabs:
+		if tab.get('url') == url and tab.get('title') == title:
+			return tab
+	for tab in tabs:
+		if tab.get('url') == url:
+			return tab
+	return None
+
+
+def _page_info_with_tab_context(
+	page_info: Any,
+	*,
+	tabs: list[dict[str, Any]] | None,
+	current_tab: dict[str, Any] | None,
+) -> Any:
+	if not isinstance(page_info, dict):
+		return page_info
+
+	enriched = dict(page_info)
+	if tabs is not None:
+		enriched.setdefault('tabs', tabs)
+		enriched.setdefault('tab_count', len(tabs))
+		if current_tab is None:
+			current_tab = _infer_current_tab(enriched, tabs)
+	if current_tab is not None:
+		enriched.setdefault('current_tab', current_tab)
+	return enriched
+
+
+def _patch_browser_harness_page_info(run_module: Any) -> None:
+	from functools import wraps
+
+	if getattr(run_module, '_browser_use_page_info_patched', False):
+		return
+
+	original_page_info = run_module.page_info
+
+	@wraps(original_page_info)
+	def page_info(*args: Any, **kwargs: Any) -> Any:
+		info = original_page_info(*args, **kwargs)
+		tabs = None
+		current_tab = None
+		try:
+			tabs = run_module.list_tabs()
+		except Exception:
+			pass
+		try:
+			current_tab = run_module.current_tab()
+		except Exception:
+			pass
+		return _page_info_with_tab_context(info, tabs=tabs, current_tab=current_tab)
+
+	run_module.page_info = page_info
+	run_module._browser_use_page_info_patched = True
+
+
 def _normalize_captured_cli_output(func, argv: list[str]) -> int:
 	stdout = StringIO()
 	stderr = StringIO()
@@ -161,6 +224,7 @@ def _patch_browser_harness_cli_text() -> None:
 
 	run.HELP = _as_browser_use_cli_text(run.HELP)
 	run.USAGE = _as_browser_use_cli_text(run.USAGE)
+	_patch_browser_harness_page_info(run)
 
 	original_auth_cli = auth.run_auth_cli
 	original_telemetry_cli = telemetry.run_telemetry_cli

--- a/tests/ci/test_browser_use_cli.py
+++ b/tests/ci/test_browser_use_cli.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -37,6 +38,69 @@ def test_normalize_captured_cli_output_handles_string_system_exit(capsys):
 	captured = capsys.readouterr()
 	assert captured.out == ''
 	assert captured.err == 'browser-use failed\n'
+
+
+def test_page_info_with_tab_context_infers_current_tab():
+	from browser_use.cli import _page_info_with_tab_context
+
+	tabs = [
+		{'target_id': 'tab-1', 'url': 'https://example.com/old', 'title': 'Old tab'},
+		{'target_id': 'tab-2', 'url': 'https://example.com/new', 'title': 'New tab'},
+	]
+
+	page_info = _page_info_with_tab_context(
+		{'url': 'https://example.com/new', 'title': 'New tab', 'w': 1280, 'h': 720},
+		tabs=tabs,
+		current_tab=None,
+	)
+
+	assert page_info['tab_count'] == 2
+	assert page_info['tabs'] == tabs
+	assert page_info['current_tab'] == tabs[1]
+
+
+def test_patch_browser_harness_page_info_adds_tabs_and_is_idempotent():
+	import browser_use.cli as browser_use_cli
+
+	tabs = [
+		{'target_id': 'tab-1', 'url': 'https://example.com/old', 'title': 'Old tab'},
+		{'target_id': 'tab-2', 'url': 'https://example.com/new', 'title': 'New tab'},
+	]
+	run = SimpleNamespace(
+		page_info=lambda: {'url': 'https://example.com/new', 'title': 'New tab'},
+		list_tabs=lambda: tabs,
+		current_tab=lambda: tabs[1],
+	)
+
+	browser_use_cli._patch_browser_harness_page_info(run)
+	patched_page_info = run.page_info
+	browser_use_cli._patch_browser_harness_page_info(run)
+
+	assert run.page_info is patched_page_info
+	assert run.page_info() == {
+		'url': 'https://example.com/new',
+		'title': 'New tab',
+		'tabs': tabs,
+		'tab_count': 2,
+		'current_tab': tabs[1],
+	}
+
+
+def test_patch_browser_harness_page_info_preserves_state_when_tab_queries_fail():
+	import browser_use.cli as browser_use_cli
+
+	def fail():
+		raise RuntimeError('browser disconnected')
+
+	run = SimpleNamespace(
+		page_info=lambda: {'url': 'https://example.com', 'title': 'Example'},
+		list_tabs=fail,
+		current_tab=fail,
+	)
+
+	browser_use_cli._patch_browser_harness_page_info(run)
+
+	assert run.page_info() == {'url': 'https://example.com', 'title': 'Example'}
 
 
 def test_browser_use_tui_is_deprecated_alias(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- enrich the Browser Use CLI's `page_info()` helper with `tab_count`, `current_tab`, and `tabs`
- infer the active tab from the current page when the explicit current-tab query is unavailable
- preserve the original page info if tab queries fail, so state output does not regress

Fixes #5251

## Tests
- `uv run pytest tests/ci/test_browser_use_cli.py -q`
- `uv run ruff check browser_use/cli.py tests/ci/test_browser_use_cli.py`
- `uv run ruff format --check browser_use/cli.py tests/ci/test_browser_use_cli.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tab context to the CLI `page_info()` so it includes `tabs`, `tab_count`, and `current_tab`. Improves state visibility and keeps output stable when tab APIs are unavailable.

- New Features
  - Add `tabs`, `tab_count`, and `current_tab` to `page_info()`.
  - Infer the active tab from URL/title when `current_tab()` is unavailable.
  - Preserve original `page_info` if `list_tabs()` or `current_tab()` fail; patch is idempotent.

<sup>Written for commit ffafb96d63384f1f9c347c9516bffbc76c4a82ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

