### PR TITLE
feat: add Eden AI LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,7 @@ BROWSER_USE_API_KEY=your_bu_api_key_here
 # DEEPSEEK_API_KEY=
 # GROK_API_KEY=
 # NOVITA_API_KEY=
+# EDENAI_API_KEY=your_edenai_api_key_here
 
 # AWS Bedrock Configuration (for AWS Bedrock models)
 # Requires: pip install browser-use[aws]

--- a/browser_use/llm/README.md
+++ b/browser_use/llm/README.md
@@ -8,6 +8,7 @@ We officially support the following LLMs:
 - Groq
 - Ollama
 - DeepSeek
+- Eden AI
 
 - Mistral
 

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.browser_use.chat import ChatBrowserUse
 	from browser_use.llm.cerebras.chat import ChatCerebras
 	from browser_use.llm.deepseek.chat import ChatDeepSeek
+	from browser_use.llm.edenai.chat import ChatEdenAI
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
 	from browser_use.llm.mistral.chat import ChatMistral
@@ -86,6 +87,7 @@ _LAZY_IMPORTS = {
 	'ChatBrowserUse': ('browser_use.llm.browser_use.chat', 'ChatBrowserUse'),
 	'ChatCerebras': ('browser_use.llm.cerebras.chat', 'ChatCerebras'),
 	'ChatDeepSeek': ('browser_use.llm.deepseek.chat', 'ChatDeepSeek'),
+	'ChatEdenAI': ('browser_use.llm.edenai.chat', 'ChatEdenAI'),
 	'ChatGoogle': ('browser_use.llm.google.chat', 'ChatGoogle'),
 	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
 	'ChatMistral': ('browser_use.llm.mistral.chat', 'ChatMistral'),
@@ -146,6 +148,7 @@ __all__ = [
 	'ChatOpenAI',
 	'ChatBrowserUse',
 	'ChatDeepSeek',
+	'ChatEdenAI',
 	'ChatGoogle',
 	'ChatAnthropic',
 	'ChatAnthropicBedrock',

--- a/browser_use/llm/edenai/__init__.py
+++ b/browser_use/llm/edenai/__init__.py
@@ -1,0 +1,3 @@
+from browser_use.llm.edenai.chat import ChatEdenAI
+
+__all__ = ['ChatEdenAI']

--- a/browser_use/llm/edenai/chat.py
+++ b/browser_use/llm/edenai/chat.py
@@ -1,0 +1,39 @@
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from browser_use.llm.openai.like import ChatOpenAILike
+
+
+@dataclass
+class ChatEdenAI(ChatOpenAILike):
+	"""
+	A class for interacting with Eden AI using the OpenAI-compatible API schema.
+
+	Eden AI (https://www.edenai.co) is an EU-based, OpenAI-compatible LLM gateway.
+	A single API key reaches models from many providers with vendor-prefixed ids,
+	e.g. 'openai/gpt-4o-mini', 'anthropic/claude-sonnet-4-5' or
+	'mistral/mistral-large-latest'.
+
+	Reads `EDENAI_API_KEY` when `api_key` is not set. For EU data residency, set
+	`base_url='https://api.eu.edenai.run/v3'`.
+
+	Args:
+		model (str): The Eden AI model id to use. Defaults to 'openai/gpt-4o-mini'.
+		api_key (str | None): Eden AI API key. Falls back to the EDENAI_API_KEY env var.
+		base_url (str | httpx.URL | None): Eden AI base url. Defaults to the global
+			endpoint 'https://api.edenai.run/v3'.
+	"""
+
+	model: str = 'openai/gpt-4o-mini'
+	base_url: str | httpx.URL | None = 'https://api.edenai.run/v3'
+
+	@property
+	def provider(self) -> str:
+		return 'edenai'
+
+	def _get_client_params(self) -> dict[str, Any]:
+		self.api_key = self.api_key or os.getenv('EDENAI_API_KEY')
+		return super()._get_client_params()

--- a/browser_use/llm/tests/test_chat_models.py
+++ b/browser_use/llm/tests/test_chat_models.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pydantic import BaseModel
 
-from browser_use.llm import ChatAnthropic, ChatGoogle, ChatGroq, ChatOpenAI, ChatOpenRouter
+from browser_use.llm import ChatAnthropic, ChatEdenAI, ChatGoogle, ChatGroq, ChatOpenAI, ChatOpenRouter
 from browser_use.llm.messages import ContentPartTextParam
 
 # Optional OCI import
@@ -86,6 +86,37 @@ class TestChatModels:
 			pytest.skip('OPENAI_API_KEY not set')
 
 		chat = ChatOpenAI(model='gpt-4o-mini', temperature=0)
+		response = await chat.ainvoke(self.STRUCTURED_MESSAGES, output_format=CapitalResponse)
+		completion = response.completion
+
+		assert isinstance(completion, CapitalResponse)
+		assert completion.country.lower() == self.EXPECTED_FRANCE_COUNTRY
+		assert completion.capital.lower() == self.EXPECTED_FRANCE_CAPITAL
+
+	# Eden AI Tests
+	@pytest.mark.asyncio
+	async def test_edenai_ainvoke_normal(self):
+		"""Test normal text response from Eden AI"""
+		# Skip if no API key
+		if not os.getenv('EDENAI_API_KEY'):
+			pytest.skip('EDENAI_API_KEY not set')
+
+		chat = ChatEdenAI(model='openai/gpt-4o-mini', temperature=0)
+		response = await chat.ainvoke(self.CONVERSATION_MESSAGES)
+
+		completion = response.completion
+
+		assert isinstance(completion, str)
+		assert self.EXPECTED_GERMANY_CAPITAL in completion.lower()
+
+	@pytest.mark.asyncio
+	async def test_edenai_ainvoke_structured(self):
+		"""Test structured output from Eden AI"""
+		# Skip if no API key
+		if not os.getenv('EDENAI_API_KEY'):
+			pytest.skip('EDENAI_API_KEY not set')
+
+		chat = ChatEdenAI(model='openai/gpt-4o-mini', temperature=0)
 		response = await chat.ainvoke(self.STRUCTURED_MESSAGES, output_format=CapitalResponse)
 		completion = response.completion
 

--- a/examples/models/edenai.py
+++ b/examples/models/edenai.py
@@ -1,0 +1,30 @@
+"""
+Use Eden AI (an EU-based, OpenAI-compatible LLM gateway) with browser-use.
+
+@dev You need to add EDENAI_API_KEY to your environment variables.
+Get a key at https://www.edenai.co
+"""
+
+import asyncio
+
+from browser_use import Agent
+from browser_use.llm import ChatEdenAI
+
+# Eden AI model ids are vendor-prefixed, e.g. 'openai/gpt-4o-mini',
+# 'anthropic/claude-sonnet-4-5' or 'mistral/mistral-large-latest'.
+# ChatEdenAI reads EDENAI_API_KEY and defaults to https://api.edenai.run/v3
+# (set base_url='https://api.eu.edenai.run/v3' for EU data residency).
+llm = ChatEdenAI(model='openai/gpt-4o-mini')
+
+agent = Agent(
+	task='Find the number of stars of the browser-use repo',
+	llm=llm,
+	use_vision=False,
+)
+
+
+async def main():
+	await agent.run(max_steps=10)
+
+
+asyncio.run(main())


### PR DESCRIPTION
### Why do we need this PR?

This adds Eden AI as a first class LLM provider. Eden AI is an EU based, OpenAI compatible gateway: one API key reaches models from many providers (OpenAI, Anthropic, Google, Mistral, Cohere and more) with vendor prefixed ids like `openai/gpt-4o-mini`, and it offers EU data residency, zero data retention, a DPA and SOC 2 / ISO 27001. For EU teams that is often the deciding factor, and today there is no dedicated way to reach it from browser-use.

### What it does

`ChatEdenAI` is a small subclass of `ChatOpenAILike` (the same base `ChatAzureOpenAI` uses), since Eden AI is a faithful OpenAI `/chat/completions` proxy. It defaults `base_url` to `https://api.edenai.run/v3`, reads `EDENAI_API_KEY` when `api_key` is not set, and passes vendor prefixed model ids straight through. EU users can set `base_url='https://api.eu.edenai.run/v3'`. It reuses all of `ChatOpenAI`'s logic (structured output, usage, reasoning handling, the empty choices guard), so there is no new dependency.

`ChatOpenAI(base_url='https://api.edenai.run/v3')` already works too, but a dedicated class gives `EDENAI_API_KEY` ergonomics and parity with the other OpenAI compatible providers (DeepSeek, OpenRouter, Cerebras, Vercel).

Changes: new `browser_use/llm/edenai/` (chat + `__init__`), the three registration spots in `browser_use/llm/__init__.py` (TYPE_CHECKING import, `_LAZY_IMPORTS`, `__all__`), a line in `browser_use/llm/README.md`, an example in `examples/models/edenai.py`, two tests in `browser_use/llm/tests/test_chat_models.py`, and a `.env.example` line. Following the DeepSeek and OpenRouter precedent, it is not added to the top level `browser_use/__init__.py`.

### How I tested it

- `ruff check` and `ruff format` are clean on the changed files.
- The new tests pass locally against the real API: `test_edenai_ainvoke_normal` and `test_edenai_ainvoke_structured`.
- Live smoke test through a normal `ainvoke`, across two vendors on the same key:

```
openai/gpt-4o-mini          -> normal + structured OK
anthropic/claude-haiku-4-5  -> normal OK
```

We will maintain the provider.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ChatEdenAI` to use Eden AI’s OpenAI‑compatible chat API from `browser_use`. Supports vendor‑prefixed models and EU data residency, while keeping `ChatOpenAI` features like structured output.

- New Features
  - Added `ChatEdenAI` (subclass of `ChatOpenAILike`) with pass‑through vendor‑prefixed model ids.
  - Defaults: model `openai/gpt-4o-mini`, `base_url='https://api.edenai.run/v3'`; reads `EDENAI_API_KEY` when `api_key` is unset.
  - Registered in `browser_use.llm` lazy imports/exports.
  - Updated docs and `.env.example`; added example `examples/models/edenai.py`.
  - Added tests for normal and structured `ainvoke`.

- Migration
  - Set `EDENAI_API_KEY` in your environment.
  - Import and use: `from browser_use.llm import ChatEdenAI`; pick a vendor‑prefixed model (e.g., `openai/gpt-4o-mini`).
  - For EU data residency: set `base_url='https://api.eu.edenai.run/v3'`.

<sup>Written for commit 2b6bb08cd9050a8b40efcf7ee13133d54778fcaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


