### PR TITLE
fix(browser): stop double-attaching pre-existing targets at session startup

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1846,24 +1846,18 @@ class BrowserSession(BaseModel):
 			assert self._cdp_client_root is not None
 			await self._cdp_client_root.start()
 
-			# Initialize event-driven session manager FIRST (before enabling autoAttach)
-			# SessionManager will:
+			# Initialize event-driven session manager
+			# SessionManager.start_monitoring() will:
 			# 1. Register attach/detach event handlers
-			# 2. Discover and attach to all existing targets
+			# 2. Enable root autoAttach (attaches existing targets AND future ones —
+			#    it owns the single attach path, so no second setAutoAttach here or
+			#    every pre-existing target would get a duplicate CDP session)
 			# 3. Initialize sessions and enable lifecycle monitoring
-			# 4. Enable autoAttach for future targets
 			from browser_use.browser.session_manager import SessionManager
 
 			self.session_manager = SessionManager(self)
 			await self.session_manager.start_monitoring()
-			self.logger.debug('Event-driven session manager started')
-
-			# Enable auto-attach so Chrome automatically notifies us when NEW targets attach/detach
-			# This is the foundation of event-driven session management
-			await self._cdp_client_root.send.Target.setAutoAttach(
-				params={'autoAttach': True, 'waitForDebuggerOnStart': False, 'flatten': True}
-			)
-			self.logger.debug('CDP client connected with auto-attach enabled')
+			self.logger.debug('Event-driven session manager started with auto-attach enabled')
 
 			# Get browser targets from SessionManager (source of truth)
 			# SessionManager has already discovered all targets via start_monitoring()
@@ -2143,18 +2137,14 @@ class BrowserSession(BaseModel):
 		)
 		await self._cdp_client_root.start()
 
-		# 4. Re-initialize SessionManager
+		# 4. Re-initialize SessionManager (start_monitoring re-enables root autoAttach;
+		#    a second setAutoAttach here would re-attach existing targets and duplicate sessions)
 		from browser_use.browser.session_manager import SessionManager
 
 		self.session_manager = SessionManager(self)
 		await self.session_manager.start_monitoring()
 
-		# 5. Re-enable autoAttach
-		await self._cdp_client_root.send.Target.setAutoAttach(
-			params={'autoAttach': True, 'waitForDebuggerOnStart': False, 'flatten': True}
-		)
-
-		# 6. Re-discover page targets and restore focus
+		# 5. Re-discover page targets and restore focus
 		page_targets = self.session_manager.get_all_page_targets()
 
 		# Prefer the old focus target if it still exists
@@ -2179,10 +2169,10 @@ class BrowserSession(BaseModel):
 				await self.get_or_create_cdp_session(target_id, focus=True)
 				self.logger.debug(f'🔄 Created new blank page during reconnect: {target_id[:8]}...')
 
-		# 7. Re-enable proxy auth if configured
+		# 6. Re-enable proxy auth if configured
 		await self._setup_proxy_auth()
 
-		# 8. Attach the WS drop detection callback to the new client
+		# 7. Attach the WS drop detection callback to the new client
 		self._attach_ws_drop_callback()
 
 	async def _auto_reconnect(self, max_attempts: int = 3) -> None:

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -133,7 +133,14 @@ class SessionManager:
 
 		self.logger.debug('[SessionManager] Event monitoring started')
 
-		# Discover and initialize ALL existing targets
+		# Enable auto-attach AFTER handlers are registered. Per CDP semantics this
+		# attaches to all EXISTING related targets as well as future ones, so it is
+		# the single attach mechanism for startup targets — explicitly calling
+		# Target.attachToTarget for them too would create a second CDP session per
+		# pre-existing target (doubled event streams and monitoring).
+		await cdp_client.send.Target.setAutoAttach(params={'autoAttach': True, 'waitForDebuggerOnStart': False, 'flatten': True})
+
+		# Wait until every existing target is covered, explicitly attaching stragglers
 		await self._initialize_existing_targets()
 
 	def get_lifecycle_events(self, target_id: TargetID) -> 'deque[dict[str, Any]]':
@@ -781,14 +788,63 @@ class SessionManager:
 			self._recovery_task = None
 			self.logger.debug('[SessionManager] Recovery state reset')
 
+	def _is_target_ready(self, target_id: TargetID) -> bool:
+		"""A target is ready when it has a session and (for pages) monitoring is enabled."""
+		session = self._get_session_for_target(target_id)
+		if not session:
+			return False
+		target = self._targets.get(target_id)
+		target_type = target.target_type if target else 'unknown'
+		if target_type in ('page', 'tab'):
+			# For pages, verify monitoring is enabled
+			return hasattr(session, '_lifecycle_events') and session._lifecycle_events is not None
+		# Non-page targets don't need monitoring
+		return True
+
+	async def _wait_for_targets_ready(self, target_ids: list[TargetID], timeout: float) -> list[TargetID]:
+		"""Wait until every target has a ready session; returns the targets still missing at timeout.
+
+		Event handlers run via create_task, so this waits event-driven instead of polling callers.
+		"""
+		ready_event = asyncio.Event()
+
+		async def check_all_ready():
+			"""Check if all sessions are ready and signal completion."""
+			while True:
+				if all(self._is_target_ready(tid) for tid in target_ids):
+					ready_event.set()
+					return
+				await asyncio.sleep(0.05)
+
+		check_task = create_task_with_error_handling(
+			check_all_ready(), name='check_all_targets_ready', logger_instance=self.logger
+		)
+		try:
+			await asyncio.wait_for(ready_event.wait(), timeout=timeout)
+		except TimeoutError:
+			pass
+		finally:
+			check_task.cancel()
+			try:
+				await check_task
+			except asyncio.CancelledError:
+				pass
+
+		return [tid for tid in target_ids if not self._is_target_ready(tid)]
+
 	async def _initialize_existing_targets(self) -> None:
-		"""Discover and initialize all existing targets at startup.
+		"""Ensure every target that existed at startup has exactly ONE session before returning.
 
-		Attaches to each target and initializes it SYNCHRONOUSLY.
-		Chrome will also fire attachedToTarget events, but _handle_target_attached() is
-		idempotent (checks if target already in pool), so duplicate handling is safe.
+		Root Target.setAutoAttach (enabled in start_monitoring) already attaches to all
+		existing top-level targets, and each attached session auto-attaches its children,
+		so under normal Chrome semantics no explicit attach is needed here. Explicitly
+		calling Target.attachToTarget for targets autoAttach covers would create a SECOND
+		CDP session per pre-existing target: doubled event streams, duplicated lifecycle
+		events in the per-target buffers, and doubled Fetch auth interception.
 
-		This eliminates race conditions - monitoring is guaranteed ready before navigation.
+		Some CDP endpoints may not deliver a target through the auto-attach cascade, so
+		targets still missing a session after a grace period get an explicit attach as a
+		fallback, preserving the guarantee that monitoring is ready before navigation.
 		"""
 		cdp_client = self.browser_session._cdp_client_root
 		assert cdp_client is not None
@@ -799,83 +855,38 @@ class SessionManager:
 
 		self.logger.debug(f'[SessionManager] Discovered {len(existing_targets)} existing targets')
 
-		# Track target IDs for verification
-		target_ids_to_wait_for = []
+		target_ids_to_wait_for = [target['targetId'] for target in existing_targets]
+		target_types = {target['targetId']: target.get('type', 'unknown') for target in existing_targets}
 
-		# Just attach to ALL existing targets - Chrome fires attachedToTarget events
-		# The on_attached handler (via create_task) does ALL the work
-		for target in existing_targets:
-			target_id = target['targetId']
-			target_type = target.get('type', 'unknown')
+		# Normal path: auto-attach delivers every existing target
+		missing = await self._wait_for_targets_ready(target_ids_to_wait_for, timeout=1.0)
+		if not missing:
+			return
 
+		# Fallback: explicitly attach targets the auto-attach cascade did not deliver
+		for target_id in missing:
+			# Re-check right before attaching: the auto-attach event may have landed
+			# during the loop, and attaching again would double the sessions.
+			if self._get_session_for_target(target_id):
+				continue
 			try:
-				# Just attach - event handler does everything
 				await cdp_client.send.Target.attachToTarget(params={'targetId': target_id, 'flatten': True})
-				target_ids_to_wait_for.append(target_id)
+				self.logger.debug(
+					f'[SessionManager] Explicitly attached straggler target {target_id[:8]}... '
+					f'(type={target_types.get(target_id, "unknown")}) not covered by auto-attach'
+				)
 			except Exception as e:
 				self.logger.debug(
-					f'[SessionManager] Failed to attach to existing target {target_id[:8]}... (type={target_type}): {e}'
+					f'[SessionManager] Failed to attach to existing target {target_id[:8]}... '
+					f'(type={target_types.get(target_id, "unknown")}): {e}'
 				)
 
-		# Wait for event handlers to complete their work (they run via create_task)
-		# Use event-driven approach instead of polling for better performance
-		ready_event = asyncio.Event()
-
-		async def check_all_ready():
-			"""Check if all sessions are ready and signal completion."""
-			while True:
-				ready_count = 0
-				for tid in target_ids_to_wait_for:
-					session = self._get_session_for_target(tid)
-					if session:
-						target = self._targets.get(tid)
-						target_type = target.target_type if target else 'unknown'
-						# For pages, verify monitoring is enabled
-						if target_type in ('page', 'tab'):
-							if hasattr(session, '_lifecycle_events') and session._lifecycle_events is not None:
-								ready_count += 1
-						else:
-							# Non-page targets don't need monitoring
-							ready_count += 1
-
-				if ready_count == len(target_ids_to_wait_for):
-					ready_event.set()
-					return
-
-				await asyncio.sleep(0.05)
-
-		# Start checking in background
-		check_task = create_task_with_error_handling(
-			check_all_ready(), name='check_all_targets_ready', logger_instance=self.logger
-		)
-
-		try:
-			# Wait for completion with timeout
-			await asyncio.wait_for(ready_event.wait(), timeout=2.0)
-		except TimeoutError:
-			# Timeout - count what's ready
-			ready_count = 0
-			for tid in target_ids_to_wait_for:
-				session = self._get_session_for_target(tid)
-				if session:
-					target = self._targets.get(tid)
-					target_type = target.target_type if target else 'unknown'
-					# For pages, verify monitoring is enabled
-					if target_type in ('page', 'tab'):
-						if hasattr(session, '_lifecycle_events') and session._lifecycle_events is not None:
-							ready_count += 1
-					else:
-						# Non-page targets don't need monitoring
-						ready_count += 1
+		still_missing = await self._wait_for_targets_ready(target_ids_to_wait_for, timeout=1.0)
+		if still_missing:
+			ready_count = len(target_ids_to_wait_for) - len(still_missing)
 			self.logger.warning(
-				f'[SessionManager] Initialization timeout after 2.0s: {ready_count}/{len(target_ids_to_wait_for)} sessions ready'
+				f'[SessionManager] Initialization timeout: {ready_count}/{len(target_ids_to_wait_for)} sessions ready'
 			)
-		finally:
-			check_task.cancel()
-			try:
-				await check_task
-			except asyncio.CancelledError:
-				pass
 
 	async def _enable_page_monitoring(self, cdp_session: 'CDPSession') -> None:
 		"""Enable lifecycle events and network monitoring for a page target.

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -52,6 +52,13 @@ class SessionManager:
 		# leave every tab but the most recently attached one without lifecycle events.
 		self._lifecycle_events: dict[TargetID, deque[dict[str, Any]]] = {}
 
+		# Targets whose attachedToTarget event has been received but whose handler
+		# task has not finished registering the session in the pool yet. Written
+		# synchronously in the event callback so _initialize_existing_targets' fallback
+		# can distinguish "attach in flight" from "auto-attach never delivered this
+		# target" — explicitly attaching in the former case would double the sessions.
+		self._attaching_targets: set[TargetID] = set()
+
 		self._lock = asyncio.Lock()
 		self._recovery_lock = asyncio.Lock()
 
@@ -85,12 +92,19 @@ class SessionManager:
 			# - Create CDPSession
 			# - Enable monitoring (for pages/tabs)
 			# - Add to pool
-			create_task_with_error_handling(
+			# Mark the attach in flight BEFORE yielding to the event loop: the handler
+			# task may not reach its pool update within the startup grace window, and
+			# the fallback in _initialize_existing_targets must not mistake an
+			# in-flight attach for a target auto-attach never delivered.
+			target_id = event['targetInfo']['targetId']
+			self._attaching_targets.add(target_id)
+			task = create_task_with_error_handling(
 				self._handle_target_attached(event),
 				name='handle_target_attached',
 				logger_instance=self.logger,
 				suppress_exceptions=True,
 			)
+			task.add_done_callback(lambda _task, target_id=target_id: self._attaching_targets.discard(target_id))
 
 		def on_detached(event: DetachedFromTargetEvent, session_id: SessionID | None = None):
 			create_task_with_error_handling(
@@ -866,8 +880,10 @@ class SessionManager:
 		# Fallback: explicitly attach targets the auto-attach cascade did not deliver
 		for target_id in missing:
 			# Re-check right before attaching: the auto-attach event may have landed
-			# during the loop, and attaching again would double the sessions.
-			if self._get_session_for_target(target_id):
+			# during the loop, or its handler may still be mid-flight — in either
+			# case attaching again would double the sessions. In-flight attaches are
+			# picked up by the ready-wait below once their handler completes.
+			if target_id in self._attaching_targets or self._get_session_for_target(target_id):
 				continue
 			try:
 				await cdp_client.send.Target.attachToTarget(params={'targetId': target_id, 'flatten': True})

--- a/tests/ci/browser/test_cdp_session_dedup.py
+++ b/tests/ci/browser/test_cdp_session_dedup.py
@@ -1,0 +1,71 @@
+"""Regression tests: startup must create exactly ONE CDP session per pre-existing target.
+
+Root Target.setAutoAttach attaches to all EXISTING related targets as well as future
+ones (CDP semantics). _initialize_existing_targets() used to also explicitly call
+Target.attachToTarget for every target discovered at startup, so each pre-existing
+target ended up with TWO CDP sessions: doubled event streams and monitoring setup,
+duplicated lifecycle events in the per-target buffers, and doubled Fetch auth
+interception when a proxy is configured. The browser always launches with one
+initial tab before the CDP connection is made, so every single startup hit this.
+"""
+
+import asyncio
+
+from browser_use.browser.events import NavigateToUrlEvent
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+
+SIMPLE_HTML = '<html><head><title>page</title></head><body>hello</body></html>'
+
+
+async def test_startup_creates_exactly_one_session_per_page_target():
+	"""The initial tab (a pre-existing target) must have exactly one CDP session after start()."""
+	session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=True))
+	await session.start()
+	try:
+		session_manager = session.session_manager
+		assert session_manager is not None
+
+		page_targets = session_manager.get_all_page_targets()
+		assert page_targets, 'expected at least the initial tab as a page target'
+
+		for target in page_targets:
+			session_ids = session_manager._target_sessions.get(target.target_id, set())
+			assert len(session_ids) == 1, (
+				f'target {target.target_id[:8]}... has {len(session_ids)} CDP sessions, expected exactly 1 — '
+				f'pre-existing targets must not be attached both explicitly and via root autoAttach'
+			)
+	finally:
+		await session.kill()
+
+
+async def test_new_tab_after_startup_gets_exactly_one_session(httpserver):
+	"""Targets created AFTER startup must still be attached (once) via root autoAttach."""
+	httpserver.expect_request('/a').respond_with_data(SIMPLE_HTML, content_type='text/html')
+	httpserver.expect_request('/b').respond_with_data(SIMPLE_HTML, content_type='text/html')
+
+	session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=True))
+	await session.start()
+	try:
+		session_manager = session.session_manager
+		assert session_manager is not None
+
+		# Occupy the initial tab first so new_tab=True cannot just reuse it
+		await session.navigate_to(httpserver.url_for('/a'))
+		targets_before = {target.target_id for target in session_manager.get_all_page_targets()}
+
+		event = session.event_bus.dispatch(NavigateToUrlEvent(url=httpserver.url_for('/b'), new_tab=True))
+		await event
+		await asyncio.sleep(0.5)  # let attach events settle
+
+		page_targets = session_manager.get_all_page_targets()
+		new_targets = [target for target in page_targets if target.target_id not in targets_before]
+		assert new_targets, 'expected the new tab to appear as a page target'
+
+		for target in page_targets:
+			session_ids = session_manager._target_sessions.get(target.target_id, set())
+			assert len(session_ids) == 1, (
+				f'target {target.target_id[:8]}... has {len(session_ids)} CDP sessions, expected exactly 1'
+			)
+	finally:
+		await session.kill()

--- a/tests/ci/browser/test_cdp_session_dedup.py
+++ b/tests/ci/browser/test_cdp_session_dedup.py
@@ -39,6 +39,49 @@ async def test_startup_creates_exactly_one_session_per_page_target():
 		await session.kill()
 
 
+async def test_slow_attach_handler_does_not_trigger_fallback_double_attach(monkeypatch):
+	"""An in-flight attach handler counts as coverage for the startup fallback.
+
+	on_attached only spawns the handler task; the session reaches the pool after
+	several awaits. If that takes longer than the auto-attach grace window, the
+	fallback in _initialize_existing_targets sees no session for the target — it
+	must recognize the attach is in flight rather than explicitly attach a second
+	session.
+	"""
+	from browser_use.browser.session_manager import SessionManager
+
+	original_handler = SessionManager._handle_target_attached
+
+	async def delayed_handler(self, event):
+		await asyncio.sleep(1.3)  # outlast the 1s auto-attach grace window
+		await original_handler(self, event)
+
+	monkeypatch.setattr(SessionManager, '_handle_target_attached', delayed_handler)
+
+	session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=True))
+	await session.start()
+	try:
+		session_manager = session.session_manager
+		assert session_manager is not None
+
+		# A wrongly-triggered fallback attach would fire a second attachedToTarget
+		# whose (equally delayed) handler registers AFTER start() returns — settle
+		# past the delay so the assertion can see it.
+		await asyncio.sleep(2.0)
+
+		page_targets = session_manager.get_all_page_targets()
+		assert page_targets, 'expected at least the initial tab as a page target'
+
+		for target in page_targets:
+			session_ids = session_manager._target_sessions.get(target.target_id, set())
+			assert len(session_ids) == 1, (
+				f'target {target.target_id[:8]}... has {len(session_ids)} CDP sessions, expected exactly 1 — '
+				f'the fallback must not explicitly attach a target whose attach handler is still running'
+			)
+	finally:
+		await session.kill()
+
+
 async def test_new_tab_after_startup_gets_exactly_one_session(httpserver):
 	"""Targets created AFTER startup must still be attached (once) via root autoAttach."""
 	httpserver.expect_request('/a').respond_with_data(SIMPLE_HTML, content_type='text/html')


### PR DESCRIPTION
Summary

Every `BrowserSession.start()` was creating two CDP sessions for each target that
existed before the CDP connection — which always includes the initial tab. This was
called out as a known follow-up in #5133 ("The double-attach (two CDP sessions per
pre-existing target) is also a separate follow-up"). This PR fixes it.

What was happening

`_initialize_existing_targets()` explicitly called `Target.attachToTarget` for every
target found at startup. Then `session.py` enabled root `Target.setAutoAttach` with a
comment saying it covers "NEW targets" — but per CDP semantics, enabling autoAttach
also attaches to all *existing* related targets immediately. So every pre-existing
target got attached twice.

I verified this empirically on main: right after `start()`, the initial page target
has 2 sessions while everything else has 1. Cost of the duplicate: doubled CDP event
traffic and monitoring setup per tab (Page.enable / Network.enable / lifecycle events
run per session), duplicated lifecycle entries in the same per-target buffer that
navigation readiness reads, and doubled Fetch auth interception when a proxy is set.

The fix

- `SessionManager.start_monitoring()` now enables root autoAttach itself, right after
  handler registration — one attach path for existing and future targets.
- `_initialize_existing_targets()` no longer blind-attaches. It waits for autoAttach
  coverage and only explicitly attaches stragglers the cascade didn't deliver (keeps
  the "monitoring ready before navigation" guarantee on CDP endpoints with different
  autoAttach behavior). Re-checks for a session right before the fallback attach so
  the fallback can't reintroduce the duplicate.
- Removed the now-redundant root `setAutoAttach` calls in `session.py` (start and
  reconnect paths).
- Deliberate second sessions are untouched — the actor API (`actor/page.py`) still
  attaches its own session on purpose, which is why I didn't go with "detach any
  duplicate on sight".

Testing

- New `tests/ci/browser/test_cdp_session_dedup.py`: exactly one session per page
  target after startup, and after opening a new tab (autoAttach for future targets
  still works). Both fail on main ("has 2 CDP sessions, expected exactly 1") and pass
  with the fix.
- Full `tests/ci/browser/` suite: 58 passed, 3 skipped — includes the #5133
  navigation-readiness regression tests, tabs, and session start.
- ruff check/format clean, pyright: 0 errors.

---
Disclosure: prepared with AI assistance (Claude); I reviewed the diff, code, the CDP
semantics reasoning, and the test runs before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-attaching of pre-existing CDP targets at startup and reconnect so each target ends up with exactly one session, including on slow hosts. This reduces duplicate CDP traffic and keeps auto-attach working for new targets.

- **Bug Fixes**
  - Enable root auto-attach inside `SessionManager.start_monitoring` right after handler registration; it now owns attaching for existing and future targets.
  - Update `_initialize_existing_targets` to wait for auto-attach coverage, treat in-flight attach handlers as coverage, and only explicitly attach true stragglers after a final re-check.
  - Remove redundant root `Target.setAutoAttach` calls from `BrowserSession` start and reconnect paths.
  - Add tests to ensure one session per page target at startup, after opening a new tab, and when the attach handler is intentionally delayed past the grace window.

<sup>Written for commit d2b175c37d4d6a6d79897f02e5f30c9b70a32057. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5263?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

