### PR TITLE
fix(downloads): fire complete callbacks for remote-browser downloads

### DIFF
--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -441,6 +441,26 @@ class DownloadsWatchdog(BaseWatchdog):
 						effective_path = file_path or str(Path(downloads_path) / suggested_filename)
 						file_name = Path(effective_path).name
 						file_ext = Path(file_name).suffix.lower().lstrip('.')
+						# Call direct callbacks first so click handlers waiting on the
+						# download (e.g. _execute_click_with_download_detection) resolve.
+						# The local branch does this inside _track_download(); the remote
+						# branch previously only emitted the event, so the click action
+						# timed out waiting for on_download_complete even though the
+						# download had finished (see issue #5132).
+						complete_info = {
+							'guid': guid,
+							'url': info.get('url', ''),
+							'path': str(effective_path),
+							'file_name': file_name,
+							'file_size': 0,
+							'file_type': file_ext if file_ext else None,
+							'auto_download': False,
+						}
+						for callback in self._download_complete_callbacks:
+							try:
+								callback(complete_info)
+							except Exception as e:
+								self.logger.debug(f'[DownloadsWatchdog] Error in download complete callback: {e}')
 						self.event_bus.dispatch(
 							FileDownloadedEvent(
 								guid=guid,

--- a/tests/ci/test_remote_download_complete_callback.py
+++ b/tests/ci/test_remote_download_complete_callback.py
@@ -1,0 +1,131 @@
+"""Regression test for remote-browser download completion callbacks (issue #5132).
+
+When a download finishes on a *remote* browser, the ``downloadProgress`` CDP
+event with ``state == 'completed'`` is the only signal the
+``DownloadsWatchdog`` receives. The local-browser branch calls the registered
+``_download_complete_callbacks`` (via ``_track_download``), but the remote
+branch used to only dispatch ``FileDownloadedEvent`` on the event bus and never
+invoke the direct callbacks.
+
+``DefaultActionWatchdog._execute_click_with_download_detection`` waits on the
+``on_download_complete`` callback (an ``asyncio.Event``), so without this call
+the click action blocks until ``download_complete_timeout`` (30s by default)
+even though the file already finished downloading. This test drives the
+``downloadProgress`` handler that ``DownloadsWatchdog.attach_to_target``
+registers with the CDP client and asserts the complete callback fires.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from browser_use.browser.watchdogs.downloads_watchdog import DownloadsWatchdog
+
+
+class _ProgressCapture:
+	"""Mimics cdp_client.register.Browser.downloadProgress and captures the handler."""
+
+	def __init__(self) -> None:
+		self.handler: Any = None
+
+	def __call__(self, handler) -> None:
+		self.handler = handler
+
+
+def _make_watchdog(tmp_path) -> tuple[DownloadsWatchdog, _ProgressCapture]:
+	"""Build a DownloadsWatchdog bound to a lightweight fake *remote* session.
+
+	Uses ``model_construct`` to bypass pydantic validation (which requires a real
+	BrowserSession / EventBus wiring that would start background tasks). We only
+	stub the handful of attributes the download-completion path reads.
+	"""
+	progress_capture = _ProgressCapture()
+	cdp_register = SimpleNamespace(
+		Browser=SimpleNamespace(
+			downloadProgress=progress_capture,
+			downloadWillBegin=lambda h: None,
+		)
+	)
+	cdp_client = SimpleNamespace(
+		register=cdp_register,
+		send=AsyncMock(),  # Browser.setDownloadBehavior is awaited in attach_to_target
+	)
+
+	browser_session = SimpleNamespace(
+		logger=logging.getLogger('test.downloads_watchdog'),
+		is_local=False,  # remote browser -> exercises the fixed branch
+		cdp_client=cdp_client,
+		browser_profile=SimpleNamespace(downloads_path=str(tmp_path), auto_download_pdfs=False),
+		id='test-session-0001',
+	)
+
+	# A real EventBus.dispatch() schedules async handler tasks that can interact
+	# with pytest's session-scoped loop; we only care about the direct callback
+	# mechanism here, so stub dispatch() to a no-op.
+	event_bus = SimpleNamespace(dispatch=lambda *a, **k: None)
+
+	wd = DownloadsWatchdog.model_construct(
+		browser_session=browser_session, event_bus=event_bus
+	)
+	return wd, progress_capture
+
+
+@pytest.mark.asyncio
+async def test_remote_download_complete_invokes_registered_callback(tmp_path) -> None:
+	wd, progress_capture = _make_watchdog(tmp_path)
+
+	# Drive attach_to_target so the downloadProgress handler is registered.
+	await wd.attach_to_target('FAKE_TARGET_1')
+	assert progress_capture.handler is not None, 'downloadProgress handler was not registered'
+
+	# Seed the "will begin" cache so the completed event can resolve a filename.
+	wd._cdp_downloads_info['guid-123'] = {
+		'url': 'https://example.com/report.pdf',
+		'suggested_filename': 'report.pdf',
+		'handled': False,
+	}
+
+	received: list[dict] = []
+	wd.register_download_callbacks(on_complete=lambda info: received.append(info))
+
+	# Simulate the CDP downloadProgress(completed) event for a remote browser.
+	completed_event = {
+		'guid': 'guid-123',
+		'state': 'completed',
+		'filePath': '/tmp/remote-downloads/report.pdf',
+		'receivedBytes': 1024,
+		'totalBytes': 1024,
+	}
+	progress_capture.handler(completed_event, session_id=None)
+
+	assert len(received) == 1, f'expected the complete callback to fire once, got {received}'
+	info = received[0]
+	assert info['file_name'] == 'report.pdf'
+	assert info['guid'] == 'guid-123'
+	assert info['auto_download'] is False
+	assert info['path'].endswith('report.pdf')
+
+
+@pytest.mark.asyncio
+async def test_remote_download_complete_clears_cdp_cache(tmp_path) -> None:
+	wd, progress_capture = _make_watchdog(tmp_path)
+	await wd.attach_to_target('FAKE_TARGET_2')
+
+	wd._cdp_downloads_info['guid-456'] = {
+		'url': 'https://example.com/data.csv',
+		'suggested_filename': 'data.csv',
+		'handled': False,
+	}
+	wd.register_download_callbacks(on_complete=lambda info: None)
+
+	progress_capture.handler(
+		{'guid': 'guid-456', 'state': 'completed', 'filePath': '/dl/data.csv', 'receivedBytes': 4, 'totalBytes': 4},
+		session_id=None,
+	)
+
+	assert 'guid-456' not in wd._cdp_downloads_info

--- a/tests/ci/test_remote_download_complete_callback.py
+++ b/tests/ci/test_remote_download_complete_callback.py
@@ -69,9 +69,7 @@ def _make_watchdog(tmp_path) -> tuple[DownloadsWatchdog, _ProgressCapture]:
 	# mechanism here, so stub dispatch() to a no-op.
 	event_bus = SimpleNamespace(dispatch=lambda *a, **k: None)
 
-	wd = DownloadsWatchdog.model_construct(
-		browser_session=browser_session, event_bus=event_bus
-	)
+	wd = DownloadsWatchdog.model_construct(browser_session=browser_session, event_bus=event_bus)
 	return wd, progress_capture
 
 


### PR DESCRIPTION
When a file download finishes on a remote browser, DownloadsWatchdog receives the CDP downloadProgress event with state == "completed", but the remote branch of that handler only dispatched FileDownloadedEvent on the event bus. It never invoked the registered _download_complete_callbacks.

The local-browser branch calls those callbacks inside _track_download(), which is exactly what DefaultActionWatchdog._execute_click_with_download_detection waits on: its on_download_complete sets an asyncio.Event the click action is awaiting. So for remote browsers the click that triggered a download blocked until download_complete_timeout (30s by default) even though the file was already on disk, as reported in #5132.

This adds the complete-callback invocation to the remote branch, using the same complete_info shape _track_download already uses (guid, url, path, file_name, file_size, file_type, auto_download), placed right before the FileDownloadedEvent dispatch.

I included a regression test (tests/ci/test_remote_download_complete_callback.py) that registers a fake CDP client via attach_to_target, drives the captured downloadProgress(completed) handler, and asserts the on_complete callback fires with the expected filename. The test fails on the unpatched code and passes with this change.

I could not run the full repo test suite locally because dependency resolution needs network access that is unavailable in this environment, but the new test passes against an isolated venv and ruff is clean on both touched files.

Refs #5132.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remote-browser downloads not firing completion callbacks. Callbacks now run when CDP `downloadProgress` reports `completed`, so actions waiting on downloads no longer time out.

- **Bug Fixes**
  - Call `_download_complete_callbacks` in the remote path before `FileDownloadedEvent` with the same payload as local; log callback errors at debug level.
  - Add regression tests (`tests/ci/test_remote_download_complete_callback.py`) that drive the CDP handler, assert the callback fires, and confirm the CDP cache is cleared.

- **Refactors**
  - Apply `ruff` formatting to the new test file.

<sup>Written for commit 81684831c1663093dc5fb6842cca9f915697c26b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

