### PR TITLE
fix(utils): rank .devN releases below pre-releases in version-check fallback

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -710,16 +710,31 @@ def _is_newer_browser_use_version(latest_version: str, current_version: str) -> 
 
 
 def _browser_use_version_key(version: str) -> tuple[tuple[int, ...], int, int, int] | None:
-	"""Small PEP 440-ish fallback for browser-use versions when packaging is unavailable."""
-	match = re.match(r'^v?(\d+(?:\.\d+)*)(?:(a|b|rc)(\d+))?(?:\.post(\d+))?', version.strip().lower())
+	"""Small PEP 440-ish fallback for browser-use versions when packaging is unavailable.
+
+	Supports pre-release segments ``a``/``b``/``rc``, ``.devN`` development releases and
+	``.postN`` post-releases so they sort in the same order as ``packaging.version.Version``:
+	``1.0.dev1`` < ``1.0a1`` < ``1.0b1`` < ``1.0rc1`` < ``1.0`` < ``1.0.post1``.
+	"""
+	match = re.match(
+		r'^v?(\d+(?:\.\d+)*)(?:(a|b|rc)(\d+))?(?:\.(dev|post)(\d+))?',
+		version.strip().lower(),
+	)
 	if not match:
 		return None
 
 	release = tuple(int(part) for part in match.group(1).split('.'))
 	phase = match.group(2)
 	phase_number = int(match.group(3) or 0)
-	post_number = int(match.group(4) or 0)
+	# dev (-1) sorts before every pre-release/final; a/b/rc take 0/1/2; a plain final is 3.
 	phase_rank = {'a': 0, 'b': 1, 'rc': 2}.get(phase, 3)
+	post_number = 0
+	if match.group(4) == 'dev':
+		# A .devN segment marks a pre-release that ranks below any a/b/rc/final of the same release.
+		phase_rank = -1
+		phase_number = int(match.group(5) or 0)
+	elif match.group(4) == 'post':
+		post_number = int(match.group(5) or 0)
 
 	return release, phase_rank, phase_number, post_number
 

--- a/tests/ci/infrastructure/test_version_check.py
+++ b/tests/ci/infrastructure/test_version_check.py
@@ -1,4 +1,4 @@
-from browser_use.utils import _is_newer_browser_use_version
+from browser_use.utils import _browser_use_version_key, _is_newer_browser_use_version
 
 
 def test_prerelease_is_newer_than_previous_stable():
@@ -11,3 +11,21 @@ def test_stable_release_is_newer_than_same_release_candidate():
 
 def test_later_release_candidate_is_newer():
 	assert _is_newer_browser_use_version('0.13.0rc4', '0.13.0rc3') is True
+
+
+def test_stable_release_is_newer_than_development_release():
+	# A .devN build (e.g. installed from a git checkout) must not be treated as equal to
+	# the final release — otherwise the update check silently misses the stable version.
+	assert _is_newer_browser_use_version('0.13.0', '0.13.0.dev1') is True
+
+
+def test_development_release_is_not_newer_than_release_candidate():
+	assert _is_newer_browser_use_version('0.13.0rc1', '0.13.0.dev1') is True
+
+
+def test_post_release_is_newer_than_final():
+	assert _is_newer_browser_use_version('0.13.0.post1', '0.13.0') is True
+
+
+def test_version_key_dev_ranks_below_alpha():
+	assert _browser_use_version_key('1.0.0.dev1') < _browser_use_version_key('1.0.0a1')

--- a/tests/ci/infrastructure/test_version_check.py
+++ b/tests/ci/infrastructure/test_version_check.py
@@ -28,4 +28,7 @@ def test_post_release_is_newer_than_final():
 
 
 def test_version_key_dev_ranks_below_alpha():
-	assert _browser_use_version_key('1.0.0.dev1') < _browser_use_version_key('1.0.0a1')
+	dev_key = _browser_use_version_key('1.0.0.dev1')
+	alpha_key = _browser_use_version_key('1.0.0a1')
+	assert dev_key is not None and alpha_key is not None
+	assert dev_key < alpha_key


### PR DESCRIPTION
The _browser_use_version_key fallback (used by check_latest_browser_use_version when the packaging library is unavailable) parsed versions with a regex that silently dropped the .devN segment, so 1.0.0.dev1 ranked identically to the final 1.0.0. As a result the update check never reported an available release for installations running a development build (for example a checkout installed between releases), because the dev build compared equal to the just-released final version.

This extends the regex to capture .devN and .postN, and assigns dev releases a phase_rank below alpha so the order matches packaging.version.Version in the primary code path: 1.0.0.dev1 < 1.0.0a1 < 1.0.0b1 < 1.0.0rc1 < 1.0.0 < 1.0.0.post1. I verified the fallback now agrees with packaging.version.Version on the dev/rc/post comparisons.

Added regression tests in test_version_check.py covering the dev-vs-final, dev-vs-rc, and post-vs-final orderings, plus a direct key comparison. The existing rc/stable tests still pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the version-check fallback that ignored .devN, which made 1.0.0.dev1 compare equal to 1.0.0. Now `.devN` ranks below all pre-releases, matching `packaging.version.Version`, so dev installs correctly see final and post updates.

- `_browser_use_version_key` now parses pre/dev/post and sorts: dev < a < b < rc < final < post; used when `packaging` is unavailable.
- Added tests covering dev vs alpha/rc/final and post > final, including a direct key comparison; narrowed comparisons to non-None to satisfy `pyright`.

<sup>Written for commit e972c581582fd2ffc75c4f2de21986a4adffeeb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

