### PR TITLE
fix(dom): preserve explicitly empty accessibility name in DOMInteractedElement

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -1022,9 +1022,11 @@ class DOMInteractedElement:
 
 	@classmethod
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
-		# Extract accessibility name if available
+		# Extract accessibility name if available.
+		# Use `is not None` so an explicitly empty name (e.g. aria-label="") is preserved
+		# as "" rather than collapsed to None, keeping "absent" and "empty" distinguishable.
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_dom_interacted_element_ax_name.py
+++ b/tests/ci/test_dom_interacted_element_ax_name.py
@@ -1,0 +1,86 @@
+"""Tests for DOMInteractedElement.load_from_enhanced_dom_tree ax_name handling.
+
+Regression test for issue #5041: an explicitly empty accessibility name
+(e.g. aria-label="") must be preserved as "" on the resulting element, not
+collapsed to None. The implicit truthiness check `if ax_node.name:` treated an
+empty string the same as a missing value, conflating two distinct states.
+"""
+
+from browser_use.dom.views import (
+	DOMInteractedElement,
+	EnhancedAXNode,
+	EnhancedDOMTreeNode,
+	EnhancedSnapshotNode,
+	NodeType,
+)
+
+
+def _make_ax_node(name: str | None) -> EnhancedAXNode:
+	return EnhancedAXNode(
+		ax_node_id='ax-1',
+		ignored=False,
+		role='button',
+		name=name,
+		description=None,
+		properties=None,
+		child_ids=None,
+	)
+
+
+def _make_node(ax_node: EnhancedAXNode | None) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={},
+		is_scrollable=None,
+		is_visible=None,
+		absolute_position=None,
+		target_id='test-target',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=EnhancedSnapshotNode(
+			is_clickable=None,
+			cursor_style=None,
+			bounds=None,
+			clientRects=None,
+			scrollRects=None,
+			computed_styles={},
+			paint_order=None,
+			stacking_contexts=None,
+		),
+	)
+
+
+class TestLoadFromEnhancedDomTreeAxName:
+	def test_non_empty_ax_name_is_preserved(self):
+		node = _make_node(_make_ax_node('Submit'))
+		element = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+		assert element.ax_name == 'Submit'
+
+	def test_explicitly_empty_ax_name_is_preserved_as_empty_string(self):
+		"""aria-label="" is a valid, intentional value and must round-trip as ""
+		rather than being flattened to None (which means "no name at all")."""
+		node = _make_node(_make_ax_node(''))
+		element = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+		assert element.ax_name == ''
+
+	def test_null_ax_name_yields_none(self):
+		"""When the AX node reports name=None the element keeps ax_name=None."""
+		node = _make_node(_make_ax_node(None))
+		element = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+		assert element.ax_name is None
+
+	def test_missing_ax_node_yields_none(self):
+		"""No AX node attached at all -> ax_name stays None."""
+		node = _make_node(None)
+		element = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+		assert element.ax_name is None


### PR DESCRIPTION
DOMInteractedElement.load_from_enhanced_dom_tree used an implicit truthiness check (ax_node.name) when extracting the accessibility name, so an element with an intentional empty name (e.g. aria-label="") ended up with ax_name=None instead of "". That conflated two distinct states — 'name is absent' and 'name is explicitly empty' — and discarded a valid value that downstream DOM matching and agent-interaction logic can rely on.

The fix switches the guard to an explicit 'is not None' check, so an empty string round-trips correctly while a missing/None name still yields None. Behaviour is unchanged for non-empty names. Closes #5041.

Added unit tests covering the non-empty, empty-string, None-name, and missing-ax-node cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves explicitly empty accessibility names (e.g. `aria-label=""`) in `DOMInteractedElement`. Previously empty names were collapsed to None; now `load_from_enhanced_dom_tree` checks `ax_node.name is not None` so empty strings round‑trip, non‑empty names are unchanged, and missing/None remain None.

Adds unit tests for non-empty, empty-string, None, and missing AX-node cases. Closes #5041.

<sup>Written for commit 9e16c1b82dab9f3c0d51fd057445812afd90a37a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

