### PR TITLE
fix: dispatch TabCreatedEvent for window.open()/target=_blank popups

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from cdp_use.cdp.target import AttachedToTargetEvent, DetachedFromTargetEvent, SessionID, TargetID
 
+from browser_use.browser.events import TabCreatedEvent
 from browser_use.utils import create_task_with_error_handling
 
 if TYPE_CHECKING:
@@ -436,6 +437,11 @@ class SessionManager:
 
 		from browser_use.browser.session import Target
 
+		# Chrome sends an empty string (not a missing key) for the URL of freshly created
+		# targets such as window.open() popups, so `.get('url', 'about:blank')` never falls
+		# back for them - normalize that here instead.
+		target_url = target_info.get('url') or 'about:blank'
+
 		async with self._lock:
 			# Track this session for the target
 			if target_id not in self._target_sessions:
@@ -450,7 +456,7 @@ class SessionManager:
 				target = Target(
 					target_id=target_id,
 					target_type=target_type,
-					url=target_info.get('url', 'about:blank'),
+					url=target_url,
 					title=target_info.get('title', 'Unknown title'),
 				)
 				self._targets[target_id] = target
@@ -458,8 +464,9 @@ class SessionManager:
 			else:
 				# Update existing target info
 				existing_target = self._targets[target_id]
-				existing_target.url = target_info.get('url', existing_target.url)
+				existing_target.url = target_info.get('url') or existing_target.url or 'about:blank'
 				existing_target.title = target_info.get('title', existing_target.title)
+				target_url = existing_target.url
 
 		# Create CDPSession (communication channel)
 		from browser_use.browser.session import CDPSession
@@ -498,6 +505,12 @@ class SessionManager:
 		# Enable lifecycle events and network monitoring for page targets
 		if target_type in ('page', 'tab'):
 			await self._enable_page_monitoring(cdp_session)
+
+			# Targets attached here include ones Chrome creates on its own (window.open(),
+			# target="_blank" links, etc.), not just tabs browser-use opens itself. Without
+			# this, watchdogs that initialize on TabCreatedEvent (popups, about:blank,
+			# security, DOM) never learn the tab exists, so it appears frozen on about:blank.
+			self.browser_session.event_bus.dispatch(TabCreatedEvent(target_id=target_id, url=target_url))
 
 		# Resume execution if waiting for debugger
 		if waiting_for_debugger:

--- a/tests/ci/browser/test_tabs.py
+++ b/tests/ci/browser/test_tabs.py
@@ -19,13 +19,19 @@ Usage:
 
 import asyncio
 import time
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
+from cdp_use import CDPClient
+from cdp_use.cdp.target import AttachedToTargetEvent, TargetInfo
 from pytest_httpserver import HTTPServer
 
 from browser_use.agent.service import Agent
 from browser_use.browser import BrowserSession
+from browser_use.browser.events import TabCreatedEvent
 from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session_manager import SessionManager
 from tests.ci.conftest import create_mock_llm
 
 
@@ -669,3 +675,104 @@ class TestMultiTabOperations:
 			assert 'Successfully' in final_result, 'Agent should report success'
 		except TimeoutError:
 			pytest.fail('Test timed out after 2 minutes - agent hung during multiple tab operations')
+
+
+def _target_attached_event(*, session_id: str, target_id: str, target_type: str, url: str, title: str) -> AttachedToTargetEvent:
+	"""Build a minimal CDP Target.attachedToTarget event as Chrome would send it."""
+	target_info = cast(
+		TargetInfo,
+		{
+			'targetId': target_id,
+			'type': target_type,
+			'url': url,
+			'title': title,
+			'attached': True,
+			'canAccessOpener': False,
+		},
+	)
+	return cast(
+		AttachedToTargetEvent,
+		{'sessionId': session_id, 'targetInfo': target_info, 'waitingForDebugger': False},
+	)
+
+
+def _build_session_manager() -> tuple[SessionManager, list, list]:
+	"""Build a SessionManager with a stubbed CDP client and event bus for unit testing
+	_handle_target_attached() without a real browser connection."""
+	cdp_client_root = CDPClient('ws://unused')
+	cast(Any, cdp_client_root).send = SimpleNamespace(Target=SimpleNamespace(setAutoAttach=_noop_async))
+
+	dispatched_events: list = []
+	monitored_sessions: list = []
+
+	browser_session = SimpleNamespace(
+		_cdp_client_root=cdp_client_root,
+		browser_profile=SimpleNamespace(proxy=None),
+		event_bus=SimpleNamespace(dispatch=dispatched_events.append),
+		logger=SimpleNamespace(debug=lambda *a, **k: None, warning=lambda *a, **k: None),
+	)
+	manager = SessionManager(cast(BrowserSession, browser_session))
+
+	async def record_page_monitoring(cdp_session):
+		monitored_sessions.append(cdp_session)
+
+	manager._enable_page_monitoring = record_page_monitoring  # type: ignore[method-assign]
+	return manager, dispatched_events, monitored_sessions
+
+
+async def _noop_async(*args, **kwargs) -> None:
+	pass
+
+
+class TestWindowOpenTabCreatedEvent:
+	"""Regression tests for #4208: window.open() popups must dispatch TabCreatedEvent.
+
+	Chrome attaches window.open()/target="_blank" popups to browser-use via
+	Target.attachedToTarget just like any other target, but SessionManager only
+	enabled page monitoring for them - it never told the rest of the system a new
+	tab existed. Without TabCreatedEvent, PopupsWatchdog/AboutBlankWatchdog/
+	SecurityWatchdog/DOMWatchdog never initialize for the popup, so it appears
+	stuck on about:blank and the opener page looks frozen.
+	"""
+
+	async def test_page_target_attach_dispatches_tab_created_event(self):
+		manager, dispatched_events, monitored_sessions = _build_session_manager()
+
+		await manager._handle_target_attached(
+			_target_attached_event(
+				session_id='session-window-open',
+				target_id='target-window-open',
+				target_type='page',
+				url='',  # Chrome sends an empty string, not a missing url, for fresh popups
+				title='',
+			)
+		)
+
+		assert len(monitored_sessions) == 1, 'popup should still get page monitoring enabled'
+		assert len(dispatched_events) == 1, 'popup attach must dispatch exactly one event'
+
+		event = dispatched_events[0]
+		assert isinstance(event, TabCreatedEvent)
+		assert event.target_id == 'target-window-open'
+		assert event.url == 'about:blank', 'empty CDP url must be normalized, not left blank'
+
+		target = manager.get_target('target-window-open')
+		assert target is not None
+		assert target.url == 'about:blank'
+
+	async def test_non_page_target_attach_does_not_dispatch_tab_created_event(self):
+		"""Workers/iframes attach through the same code path but are not tabs."""
+		manager, dispatched_events, monitored_sessions = _build_session_manager()
+
+		await manager._handle_target_attached(
+			_target_attached_event(
+				session_id='session-worker',
+				target_id='target-worker',
+				target_type='worker',
+				url='https://example.com/worker.js',
+				title='',
+			)
+		)
+
+		assert monitored_sessions == []
+		assert dispatched_events == []


### PR DESCRIPTION
## Summary

Fixes #4208 — `window.open()` causes the previous page to freeze and the new page never navigates past `about:blank`.

## Root cause

When Chrome attaches a popup target created by `window.open()` (or a `target="_blank"` link), it goes through `Target.attachedToTarget` exactly like any browser-use-initiated tab. `SessionManager._handle_target_attached()` enables page monitoring for it, but never dispatched `TabCreatedEvent`. Every watchdog that initializes on that event — `PopupsWatchdog`, `AboutBlankWatchdog`, `SecurityWatchdog`, `DOMWatchdog` — never learns the popup exists, so it stays stuck on `about:blank` and the opener appears frozen.

Two prior PRs (#4239, #4843) independently diagnosed this exact root cause and were reviewed/CI-passing, but both were closed stale without being merged.

## Change

`browser_use/browser/session_manager.py`:
- Dispatch `TabCreatedEvent(target_id=target_id, url=target_url)` from `_handle_target_attached()` for `page`/`tab` targets, right after `_enable_page_monitoring()`.
- Normalize the target URL: Chrome sends an **empty string** (not a missing key) for fresh popup targets, so the existing `target_info.get('url', 'about:blank')` never actually fell back. Now uses `target_info.get('url') or 'about:blank'`.

## Tests

Added `TestWindowOpenTabCreatedEvent` in `tests/ci/browser/test_tabs.py`:
- `test_page_target_attach_dispatches_tab_created_event` — asserts a `page`-type attach with an empty URL (matching what Chrome sends for `window.open()` popups) dispatches exactly one `TabCreatedEvent` with `url` normalized to `about:blank`.
- `test_non_page_target_attach_does_not_dispatch_tab_created_event` — asserts worker/iframe attaches (which go through the same code path) do **not** get treated as tabs.

Verified the first test fails on the pre-fix code (`0 == 1`) and passes after the fix, confirming it actually catches the regression.

```
uv run ruff check browser_use/browser/session_manager.py tests/ci/browser/test_tabs.py   # passed
uv run ruff format --check browser_use/browser/session_manager.py tests/ci/browser/test_tabs.py  # passed
uv run pyright browser_use/browser/session_manager.py tests/ci/browser/test_tabs.py      # 0 errors
uv run pytest tests/ci/browser/test_tabs.py::TestWindowOpenTabCreatedEvent -v            # 2 passed
```

Fixes #4208


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dispatches `TabCreatedEvent` for popup tabs opened via `window.open()` or `target="_blank"` and normalizes empty URLs to `about:blank`, so popups no longer get stuck and the opener doesn’t freeze. Fixes #4208.

- **Bug Fixes**
  - Fire `TabCreatedEvent` in `SessionManager._handle_target_attached()` for `page`/`tab` targets right after enabling page monitoring.
  - Normalize popup target URLs: use `'about:blank'` when CDP provides an empty string.
  - Tests cover event dispatch for popups (empty URL → `'about:blank'`) and ensure non-`page` targets don’t dispatch.

<sup>Written for commit 4eb0199c074f296ce94d8014b6d12ab3a9998866. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

