### PR TITLE
fix(mcp): report tool execution failures with isError=true

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -457,19 +457,26 @@ class BrowserUseServer:
 			return []
 
 		@self.server.call_tool()
-		async def handle_call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.TextContent | types.ImageContent]:
+		async def handle_call_tool(
+			name: str, arguments: dict[str, Any] | None
+		) -> types.CallToolResult | list[types.TextContent | types.ImageContent]:
 			"""Handle tool execution."""
 			start_time = time.time()
 			error_msg = None
 			try:
 				result = await self._execute_tool(name, arguments or {})
+				if isinstance(result, types.CallToolResult):
+					return result
 				if isinstance(result, list):
 					return result
 				return [types.TextContent(type='text', text=result)]
 			except Exception as e:
 				error_msg = str(e)
 				logger.error(f'Tool execution failed: {e}', exc_info=True)
-				return [types.TextContent(type='text', text=f'Error: {str(e)}')]
+				return types.CallToolResult(
+					content=[types.TextContent(type='text', text=f'Error: {str(e)}')],
+					isError=True,
+				)
 			finally:
 				# Capture telemetry for tool calls
 				duration = time.time() - start_time

--- a/tests/ci/unit/test_mcp_is_error.py
+++ b/tests/ci/unit/test_mcp_is_error.py
@@ -1,0 +1,39 @@
+"""Tests for MCP server error reporting (isError=True)."""
+
+from typing import Any
+
+import pytest
+import mcp.types as types
+
+from browser_use.mcp.server import BrowserUseServer
+
+
+@pytest.fixture
+def server() -> BrowserUseServer:
+	return BrowserUseServer()
+
+
+async def test_handle_call_tool_returns_is_error_true_on_exception(server: BrowserUseServer) -> None:
+	"""Execution exception -> handle_call_tool must return CallToolResult with isError=True."""
+
+	async def throwing_stub(**kwargs: Any) -> str:
+		raise RuntimeError('Failed to establish CDP connection to browser')
+
+	server._retry_with_browser_use_agent = throwing_stub  # type: ignore[method-assign]
+
+	handler = server.server.request_handlers[types.CallToolRequest]
+	request = types.CallToolRequest(
+		params=types.CallToolRequestParams(name='retry_with_browser_use_agent', arguments={'task': 'noop'})
+	)
+
+	result = await handler(request)
+
+	# The mcp server wraps the result in a ServerResult root
+	assert hasattr(result, 'root') or isinstance(result, types.CallToolResult)
+	tool_result = result.root if hasattr(result, 'root') else result
+
+	assert isinstance(tool_result, types.CallToolResult)
+	assert tool_result.isError is True
+	assert len(tool_result.content) == 1
+	assert tool_result.content[0].type == 'text'
+	assert 'Failed to establish CDP connection' in tool_result.content[0].text


### PR DESCRIPTION
﻿## Summary
- Return `types.CallToolResult(isError=True)` when MCP tool execution fails or encounters uncaught exceptions.
- Add unit test verifying `isError=True` is returned on execution errors.

## Root cause
`handle_call_tool` caught exceptions and formatted error messages into a plain text content list without setting `isError=True` on `CallToolResult`. Conforming MCP hosts (such as Claude / Codex) interpret `isError=False` as a successful tool execution, breaking model error recovery and telemetry.

Fixes #5252.

## Validation
- `uv run pytest tests/ci/unit/test_mcp_is_error.py`
- `uv run pytest tests/ci/security/test_mcp_allowed_domains.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report MCP tool execution failures as errors by returning `types.CallToolResult` with `isError=true`, so hosts don’t treat failures as successes and telemetry is accurate.

- **Bug Fixes**
  - Updated `handle_call_tool` in `browser_use/mcp/server.py` to return `types.CallToolResult(isError=True)` on exceptions and pass through an existing `CallToolResult`.
  - Expanded return type to `types.CallToolResult | list[types.TextContent | types.ImageContent]`.
  - Added `tests/ci/unit/test_mcp_is_error.py` to verify `isError=True` and error text content on execution failures.

<sup>Written for commit de85363f57be432826eeddd3813c55405d035ce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

