### PR TITLE
Fix tool name in flash prompts: replace_file_str -> replace_file

### DIFF
--- a/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_anthropic_flash.md
@@ -12,7 +12,7 @@ You excel at following tasks:
 <user_request>Ultimate objective. Specific tasks: follow each step precisely. Open-ended: plan your own approach.</user_request>
 <browser_state>Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new element since last step.</browser_state>
 <file_system>
-PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. In available_file_paths, you can read downloaded files and user attachment files.
+PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file when completing items. In available_file_paths, you can read downloaded files and user attachment files.
 - Your file system is initialized with a `todo.md`: Use this to keep a checklist for known subtasks.
 - If you are writing a `csv` file, make sure to use double quotes if cell elements contain commas.
 - If the file is too large, you are only given a preview of your file. Use `read_file` to see the full content if necessary.
@@ -217,7 +217,7 @@ Common actions you can use:
 - done: Complete the task and report results
 - write_file: Write content to a file
 - read_file: Read content from a file
-- replace_file_str: Replace text in a file
+- replace_file: Replace text in a file
 Each action has specific parameters - refer to the action schema for details.
 </action_reference>
 <error_recovery>

--- a/browser_use/agent/system_prompts/system_prompt_flash.md
+++ b/browser_use/agent/system_prompts/system_prompt_flash.md
@@ -2,7 +2,7 @@ You are an AI agent designed to operate in an iterative loop to automate browser
 <language_settings>Default: English. Match user's language.</language_settings>
 <user_request>Ultimate objective. Specific tasks: follow each step. Open-ended: plan approach.</user_request>
 <browser_state>Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new.</browser_state>
-<file_system>- PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. When writing CSV, use double quotes for commas. In available_file_paths, you can read downloaded files and user attachment files.</file_system>
+<file_system>- PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file when completing items. When writing CSV, use double quotes for commas. In available_file_paths, you can read downloaded files and user attachment files.</file_system>
 <action_rules>
 You are allowed to use a maximum of {max_actions} actions per step. Check the browser state each step to verify your previous action achieved its goal. When chaining multiple actions, never take consequential actions (submitting forms, clicking consequential buttons) without confirming necessary changes occurred.
 </action_rules>

--- a/browser_use/agent/system_prompts/system_prompt_flash_anthropic.md
+++ b/browser_use/agent/system_prompts/system_prompt_flash_anthropic.md
@@ -6,7 +6,7 @@ User request is the ultimate objective. For tasks with specific instructions, fo
 Elements: [index]<type>text</type>. Only [indexed] are interactive. Indentation=child. *[=new.
 </browser_state>
 <file_system>
-PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking and saving data. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file_str when completing items. In available_file_paths, you can read downloaded files and user attachment files.
+PDFs are auto-downloaded to available_file_paths - use read_file to read the doc or look at screenshot. You have access to persistent file system for progress tracking and saving data. Long tasks >10 steps: use todo.md: checklist for subtasks, update with replace_file when completing items. In available_file_paths, you can read downloaded files and user attachment files.
 </file_system>
 <action_rules>
 You are allowed to use a maximum of {max_actions} actions per step. Check the browser state each step to verify your previous action achieved its goal. When chaining multiple actions, never take consequential actions (submitting forms, clicking consequential buttons) without confirming necessary changes occurred.


### PR DESCRIPTION
The flash system prompts (`system_prompt_flash.md`, `system_prompt_anthropic_flash.md`, `system_prompt_flash_anthropic.md`) instruct the model to use `replace_file_str`, but the registered tool is `replace_file` (`tools/service.py:1776`). Models cope by inferring the right name (0 wrong-name calls observed in 42k eval steps), so impact is hygiene — but the prompt should name the tool that exists. The two remaining `replace_file_str` occurrences are the internal `FileSystem` method, which is not model-facing and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated flash system prompts to reference the correct tool `replace_file` instead of `replace_file_str`. Aligns instructions with the registered tool to avoid confusion when updating files.

<sup>Written for commit daf7a3e112f6972e3aefaa9044783c328a2f61c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

