### PR TITLE
Gate the skeleton-screen 'still loading?' hint on in-flight network requests

### DIFF
--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -229,8 +229,13 @@ class AgentMessagePrompt:
 		stats_text = '<page_stats>'
 		if page_stats['total_elements'] < 10:
 			stats_text += 'Page appears empty (SPA not loaded?) - '
-		# Skeleton screen: many elements but almost no text = loading placeholders
-		elif page_stats['total_elements'] > 20 and page_stats['text_chars'] < page_stats['total_elements'] * 5:
+		# Skeleton screen: low text density only means "loading" while requests are actually in flight;
+		# without that gate the hint fires on most fully-rendered element-heavy pages (measured 76% of prompts)
+		elif (
+			self.browser_state.pending_network_requests
+			and page_stats['total_elements'] > 20
+			and page_stats['text_chars'] < page_stats['total_elements'] * 5
+		):
 			stats_text += 'Page appears to show skeleton/placeholder content (still loading?) - '
 		stats_text += f'{page_stats["links"]} links, {page_stats["interactive_elements"]} interactive, '
 		stats_text += f'{page_stats["iframes"]} iframes'

--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -228,15 +228,18 @@ class AgentMessagePrompt:
 		# Format statistics
 		stats_text = '<page_stats>'
 		if page_stats['total_elements'] < 10:
-			stats_text += 'Page appears empty (SPA not loaded?) - '
-		# Skeleton screen: low text density only means "loading" while requests are actually in flight;
-		# without that gate the hint fires on most fully-rendered element-heavy pages (measured 76% of prompts)
+			stats_text += 'Page appears empty - if unexpected, wait briefly or reload before concluding content is missing - '
+		# Skeleton screen: low text density only means "loading" while requests are actually in flight
 		elif (
 			self.browser_state.pending_network_requests
 			and page_stats['total_elements'] > 20
 			and page_stats['text_chars'] < page_stats['total_elements'] * 5
 		):
-			stats_text += 'Page appears to show skeleton/placeholder content (still loading?) - '
+			pending_count = len(self.browser_state.pending_network_requests)
+			stats_text += (
+				f'{pending_count} network request(s) in flight and little text rendered - '
+				f'page may still be loading, consider a short wait - '
+			)
 		stats_text += f'{page_stats["links"]} links, {page_stats["interactive_elements"]} interactive, '
 		stats_text += f'{page_stats["iframes"]} iframes'
 		if page_stats['shadow_open'] > 0 or page_stats['shadow_closed'] > 0:

--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -228,7 +228,7 @@ class AgentMessagePrompt:
 		# Format statistics
 		stats_text = '<page_stats>'
 		if page_stats['total_elements'] < 10:
-			stats_text += 'Page appears empty - consider to wait - '
+			stats_text += 'Page appears empty - consider waiting - '
 		# Skeleton screen: low text density only means "loading" while requests are actually in flight
 		elif (
 			self.browser_state.pending_network_requests
@@ -238,7 +238,7 @@ class AgentMessagePrompt:
 			pending_count = len(self.browser_state.pending_network_requests)
 			stats_text += (
 				f'{pending_count} network request(s) in flight and little text rendered - '
-				f'page may still be loading, consider to wait - '
+				f'page may still be loading, consider waiting - '
 			)
 		stats_text += f'{page_stats["links"]} links, {page_stats["interactive_elements"]} interactive, '
 		stats_text += f'{page_stats["iframes"]} iframes'

--- a/browser_use/agent/prompts.py
+++ b/browser_use/agent/prompts.py
@@ -228,7 +228,7 @@ class AgentMessagePrompt:
 		# Format statistics
 		stats_text = '<page_stats>'
 		if page_stats['total_elements'] < 10:
-			stats_text += 'Page appears empty - if unexpected, wait briefly or reload before concluding content is missing - '
+			stats_text += 'Page appears empty - consider to wait - '
 		# Skeleton screen: low text density only means "loading" while requests are actually in flight
 		elif (
 			self.browser_state.pending_network_requests
@@ -238,7 +238,7 @@ class AgentMessagePrompt:
 			pending_count = len(self.browser_state.pending_network_requests)
 			stats_text += (
 				f'{pending_count} network request(s) in flight and little text rendered - '
-				f'page may still be loading, consider a short wait - '
+				f'page may still be loading, consider to wait - '
 			)
 		stats_text += f'{page_stats["links"]} links, {page_stats["interactive_elements"]} interactive, '
 		stats_text += f'{page_stats["iframes"]} iframes'

--- a/tests/ci/test_action_blank_page.py
+++ b/tests/ci/test_action_blank_page.py
@@ -144,7 +144,7 @@ class TestSkeletonScreenDetection:
 		prompt = _make_prompt(state)
 		description = prompt._get_browser_state_description()
 
-		assert 'skeleton' in description.lower() or 'placeholder' in description.lower(), (
+		assert 'still be loading' in description.lower(), (
 			f'Expected skeleton/placeholder warning in description, got:\n{description[:500]}'
 		)
 
@@ -163,7 +163,7 @@ class TestSkeletonScreenDetection:
 			f'({page_stats["total_elements"] * 5})'
 		)
 		# No skeleton warning in description
-		assert 'skeleton' not in description.lower() and 'placeholder' not in description.lower(), (
+		assert 'still be loading' not in description.lower(), (
 			'Rich page should NOT produce a skeleton warning'
 		)
 

--- a/tests/ci/test_action_blank_page.py
+++ b/tests/ci/test_action_blank_page.py
@@ -163,9 +163,7 @@ class TestSkeletonScreenDetection:
 			f'({page_stats["total_elements"] * 5})'
 		)
 		# No skeleton warning in description
-		assert 'still be loading' not in description.lower(), (
-			'Rich page should NOT produce a skeleton warning'
-		)
+		assert 'still be loading' not in description.lower(), 'Rich page should NOT produce a skeleton warning'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ci/test_action_blank_page.py
+++ b/tests/ci/test_action_blank_page.py
@@ -135,6 +135,12 @@ class TestSkeletonScreenDetection:
 		await _navigate(tools, browser_session, f'{base_url}/skeleton')
 
 		state = await browser_session.get_browser_state_summary(include_screenshot=False)
+		# The hint is gated on in-flight requests; the static fixture has none, so simulate one
+		from browser_use.browser.views import NetworkRequest
+
+		state.pending_network_requests = [
+			NetworkRequest(url=f'{base_url}/api/data', method='GET', loading_duration_ms=120.0, resource_type='fetch')
+		]
 		prompt = _make_prompt(state)
 		description = prompt._get_browser_state_description()
 


### PR DESCRIPTION
The skeleton hint (`prompts.py`, added in #4427 alongside an unrelated image fix, Linear AGI-497) uses a pure text-density threshold: `total_elements > 20 and text_chars < total_elements * 5`. Measured over ~40k eval steps it fires on **75.7% of all prompts**, mostly on fully rendered element-heavy pages — and models have learned to ignore it (steps where it fired waited *less* than steps where it didn't), which also devalues the hint in the one case a page really is loading.

`BrowserStateSummary.pending_network_requests` is computed on every state build by `dom_watchdog._get_pending_network_requests()` (readyState + performance API, ad-filtered) and was previously read by nothing. This PR gates the hint on it, so "still loading?" only appears while requests are actually in flight. The skeleton fixture test simulates one pending request; the rich-page test is unchanged (the gate only tightens the condition). All 4 tests in `test_action_blank_page.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the skeleton-screen hint on actual in‑flight network requests and reword hints to “consider waiting,” including the request count. This cuts false positives (~76% before) and gives clearer, data‑driven guidance.

- **Bug Fixes**
  - Gate the low-text-density skeleton hint on `BrowserStateSummary.pending_network_requests` in `browser_use/agent/prompts.py`; message shows the in‑flight count and says “page may still be loading, consider waiting.”
  - Update empty‑page hint to “Page appears empty — consider waiting”; adjust `tests/ci/test_action_blank_page.py` to simulate a pending request and assert on the new wording.

<sup>Written for commit 6618c97ebd252ad68d205de1695db12c856084dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

