### PR TITLE
Fix clear-to-empty on React controlled inputs (native value setter)

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1383,7 +1383,19 @@ class DefaultActionWatchdog(BaseWatchdog):
 								} catch (e) {
 									// ignore
 								}
-								this.value = "";
+								// Use the prototype's native value setter: React patches the instance
+								// setter to track values, so a direct `this.value = ""` makes React's
+								// tracker think nothing changed and the input event gets ignored,
+								// leaving controlled components with the old value.
+								const proto = this.tagName === 'TEXTAREA'
+									? window.HTMLTextAreaElement.prototype
+									: window.HTMLInputElement.prototype;
+								const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+								if (desc && desc.set) {
+									desc.set.call(this, "");
+								} else {
+									this.value = "";
+								}
 								this.dispatchEvent(new Event("input", { bubbles: true }));
 								this.dispatchEvent(new Event("change", { bubbles: true }));
 								return {cleared: true, method: 'value', finalText: this.value};

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1383,16 +1383,23 @@ class DefaultActionWatchdog(BaseWatchdog):
 								} catch (e) {
 									// ignore
 								}
-								// Use the prototype's native value setter: React patches the instance
-								// setter to track values, so a direct `this.value = ""` makes React's
-								// tracker think nothing changed and the input event gets ignored,
-								// leaving controlled components with the old value.
-								const proto = this.tagName === 'TEXTAREA'
-									? window.HTMLTextAreaElement.prototype
-									: window.HTMLInputElement.prototype;
-								const desc = Object.getOwnPropertyDescriptor(proto, 'value');
-								if (desc && desc.set) {
-									desc.set.call(this, "");
+								// For real <input>/<textarea>, use the prototype's native value setter:
+								// React patches the instance setter to track values, so a direct
+								// `this.value = ""` makes React's tracker think nothing changed and the
+								// input event gets ignored, leaving controlled components with the old
+								// value. For anything else with a .value accessor (web components,
+								// selects), the prototype setter throws Illegal invocation - keep using
+								// the element's own setter there.
+								if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
+									const proto = this instanceof HTMLTextAreaElement
+										? window.HTMLTextAreaElement.prototype
+										: window.HTMLInputElement.prototype;
+									const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+									try {
+										desc.set.call(this, "");
+									} catch (e) {
+										this.value = "";
+									}
 								} else {
 									this.value = "";
 								}
@@ -1841,9 +1848,6 @@ class DefaultActionWatchdog(BaseWatchdog):
 			if clear:
 				cleared_successfully = await self._clear_text_field(object_id=object_id, cdp_session=cdp_session)
 				if not cleared_successfully:
-					if not text:
-						# Pure clear: surface the failure instead of letting the action report success
-						raise BrowserError('Failed to clear text field: field still contains previous text')
 					self.logger.warning('⚠️ Text field clearing failed, typing may append to existing text')
 
 			# Step 4: Type the text character by character using proper human-like key events
@@ -2033,13 +2037,21 @@ class DefaultActionWatchdog(BaseWatchdog):
 								'functionDeclaration': """
 									function(newValue) {
 										if (this.value !== undefined) {
-											var desc = Object.getOwnPropertyDescriptor(
-												HTMLInputElement.prototype, 'value'
-											) || Object.getOwnPropertyDescriptor(
-												HTMLTextAreaElement.prototype, 'value'
-											);
+											// Pick the descriptor for THIS element type; calling the
+											// HTMLInputElement setter on a textarea or web component
+											// throws Illegal invocation.
+											var desc = null;
+											if (this instanceof HTMLInputElement) {
+												desc = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+											} else if (this instanceof HTMLTextAreaElement) {
+												desc = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value');
+											}
 											if (desc && desc.set) {
-												desc.set.call(this, newValue);
+												try {
+													desc.set.call(this, newValue);
+												} catch (e) {
+													this.value = newValue;
+												}
 											} else {
 												this.value = newValue;
 											}

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1841,6 +1841,9 @@ class DefaultActionWatchdog(BaseWatchdog):
 			if clear:
 				cleared_successfully = await self._clear_text_field(object_id=object_id, cdp_session=cdp_session)
 				if not cleared_successfully:
+					if not text:
+						# Pure clear: surface the failure instead of letting the action report success
+						raise BrowserError('Failed to clear text field: field still contains previous text')
 					self.logger.warning('⚠️ Text field clearing failed, typing may append to existing text')
 
 			# Step 4: Type the text character by character using proper human-like key events


### PR DESCRIPTION
`_clear_text_field` clears via the instance `this.value = \"\"`. React patches the instance value setter to track changes, so that assignment updates React's tracker and the synthetic `input` event gets deduped — onChange never fires and the controlled component keeps its old state while the DOM looks empty. The synchronous `finalText` check reads `\"\"` at that instant, so the keystroke fallbacks (which would work) are unreachable, and the action reports "Typed ''" success.

**Blast radius is narrow but real**: only `input(index, \"\", clear=true)` (pure clear). When text follows the clear, the real per-character key events resync React on the first keystroke, and #4023's concat retry backstops. The pure-clear path is the silent one — observed in evals as an agent retrying a search-box clear 11 times while the React-filtered list never reset.

History (why this is a gap, not a choice): the original `_clear_text_field` (d80549038, Aug 2025) used real Ctrl+A+Backspace key events — React-safe. A same-day follow-up (f4a34bc1d "fix-clear-text", no body) promoted JS value-set to Strategy 1. Later commits added the correct native-setter technique for date inputs (`_set_value_directly`, 0badc5d4c) and for the type-retry path (#4023) — it just never reached the clear path. Related user reports: #3415, #2867 (dropdown flavor of the same tracker mechanism).

Two changes:
1. `_clear_text_field` uses the prototype's native value setter (same technique as `_set_value_directly`), so React's tracker sees the change and onChange fires with the cleared value.
2. If a pure clear still fails, raise `BrowserError` instead of logging a warning and reporting success — the agent gets an honest failure it can react to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clearing React‑controlled text fields so the DOM and component state stay in sync. Uses the native prototype value setter on real inputs so React sees the change and `onChange` fires.

- **Bug Fixes**
  - Clear now calls the element‑type’s native value setter for `HTMLInputElement`/`HTMLTextAreaElement` with `instanceof` guards; web components and other elements keep their own setter to avoid Illegal invocation.
  - Fixed the descriptor lookup in the concat‑retry path to pick the correct setter per element type, with a safe fallback to `this.value`.

<sup>Written for commit d4abb27612ea7a6a11256917f25a2f03a57151a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

