### PR TITLE
fix: handle file:// urls in _extract_start_url

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2288,7 +2288,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		# Look for common URL patterns
 		patterns = [
-			r'https?://[^\s<>"\']+',  # Full URLs with http/https
+			r'(?:https?|file)://[^\s<>"\']+',  # Full URLs
 			r'(?:www\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}(?:/[^\s<>"\']*)?',  # Domain names with subdomains and optional paths
 		]
 
@@ -2373,11 +2373,16 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		}
 
 		found_urls = []
+		matched_spans: list[tuple[int, int]] = []
 		for pattern in patterns:
 			matches = re.finditer(pattern, task_without_emails)
 			for match in matches:
 				url = match.group(0)
 				original_position = match.start()  # Store original position before URL modification
+
+				# Skip fragments of URLs already matched by earlier pattern				if any(match.start() < end and match.end() > start for start, end in matched_spans):
+					continue
+				matched_spans.append((match.start(), match.end()))
 
 				# Remove trailing punctuation that's not part of URLs
 				url = sanitize_url_candidate(url)
@@ -2386,13 +2391,18 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					self.logger.debug(f'Excluding placeholder URL from auto-navigation: {url}')
 					continue
 
-				# Check if URL ends with a file extension that should be excluded
 				url_lower = url.lower()
+				has_scheme = url_lower.startswith(('http://', 'https://', 'file://'))
+
+				# Check if URL ends with file extension
 				should_exclude = False
-				for ext in excluded_extensions:
-					if f'.{ext}' in url_lower:
+				if not url_lower.startswith('file://'):
+					for ext in excluded_extensions:
+						if f'.{ext}' in url_lower:
+							should_exclude = True
+							break
+					if not has_scheme and '.htm' in url_lower:
 						should_exclude = True
-						break
 
 				if should_exclude:
 					self.logger.debug(f'Excluding URL with file extension from auto-navigation: {url}')
@@ -2408,7 +2418,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					continue
 
 				# Add https:// if missing (after excluded words check to avoid position calculation issues)
-				if not url.startswith(('http://', 'https://')):
+				if not has_scheme:
 					url = 'https://' + url
 
 				found_urls.append(url)

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2380,7 +2380,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				url = match.group(0)
 				original_position = match.start()  # Store original position before URL modification
 
-				# Skip fragments of URLs already matched by earlier pattern				if any(match.start() < end and match.end() > start for start, end in matched_spans):
+				# Skip fragments of URLs already matched by earlier pattern
+				if any(match.start() < end and match.end() > start for start, end in matched_spans):
 					continue
 				matched_spans.append((match.start(), match.end()))
 

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -1397,7 +1397,7 @@ def _task_with_sensitive_data_context(task: str, sensitive_context: dict[str, An
 def _extract_start_url(task: str) -> str | None:
 	task_without_emails = re.sub(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b', '', task)
 	patterns = [
-		r'https?://[^\s<>"\']+',
+		r'(?:https?|file)://[^\s<>"\']+',
 		r'(?:www\.)?[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}(?:/[^\s<>"\']*)?',
 	]
 	excluded_extensions = {
@@ -1463,19 +1463,29 @@ def _extract_start_url(task: str) -> str | None:
 	excluded_words = {'never', 'dont', 'not', "don't"}
 
 	found_urls = []
+	matched_spans: list[tuple[int, int]] = []
 	for pattern in patterns:
 		for match in re.finditer(pattern, task_without_emails):
+			# Skip fragments of URLs already matched by an earlier pattern
+			if any(match.start() < end and match.end() > start for start, end in matched_spans):
+				continue
+			matched_spans.append((match.start(), match.end()))
 			url = sanitize_url_candidate(match.group(0))
 			url_lower = url.lower()
+			has_scheme = url_lower.startswith(('http://', 'https://', 'file://'))
 			if is_placeholder_url(url):
 				continue
-			if any(f'.{ext}' in url_lower for ext in excluded_extensions):
-				continue
+			# file:// URLs are explicit navigation targets, keep them as-is
+			if not url_lower.startswith('file://'):
+				if any(f'.{ext}' in url_lower for ext in excluded_extensions):
+					continue
+				if not has_scheme and '.htm' in url_lower:
+					continue
 			context_start = max(0, match.start() - 20)
 			context_text = task_without_emails[context_start : match.start()]
 			if any(word in context_text.lower() for word in excluded_words):
 				continue
-			if not url.startswith(('http://', 'https://')):
+			if not has_scheme:
 				url = 'https://' + url
 			found_urls.append(url)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for `file://` URLs in start URL extraction and reduce false positives. Keeps local file paths intact and avoids forcing `https://`.

- **Bug Fixes**
  - Add `file://` to URL regex and scheme detection; keep `file://` as-is and skip extension filtering for them.
  - De-duplicate overlapping matches by tracking matched spans across patterns.
  - Safer heuristics: only prepend `https://` when no scheme is present, and only exclude `.htm` when the match is domain-like; still respects nearby “never/don’t” context.

<sup>Written for commit 581ab0d9012d17b9969b7115836e0cdf467b7075. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

