### PR TITLE
fix: pass evaluate JavaScript to CDP unchanged

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1825,6 +1825,15 @@ You will be given a query and the markdown of a webpage that has been filtered t
 
 			cdp_session = await browser_session.get_or_create_cdp_session()
 
+			# Action parameters are not otherwise retained in the model-visible step history.
+			# Keep the original submitted code (never a transformed variant) so later steps
+			# can understand what produced the result or error.
+			MAX_CODE_MEMORY_LENGTH = 2000
+			code_for_memory = code[:MAX_CODE_MEMORY_LENGTH]
+			if len(code) > MAX_CODE_MEMORY_LENGTH:
+				code_for_memory += f'\n... [JavaScript truncated; original length: {len(code)} characters]'
+			submitted_code_memory = f'Submitted JavaScript:\n{code_for_memory}'
+
 			try:
 				# Always use awaitPromise=True - it's ignored for non-promises
 				result = await cdp_session.cdp_client.send.Runtime.evaluate(
@@ -1846,7 +1855,10 @@ Submitted Code:
 """
 
 					logger.debug(enhanced_msg)
-					return ActionResult(error=enhanced_msg)
+					return ActionResult(
+						error=enhanced_msg,
+						long_term_memory=f'{submitted_code_memory}\nExecution failed: {error_msg}',
+					)
 
 				# Get the result data
 				result_data = result.get('result', {})
@@ -1855,7 +1867,10 @@ Submitted Code:
 				if result_data.get('wasThrown'):
 					msg = f'JavaScript code: {code} execution failed (wasThrown=true)'
 					logger.debug(msg)
-					return ActionResult(error=msg)
+					return ActionResult(
+						error=msg,
+						long_term_memory=f'{submitted_code_memory}\nExecution failed (wasThrown=true).',
+					)
 
 				# Get the actual value
 				value = result_data.get('value')
@@ -1903,13 +1918,17 @@ Submitted Code:
 				# but use truncated version in long_term_memory if too large
 				MAX_MEMORY_LENGTH = 10000
 				if len(result_text) < MAX_MEMORY_LENGTH:
-					memory = result_text
+					memory = f'{submitted_code_memory}\nResult:\n{result_text}'
 					include_extracted_content_only_once = False
 				else:
-					memory = f'JavaScript executed successfully, result length: {len(result_text)} characters.'
+					memory = (
+						f'{submitted_code_memory}\n'
+						f'JavaScript executed successfully, result length: {len(result_text)} characters.'
+					)
 					include_extracted_content_only_once = True
 
-				# Return only the result, not the code (code is already in user's cell)
+				# Keep the current-step content focused on the result; submitted code
+				# remains available to later steps through long_term_memory.
 				return ActionResult(
 					extracted_content=result_text,
 					long_term_memory=memory,
@@ -1921,7 +1940,10 @@ Submitted Code:
 				# CDP communication or other system errors
 				error_msg = f'Failed to execute JavaScript: {type(e).__name__}: {e}'
 				logger.debug(f'JavaScript code that failed: {code[:200]}...')
-				return ActionResult(error=error_msg)
+				return ActionResult(
+					error=error_msg,
+					long_term_memory=f'{submitted_code_memory}\nExecution failed: {error_msg}',
+				)
 
 	def _register_done_action(self, output_model: type[T] | None, display_files_in_done_text: bool = True):
 		if output_model is not None:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1829,7 +1829,9 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			# Keep the original submitted code (never a transformed variant) so later steps
 			# can understand what produced the result or error.
 			MAX_CODE_MEMORY_LENGTH = 2000
-			code_for_memory = code[:MAX_CODE_MEMORY_LENGTH]
+			# CDP still receives code exactly as submitted. Sanitize only the history copy
+			# so an unpaired surrogate cannot poison model-visible state or persistence.
+			code_for_memory = sanitize_surrogates(code[:MAX_CODE_MEMORY_LENGTH])
 			if len(code) > MAX_CODE_MEMORY_LENGTH:
 				code_for_memory += f'\n... [JavaScript truncated; original length: {len(code)} characters]'
 			submitted_code_memory = f'Submitted JavaScript:\n{code_for_memory}'

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1826,12 +1826,9 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			cdp_session = await browser_session.get_or_create_cdp_session()
 
 			try:
-				# Validate and potentially fix JavaScript code before execution
-				validated_code = self._validate_and_fix_javascript(code)
-
 				# Always use awaitPromise=True - it's ignored for non-promises
 				result = await cdp_session.cdp_client.send.Runtime.evaluate(
-					params={'expression': validated_code, 'returnByValue': True, 'awaitPromise': True},
+					params={'expression': code, 'returnByValue': True, 'awaitPromise': True},
 					session_id=cdp_session.session_id,
 				)
 
@@ -1844,8 +1841,8 @@ You will be given a query and the markdown of a webpage that has been filtered t
 					enhanced_msg = f"""JavaScript Execution Failed:
 {error_msg}
 
-Validated Code (after quote fixing):
-{validated_code[:500]}{'...' if len(validated_code) > 500 else ''}
+Submitted Code:
+{code[:500]}{'...' if len(code) > 500 else ''}
 """
 
 					logger.debug(enhanced_msg)
@@ -1925,71 +1922,6 @@ Validated Code (after quote fixing):
 				error_msg = f'Failed to execute JavaScript: {type(e).__name__}: {e}'
 				logger.debug(f'JavaScript code that failed: {code[:200]}...')
 				return ActionResult(error=error_msg)
-
-	def _validate_and_fix_javascript(self, code: str) -> str:
-		"""Validate and fix common JavaScript issues before execution"""
-
-		import re
-
-		# Pattern 1: Fix double-escaped quotes (\\\" → \")
-		fixed_code = re.sub(r'\\"', '"', code)
-
-		# Pattern 2: Fix over-escaped regex patterns (\\\\d → \\d)
-		# Common issue: regex gets double-escaped during parsing
-		fixed_code = re.sub(r'\\\\([dDsSwWbBnrtfv])', r'\\\1', fixed_code)
-		fixed_code = re.sub(r'\\\\([.*+?^${}()|[\]])', r'\\\1', fixed_code)
-
-		# Pattern 3: Fix XPath expressions with mixed quotes
-		xpath_pattern = r'document\.evaluate\s*\(\s*"([^"]*)"\s*,'
-
-		def fix_xpath_quotes(match):
-			xpath_with_quotes = match.group(1)
-			return f'document.evaluate(`{xpath_with_quotes}`,'
-
-		fixed_code = re.sub(xpath_pattern, fix_xpath_quotes, fixed_code)
-
-		# Pattern 4: Fix querySelector/querySelectorAll with mixed quotes
-		selector_pattern = r'(querySelector(?:All)?)\s*\(\s*"([^"]*)"\s*\)'
-
-		def fix_selector_quotes(match):
-			method_name = match.group(1)
-			selector_with_quotes = match.group(2)
-			return f'{method_name}(`{selector_with_quotes}`)'
-
-		fixed_code = re.sub(selector_pattern, fix_selector_quotes, fixed_code)
-
-		# Pattern 5: Fix closest() calls with mixed quotes
-		closest_pattern = r'\.closest\s*\(\s*"([^"]*)"\s*\)'
-
-		def fix_closest_quotes(match):
-			selector_with_quotes = match.group(1)
-			return f'.closest(`{selector_with_quotes}`)'
-
-		fixed_code = re.sub(closest_pattern, fix_closest_quotes, fixed_code)
-
-		# Pattern 6: Fix .matches() calls with mixed quotes (similar to closest)
-		matches_pattern = r'\.matches\s*\(\s*"([^"]*)"\s*\)'
-
-		def fix_matches_quotes(match):
-			selector_with_quotes = match.group(1)
-			return f'.matches(`{selector_with_quotes}`)'
-
-		fixed_code = re.sub(matches_pattern, fix_matches_quotes, fixed_code)
-
-		# Note: Removed getAttribute fix - attribute names rarely have mixed quotes
-		# getAttribute typically uses simple names like "data-value", not complex selectors
-
-		# Log changes made
-		changes_made = []
-		if r'\"' in code and r'\"' not in fixed_code:
-			changes_made.append('fixed escaped quotes')
-		if '`' in fixed_code and '`' not in code:
-			changes_made.append('converted mixed quotes to template literals')
-
-		if changes_made:
-			logger.debug(f'JavaScript fixes applied: {", ".join(changes_made)}')
-
-		return fixed_code
 
 	def _register_done_action(self, output_model: type[T] | None, display_files_in_done_text: bool = True):
 		if output_model is not None:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1843,7 +1843,9 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			# Keep the original submitted code (never a transformed variant) so later steps
 			# can understand what produced the result or error.
 			MAX_CODE_MEMORY_LENGTH = 2000
-			code_for_memory = code[:MAX_CODE_MEMORY_LENGTH]
+			# CDP still receives code exactly as submitted. Sanitize only the history copy
+			# so an unpaired surrogate cannot poison model-visible state or persistence.
+			code_for_memory = sanitize_surrogates(code[:MAX_CODE_MEMORY_LENGTH])
 			if len(code) > MAX_CODE_MEMORY_LENGTH:
 				code_for_memory += f'\n... [JavaScript truncated; original length: {len(code)} characters]'
 			submitted_code_memory = f'Submitted JavaScript:\n{code_for_memory}'

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1840,12 +1840,9 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			cdp_session = await browser_session.get_or_create_cdp_session()
 
 			try:
-				# Validate and potentially fix JavaScript code before execution
-				validated_code = self._validate_and_fix_javascript(code)
-
 				# Always use awaitPromise=True - it's ignored for non-promises
 				result = await cdp_session.cdp_client.send.Runtime.evaluate(
-					params={'expression': validated_code, 'returnByValue': True, 'awaitPromise': True},
+					params={'expression': code, 'returnByValue': True, 'awaitPromise': True},
 					session_id=cdp_session.session_id,
 				)
 
@@ -1858,8 +1855,8 @@ You will be given a query and the markdown of a webpage that has been filtered t
 					enhanced_msg = f"""JavaScript Execution Failed:
 {error_msg}
 
-Validated Code (after quote fixing):
-{validated_code[:500]}{'...' if len(validated_code) > 500 else ''}
+Submitted Code:
+{code[:500]}{'...' if len(code) > 500 else ''}
 """
 
 					logger.debug(enhanced_msg)
@@ -1939,71 +1936,6 @@ Validated Code (after quote fixing):
 				error_msg = f'Failed to execute JavaScript: {type(e).__name__}: {e}'
 				logger.debug(f'JavaScript code that failed: {code[:200]}...')
 				return ActionResult(error=error_msg)
-
-	def _validate_and_fix_javascript(self, code: str) -> str:
-		"""Validate and fix common JavaScript issues before execution"""
-
-		import re
-
-		# Pattern 1: Fix double-escaped quotes (\\\" → \")
-		fixed_code = re.sub(r'\\"', '"', code)
-
-		# Pattern 2: Fix over-escaped regex patterns (\\\\d → \\d)
-		# Common issue: regex gets double-escaped during parsing
-		fixed_code = re.sub(r'\\\\([dDsSwWbBnrtfv])', r'\\\1', fixed_code)
-		fixed_code = re.sub(r'\\\\([.*+?^${}()|[\]])', r'\\\1', fixed_code)
-
-		# Pattern 3: Fix XPath expressions with mixed quotes
-		xpath_pattern = r'document\.evaluate\s*\(\s*"([^"]*)"\s*,'
-
-		def fix_xpath_quotes(match):
-			xpath_with_quotes = match.group(1)
-			return f'document.evaluate(`{xpath_with_quotes}`,'
-
-		fixed_code = re.sub(xpath_pattern, fix_xpath_quotes, fixed_code)
-
-		# Pattern 4: Fix querySelector/querySelectorAll with mixed quotes
-		selector_pattern = r'(querySelector(?:All)?)\s*\(\s*"([^"]*)"\s*\)'
-
-		def fix_selector_quotes(match):
-			method_name = match.group(1)
-			selector_with_quotes = match.group(2)
-			return f'{method_name}(`{selector_with_quotes}`)'
-
-		fixed_code = re.sub(selector_pattern, fix_selector_quotes, fixed_code)
-
-		# Pattern 5: Fix closest() calls with mixed quotes
-		closest_pattern = r'\.closest\s*\(\s*"([^"]*)"\s*\)'
-
-		def fix_closest_quotes(match):
-			selector_with_quotes = match.group(1)
-			return f'.closest(`{selector_with_quotes}`)'
-
-		fixed_code = re.sub(closest_pattern, fix_closest_quotes, fixed_code)
-
-		# Pattern 6: Fix .matches() calls with mixed quotes (similar to closest)
-		matches_pattern = r'\.matches\s*\(\s*"([^"]*)"\s*\)'
-
-		def fix_matches_quotes(match):
-			selector_with_quotes = match.group(1)
-			return f'.matches(`{selector_with_quotes}`)'
-
-		fixed_code = re.sub(matches_pattern, fix_matches_quotes, fixed_code)
-
-		# Note: Removed getAttribute fix - attribute names rarely have mixed quotes
-		# getAttribute typically uses simple names like "data-value", not complex selectors
-
-		# Log changes made
-		changes_made = []
-		if r'\"' in code and r'\"' not in fixed_code:
-			changes_made.append('fixed escaped quotes')
-		if '`' in fixed_code and '`' not in code:
-			changes_made.append('converted mixed quotes to template literals')
-
-		if changes_made:
-			logger.debug(f'JavaScript fixes applied: {", ".join(changes_made)}')
-
-		return fixed_code
 
 	def _register_done_action(self, output_model: type[T] | None, display_files_in_done_text: bool = True):
 		if output_model is not None:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1839,6 +1839,15 @@ You will be given a query and the markdown of a webpage that has been filtered t
 
 			cdp_session = await browser_session.get_or_create_cdp_session()
 
+			# Action parameters are not otherwise retained in the model-visible step history.
+			# Keep the original submitted code (never a transformed variant) so later steps
+			# can understand what produced the result or error.
+			MAX_CODE_MEMORY_LENGTH = 2000
+			code_for_memory = code[:MAX_CODE_MEMORY_LENGTH]
+			if len(code) > MAX_CODE_MEMORY_LENGTH:
+				code_for_memory += f'\n... [JavaScript truncated; original length: {len(code)} characters]'
+			submitted_code_memory = f'Submitted JavaScript:\n{code_for_memory}'
+
 			try:
 				# Always use awaitPromise=True - it's ignored for non-promises
 				result = await cdp_session.cdp_client.send.Runtime.evaluate(
@@ -1860,7 +1869,10 @@ Submitted Code:
 """
 
 					logger.debug(enhanced_msg)
-					return ActionResult(error=enhanced_msg)
+					return ActionResult(
+						error=enhanced_msg,
+						long_term_memory=f'{submitted_code_memory}\nExecution failed: {error_msg}',
+					)
 
 				# Get the result data
 				result_data = result.get('result', {})
@@ -1869,7 +1881,10 @@ Submitted Code:
 				if result_data.get('wasThrown'):
 					msg = f'JavaScript code: {code} execution failed (wasThrown=true)'
 					logger.debug(msg)
-					return ActionResult(error=msg)
+					return ActionResult(
+						error=msg,
+						long_term_memory=f'{submitted_code_memory}\nExecution failed (wasThrown=true).',
+					)
 
 				# Get the actual value
 				value = result_data.get('value')
@@ -1917,13 +1932,17 @@ Submitted Code:
 				# but use truncated version in long_term_memory if too large
 				MAX_MEMORY_LENGTH = 10000
 				if len(result_text) < MAX_MEMORY_LENGTH:
-					memory = result_text
+					memory = f'{submitted_code_memory}\nResult:\n{result_text}'
 					include_extracted_content_only_once = False
 				else:
-					memory = f'JavaScript executed successfully, result length: {len(result_text)} characters.'
+					memory = (
+						f'{submitted_code_memory}\n'
+						f'JavaScript executed successfully, result length: {len(result_text)} characters.'
+					)
 					include_extracted_content_only_once = True
 
-				# Return only the result, not the code (code is already in user's cell)
+				# Keep the current-step content focused on the result; submitted code
+				# remains available to later steps through long_term_memory.
 				return ActionResult(
 					extracted_content=result_text,
 					long_term_memory=memory,
@@ -1935,7 +1954,10 @@ Submitted Code:
 				# CDP communication or other system errors
 				error_msg = f'Failed to execute JavaScript: {type(e).__name__}: {e}'
 				logger.debug(f'JavaScript code that failed: {code[:200]}...')
-				return ActionResult(error=error_msg)
+				return ActionResult(
+					error=error_msg,
+					long_term_memory=f'{submitted_code_memory}\nExecution failed: {error_msg}',
+				)
 
 	def _register_done_action(self, output_model: type[T] | None, display_files_in_done_text: bool = True):
 		if output_model is not None:

--- a/tests/ci/test_evaluate_javascript.py
+++ b/tests/ci/test_evaluate_javascript.py
@@ -1,8 +1,18 @@
+from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
 
+from browser_use.agent.message_manager.service import MessageManager
+from browser_use.agent.views import AgentOutput, AgentStepInfo, MessageCompactionSettings
+from browser_use.browser.views import BrowserStateSummary
+from browser_use.dom.views import SerializedDOMState
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.messages import SystemMessage
+from browser_use.llm.views import ChatInvokeCompletion
 from browser_use.tools.service import Tools
 
 
@@ -29,7 +39,136 @@ async def test_evaluate_sends_valid_javascript_to_cdp_unchanged(code: str):
 	result = await Tools().evaluate(code=code, browser_session=browser_session)
 
 	assert result.error is None
+	assert result.long_term_memory is not None
+	assert code in result.long_term_memory
+	assert 'Result:\nTrue' in result.long_term_memory
 	runtime_evaluate.assert_awaited_once_with(
 		params={'expression': code, 'returnByValue': True, 'awaitPromise': True},
 		session_id='test-session',
 	)
+
+
+@pytest.mark.parametrize(
+	'runtime_result',
+	[
+		{'exceptionDetails': {'text': 'SyntaxError'}},
+		{'result': {'wasThrown': True}},
+		RuntimeError('CDP disconnected'),
+	],
+	ids=['exception-details', 'was-thrown', 'cdp-error'],
+)
+async def test_evaluate_failure_retains_original_javascript_in_long_term_memory(runtime_result):
+	code = r'JSON.parse("{\"path\":\"C:\\\\temp\\\\report.json\"}")'
+	if isinstance(runtime_result, Exception):
+		runtime_evaluate = AsyncMock(side_effect=runtime_result)
+	else:
+		runtime_evaluate = AsyncMock(return_value=runtime_result)
+	cdp_session = SimpleNamespace(
+		cdp_client=SimpleNamespace(send=SimpleNamespace(Runtime=SimpleNamespace(evaluate=runtime_evaluate))),
+		session_id='test-session',
+	)
+	browser_session = SimpleNamespace(
+		cdp_client=cdp_session.cdp_client,
+		get_or_create_cdp_session=AsyncMock(return_value=cdp_session),
+	)
+
+	result = await Tools().evaluate(code=code, browser_session=browser_session)
+
+	assert result.error is not None
+	assert result.long_term_memory is not None
+	assert code in result.long_term_memory
+
+
+async def test_evaluate_bounds_javascript_in_long_term_memory():
+	code = f'const payload = "{"x" * 3000}";'
+	runtime_evaluate = AsyncMock(return_value={'result': {'value': True}})
+	cdp_session = SimpleNamespace(
+		cdp_client=SimpleNamespace(send=SimpleNamespace(Runtime=SimpleNamespace(evaluate=runtime_evaluate))),
+		session_id='test-session',
+	)
+	browser_session = SimpleNamespace(
+		cdp_client=cdp_session.cdp_client,
+		get_or_create_cdp_session=AsyncMock(return_value=cdp_session),
+	)
+
+	result = await Tools().evaluate(code=code, browser_session=browser_session)
+
+	assert result.long_term_memory is not None
+	assert code[:2000] in result.long_term_memory
+	assert code not in result.long_term_memory
+	assert f'original length: {len(code)} characters' in result.long_term_memory
+
+
+async def test_evaluate_javascript_survives_model_history_and_compaction(tmp_path: Path):
+	code = r'JSON.parse("{\"path\":\"C:\\\\temp\\\\report.json\"}")'
+	runtime_evaluate = AsyncMock(return_value={'result': {'value': 'found'}})
+	cdp_session = SimpleNamespace(
+		cdp_client=SimpleNamespace(send=SimpleNamespace(Runtime=SimpleNamespace(evaluate=runtime_evaluate))),
+		session_id='test-session',
+	)
+	browser_session = SimpleNamespace(
+		cdp_client=cdp_session.cdp_client,
+		get_or_create_cdp_session=AsyncMock(return_value=cdp_session),
+	)
+	action_result = await Tools().evaluate(code=code, browser_session=browser_session)
+
+	message_manager = MessageManager(
+		task='Inspect the page',
+		system_message=SystemMessage(content='Test system message'),
+		file_system=FileSystem(tmp_path),
+	)
+	browser_state = BrowserStateSummary(
+		url='https://example.com',
+		title='Example',
+		tabs=[],
+		dom_state=SerializedDOMState(_root=None, selector_map={}),
+	)
+	model_output = AgentOutput(
+		evaluation_previous_goal='Need to inspect page data',
+		memory='Running a JavaScript query',
+		next_goal='Use the query result',
+		action=[],
+	)
+	step_info = AgentStepInfo(step_number=1, max_steps=10)
+	message_manager.create_state_messages(
+		browser_state_summary=browser_state,
+		model_output=model_output,
+		result=[action_result],
+		step_info=step_info,
+		use_vision=False,
+	)
+
+	assert code in message_manager.get_messages()[-1].text
+
+	class RecordingCompactionLLM:
+		model = 'test-compaction-model'
+
+		def __init__(self):
+			self.input_text = ''
+
+		async def ainvoke(self, messages, output_format=None, **kwargs):
+			self.input_text = messages[-1].text
+			return ChatInvokeCompletion(completion=f'Prior JavaScript: {code}', usage=None)
+
+	compaction_llm = RecordingCompactionLLM()
+	compacted = await message_manager.maybe_compact_messages(
+		llm=cast(BaseChatModel, compaction_llm),
+		settings=MessageCompactionSettings(
+			compact_every_n_steps=1,
+			trigger_char_count=1,
+			keep_last_items=0,
+		),
+		step_info=AgentStepInfo(step_number=2, max_steps=10),
+	)
+
+	assert compacted is True
+	assert code in compaction_llm.input_text
+	assert code in message_manager.agent_history_description
+
+	message_manager.create_state_messages(
+		browser_state_summary=browser_state,
+		step_info=AgentStepInfo(step_number=2, max_steps=10),
+		use_vision=False,
+		skip_state_update=True,
+	)
+	assert code in message_manager.get_messages()[-1].text

--- a/tests/ci/test_evaluate_javascript.py
+++ b/tests/ci/test_evaluate_javascript.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from browser_use.tools.service import Tools
+
+
+@pytest.mark.parametrize(
+	'code',
+	[
+		r'JSON.parse("{\"path\":\"C:\\\\temp\\\\report.json\"}")',
+		r'(() => /^C:\\temp\\files$/.test("C:\\temp\\files"))()',
+		r'document.querySelector("[data-label=\"Save\"]")',
+	],
+	ids=['escaped-json', 'regex-backslashes', 'escaped-selector'],
+)
+async def test_evaluate_sends_valid_javascript_to_cdp_unchanged(code: str):
+	runtime_evaluate = AsyncMock(return_value={'result': {'value': True}})
+	cdp_session = SimpleNamespace(
+		cdp_client=SimpleNamespace(send=SimpleNamespace(Runtime=SimpleNamespace(evaluate=runtime_evaluate))),
+		session_id='test-session',
+	)
+	browser_session = SimpleNamespace(
+		cdp_client=cdp_session.cdp_client,
+		get_or_create_cdp_session=AsyncMock(return_value=cdp_session),
+	)
+
+	result = await Tools().evaluate(code=code, browser_session=browser_session)
+
+	assert result.error is None
+	runtime_evaluate.assert_awaited_once_with(
+		params={'expression': code, 'returnByValue': True, 'awaitPromise': True},
+		session_id='test-session',
+	)

--- a/tests/ci/test_evaluate_javascript.py
+++ b/tests/ci/test_evaluate_javascript.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from browser_use.agent.message_manager.service import MessageManager
+from browser_use.agent.message_manager.views import MessageManagerState
 from browser_use.agent.views import AgentOutput, AgentStepInfo, MessageCompactionSettings
 from browser_use.browser.views import BrowserStateSummary
 from browser_use.dom.views import SerializedDOMState
@@ -14,6 +15,7 @@ from browser_use.llm.base import BaseChatModel
 from browser_use.llm.messages import SystemMessage
 from browser_use.llm.views import ChatInvokeCompletion
 from browser_use.tools.service import Tools
+from browser_use.utils import sanitize_surrogates
 
 
 @pytest.mark.parametrize(
@@ -116,6 +118,7 @@ async def test_evaluate_javascript_survives_model_history_and_compaction(tmp_pat
 		task='Inspect the page',
 		system_message=SystemMessage(content='Test system message'),
 		file_system=FileSystem(tmp_path),
+		state=MessageManagerState(),
 	)
 	browser_state = BrowserStateSummary(
 		url='https://example.com',
@@ -172,3 +175,86 @@ async def test_evaluate_javascript_survives_model_history_and_compaction(tmp_pat
 		skip_state_update=True,
 	)
 	assert code in message_manager.get_messages()[-1].text
+
+
+async def test_evaluate_sanitizes_surrogates_only_in_model_history_copy(tmp_path: Path):
+	code = '(() => "before\ud800after")()'
+	safe_code = sanitize_surrogates(code)
+	runtime_evaluate = AsyncMock(return_value={'result': {'value': 'found'}})
+	cdp_session = SimpleNamespace(
+		cdp_client=SimpleNamespace(send=SimpleNamespace(Runtime=SimpleNamespace(evaluate=runtime_evaluate))),
+		session_id='test-session',
+	)
+	browser_session = SimpleNamespace(
+		cdp_client=cdp_session.cdp_client,
+		get_or_create_cdp_session=AsyncMock(return_value=cdp_session),
+	)
+	action_result = await Tools().evaluate(code=code, browser_session=browser_session)
+
+	runtime_evaluate.assert_awaited_once_with(
+		params={'expression': code, 'returnByValue': True, 'awaitPromise': True},
+		session_id='test-session',
+	)
+	assert action_result.long_term_memory is not None
+	assert safe_code in action_result.long_term_memory
+	assert '\ud800' not in action_result.long_term_memory
+	action_result.long_term_memory.encode('utf-8')
+
+	message_manager = MessageManager(
+		task='Inspect the page',
+		system_message=SystemMessage(content='Test system message'),
+		file_system=FileSystem(tmp_path),
+		state=MessageManagerState(),
+	)
+	browser_state = BrowserStateSummary(
+		url='https://example.com',
+		title='Example',
+		tabs=[],
+		dom_state=SerializedDOMState(_root=None, selector_map={}),
+	)
+	message_manager.create_state_messages(
+		browser_state_summary=browser_state,
+		model_output=AgentOutput(
+			evaluation_previous_goal='Need to inspect page data',
+			memory='Running a JavaScript query',
+			next_goal='Use the query result',
+			action=[],
+		),
+		result=[action_result],
+		step_info=AgentStepInfo(step_number=1, max_steps=10),
+		use_vision=False,
+	)
+
+	state_text = message_manager.get_messages()[-1].text
+	assert safe_code in state_text
+	assert '\ud800' not in state_text
+	state_text.encode('utf-8')
+
+	class RecordingCompactionLLM:
+		model = 'test-compaction-model'
+
+		def __init__(self):
+			self.input_text = ''
+
+		async def ainvoke(self, messages, output_format=None, **kwargs):
+			self.input_text = messages[-1].text
+			return ChatInvokeCompletion(completion=f'Prior JavaScript: {safe_code}', usage=None)
+
+	compaction_llm = RecordingCompactionLLM()
+	compacted = await message_manager.maybe_compact_messages(
+		llm=cast(BaseChatModel, compaction_llm),
+		settings=MessageCompactionSettings(
+			compact_every_n_steps=1,
+			trigger_char_count=1,
+			keep_last_items=0,
+		),
+		step_info=AgentStepInfo(step_number=2, max_steps=10),
+	)
+
+	assert compacted is True
+	assert safe_code in compaction_llm.input_text
+	assert '\ud800' not in compaction_llm.input_text
+	compaction_llm.input_text.encode('utf-8')
+	assert safe_code in message_manager.agent_history_description
+	assert '\ud800' not in message_manager.agent_history_description
+	message_manager.agent_history_description.encode('utf-8')


### PR DESCRIPTION
## Summary

- send evaluate JavaScript to CDP exactly as submitted
- retain a bounded, UTF-8-safe copy of the submitted JavaScript in action long-term memory on success and failure
- keep the submitted source available in subsequent model history and compaction input

## Tests

- uv run pytest -q tests/ci/test_evaluate_javascript.py
- uv run ruff check browser_use/tools/service.py tests/ci/test_evaluate_javascript.py
- uv run ruff format --check browser_use/tools/service.py tests/ci/test_evaluate_javascript.py
- uv run pre-commit run --all-files