### PR TITLE
extract: stop auto-inheriting output_model_schema into per-page extraction

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -362,10 +362,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if self.output_model_schema is not None:
 			self.tools.use_structured_output_action(self.output_model_schema)
 
-		# Extraction schema: explicit param takes priority, otherwise auto-bridge from output_model_schema
+		# Per-page extract uses a schema only when the caller explicitly asks for one.
+		# It must NOT inherit output_model_schema: that describes the final task result
+		# (e.g. {summary, step_results}), which is the wrong shape for a single-page
+		# extraction and, on the browser-use gateway, routes extract into the agent
+		# action protocol and breaks it.
 		self.extraction_schema = extraction_schema
-		if self.extraction_schema is None and self.output_model_schema is not None:
-			self.extraction_schema = self.output_model_schema.model_json_schema()
 
 		# Core components - task enhancement now has access to output_model_schema from tools
 		self.task = self._enhance_task_with_schema(task, output_model_schema)

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -4365,9 +4365,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			from browser_use.skills import SkillService
 
 			self.skill_service = SkillService(skill_ids=skill_ids)
+		# Per-page extract uses a schema only when explicitly requested; it must not
+		# inherit output_model_schema (the final-result shape), which is wrong for a
+		# single-page extraction and breaks extract on the browser-use gateway.
 		self.extraction_schema = extraction_schema
-		if self.extraction_schema is None and output_model_schema is not None:
-			self.extraction_schema = output_model_schema.model_json_schema()
 		self._fallback_llm = fallback_llm
 		self._using_fallback_llm = False
 		self._original_llm = llm

--- a/tests/ci/test_structured_extraction.py
+++ b/tests/ci/test_structured_extraction.py
@@ -6,7 +6,7 @@ import tempfile
 from unittest.mock import AsyncMock
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 from pytest_httpserver import HTTPServer
 
 from browser_use.agent.views import ActionResult
@@ -629,3 +629,42 @@ class TestExtractionSchemaInjection:
 		assert isinstance(result, ActionResult)
 		assert result.extracted_content is not None
 		assert '<structured_result>' in result.extracted_content
+
+
+class TestOutputModelSchemaDoesNotAutoBridge:
+	"""output_model_schema must NOT auto-populate the per-page extraction_schema.
+
+	It describes the final task result (e.g. {summary, step_results}), which is the
+	wrong shape for a single-page extract and breaks extract on the browser-use
+	gateway. Per-page extract stays free-text unless extraction_schema is explicit.
+	"""
+
+	async def test_output_model_schema_does_not_set_extraction_schema(self, browser_session, mock_llm):
+		from browser_use import Agent
+
+		class FinalResult(BaseModel):
+			summary: str
+			items: list[str]
+
+		agent = Agent(
+			task='Test task',
+			llm=mock_llm,
+			browser_session=browser_session,
+			output_model_schema=FinalResult,
+		)
+		assert agent.extraction_schema is None
+
+	async def test_explicit_extraction_schema_still_honored(self, browser_session, mock_llm):
+		from browser_use import Agent
+
+		class FinalResult(BaseModel):
+			summary: str
+
+		agent = Agent(
+			task='Test task',
+			llm=mock_llm,
+			browser_session=browser_session,
+			output_model_schema=FinalResult,
+			extraction_schema=PRODUCT_SCHEMA,
+		)
+		assert agent.extraction_schema == PRODUCT_SCHEMA


### PR DESCRIPTION
## What

Removes the auto-bridge (both `Agent` and beta agent) that copied `output_model_schema` into `extraction_schema`. Per-page `extract` now uses a schema only when the caller passes `extraction_schema=` explicitly.

## Why

`output_model_schema` describes the **final task result** — e.g. `{summary, step_results}`. The auto-bridge (added Feb 2026) fed that same schema to **every per-page extract**, asking the model to produce the whole-task shape from one page. That's the wrong shape for a single-page extraction, and on the **browser-use gateway** it routes the structured extract sub-call through the agent action protocol, which the fine-tuned bu-* models answer with `done(data={...})` — the client then dies with `KeyError: 'action'` (deterministic, every structured-extract call, all releases since 0.11.8).

Reproduced live against production: a bu-2-0 agent with `output_model_schema` set failed `extract` 4/4 times ("Error executing action extract: 'action'") on browser-use.com, then completed the task by reading state directly — so it was silent wasted steps, not a hard failure.

## Behavior change (called out deliberately)

- Users who set **only** `output_model_schema` (final structured output): `extract` returns to free-text (the pre-Feb-2026 default). Their final `done` result is still structured — unchanged.
- Users who want structured per-page extraction: pass `Agent(extraction_schema=...)` explicitly — unchanged.

This is complementary to the gateway-side fix (cloud, unwraps `done.data` for non-agent schemas), which fixes existing installs without an upgrade; this PR fixes the root coupling for anyone who upgrades and also stops feeding a semantically wrong schema to non-gateway models.

## Tests

`tests/ci/test_structured_extraction.py` (28) pass — none depended on the auto-bridge; they exercise explicit `extraction_schema` via `act()`, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-inheriting `output_model_schema` into per-page `extract`, restoring the free-text default and fixing `browser-use` gateway failures; adds tests to lock in this behavior.

- **Bug Fixes**
  - Avoids using the final-result shape for single-page extraction, which caused `KeyError: 'action'` on the `browser-use` gateway.
  - Final `done` output remains structured when `output_model_schema` is set; only per-page extraction behavior changes.

- **Migration**
  - To get structured per-page results, pass `extraction_schema=...` to the `Agent`.

<sup>Written for commit ba755a735c692658193570dbd22a2a1aad206875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

