### PR TITLE
fix: use canonical LLM model property in cloud events

### DIFF
--- a/browser_use/agent/cloud_events.py
+++ b/browser_use/agent/cloud_events.py
@@ -214,7 +214,7 @@ class CreateAgentTaskEvent(BaseEvent):
 			else None,
 			agent_session_id=str(agent.session_id),
 			task=agent.task,
-			llm_model=agent.llm.model_name,
+			llm_model=agent.llm.model,
 			agent_state=agent.state.model_dump() if hasattr(agent.state, 'model_dump') else {},
 			stopped=False,
 			paused=False,

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -4150,8 +4150,8 @@ def _eventbus_name(agent_id: str, prefix: str = 'Agent') -> str:
 
 
 class _CloudEventLLMProxy:
-	def __init__(self, model_name: str):
-		self.model_name = model_name
+	def __init__(self, model: str):
+		self.model = model
 
 
 class _CloudEventAgentProxy:

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -4149,8 +4149,8 @@ def _eventbus_name(agent_id: str, prefix: str = 'Agent') -> str:
 
 
 class _CloudEventLLMProxy:
-	def __init__(self, model_name: str):
-		self.model_name = model_name
+	def __init__(self, model: str):
+		self.model = model
 
 
 class _CloudEventAgentProxy:

--- a/tests/ci/test_agent_cloud_events.py
+++ b/tests/ci/test_agent_cloud_events.py
@@ -1,0 +1,36 @@
+from types import SimpleNamespace
+
+from browser_use.agent.cloud_events import CreateAgentTaskEvent
+
+
+class CustomAdapter:
+	model = 'custom-model'
+
+	@property
+	def provider(self) -> str:
+		return 'custom'
+
+	@property
+	def name(self) -> str:
+		return self.model
+
+	async def ainvoke(self, messages, output_format=None, **kwargs):
+		raise AssertionError('not used by this test')
+
+
+def test_create_agent_task_event_uses_canonical_llm_model_property():
+	llm = CustomAdapter()
+	assert not hasattr(llm, 'model_name')
+	agent = SimpleNamespace(
+		task_id='task-id',
+		session_id='session-id',
+		task='test task',
+		llm=llm,
+		state=SimpleNamespace(model_dump=lambda: {}),
+		_task_start_time=0,
+		cloud_sync=None,
+	)
+
+	event = CreateAgentTaskEvent.from_agent(agent)
+
+	assert event.llm_model == 'custom-model'


### PR DESCRIPTION
## Summary

- use the canonical LLM model property throughout the related adapter paths
- align the internal proxy with the canonical interface
- add focused regression coverage for a minimal adapter

## Tests

- `uv run pytest -q tests/ci/test_beta_agent.py::test_beta_agent_runs_through_sdk_and_reuses_session_for_followup tests/ci/test_agent_cloud_events.py`
- `uv run ruff check browser_use/beta/service.py browser_use/agent/cloud_events.py tests/ci/test_agent_cloud_events.py tests/ci/test_beta_agent.py`
- `uv run ruff format --check browser_use/beta/service.py browser_use/agent/cloud_events.py tests/ci/test_agent_cloud_events.py tests/ci/test_beta_agent.py`
- `uv run pre-commit run --all-files`