### PR TITLE
filesystem: write_file can create tiny binary images (png/gif/jpg/webp) for upload flows

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -347,10 +347,46 @@ class Base64BinaryFile(BaseFile):
 	flows, not for arbitrary large binaries.
 	"""
 
+	# Leading magic bytes that identify a real file of this type. Keyed by extension so
+	# base64 that decodes but isn't actually an image (e.g. 'aGVsbG8=' -> b'hello') is
+	# rejected instead of written as a corrupt upload.
+	_MAGIC: dict[str, tuple[bytes, ...]] = {
+		'png': (b'\x89PNG\r\n\x1a\n',),
+		'gif': (b'GIF87a', b'GIF89a'),
+		'jpg': (b'\xff\xd8\xff',),
+		'jpeg': (b'\xff\xd8\xff',),
+		'webp': (b'RIFF',),  # RIFF container; 'WEBP' tag checked below
+	}
+
 	def _decoded(self) -> bytes:
 		# Strip all whitespace (the write_file action appends a trailing newline) then
 		# decode strictly so non-base64 text is rejected rather than silently corrupted.
 		return base64.b64decode(''.join(self.content.split()), validate=True)
+
+	def _validate(self, content: str) -> None:
+		"""Decode and confirm the bytes actually are an image of this extension. Raises FileSystemError."""
+		try:
+			data = base64.b64decode(''.join(content.split()), validate=True)
+		except Exception as e:
+			raise FileSystemError(
+				f"Error: content for '{self.full_name}' is not valid base64. "
+				f'For images, provide the base64 of a valid {self.extension} file. ({e})'
+			)
+		magic = self._MAGIC.get(self.extension, ())
+		if magic and not any(data.startswith(m) for m in magic):
+			raise FileSystemError(
+				f"Error: content for '{self.full_name}' is valid base64 but not a {self.extension} image "
+				f'(wrong magic bytes). Provide the base64 of a real {self.extension} file.'
+			)
+		if self.extension == 'webp' and not (data[:4] == b'RIFF' and data[8:12] == b'WEBP'):
+			raise FileSystemError(f"Error: content for '{self.full_name}' is not a valid WEBP file.")
+
+	def write_file_content(self, content: str) -> None:
+		self._validate(content)
+		self.update_content(content)
+
+	def append_file_content(self, content: str) -> None:
+		raise FileSystemError(f"Error: cannot append to binary file '{self.full_name}'. Overwrite it instead.")
 
 	def sync_to_disk_sync(self, path: Path) -> None:
 		(path / self.full_name).write_bytes(self._decoded())
@@ -801,15 +837,16 @@ class FileSystem:
 			if not file_class:
 				raise ValueError(f"Error: Invalid file extension '{extension}' for file '{full_filename}'.")
 
-			# Create or get existing file using full filename as key
-			if full_filename in self.files:
-				file_obj = self.files[full_filename]
-			else:
-				file_obj = file_class(name=name_without_ext)
-				self.files[full_filename] = file_obj  # Use full filename as key
+			# Create or get existing file using full filename as key. A NEW file is only
+			# registered after a successful write, so a failed write (e.g. invalid base64
+			# for an image) leaves no ghost entry in self.files / state.
+			is_new = full_filename not in self.files
+			file_obj = self.files[full_filename] if not is_new else file_class(name=name_without_ext)
 
 			# Use file-specific write method
 			await file_obj.write(content, self.data_dir)
+			if is_new:
+				self.files[full_filename] = file_obj
 			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
 			return f'Data written to file {full_filename} successfully.{sanitize_note}'
 		except FileSystemError as e:

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -13,13 +13,8 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 UNSUPPORTED_BINARY_EXTENSIONS = {
-	'png',
-	'jpg',
-	'jpeg',
-	'gif',
 	'bmp',
 	'svg',
-	'webp',
 	'ico',
 	'mp3',
 	'mp4',
@@ -342,6 +337,73 @@ class XmlFile(BaseFile):
 		return 'xml'
 
 
+class Base64BinaryFile(BaseFile):
+	"""Small binary file the agent authors as base64 text.
+
+	``content`` holds the base64 string; the decoded bytes are written to disk so the
+	file is a real, uploadable image. ``read()`` returns a short stub instead of the
+	base64 so it never bloats or confuses the agent prompt (describe() calls read()
+	every step). Intended for tiny fixtures (e.g. a 1x1 PNG) for upload-validation
+	flows, not for arbitrary large binaries.
+	"""
+
+	def _decoded(self) -> bytes:
+		# Strip all whitespace (the write_file action appends a trailing newline) then
+		# decode strictly so non-base64 text is rejected rather than silently corrupted.
+		return base64.b64decode(''.join(self.content.split()), validate=True)
+
+	def sync_to_disk_sync(self, path: Path) -> None:
+		(path / self.full_name).write_bytes(self._decoded())
+
+	async def sync_to_disk(self, path: Path) -> None:
+		with ThreadPoolExecutor() as executor:
+			await asyncio.get_event_loop().run_in_executor(executor, lambda: self.sync_to_disk_sync(path))
+
+	def read(self) -> str:
+		try:
+			n = len(self._decoded())
+		except Exception:
+			return '[binary file: content is not valid base64]'
+		return f'[binary {self.extension} file, {n} bytes]'
+
+	@property
+	def get_size(self) -> int:
+		try:
+			return len(self._decoded())
+		except Exception:
+			return 0
+
+
+class PngFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'png'
+
+
+class GifFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'gif'
+
+
+class JpgFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'jpg'
+
+
+class JpegFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'jpeg'
+
+
+class WebpFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'webp'
+
+
 class FileSystemState(BaseModel):
 	"""Serializable state of the file system"""
 
@@ -375,6 +437,11 @@ class FileSystem:
 			'docx': DocxFile,
 			'html': HtmlFile,
 			'xml': XmlFile,
+			'png': PngFile,
+			'gif': GifFile,
+			'jpg': JpgFile,
+			'jpeg': JpegFile,
+			'webp': WebpFile,
 		}
 
 		self.files = {}
@@ -524,7 +591,7 @@ class FileSystem:
 					return result
 
 				# Text-based extensions: derive from _file_types, excluding those with special readers
-				_special_extensions = {'docx', 'pdf', 'jpg', 'jpeg', 'png'}
+				_special_extensions = {'docx', 'pdf', 'jpg', 'jpeg', 'png', 'gif', 'webp'}
 				text_extensions = [ext for ext in self._file_types if ext not in _special_extensions]
 
 				if extension in text_extensions:
@@ -659,7 +726,7 @@ class FileSystem:
 					)
 					return result
 
-				elif extension in ['jpg', 'jpeg', 'png']:
+				elif extension in ['jpg', 'jpeg', 'png', 'gif', 'webp']:
 					import anyio
 
 					# Read image file and convert to base64
@@ -926,6 +993,11 @@ class FileSystem:
 				'DocxFile': DocxFile,
 				'HtmlFile': HtmlFile,
 				'XmlFile': XmlFile,
+				'PngFile': PngFile,
+				'GifFile': GifFile,
+				'JpgFile': JpgFile,
+				'JpegFile': JpegFile,
+				'WebpFile': WebpFile,
 			}
 
 			file_class = file_type_map.get(file_type)

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -14,13 +14,8 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 UNSUPPORTED_BINARY_EXTENSIONS = {
-	'png',
-	'jpg',
-	'jpeg',
-	'gif',
 	'bmp',
 	'svg',
-	'webp',
 	'ico',
 	'mp3',
 	'mp4',
@@ -394,6 +389,73 @@ class XmlFile(BaseFile):
 		return 'xml'
 
 
+class Base64BinaryFile(BaseFile):
+	"""Small binary file the agent authors as base64 text.
+
+	``content`` holds the base64 string; the decoded bytes are written to disk so the
+	file is a real, uploadable image. ``read()`` returns a short stub instead of the
+	base64 so it never bloats or confuses the agent prompt (describe() calls read()
+	every step). Intended for tiny fixtures (e.g. a 1x1 PNG) for upload-validation
+	flows, not for arbitrary large binaries.
+	"""
+
+	def _decoded(self) -> bytes:
+		# Strip all whitespace (the write_file action appends a trailing newline) then
+		# decode strictly so non-base64 text is rejected rather than silently corrupted.
+		return base64.b64decode(''.join(self.content.split()), validate=True)
+
+	def sync_to_disk_sync(self, path: Path) -> None:
+		(path / self.full_name).write_bytes(self._decoded())
+
+	async def sync_to_disk(self, path: Path) -> None:
+		with ThreadPoolExecutor() as executor:
+			await asyncio.get_event_loop().run_in_executor(executor, lambda: self.sync_to_disk_sync(path))
+
+	def read(self) -> str:
+		try:
+			n = len(self._decoded())
+		except Exception:
+			return '[binary file: content is not valid base64]'
+		return f'[binary {self.extension} file, {n} bytes]'
+
+	@property
+	def get_size(self) -> int:
+		try:
+			return len(self._decoded())
+		except Exception:
+			return 0
+
+
+class PngFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'png'
+
+
+class GifFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'gif'
+
+
+class JpgFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'jpg'
+
+
+class JpegFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'jpeg'
+
+
+class WebpFile(Base64BinaryFile):
+	@property
+	def extension(self) -> str:
+		return 'webp'
+
+
 class FileSystemState(BaseModel):
 	"""Serializable state of the file system"""
 
@@ -427,6 +489,11 @@ class FileSystem:
 			'docx': DocxFile,
 			'html': HtmlFile,
 			'xml': XmlFile,
+			'png': PngFile,
+			'gif': GifFile,
+			'jpg': JpgFile,
+			'jpeg': JpegFile,
+			'webp': WebpFile,
 		}
 
 		self.files = {}
@@ -576,7 +643,7 @@ class FileSystem:
 					return result
 
 				# Text-based extensions: derive from _file_types, excluding those with special readers
-				_special_extensions = {'docx', 'pdf', 'jpg', 'jpeg', 'png'}
+				_special_extensions = {'docx', 'pdf', 'jpg', 'jpeg', 'png', 'gif', 'webp'}
 				text_extensions = [ext for ext in self._file_types if ext not in _special_extensions]
 
 				if extension in text_extensions:
@@ -711,7 +778,7 @@ class FileSystem:
 					)
 					return result
 
-				elif extension in ['jpg', 'jpeg', 'png']:
+				elif extension in ['jpg', 'jpeg', 'png', 'gif', 'webp']:
 					import anyio
 
 					# Read image file and convert to base64
@@ -980,6 +1047,11 @@ class FileSystem:
 				'DocxFile': DocxFile,
 				'HtmlFile': HtmlFile,
 				'XmlFile': XmlFile,
+				'PngFile': PngFile,
+				'GifFile': GifFile,
+				'JpgFile': JpgFile,
+				'JpegFile': JpegFile,
+				'WebpFile': WebpFile,
 			}
 
 			file_class = file_type_map.get(file_type)

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -399,10 +399,46 @@ class Base64BinaryFile(BaseFile):
 	flows, not for arbitrary large binaries.
 	"""
 
+	# Leading magic bytes that identify a real file of this type. Keyed by extension so
+	# base64 that decodes but isn't actually an image (e.g. 'aGVsbG8=' -> b'hello') is
+	# rejected instead of written as a corrupt upload.
+	_MAGIC: dict[str, tuple[bytes, ...]] = {
+		'png': (b'\x89PNG\r\n\x1a\n',),
+		'gif': (b'GIF87a', b'GIF89a'),
+		'jpg': (b'\xff\xd8\xff',),
+		'jpeg': (b'\xff\xd8\xff',),
+		'webp': (b'RIFF',),  # RIFF container; 'WEBP' tag checked below
+	}
+
 	def _decoded(self) -> bytes:
 		# Strip all whitespace (the write_file action appends a trailing newline) then
 		# decode strictly so non-base64 text is rejected rather than silently corrupted.
 		return base64.b64decode(''.join(self.content.split()), validate=True)
+
+	def _validate(self, content: str) -> None:
+		"""Decode and confirm the bytes actually are an image of this extension. Raises FileSystemError."""
+		try:
+			data = base64.b64decode(''.join(content.split()), validate=True)
+		except Exception as e:
+			raise FileSystemError(
+				f"Error: content for '{self.full_name}' is not valid base64. "
+				f'For images, provide the base64 of a valid {self.extension} file. ({e})'
+			)
+		magic = self._MAGIC.get(self.extension, ())
+		if magic and not any(data.startswith(m) for m in magic):
+			raise FileSystemError(
+				f"Error: content for '{self.full_name}' is valid base64 but not a {self.extension} image "
+				f'(wrong magic bytes). Provide the base64 of a real {self.extension} file.'
+			)
+		if self.extension == 'webp' and not (data[:4] == b'RIFF' and data[8:12] == b'WEBP'):
+			raise FileSystemError(f"Error: content for '{self.full_name}' is not a valid WEBP file.")
+
+	def write_file_content(self, content: str) -> None:
+		self._validate(content)
+		self.update_content(content)
+
+	def append_file_content(self, content: str) -> None:
+		raise FileSystemError(f"Error: cannot append to binary file '{self.full_name}'. Overwrite it instead.")
 
 	def sync_to_disk_sync(self, path: Path) -> None:
 		(path / self.full_name).write_bytes(self._decoded())
@@ -853,15 +889,16 @@ class FileSystem:
 			if not file_class:
 				raise ValueError(f"Error: Invalid file extension '{extension}' for file '{full_filename}'.")
 
-			# Create or get existing file using full filename as key
-			if full_filename in self.files:
-				file_obj = self.files[full_filename]
-			else:
-				file_obj = file_class(name=name_without_ext)
-				self.files[full_filename] = file_obj  # Use full filename as key
+			# Create or get existing file using full filename as key. A NEW file is only
+			# registered after a successful write, so a failed write (e.g. invalid base64
+			# for an image) leaves no ghost entry in self.files / state.
+			is_new = full_filename not in self.files
+			file_obj = self.files[full_filename] if not is_new else file_class(name=name_without_ext)
 
 			# Use file-specific write method
 			await file_obj.write(content, self.data_dir)
+			if is_new:
+				self.files[full_filename] = file_obj
 			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
 			return f'Data written to file {full_filename} successfully.{sanitize_note}'
 		except FileSystemError as e:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1743,7 +1743,9 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			'Write content to a file. By default this OVERWRITES the entire file - use append=true to add to an existing file, or use replace_file for targeted edits within a file. '
 			'FILENAME RULES: Use only letters, numbers, underscores, hyphens, dots, parentheses. Spaces are auto-converted to hyphens. '
 			'SUPPORTED EXTENSIONS: .txt, .md, .json, .jsonl, .csv, .html, .xml, .pdf, .docx. '
-			'CANNOT write binary/image files (.png, .jpg, .mp4, etc.) - do not attempt to save screenshots as files. '
+			'For small images (.png, .gif, .jpg, .webp) — e.g. a tiny file to upload — set content to the '
+			'base64 of a valid image (a 1x1 PNG is ~92 base64 chars); the bytes are decoded and written for you. '
+			'CANNOT write other binary files (.mp4, .zip, etc.) and do not attempt to save screenshots as files. '
 			'For PDF files, write content in markdown format and it will be auto-converted to PDF.'
 		)
 		async def write_file(

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1755,7 +1755,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			'Write content to a file. By default this OVERWRITES the entire file - use append=true to add to an existing file, or use replace_file for targeted edits within a file. '
 			'FILENAME RULES: Use only letters, numbers, underscores, hyphens, dots, parentheses. Spaces are auto-converted to hyphens. '
 			'SUPPORTED EXTENSIONS: .txt, .md, .json, .jsonl, .csv, .html, .xml, .pdf, .docx. '
-			'For small images (.png, .gif, .jpg, .webp) — e.g. a tiny file to upload — set content to the '
+			'For small images (.png, .gif, .jpg, .jpeg, .webp) — e.g. a tiny file to upload — set content to the '
 			'base64 of a valid image (a 1x1 PNG is ~92 base64 chars); the bytes are decoded and written for you. '
 			'CANNOT write other binary files (.mp4, .zip, etc.) and do not attempt to save screenshots as files. '
 			'For PDF files, write content in markdown format and it will be auto-converted to PDF.'

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1755,7 +1755,9 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			'Write content to a file. By default this OVERWRITES the entire file - use append=true to add to an existing file, or use replace_file for targeted edits within a file. '
 			'FILENAME RULES: Use only letters, numbers, underscores, hyphens, dots, parentheses. Spaces are auto-converted to hyphens. '
 			'SUPPORTED EXTENSIONS: .txt, .md, .json, .jsonl, .csv, .html, .xml, .pdf, .docx. '
-			'CANNOT write binary/image files (.png, .jpg, .mp4, etc.) - do not attempt to save screenshots as files. '
+			'For small images (.png, .gif, .jpg, .webp) — e.g. a tiny file to upload — set content to the '
+			'base64 of a valid image (a 1x1 PNG is ~92 base64 chars); the bytes are decoded and written for you. '
+			'CANNOT write other binary files (.mp4, .zip, etc.) and do not attempt to save screenshots as files. '
 			'For PDF files, write content in markdown format and it will be auto-converted to PDF.'
 		)
 		async def write_file(

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -293,8 +293,16 @@ class TestFileSystem:
 		assert fs._is_valid_filename('.json') is False  # no name
 		assert fs._is_valid_filename('.jsonl') is False  # no name
 		assert fs._is_valid_filename('.csv') is False  # no name
-		assert fs._is_valid_filename('screenshot.png') is False  # binary extension
-		assert fs._is_valid_filename('image.jpg') is False  # binary extension
+		# Small image extensions are now supported (base64 content -> real bytes, for upload flows)
+		assert fs._is_valid_filename('screenshot.png') is True
+		assert fs._is_valid_filename('image.jpg') is True
+		assert fs._is_valid_filename('pic.gif') is True
+		assert fs._is_valid_filename('photo.webp') is True
+
+		# Other binary types remain unsupported
+		assert fs._is_valid_filename('clip.mp4') is False  # binary extension
+		assert fs._is_valid_filename('archive.zip') is False  # binary extension
+		assert fs._is_valid_filename('icon.svg') is False  # binary extension
 
 	def test_filename_parsing(self, temp_filesystem):
 		"""Test filename parsing into name and extension."""
@@ -1001,16 +1009,28 @@ class TestFilenameSanitization:
 			fs.nuke()
 
 	async def test_write_file_binary_extension_error(self):
-		"""Test that writing to binary extensions gives a clear error."""
+		"""Unsupported binary extensions give a clear error; small images accept base64."""
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			fs = FileSystem(base_dir=tmp_dir, create_default_files=False)
 
-			result = await fs.write_file('screenshot.png', 'content')
+			# Non-image binaries are still rejected outright
+			result = await fs.write_file('clip.mp4', 'content')
 			assert 'binary/image' in result.lower() or 'Cannot write' in result
-			assert 'screenshot.png' not in fs.list_files()
+			assert 'clip.mp4' not in fs.list_files()
 
-			result = await fs.write_file('photo.jpg', 'content')
+			result = await fs.write_file('archive.zip', 'content')
 			assert 'binary/image' in result.lower() or 'Cannot write' in result
+
+			# Small images are supported: non-base64 content is rejected (no corrupt file),
+			# valid base64 is written as real bytes.
+			result = await fs.write_file('screenshot.png', 'not base64!!!')
+			assert 'Error' in result
+			assert not (fs.get_dir() / 'screenshot.png').exists()
+
+			png_1x1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8AAAAASUVORK5CYII='
+			result = await fs.write_file('logo.png', png_1x1)
+			assert 'successfully' in result
+			assert (fs.get_dir() / 'logo.png').read_bytes()[:8] == b'\x89PNG\r\n\x1a\n'
 
 			fs.nuke()
 
@@ -1131,8 +1151,8 @@ class TestFilenameSanitization:
 			result = await fs.read_file('noextension')
 			assert 'no extension' in result.lower()
 
-			# Binary extension - specific error
-			result = await fs.write_file('image.png', 'data')
+			# Unsupported binary extension - specific error
+			result = await fs.write_file('clip.mp4', 'data')
 			assert 'binary' in result.lower() or 'Cannot write' in result
 
 			fs.nuke()

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -465,8 +465,16 @@ class TestFileSystem:
 		assert fs._is_valid_filename('.json') is False  # no name
 		assert fs._is_valid_filename('.jsonl') is False  # no name
 		assert fs._is_valid_filename('.csv') is False  # no name
-		assert fs._is_valid_filename('screenshot.png') is False  # binary extension
-		assert fs._is_valid_filename('image.jpg') is False  # binary extension
+		# Small image extensions are now supported (base64 content -> real bytes, for upload flows)
+		assert fs._is_valid_filename('screenshot.png') is True
+		assert fs._is_valid_filename('image.jpg') is True
+		assert fs._is_valid_filename('pic.gif') is True
+		assert fs._is_valid_filename('photo.webp') is True
+
+		# Other binary types remain unsupported
+		assert fs._is_valid_filename('clip.mp4') is False  # binary extension
+		assert fs._is_valid_filename('archive.zip') is False  # binary extension
+		assert fs._is_valid_filename('icon.svg') is False  # binary extension
 
 	def test_filename_parsing(self, temp_filesystem):
 		"""Test filename parsing into name and extension."""
@@ -1185,16 +1193,28 @@ class TestFilenameSanitization:
 			fs.nuke()
 
 	async def test_write_file_binary_extension_error(self):
-		"""Test that writing to binary extensions gives a clear error."""
+		"""Unsupported binary extensions give a clear error; small images accept base64."""
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			fs = FileSystem(base_dir=tmp_dir, create_default_files=False)
 
-			result = await fs.write_file('screenshot.png', 'content')
+			# Non-image binaries are still rejected outright
+			result = await fs.write_file('clip.mp4', 'content')
 			assert 'binary/image' in result.lower() or 'Cannot write' in result
-			assert 'screenshot.png' not in fs.list_files()
+			assert 'clip.mp4' not in fs.list_files()
 
-			result = await fs.write_file('photo.jpg', 'content')
+			result = await fs.write_file('archive.zip', 'content')
 			assert 'binary/image' in result.lower() or 'Cannot write' in result
+
+			# Small images are supported: non-base64 content is rejected (no corrupt file),
+			# valid base64 is written as real bytes.
+			result = await fs.write_file('screenshot.png', 'not base64!!!')
+			assert 'Error' in result
+			assert not (fs.get_dir() / 'screenshot.png').exists()
+
+			png_1x1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8AAAAASUVORK5CYII='
+			result = await fs.write_file('logo.png', png_1x1)
+			assert 'successfully' in result
+			assert (fs.get_dir() / 'logo.png').read_bytes()[:8] == b'\x89PNG\r\n\x1a\n'
 
 			fs.nuke()
 
@@ -1315,8 +1335,8 @@ class TestFilenameSanitization:
 			result = await fs.read_file('noextension')
 			assert 'no extension' in result.lower()
 
-			# Binary extension - specific error
-			result = await fs.write_file('image.png', 'data')
+			# Unsupported binary extension - specific error
+			result = await fs.write_file('clip.mp4', 'data')
 			assert 'binary' in result.lower() or 'Cannot write' in result
 
 			fs.nuke()

--- a/tests/ci/test_file_system_images.py
+++ b/tests/ci/test_file_system_images.py
@@ -247,3 +247,44 @@ class TestActionResultImages:
 
 if __name__ == '__main__':
 	pytest.main([__file__, '-v'])
+
+
+class TestBinaryFileCreation:
+	"""The agent can author a tiny binary file (base64) that becomes a real, uploadable image."""
+
+	PNG_1X1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8AAAAASUVORK5CYII='
+
+	async def test_write_png_produces_real_bytes(self, tmp_path: Path):
+		fs = FileSystem(str(tmp_path))
+		# write_file action appends a trailing newline; that must be tolerated
+		result = await fs.write_file('logo.png', self.PNG_1X1 + '\n')
+		assert 'successfully' in result
+		raw = (fs.get_dir() / 'logo.png').read_bytes()
+		assert raw[:8] == b'\x89PNG\r\n\x1a\n'  # real PNG magic, not base64 text
+		assert len(raw) > 0
+
+	async def test_binary_file_is_uploadable_by_basename(self, tmp_path: Path):
+		fs = FileSystem(str(tmp_path))
+		await fs.write_file('pic.gif', 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7')
+		fobj = fs.get_file('pic.gif')  # the exact resolution upload_file uses
+		assert fobj is not None
+		assert fobj.full_name == 'pic.gif'
+
+	async def test_describe_does_not_leak_base64(self, tmp_path: Path):
+		fs = FileSystem(str(tmp_path))
+		await fs.write_file('logo.png', self.PNG_1X1)
+		desc = fs.describe()
+		assert self.PNG_1X1[:24] not in desc  # base64 never enters the prompt
+		assert '[binary png file' in desc
+
+	async def test_invalid_base64_is_rejected_no_corrupt_file(self, tmp_path: Path):
+		fs = FileSystem(str(tmp_path))
+		result = await fs.write_file('bad.png', 'this is definitely not base64 @@@')
+		assert 'Error' in result
+		assert not (fs.get_dir() / 'bad.png').exists()  # no 0-byte / corrupt file left for upload
+
+	async def test_state_round_trip_preserves_binary(self, tmp_path: Path):
+		fs = FileSystem(str(tmp_path))
+		await fs.write_file('logo.png', self.PNG_1X1)
+		fs2 = FileSystem.from_state(fs.get_state())
+		assert fs2.get_file('logo.png') is not None

--- a/tests/ci/test_file_system_images.py
+++ b/tests/ci/test_file_system_images.py
@@ -282,9 +282,32 @@ class TestBinaryFileCreation:
 		result = await fs.write_file('bad.png', 'this is definitely not base64 @@@')
 		assert 'Error' in result
 		assert not (fs.get_dir() / 'bad.png').exists()  # no 0-byte / corrupt file left for upload
+		# No ghost entry in the in-memory filesystem / state either
+		assert 'bad.png' not in fs.list_files()
+		assert 'bad.png' not in [f for f in fs.get_state().model_dump().get('files', {})]
+
+	async def test_valid_base64_but_not_an_image_is_rejected(self, tmp_path: Path):
+		"""'aGVsbG8=' is valid base64 (-> b'hello') but not a PNG: must be rejected, not written."""
+		fs = FileSystem(str(tmp_path))
+		result = await fs.write_file('fake.png', 'aGVsbG8=')
+		assert 'Error' in result
+		assert not (fs.get_dir() / 'fake.png').exists()
+		assert 'fake.png' not in fs.list_files()
+
+	async def test_wrong_magic_for_extension_is_rejected(self, tmp_path: Path):
+		"""PNG bytes written under a .gif name are rejected (magic mismatch)."""
+		fs = FileSystem(str(tmp_path))
+		result = await fs.write_file('mislabeled.gif', self.PNG_1X1)
+		assert 'Error' in result
+		assert 'mislabeled.gif' not in fs.list_files()
 
 	async def test_state_round_trip_preserves_binary(self, tmp_path: Path):
 		fs = FileSystem(str(tmp_path))
 		await fs.write_file('logo.png', self.PNG_1X1)
+		original_bytes = (fs.get_dir() / 'logo.png').read_bytes()
 		fs2 = FileSystem.from_state(fs.get_state())
-		assert fs2.get_file('logo.png') is not None
+		restored = fs2.get_file('logo.png')
+		assert restored is not None
+		# Content integrity, not just existence: decoded bytes must round-trip and be a real PNG
+		assert restored._decoded() == original_bytes
+		assert restored._decoded()[:8] == b'\x89PNG\r\n\x1a\n'

--- a/tests/ci/test_file_system_images.py
+++ b/tests/ci/test_file_system_images.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
-from browser_use.filesystem.file_system import FileSystem
+from browser_use.filesystem.file_system import Base64BinaryFile, FileSystem
 
 
 class TestImageFiles:
@@ -307,7 +307,7 @@ class TestBinaryFileCreation:
 		original_bytes = (fs.get_dir() / 'logo.png').read_bytes()
 		fs2 = FileSystem.from_state(fs.get_state())
 		restored = fs2.get_file('logo.png')
-		assert restored is not None
+		assert isinstance(restored, Base64BinaryFile)
 		# Content integrity, not just existence: decoded bytes must round-trip and be a real PNG
 		assert restored._decoded() == original_bytes
 		assert restored._decoded()[:8] == b'\x89PNG\r\n\x1a\n'


### PR DESCRIPTION
## Problem

The agent's file tools only write text formats, so any task that needs to **upload an image/file** (a photo, a GIF, a document) is unwinnable by construction — the model burns steps on `DataTransfer` JS hacks and then gives up or fabricates. In evals this made whole upload-validation tasks impossible for every model.

## Fix

`write_file` now accepts small image extensions (`.png .gif .jpg .jpeg .webp`) where `content` is the **base64 of a valid image**. The bytes are decoded and written to disk, so the file is a real, uploadable image. A 1×1 PNG is ~92 base64 chars (~23 tokens), a GIF just 56 — cheap for the model to emit.

- `Base64BinaryFile` writes decoded **bytes** to disk (not the base64 text) and `read()` returns a `[binary png file, N bytes]` stub, so base64 never enters the agent prompt (`describe()` runs every step).
- **Strict** base64 decode — invalid content returns an error and **no file is created**, so a corrupt 'image' can't pass upload's `file_size > 0` check.
- Registered in `_file_types` so `upload_file.get_file` resolves it by basename (the load-bearing bit — upload only finds FileSystem files whose extension is registered), and in `from_state` so restored sessions keep it. Removed the now-supported extensions from `UNSUPPORTED_BINARY_EXTENSIONS`.
- Untouched: text `write_file`, PDF/DOCX rendering (still markdown→document), and rejection of other binaries (`.mp4 .zip .exe …`).

## Testing

5 new tests + all 13 existing image tests pass (18 total): real PNG magic bytes on disk, uploadable by basename, no base64 leak in `describe()`, invalid-base64 rejected with no corrupt file, state round-trip. Verified end-to-end that a written `.png` resolves through the exact `upload_file` path.

Scoped deliberately to tiny fixtures (images only, strict decode) — not a general binary-write feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`write_file` can now create tiny binary images (.png, .gif, .jpg/.jpeg, .webp) from base64 so upload flows use real files. We validate base64 and magic bytes, reject mismatched types, and only register files after a successful write to avoid ghost entries.

- **New Features**
  - Added `Base64BinaryFile` that decodes bytes to disk; `read()` returns “[binary <ext> file, N bytes]” so base64 stays out of prompts.
  - `write_file` accepts `.png .gif .jpg .jpeg .webp`; strict base64 + magic-byte checks (incl. RIFF/WEBP) and extension match; invalid or mismatched content errors and no file created; new files are registered only on success.
  - Binary images cannot be appended (append is rejected to prevent corruption).
  - Registered new types in `_file_types`/`from_state`, pruned `UNSUPPORTED_BINARY_EXTENSIONS`, extended structured reads to include `gif`/`webp`, and allowed these extensions in filename validation.
  - Updated help text to document small-image support; other binaries (.mp4, .zip, etc.) remain blocked.

<sup>Written for commit d828d83d7aa2becaa231de400f1a4ff77cb490a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

