### PR TITLE
fix:  `allowed_domains` Hostname Boundary Bypass Fix

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -11,6 +11,7 @@ from browser_use.browser.events import (
 	TabCreatedEvent,
 )
 from browser_use.browser.watchdog_base import BaseWatchdog
+from browser_use.utils import match_url_with_domain_pattern
 
 if TYPE_CHECKING:
 	pass
@@ -282,9 +283,10 @@ class SecurityWatchdog(BaseWatchdog):
 		else:
 			# Exact match
 			if '://' in pattern:
-				# Full URL pattern
-				if url.startswith(pattern):
-					return True
+				# Match parsed scheme and hostname instead of a raw string prefix.
+				# Raw prefix matching allows URLs such as
+				# https://example.com.evil.test to bypass https://example.com.
+				return match_url_with_domain_pattern(url, pattern)
 			else:
 				# Domain-only pattern (case-insensitive comparison)
 				if host.lower() == pattern.lower():

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -252,7 +252,7 @@ class SecurityWatchdog(BaseWatchdog):
 		"""Match a scheme-qualified URL pattern without losing path-prefix semantics.
 
 		The scheme and hostname are compared as parsed URL components so lookalike
-		hosts cannot match. An explicit pattern port must also match.Non-root
+		hosts cannot match. An explicit pattern port must also match. Non-root
 		paths, queries, and fragments retain the historical prefix behavior.
 		"""
 		try:

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -1,6 +1,7 @@
 """Security watchdog for enforcing URL access policies."""
 
 from typing import TYPE_CHECKING, ClassVar
+from urllib.parse import urlparse
 
 from bubus import BaseEvent
 
@@ -11,7 +12,6 @@ from browser_use.browser.events import (
 	TabCreatedEvent,
 )
 from browser_use.browser.watchdog_base import BaseWatchdog
-from browser_use.utils import match_url_with_domain_pattern
 
 if TYPE_CHECKING:
 	pass
@@ -188,9 +188,6 @@ class SecurityWatchdog(BaseWatchdog):
 		if url in ['about:blank', 'chrome://new-tab-page/', 'chrome://new-tab-page', 'chrome://newtab/']:
 			return True
 
-		# Parse the URL to extract components
-		from urllib.parse import urlparse
-
 		try:
 			parsed = urlparse(url)
 		except Exception:
@@ -250,6 +247,40 @@ class SecurityWatchdog(BaseWatchdog):
 
 		return True
 
+	@staticmethod
+	def _is_scheme_qualified_url_match(url: str, pattern: str) -> bool:
+		"""Match a scheme-qualified URL pattern without losing path-prefix semantics.
+
+		The scheme and hostname are compared as parsed URL components so lookalike
+		hosts cannot match. An explicit pattern port must also match. Non-root
+		paths, queries, and fragments retain the historical prefix behavior.
+		"""
+		try:
+			parsed_url = urlparse(url)
+			parsed_pattern = urlparse(pattern)
+
+			if not parsed_url.hostname or not parsed_pattern.hostname:
+				return False
+			if parsed_url.scheme.lower() != parsed_pattern.scheme.lower():
+				return False
+			if parsed_url.hostname.lower() != parsed_pattern.hostname.lower():
+				return False
+			if parsed_pattern.port is not None and parsed_url.port != parsed_pattern.port:
+				return False
+		except (TypeError, ValueError):
+			return False
+
+		if parsed_pattern.path not in ('', '/') and not parsed_url.path.startswith(parsed_pattern.path):
+			return False
+		if parsed_pattern.params and not parsed_url.params.startswith(parsed_pattern.params):
+			return False
+		if parsed_pattern.query and not parsed_url.query.startswith(parsed_pattern.query):
+			return False
+		if parsed_pattern.fragment and not parsed_url.fragment.startswith(parsed_pattern.fragment):
+			return False
+
+		return True
+
 	def _is_url_match(self, url: str, host: str, scheme: str, pattern: str) -> bool:
 		"""Check if a URL matches a pattern."""
 
@@ -283,10 +314,7 @@ class SecurityWatchdog(BaseWatchdog):
 		else:
 			# Exact match
 			if '://' in pattern:
-				# Match parsed scheme and hostname instead of a raw string prefix.
-				# Raw prefix matching allows URLs such as
-				# https://example.com.evil.test to bypass https://example.com.
-				return match_url_with_domain_pattern(url, pattern)
+				return self._is_scheme_qualified_url_match(url, pattern)
 			else:
 				# Domain-only pattern (case-insensitive comparison)
 				if host.lower() == pattern.lower():

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -252,7 +252,7 @@ class SecurityWatchdog(BaseWatchdog):
 		"""Match a scheme-qualified URL pattern without losing path-prefix semantics.
 
 		The scheme and hostname are compared as parsed URL components so lookalike
-		hosts cannot match. An explicit pattern port must also match. Non-root
+		hosts cannot match. An explicit pattern port must also match.Non-root
 		paths, queries, and fragments retain the historical prefix behavior.
 		"""
 		try:

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -254,6 +254,26 @@ class TestUrlAllowlistSecurity:
 		assert watchdog._is_url_allowed('https://www.example.com') is False
 		assert watchdog._is_url_allowed('http://www.test.org') is False
 
+	def test_full_url_patterns_enforce_hostname_boundaries(self):
+		"""Full URL patterns must not match attacker-controlled hostname prefixes."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(
+			allowed_domains=['https://example.com'],
+			headless=True,
+			user_data_dir=None,
+		)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('https://example.com/login') is True
+		assert watchdog._is_url_allowed('https://example.com.evil.test/steal') is False
+		assert watchdog._is_url_allowed('https://example.com@evil.test/steal') is False
+		assert watchdog._is_url_allowed('http://example.com/login') is False
+
 	def test_is_root_domain_helper(self):
 		"""Test the _is_root_domain helper method logic."""
 		from bubus import EventBus
@@ -353,6 +373,8 @@ class TestUrlProhibitlistSecurity:
 		assert watchdog._is_url_allowed('http://wiki.org') is True
 		assert watchdog._is_url_allowed('https://wiki.org') is False
 		assert watchdog._is_url_allowed('https://wiki.org/path') is False
+		assert watchdog._is_url_allowed('https://wiki.org.evil.test/path') is True
+		assert watchdog._is_url_allowed('https://wiki.org@evil.test/path') is True
 
 		# Internal URL prefix blocking
 		assert watchdog._is_url_allowed('brave://anything/') is False

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -274,6 +274,52 @@ class TestUrlAllowlistSecurity:
 		assert watchdog._is_url_allowed('https://example.com@evil.test/steal') is False
 		assert watchdog._is_url_allowed('http://example.com/login') is False
 
+	def test_full_url_patterns_preserve_path_prefixes(self):
+		"""Full URL patterns retain trailing-slash and path-prefix matching."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(
+			allowed_domains=['https://example.com/safe'],
+			headless=True,
+			user_data_dir=None,
+		)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('https://example.com/safe') is True
+		assert watchdog._is_url_allowed('https://example.com/safe/nested') is True
+		assert watchdog._is_url_allowed('https://example.com/unsafe') is False
+		assert watchdog._is_url_allowed('https://example.com.evil.test/safe') is False
+
+		trailing_slash_profile = BrowserProfile(
+			allowed_domains=['https://example.com/'],
+			headless=True,
+			user_data_dir=None,
+		)
+		trailing_slash_watchdog = SecurityWatchdog(
+			browser_session=BrowserSession(browser_profile=trailing_slash_profile),
+			event_bus=EventBus(),
+		)
+
+		assert trailing_slash_watchdog._is_url_allowed('https://example.com/path') is True
+
+		explicit_port_profile = BrowserProfile(
+			allowed_domains=['https://example.com:8443/'],
+			headless=True,
+			user_data_dir=None,
+		)
+		explicit_port_watchdog = SecurityWatchdog(
+			browser_session=BrowserSession(browser_profile=explicit_port_profile),
+			event_bus=EventBus(),
+		)
+
+		assert explicit_port_watchdog._is_url_allowed('https://example.com:8443/path') is True
+		assert explicit_port_watchdog._is_url_allowed('https://example.com/path') is False
+		assert explicit_port_watchdog._is_url_allowed('https://example.com:9443/path') is False
+
 	def test_is_root_domain_helper(self):
 		"""Test the _is_root_domain helper method logic."""
 		from bubus import EventBus
@@ -364,7 +410,11 @@ class TestUrlProhibitlistSecurity:
 
 		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
 
-		browser_profile = BrowserProfile(prohibited_domains=['https://wiki.org', 'brave://*'], headless=True, user_data_dir=None)
+		browser_profile = BrowserProfile(
+			prohibited_domains=['https://wiki.org', 'https://evil.test/', 'https://secure.test/private', 'brave://*'],
+			headless=True,
+			user_data_dir=None,
+		)
 		browser_session = BrowserSession(browser_profile=browser_profile)
 		event_bus = EventBus()
 		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
@@ -374,7 +424,12 @@ class TestUrlProhibitlistSecurity:
 		assert watchdog._is_url_allowed('https://wiki.org') is False
 		assert watchdog._is_url_allowed('https://wiki.org/path') is False
 		assert watchdog._is_url_allowed('https://wiki.org.evil.test/path') is True
-		assert watchdog._is_url_allowed('https://wiki.org@evil.test/path') is True
+		assert watchdog._is_url_allowed('https://wiki.org@outside.test/path') is True
+
+		# Trailing slashes and path prefixes remain meaningful
+		assert watchdog._is_url_allowed('https://evil.test/download') is False
+		assert watchdog._is_url_allowed('https://secure.test/private/report') is False
+		assert watchdog._is_url_allowed('https://secure.test/public/report') is True
 
 		# Internal URL prefix blocking
 		assert watchdog._is_url_allowed('brave://anything/') is False


### PR DESCRIPTION
## Summary

replace raw URL prefix matching for scheme-qualified domain rules with the existing security-focused
`match_url_with_domain_pattern()` helper

cover allowed-domain hostname boundaries, user-info injection, scheme enforcement, and prohibited-domain false positives
with regression tests

## Why

The previous implementation used `url.startswith(pattern)` for scheme-qualified domain rules. As a result, an allowlist
entry such as `https://example.com` also accepted attacker-controlled URLs including
`https://example.com.evil.test` and `https://example.com@evil.test`.

Parsing and comparing the URL scheme and hostname prevents prefix-based allowlist bypasses while preserving legitimate
paths on the configured domain.

Closes the full-URL `allowed_domains` hostname-boundary bypass identified during security review.

## Summary by cubic

Replaces unsafe prefix matching for scheme-qualified browser domain rules with parsed scheme and hostname matching,
preventing lookalike domains and user-info URLs from bypassing `allowed_domains`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hostname-boundary bypass in `allowed_domains` by replacing prefix checks with parsed scheme/host/port matching for scheme-qualified patterns. Keeps trailing-slash and path-prefix behavior for both allow and block lists, and reduces false positives in `prohibited_domains`.

- **Bug Fixes**
  - Replaced `url.startswith(pattern)` with `_is_scheme_qualified_url_match` in the security watchdog.
  - Enforces exact scheme, hostname, and explicit port; blocks lookalike hosts and user-info; rejects `http://` when `https://` is required.
  - Preserves path-prefix semantics (including trailing slash) and honors explicit-port rules; added tests for hostname boundaries, user-info, path prefixes, explicit ports, and `prohibited_domains` boundary and path-prefix cases.

<sup>Written for commit 85013b81d7a9a04731ecfe98054ce6efca17bba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

