### PR TITLE
Use running loop for async browser timing

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -1035,7 +1035,7 @@ class BrowserSession(BaseModel):
 			)
 			timeout = 3.0 if same_domain else 8.0
 
-		nav_start_time = asyncio.get_event_loop().time()
+		nav_start_time = asyncio.get_running_loop().time()
 
 		# Wrap Page.navigate() with timeout — heavy sites can block here for 10s+
 		# Use nav_timeout parameter if provided, otherwise default to 20.0
@@ -1050,14 +1050,14 @@ class BrowserSession(BaseModel):
 				timeout=nav_timeout,
 			)
 		except TimeoutError:
-			duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
+			duration_ms = (asyncio.get_running_loop().time() - nav_start_time) * 1000
 			raise RuntimeError(f'Page.navigate() timed out after {nav_timeout}s ({duration_ms:.0f}ms) for {url}')
 
 		if nav_result.get('errorText'):
 			raise RuntimeError(f'Navigation failed: {nav_result["errorText"]}')
 
 		if wait_until == 'commit':
-			duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
+			duration_ms = (asyncio.get_running_loop().time() - nav_start_time) * 1000
 			self.logger.debug(f'✅ Page ready for {url} (commit, {duration_ms:.0f}ms)')
 			return None
 
@@ -1068,10 +1068,10 @@ class BrowserSession(BaseModel):
 		# load/DOMContentLoaded lifecycle events for it — waiting would only burn
 		# the timeout against stale events from the previous document load.
 		if not navigation_id:
-			duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
+			duration_ms = (asyncio.get_running_loop().time() - nav_start_time) * 1000
 			self.logger.debug(f'✅ Page ready for {url} (same-document navigation, {duration_ms:.0f}ms)')
 			return None
-		start_time = asyncio.get_event_loop().time()
+		start_time = asyncio.get_running_loop().time()
 		seen_events = []
 
 		# Per-target buffer owned by SessionManager — NOT a per-session attribute, whose
@@ -1086,7 +1086,7 @@ class BrowserSession(BaseModel):
 			acceptable_events.add('DOMContentLoaded')
 
 		poll_interval = 0.05
-		while (asyncio.get_event_loop().time() - start_time) < timeout:
+		while (asyncio.get_running_loop().time() - start_time) < timeout:
 			try:
 				for event_data in list(lifecycle_events):
 					event_name = event_data.get('name')
@@ -1107,7 +1107,7 @@ class BrowserSession(BaseModel):
 						continue
 
 					if event_name in acceptable_events:
-						duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
+						duration_ms = (asyncio.get_running_loop().time() - nav_start_time) * 1000
 						self.logger.debug(f'✅ Page ready for {url} ({event_name}, {duration_ms:.0f}ms)')
 						return None
 
@@ -1116,7 +1116,7 @@ class BrowserSession(BaseModel):
 
 			await asyncio.sleep(poll_interval)
 
-		duration_ms = (asyncio.get_event_loop().time() - nav_start_time) * 1000
+		duration_ms = (asyncio.get_running_loop().time() - nav_start_time) * 1000
 		if not seen_events:
 			self.logger.error(
 				f'❌ No lifecycle events received for {url} after {duration_ms:.0f}ms! '

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -370,9 +370,9 @@ class SessionManager:
 		# Wait for recovery complete event (event-driven, not polling!)
 		if self._recovery_complete_event:
 			try:
-				start_time = asyncio.get_event_loop().time()
+				start_time = asyncio.get_running_loop().time()
 				await asyncio.wait_for(self._recovery_complete_event.wait(), timeout=timeout)
-				elapsed = asyncio.get_event_loop().time() - start_time
+				elapsed = asyncio.get_running_loop().time() - start_time
 
 				# Verify recovery succeeded - simple existence check
 				focus_id = self.browser_session.agent_focus_target_id

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -956,9 +956,9 @@ class DownloadsWatchdog(BaseWatchdog):
 
 		# Poll for new files
 		max_wait = 20  # seconds
-		start_time = asyncio.get_event_loop().time()
+		start_time = asyncio.get_running_loop().time()
 
-		while asyncio.get_event_loop().time() - start_time < max_wait:  # noqa: ASYNC110
+		while asyncio.get_running_loop().time() - start_time < max_wait:  # noqa: ASYNC110
 			await asyncio.sleep(5.0)  # Check every 5 seconds
 
 			if Path(downloads_dir).exists():

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -409,9 +409,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		"""Wait for the browser to start and return the CDP URL."""
 		import aiohttp
 
-		start_time = asyncio.get_event_loop().time()
+		start_time = asyncio.get_running_loop().time()
 
-		while asyncio.get_event_loop().time() - start_time < timeout:
+		while asyncio.get_running_loop().time() - start_time < timeout:
 			try:
 				async with aiohttp.ClientSession() as session:
 					async with session.get(f'http://127.0.0.1:{port}/json/version') as resp:


### PR DESCRIPTION
## Summary
- Replace `asyncio.get_event_loop().time()` with `asyncio.get_running_loop().time()` in async browser timing paths.
- Keep the remaining synchronous lifecycle callback unchanged.

## Problem
These code paths run inside active coroutines, but they still use `asyncio.get_event_loop()` for monotonic timing. That implicit event-loop lookup is deprecated in newer Python versions when no current loop is set, and `get_running_loop()` expresses the actual requirement more directly inside async code.

## Before / After
Before: navigation waits, focus recovery, CDP download polling, and local browser CDP polling used implicit event-loop lookup for elapsed time calculations.

After: those same elapsed-time calculations use the currently running loop without changing timeout behavior.

## Verification
- `python -m py_compile browser_use/browser/session.py browser_use/browser/session_manager.py browser_use/browser/watchdogs/downloads_watchdog.py browser_use/browser/watchdogs/local_browser_watchdog.py`
- `uv run ruff check browser_use/browser/session.py browser_use/browser/session_manager.py browser_use/browser/watchdogs/downloads_watchdog.py browser_use/browser/watchdogs/local_browser_watchdog.py`
- `uv run python -m pytest -q tests/ci/browser/test_profile_copy.py` (`2 passed`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced async timing calls from `asyncio.get_event_loop().time()` to `asyncio.get_running_loop().time()` across navigation and watchdog paths. This removes deprecated implicit loop lookups on newer Python while keeping timeout behavior unchanged.

- **Bug Fixes**
  - Updated timing in navigation waits, focus recovery, CDP download polling, and local browser CDP URL polling.
  - Left the synchronous lifecycle callback unchanged.

<sup>Written for commit c374355ecdd709690e8d065cf52f45873d2f9641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

