### PR TITLE
fix(browser): restore event handlers after shutdown

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -692,6 +692,10 @@ class BrowserSession(BaseModel):
 		self._reconnect_event = asyncio.Event()
 		self._reconnect_event.set()
 
+		self._register_core_event_handlers()
+
+	def _register_core_event_handlers(self) -> None:
+		"""Register BrowserSession handlers on the current event bus."""
 		# Check if handlers are already registered to prevent duplicates
 		from browser_use.browser.watchdog_base import BaseWatchdog
 
@@ -714,6 +718,11 @@ class BrowserSession(BaseModel):
 		BaseWatchdog.attach_handler_to_session(self, AgentFocusChangedEvent, self.on_AgentFocusChangedEvent)
 		BaseWatchdog.attach_handler_to_session(self, FileDownloadedEvent, self.on_FileDownloadedEvent)
 		BaseWatchdog.attach_handler_to_session(self, CloseTabEvent, self.on_CloseTabEvent)
+
+	def _replace_event_bus(self) -> None:
+		"""Replace the stopped event bus and register the handlers needed by start()."""
+		self.event_bus = ResilientEventBus()
+		self._register_core_event_handlers()
 
 	@observe_debug(ignore_input=True, ignore_output=True, name='browser_session_start')
 	async def start(self) -> None:
@@ -740,8 +749,8 @@ class BrowserSession(BaseModel):
 		await self.event_bus.stop(clear=True, timeout=5)
 		# Reset all state
 		await self.reset()
-		# Create fresh event bus
-		self.event_bus = ResilientEventBus()
+		# Create a fresh, usable event bus
+		self._replace_event_bus()
 
 	async def stop(self) -> None:
 		"""Stop the browser session without killing the browser process.
@@ -765,8 +774,8 @@ class BrowserSession(BaseModel):
 		await self.event_bus.stop(clear=True, timeout=5)
 		# Reset all state
 		await self.reset()
-		# Create fresh event bus
-		self.event_bus = ResilientEventBus()
+		# Create a fresh, usable event bus
+		self._replace_event_bus()
 
 	async def close(self) -> None:
 		"""Alias for stop()."""

--- a/tests/ci/browser/test_session_start.py
+++ b/tests/ci/browser/test_session_start.py
@@ -58,6 +58,22 @@ class TestBrowserSessionStart:
 		await browser_session.start()
 		assert browser_session._cdp_client_root is not None
 
+	@pytest.mark.parametrize('shutdown_method', ['stop', 'kill'])
+	async def test_start_after_shutdown(self, browser_session: BrowserSession, shutdown_method: str):
+		"""A stopped or killed session can create a new browser connection."""
+		from browser_use.browser.events import BrowserStartEvent
+
+		await browser_session.start()
+		previous_event_bus = browser_session.event_bus
+
+		await getattr(browser_session, shutdown_method)()
+
+		assert browser_session.event_bus is not previous_event_bus
+		assert browser_session.event_bus.handlers.get(BrowserStartEvent.__name__)
+
+		await browser_session.start()
+		assert browser_session._cdp_client_root is not None
+
 	# @pytest.mark.skip(reason="Race condition - DOMWatchdog tries to inject scripts into tab that's being closed")
 	# async def test_page_lifecycle_management(self, browser_session: BrowserSession):
 	# 	"""Test session handles page lifecycle correctly."""


### PR DESCRIPTION

  ## Summary

  Make `BrowserSession` reusable after calling either `stop()` or `kill()`.

  Both shutdown methods previously replaced the session's event bus with a fresh `ResilientEventBus` but did not register the core session
  handlers on it. A subsequent `start()` therefore dispatched `BrowserStartEvent` onto a handlerless bus and never reconnected or launched a
  browser.

  ## Changes

  - Extract core `BrowserSession` handler registration into `_register_core_event_handlers()`
  - Add `_replace_event_bus()` to create a fresh event bus and immediately register its lifecycle handlers
  - Use `_replace_event_bus()` from both `stop()` and `kill()`
  - Add parameterized regression coverage for:
    - `start() → stop() → start()`
    - `start() → kill() → start()`

  The tests verify that:

  - A new event bus is created after shutdown
  - The new bus has a `BrowserStartEvent` handler
  - Calling `start()` establishes a new CDP connection

  ## Why

  `stop()` documents that callers can reconnect later, but the previous handlerless replacement bus made that impossible. This affected session
  pooling, application lifespan reuse, and recovery workflows.

  ## Testing

  - `uv run pytest tests/ci/browser/test_session_start.py -q`
    - 11 passed
  - `uv run pre-commit run --all-files`
    - All hooks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore core event handlers after shutdown so `BrowserSession` can restart after `stop()` or `kill()`. Fixes a bug where `start()` posted `BrowserStartEvent` to a handlerless bus and never reconnected.

- **Bug Fixes**
  - Added `_register_core_event_handlers()` and `_replace_event_bus()`; `stop()`/`kill()` now create a fresh `ResilientEventBus` and register required handlers.
  - Ensured the new bus includes a `BrowserStartEvent` handler so `start()` works after shutdown.
  - Added regression tests for `start → stop/kill → start` flows.

<sup>Written for commit 01e69fb4b5567504690de661f6c940e0f08e953c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

