### PR TITLE
fix(mcp): repair legacy registry integration

### DIFF
--- a/browser_use/mcp/client.py
+++ b/browser_use/mcp/client.py
@@ -222,10 +222,23 @@ class MCPClient:
 			tool_filter: Optional list of tool names to register (None = all tools)
 			prefix: Optional prefix to add to action names (e.g., "playwright_")
 		"""
+		await self.register_to_registry(tools.registry, tool_filter=tool_filter, prefix=prefix)
+
+	async def register_to_registry(
+		self,
+		registry: Registry,
+		tool_filter: list[str] | None = None,
+		prefix: str | None = None,
+	) -> None:
+		"""Register MCP tools directly with an action registry.
+
+		Args:
+			registry: Browser-use action registry
+			tool_filter: Optional list of tool names to register (None = all tools)
+			prefix: Optional prefix to add to action names (e.g., "playwright_")
+		"""
 		if not self._connected:
 			await self.connect()
-
-		registry = tools.registry
 
 		for tool_name, tool in self._tools.items():
 			# Skip if not in filter

--- a/browser_use/mcp/controller.py
+++ b/browser_use/mcp/controller.py
@@ -1,263 +1,56 @@
-"""MCP (Model Context Protocol) tool wrapper for browser-use.
+"""Backward-compatible MCP integration.
 
-This module provides integration between MCP tools and browser-use's action registry system.
-MCP tools are dynamically discovered and registered as browser-use actions.
+New integrations should use :class:`browser_use.mcp.client.MCPClient`.
 """
 
-import asyncio
-import logging
-from typing import Any
+import warnings
 
-from pydantic import Field, create_model
-
-from browser_use.agent.views import ActionResult
+from browser_use.mcp.client import MCPClient
 from browser_use.tools.registry.service import Registry
 
-logger = logging.getLogger(__name__)
 
-try:
-	from mcp import ClientSession, StdioServerParameters
-	from mcp.client.stdio import stdio_client
-	from mcp.types import TextContent, Tool
-
-	MCP_AVAILABLE = True
-except ImportError:
-	MCP_AVAILABLE = False
-	logger.warning('MCP SDK not installed. Install with: pip install mcp')
-
-
-class MCPToolWrapper:
-	"""Wrapper to integrate MCP tools as browser-use actions."""
+class MCPToolWrapper(MCPClient):
+	"""Deprecated compatibility adapter for the original registry-based API."""
 
 	def __init__(self, registry: Registry, mcp_command: str, mcp_args: list[str] | None = None):
-		"""Initialize MCP tool wrapper.
+		"""Initialize the legacy wrapper.
 
 		Args:
-			registry: Browser-use action registry to register MCP tools
-			mcp_command: Command to start MCP server (e.g., "npx")
-			mcp_args: Arguments for MCP command (e.g., ["@playwright/mcp@latest"])
+			registry: Browser-use action registry to register MCP tools with
+			mcp_command: Command used to start the MCP server
+			mcp_args: Arguments passed to the MCP server command
 		"""
-		if not MCP_AVAILABLE:
-			raise ImportError('MCP SDK not installed. Install with: pip install mcp')
-
-		self.registry = registry
-		self.mcp_command = mcp_command
-		self.mcp_args = mcp_args or []
-		self.session: ClientSession | None = None
-		self._tools: dict[str, Tool] = {}
-		self._registered_actions: set[str] = set()
-		self._shutdown_event = asyncio.Event()
-
-	async def connect(self):
-		"""Connect to MCP server and discover available tools."""
-		if self.session:
-			return  # Already connected
-
-		logger.info(f'🔌 Connecting to MCP server: {self.mcp_command} {" ".join(self.mcp_args)}')
-
-		# Create server parameters
-		server_params = StdioServerParameters(command=self.mcp_command, args=self.mcp_args, env=None)
-
-		# Connect to the MCP server
-		async with stdio_client(server_params) as (read, write):
-			async with ClientSession(read, write) as session:
-				self.session = session
-
-				# Initialize the connection
-				await session.initialize()
-
-				# Discover available tools
-				tools_response = await session.list_tools()
-				self._tools = {tool.name: tool for tool in tools_response.tools}
-
-				logger.info(f'📦 Discovered {len(self._tools)} MCP tools: {list(self._tools.keys())}')
-
-				# Register all discovered tools as actions
-				for tool_name, tool in self._tools.items():
-					self._register_tool_as_action(tool_name, tool)
-
-				# Keep session alive while tools are being used
-				await self._keep_session_alive()
-
-	async def _keep_session_alive(self):
-		"""Keep the MCP session alive."""
-		# This will block until the session is closed
-		# In practice, you'd want to manage this lifecycle better
-		try:
-			await self._shutdown_event.wait()
-		except asyncio.CancelledError:
-			pass
-
-	def _register_tool_as_action(self, tool_name: str, tool: Tool):
-		"""Register an MCP tool as a browser-use action.
-
-		Args:
-			tool_name: Name of the MCP tool
-			tool: MCP Tool object with schema information
-		"""
-		if tool_name in self._registered_actions:
-			return  # Already registered
-
-		# Parse tool parameters to create Pydantic model
-		param_fields = {}
-
-		if tool.inputSchema:
-			# MCP tools use JSON Schema for parameters
-			properties = tool.inputSchema.get('properties', {})
-			required = set(tool.inputSchema.get('required', []))
-
-			for param_name, param_schema in properties.items():
-				# Convert JSON Schema type to Python type
-				param_type = self._json_schema_to_python_type(param_schema)
-
-				# Determine if field is required
-				if param_name in required:
-					default = ...  # Required field
-				else:
-					default = param_schema.get('default', None)
-
-				# Add field description if available
-				field_kwargs = {}
-				if 'description' in param_schema:
-					field_kwargs['description'] = param_schema['description']
-
-				param_fields[param_name] = (param_type, Field(default, **field_kwargs))
-
-		# Create Pydantic model for the tool parameters
-		param_model = create_model(f'{tool_name}_Params', **param_fields) if param_fields else None
-
-		# Determine if this is a browser-specific tool
-		is_browser_tool = tool_name.startswith('browser_')
-		domains = None
-		# Note: page_filter has been removed since we no longer use Page objects
-
-		# Create wrapper function for the MCP tool
-		async def mcp_action_wrapper(**kwargs):
-			"""Wrapper function that calls the MCP tool."""
-			if not self.session:
-				raise RuntimeError(f'MCP session not connected for tool {tool_name}')
-
-			# Extract parameters (excluding special injected params)
-			special_params = {
-				'page',
-				'browser_session',
-				'context',
-				'page_extraction_llm',
-				'file_system',
-				'available_file_paths',
-				'has_sensitive_data',
-				'browser',
-				'browser_context',
-			}
-
-			tool_params = {k: v for k, v in kwargs.items() if k not in special_params}
-
-			logger.debug(f'🔧 Calling MCP tool {tool_name} with params: {tool_params}')
-
-			try:
-				# Call the MCP tool
-				result = await self.session.call_tool(tool_name, tool_params)
-
-				# Convert MCP result to ActionResult
-				# MCP tools return results in various formats
-				if hasattr(result, 'content'):
-					# Handle structured content responses
-					if isinstance(result.content, list):
-						# Multiple content items
-						content_parts = []
-						for item in result.content:
-							if isinstance(item, TextContent):
-								content_parts.append(item.text)  # type: ignore[reportAttributeAccessIssue]
-							else:
-								content_parts.append(str(item))
-						extracted_content = '\n'.join(content_parts)
-					else:
-						extracted_content = str(result.content)
-				else:
-					# Direct result
-					extracted_content = str(result)
-
-				return ActionResult(extracted_content=extracted_content)
-
-			except Exception as e:
-				logger.error(f'❌ MCP tool {tool_name} failed: {e}')
-				return ActionResult(extracted_content=f'MCP tool {tool_name} failed: {str(e)}', error=str(e))
-
-		# Set function name for better debugging
-		mcp_action_wrapper.__name__ = tool_name
-		mcp_action_wrapper.__qualname__ = f'mcp.{tool_name}'
-
-		# Register the action with browser-use
-		description = tool.description or f'MCP tool: {tool_name}'
-
-		# Use the decorator to register the action
-		decorated_wrapper = self.registry.action(description=description, param_model=param_model, domains=domains)(
-			mcp_action_wrapper
+		warnings.warn(
+			'MCPToolWrapper is deprecated; use MCPClient.register_to_tools() instead.',
+			DeprecationWarning,
+			stacklevel=2,
 		)
+		super().__init__(server_name=mcp_command, command=mcp_command, args=mcp_args)
+		self.registry = registry
 
-		self._registered_actions.add(tool_name)
-		logger.info(f'✅ Registered MCP tool as action: {tool_name}')
+		# Preserve the original public attribute names for existing callers.
+		self.mcp_command = mcp_command
+		self.mcp_args = self.args
 
-	async def disconnect(self):
-		"""Disconnect from the MCP server and clean up resources."""
-		self._shutdown_event.set()
-		if self.session:
-			# Session cleanup will be handled by the context manager
-			self.session = None
-
-	def _json_schema_to_python_type(self, schema: dict) -> Any:
-		"""Convert JSON Schema type to Python type.
-
-		Args:
-			schema: JSON Schema definition
-
-		Returns:
-			Python type corresponding to the schema
-		"""
-		json_type = schema.get('type', 'string')
-
-		type_mapping = {
-			'string': str,
-			'number': float,
-			'integer': int,
-			'boolean': bool,
-			'array': list,
-			'object': dict,
-		}
-
-		base_type = type_mapping.get(json_type, str)
-
-		# Handle nullable types
-		if schema.get('nullable', False):
-			return base_type | None
-
-		return base_type
+	async def connect(self) -> None:
+		"""Connect to the MCP server and register its tools without blocking."""
+		await super().connect()
+		await self.register_to_registry(self.registry)
 
 
-# Convenience function for easy integration
 async def register_mcp_tools(registry: Registry, mcp_command: str, mcp_args: list[str] | None = None) -> MCPToolWrapper:
-	"""Register MCP tools with a browser-use registry.
+	"""Connect an MCP server and register its tools with a registry.
+
+	Deprecated:
+		Use :meth:`MCPClient.register_to_tools` for new integrations.
 
 	Args:
 		registry: Browser-use action registry
-		mcp_command: Command to start MCP server
-		mcp_args: Arguments for MCP command
+		mcp_command: Command used to start the MCP server
+		mcp_args: Arguments passed to the MCP server command
 
 	Returns:
-		MCPToolWrapper instance (connected)
-
-	Example:
-		```python
-	        from browser_use import Tools
-	        from browser_use.mcp.tools import register_mcp_tools
-
-	        tools = Tools()
-
-	        # Register Playwright MCP tools
-	        mcp = await register_mcp_tools(tools.registry, 'npx', ['@playwright/mcp@latest', '--headless'])
-
-	        # Now all MCP tools are available as browser-use actions
-		```
+		A connected compatibility wrapper. Call ``disconnect()`` when finished.
 	"""
 	wrapper = MCPToolWrapper(registry, mcp_command, mcp_args)
 	await wrapper.connect()

--- a/tests/ci/test_mcp_legacy_wrapper.py
+++ b/tests/ci/test_mcp_legacy_wrapper.py
@@ -1,0 +1,68 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from mcp import types
+
+from browser_use.mcp.client import MCPClient
+from browser_use.mcp.controller import MCPToolWrapper, register_mcp_tools
+from browser_use.tools.registry.service import Registry
+
+
+@pytest.fixture
+def echo_tool() -> types.Tool:
+	return types.Tool(
+		name='echo',
+		description='Echo a message',
+		inputSchema={
+			'type': 'object',
+			'properties': {'message': {'type': 'string'}},
+			'required': ['message'],
+		},
+	)
+
+
+@pytest.fixture
+def connected_mcp_client(monkeypatch: pytest.MonkeyPatch, echo_tool: types.Tool) -> AsyncMock:
+	session = AsyncMock()
+	session.call_tool.return_value = SimpleNamespace(content=[types.TextContent(type='text', text='hello')])
+
+	async def connect(client: MCPClient) -> None:
+		client.session = session
+		client._tools = {echo_tool.name: echo_tool}
+		client._connected = True
+
+	monkeypatch.setattr(MCPClient, 'connect', connect)
+	return session
+
+
+async def test_legacy_wrapper_registers_typed_actions_without_blocking(
+	connected_mcp_client: AsyncMock,
+) -> None:
+	registry = Registry()
+
+	with pytest.warns(DeprecationWarning, match='MCPToolWrapper is deprecated'):
+		wrapper = MCPToolWrapper(registry, 'test-mcp-server')
+
+	await wrapper.connect()
+
+	action = registry.registry.actions['echo']
+	assert set(action.param_model.model_fields) == {'message'}
+
+	result = await registry.execute_action('echo', {'message': 'hello'})
+	assert result.extracted_content == 'hello'
+	connected_mcp_client.call_tool.assert_awaited_once_with('echo', {'message': 'hello'})
+
+
+async def test_register_mcp_tools_returns_connected_wrapper(
+	connected_mcp_client: AsyncMock,
+) -> None:
+	registry = Registry()
+
+	with pytest.warns(DeprecationWarning, match='MCPToolWrapper is deprecated'):
+		wrapper = await asyncio.wait_for(register_mcp_tools(registry, 'test-mcp-server'), timeout=1)
+
+	assert isinstance(wrapper, MCPToolWrapper)
+	assert wrapper._connected is True
+	assert 'echo' in registry.registry.actions


### PR DESCRIPTION
## Summary

  Repair the exported legacy `MCPToolWrapper` and `register_mcp_tools()` APIs while guiding new integrations toward `MCPClient`.

  The legacy implementation had two independent failures:

  1. It registered actions using `**kwargs`, which the current action registry rejects.
  2. Its `connect()` method waited for shutdown before returning, causing `register_mcp_tools()` to block indefinitely.

  ## Changes

  - Add `MCPClient.register_to_registry()` for registering discovered MCP tools directly with a `Registry`
  - Make `register_to_tools()` delegate to the new registry-level method
  - Replace the duplicated legacy MCP implementation with a compatibility adapter over `MCPClient`
  - Preserve the legacy constructor and public `mcp_command`/`mcp_args` attributes
  - Emit a `DeprecationWarning` directing new callers to `MCPClient.register_to_tools()`
  - Keep `register_mcp_tools()` functional and ensure it returns a connected wrapper
  - Remove the legacy `**kwargs` action wrapper and blocking stdio lifecycle

  The compatibility adapter now uses the modern implementation's generated Pydantic parameter models and background MCP connection lifecycle.

  ## Testing

  Added regression coverage verifying that:

  - Legacy MCP tools register successfully with typed parameters
  - Registered actions can execute and forward validated arguments to MCP
  - `register_mcp_tools()` returns promptly
  - The returned wrapper is connected and its actions are available

  Commands run:

  - `uv run pytest tests/ci/test_mcp_legacy_wrapper.py -q`
    - 2 passed
  - `uv run pre-commit run --all-files`
    - All hooks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repair legacy MCP registry integration so tools register with typed params and connections no longer block. Steers new integrations to `MCPClient` while keeping `register_mcp_tools()` working.

- **Bug Fixes**
  - Replaced legacy wrapper with a compatibility adapter over `MCPClient`; preserves `mcp_command`/`mcp_args`.
  - Added `MCPClient.register_to_registry()` and made `register_to_tools()` delegate to it.
  - Fixed action registration by using generated Pydantic models instead of a `**kwargs` wrapper.
  - Made `connect()` non-blocking; `register_mcp_tools()` now returns a connected wrapper promptly.
  - Emitted `DeprecationWarning` to guide callers to `MCPClient.register_to_tools()`.
  - Added tests covering typed registration, action execution, and non-blocking behavior.

<sup>Written for commit a053e2640d048ea9226ab02fcb90b9605c5ed188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

