### PR TITLE
fix(async): avoid re-raising task callback errors

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -802,9 +802,8 @@ def create_task_with_error_handling(
 		coro: The coroutine to wrap in a task
 		name: Optional name for the task (useful for debugging)
 		logger_instance: Optional logger instance to use. If None, uses module logger.
-		suppress_exceptions: If True, logs exceptions at ERROR level. If False, logs at WARNING level
-			and exceptions remain retrievable via task.exception() if the caller awaits the task.
-			Default False.
+		suppress_exceptions: If True, logs exceptions at ERROR level. If False, logs at WARNING level.
+			Awaiting the task raises the original exception in both modes. Default False.
 
 	Returns:
 		asyncio.Task: The created task with exception handling callback
@@ -822,21 +821,19 @@ def create_task_with_error_handling(
 
 	def _handle_task_exception(t: asyncio.Task[T]) -> None:
 		"""Callback to handle task exceptions"""
-		exc_to_raise = None
 		try:
-			# This will raise if the task had an exception
+			# Retrieve the exception so fire-and-forget tasks do not emit
+			# "Task exception was never retrieved" warnings.
 			exc = t.exception()
 			if exc is not None:
 				task_name = t.get_name() if hasattr(t, 'get_name') else 'unnamed'
 				if suppress_exceptions:
 					log.error(f'Exception in background task [{task_name}]: {type(exc).__name__}: {exc}', exc_info=exc)
 				else:
-					# Log at warning level then mark for re-raising
 					log.warning(
 						f'Exception in background task [{task_name}]: {type(exc).__name__}: {exc}',
 						exc_info=exc,
 					)
-					exc_to_raise = exc
 		except asyncio.CancelledError:
 			# Task was cancelled, this is normal behavior
 			pass
@@ -844,10 +841,6 @@ def create_task_with_error_handling(
 			# Catch any other exception during exception handling (e.g., t.exception() itself failing)
 			task_name = t.get_name() if hasattr(t, 'get_name') else 'unnamed'
 			log.error(f'Error handling exception in task [{task_name}]: {type(e).__name__}: {e}')
-
-		# Re-raise outside the try-except block so it propagates to the event loop
-		if exc_to_raise is not None:
-			raise exc_to_raise
 
 	task.add_done_callback(_handle_task_exception)
 	return task

--- a/tests/ci/test_async_task_error_handling.py
+++ b/tests/ci/test_async_task_error_handling.py
@@ -1,0 +1,50 @@
+import asyncio
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from browser_use.utils import create_task_with_error_handling
+
+
+class ExpectedTaskError(RuntimeError):
+	"""Exception used to verify task propagation."""
+
+
+@pytest.mark.parametrize('suppress_exceptions', [False, True])
+async def test_task_exception_is_not_reported_as_callback_failure(suppress_exceptions: bool) -> None:
+	loop = asyncio.get_running_loop()
+	previous_exception_handler = loop.get_exception_handler()
+	exception_contexts: list[dict] = []
+	test_logger = Mock(spec=logging.Logger)
+
+	def capture_loop_exception(_loop: asyncio.AbstractEventLoop, context: dict) -> None:
+		exception_contexts.append(context)
+
+	async def fail() -> None:
+		raise ExpectedTaskError('expected failure')
+
+	loop.set_exception_handler(capture_loop_exception)
+	try:
+		task = create_task_with_error_handling(
+			fail(),
+			name='expected-failure',
+			logger_instance=test_logger,
+			suppress_exceptions=suppress_exceptions,
+		)
+
+		with pytest.raises(ExpectedTaskError, match='expected failure'):
+			await task
+
+		# Let all callbacks queued by task completion run.
+		await asyncio.sleep(0)
+	finally:
+		loop.set_exception_handler(previous_exception_handler)
+
+	assert exception_contexts == []
+	if suppress_exceptions:
+		test_logger.error.assert_called_once()
+		test_logger.warning.assert_not_called()
+	else:
+		test_logger.warning.assert_called_once()
+		test_logger.error.assert_not_called()


### PR DESCRIPTION
## Summary

  Prevent `create_task_with_error_handling()` from reporting handled task failures as additional event-loop callback failures.

  The task's done callback previously retrieved the original exception and then re-raised it. Exceptions raised by a done callback cannot
  propagate to code awaiting the task; instead, asyncio reports them separately as `Exception in callback`.

  This caused duplicate error reporting for awaited tasks and noisy event-loop failures for fire-and-forget tasks.

  ## Changes

  - Remove the exception re-raise from the task completion callback
  - Continue retrieving the exception to prevent `Task exception was never retrieved` warnings
  - Preserve existing logging behavior:
    - `suppress_exceptions=False` logs at warning level
    - `suppress_exceptions=True` logs at error level
  - Clarify that awaiting the returned task raises the original exception in both modes
  - Add focused tests for both suppression settings

  ## Behavior after this change

  For awaited tasks:

  - The original exception still propagates through `await task`
  - The event loop does not receive a duplicate callback failure

  For fire-and-forget tasks:

  - The done callback retrieves and logs the exception
  - Asyncio does not emit an unhandled-task or callback exception

  ## Testing

  The new parameterized regression test:

  - Installs a custom event-loop exception handler
  - Runs a failing task in both logging modes
  - Confirms awaiting the task raises the original exception
  - Confirms the event-loop exception handler is never invoked
  - Confirms the expected logger method is called exactly once

  Commands run:

  - `uv run pytest tests/ci/test_async_task_error_handling.py -q`
    - 2 passed
  - `uv run pre-commit run --all-files`
    - All hooks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix async task error handling to stop reporting handled task failures as event-loop callback errors. Prevents duplicate error logs for awaited tasks and noisy “Exception in callback” for fire-and-forget tasks.

- **Bug Fixes**
  - In `browser_use.utils.create_task_with_error_handling()`, stop re-raising exceptions in the task done callback.
  - Still retrieve the exception to avoid “Task exception was never retrieved” warnings.
  - Awaiting the returned task still raises the original exception; logging levels unchanged by `suppress_exceptions`.
  - Added tests for both suppression modes to ensure no event-loop callback errors and exactly one log call.

<sup>Written for commit 5f0af66e74e124a5b82f06eda68899e7af0037a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

