### PR TITLE
fix(mcp): make client lifecycle reconnect-safe

### DIFF
--- a/browser_use/mcp/client.py
+++ b/browser_use/mcp/client.py
@@ -43,6 +43,9 @@ from mcp.client.stdio import stdio_client
 
 MCP_AVAILABLE = True
 
+MCP_CONNECT_TIMEOUT_SECONDS = 10.0
+MCP_DISCONNECT_TIMEOUT_SECONDS = 2.0
+
 
 class MCPClient:
 	"""Client for connecting to MCP servers and exposing their tools as browser-use actions."""
@@ -68,48 +71,76 @@ class MCPClient:
 		self.env = env
 
 		self.session: ClientSession | None = None
-		self._stdio_task = None
+		self._stdio_task: asyncio.Task[None] | None = None
 		self._read_stream = None
 		self._write_stream = None
 		self._tools: dict[str, types.Tool] = {}
 		self._registered_actions: set[str] = set()
 		self._connected = False
 		self._disconnect_event = asyncio.Event()
+		self._connection_ready_event = asyncio.Event()
+		self._connection_error: Exception | None = None
+		self._lifecycle_lock = asyncio.Lock()
 		self._telemetry = ProductTelemetry()
 
 	async def connect(self) -> None:
 		"""Connect to the MCP server and discover available tools."""
-		if self._connected:
-			logger.debug(f'Already connected to {self.server_name}')
-			return
-
 		start_time = time.time()
 		error_msg = None
+		stdio_task: asyncio.Task[None] | None = None
 
 		try:
-			logger.info(f"🔌 Connecting to MCP server '{self.server_name}': {self.command} {' '.join(self.args)}")
+			async with self._lifecycle_lock:
+				if self._connected:
+					logger.debug(f'Already connected to {self.server_name}')
+					return
 
-			# Create server parameters
-			server_params = StdioServerParameters(command=self.command, args=self.args, env=self.env)
+				if self._stdio_task is None or self._stdio_task.done():
+					logger.info(f"🔌 Connecting to MCP server '{self.server_name}': {self.command} {' '.join(self.args)}")
 
-			# Start stdio client in background task
-			self._stdio_task = create_task_with_error_handling(
-				self._run_stdio_client(server_params), name='mcp_stdio_client', suppress_exceptions=True
-			)
+					self._disconnect_event.clear()
+					self._connection_ready_event.clear()
+					self._connection_error = None
 
-			# Wait for connection to be established
-			retries = 0
-			max_retries = 100  # 10 second timeout (increased for parallel test execution)
-			while not self._connected and retries < max_retries:
-				await asyncio.sleep(0.1)
-				retries += 1
+					server_params = StdioServerParameters(command=self.command, args=self.args, env=self.env)
+					self._stdio_task = create_task_with_error_handling(
+						self._run_stdio_client(server_params), name='mcp_stdio_client', suppress_exceptions=True
+					)
+
+				stdio_task = self._stdio_task
+
+			assert stdio_task is not None
+
+			try:
+				await asyncio.wait_for(
+					self._connection_ready_event.wait(),
+					timeout=MCP_CONNECT_TIMEOUT_SECONDS,
+				)
+			except TimeoutError:
+				error_msg = f"Failed to connect to MCP server '{self.server_name}' after {MCP_CONNECT_TIMEOUT_SECONDS} seconds"
+				async with self._lifecycle_lock:
+					if self._stdio_task is stdio_task:
+						await self._cancel_stdio_task(stdio_task)
+				raise RuntimeError(error_msg)
 
 			if not self._connected:
-				error_msg = f"Failed to connect to MCP server '{self.server_name}' after {max_retries * 0.1} seconds"
-				raise RuntimeError(error_msg)
+				connection_error = self._connection_error
+				error_msg = f"Failed to connect to MCP server '{self.server_name}'"
+				if connection_error:
+					error_msg = f'{error_msg}: {connection_error}'
+				async with self._lifecycle_lock:
+					if self._stdio_task is stdio_task:
+						await self._cancel_stdio_task(stdio_task)
+				raise RuntimeError(error_msg) from connection_error
 
 			logger.info(f"📦 Discovered {len(self._tools)} tools from '{self.server_name}': {list(self._tools.keys())}")
 
+		except asyncio.CancelledError:
+			if stdio_task is not None:
+				async with self._lifecycle_lock:
+					if self._stdio_task is stdio_task:
+						await self._cancel_stdio_task(stdio_task)
+			raise
 		except Exception as e:
 			error_msg = str(e)
 			raise
@@ -148,47 +179,80 @@ class MCPClient:
 
 					# Mark as connected
 					self._connected = True
+					self._connection_ready_event.set()
 
 					# Keep the connection alive until disconnect is called
 					await self._disconnect_event.wait()
 
+		except asyncio.CancelledError:
+			raise
 		except Exception as e:
 			logger.error(f'MCP server connection error: {e}')
 			self._connected = False
+			self._connection_error = e
 			raise
 		finally:
 			self._connected = False
 			self.session = None
+			self._read_stream = None
+			self._write_stream = None
+			self._connection_ready_event.set()
+
+	async def _cancel_stdio_task(self, stdio_task: asyncio.Task[None]) -> None:
+		"""Cancel and await a stdio task, then clear it if it is still current."""
+		if not stdio_task.done():
+			stdio_task.cancel()
+
+		try:
+			await stdio_task
+		except asyncio.CancelledError:
+			pass
+		except Exception:
+			# The task helper already logged the connection failure.
+			pass
+
+		if self._stdio_task is stdio_task:
+			self._stdio_task = None
 
 	async def disconnect(self) -> None:
 		"""Disconnect from the MCP server."""
-		if not self._connected:
-			return
-
 		start_time = time.time()
 		error_msg = None
 
 		try:
-			logger.info(f"🔌 Disconnecting from MCP server '{self.server_name}'")
+			async with self._lifecycle_lock:
+				stdio_task = self._stdio_task
+				if not self._connected and stdio_task is None:
+					return
 
-			# Signal disconnect
-			self._connected = False
-			self._disconnect_event.set()
+				logger.info(f"🔌 Disconnecting from MCP server '{self.server_name}'")
+				was_connected = self._connected
+				self._connected = False
+				self._disconnect_event.set()
 
-			# Wait for stdio task to finish
-			if self._stdio_task:
-				try:
-					await asyncio.wait_for(self._stdio_task, timeout=2.0)
-				except TimeoutError:
-					logger.warning(f"Timeout waiting for MCP server '{self.server_name}' to disconnect")
-					self._stdio_task.cancel()
-					try:
-						await self._stdio_task
-					except asyncio.CancelledError:
-						pass
+				if stdio_task:
+					if not was_connected:
+						await self._cancel_stdio_task(stdio_task)
+					else:
+						try:
+							await asyncio.wait_for(
+								asyncio.shield(stdio_task),
+								timeout=MCP_DISCONNECT_TIMEOUT_SECONDS,
+							)
+						except TimeoutError:
+							logger.warning(f"Timeout waiting for MCP server '{self.server_name}' to disconnect")
+							await self._cancel_stdio_task(stdio_task)
+						except Exception:
+							# The task helper already logged the connection failure.
+							if self._stdio_task is stdio_task:
+								self._stdio_task = None
+						else:
+							if self._stdio_task is stdio_task:
+								self._stdio_task = None
 
-			self._tools.clear()
-			self._registered_actions.clear()
+				self._connection_ready_event.set()
+				self._tools.clear()
+				self._registered_actions.clear()
 
 		except Exception as e:
 			error_msg = str(e)

--- a/tests/ci/test_mcp_client_lifecycle.py
+++ b/tests/ci/test_mcp_client_lifecycle.py
@@ -1,0 +1,127 @@
+import asyncio
+from typing import Any
+
+import pytest
+
+from browser_use.mcp import client as client_module
+from browser_use.mcp.client import MCPClient
+
+
+@pytest.fixture
+def mcp_client() -> MCPClient:
+	return MCPClient(server_name='test-server', command='test-command')
+
+
+async def test_connection_timeout_cancels_stdio_task(
+	mcp_client: MCPClient,
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	task_finished = asyncio.Event()
+
+	async def stalled_stdio_client(_server_params: Any) -> None:
+		try:
+			await asyncio.Event().wait()
+		finally:
+			task_finished.set()
+
+	monkeypatch.setattr(client_module, 'MCP_CONNECT_TIMEOUT_SECONDS', 0.01)
+	monkeypatch.setattr(mcp_client, '_run_stdio_client', stalled_stdio_client)
+
+	with pytest.raises(RuntimeError, match='Failed to connect'):
+		await mcp_client.connect()
+
+	assert task_finished.is_set()
+	assert mcp_client._stdio_task is None
+	assert mcp_client._connected is False
+
+
+async def test_disconnect_cancels_connection_in_progress(
+	mcp_client: MCPClient,
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	task_started = asyncio.Event()
+	task_finished = asyncio.Event()
+
+	async def stalled_stdio_client(_server_params: Any) -> None:
+		task_started.set()
+		try:
+			await asyncio.Event().wait()
+		finally:
+			task_finished.set()
+
+	monkeypatch.setattr(mcp_client, '_run_stdio_client', stalled_stdio_client)
+
+	connect_task = asyncio.create_task(mcp_client.connect())
+	await task_started.wait()
+	await mcp_client.disconnect()
+
+	with pytest.raises(RuntimeError, match='Failed to connect'):
+		await connect_task
+
+	assert task_finished.is_set()
+	assert mcp_client._stdio_task is None
+	assert mcp_client._connected is False
+
+
+async def test_cancelling_connect_cleans_up_stdio_task(
+	mcp_client: MCPClient,
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	task_started = asyncio.Event()
+	task_finished = asyncio.Event()
+
+	async def stalled_stdio_client(_server_params: Any) -> None:
+		task_started.set()
+		try:
+			await asyncio.Event().wait()
+		finally:
+			task_finished.set()
+
+	monkeypatch.setattr(mcp_client, '_run_stdio_client', stalled_stdio_client)
+
+	connect_task = asyncio.create_task(mcp_client.connect())
+	await task_started.wait()
+	connect_task.cancel()
+
+	with pytest.raises(asyncio.CancelledError):
+		await connect_task
+
+	assert task_finished.is_set()
+	assert mcp_client._stdio_task is None
+	assert mcp_client._connected is False
+
+
+async def test_client_can_reconnect_after_disconnect(
+	mcp_client: MCPClient,
+	monkeypatch: pytest.MonkeyPatch,
+) -> None:
+	connection_attempts = 0
+
+	async def connected_stdio_client(_server_params: Any) -> None:
+		nonlocal connection_attempts
+		connection_attempts += 1
+		mcp_client._connected = True
+		mcp_client._connection_ready_event.set()
+		try:
+			await mcp_client._disconnect_event.wait()
+		finally:
+			mcp_client._connected = False
+			mcp_client._connection_ready_event.set()
+
+	monkeypatch.setattr(mcp_client, '_run_stdio_client', connected_stdio_client)
+
+	await asyncio.gather(mcp_client.connect(), mcp_client.connect())
+	assert connection_attempts == 1
+	assert mcp_client._connected is True
+
+	await mcp_client.disconnect()
+	assert mcp_client._stdio_task is None
+
+	await mcp_client.connect()
+	assert connection_attempts == 2
+	assert mcp_client._connected is True
+	assert mcp_client._disconnect_event.is_set() is False
+	assert mcp_client._stdio_task is not None
+	assert mcp_client._stdio_task.done() is False
+
+	await mcp_client.disconnect()


### PR DESCRIPTION
## Summary

  Make `MCPClient` clean up failed connection attempts and support safe reconnection after disconnecting.

  Previously:

  - A connection timeout left the background stdio task and possibly its subprocess running
  - `disconnect()` returned immediately during partial initialization
  - The disconnect event remained set permanently, causing reconnected sessions to exit immediately
  - Cancelling `connect()` could orphan its stdio task
  - Concurrent lifecycle operations could replace or clean up the wrong task

  ## Changes

  - Add a lifecycle lock to serialize stdio task creation and cleanup
  - Add a connection readiness event that is signalled on both success and failure
  - Preserve connection failures so `connect()` can report their underlying cause
  - Clear the disconnect event before every new connection attempt
  - Replace polling with an event-based connection timeout
  - Add `_cancel_stdio_task()` to consistently:
    - Cancel the active task
    - Await its completion
    - Consume expected cancellation/failure
    - Clear the task reference only when it is still current
  - Cancel and await the stdio task when:
    - Connection initialization times out
    - Initialization fails
    - `connect()` itself is cancelled
    - `disconnect()` is called during initialization
    - Graceful disconnection exceeds its timeout
  - Reset session and stream references when the stdio lifecycle exits
  - Allow concurrent `connect()` callers to share one initialization task
  - Keep graceful shutdown for established connections

  ## Behavior after this change

  A client can now safely perform:

  ```python
  await client.connect()
  await client.disconnect()
  await client.connect()

  The second connection receives a fresh disconnect event and remains active until explicitly disconnected.

  Calling disconnect() while connect() is still initializing also cancels and awaits the in-progress stdio task instead of returning early.

  ## Testing

  Added focused lifecycle tests covering:

  - Connection timeout cancels and awaits the stdio task
  - Disconnect during initialization cleans up the partial connection
  - Cancelling connect() cleans up its background task
  - Concurrent connect calls share one stdio task
  - Connect → disconnect → reconnect creates a live second connection
  - Reconnection starts with a cleared disconnect event

  Commands run:

  - uv run pytest tests/ci/test_mcp_client_lifecycle.py -q
      - 4 passed

  - uv run pre-commit run --all-files
      - All hooks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `MCPClient` lifecycle reconnect-safe by reliably cancelling/awaiting the stdio task on timeouts, failures, and disconnects, and by clearing lifecycle events for fresh sessions. This prevents orphaned tasks/subprocesses and enables safe connect → disconnect → reconnect flows.

- **Bug Fixes**
  - Serialize stdio task lifecycle with a lock; add `_cancel_stdio_task()` to cancel/await and clear the current task safely.
  - Add a connection readiness event and preserve connection errors so `connect()` reports the root cause.
  - Clear the disconnect event on new connects; reset session/streams when the lifecycle exits; share one init task across concurrent `connect()` calls.
  - Replace polling with an event-based timeout; introduce `MCP_CONNECT_TIMEOUT_SECONDS` and `MCP_DISCONNECT_TIMEOUT_SECONDS`.
  - Cancel and await the stdio task on timeout, init failure, `connect()` cancellation, disconnect during init, or slow graceful shutdown.

<sup>Written for commit 381e031f1d422dfad892076ba005de93109e76fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

