### PR TITLE
fix: coordinate signal handlers across parallel agents

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -409,6 +409,8 @@ class SignalHandler:
 			if self.exit_on_second_int:
 				self._handle_second_ctrl_c()
 
+		# Keep direct callers consistent with coordinator-driven interrupts.
+		setattr(self.loop, 'ctrl_c_pressed', True)
 		self._pause_for_sigint()
 		print('----------------------------------------------------------------------', file=stderr)
 
@@ -469,16 +471,6 @@ class SignalHandler:
 		# Set flag to indicate we're waiting for input
 		setattr(self.loop, 'waiting_for_input', True)
 
-		# Temporarily restore default signal handling for SIGINT
-		# This ensures KeyboardInterrupt will be raised during input()
-		original_handler = signal.getsignal(signal.SIGINT)
-		try:
-			signal.signal(signal.SIGINT, signal.default_int_handler)
-		except ValueError:
-			# we are running in a thread other than the main thread
-			# or signal handlers are not supported for some other reason
-			pass
-
 		green = '\x1b[32;1m'
 		red = '\x1b[31m'
 		blink = '\033[33;5m'
@@ -501,12 +493,7 @@ class SignalHandler:
 			# Use the shared method to handle second Ctrl+C
 			self._handle_second_ctrl_c()
 		finally:
-			try:
-				# Restore our signal handler
-				signal.signal(signal.SIGINT, original_handler)
-				setattr(self.loop, 'waiting_for_input', False)
-			except Exception:
-				pass
+			setattr(self.loop, 'waiting_for_input', False)
 
 	def reset(self) -> None:
 		"""Reset state after resuming."""

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from sys import stderr
 from typing import Any, ParamSpec, TypeVar
 from urllib.parse import urlparse
+from weakref import WeakKeyDictionary
 
 import httpx
 from dotenv import load_dotenv
@@ -109,6 +110,123 @@ def _get_groq_bad_request_error() -> type | None:
 # Global flag to prevent duplicate exit messages
 _exiting = False
 
+
+class _SignalCoordinator:
+	"""Own process signal registration and fan signals out to handlers on one event loop."""
+
+	def __init__(self, loop: asyncio.AbstractEventLoop, is_windows: bool) -> None:
+		self.loop = loop
+		self.is_windows = is_windows
+		self.subscribers: list[SignalHandler] = []
+		self.original_sigint_handler: Any = None
+		self.original_sigterm_handler: Any = None
+		self.installed = False
+
+	def install(self) -> bool:
+		"""Install the process handlers once for this event loop."""
+		try:
+			self.original_sigint_handler = signal.getsignal(signal.SIGINT)
+			if self.is_windows:
+				signal.signal(signal.SIGINT, self._windows_sigint_handler)
+			else:
+				self.original_sigterm_handler = signal.getsignal(signal.SIGTERM)
+				self.loop.add_signal_handler(signal.SIGINT, self.handle_sigint)
+				try:
+					self.loop.add_signal_handler(signal.SIGTERM, self.handle_sigterm)
+				except Exception:
+					self.loop.remove_signal_handler(signal.SIGINT)
+					signal.signal(signal.SIGINT, self.original_sigint_handler)
+					raise
+		except Exception:
+			# Signal handlers are unavailable outside the main thread and in some
+			# embedded event loops (for example, notebooks).
+			return False
+
+		self.installed = True
+		return True
+
+	def teardown(self) -> None:
+		"""Restore process handlers after the final subscriber leaves."""
+		if not self.installed:
+			return
+
+		try:
+			if self.is_windows:
+				signal.signal(signal.SIGINT, self.original_sigint_handler)
+			else:
+				self.loop.remove_signal_handler(signal.SIGINT)
+				self.loop.remove_signal_handler(signal.SIGTERM)
+				signal.signal(signal.SIGINT, self.original_sigint_handler)
+				signal.signal(signal.SIGTERM, self.original_sigterm_handler)
+		except Exception as e:
+			logger.warning(f'Error while unregistering signal handlers: {e}')
+		finally:
+			self.installed = False
+
+	def subscribe(self, subscriber: 'SignalHandler') -> None:
+		"""Add a handler without duplicating an existing subscription."""
+		if subscriber not in self.subscribers:
+			self.subscribers.append(subscriber)
+
+	def unsubscribe(self, subscriber: 'SignalHandler') -> None:
+		"""Remove a handler while preserving registration for remaining subscribers."""
+		if subscriber in self.subscribers:
+			self.subscribers.remove(subscriber)
+
+	def _run_exit_callbacks(self) -> None:
+		"""Run every active subscriber's exit callback once."""
+		for subscriber in list(self.subscribers):
+			if subscriber.custom_exit_callback:
+				try:
+					subscriber.custom_exit_callback()
+				except Exception as e:
+					logger.error(f'Error in exit callback: {e}')
+
+	def _windows_sigint_handler(self, _signal_number: int, _frame: Any) -> None:
+		"""Immediately notify all subscribers and exit on Windows."""
+		print('\n\n🛑 Got Ctrl+C. Exiting immediately on Windows...\n', file=stderr)
+		self._run_exit_callbacks()
+		os._exit(0)
+
+	def handle_sigint(self) -> None:
+		"""Interpret one SIGINT and broadcast its pause or exit action once."""
+		global _exiting
+
+		if _exiting:
+			os._exit(0)
+
+		if getattr(self.loop, 'ctrl_c_pressed', False):
+			if getattr(self.loop, 'waiting_for_input', False):
+				return
+			if any(subscriber.exit_on_second_int for subscriber in self.subscribers):
+				self._run_exit_callbacks()
+				self._exit_after_second_ctrl_c()
+			return
+
+		setattr(self.loop, 'ctrl_c_pressed', True)
+		for subscriber in list(self.subscribers):
+			subscriber._pause_for_sigint()
+		print('----------------------------------------------------------------------', file=stderr)
+
+	def _exit_after_second_ctrl_c(self) -> None:
+		"""Exit once after the coordinator has notified all subscribers."""
+		global _exiting
+		_exiting = True
+		SignalHandler._print_terminal_reset()
+		os._exit(0)
+
+	def handle_sigterm(self) -> None:
+		"""Notify every subscriber and exit the process once."""
+		global _exiting
+		if not _exiting:
+			_exiting = True
+			print('\n\n🛑 SIGTERM received. Exiting immediately...\n\n', file=stderr)
+			self._run_exit_callbacks()
+		os._exit(0)
+
+
+_signal_coordinators: WeakKeyDictionary[asyncio.AbstractEventLoop, _SignalCoordinator] = WeakKeyDictionary()
+
 # Define generic type variables for return type and parameters
 R = TypeVar('R')
 T = TypeVar('T')
@@ -168,11 +286,14 @@ class SignalHandler:
 		# Store original signal handlers to restore them later if needed
 		self.original_sigint_handler = None
 		self.original_sigterm_handler = None
+		self._coordinator: _SignalCoordinator | None = None
 
 	def _initialize_loop_state(self) -> None:
 		"""Initialize loop state attributes used for signal handling."""
-		setattr(self.loop, 'ctrl_c_pressed', False)
-		setattr(self.loop, 'waiting_for_input', False)
+		if not hasattr(self.loop, 'ctrl_c_pressed'):
+			setattr(self.loop, 'ctrl_c_pressed', False)
+		if not hasattr(self.loop, 'waiting_for_input'):
+			setattr(self.loop, 'waiting_for_input', False)
 
 	def register(self) -> None:
 		"""Register signal handlers for SIGINT and SIGTERM.
@@ -182,28 +303,20 @@ class SignalHandler:
 		if self.disabled:
 			return
 
-		try:
-			if self.is_windows:
-				# On Windows, use simple signal handling with immediate exit on Ctrl+C
-				def windows_handler(sig, frame):
-					print('\n\n🛑 Got Ctrl+C. Exiting immediately on Windows...\n', file=stderr)
-					# Run the custom exit callback if provided
-					if self.custom_exit_callback:
-						self.custom_exit_callback()
-					os._exit(0)
+		if self._coordinator is not None:
+			return
 
-				self.original_sigint_handler = signal.signal(signal.SIGINT, windows_handler)
-			else:
-				# On Unix-like systems, use asyncio's signal handling for smoother experience
-				self.original_sigint_handler = self.loop.add_signal_handler(signal.SIGINT, lambda: self.sigint_handler())
-				self.original_sigterm_handler = self.loop.add_signal_handler(signal.SIGTERM, lambda: self.sigterm_handler())
+		coordinator = _signal_coordinators.get(self.loop)
+		if coordinator is None:
+			coordinator = _SignalCoordinator(self.loop, self.is_windows)
+			if not coordinator.install():
+				return
+			_signal_coordinators[self.loop] = coordinator
 
-		except Exception:
-			# there are situations where signal handlers are not supported, e.g.
-			# - when running in a thread other than the main thread
-			# - some operating systems
-			# - inside jupyter notebooks
-			pass
+		coordinator.subscribe(self)
+		self._coordinator = coordinator
+		self.original_sigint_handler = coordinator.original_sigint_handler
+		self.original_sigterm_handler = coordinator.original_sigterm_handler
 
 	def unregister(self) -> None:
 		"""Unregister signal handlers and restore original handlers if possible.
@@ -213,46 +326,21 @@ class SignalHandler:
 		if self.disabled:
 			return
 
-		try:
-			if self.is_windows:
-				# On Windows, just restore the original SIGINT handler
-				if self.original_sigint_handler:
-					signal.signal(signal.SIGINT, self.original_sigint_handler)
-			else:
-				# On Unix-like systems, use asyncio's signal handler removal
-				self.loop.remove_signal_handler(signal.SIGINT)
-				self.loop.remove_signal_handler(signal.SIGTERM)
+		coordinator = self._coordinator
+		if coordinator is None:
+			return
 
-				# Restore original handlers if available
-				if self.original_sigint_handler:
-					signal.signal(signal.SIGINT, self.original_sigint_handler)
-				if self.original_sigterm_handler:
-					signal.signal(signal.SIGTERM, self.original_sigterm_handler)
-		except Exception as e:
-			logger.warning(f'Error while unregistering signal handlers: {e}')
+		coordinator.unsubscribe(self)
+		self._coordinator = None
+		if not coordinator.subscribers:
+			coordinator.teardown()
+			if _signal_coordinators.get(self.loop) is coordinator:
+				del _signal_coordinators[self.loop]
 
-	def _handle_second_ctrl_c(self) -> None:
-		"""
-		Handle a second Ctrl+C press by performing cleanup and exiting.
-		This is shared logic used by both sigint_handler and wait_for_resume.
-		"""
-		global _exiting
-
-		if not _exiting:
-			_exiting = True
-
-			# Call custom exit callback if provided
-			if self.custom_exit_callback:
-				try:
-					self.custom_exit_callback()
-				except Exception as e:
-					logger.error(f'Error in exit callback: {e}')
-
-		# Force immediate exit - more reliable than sys.exit()
+	@staticmethod
+	def _print_terminal_reset() -> None:
+		"""Print the terminal cleanup sequence used before a forced exit."""
 		print('\n\n🛑  Got second Ctrl+C. Exiting immediately...\n', file=stderr)
-
-		# Reset terminal to a clean state by sending multiple escape sequences
-		# Order matters for terminal resets - we try different approaches
 
 		# Reset terminal modes for both stdout and stderr
 		print('\033[?25h', end='', flush=True, file=stderr)  # Show cursor
@@ -278,6 +366,25 @@ class SignalHandler:
 		# we still dont know what causes the broken input, if you know how to fix it, please let us know
 		print('(tip: press [Enter] once to fix escape codes appearing after chrome exit)', file=stderr)
 
+	def _handle_second_ctrl_c(self) -> None:
+		"""
+		Handle a second Ctrl+C press by performing cleanup and exiting.
+		This is shared logic used by both sigint_handler and wait_for_resume.
+		"""
+		global _exiting
+
+		if not _exiting:
+			_exiting = True
+
+			# Call custom exit callback if provided
+			if self.custom_exit_callback:
+				try:
+					self.custom_exit_callback()
+				except Exception as e:
+					logger.error(f'Error in exit callback: {e}')
+
+		self._print_terminal_reset()
+
 		os._exit(0)
 
 	def sigint_handler(self) -> None:
@@ -302,21 +409,17 @@ class SignalHandler:
 			if self.exit_on_second_int:
 				self._handle_second_ctrl_c()
 
-		# Mark that Ctrl+C was pressed
-		setattr(self.loop, 'ctrl_c_pressed', True)
+		self._pause_for_sigint()
+		print('----------------------------------------------------------------------', file=stderr)
 
-		# Cancel current tasks that should be interruptible - this is crucial for immediate pausing
+	def _pause_for_sigint(self) -> None:
+		"""Cancel interruptible work and notify this agent of a first Ctrl+C."""
 		self._cancel_interruptible_tasks()
-
-		# Call pause callback if provided - this sets the paused flag
 		if self.pause_callback:
 			try:
 				self.pause_callback()
 			except Exception as e:
 				logger.error(f'Error in pause callback: {e}')
-
-		# Log pause message after pause_callback is called (not before)
-		print('----------------------------------------------------------------------', file=stderr)
 
 	def sigterm_handler(self) -> None:
 		"""

--- a/tests/ci/test_signal_coordinator.py
+++ b/tests/ci/test_signal_coordinator.py
@@ -8,8 +8,8 @@ from browser_use import utils
 @pytest.mark.asyncio
 async def test_parallel_signal_handlers_share_one_coordinator(monkeypatch: pytest.MonkeyPatch) -> None:
 	loop = utils.asyncio.get_running_loop()
-	loop.ctrl_c_pressed = False
-	loop.waiting_for_input = False
+	setattr(loop, 'ctrl_c_pressed', False)
+	setattr(loop, 'waiting_for_input', False)
 	utils._signal_coordinators.pop(loop, None)
 
 	install = Mock(return_value=True)
@@ -43,5 +43,5 @@ async def test_parallel_signal_handlers_share_one_coordinator(monkeypatch: pytes
 	finally:
 		first.unregister()
 		second.unregister()
-		loop.ctrl_c_pressed = False
-		loop.waiting_for_input = False
+		setattr(loop, 'ctrl_c_pressed', False)
+		setattr(loop, 'waiting_for_input', False)

--- a/tests/ci/test_signal_coordinator.py
+++ b/tests/ci/test_signal_coordinator.py
@@ -1,0 +1,47 @@
+from unittest.mock import Mock
+
+import pytest
+
+from browser_use import utils
+
+
+@pytest.mark.asyncio
+async def test_parallel_signal_handlers_share_one_coordinator(monkeypatch: pytest.MonkeyPatch) -> None:
+	loop = utils.asyncio.get_running_loop()
+	loop.ctrl_c_pressed = False
+	loop.waiting_for_input = False
+	utils._signal_coordinators.pop(loop, None)
+
+	install = Mock(return_value=True)
+	teardown = Mock()
+	monkeypatch.setattr(utils._SignalCoordinator, 'install', install)
+	monkeypatch.setattr(utils._SignalCoordinator, 'teardown', teardown)
+
+	first_pause = Mock()
+	second_pause = Mock()
+	first = utils.SignalHandler(loop=loop, pause_callback=first_pause)
+	second = utils.SignalHandler(loop=loop, pause_callback=second_pause)
+	try:
+		first.register()
+		second.register()
+
+		coordinator = utils._signal_coordinators[loop]
+		assert install.call_count == 1
+		assert coordinator.subscribers == [first, second]
+
+		coordinator.handle_sigint()
+		first_pause.assert_called_once_with()
+		second_pause.assert_called_once_with()
+
+		first.unregister()
+		teardown.assert_not_called()
+		assert coordinator.subscribers == [second]
+
+		second.unregister()
+		teardown.assert_called_once_with()
+		assert loop not in utils._signal_coordinators
+	finally:
+		first.unregister()
+		second.unregister()
+		loop.ctrl_c_pressed = False
+		loop.waiting_for_input = False


### PR DESCRIPTION
## Summary

  - Coordinate SIGINT/SIGTERM handling across concurrent agents on the same event loop.
  - Prevent one agent from removing signal handlers while others are still running.
  - Broadcast pause and exit callbacks to all active subscribers.
  - Add regression coverage for shared registration and reference-counted teardown.

  ## Testing

  - `uv run pytest tests/ci/test_signal_coordinator.py -q`
  - `uv run pre-commit run --all-files`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coordinate SIGINT/SIGTERM across parallel agents via a shared per-loop coordinator that installs handlers once, fans signals to all agents, and exits consistently. Preserves coordinated ownership during registration, unregistration, and input prompts to prevent handler clobbering.

- **Bug Fixes**
  - Add per-loop `_SignalCoordinator` stored in a `WeakKeyDictionary`; install once, subscribe/unsubscribe agents, and restore original handlers only on final teardown.
  - Fan out first Ctrl+C to pause all agents; second Ctrl+C exits after running exit callbacks and printing a shared terminal reset; SIGTERM exits immediately; Windows exits immediately on first Ctrl+C.
  - Preserve loop state (`ctrl_c_pressed`, `waiting_for_input`) across agents and stop swapping in default SIGINT during `wait_for_resume`, keeping the coordinator in control.
  - Add regression test to verify single install, pause broadcast, and teardown when the last agent unregisters.

<sup>Written for commit f87eb611034902bed08a6bad3e4d7c5cff9ef7b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

