### PR TITLE
fix: preserve domain policy semantics for large lists

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -616,11 +616,11 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	deterministic_rendering: bool = Field(default=False, description='Enable deterministic rendering flags.')
 	allowed_domains: list[str] | set[str] | None = Field(
 		default=None,
-		description='List of allowed domains for navigation e.g. ["*.google.com", "https://example.com", "chrome-extension://*"]. Lists with 100+ items are auto-optimized to sets (no pattern matching).',
+		description='List of allowed domains for navigation e.g. ["*.google.com", "https://example.com", "chrome-extension://*"]. Lists with 100+ items are auto-optimized to sets while preserving matching semantics.',
 	)
 	prohibited_domains: list[str] | set[str] | None = Field(
 		default=None,
-		description='List of prohibited domains for navigation e.g. ["*.google.com", "https://example.com", "chrome-extension://*"]. Allowed domains take precedence over prohibited domains. Lists with 100+ items are auto-optimized to sets (no pattern matching).',
+		description='List of prohibited domains for navigation e.g. ["*.google.com", "https://example.com", "chrome-extension://*"]. Allowed domains take precedence over prohibited domains. Lists with 100+ items are auto-optimized to sets while preserving matching semantics.',
 	)
 	block_ip_addresses: bool = Field(
 		default=False,
@@ -745,8 +745,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		if len(v) >= DOMAIN_OPTIMIZATION_THRESHOLD:
 			logger.warning(
 				f'🔧 Optimizing domain list with {len(v)} items to set for O(1) lookup. '
-				f'Note: Pattern matching (*.domain.com, etc.) is not supported for lists >= {DOMAIN_OPTIMIZATION_THRESHOLD} items. '
-				f'Use exact domains only or keep list size < {DOMAIN_OPTIMIZATION_THRESHOLD} for pattern support.'
+				f'Pattern matching remains supported for optimized domain sets.'
 			)
 			return set(v)
 

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -217,35 +217,17 @@ class SecurityWatchdog(BaseWatchdog):
 		):
 			return True
 
-		# Check allowed domains (fast path for sets, slow path for lists with patterns)
+		# Use the same matcher for lists and optimized sets. Sets may contain
+		# protocol-qualified or glob patterns, so hostname-only comparisons would
+		# change policy semantics when optimization is enabled.
 		if self.browser_session.browser_profile.allowed_domains:
 			allowed_domains = self.browser_session.browser_profile.allowed_domains
+			return any(self._is_url_match(url, host, parsed.scheme, pattern) for pattern in allowed_domains)
 
-			if isinstance(allowed_domains, set):
-				# Fast path: O(1) exact hostname match - check both www and non-www variants
-				host_variant, host_alt = self._get_domain_variants(host)
-				return host_variant in allowed_domains or host_alt in allowed_domains
-			else:
-				# Slow path: O(n) pattern matching for lists
-				for pattern in allowed_domains:
-					if self._is_url_match(url, host, parsed.scheme, pattern):
-						return True
-				return False
-
-		# Check prohibited domains (fast path for sets, slow path for lists with patterns)
+		# Apply the same matcher for lists and optimized sets.
 		if self.browser_session.browser_profile.prohibited_domains:
 			prohibited_domains = self.browser_session.browser_profile.prohibited_domains
-
-			if isinstance(prohibited_domains, set):
-				# Fast path: O(1) exact hostname match - check both www and non-www variants
-				host_variant, host_alt = self._get_domain_variants(host)
-				return host_variant not in prohibited_domains and host_alt not in prohibited_domains
-			else:
-				# Slow path: O(n) pattern matching for lists
-				for pattern in prohibited_domains:
-					if self._is_url_match(url, host, parsed.scheme, pattern):
-						return False
-				return True
+			return not any(self._is_url_match(url, host, parsed.scheme, pattern) for pattern in prohibited_domains)
 
 		return True
 

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -516,7 +516,8 @@ class TestDomainListOptimization:
 
 		# Test www variant matching for domains with www prefix
 		assert watchdog._is_url_allowed('https://www.domain0.org') is False
-		assert watchdog._is_url_allowed('https://domain0.org') is False  # Should also be blocked
+		# A www-prefixed root entry does not implicitly match the bare domain.
+		assert watchdog._is_url_allowed('https://domain0.org') is True
 
 		# Test that unrelated domains are allowed
 		assert watchdog._is_url_allowed('https://example.com') is True
@@ -539,10 +540,27 @@ class TestDomainListOptimization:
 		# Should be converted to set
 		assert isinstance(browser_session.browser_profile.allowed_domains, set)
 
+	def test_large_sets_preserve_protocol_case_and_www_semantics(self):
+		"""Optimization must not change the list matcher semantics."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		patterns = ['https://Example.COM'] + [f'allowed{i}.com' for i in range(99)]
+		browser_profile = BrowserProfile(allowed_domains=patterns, headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=EventBus())
+
+		assert isinstance(browser_session.browser_profile.allowed_domains, set)
+		assert watchdog._is_url_allowed('https://Example.COM/path') is True
+		assert watchdog._is_url_allowed('https://example.com/path') is False
+		assert watchdog._is_url_allowed('http://Example.COM/path') is False
+		assert watchdog._is_url_allowed('https://www.allowed0.com') is True
+
 		# Allowed domains should work
 		assert watchdog._is_url_allowed('https://allowed0.com') is True
 		assert watchdog._is_url_allowed('https://www.allowed0.com') is True
-		assert watchdog._is_url_allowed('https://allowed99.com') is True
+		assert watchdog._is_url_allowed('https://allowed98.com') is True
 
 		# Other domains should be blocked
 		assert watchdog._is_url_allowed('https://example.com') is False


### PR DESCRIPTION
## Summary

  - Ensure 100+ domain configurations use the same matcher as smaller lists.
  - Preserve protocol-qualified entries, glob patterns, case handling, and `www` expansion rules.
  - Update documentation and add regression coverage for optimized lists.

  ## Testing

  - `uv run pytest tests/ci/security/test_domain_filtering.py -q`
  - `uv run pre-commit run --all-files`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes domain filtering so that large allowed/prohibited domain lists (100+ items) keep the same matching rules as small lists, preventing unintended allow/deny behavior. Sets now use the same matcher as lists, preserving protocol, glob patterns, case sensitivity, and `www` semantics.

- **Bug Fixes**
  - Use a single URL matcher for both lists and optimized sets in the security watchdog.
  - Preserve protocol-qualified rules, wildcard/glob patterns, case handling, and explicit `www` behavior.
  - Update profile field descriptions to reflect preserved semantics for optimized lists.
  - Add regression tests to verify protocol/case/`www` behavior and large-set handling.

<sup>Written for commit 0282ad3c884268900282ee68d94521f0faf1de2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

