### PR TITLE
fix: resolve modern custom action annotations

### DIFF
--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Callable
 from inspect import Parameter, iscoroutinefunction, signature
 from types import UnionType
-from typing import Any, Generic, Optional, TypeVar, Union, get_args, get_origin
+from typing import Any, Generic, Optional, TypeVar, Union, get_args, get_origin, get_type_hints
 
 import pyotp
 from pydantic import BaseModel, Field, RootModel, create_model
@@ -87,6 +87,12 @@ class Registry(Generic[Context]):
 		"""
 		sig = signature(func)
 		parameters = list(sig.parameters.values())
+		try:
+			resolved_annotations = get_type_hints(func, include_extras=True)
+		except (NameError, TypeError):
+			# Preserve the previous behavior for dynamically-created functions whose
+			# forward references cannot be resolved in their defining namespace.
+			resolved_annotations = {}
 		special_param_types = self._get_special_param_types()
 		special_param_names = set(special_param_types.keys())
 
@@ -113,11 +119,12 @@ class Registry(Generic[Context]):
 			if param.name in special_param_names:
 				# Validate special parameter type
 				expected_type = special_param_types.get(param.name)
-				if param.annotation != Parameter.empty and expected_type is not None:
+				param_annotation = resolved_annotations.get(param.name, param.annotation)
+				if param_annotation != Parameter.empty and expected_type is not None:
 					# Handle Optional types - normalize both sides
-					param_type = param.annotation
+					param_type = param_annotation
 					origin = get_origin(param_type)
-					if origin is Union:
+					if origin in (Union, UnionType):
 						args = get_args(param_type)
 						# Find non-None type
 						param_type = next((arg for arg in args if arg is not type(None)), param_type)
@@ -152,7 +159,8 @@ class Registry(Generic[Context]):
 			if action_params:
 				params_dict = {}
 				for param in action_params:
-					annotation = param.annotation if param.annotation != Parameter.empty else str
+					annotation = resolved_annotations.get(param.name, param.annotation)
+					annotation = annotation if annotation != Parameter.empty else str
 					default = ... if param.default == Parameter.empty else param.default
 					params_dict[param.name] = (annotation, default)
 

--- a/tests/ci/infrastructure/test_registry_validation.py
+++ b/tests/ci/infrastructure/test_registry_validation.py
@@ -26,6 +26,17 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
+def test_modern_special_parameter_annotations_are_resolved():
+	"""Postponed and PEP 604 annotations should validate like concrete types."""
+	registry = Registry()
+
+	@registry.action('Use browser session')
+	async def use_browser_session(browser_session: 'BrowserSession | None' = None):
+		return ActionResult(extracted_content='ok')
+
+	assert 'use_browser_session' in registry.registry.actions
+
+
 class TestType1Pattern:
 	"""Test Type 1 Pattern: Pydantic model first (from normalization tests)"""
 


### PR DESCRIPTION
## Summary

  - Resolve postponed custom-action annotations before registry validation.
  - Normalize both `typing.Union` and PEP 604 union types.
  - Preserve resolved annotations when generating action parameter models.
  - Add regression coverage for `BrowserSession | None`.

  ## Testing

  - `uv run pytest tests/ci/infrastructure/test_registry_validation.py -q`
  - `uv run pre-commit run --all-files`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix custom action validation by resolving postponed annotations and PEP 604 unions before registry checks. Special params like `BrowserSession | None` now validate, and resolved types are used when building action parameter models.

- **Bug Fixes**
  - Resolve annotations with `typing.get_type_hints(include_extras=True)` and use them in validation and model generation, with a safe fallback for unresolved refs.
  - Normalize both `typing.Union` and `|` unions when checking special parameters.
  - Add regression test for `'BrowserSession | None'` in a custom action.

<sup>Written for commit aac47a2240bc665836dcffc55c02c8c72826bedc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

