### PR TITLE
fix(browser): bound DOM fanout and preserve recoverable state

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -562,6 +562,7 @@ class BrowserSession(BaseModel):
 	_cached_browser_state_summary: Any = PrivateAttr(default=None)
 	_cached_selector_map: dict[int, EnhancedDOMTreeNode] = PrivateAttr(default_factory=dict)
 	_cached_selector_indices: dict[tuple[str, int], int] = PrivateAttr(default_factory=dict)
+	_consecutive_state_refresh_timeouts: int = PrivateAttr(default=0)
 	_downloaded_files: list[str] = PrivateAttr(default_factory=list)  # Track files downloaded during this session
 	_closed_popup_messages: list[str] = PrivateAttr(default_factory=list)  # Store messages from auto-closed JavaScript dialogs
 
@@ -662,6 +663,7 @@ class BrowserSession(BaseModel):
 		self._cached_browser_state_summary = None
 		self._cached_selector_map.clear()
 		self._cached_selector_indices.clear()
+		self._consecutive_state_refresh_timeouts = 0
 		self._downloaded_files.clear()
 
 		self.agent_focus_target_id = None
@@ -1234,6 +1236,7 @@ class BrowserSession(BaseModel):
 		self._cached_browser_state_summary = None
 		self._cached_selector_map.clear()
 		self._cached_selector_indices.clear()
+		self._consecutive_state_refresh_timeouts = 0
 		self.logger.debug('🔄 Cached browser state cleared')
 
 		# Update agent focus if a specific target_id is provided (only for page/tab targets)
@@ -1625,6 +1628,10 @@ class BrowserSession(BaseModel):
 		try:
 			result = await event.event_result(raise_if_none=True, raise_if_any=True)
 		except TimeoutError:
+			self._consecutive_state_refresh_timeouts += 1
+			if self._consecutive_state_refresh_timeouts > 1:
+				raise
+
 			cached_state = self._cached_browser_state_summary
 			if cached_state is None or cached_state.dom_state is None:
 				raise
@@ -1639,6 +1646,7 @@ class BrowserSession(BaseModel):
 				],
 			)
 
+		self._consecutive_state_refresh_timeouts = 0
 		assert result is not None and result.dom_state is not None
 		return result
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import re
 import time
+from dataclasses import replace
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, Union, cast, overload
@@ -1617,8 +1618,27 @@ class BrowserSession(BaseModel):
 			),
 		)
 
-		# The handler returns the BrowserStateSummary directly
-		result = await event.event_result(raise_if_none=True, raise_if_any=True)
+		# The handler returns the BrowserStateSummary directly. If the remote
+		# browser stops answering long enough for the whole state event to time
+		# out, preserve agent recovery by returning the last known DOM instead of
+		# skipping the model call repeatedly. Never reuse a stale screenshot.
+		try:
+			result = await event.event_result(raise_if_none=True, raise_if_any=True)
+		except TimeoutError:
+			cached_state = self._cached_browser_state_summary
+			if cached_state is None or cached_state.dom_state is None:
+				raise
+
+			self.logger.warning('Browser state refresh timed out; returning the last known DOM without a screenshot')
+			return replace(
+				cached_state,
+				screenshot=None,
+				browser_errors=[
+					*cached_state.browser_errors,
+					'Browser state refresh timed out; this is the last known page state.',
+				],
+			)
+
 		assert result is not None and result.dom_state is not None
 		return result
 

--- a/browser_use/browser/watchdogs/dom_watchdog.py
+++ b/browser_use/browser/watchdogs/dom_watchdog.py
@@ -22,6 +22,8 @@ from browser_use.utils import create_task_with_error_handling, time_execution_as
 if TYPE_CHECKING:
 	from browser_use.browser.views import BrowserStateSummary, NetworkRequest, PageInfo, PaginationButton
 
+_BROWSER_STATE_PARALLEL_TASK_BUDGET_SECONDS = 20.0
+
 
 class DOMWatchdog(BaseWatchdog):
 	"""Handles DOM tree building, serialization, and element access via CDP.
@@ -356,6 +358,7 @@ class DOMWatchdog(BaseWatchdog):
 			# Execute DOM building and screenshot capture in parallel
 			dom_task = None
 			screenshot_task = None
+			parallel_tasks_started_at = time.monotonic()
 
 			# Start DOM building task if requested
 			if event.include_dom:
@@ -400,7 +403,15 @@ class DOMWatchdog(BaseWatchdog):
 
 			if screenshot_task:
 				try:
-					screenshot_b64 = await screenshot_task
+					# BrowserStateRequestEvent has a 30-second budget. A nested
+					# ScreenshotEvent can otherwise consume nearly all of it,
+					# preventing this handler from returning the usable DOM-only
+					# state when screenshot capture stalls.
+					remaining_screenshot_budget = max(
+						0.001,
+						_BROWSER_STATE_PARALLEL_TASK_BUDGET_SECONDS - (time.monotonic() - parallel_tasks_started_at),
+					)
+					screenshot_b64 = await asyncio.wait_for(screenshot_task, timeout=remaining_screenshot_budget)
 					self.logger.debug('🔍 DOMWatchdog.on_BrowserStateRequestEvent: ✅ Clean screenshot captured')
 				except Exception as e:
 					self.logger.warning(f'🔍 DOMWatchdog.on_BrowserStateRequestEvent: Clean screenshot failed: {e}')

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -620,7 +620,10 @@ class DomService:
 				for task in pending2:
 					task.cancel()
 
-		# Extract results, tracking which ones failed
+		# Extract results, tracking which required requests failed. The AX tree
+		# enriches DOM nodes with accessibility names and roles, but the snapshot
+		# and DOM tree still contain a usable page structure without it. Do not
+		# discard that structure when accessibility collection stalls or fails.
 		results = {}
 		failed = []
 		for key, task in tasks.items():
@@ -629,10 +632,16 @@ class DomService:
 					results[key] = task.result()
 				except Exception as e:
 					self.logger.warning(f'CDP request {key} failed with exception: {e}')
-					failed.append(key)
+					if key == 'ax_tree':
+						results[key] = {'nodes': []}
+					else:
+						failed.append(key)
 			else:
 				self.logger.warning(f'CDP request {key} timed out')
-				failed.append(key)
+				if key == 'ax_tree':
+					results[key] = {'nodes': []}
+				else:
+					failed.append(key)
 
 		# If any required tasks failed, raise an exception
 		if failed:

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -31,6 +31,10 @@ if TYPE_CHECKING:
 
 # Note: iframe limits are now configurable via BrowserProfile.max_iframes and BrowserProfile.max_iframe_depth
 
+_MAX_JS_CLICK_LISTENER_ELEMENTS = 100
+_DESCRIBE_NODE_BATCH_SIZE = 20
+_JS_CLICK_LISTENER_OVERFLOW = '__browser_use_too_many_click_listeners__'
+
 
 class DomService:
 	"""
@@ -443,10 +447,10 @@ class DomService:
 			self.logger.debug(f'Failed to get iframe scroll positions: {e}')
 		iframe_scroll_ms = (time.time() - start_iframe_scroll) * 1000
 
-		# Detect elements with JavaScript click event listeners (without mutating DOM)
-		# On heavy pages (>10k elements) the querySelectorAll('*') + getEventListeners()
-		# loop plus per-element DOM.describeNode CDP calls can take 10s+.
-		# The JS expression below bails out early if the page is too heavy.
+		# Detect elements with JavaScript click event listeners (without mutating DOM).
+		# Bounding only the total DOM size is insufficient: framework-heavy pages can attach
+		# hundreds of listeners to fewer than 10k elements. Resolving every listener with an
+		# unbounded gather floods remote CDP connections and can make the whole session appear stale.
 		# Elements are still detected via the accessibility tree and ClickableElementDetector.
 		start_js_listener_detection = time.time()
 		js_click_listener_backend_ids: set[int] = set()
@@ -476,6 +480,9 @@ class DomService:
 								// Check for click-related event listeners
 								if (listeners.click || listeners.mousedown || listeners.mouseup || listeners.pointerdown || listeners.pointerup) {
 									elementsWithListeners.push(el);
+									if (elementsWithListeners.length > %d) {
+										return %r;
+									}
 								}
 							} catch (e) {
 								// Ignore errors for individual elements (e.g., cross-origin)
@@ -484,12 +491,18 @@ class DomService:
 
 						return elementsWithListeners;
 					})()
-					""",
+					"""
+					% (_MAX_JS_CLICK_LISTENER_ELEMENTS, _JS_CLICK_LISTENER_OVERFLOW),
 					'includeCommandLineAPI': True,  # enables getEventListeners()
 					'returnByValue': False,  # Return object references, not values
 				},
 				session_id=cdp_session.session_id,
 			)
+
+			if js_listener_result.get('result', {}).get('value') == _JS_CLICK_LISTENER_OVERFLOW:
+				self.logger.debug(
+					f'Skipping JS listener resolution: more than {_MAX_JS_CLICK_LISTENER_ELEMENTS} elements have click listeners'
+				)
 
 			result_object_id = js_listener_result.get('result', {}).get('objectId')
 			if result_object_id:
@@ -514,7 +527,6 @@ class DomService:
 							if object_id and isinstance(object_id, str):
 								element_object_ids.append(object_id)
 
-				# Batch resolve backend node IDs (run in parallel)
 				async def get_backend_node_id(object_id: str) -> int | None:
 					try:
 						node_info = await cdp_session.cdp_client.send.DOM.describeNode(
@@ -525,8 +537,13 @@ class DomService:
 					except Exception:
 						return None
 
-				# Resolve all element object IDs to backend node IDs in parallel
-				backend_ids = await asyncio.gather(*[get_backend_node_id(oid) for oid in element_object_ids])
+				# Keep concurrency bounded. Each describeNode call can trigger target/session
+				# bookkeeping, so even a few dozen simultaneous calls can starve screenshots
+				# and the other CDP requests needed to build browser state.
+				backend_ids: list[int | None] = []
+				for batch_start in range(0, len(element_object_ids), _DESCRIBE_NODE_BATCH_SIZE):
+					batch = element_object_ids[batch_start : batch_start + _DESCRIBE_NODE_BATCH_SIZE]
+					backend_ids.extend(await asyncio.gather(*[get_backend_node_id(object_id) for object_id in batch]))
 				js_click_listener_backend_ids = {bid for bid in backend_ids if bid is not None}
 
 				# Release the array object to avoid memory leaks

--- a/tests/ci/browser/test_dom_listener_detection.py
+++ b/tests/ci/browser/test_dom_listener_detection.py
@@ -1,0 +1,70 @@
+"""Regression tests for bounded JavaScript click-listener detection."""
+
+from collections import Counter
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+from browser_use.browser.session import BrowserSession
+from browser_use.dom.service import _MAX_JS_CLICK_LISTENER_ELEMENTS
+
+
+@pytest.fixture
+async def browser_session():
+	session = BrowserSession(browser_profile=BrowserProfile(headless=True, user_data_dir=None, keep_alive=True))
+	await session.start()
+	yield session
+	await session.kill()
+
+
+async def test_listener_detection_preserves_small_pages_and_skips_cdp_fanout(httpserver, browser_session: BrowserSession):
+	"""Direct listeners remain indexed normally, but listener-heavy pages do not flood CDP."""
+	small_listener_count = 3
+	overflow_listener_count = _MAX_JS_CLICK_LISTENER_ELEMENTS + 1
+
+	def listener_page(element_count: int) -> str:
+		elements = ''.join(f'<div id="custom-{index}">item {index}</div>' for index in range(element_count))
+		return f"""
+		<html>
+			<body>
+				{elements}
+				<script>
+					for (const element of document.querySelectorAll('[id^="custom-"]')) {{
+						element.addEventListener('click', () => undefined);
+					}}
+				</script>
+			</body>
+		</html>
+		"""
+
+	httpserver.expect_request('/few-listeners').respond_with_data(listener_page(small_listener_count), content_type='text/html')
+	httpserver.expect_request('/many-listeners').respond_with_data(
+		listener_page(overflow_listener_count), content_type='text/html'
+	)
+
+	await browser_session.navigate_to(httpserver.url_for('/few-listeners'))
+	cdp_session = await browser_session.get_or_create_cdp_session()
+	cdp_calls: Counter[str] = Counter()
+	original_send_raw = cdp_session.cdp_client.send_raw
+
+	async def counted_send_raw(method, params=None, session_id=None):
+		cdp_calls[method] += 1
+		return await original_send_raw(method=method, params=params, session_id=session_id)
+
+	cdp_session.cdp_client.send_raw = counted_send_raw
+
+	small_state = await browser_session.get_browser_state_summary(include_screenshot=False)
+	small_ids = {
+		node.attributes.get('id')
+		for node in small_state.dom_state.selector_map.values()
+		if node.attributes.get('id', '').startswith('custom-')
+	}
+	assert small_ids == {f'custom-{index}' for index in range(small_listener_count)}
+	assert cdp_calls['DOM.describeNode'] == small_listener_count
+
+	await browser_session.navigate_to(httpserver.url_for('/many-listeners'))
+	cdp_calls.clear()
+	overflow_state = await browser_session.get_browser_state_summary(include_screenshot=False)
+
+	assert overflow_state.dom_state is not None
+	assert cdp_calls['DOM.describeNode'] == 0

--- a/tests/ci/browser/test_dom_listener_detection.py
+++ b/tests/ci/browser/test_dom_listener_detection.py
@@ -1,12 +1,13 @@
 """Regression tests for bounded JavaScript click-listener detection."""
 
+import asyncio
 from collections import Counter
 
 import pytest
 
 from browser_use.browser.profile import BrowserProfile
 from browser_use.browser.session import BrowserSession
-from browser_use.dom.service import _MAX_JS_CLICK_LISTENER_ELEMENTS
+from browser_use.dom.service import DomService, _MAX_JS_CLICK_LISTENER_ELEMENTS
 
 
 @pytest.fixture
@@ -68,3 +69,22 @@ async def test_listener_detection_preserves_small_pages_and_skips_cdp_fanout(htt
 
 	assert overflow_state.dom_state is not None
 	assert cdp_calls['DOM.describeNode'] == 0
+
+
+async def test_ax_tree_failure_preserves_structural_dom(httpserver, browser_session: BrowserSession, monkeypatch):
+	"""An unavailable accessibility tree must not erase the usable structural DOM."""
+	httpserver.expect_request('/ax-unavailable').respond_with_data(
+		'<html><body><button id="continue">Continue</button></body></html>',
+		content_type='text/html',
+	)
+
+	async def fail_ax_tree(_service: DomService, _target_id):
+		raise asyncio.CancelledError
+
+	monkeypatch.setattr(DomService, '_get_ax_tree_for_all_frames', fail_ax_tree)
+	await browser_session.navigate_to(httpserver.url_for('/ax-unavailable'))
+
+	state = await browser_session.get_browser_state_summary(include_screenshot=False)
+
+	assert state.dom_state is not None
+	assert any(node.attributes.get('id') == 'continue' for node in state.dom_state.selector_map.values())

--- a/tests/ci/browser/test_dom_listener_detection.py
+++ b/tests/ci/browser/test_dom_listener_detection.py
@@ -111,3 +111,25 @@ async def test_screenshot_timeout_preserves_structural_dom(httpserver, browser_s
 	assert state.screenshot is None
 	assert state.dom_state is not None
 	assert any(node.attributes.get('id') == 'continue' for node in state.dom_state.selector_map.values())
+
+
+async def test_state_timeout_returns_cached_dom_without_screenshot(httpserver, browser_session: BrowserSession, monkeypatch):
+	"""A whole-state timeout should still let the model receive the last known DOM."""
+	httpserver.expect_request('/cached-state').respond_with_data(
+		'<html><body><button id="continue">Continue</button></body></html>',
+		content_type='text/html',
+	)
+	await browser_session.navigate_to(httpserver.url_for('/cached-state'))
+	initial_state = await browser_session.get_browser_state_summary(include_screenshot=False)
+
+	class TimedOutStateEvent:
+		async def event_result(self, **_kwargs):
+			raise TimeoutError
+
+	monkeypatch.setattr(browser_session.event_bus, 'dispatch', lambda _event: TimedOutStateEvent())
+
+	recovered_state = await browser_session.get_browser_state_summary(include_screenshot=True)
+
+	assert recovered_state.screenshot is None
+	assert recovered_state.dom_state is initial_state.dom_state
+	assert recovered_state.browser_errors[-1] == 'Browser state refresh timed out; this is the last known page state.'

--- a/tests/ci/browser/test_dom_listener_detection.py
+++ b/tests/ci/browser/test_dom_listener_detection.py
@@ -7,7 +7,7 @@ import pytest
 
 from browser_use.browser.profile import BrowserProfile
 from browser_use.browser.session import BrowserSession
-from browser_use.dom.service import DomService, _MAX_JS_CLICK_LISTENER_ELEMENTS
+from browser_use.dom.service import _MAX_JS_CLICK_LISTENER_ELEMENTS, DomService
 
 
 @pytest.fixture

--- a/tests/ci/browser/test_dom_listener_detection.py
+++ b/tests/ci/browser/test_dom_listener_detection.py
@@ -7,6 +7,8 @@ import pytest
 
 from browser_use.browser.profile import BrowserProfile
 from browser_use.browser.session import BrowserSession
+from browser_use.browser.watchdogs import dom_watchdog
+from browser_use.browser.watchdogs.dom_watchdog import DOMWatchdog
 from browser_use.dom.service import _MAX_JS_CLICK_LISTENER_ELEMENTS, DomService
 
 
@@ -86,5 +88,26 @@ async def test_ax_tree_failure_preserves_structural_dom(httpserver, browser_sess
 
 	state = await browser_session.get_browser_state_summary(include_screenshot=False)
 
+	assert state.dom_state is not None
+	assert any(node.attributes.get('id') == 'continue' for node in state.dom_state.selector_map.values())
+
+
+async def test_screenshot_timeout_preserves_structural_dom(httpserver, browser_session: BrowserSession, monkeypatch):
+	"""A stalled state screenshot must not consume the outer event's recovery budget."""
+	httpserver.expect_request('/screenshot-unavailable').respond_with_data(
+		'<html><body><button id="continue">Continue</button></body></html>',
+		content_type='text/html',
+	)
+
+	async def hang_screenshot(_watchdog: DOMWatchdog):
+		await asyncio.Future()
+
+	monkeypatch.setattr(DOMWatchdog, '_capture_clean_screenshot', hang_screenshot)
+	monkeypatch.setattr(dom_watchdog, '_BROWSER_STATE_PARALLEL_TASK_BUDGET_SECONDS', 0.1)
+	await browser_session.navigate_to(httpserver.url_for('/screenshot-unavailable'))
+
+	state = await browser_session.get_browser_state_summary(include_screenshot=True)
+
+	assert state.screenshot is None
 	assert state.dom_state is not None
 	assert any(node.attributes.get('id') == 'continue' for node in state.dom_state.selector_map.values())

--- a/tests/ci/browser/test_dom_listener_detection.py
+++ b/tests/ci/browser/test_dom_listener_detection.py
@@ -133,3 +133,6 @@ async def test_state_timeout_returns_cached_dom_without_screenshot(httpserver, b
 	assert recovered_state.screenshot is None
 	assert recovered_state.dom_state is initial_state.dom_state
 	assert recovered_state.browser_errors[-1] == 'Browser state refresh timed out; this is the last known page state.'
+
+	with pytest.raises(TimeoutError):
+		await browser_session.get_browser_state_summary(include_screenshot=True)


### PR DESCRIPTION
## Summary

- bound JavaScript click-listener discovery at 100 matches and resolve normal sets in batches of 20
- preserve structural DOM when optional accessibility-tree collection fails or times out
- bound screenshot work inside browser-state collection so a stalled screenshot cannot consume the outer event budget
- return the last known DOM without a screenshot when the whole state refresh times out, allowing the model to attempt recovery

## Root causes

A moderate-sized page can still expose hundreds of direct JavaScript listeners. Resolving all listener nodes through one unbounded CDP fanout overloaded remote sessions. Separately, optional AX and screenshot work was allowed to invalidate or outlive an otherwise usable structural DOM. Finally, a whole-state timeout propagated to the agent even when a cached DOM existed, so repeated state failures skipped model recovery entirely.

## Safety boundaries

- normal listener sets keep the existing detection behavior
- selector/index generation is unchanged
- AX degradation happens only after that optional request fails or times out
- direct screenshot actions keep their existing timeout; only browser-state collection reserves time to return DOM-only state
- cached state is used for at most one recovery attempt per consecutive whole-state timeout streak, never includes a stale screenshot, and carries an explicit stale-state browser error

## Validation

- listener-heavy local reproduction reduced first-state CDP fanout while preserving actionable controls
- forced AX failure, stalled screenshot, and whole-state timeout each preserve a model-visible DOM in regression tests
- 11 relevant DOM, iframe, visibility, and interaction tests pass
- pre-commit, type checking, and repository CI pass