### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![MCP Toplist](https://mcptoplist.com/badge/pulsemcp%2Fbrowser-use.svg)](https://mcptoplist.com/server/pulsemcp%2Fbrowser-use)
+
 <!-- mcp-name: com.browser-use/browser-use -->
 <picture>
   <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/2ccdb752-22fb-41c7-8948-857fc1ad7e24">


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 77,122 MCP servers across the major
registries, and **Browser Use** is currently ranked **#1**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/pulsemcp%2Fbrowser-use.svg)](https://mcptoplist.com/server/pulsemcp%2Fbrowser-use)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Browser Use!


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a live MCP Toplist rank badge to the README that shows Browser Use’s current ranking and links to its MCP Toplist page. The badge updates automatically as the leaderboard changes.

<sup>Written for commit 6b79e833655e910ab4957bbf849c2d15a46796df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

