### PR TITLE
Fix compact cross-origin payment field extraction

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
 _MAX_JS_CLICK_LISTENER_ELEMENTS = 100
 _DESCRIBE_NODE_BATCH_SIZE = 20
 _JS_CLICK_LISTENER_OVERFLOW = '__browser_use_too_many_click_listeners__'
-_MIN_CROSS_ORIGIN_IFRAME_AREA = 16 * 16
-_MIN_CROSS_ORIGIN_IFRAME_EDGE = 8
+_MIN_CROSS_ORIGIN_IFRAME_AREA = 50 * 50
+_MIN_CROSS_ORIGIN_IFRAME_EDGE = 10
 
 
 def _is_cross_origin_iframe_size_eligible(width: float, height: float) -> bool:

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
 _MAX_JS_CLICK_LISTENER_ELEMENTS = 100
 _DESCRIBE_NODE_BATCH_SIZE = 20
 _JS_CLICK_LISTENER_OVERFLOW = '__browser_use_too_many_click_listeners__'
-_MIN_CROSS_ORIGIN_IFRAME_AREA = 50 * 50
-_MIN_CROSS_ORIGIN_IFRAME_EDGE = 10
+_MIN_CROSS_ORIGIN_IFRAME_AREA = 16 * 16
+_MIN_CROSS_ORIGIN_IFRAME_EDGE = 8
 
 
 def _is_cross_origin_iframe_size_eligible(width: float, height: float) -> bool:

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -34,6 +34,17 @@ if TYPE_CHECKING:
 _MAX_JS_CLICK_LISTENER_ELEMENTS = 100
 _DESCRIBE_NODE_BATCH_SIZE = 20
 _JS_CLICK_LISTENER_OVERFLOW = '__browser_use_too_many_click_listeners__'
+_MIN_CROSS_ORIGIN_IFRAME_AREA = 50 * 50
+_MIN_CROSS_ORIGIN_IFRAME_EDGE = 10
+
+
+def _is_cross_origin_iframe_size_eligible(width: float, height: float) -> bool:
+	"""Keep tiny tracking frames out while allowing input-shaped hosted fields."""
+	return (
+		width >= _MIN_CROSS_ORIGIN_IFRAME_EDGE
+		and height >= _MIN_CROSS_ORIGIN_IFRAME_EDGE
+		and width * height >= _MIN_CROSS_ORIGIN_IFRAME_AREA
+	)
 
 
 class DomService:
@@ -958,7 +969,9 @@ class DomService:
 						f'Skipping iframe at depth {iframe_depth} to prevent infinite recursion (max depth: {self.max_iframe_depth})'
 					)
 				else:
-					# Check if iframe is visible and large enough (>= 50px in both dimensions)
+					# Check if the iframe is visible and large enough to contain an interactive control.
+					# Use area rather than requiring both edges to be >= 50px: hosted payment fields
+					# are commonly wide but only ~40px tall.
 					should_process_iframe = False
 
 					# First check if the iframe element itself is visible
@@ -969,13 +982,14 @@ class DomService:
 							width = bounds.width
 							height = bounds.height
 
-							# Only process if iframe is at least 50px in both dimensions
-							if width >= 50 and height >= 50:
+							if _is_cross_origin_iframe_size_eligible(width, height):
 								should_process_iframe = True
 								self.logger.debug(f'Processing cross-origin iframe: visible=True, width={width}, height={height}')
 							else:
 								self.logger.debug(
-									f'Skipping small cross-origin iframe: width={width}, height={height} (needs >= 50px)'
+									f'Skipping small cross-origin iframe: width={width}, height={height} '
+									f'(needs >= {_MIN_CROSS_ORIGIN_IFRAME_AREA}px² area and '
+									f'>= {_MIN_CROSS_ORIGIN_IFRAME_EDGE}px per edge)'
 								)
 						else:
 							self.logger.debug('Skipping cross-origin iframe: no bounds available')

--- a/tests/ci/test_dom_visibility.py
+++ b/tests/ci/test_dom_visibility.py
@@ -116,9 +116,6 @@ class TestCrossOriginIframeSizeEligibility:
 		"""Area alone must not admit a one-pixel tracking iframe."""
 		assert _is_cross_origin_iframe_size_eligible(width=1, height=2500) is False
 
-	def test_accepts_small_interactive_frame(self):
-		assert _is_cross_origin_iframe_size_eligible(width=16, height=16) is True
-
-	def test_rejects_frames_below_the_area_or_edge_floor(self):
-		assert _is_cross_origin_iframe_size_eligible(width=15, height=15) is False
-		assert _is_cross_origin_iframe_size_eligible(width=7, height=100) is False
+	def test_preserves_previous_minimum_area(self):
+		assert _is_cross_origin_iframe_size_eligible(width=50, height=50) is True
+		assert _is_cross_origin_iframe_size_eligible(width=49, height=49) is False

--- a/tests/ci/test_dom_visibility.py
+++ b/tests/ci/test_dom_visibility.py
@@ -116,6 +116,9 @@ class TestCrossOriginIframeSizeEligibility:
 		"""Area alone must not admit a one-pixel tracking iframe."""
 		assert _is_cross_origin_iframe_size_eligible(width=1, height=2500) is False
 
-	def test_preserves_previous_minimum_area(self):
-		assert _is_cross_origin_iframe_size_eligible(width=50, height=50) is True
-		assert _is_cross_origin_iframe_size_eligible(width=49, height=49) is False
+	def test_accepts_small_interactive_frame(self):
+		assert _is_cross_origin_iframe_size_eligible(width=16, height=16) is True
+
+	def test_rejects_frames_below_the_area_or_edge_floor(self):
+		assert _is_cross_origin_iframe_size_eligible(width=15, height=15) is False
+		assert _is_cross_origin_iframe_size_eligible(width=7, height=100) is False

--- a/tests/ci/test_dom_visibility.py
+++ b/tests/ci/test_dom_visibility.py
@@ -6,7 +6,7 @@ node must not be transformed by its own bounds when it appears in its own
 frame chain (as built by _construct_enhanced_node).
 """
 
-from browser_use.dom.service import DomService
+from browser_use.dom.service import DomService, _is_cross_origin_iframe_size_eligible
 from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, EnhancedSnapshotNode, NodeType
 
 
@@ -101,3 +101,21 @@ class TestVisibilityDoesNotMutateBounds:
 		assert visible is True
 		assert iframe.snapshot_node is not None and iframe.snapshot_node.bounds is not None
 		assert iframe.snapshot_node.bounds.y == 1200
+
+
+class TestCrossOriginIframeSizeEligibility:
+	def test_accepts_wide_secure_card_field(self):
+		"""Hosted card fields are often only 40px tall but have enough area to be interactive."""
+		assert _is_cross_origin_iframe_size_eligible(width=250, height=40) is True
+
+	def test_accepts_compact_secure_cvv_field(self):
+		"""A compact CVV frame must not be dropped solely because both edges are below 50px."""
+		assert _is_cross_origin_iframe_size_eligible(width=90, height=40) is True
+
+	def test_rejects_tiny_tracking_frame(self):
+		"""Area alone must not admit a one-pixel tracking iframe."""
+		assert _is_cross_origin_iframe_size_eligible(width=1, height=2500) is False
+
+	def test_preserves_previous_minimum_area(self):
+		assert _is_cross_origin_iframe_size_eligible(width=50, height=50) is True
+		assert _is_cross_origin_iframe_size_eligible(width=49, height=49) is False


### PR DESCRIPTION
## Summary

- allow compact, input-shaped cross-origin iframes to be extracted without removing the tracking-frame guard
- replace the square 50 x 50 requirement with a 2,500 px² area floor and a 10 px minimum edge
- add regression coverage for hosted card/CVV dimensions and the preserved minimum area

## Root cause

Cross-origin iframe descent required both dimensions to be at least 50 px. Hosted payment fields are commonly wide but short. Local Chromium may expose those documents inline, while remote OOPIF extraction takes the guarded cross-origin path and skips loaded field targets before recursion.

I reproduced the remote nested topology on Browser Use Cloud with a same-site cross-origin wrapper, shadow-root inputs, and two cross-site 40 px-high grandchild OOPIFs. Before this change the wrapper inputs were indexed while both secure inputs were missing. After the change both secure inputs were indexed in their own CDP sessions.

I also verified Datatrans own public Secure Fields showcase over Browser Use Cloud. On current main, the page produced 15 selectors from only the top target and neither hosted input was indexed. With this change, it produced 17 selectors across three targets and indexed both real Datatrans inputs (300 x 25 and 116 x 25).

## Safety

This does not enable cross-origin extraction by default, remove iframe filtering, or increase recursion depth. Frames must remain visible, have at least 10 px on each edge, have at least 2,500 px² of area, and stay within the existing recursion-depth guard. The threshold admits normal card/CVV fields such as 250 x 40 and 90 x 40 while rejecting 1 px trackers and frames smaller than the previous 2,500 px² minimum area.

A broader 16 x 16 relaxation was tested and intentionally reverted: recursive OOPIF traversal is not currently governed by a global target-count budget, so admitting very small frames would create avoidable fanout and content/highlight amplification.

## Validation

- `uv run pytest -q tests/ci/test_dom_visibility.py tests/ci/browser/test_dom_serializer_session_identity.py tests/ci/browser/test_dom_selector_index_collisions.py`
- `uv run pytest -q tests/ci/browser/test_dom_serializer.py tests/ci/browser/test_cross_origin_click.py tests/ci/browser/test_true_cross_origin_click.py`
- `uv run pre-commit run --all-files`
- Browser Use Cloud nested remote-CDP before/after reproduction: 0 -> 2 indexed secure-field inputs
- Browser Use Cloud on Datatrans public showcase: 0 -> 2 indexed hosted inputs on separate CDP targets