### PR TITLE
Stop reusing cached DOM after browser-state timeouts

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -562,7 +562,6 @@ class BrowserSession(BaseModel):
 	_cached_browser_state_summary: Any = PrivateAttr(default=None)
 	_cached_selector_map: dict[int, EnhancedDOMTreeNode] = PrivateAttr(default_factory=dict)
 	_cached_selector_indices: dict[tuple[str, int], int] = PrivateAttr(default_factory=dict)
-	_consecutive_state_refresh_timeouts: int = PrivateAttr(default=0)
 	_downloaded_files: list[str] = PrivateAttr(default_factory=list)  # Track files downloaded during this session
 	_closed_popup_messages: list[str] = PrivateAttr(default_factory=list)  # Store messages from auto-closed JavaScript dialogs
 
@@ -663,7 +662,6 @@ class BrowserSession(BaseModel):
 		self._cached_browser_state_summary = None
 		self._cached_selector_map.clear()
 		self._cached_selector_indices.clear()
-		self._consecutive_state_refresh_timeouts = 0
 		self._downloaded_files.clear()
 
 		self.agent_focus_target_id = None
@@ -1236,7 +1234,6 @@ class BrowserSession(BaseModel):
 		self._cached_browser_state_summary = None
 		self._cached_selector_map.clear()
 		self._cached_selector_indices.clear()
-		self._consecutive_state_refresh_timeouts = 0
 		self.logger.debug('🔄 Cached browser state cleared')
 
 		# Update agent focus if a specific target_id is provided (only for page/tab targets)
@@ -1628,10 +1625,6 @@ class BrowserSession(BaseModel):
 		try:
 			result = await event.event_result(raise_if_none=True, raise_if_any=True)
 		except TimeoutError:
-			self._consecutive_state_refresh_timeouts += 1
-			if self._consecutive_state_refresh_timeouts > 1:
-				raise
-
 			cached_state = self._cached_browser_state_summary
 			if cached_state is None or cached_state.dom_state is None:
 				raise
@@ -1646,7 +1639,6 @@ class BrowserSession(BaseModel):
 				],
 			)
 
-		self._consecutive_state_refresh_timeouts = 0
 		assert result is not None and result.dom_state is not None
 		return result
 

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import re
 import time
-from dataclasses import replace
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, Self, Union, cast, overload
@@ -1618,27 +1617,8 @@ class BrowserSession(BaseModel):
 			),
 		)
 
-		# The handler returns the BrowserStateSummary directly. If the remote
-		# browser stops answering long enough for the whole state event to time
-		# out, preserve agent recovery by returning the last known DOM instead of
-		# skipping the model call repeatedly. Never reuse a stale screenshot.
-		try:
-			result = await event.event_result(raise_if_none=True, raise_if_any=True)
-		except TimeoutError:
-			cached_state = self._cached_browser_state_summary
-			if cached_state is None or cached_state.dom_state is None:
-				raise
-
-			self.logger.warning('Browser state refresh timed out; returning the last known DOM without a screenshot')
-			return replace(
-				cached_state,
-				screenshot=None,
-				browser_errors=[
-					*cached_state.browser_errors,
-					'Browser state refresh timed out; this is the last known page state.',
-				],
-			)
-
+		# The handler returns the BrowserStateSummary directly
+		result = await event.event_result(raise_if_none=True, raise_if_any=True)
 		assert result is not None and result.dom_state is not None
 		return result
 

--- a/tests/ci/browser/test_dom_listener_detection.py
+++ b/tests/ci/browser/test_dom_listener_detection.py
@@ -133,6 +133,3 @@ async def test_state_timeout_returns_cached_dom_without_screenshot(httpserver, b
 	assert recovered_state.screenshot is None
 	assert recovered_state.dom_state is initial_state.dom_state
 	assert recovered_state.browser_errors[-1] == 'Browser state refresh timed out; this is the last known page state.'
-
-	with pytest.raises(TimeoutError):
-		await browser_session.get_browser_state_summary(include_screenshot=True)

--- a/tests/ci/browser/test_dom_listener_detection.py
+++ b/tests/ci/browser/test_dom_listener_detection.py
@@ -111,25 +111,3 @@ async def test_screenshot_timeout_preserves_structural_dom(httpserver, browser_s
 	assert state.screenshot is None
 	assert state.dom_state is not None
 	assert any(node.attributes.get('id') == 'continue' for node in state.dom_state.selector_map.values())
-
-
-async def test_state_timeout_returns_cached_dom_without_screenshot(httpserver, browser_session: BrowserSession, monkeypatch):
-	"""A whole-state timeout should still let the model receive the last known DOM."""
-	httpserver.expect_request('/cached-state').respond_with_data(
-		'<html><body><button id="continue">Continue</button></body></html>',
-		content_type='text/html',
-	)
-	await browser_session.navigate_to(httpserver.url_for('/cached-state'))
-	initial_state = await browser_session.get_browser_state_summary(include_screenshot=False)
-
-	class TimedOutStateEvent:
-		async def event_result(self, **_kwargs):
-			raise TimeoutError
-
-	monkeypatch.setattr(browser_session.event_bus, 'dispatch', lambda _event: TimedOutStateEvent())
-
-	recovered_state = await browser_session.get_browser_state_summary(include_screenshot=True)
-
-	assert recovered_state.screenshot is None
-	assert recovered_state.dom_state is initial_state.dom_state
-	assert recovered_state.browser_errors[-1] == 'Browser state refresh timed out; this is the last known page state.'

--- a/tests/ci/browser/test_dom_listener_detection.py
+++ b/tests/ci/browser/test_dom_listener_detection.py
@@ -111,3 +111,23 @@ async def test_screenshot_timeout_preserves_structural_dom(httpserver, browser_s
 	assert state.screenshot is None
 	assert state.dom_state is not None
 	assert any(node.attributes.get('id') == 'continue' for node in state.dom_state.selector_map.values())
+
+
+async def test_whole_state_timeout_does_not_reuse_cached_actionable_dom(httpserver, browser_session: BrowserSession, monkeypatch):
+	"""A whole-state timeout must not expose selectors from an earlier page state."""
+	httpserver.expect_request('/cached-state').respond_with_data(
+		'<html><body><button id="continue">Continue</button></body></html>',
+		content_type='text/html',
+	)
+	await browser_session.navigate_to(httpserver.url_for('/cached-state'))
+	initial_state = await browser_session.get_browser_state_summary(include_screenshot=False)
+	assert initial_state.dom_state.selector_map
+
+	class TimedOutStateEvent:
+		async def event_result(self, **_kwargs):
+			raise TimeoutError
+
+	monkeypatch.setattr(browser_session.event_bus, 'dispatch', lambda _event: TimedOutStateEvent())
+
+	with pytest.raises(TimeoutError):
+		await browser_session.get_browser_state_summary(include_screenshot=True)


### PR DESCRIPTION
## Summary

- revert only the cached-DOM recovery path added in #5292
- let whole `BrowserStateRequestEvent` timeouts propagate again instead of giving the model stale actionable selectors
- keep the bounded listener fanout, optional AX degradation, and screenshot-only degradation from #5292
- add a regression test proving a cached selector map is not returned after a whole-state timeout

## Root cause

The timeout fallback removed the old screenshot but retained the cached `dom_state` and `_cached_selector_map`. Same-document UI changes can preserve a backend node while changing what that node does, so an old model-visible selector can successfully invoke a new live action.

Deterministic reproduction:

1. Capture `[3]` as a `Preview order` button.
2. Mutate that same live DOM node to `Confirm purchase` with a different handler.
3. Force the whole browser-state event to time out.
4. The current fallback returns cached DOM still describing `[3]` as `Preview order`.
5. Clicking `[3]` succeeds against the live changed node and triggers the `PURCHASED` handler.

The `browser_errors` warning does not make this safe because it is not rendered into the agent browser-state prompt.

## Behavior after this PR

- Whole state-event timeout: propagates; the model call is skipped for that step, matching behavior before the two cached-recovery commits.
- DOM/snapshot build failure handled inside `DOMWatchdog`: still returns the existing minimal empty DOM state.
- Screenshot-only failure: still returns fresh DOM without a screenshot.
- AX-only failure: still returns structural DOM without AX enrichment.

## Validation

- `uv run pytest -q tests/ci/browser/test_dom_listener_detection.py` (4 passed)
- `uv run ruff check browser_use/browser/session.py tests/ci/browser/test_dom_listener_detection.py`
- `uv run pyright browser_use/browser/session.py tests/ci/browser/test_dom_listener_detection.py`
- `uv run pre-commit run --all-files`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop reusing cached DOM on whole browser-state timeouts to prevent stale selectors from triggering wrong actions. Timeouts now propagate, matching pre-#5292 behavior for safer execution.

- **Bug Fixes**
  - Removed cached-DOM recovery on whole-state timeouts; no reuse of `dom_state` or `_cached_selector_map`.
  - Kept partial degradation: screenshot-only and AX-only still return fresh/structural DOM; `DOMWatchdog` still returns minimal empty DOM on snapshot build failure.
  - Added regression test to ensure no cached selector map is exposed after a timeout and that the timeout is raised.

<sup>Written for commit fa12474a87ebc114ac5ed84f6e1ed19fe235e4b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

