### PR TITLE
Release 0.13.7 with Browser Harness 0.1.8

### DIFF
--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -7,6 +7,10 @@ description: "Direct browser control via CDP for web interaction: automation, sc
 
 Direct browser control via CDP. For task-specific edits, use `agent-workspace/agent_helpers.py`. For setup, install, or connection problems, read https://github.com/browser-use/browser-harness/blob/main/install.md.
 
+## When Not to Use
+
+A basic fetch of public information needs no browser. If a plain HTTP request can read it — a public page, an API, docs — use `curl` or your fetch tool, and leave the browser alone. Use browser-use when the task needs interaction (click, type, navigate), the user's logged-in session, JS rendering, or a bot-protected page. If a direct fetch fails or returns a shell page, then escalate to the browser.
+
 Domain skills are off by default. Set `BH_DOMAIN_SKILLS=1` to enable them; see the bottom section.
 
 **If `BH_DOMAIN_SKILLS=1` and the task is site-specific, read every file in the matching `$BH_AGENT_WORKSPACE/domain-skills/<site>/` directory before inventing an approach.**
@@ -32,7 +36,9 @@ If the daemon cannot connect, run diagnostics:
 browser-use --doctor
 ```
 
-If Chrome remote debugging is not enabled, the harness opens:
+If Chrome is not running at all, the harness launches it automatically and retries — no user action needed beyond clicking Allow if a permission popup appears.
+
+If Chrome is running but remote debugging is not enabled, the harness opens:
 
 ```text
 chrome://inspect/#remote-debugging
@@ -154,7 +160,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 ## Gotchas
 
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
-- Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow.
+- Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow. Do not retry in a loop — Chrome pops a fresh dialog for every new connection, and the daemon's single held connection is what makes this a one-time click.
 - Omnibox popups are not real work tabs.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.13.6"
+version = "0.13.7"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [
@@ -46,7 +46,7 @@ dependencies = [
     "markdownify==1.2.2",
     "python-docx==1.2.0",
     "browser-use-sdk==3.4.2",
-    "browser-harness==0.1.6",
+    "browser-harness==0.1.8",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -7,6 +7,10 @@ description: "Direct browser control via CDP for web interaction: automation, sc
 
 Direct browser control via CDP. For task-specific edits, use `agent-workspace/agent_helpers.py`. For setup, install, or connection problems, read https://github.com/browser-use/browser-harness/blob/main/install.md.
 
+## When Not to Use
+
+A basic fetch of public information needs no browser. If a plain HTTP request can read it — a public page, an API, docs — use `curl` or your fetch tool, and leave the browser alone. Use browser-use when the task needs interaction (click, type, navigate), the user's logged-in session, JS rendering, or a bot-protected page. If a direct fetch fails or returns a shell page, then escalate to the browser.
+
 Domain skills are off by default. Set `BH_DOMAIN_SKILLS=1` to enable them; see the bottom section.
 
 **If `BH_DOMAIN_SKILLS=1` and the task is site-specific, read every file in the matching `$BH_AGENT_WORKSPACE/domain-skills/<site>/` directory before inventing an approach.**
@@ -32,7 +36,9 @@ If the daemon cannot connect, run diagnostics:
 browser-use --doctor
 ```
 
-If Chrome remote debugging is not enabled, the harness opens:
+If Chrome is not running at all, the harness launches it automatically and retries — no user action needed beyond clicking Allow if a permission popup appears.
+
+If Chrome is running but remote debugging is not enabled, the harness opens:
 
 ```text
 chrome://inspect/#remote-debugging
@@ -154,7 +160,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 ## Gotchas
 
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
-- Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow.
+- Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow. Do not retry in a loop — Chrome pops a fresh dialog for every new connection, and the daemon's single held connection is what makes this a one-time click.
 - Omnibox popups are not real work tabs.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.


### PR DESCRIPTION
Bumps the CLI's pinned harness to [browser-harness 0.1.8](https://github.com/browser-use/browser-harness/releases/tag/v0.1.8) and bumps browser-use to 0.13.7.

### What 0.1.8 brings to the CLI
- Chrome no longer has to be open first — if no Chromium-family browser is running, the harness launches one, preferring a profile that already has remote debugging enabled and skipping the profile picker.
- Attaches to a reusable tab (about:blank / New Tab / an existing `chrome://inspect` tab) instead of always opening a new one: faster startup, fewer prompts.
- Only closes leftover `chrome://inspect` tabs the harness itself opened — user tabs are left alone.
- Guards against stale DevToolsActivePort files; clearer, actionable setup/permission errors.

### Changes
- `pyproject.toml`: `version` 0.13.6 → 0.13.7, `browser-harness` 0.1.6 → 0.1.8.
- Both `SKILL.md` copies re-synced from browser-harness main via `scripts/sync_browser_harness_skill.py` (picks up the auto-launch note, the "When Not to Use" section, and the Allow-popup retry gotcha).

`scripts/sync_browser_harness_skill.py --check` passes; `tests/ci/test_browser_use_skill_install_docs.py` and `tests/ci/test_browser_use_cli.py` pass (6/6) locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `browser-use` 0.13.7 and pin `browser-harness` 0.1.8 to improve startup and reliability: auto-launch Chrome if none is running, reuse existing tabs for faster attach, avoid closing user tabs, and handle stale DevTools ports more clearly. Synced SKILL docs with a new “When Not to Use” section, auto-launch notes, and guidance to avoid looping on the “Allow remote debugging?” popup.

- **Dependencies**
  - `browser-use` → 0.13.7
  - `browser-harness` → 0.1.8 (was 0.1.6)

<sup>Written for commit 449e9ad5b97ddd63d8915f67a75e2256ec82bd19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

