### PR TITLE
Use UTF-8 for agent file writes

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -115,9 +115,7 @@ class BaseFile(BaseModel, ABC):
 	async def sync_to_disk(self, path: Path) -> None:
 		file_path = path / self.full_name
 		with ThreadPoolExecutor() as executor:
-			await asyncio.get_event_loop().run_in_executor(
-				executor, lambda: file_path.write_text(self.content, encoding='utf-8')
-			)
+			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content, encoding='utf-8'))
 
 	async def write(self, content: str, path: Path) -> None:
 		self.write_file_content(content)

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -110,12 +110,14 @@ class BaseFile(BaseModel, ABC):
 
 	def sync_to_disk_sync(self, path: Path) -> None:
 		file_path = path / self.full_name
-		file_path.write_text(self.content)
+		file_path.write_text(self.content, encoding='utf-8')
 
 	async def sync_to_disk(self, path: Path) -> None:
 		file_path = path / self.full_name
 		with ThreadPoolExecutor() as executor:
-			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content))
+			await asyncio.get_event_loop().run_in_executor(
+				executor, lambda: file_path.write_text(self.content, encoding='utf-8')
+			)
 
 	async def write(self, content: str, path: Path) -> None:
 		self.write_file_content(content)

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -106,7 +106,7 @@ class TestBaseFile:
 		"""Test file sync to disk operations."""
 		with tempfile.TemporaryDirectory() as tmp_dir:
 			tmp_path = Path(tmp_dir)
-			file_obj = MarkdownFile(name='test', content='# Test Content')
+			file_obj = MarkdownFile(name='test', content='# Test Content\nJosé')
 
 			# Test sync to disk
 			await file_obj.sync_to_disk(tmp_path)
@@ -114,7 +114,8 @@ class TestBaseFile:
 			# Verify file was created on disk
 			file_path = tmp_path / 'test.md'
 			assert file_path.exists()
-			assert file_path.read_text() == '# Test Content'
+			assert file_path.read_text(encoding='utf-8') == '# Test Content\nJosé'
+			assert file_path.read_bytes().endswith('José'.encode('utf-8'))
 
 			# Test write operation
 			await file_obj.write('# New Content', tmp_path)

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -115,7 +115,7 @@ class TestBaseFile:
 			file_path = tmp_path / 'test.md'
 			assert file_path.exists()
 			assert file_path.read_text(encoding='utf-8') == '# Test Content\nJosé'
-			assert file_path.read_bytes().endswith('José'.encode('utf-8'))
+			assert file_path.read_bytes().endswith('José'.encode())
 
 			# Test write operation
 			await file_obj.write('# New Content', tmp_path)


### PR DESCRIPTION
## Problem
The agent file system writes text files with Path.write_text() but does not pass an explicit encoding. On machines where the default text encoding is not UTF-8, non-ASCII agent-generated notes can be written inconsistently.

## Before / after
Before, BaseFile.sync_to_disk_sync() and the async sync path used the platform default encoding.

After, both write paths use encoding='utf-8', and the filesystem test now includes a non-ASCII markdown line to verify the bytes are UTF-8.

## Verification
- python -m py_compile browser_use\filesystem\file_system.py tests\ci\infrastructure\test_filesystem.py
- uv run pytest tests\ci\infrastructure\test_filesystem.py::TestBaseFile::test_file_disk_operations -q

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force UTF-8 for all agent file writes (sync and async) to avoid platform defaults and preserve non-ASCII text. Tests write "José", read with UTF-8, and assert raw bytes to confirm UTF-8 encoding.

<sup>Written for commit bb2dd70c86a577fbc4d0507d79d77a14c9b8c37a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

