### PR TITLE
fix: preserve empty accessibility names with explicit None check

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -850,7 +850,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -878,7 +878,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1024,7 +1024,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(


### PR DESCRIPTION
## Fix: Preserve empty accessibility names with explicit None check

### Problem

In `browser_use/dom/views.py`, three locations used an implicit truthiness check to test whether an accessibility name exists:

```python
if self.ax_node and self.ax_node.name:
```

In Python, an empty string `""` evaluates to `False`. When a DOM element explicitly has an empty accessibility name (e.g. `aria-label=""`), this condition fails and the name is silently dropped — assigned `None` instead of the explicit `""`.

This conflates two distinct states:
- **`None`**: the attribute does not exist
- **`""`**: the attribute exists but is intentionally empty

This can cause issues for downstream DOM matching, hashing, and agent interaction logic, since elements with `aria-label=""` would produce different hashes than expected.

### Fix

Replace the implicit truthiness check with an explicit `is not None` check in all three locations:

1. **`EnhancedDOMTreeNode.compute_hash()`** (line ~853) — affects element hashing
2. **`EnhancedDOMTreeNode.compute_stable_hash()`** (line ~881) — affects stable element hashing
3. **`DOMInteractedElement.load_from_enhanced_dom_tree()`** (line ~1027) — affects interacted element serialization

```python
# Before
if self.ax_node and self.ax_node.name:

# After
if self.ax_node and self.ax_node.name is not None:
```

### Testing

The fix is backward-compatible: `None` still produces `None`/empty string as before, but now `""` is correctly preserved.

Fixes #5041

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve empty accessibility names by replacing truthiness checks with explicit is not None in compute_stable_hash, __hash__, and load_from_enhanced_dom_tree. This keeps aria-label='' through hashing and serialization, preventing mismatched DOM hashes and agent interactions (fixes #5041).

<sup>Written for commit a7d7e704d7496c46b8d3ee74ba56ad831d350f76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

