### PR TITLE
Use timezone-aware UTC timestamps

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cache
 from pathlib import Path
 from typing import Any
@@ -248,7 +248,7 @@ class DBStyleEntry(BaseModel):
 
 	id: str = Field(default_factory=lambda: str(uuid4()))
 	default: bool = Field(default=False)
-	created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+	created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
 
 class BrowserProfileEntry(DBStyleEntry):

--- a/examples/apps/news-use/news_monitor.py
+++ b/examples/apps/news-use/news_monitor.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
 from dateutil import parser as dtparser
@@ -219,7 +219,7 @@ def _fmt(ts_raw: str) -> str:
 	try:
 		return dtparser.parse(ts_raw).strftime('%Y-%m-%d %H:%M:%S')
 	except Exception:
-		return datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+		return datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
 
 
 async def run_once(url: str, output_path: str, debug: bool):


### PR DESCRIPTION
## Problem
`datetime.utcnow()` returns a naive datetime and is deprecated for UTC timestamp creation in modern Python. The config entry timestamp and the news monitor fallback timestamp currently use it.

## Before / after
Before, these timestamps were generated from naive UTC datetimes.

After, they use `datetime.now(timezone.utc)`, making the UTC timezone explicit while preserving the existing string-based timestamp behavior.

## Verification
- `python -m compileall browser_use\config.py examples\apps\news-use\news_monitor.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace `datetime.utcnow()` with `datetime.now(timezone.utc)` to make UTC timestamps explicit and avoid naive datetimes. Affects `created_at` in config and the news monitor’s fallback; output format remains unchanged.

<sup>Written for commit 1920141f1f9c336833b2e64f6480375a804a8bdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

