### PR TITLE
fix: preserve explicitly empty accessibility names

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -850,7 +850,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -878,7 +878,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1024,7 +1024,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/browser/test_dom_interacted_element.py
+++ b/tests/ci/browser/test_dom_interacted_element.py
@@ -1,0 +1,75 @@
+from browser_use.dom.views import DOMInteractedElement, EnhancedAXNode, EnhancedDOMTreeNode, NodeType
+
+
+def test_load_from_enhanced_dom_tree_preserves_empty_ax_name():
+	# Setup node with explicit empty string ax_name
+	ax_node = EnhancedAXNode(
+		ax_node_id='1',
+		ignored=False,
+		role='button',
+		name='',  # explicitly empty string
+		description=None,
+		properties=None,
+		child_ids=None,
+	)
+
+	enhanced_node = EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=None,
+	)
+
+	interacted_element = DOMInteractedElement.load_from_enhanced_dom_tree(enhanced_node)
+
+	# Assert ax_name is preserved as empty string, not None
+	assert interacted_element.ax_name == ''
+
+
+def test_load_from_enhanced_dom_tree_handles_none_ax_name():
+	# Setup node with None ax_name
+	ax_node = EnhancedAXNode(
+		ax_node_id='1', ignored=False, role='button', name=None, description=None, properties=None, child_ids=None
+	)
+
+	enhanced_node = EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=None,
+	)
+
+	interacted_element = DOMInteractedElement.load_from_enhanced_dom_tree(enhanced_node)
+
+	# Assert ax_name is None
+	assert interacted_element.ax_name is None


### PR DESCRIPTION
Fixes #5041.

When extracting the accessibility name, the code used an implicit truthiness check. As a result, explicit empty accessibility names were improperly assigned `None`. This fix explicitly checks against `None` to preserve explicitly empty accessibility names (e.g., `aria-label=''`). Tests were added to ensure this behavior is preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5041. Preserve explicitly empty accessibility names (e.g., `aria-label=''`) instead of converting them to None so element hashing and serialization stay correct.

- **Bug Fixes**
  - Replace truthiness checks with `name is not None` in stable hash, `__hash__`, and `load_from_enhanced_dom_tree`.
  - Add tests for empty-string and None `ax_node.name` to lock expected behavior.

<sup>Written for commit cf79107b6ab2c475b109639679f80a4e4d1e9e6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

