### PR TITLE
fix(mcp): prevent screenshot blob from poisoning conversation context

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -207,6 +207,7 @@ class BrowserUseServer:
 		self.active_sessions: dict[str, dict[str, Any]] = {}  # session_id -> session info
 		self.session_timeout_minutes = session_timeout_minutes
 		self._cleanup_task: Any = None
+		self._temp_files: set[str] = set()
 
 		# Setup handlers
 		self._setup_handlers()
@@ -1062,9 +1063,16 @@ class BrowserUseServer:
 			with os.fdopen(fd, 'wb') as fh:
 				fh.write(png_bytes)
 		except Exception:
-			# fd is already consumed by os.fdopen; just remove the empty file.
-			os.unlink(path)
+			try:
+				os.close(fd)
+			except OSError:
+				pass
+			try:
+				os.unlink(path)
+			except OSError:
+				pass
 			raise
+		self._temp_files.add(path)
 		return path
 
 	async def _extract_content(self, query: str, extract_links: bool = False) -> str:
@@ -1299,6 +1307,23 @@ class BrowserUseServer:
 				logger.info(f'Auto-closed expired session {session_id}')
 			except Exception as e:
 				logger.error(f'Error auto-closing session {session_id}: {e}')
+
+		# Also clean up expired temp files (screenshots)
+		expired_files = []
+		for path in self._temp_files:
+			try:
+				if current_time - os.path.getmtime(path) > timeout_seconds:
+					expired_files.append(path)
+			except OSError:
+				# File might already be deleted or inaccessible
+				expired_files.append(path)
+
+		for path in expired_files:
+			try:
+				os.unlink(path)
+			except OSError:
+				pass
+			self._temp_files.discard(path)
 
 	async def _start_cleanup_task(self) -> None:
 		"""Start the background cleanup task."""

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -284,6 +284,11 @@ class BrowserUseServer:
 								'type': 'boolean',
 								'description': 'Whether to include a screenshot of the current page',
 								'default': False,
+							},
+							'save_screenshot_to_file': {
+								'type': 'boolean',
+								'description': 'If include_screenshot is true, saves to a file instead of returning raw data (recommended to avoid context bloat)',
+								'default': False,
 							}
 						},
 					},
@@ -319,13 +324,18 @@ class BrowserUseServer:
 				),
 				types.Tool(
 					name='browser_screenshot',
-					description='Take a screenshot of the current page. Returns viewport metadata as text and the screenshot as an image.',
+					description='Take a screenshot of the current page. By default, saves to a file to prevent context bloat. Set return_image_data to true to get the actual image data.',
 					inputSchema={
 						'type': 'object',
 						'properties': {
 							'full_page': {
 								'type': 'boolean',
 								'description': 'Whether to capture the full scrollable page or just the visible viewport',
+								'default': False,
+							},
+							'return_image_data': {
+								'type': 'boolean',
+								'description': 'If true, returns the raw image data. If false (default), saves to a file and returns the path.',
 								'default': False,
 							},
 						},
@@ -529,8 +539,13 @@ class BrowserUseServer:
 				return await self._type_text(arguments['index'], arguments['text'])
 
 			elif tool_name == 'browser_get_state':
-				state_json, screenshot_b64 = await self._get_browser_state(arguments.get('include_screenshot', False))
+				state_json, screenshot_b64, filepath = await self._get_browser_state(
+					arguments.get('include_screenshot', False),
+					arguments.get('save_screenshot_to_file', False)
+				)
 				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=state_json)]
+				if filepath:
+					content.append(types.TextContent(type='text', text=f"Screenshot saved to: {filepath}"))
 				if screenshot_b64:
 					content.append(types.ImageContent(type='image', data=screenshot_b64, mimeType='image/png'))
 				return content
@@ -539,8 +554,13 @@ class BrowserUseServer:
 				return await self._get_html(arguments.get('selector'))
 
 			elif tool_name == 'browser_screenshot':
-				meta_json, screenshot_b64 = await self._screenshot(arguments.get('full_page', False))
+				meta_json, screenshot_b64, filepath = await self._screenshot(
+					arguments.get('full_page', False),
+					arguments.get('return_image_data', False)
+				)
 				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=meta_json)]
+				if filepath:
+					content.append(types.TextContent(type='text', text=f"Screenshot saved to: {filepath}"))
 				if screenshot_b64:
 					content.append(types.ImageContent(type='image', data=screenshot_b64, mimeType='image/png'))
 				return content
@@ -873,10 +893,10 @@ class BrowserUseServer:
 		else:
 			return f"Typed '{text}' into element {index}"
 
-	async def _get_browser_state(self, include_screenshot: bool = False) -> tuple[str, str | None]:
-		"""Get current browser state. Returns (state_json, screenshot_b64 | None)."""
+	async def _get_browser_state(self, include_screenshot: bool = False, save_screenshot_to_file: bool = False) -> tuple[str, str | None, str | None]:
+		"""Get current browser state. Returns (state_json, screenshot_b64 | None, filepath | None)."""
 		if not self.browser_session:
-			return 'Error: No browser session active', None
+			return 'Error: No browser session active', None, None
 
 		state = await self.browser_session.get_browser_state_summary()
 
@@ -918,8 +938,19 @@ class BrowserUseServer:
 
 		# Return screenshot separately as ImageContent instead of embedding base64 in JSON
 		screenshot_b64 = None
+		filepath = None
 		if include_screenshot and state.screenshot:
-			screenshot_b64 = state.screenshot
+			if save_screenshot_to_file:
+				import base64
+				import tempfile
+				import os
+				fd, path = tempfile.mkstemp(suffix='.png', prefix='browser_use_screenshot_')
+				with os.fdopen(fd, 'wb') as f:
+					f.write(base64.b64decode(state.screenshot))
+				filepath = path
+			else:
+				screenshot_b64 = state.screenshot
+				
 			# Include viewport dimensions in JSON so LLM can map pixels to coordinates
 			if state.page_info:
 				result['screenshot_dimensions'] = {
@@ -927,7 +958,7 @@ class BrowserUseServer:
 					'height': state.page_info.viewport_height,
 				}
 
-		return json.dumps(result, indent=2), screenshot_b64
+		return json.dumps(result, indent=2), screenshot_b64, filepath
 
 	async def _get_html(self, selector: str | None = None) -> str:
 		"""Get raw HTML of the page or a specific element."""
@@ -956,17 +987,28 @@ class BrowserUseServer:
 			return f'No element found for selector: {selector}' if selector else 'Error: Could not get page HTML'
 		return html
 
-	async def _screenshot(self, full_page: bool = False) -> tuple[str, str | None]:
-		"""Take a screenshot. Returns (metadata_json, screenshot_b64 | None)."""
+	async def _screenshot(self, full_page: bool = False, return_image_data: bool = False) -> tuple[str, str | None, str | None]:
+		"""Take a screenshot. Returns (metadata_json, screenshot_b64 | None, filepath | None)."""
 		if not self.browser_session:
-			return 'Error: No browser session active', None
+			return 'Error: No browser session active', None, None
 
 		import base64
+		import tempfile
+		import os
 
 		self._update_session_activity(self.browser_session.id)
-
-		data = await self.browser_session.take_screenshot(full_page=full_page)
-		b64 = base64.b64encode(data).decode()
+		
+		filepath = None
+		b64 = None
+		
+		if not return_image_data:
+			fd, path = tempfile.mkstemp(suffix='.png', prefix='browser_use_screenshot_')
+			os.close(fd)
+			filepath = path
+			data = await self.browser_session.take_screenshot(path=filepath, full_page=full_page)
+		else:
+			data = await self.browser_session.take_screenshot(full_page=full_page)
+			b64 = base64.b64encode(data).decode()
 
 		# Return screenshot separately as ImageContent instead of embedding base64 in JSON
 		state = await self.browser_session.get_browser_state_summary()
@@ -978,7 +1020,7 @@ class BrowserUseServer:
 				'width': state.page_info.viewport_width,
 				'height': state.page_info.viewport_height,
 			}
-		return json.dumps(result), b64
+		return json.dumps(result), b64, filepath
 
 	async def _extract_content(self, query: str, extract_links: bool = False) -> str:
 		"""Extract content from current page."""

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -961,9 +961,9 @@ class BrowserUseServer:
 					'height': state.page_info.viewport_height,
 				}
 			if save_to_file:
-				# Decode the base64 blob and write to a temp file to avoid embedding large
-				# data directly in the MCP tool result, which causes API 400 errors on replay.
-				filepath = self._save_screenshot_to_temp(state.screenshot)
+				# state.screenshot is base64-encoded; decode to raw bytes before writing
+				# to disk to avoid embedding the blob in the MCP tool result (API 400).
+				filepath = self._save_screenshot_to_temp(base64.b64decode(state.screenshot))
 			else:
 				screenshot_b64 = state.screenshot
 
@@ -1024,7 +1024,8 @@ class BrowserUseServer:
 
 		raw_bytes: bytes = await self.browser_session.take_screenshot(full_page=full_page)
 		if save_to_file:
-			filepath = self._save_screenshot_to_temp(base64.b64encode(raw_bytes).decode())
+			# Pass raw bytes directly — no need to encode then immediately decode again.
+			filepath = self._save_screenshot_to_temp(raw_bytes)
 		else:
 			screenshot_b64 = base64.b64encode(raw_bytes).decode()
 
@@ -1039,25 +1040,29 @@ class BrowserUseServer:
 			}
 		return json.dumps(result), screenshot_b64, filepath
 
-	def _save_screenshot_to_temp(self, screenshot_b64: str) -> str:
-		"""Decode a base64 PNG string and write it to a temporary file.
+	def _save_screenshot_to_temp(self, png_bytes: bytes) -> str:
+		"""Write raw PNG bytes to a temporary file and return its path.
 
 		The caller owns the file and is responsible for deleting it when done.
 		The file is created with a descriptive prefix so it is easy to identify
 		in /tmp (or the OS temp dir) during debugging.
 
 		Args:
-			screenshot_b64: Base64-encoded PNG bytes.
+			png_bytes: Raw PNG image bytes to write.
 
 		Returns:
 			Absolute path to the written PNG file.
+
+		Raises:
+			OSError: If the file cannot be created or written. The incomplete
+				temp file is deleted before the exception propagates.
 		"""
 		fd, path = tempfile.mkstemp(suffix='.png', prefix='browser_use_screenshot_')
 		try:
 			with os.fdopen(fd, 'wb') as fh:
-				fh.write(base64.b64decode(screenshot_b64))
+				fh.write(png_bytes)
 		except Exception:
-			os.close(fd)
+			# fd is already consumed by os.fdopen; just remove the empty file.
 			os.unlink(path)
 			raise
 		return path

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -23,8 +23,10 @@ Or as an MCP server in Claude Desktop or other MCP clients:
     }
 """
 
+import base64
 import os
 import sys
+import tempfile
 
 # Set environment variables BEFORE any browser_use imports to prevent early logging
 os.environ['BROWSER_USE_LOGGING_LEVEL'] = 'critical'
@@ -285,11 +287,11 @@ class BrowserUseServer:
 								'description': 'Whether to include a screenshot of the current page',
 								'default': False,
 							},
-							'save_screenshot_to_file': {
+							'save_to_file': {
 								'type': 'boolean',
-								'description': 'If include_screenshot is true, saves to a file instead of returning raw data (recommended to avoid context bloat)',
-								'default': False,
-							}
+								'description': 'When include_screenshot is true, save the image to a temp file and return its path instead of embedding the raw base64 blob. Strongly recommended to avoid API 400 errors from context bloat.',
+								'default': True,
+							},
 						},
 					},
 				),
@@ -324,7 +326,10 @@ class BrowserUseServer:
 				),
 				types.Tool(
 					name='browser_screenshot',
-					description='Take a screenshot of the current page. By default, saves to a file to prevent context bloat. Set return_image_data to true to get the actual image data.',
+					description=(
+						'Take a screenshot of the current page. By default saves to a temp file and returns the '
+						'path, avoiding context bloat. Set save_to_file=false to receive the raw image data instead.'
+					),
 					inputSchema={
 						'type': 'object',
 						'properties': {
@@ -333,10 +338,10 @@ class BrowserUseServer:
 								'description': 'Whether to capture the full scrollable page or just the visible viewport',
 								'default': False,
 							},
-							'return_image_data': {
+							'save_to_file': {
 								'type': 'boolean',
-								'description': 'If true, returns the raw image data. If false (default), saves to a file and returns the path.',
-								'default': False,
+								'description': 'Save the screenshot to a temp file and return its path instead of embedding raw data. Default true to prevent context poisoning.',
+								'default': True,
 							},
 						},
 					},
@@ -540,12 +545,12 @@ class BrowserUseServer:
 
 			elif tool_name == 'browser_get_state':
 				state_json, screenshot_b64, filepath = await self._get_browser_state(
-					arguments.get('include_screenshot', False),
-					arguments.get('save_screenshot_to_file', False)
+					include_screenshot=arguments.get('include_screenshot', False),
+					save_to_file=arguments.get('save_to_file', True),
 				)
 				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=state_json)]
 				if filepath:
-					content.append(types.TextContent(type='text', text=f"Screenshot saved to: {filepath}"))
+					content.append(types.TextContent(type='text', text=f'screenshot saved to: {filepath}'))
 				if screenshot_b64:
 					content.append(types.ImageContent(type='image', data=screenshot_b64, mimeType='image/png'))
 				return content
@@ -555,12 +560,12 @@ class BrowserUseServer:
 
 			elif tool_name == 'browser_screenshot':
 				meta_json, screenshot_b64, filepath = await self._screenshot(
-					arguments.get('full_page', False),
-					arguments.get('return_image_data', False)
+					full_page=arguments.get('full_page', False),
+					save_to_file=arguments.get('save_to_file', True),
 				)
 				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=meta_json)]
 				if filepath:
-					content.append(types.TextContent(type='text', text=f"Screenshot saved to: {filepath}"))
+					content.append(types.TextContent(type='text', text=f'screenshot saved to: {filepath}'))
 				if screenshot_b64:
 					content.append(types.ImageContent(type='image', data=screenshot_b64, mimeType='image/png'))
 				return content
@@ -893,8 +898,18 @@ class BrowserUseServer:
 		else:
 			return f"Typed '{text}' into element {index}"
 
-	async def _get_browser_state(self, include_screenshot: bool = False, save_screenshot_to_file: bool = False) -> tuple[str, str | None, str | None]:
-		"""Get current browser state. Returns (state_json, screenshot_b64 | None, filepath | None)."""
+	async def _get_browser_state(
+		self,
+		include_screenshot: bool = False,
+		save_to_file: bool = True,
+	) -> tuple[str, str | None, str | None]:
+		"""Get current browser state.
+
+		Returns:
+			A 3-tuple of (state_json, screenshot_b64 | None, filepath | None).
+			Exactly one of screenshot_b64 and filepath will be non-None when
+			include_screenshot is True; both are None otherwise.
+		"""
 		if not self.browser_session:
 			return 'Error: No browser session active', None, None
 
@@ -936,27 +951,21 @@ class BrowserUseServer:
 				elem_info['href'] = element.attributes['href']
 			result['interactive_elements'].append(elem_info)
 
-		# Return screenshot separately as ImageContent instead of embedding base64 in JSON
-		screenshot_b64 = None
-		filepath = None
+		screenshot_b64: str | None = None
+		filepath: str | None = None
 		if include_screenshot and state.screenshot:
-			if save_screenshot_to_file:
-				import base64
-				import tempfile
-				import os
-				fd, path = tempfile.mkstemp(suffix='.png', prefix='browser_use_screenshot_')
-				with os.fdopen(fd, 'wb') as f:
-					f.write(base64.b64decode(state.screenshot))
-				filepath = path
-			else:
-				screenshot_b64 = state.screenshot
-				
-			# Include viewport dimensions in JSON so LLM can map pixels to coordinates
+			# Include viewport dimensions so the LLM can map screenshot pixels to coordinates
 			if state.page_info:
 				result['screenshot_dimensions'] = {
 					'width': state.page_info.viewport_width,
 					'height': state.page_info.viewport_height,
 				}
+			if save_to_file:
+				# Decode the base64 blob and write to a temp file to avoid embedding large
+				# data directly in the MCP tool result, which causes API 400 errors on replay.
+				filepath = self._save_screenshot_to_temp(state.screenshot)
+			else:
+				screenshot_b64 = state.screenshot
 
 		return json.dumps(result, indent=2), screenshot_b64, filepath
 
@@ -987,40 +996,71 @@ class BrowserUseServer:
 			return f'No element found for selector: {selector}' if selector else 'Error: Could not get page HTML'
 		return html
 
-	async def _screenshot(self, full_page: bool = False, return_image_data: bool = False) -> tuple[str, str | None, str | None]:
-		"""Take a screenshot. Returns (metadata_json, screenshot_b64 | None, filepath | None)."""
+	async def _screenshot(
+		self,
+		full_page: bool = False,
+		save_to_file: bool = True,
+	) -> tuple[str, str | None, str | None]:
+		"""Take a screenshot of the current page.
+
+		Args:
+			full_page: Capture the full scrollable page instead of only the viewport.
+			save_to_file: When True (default), write the PNG to a temp file and return
+				its path.  When False, encode the bytes as base64 and return the data
+				directly.  Prefer the default to avoid embedding large blobs in the MCP
+				tool result that poison the conversation context.
+
+		Returns:
+			A 3-tuple of (metadata_json, screenshot_b64 | None, filepath | None).
+			Exactly one of screenshot_b64 and filepath will be non-None.
+		"""
 		if not self.browser_session:
 			return 'Error: No browser session active', None, None
 
-		import base64
-		import tempfile
-		import os
-
 		self._update_session_activity(self.browser_session.id)
-		
-		filepath = None
-		b64 = None
-		
-		if not return_image_data:
-			fd, path = tempfile.mkstemp(suffix='.png', prefix='browser_use_screenshot_')
-			os.close(fd)
-			filepath = path
-			data = await self.browser_session.take_screenshot(path=filepath, full_page=full_page)
-		else:
-			data = await self.browser_session.take_screenshot(full_page=full_page)
-			b64 = base64.b64encode(data).decode()
 
-		# Return screenshot separately as ImageContent instead of embedding base64 in JSON
+		screenshot_b64: str | None = None
+		filepath: str | None = None
+
+		raw_bytes: bytes = await self.browser_session.take_screenshot(full_page=full_page)
+		if save_to_file:
+			filepath = self._save_screenshot_to_temp(base64.b64encode(raw_bytes).decode())
+		else:
+			screenshot_b64 = base64.b64encode(raw_bytes).decode()
+
 		state = await self.browser_session.get_browser_state_summary()
 		result: dict[str, Any] = {
-			'size_bytes': len(data),
+			'size_bytes': os.path.getsize(filepath) if filepath else len(raw_bytes),
 		}
 		if state.page_info:
 			result['viewport'] = {
 				'width': state.page_info.viewport_width,
 				'height': state.page_info.viewport_height,
 			}
-		return json.dumps(result), b64, filepath
+		return json.dumps(result), screenshot_b64, filepath
+
+	def _save_screenshot_to_temp(self, screenshot_b64: str) -> str:
+		"""Decode a base64 PNG string and write it to a temporary file.
+
+		The caller owns the file and is responsible for deleting it when done.
+		The file is created with a descriptive prefix so it is easy to identify
+		in /tmp (or the OS temp dir) during debugging.
+
+		Args:
+			screenshot_b64: Base64-encoded PNG bytes.
+
+		Returns:
+			Absolute path to the written PNG file.
+		"""
+		fd, path = tempfile.mkstemp(suffix='.png', prefix='browser_use_screenshot_')
+		try:
+			with os.fdopen(fd, 'wb') as fh:
+				fh.write(base64.b64decode(screenshot_b64))
+		except Exception:
+			os.close(fd)
+			os.unlink(path)
+			raise
+		return path
 
 	async def _extract_content(self, query: str, extract_links: bool = False) -> str:
 		"""Extract content from current page."""

--- a/tests/ci/test_mcp_screenshot_safe_default.py
+++ b/tests/ci/test_mcp_screenshot_safe_default.py
@@ -27,36 +27,36 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _TINY_PNG = (
-    b'\x89PNG\r\n\x1a\n'  # PNG signature
-    b'\x00\x00\x00\rIHDR'  # IHDR chunk length + type
-    b'\x00\x00\x00\x01'    # width = 1
-    b'\x00\x00\x00\x01'    # height = 1
-    b'\x08\x02'            # bit depth = 8, colour type = RGB
-    b'\x00\x00\x00'        # compression, filter, interlace
-    b'\x90wS\xde'          # CRC
-    b'\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N'
-    b'\x00\x00\x00\x00IEND\xaeB`\x82'
+	b'\x89PNG\r\n\x1a\n'  # PNG signature
+	b'\x00\x00\x00\rIHDR'  # IHDR chunk length + type
+	b'\x00\x00\x00\x01'  # width = 1
+	b'\x00\x00\x00\x01'  # height = 1
+	b'\x08\x02'  # bit depth = 8, colour type = RGB
+	b'\x00\x00\x00'  # compression, filter, interlace
+	b'\x90wS\xde'  # CRC
+	b'\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N'
+	b'\x00\x00\x00\x00IEND\xaeB`\x82'
 )
 
 _TINY_PNG_B64 = base64.b64encode(_TINY_PNG).decode()
 
 
 def _make_server():
-    """Return a BrowserUseServer instance with minimal mocking."""
-    # Importing inside the function avoids triggering the MCP SDK at module load
-    # time (it writes to stdout which breaks pytest output capture).
-    with patch('browser_use.mcp.server.MCP_AVAILABLE', True), \
-         patch('browser_use.mcp.server.Server'):
-        from browser_use.mcp.server import BrowserUseServer
-        server = BrowserUseServer.__new__(BrowserUseServer)
-        server.active_sessions = {}
-        server.session_timeout_minutes = 10
-        server._cleanup_task = None
-        server.browser_session = None
-        server.tools = None
-        server.llm = None
-        server.file_system = None
-        return server
+	"""Return a BrowserUseServer instance with minimal mocking."""
+	# Importing inside the function avoids triggering the MCP SDK at module load
+	# time (it writes to stdout which breaks pytest output capture).
+	with patch('browser_use.mcp.server.MCP_AVAILABLE', True), patch('browser_use.mcp.server.Server'):
+		from browser_use.mcp.server import BrowserUseServer
+
+		server = BrowserUseServer.__new__(BrowserUseServer)
+		server.active_sessions = {}
+		server.session_timeout_minutes = 10
+		server._cleanup_task = None
+		server.browser_session = None
+		server.tools = None
+		server.llm = None
+		server.file_system = None
+		return server
 
 
 # ---------------------------------------------------------------------------
@@ -65,69 +65,66 @@ def _make_server():
 
 
 class TestSaveScreenshotToTemp:
-    """Tests for the _save_screenshot_to_temp() helper."""
+	"""Tests for the _save_screenshot_to_temp() helper."""
 
-    def test_writes_raw_bytes_to_temp_file(self):
-        server = _make_server()
-        path = server._save_screenshot_to_temp(_TINY_PNG)
-        try:
-            assert os.path.exists(path)
-            with open(path, 'rb') as fh:
-                assert fh.read() == _TINY_PNG
-        finally:
-            os.unlink(path)
+	def test_writes_raw_bytes_to_temp_file(self):
+		server = _make_server()
+		path = server._save_screenshot_to_temp(_TINY_PNG)
+		try:
+			assert os.path.exists(path)
+			with open(path, 'rb') as fh:
+				assert fh.read() == _TINY_PNG
+		finally:
+			os.unlink(path)
 
-    def test_returned_path_has_png_suffix(self):
-        server = _make_server()
-        path = server._save_screenshot_to_temp(_TINY_PNG)
-        try:
-            assert path.endswith('.png')
-        finally:
-            os.unlink(path)
+	def test_returned_path_has_png_suffix(self):
+		server = _make_server()
+		path = server._save_screenshot_to_temp(_TINY_PNG)
+		try:
+			assert path.endswith('.png')
+		finally:
+			os.unlink(path)
 
-    def test_returned_path_has_descriptive_prefix(self):
-        server = _make_server()
-        path = server._save_screenshot_to_temp(_TINY_PNG)
-        try:
-            assert os.path.basename(path).startswith('browser_use_screenshot_')
-        finally:
-            os.unlink(path)
+	def test_returned_path_has_descriptive_prefix(self):
+		server = _make_server()
+		path = server._save_screenshot_to_temp(_TINY_PNG)
+		try:
+			assert os.path.basename(path).startswith('browser_use_screenshot_')
+		finally:
+			os.unlink(path)
 
-    def test_cleans_up_temp_file_on_write_error(self):
-        """If writing fails the temp file must not be left behind."""
-        server = _make_server()
+	def test_cleans_up_temp_file_on_write_error(self):
+		"""If writing fails the temp file must not be left behind."""
+		server = _make_server()
 
-        original_mkstemp = tempfile.mkstemp
+		original_mkstemp = tempfile.mkstemp
 
-        def fake_mkstemp(**kwargs):
-            fd, path = original_mkstemp(**kwargs)
-            return fd, path
+		def fake_mkstemp(**kwargs):
+			fd, path = original_mkstemp(**kwargs)
+			return fd, path
 
-        created_path = None
+		created_path = None
 
-        def capturing_mkstemp(*args, **kwargs):
-            nonlocal created_path
-            fd, path = original_mkstemp(*args, **kwargs)
-            created_path = path
-            return fd, path
+		def capturing_mkstemp(*args, **kwargs):
+			nonlocal created_path
+			fd, path = original_mkstemp(*args, **kwargs)
+			created_path = path
+			return fd, path
 
-        with patch('tempfile.mkstemp', side_effect=capturing_mkstemp), \
-             patch('os.fdopen', side_effect=OSError('disk full')):
-            with pytest.raises(OSError, match='disk full'):
-                server._save_screenshot_to_temp(_TINY_PNG)
+		with patch('tempfile.mkstemp', side_effect=capturing_mkstemp), patch('os.fdopen', side_effect=OSError('disk full')):
+			with pytest.raises(OSError, match='disk full'):
+				server._save_screenshot_to_temp(_TINY_PNG)
 
-        # The partial temp file must have been removed
-        assert created_path is not None
-        assert not os.path.exists(created_path), (
-            f'Temp file {created_path} was not cleaned up after write failure'
-        )
+		# The partial temp file must have been removed
+		assert created_path is not None
+		assert not os.path.exists(created_path), f'Temp file {created_path} was not cleaned up after write failure'
 
-    def test_accepts_bytes_not_str(self):
-        """Callers must not need to base64-encode before calling the helper."""
-        server = _make_server()
-        # Passing str should raise TypeError, not silently corrupt the file
-        with pytest.raises((TypeError, AttributeError)):
-            server._save_screenshot_to_temp(_TINY_PNG_B64)  # str, not bytes
+	def test_accepts_bytes_not_str(self):
+		"""Callers must not need to base64-encode before calling the helper."""
+		server = _make_server()
+		# Passing str should raise TypeError, not silently corrupt the file
+		with pytest.raises((TypeError, AttributeError)):
+			server._save_screenshot_to_temp(_TINY_PNG_B64)  # type: ignore
 
 
 # ---------------------------------------------------------------------------
@@ -136,109 +133,110 @@ class TestSaveScreenshotToTemp:
 
 
 class TestScreenshotSafeDefault:
-    """Tests for BrowserUseServer._screenshot()."""
+	"""Tests for BrowserUseServer._screenshot()."""
 
-    def _make_server_with_session(self):
-        server = _make_server()
-        mock_session = MagicMock()
-        mock_session.id = 'test-session-id'
-        mock_session.take_screenshot = AsyncMock(return_value=_TINY_PNG)
-        mock_session.get_browser_state_summary = AsyncMock(return_value=MagicMock(page_info=None))
-        server.browser_session = mock_session
-        server.active_sessions = {'test-session-id': {'last_activity': 0}}
-        return server
+	def _make_server_with_session(self):
+		server = _make_server()
+		mock_session = MagicMock()
+		mock_session.id = 'test-session-id'
+		mock_session.take_screenshot = AsyncMock(return_value=_TINY_PNG)
+		mock_session.get_browser_state_summary = AsyncMock(return_value=MagicMock(page_info=None))
+		server.browser_session = mock_session
+		server.active_sessions = {'test-session-id': {'last_activity': 0}}
+		return server
 
-    @pytest.mark.asyncio
-    async def test_default_saves_to_file_not_inline(self):
-        """save_to_file=True (default) must return filepath, not b64 data."""
-        server = self._make_server_with_session()
-        _meta, screenshot_b64, filepath = await server._screenshot()
+	@pytest.mark.asyncio
+	async def test_default_saves_to_file_not_inline(self):
+		"""save_to_file=True (default) must return filepath, not b64 data."""
+		server = self._make_server_with_session()
+		_meta, screenshot_b64, filepath = await server._screenshot()
 
-        assert filepath is not None, 'Expected a file path, got None'
-        assert screenshot_b64 is None, 'Expected no inline b64 data with save_to_file=True'
-        assert os.path.exists(filepath)
-        os.unlink(filepath)
+		assert filepath is not None, 'Expected a file path, got None'
+		assert screenshot_b64 is None, 'Expected no inline b64 data with save_to_file=True'
+		assert os.path.exists(filepath)
+		os.unlink(filepath)
 
-    @pytest.mark.asyncio
-    async def test_default_file_contains_correct_png_bytes(self):
-        server = self._make_server_with_session()
-        _meta, _b64, filepath = await server._screenshot()
+	@pytest.mark.asyncio
+	async def test_default_file_contains_correct_png_bytes(self):
+		server = self._make_server_with_session()
+		_meta, _b64, filepath = await server._screenshot()
 
-        with open(filepath, 'rb') as fh:
-            assert fh.read() == _TINY_PNG
-        os.unlink(filepath)
+		assert filepath is not None
+		with open(filepath, 'rb') as fh:  # noqa: ASYNC230
+			assert fh.read() == _TINY_PNG
+		os.unlink(filepath)
 
-    @pytest.mark.asyncio
-    async def test_inline_mode_returns_b64_not_filepath(self):
-        """save_to_file=False must return inline b64 and no filepath."""
-        server = self._make_server_with_session()
-        _meta, screenshot_b64, filepath = await server._screenshot(save_to_file=False)
+	@pytest.mark.asyncio
+	async def test_inline_mode_returns_b64_not_filepath(self):
+		"""save_to_file=False must return inline b64 and no filepath."""
+		server = self._make_server_with_session()
+		_meta, screenshot_b64, filepath = await server._screenshot(save_to_file=False)
 
-        assert screenshot_b64 is not None, 'Expected inline b64 data'
-        assert filepath is None, 'Expected no filepath in inline mode'
-        assert base64.b64decode(screenshot_b64) == _TINY_PNG
+		assert screenshot_b64 is not None, 'Expected inline b64 data'
+		assert filepath is None, 'Expected no filepath in inline mode'
+		assert base64.b64decode(screenshot_b64) == _TINY_PNG
 
-    @pytest.mark.asyncio
-    async def test_no_redundant_encode_decode_in_save_path(self):
-        """_screenshot must NOT encode raw bytes to b64 only to decode back.
+	@pytest.mark.asyncio
+	async def test_no_redundant_encode_decode_in_save_path(self):
+		"""_screenshot must NOT encode raw bytes to b64 only to decode back.
 
-        Regression guard: previously the code called
-            self._save_screenshot_to_temp(base64.b64encode(raw_bytes).decode())
-        and the helper immediately decoded it back.  Now raw bytes flow
-        straight through.
-        """
-        server = self._make_server_with_session()
-        encode_calls = []
+		Regression guard: previously the code called
+		    self._save_screenshot_to_temp(base64.b64encode(raw_bytes).decode())
+		and the helper immediately decoded it back.  Now raw bytes flow
+		straight through.
+		"""
+		server = self._make_server_with_session()
+		encode_calls = []
 
-        original_b64encode = base64.b64encode
+		original_b64encode = base64.b64encode
 
-        def spy_b64encode(data):
-            encode_calls.append(data)
-            return original_b64encode(data)
+		def spy_b64encode(data):
+			encode_calls.append(data)
+			return original_b64encode(data)
 
-        with patch('base64.b64encode', side_effect=spy_b64encode):
-            _meta, _b64, filepath = await server._screenshot(save_to_file=True)
+		with patch('base64.b64encode', side_effect=spy_b64encode):
+			_meta, _b64, filepath = await server._screenshot(save_to_file=True)
 
-        try:
-            # When saving to file, b64encode must NOT be called at all
-            # (the raw bytes go straight to disk).
-            assert encode_calls == [], (
-                'base64.b64encode should not be called when save_to_file=True; '
-                f'was called {len(encode_calls)} time(s)'
-            )
-        finally:
-            if filepath:
-                os.unlink(filepath)
+		try:
+			# When saving to file, b64encode must NOT be called at all
+			# (the raw bytes go straight to disk).
+			assert encode_calls == [], (
+				f'base64.b64encode should not be called when save_to_file=True; was called {len(encode_calls)} time(s)'
+			)
+		finally:
+			if filepath:
+				os.unlink(filepath)
 
-    @pytest.mark.asyncio
-    async def test_size_bytes_matches_file_on_disk(self):
-        server = self._make_server_with_session()
-        meta_json, _b64, filepath = await server._screenshot(save_to_file=True)
+	@pytest.mark.asyncio
+	async def test_size_bytes_matches_file_on_disk(self):
+		server = self._make_server_with_session()
+		meta_json, _b64, filepath = await server._screenshot(save_to_file=True)
 
-        import json
-        meta = json.loads(meta_json)
-        expected = os.path.getsize(filepath)
-        assert meta['size_bytes'] == expected, (
-            f"size_bytes {meta['size_bytes']} != actual file size {expected}"
-        )
-        os.unlink(filepath)
+		import json
 
-    @pytest.mark.asyncio
-    async def test_size_bytes_matches_raw_length_in_inline_mode(self):
-        server = self._make_server_with_session()
-        meta_json, _b64, _fp = await server._screenshot(save_to_file=False)
+		meta = json.loads(meta_json)
+		assert filepath is not None
+		expected = os.path.getsize(filepath)
+		assert meta['size_bytes'] == expected, f'size_bytes {meta["size_bytes"]} != actual file size {expected}'
+		os.unlink(filepath)
 
-        import json
-        meta = json.loads(meta_json)
-        assert meta['size_bytes'] == len(_TINY_PNG)
+	@pytest.mark.asyncio
+	async def test_size_bytes_matches_raw_length_in_inline_mode(self):
+		server = self._make_server_with_session()
+		meta_json, _b64, _fp = await server._screenshot(save_to_file=False)
 
-    @pytest.mark.asyncio
-    async def test_returns_error_when_no_browser_session(self):
-        server = _make_server()  # no browser_session set
-        meta, b64, fp = await server._screenshot()
-        assert 'Error' in meta
-        assert b64 is None
-        assert fp is None
+		import json
+
+		meta = json.loads(meta_json)
+		assert meta['size_bytes'] == len(_TINY_PNG)
+
+	@pytest.mark.asyncio
+	async def test_returns_error_when_no_browser_session(self):
+		server = _make_server()  # no browser_session set
+		meta, b64, fp = await server._screenshot()
+		assert 'Error' in meta
+		assert b64 is None
+		assert fp is None
 
 
 # ---------------------------------------------------------------------------
@@ -247,87 +245,79 @@ class TestScreenshotSafeDefault:
 
 
 class TestGetBrowserStateScreenshot:
-    """Tests for the screenshot branches inside _get_browser_state()."""
+	"""Tests for the screenshot branches inside _get_browser_state()."""
 
-    def _make_server_with_state(self, has_screenshot: bool = True):
-        server = _make_server()
-        mock_state = MagicMock()
-        mock_state.url = 'https://example.com'
-        mock_state.title = 'Example'
-        mock_state.tabs = []
-        mock_state.page_info = None
-        mock_state.dom_state = MagicMock()
-        mock_state.dom_state.selector_map = {}
-        mock_state.screenshot = _TINY_PNG_B64 if has_screenshot else None
+	def _make_server_with_state(self, has_screenshot: bool = True):
+		server = _make_server()
+		mock_state = MagicMock()
+		mock_state.url = 'https://example.com'
+		mock_state.title = 'Example'
+		mock_state.tabs = []
+		mock_state.page_info = None
+		mock_state.dom_state = MagicMock()
+		mock_state.dom_state.selector_map = {}
+		mock_state.screenshot = _TINY_PNG_B64 if has_screenshot else None
 
-        mock_session = MagicMock()
-        mock_session.get_browser_state_summary = AsyncMock(return_value=mock_state)
-        server.browser_session = mock_session
-        return server
+		mock_session = MagicMock()
+		mock_session.get_browser_state_summary = AsyncMock(return_value=mock_state)
+		server.browser_session = mock_session
+		return server
 
-    @pytest.mark.asyncio
-    async def test_no_screenshot_when_include_false(self):
-        server = self._make_server_with_state()
-        _json, b64, fp = await server._get_browser_state(include_screenshot=False)
-        assert b64 is None
-        assert fp is None
+	@pytest.mark.asyncio
+	async def test_no_screenshot_when_include_false(self):
+		server = self._make_server_with_state()
+		_json, b64, fp = await server._get_browser_state(include_screenshot=False)
+		assert b64 is None
+		assert fp is None
 
-    @pytest.mark.asyncio
-    async def test_save_to_file_true_returns_filepath(self):
-        server = self._make_server_with_state()
-        _json, b64, fp = await server._get_browser_state(
-            include_screenshot=True, save_to_file=True
-        )
-        assert fp is not None
-        assert b64 is None
-        assert os.path.exists(fp)
-        with open(fp, 'rb') as fh:
-            assert fh.read() == _TINY_PNG   # decoded from b64, written as raw bytes
-        os.unlink(fp)
+	@pytest.mark.asyncio
+	async def test_save_to_file_true_returns_filepath(self):
+		server = self._make_server_with_state()
+		_json, b64, fp = await server._get_browser_state(include_screenshot=True, save_to_file=True)
+		assert fp is not None
+		assert b64 is None
+		assert os.path.exists(fp)
+		with open(fp, 'rb') as fh:  # noqa: ASYNC230
+			assert fh.read() == _TINY_PNG  # decoded from b64, written as raw bytes
+		os.unlink(fp)
 
-    @pytest.mark.asyncio
-    async def test_save_to_file_false_returns_inline_b64(self):
-        server = self._make_server_with_state()
-        _json, b64, fp = await server._get_browser_state(
-            include_screenshot=True, save_to_file=False
-        )
-        assert b64 == _TINY_PNG_B64
-        assert fp is None
+	@pytest.mark.asyncio
+	async def test_save_to_file_false_returns_inline_b64(self):
+		server = self._make_server_with_state()
+		_json, b64, fp = await server._get_browser_state(include_screenshot=True, save_to_file=False)
+		assert b64 == _TINY_PNG_B64
+		assert fp is None
 
-    @pytest.mark.asyncio
-    async def test_no_double_decode_in_save_path(self):
-        """_get_browser_state must decode state.screenshot ONCE, not twice.
+	@pytest.mark.asyncio
+	async def test_no_double_decode_in_save_path(self):
+		"""_get_browser_state must decode state.screenshot ONCE, not twice.
 
-        Regression guard for the earlier bug where the helper accepted a b64
-        string and decoded it internally — callers that already had raw bytes
-        would have double-decoded.
-        """
-        server = self._make_server_with_state()
-        decode_calls = []
+		Regression guard for the earlier bug where the helper accepted a b64
+		string and decoded it internally — callers that already had raw bytes
+		would have double-decoded.
+		"""
+		server = self._make_server_with_state()
+		decode_calls = []
 
-        original_b64decode = base64.b64decode
+		original_b64decode = base64.b64decode
 
-        def spy_b64decode(data, **kwargs):
-            decode_calls.append(data)
-            return original_b64decode(data, **kwargs)
+		def spy_b64decode(data, **kwargs):
+			decode_calls.append(data)
+			return original_b64decode(data, **kwargs)
 
-        with patch('base64.b64decode', side_effect=spy_b64decode):
-            _json, _b64, fp = await server._get_browser_state(
-                include_screenshot=True, save_to_file=True
-            )
+		with patch('base64.b64decode', side_effect=spy_b64decode):
+			_json, _b64, fp = await server._get_browser_state(include_screenshot=True, save_to_file=True)
 
-        try:
-            assert len(decode_calls) == 1, (
-                f'base64.b64decode should be called exactly once; called {len(decode_calls)} time(s)'
-            )
-        finally:
-            if fp:
-                os.unlink(fp)
+		try:
+			assert len(decode_calls) == 1, f'base64.b64decode should be called exactly once; called {len(decode_calls)} time(s)'
+		finally:
+			if fp:
+				os.unlink(fp)
 
-    @pytest.mark.asyncio
-    async def test_returns_error_when_no_browser_session(self):
-        server = _make_server()
-        state_json, b64, fp = await server._get_browser_state(include_screenshot=True)
-        assert 'Error' in state_json
-        assert b64 is None
-        assert fp is None
+	@pytest.mark.asyncio
+	async def test_returns_error_when_no_browser_session(self):
+		server = _make_server()
+		state_json, b64, fp = await server._get_browser_state(include_screenshot=True)
+		assert 'Error' in state_json
+		assert b64 is None
+		assert fp is None

--- a/tests/ci/test_mcp_screenshot_safe_default.py
+++ b/tests/ci/test_mcp_screenshot_safe_default.py
@@ -1,0 +1,333 @@
+"""Tests for MCP screenshot context-poisoning fix (Issue #4742).
+
+Bug: screenshot blobs embedded in MCP tool results were stored in the
+conversation history of clients like Claude Code.  On every subsequent
+turn the Anthropic API received the full history (including the blob)
+and rejected it with HTTP 400 "Could not process image", permanently
+bricking the session.
+
+Fix: BrowserUseServer._save_screenshot_to_temp() writes raw PNG bytes
+to a temp file and the tool result carries only the file path as plain
+text.  This is the default behaviour for both browser_screenshot and
+browser_get_state.
+
+All tests below are pure-unit (no browser, no network) and rely only on
+stdlib mocks.
+"""
+
+import base64
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TINY_PNG = (
+    b'\x89PNG\r\n\x1a\n'  # PNG signature
+    b'\x00\x00\x00\rIHDR'  # IHDR chunk length + type
+    b'\x00\x00\x00\x01'    # width = 1
+    b'\x00\x00\x00\x01'    # height = 1
+    b'\x08\x02'            # bit depth = 8, colour type = RGB
+    b'\x00\x00\x00'        # compression, filter, interlace
+    b'\x90wS\xde'          # CRC
+    b'\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00\x00\x01\x01\x00\x05\x18\xd8N'
+    b'\x00\x00\x00\x00IEND\xaeB`\x82'
+)
+
+_TINY_PNG_B64 = base64.b64encode(_TINY_PNG).decode()
+
+
+def _make_server():
+    """Return a BrowserUseServer instance with minimal mocking."""
+    # Importing inside the function avoids triggering the MCP SDK at module load
+    # time (it writes to stdout which breaks pytest output capture).
+    with patch('browser_use.mcp.server.MCP_AVAILABLE', True), \
+         patch('browser_use.mcp.server.Server'):
+        from browser_use.mcp.server import BrowserUseServer
+        server = BrowserUseServer.__new__(BrowserUseServer)
+        server.active_sessions = {}
+        server.session_timeout_minutes = 10
+        server._cleanup_task = None
+        server.browser_session = None
+        server.tools = None
+        server.llm = None
+        server.file_system = None
+        return server
+
+
+# ---------------------------------------------------------------------------
+# _save_screenshot_to_temp
+# ---------------------------------------------------------------------------
+
+
+class TestSaveScreenshotToTemp:
+    """Tests for the _save_screenshot_to_temp() helper."""
+
+    def test_writes_raw_bytes_to_temp_file(self):
+        server = _make_server()
+        path = server._save_screenshot_to_temp(_TINY_PNG)
+        try:
+            assert os.path.exists(path)
+            with open(path, 'rb') as fh:
+                assert fh.read() == _TINY_PNG
+        finally:
+            os.unlink(path)
+
+    def test_returned_path_has_png_suffix(self):
+        server = _make_server()
+        path = server._save_screenshot_to_temp(_TINY_PNG)
+        try:
+            assert path.endswith('.png')
+        finally:
+            os.unlink(path)
+
+    def test_returned_path_has_descriptive_prefix(self):
+        server = _make_server()
+        path = server._save_screenshot_to_temp(_TINY_PNG)
+        try:
+            assert os.path.basename(path).startswith('browser_use_screenshot_')
+        finally:
+            os.unlink(path)
+
+    def test_cleans_up_temp_file_on_write_error(self):
+        """If writing fails the temp file must not be left behind."""
+        server = _make_server()
+
+        original_mkstemp = tempfile.mkstemp
+
+        def fake_mkstemp(**kwargs):
+            fd, path = original_mkstemp(**kwargs)
+            return fd, path
+
+        created_path = None
+
+        def capturing_mkstemp(*args, **kwargs):
+            nonlocal created_path
+            fd, path = original_mkstemp(*args, **kwargs)
+            created_path = path
+            return fd, path
+
+        with patch('tempfile.mkstemp', side_effect=capturing_mkstemp), \
+             patch('os.fdopen', side_effect=OSError('disk full')):
+            with pytest.raises(OSError, match='disk full'):
+                server._save_screenshot_to_temp(_TINY_PNG)
+
+        # The partial temp file must have been removed
+        assert created_path is not None
+        assert not os.path.exists(created_path), (
+            f'Temp file {created_path} was not cleaned up after write failure'
+        )
+
+    def test_accepts_bytes_not_str(self):
+        """Callers must not need to base64-encode before calling the helper."""
+        server = _make_server()
+        # Passing str should raise TypeError, not silently corrupt the file
+        with pytest.raises((TypeError, AttributeError)):
+            server._save_screenshot_to_temp(_TINY_PNG_B64)  # str, not bytes
+
+
+# ---------------------------------------------------------------------------
+# _screenshot() — safe default
+# ---------------------------------------------------------------------------
+
+
+class TestScreenshotSafeDefault:
+    """Tests for BrowserUseServer._screenshot()."""
+
+    def _make_server_with_session(self):
+        server = _make_server()
+        mock_session = MagicMock()
+        mock_session.id = 'test-session-id'
+        mock_session.take_screenshot = AsyncMock(return_value=_TINY_PNG)
+        mock_session.get_browser_state_summary = AsyncMock(return_value=MagicMock(page_info=None))
+        server.browser_session = mock_session
+        server.active_sessions = {'test-session-id': {'last_activity': 0}}
+        return server
+
+    @pytest.mark.asyncio
+    async def test_default_saves_to_file_not_inline(self):
+        """save_to_file=True (default) must return filepath, not b64 data."""
+        server = self._make_server_with_session()
+        _meta, screenshot_b64, filepath = await server._screenshot()
+
+        assert filepath is not None, 'Expected a file path, got None'
+        assert screenshot_b64 is None, 'Expected no inline b64 data with save_to_file=True'
+        assert os.path.exists(filepath)
+        os.unlink(filepath)
+
+    @pytest.mark.asyncio
+    async def test_default_file_contains_correct_png_bytes(self):
+        server = self._make_server_with_session()
+        _meta, _b64, filepath = await server._screenshot()
+
+        with open(filepath, 'rb') as fh:
+            assert fh.read() == _TINY_PNG
+        os.unlink(filepath)
+
+    @pytest.mark.asyncio
+    async def test_inline_mode_returns_b64_not_filepath(self):
+        """save_to_file=False must return inline b64 and no filepath."""
+        server = self._make_server_with_session()
+        _meta, screenshot_b64, filepath = await server._screenshot(save_to_file=False)
+
+        assert screenshot_b64 is not None, 'Expected inline b64 data'
+        assert filepath is None, 'Expected no filepath in inline mode'
+        assert base64.b64decode(screenshot_b64) == _TINY_PNG
+
+    @pytest.mark.asyncio
+    async def test_no_redundant_encode_decode_in_save_path(self):
+        """_screenshot must NOT encode raw bytes to b64 only to decode back.
+
+        Regression guard: previously the code called
+            self._save_screenshot_to_temp(base64.b64encode(raw_bytes).decode())
+        and the helper immediately decoded it back.  Now raw bytes flow
+        straight through.
+        """
+        server = self._make_server_with_session()
+        encode_calls = []
+
+        original_b64encode = base64.b64encode
+
+        def spy_b64encode(data):
+            encode_calls.append(data)
+            return original_b64encode(data)
+
+        with patch('base64.b64encode', side_effect=spy_b64encode):
+            _meta, _b64, filepath = await server._screenshot(save_to_file=True)
+
+        try:
+            # When saving to file, b64encode must NOT be called at all
+            # (the raw bytes go straight to disk).
+            assert encode_calls == [], (
+                'base64.b64encode should not be called when save_to_file=True; '
+                f'was called {len(encode_calls)} time(s)'
+            )
+        finally:
+            if filepath:
+                os.unlink(filepath)
+
+    @pytest.mark.asyncio
+    async def test_size_bytes_matches_file_on_disk(self):
+        server = self._make_server_with_session()
+        meta_json, _b64, filepath = await server._screenshot(save_to_file=True)
+
+        import json
+        meta = json.loads(meta_json)
+        expected = os.path.getsize(filepath)
+        assert meta['size_bytes'] == expected, (
+            f"size_bytes {meta['size_bytes']} != actual file size {expected}"
+        )
+        os.unlink(filepath)
+
+    @pytest.mark.asyncio
+    async def test_size_bytes_matches_raw_length_in_inline_mode(self):
+        server = self._make_server_with_session()
+        meta_json, _b64, _fp = await server._screenshot(save_to_file=False)
+
+        import json
+        meta = json.loads(meta_json)
+        assert meta['size_bytes'] == len(_TINY_PNG)
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_no_browser_session(self):
+        server = _make_server()  # no browser_session set
+        meta, b64, fp = await server._screenshot()
+        assert 'Error' in meta
+        assert b64 is None
+        assert fp is None
+
+
+# ---------------------------------------------------------------------------
+# _get_browser_state() — screenshot path
+# ---------------------------------------------------------------------------
+
+
+class TestGetBrowserStateScreenshot:
+    """Tests for the screenshot branches inside _get_browser_state()."""
+
+    def _make_server_with_state(self, has_screenshot: bool = True):
+        server = _make_server()
+        mock_state = MagicMock()
+        mock_state.url = 'https://example.com'
+        mock_state.title = 'Example'
+        mock_state.tabs = []
+        mock_state.page_info = None
+        mock_state.dom_state = MagicMock()
+        mock_state.dom_state.selector_map = {}
+        mock_state.screenshot = _TINY_PNG_B64 if has_screenshot else None
+
+        mock_session = MagicMock()
+        mock_session.get_browser_state_summary = AsyncMock(return_value=mock_state)
+        server.browser_session = mock_session
+        return server
+
+    @pytest.mark.asyncio
+    async def test_no_screenshot_when_include_false(self):
+        server = self._make_server_with_state()
+        _json, b64, fp = await server._get_browser_state(include_screenshot=False)
+        assert b64 is None
+        assert fp is None
+
+    @pytest.mark.asyncio
+    async def test_save_to_file_true_returns_filepath(self):
+        server = self._make_server_with_state()
+        _json, b64, fp = await server._get_browser_state(
+            include_screenshot=True, save_to_file=True
+        )
+        assert fp is not None
+        assert b64 is None
+        assert os.path.exists(fp)
+        with open(fp, 'rb') as fh:
+            assert fh.read() == _TINY_PNG   # decoded from b64, written as raw bytes
+        os.unlink(fp)
+
+    @pytest.mark.asyncio
+    async def test_save_to_file_false_returns_inline_b64(self):
+        server = self._make_server_with_state()
+        _json, b64, fp = await server._get_browser_state(
+            include_screenshot=True, save_to_file=False
+        )
+        assert b64 == _TINY_PNG_B64
+        assert fp is None
+
+    @pytest.mark.asyncio
+    async def test_no_double_decode_in_save_path(self):
+        """_get_browser_state must decode state.screenshot ONCE, not twice.
+
+        Regression guard for the earlier bug where the helper accepted a b64
+        string and decoded it internally — callers that already had raw bytes
+        would have double-decoded.
+        """
+        server = self._make_server_with_state()
+        decode_calls = []
+
+        original_b64decode = base64.b64decode
+
+        def spy_b64decode(data, **kwargs):
+            decode_calls.append(data)
+            return original_b64decode(data, **kwargs)
+
+        with patch('base64.b64decode', side_effect=spy_b64decode):
+            _json, _b64, fp = await server._get_browser_state(
+                include_screenshot=True, save_to_file=True
+            )
+
+        try:
+            assert len(decode_calls) == 1, (
+                f'base64.b64decode should be called exactly once; called {len(decode_calls)} time(s)'
+            )
+        finally:
+            if fp:
+                os.unlink(fp)
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_no_browser_session(self):
+        server = _make_server()
+        state_json, b64, fp = await server._get_browser_state(include_screenshot=True)
+        assert 'Error' in state_json
+        assert b64 is None
+        assert fp is None

--- a/tests/ci/test_mcp_screenshot_safe_default.py
+++ b/tests/ci/test_mcp_screenshot_safe_default.py
@@ -56,6 +56,7 @@ def _make_server():
 		server.tools = None
 		server.llm = None
 		server.file_system = None
+		server._temp_files = set()
 		return server
 
 


### PR DESCRIPTION
## Fixes

Closes #4742

---

## The Problem

When using browser-use as an MCP server with a client like Claude Code, any tool call that triggered a screenshot (`browser_screenshot`, `browser_get_state` with `include_screenshot: true`) embedded the raw base64-encoded PNG **directly into the MCP tool result** as an `ImageContent` blob.

MCP clients re-send the full conversation history on every turn. The Anthropic API rejected the oversized, re-serialised image blob with:

```
HTTP 400 - Could not process image
```

This error persisted on **every subsequent message**, permanently bricking the session. The only escape was starting a brand-new Claude Code session.

---

## High-Level Fix

**Instead of returning the screenshot as an inline blob, write it to a temp file and return the file path as plain text.**

The MCP tool result now contains a `TextContent` string like:

```
screenshot saved to: /tmp/browser_use_screenshot_abc123.png
```

No image bytes ever touch the conversation history. The API 400 cannot occur.

Both affected tools are fixed:
- `browser_screenshot`
- `browser_get_state` (when `include_screenshot: true`)

Clients that genuinely need the raw image data can opt in with `save_to_file: false`.

---

## Detailed Changes

### `browser_use/mcp/server.py`

#### New helper: `_save_screenshot_to_temp(png_bytes: bytes) -> str`

A single, shared helper that:
1. Calls `tempfile.mkstemp(suffix='.png', prefix='browser_use_screenshot_')` to create a uniquely named temp file
2. Writes the raw PNG bytes to disk
3. Returns the absolute path
4. On write failure, removes the incomplete file before re-raising — no resource leaks

Both `_screenshot` and `_get_browser_state` call this helper, eliminating the previously duplicated logic.

#### `_screenshot(full_page, save_to_file=True)`

| Before | After |
|---|---|
| Always returned `ImageContent` blob | Returns file path (default) or blob (opt-in) |
| `take_screenshot()` bytes encoded to b64 and returned inline | Raw bytes written directly to disk |
| `size_bytes: len(data)` would crash if `data` is `None` | `size_bytes: os.path.getsize(filepath)` — always correct |
| `import base64` inside method body | Import at top of module (PEP 8) |

#### `_get_browser_state(include_screenshot, save_to_file=True)`

| Before | After |
|---|---|
| Always returned `ImageContent` blob | Returns file path (default) or blob (opt-in) |
| `screenshot_dimensions` only added in inline branch | Added unconditionally when `include_screenshot=True` |
| Inline `import base64, tempfile, os` | Imports at top of module |

#### Tool schema changes

Both tools now expose a `save_to_file` parameter defaulting to `true`:

```json
"save_to_file": {
  "type": "boolean",
  "description": "Save the screenshot to a temp file and return its path instead of embedding raw data. Default true to prevent context poisoning.",
  "default": true
}
```

The default is `true`, so existing integrations are protected without any configuration change.

---

## Tests

**File:** `tests/ci/test_mcp_screenshot_safe_default.py`
**17 unit tests — no browser, no network required (runs in ~1 s)**

```
TestSaveScreenshotToTemp (5 tests)
  test_writes_raw_bytes_to_temp_file
  test_returned_path_has_png_suffix
  test_returned_path_has_descriptive_prefix
  test_cleans_up_temp_file_on_write_error
  test_accepts_bytes_not_str

TestScreenshotSafeDefault (7 tests)
  test_default_saves_to_file_not_inline
  test_default_file_contains_correct_png_bytes
  test_inline_mode_returns_b64_not_filepath
  test_no_redundant_encode_decode_in_save_path   <- regression guard
  test_size_bytes_matches_file_on_disk
  test_size_bytes_matches_raw_length_in_inline_mode
  test_returns_error_when_no_browser_session

TestGetBrowserStateScreenshot (5 tests)
  test_no_screenshot_when_include_false
  test_save_to_file_true_returns_filepath
  test_save_to_file_false_returns_inline_b64
  test_no_double_decode_in_save_path             <- regression guard
  test_returns_error_when_no_browser_session
```

Two regression guards are worth calling out:
- **`test_no_redundant_encode_decode_in_save_path`** spies on `base64.b64encode` and asserts it is never called when `save_to_file=True`, catching any future regression where the encode-then-immediately-decode round-trip is reintroduced.
- **`test_no_double_decode_in_save_path`** asserts `base64.b64decode` is called exactly once in `_get_browser_state`, preventing a double-decode if the `state.screenshot` format ever changes.

---

## Scope Note

This PR fixes the issue as reported — the MCP server code path. The agent-loop path (`browser_use/tools/service.py` → `ActionResult.images`) can also embed screenshots into LLM context but is a separate concern and is not touched here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents MCP screenshot blobs from being embedded in tool results by saving PNGs to a temp file and returning the file path as text, stopping oversized history and Anthropic 400 errors. Adds automatic cleanup of temp screenshots to avoid leaks.

- **Bug Fixes**
  - `browser_screenshot` and `browser_get_state` now default to saving screenshots to a temp `.png` and returning “screenshot saved to: <path>” as text; no inline image bytes in conversation.
  - Added `save_to_file` (default `true`) so clients can opt into inline base64 only when needed.
  - Always include `screenshot_dimensions` when a screenshot is requested; fix `size_bytes` accuracy; remove redundant base64 encode/decode; shared `_save_screenshot_to_temp` helper.
  - Track created temp files and auto-delete them in the periodic cleanup loop; defensively close/unlink files on write errors to avoid leaks.
  - Resolved `pyright` and `ruff` errors in MCP tests to keep CI green.

<sup>Written for commit 7ad36b8d9495c4f9dabf27618b79c9c17e936a71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

