### PR TITLE
fix(skill): honor explicit browser-use requests

### DIFF
--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -9,6 +9,8 @@ Direct browser control via CDP. For task-specific edits, use `agent-workspace/ag
 
 ## When Not to Use
 
+If the user explicitly asks you to use `browser-use` or a browser, use it; this section only governs tool choice when the user did not specify one.
+
 A basic fetch of public information needs no browser. If a plain HTTP request can read it — a public page, an API, docs — use `curl` or your fetch tool, and leave the browser alone. Use browser-use when the task needs interaction (click, type, navigate), the user's logged-in session, JS rendering, or a bot-protected page. If a direct fetch fails or returns a shell page, then escalate to the browser.
 
 Domain skills are off by default. Set `BH_DOMAIN_SKILLS=1` to enable them; see the bottom section.

--- a/browser_use/skills/browser_use.py
+++ b/browser_use/skills/browser_use.py
@@ -6,6 +6,11 @@ import re
 from importlib import resources
 from pathlib import Path
 
+EXPLICIT_REQUEST_GUIDANCE = (
+	'If the user explicitly asks you to use `browser-use` or a browser, use it; '
+	'this section only governs tool choice when the user did not specify one.'
+)
+
 
 def as_browser_use_skill(text: str) -> str:
 	"""Expose the Browser Harness skill under the Browser Use skill identity."""
@@ -44,6 +49,13 @@ def as_browser_use_skill(text: str) -> str:
 	# Rebrand every mention except repo URLs (github.com/browser-use/browser-harness/...)
 	body = re.sub(r'(?<!/)browser-harness', 'browser-use', body)
 	body = body.replace('Browser Harness', 'Browser Use')
+	when_not_to_use_heading = '## When Not to Use\n'
+	if EXPLICIT_REQUEST_GUIDANCE not in body and when_not_to_use_heading in body:
+		body = body.replace(
+			when_not_to_use_heading,
+			f'{when_not_to_use_heading}\n{EXPLICIT_REQUEST_GUIDANCE}\n',
+			1,
+		)
 	frontmatter_text = '\n'.join(lines)
 	return f'---\n{frontmatter_text}\n---\n{body}'
 

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -9,6 +9,8 @@ Direct browser control via CDP. For task-specific edits, use `agent-workspace/ag
 
 ## When Not to Use
 
+If the user explicitly asks you to use `browser-use` or a browser, use it; this section only governs tool choice when the user did not specify one.
+
 A basic fetch of public information needs no browser. If a plain HTTP request can read it — a public page, an API, docs — use `curl` or your fetch tool, and leave the browser alone. Use browser-use when the task needs interaction (click, type, navigate), the user's logged-in session, JS rendering, or a bot-protected page. If a direct fetch fails or returns a shell page, then escalate to the browser.
 
 Domain skills are off by default. Set `BH_DOMAIN_SKILLS=1` to enable them; see the bottom section.

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from browser_use.skills.browser_use import as_browser_use_skill
+
 ROOT = Path(__file__).resolve().parents[2]
 BROWSER_USE_REPO_SKILL_URL = 'https://raw.githubusercontent.com/browser-use/browser-use/main/skills/browser-use/SKILL.md'
 EXPECTED_SKILL_INSTALL_PATHS = (
@@ -14,6 +16,20 @@ EXPECTED_SKILL_INSTALL_PATHS = (
 	Path('.gemini') / 'skills' / 'browser-use' / 'SKILL.md',
 	Path('.config') / 'opencode' / 'skills' / 'browser-use' / 'SKILL.md',
 )
+
+
+def test_browser_use_skill_copies_are_synchronized_and_honor_explicit_requests():
+	repository_skill = (ROOT / 'skills' / 'browser-use' / 'SKILL.md').read_text(encoding='utf-8')
+	packaged_skill = (ROOT / 'browser_use' / 'skills' / 'browser-use' / 'SKILL.md').read_text(encoding='utf-8')
+	explicit_request_guidance = (
+		'If the user explicitly asks you to use `browser-use` or a browser, use it; '
+		'this section only governs tool choice when the user did not specify one.'
+	)
+
+	assert repository_skill == packaged_skill
+	assert explicit_request_guidance in repository_skill
+	assert explicit_request_guidance in packaged_skill
+	assert as_browser_use_skill(packaged_skill).count(explicit_request_guidance) == 1
 
 
 def _fake_browser_harness_tools(tmp_path: Path, skill_text: str) -> Path:
@@ -57,7 +73,10 @@ def test_docs_install_browser_use_skill_from_package_alias():
 
 
 def test_browser_use_cli_installs_browser_harness_package_skill(tmp_path):
-	bin_dir = _fake_browser_harness_tools(tmp_path, '---\nname: browser-harness\n---\n\n# Browser Harness\n')
+	bin_dir = _fake_browser_harness_tools(
+		tmp_path,
+		'---\nname: browser-harness\n---\n\n# Browser Harness\n\n## When Not to Use\n\nUse curl for public pages.\n',
+	)
 
 	home = tmp_path / 'home'
 	for stale in (home / path for path in EXPECTED_SKILL_INSTALL_PATHS):
@@ -87,7 +106,11 @@ def test_browser_use_cli_installs_browser_harness_package_skill(tmp_path):
 		'name: browser-use\n'
 		'description: "Direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/app work."\n'
 		'---\n\n'
-		'# Browser Use\n'
+		'# Browser Use\n\n'
+		'## When Not to Use\n\n'
+		'If the user explicitly asks you to use `browser-use` or a browser, use it; '
+		'this section only governs tool choice when the user did not specify one.\n\n'
+		'Use curl for public pages.\n'
 	)
 	for installed in (home / path for path in EXPECTED_SKILL_INSTALL_PATHS):
 		assert installed.read_text(encoding='utf-8') == expected


### PR DESCRIPTION
## Summary

- Add one sentence at the top of the packaged skill's "When Not to Use" section, so an explicit user request for `browser-use` is always honored.
- Inject the same sentence in `browser_use/skills/browser_use.py`, so regenerated skills keep it.
- Assert the guidance in `tests/ci/test_browser_use_skill_install_docs.py`.

## Why

The "When Not to Use" section opens with:

```text
A basic fetch of public information needs no browser. If a plain HTTP request can read it — a public page, an API, docs — use `curl` or your fetch tool, and leave the browser alone.
```

It has no exemption for a user who explicitly asked for browser-use, and agents follow it literally. In our trials, an agent given "Hey, can you use the browser-use command to visit https://example.com and tell me the page heading and the sentence below it?" read the skill, fetched with curl, and told the user:

> One note: I used `curl` rather than `browser-use`. The browser-use skill's own guidance says to skip the browser when a plain HTTP request can read a public page, and example.com is static HTML with no JS. Say the word if you want me to actually drive the browser for it — e.g. to grab a screenshot.

This change adds one sentence above that paragraph:

```text
If the user explicitly asks you to use `browser-use` or a browser, use it; this section only governs tool choice when the user did not specify one.
```

With it, the same model on the identical prompt drove the page through browser-use:

```text
browser-use <<'PY'
new_tab("https://example.com")
print(page_info())
PY
browser-use <<'PY'
print(js("document.querySelector('h1').innerText + ' | ' + document.querySelector('p').innerText"))
PY
```

## Validation

- `tests/ci/test_browser_use_skill_install_docs.py` passes with the new assertion (4 passed).
- Four AI coding agents ran the prompt above in clean containers, against the current skill and against this change. Requested-tool compliance went from 3 of 4 to 4 of 4; all eight answers were correct. All eight sessions: [full transcripts](https://gist.github.com/sshkeda/b09ce41c48ba6a30cbc149edd9c89174).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure explicit user requests to use `browser-use` are honored, even when a simple fetch would work. This improves requested-tool compliance and reduces surprise behavior.

- **Bug Fixes**
  - Added a clear sentence to the “When Not to Use” section in both skill docs so explicit `browser-use` requests take priority.
  - Updated `browser_use/skills/browser_use.py` to inject that sentence during skill generation and ensure it appears only once.
  - Extended tests to verify both skill copies stay in sync and that CLI-installed skills include the guidance.

<sup>Written for commit 8962097041f53f86e7aa2b08000051e879697a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

