### PR TITLE
fix: migrate uv dev-dependencies to dependency-groups and normalize test localhost bind

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,17 +213,8 @@ log_level = "DEBUG"
 [tool.hatch.metadata]
 allow-direct-references = true
 
-[tool.uv]
-# required-environments = [
-#     "sys_platform == 'darwin' and platform_machine == 'arm64'",
-#     "sys_platform == 'darwin' and platform_machine == 'x86_64'",
-#     "sys_platform == 'linux' and platform_machine == 'x86_64'",
-#     "sys_platform == 'linux' and platform_machine == 'aarch64'",
-#     # "sys_platform == 'linux' and platform_machine == 'arm64'",  # no pytorch wheels available yet
-#     "sys_platform == 'win32' and platform_machine == 'x86_64'",
-#     # "sys_platform == 'win32' and platform_machine == 'arm64'",  # no pytorch wheels available yet
-# ]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff==0.14.14",
     "tokencost==0.1.26",
     "build==1.4.0",

--- a/tests/ci/models/test_llm_browseruse.py
+++ b/tests/ci/models/test_llm_browseruse.py
@@ -77,7 +77,7 @@ async def test_provider_prefixed_model_forwarded_in_payload(httpserver):
 	chat = ChatBrowserUse(
 		model='anthropic/claude-sonnet-4-6',
 		api_key=TEST_API_KEY,
-		base_url=httpserver.url_for('/').rstrip('/'),
+		base_url=httpserver.url_for('/').rstrip('/').replace('localhost', '127.0.0.1'),
 	)
 	result = await chat.ainvoke([UserMessage(content='hi')])
 


### PR DESCRIPTION
### Summary
This PR fixes a `tool.uv.dev-dependencies` deprecation warning and normalizes unit test `localhost` resolution for the `httpserver` mock endpoint in `test_llm_browseruse.py`.

### Key Changes
1. **PEP 735 Dependency Groups Migration**:
   - Migrated `[tool.uv.dev-dependencies]` in `pyproject.toml` to `[dependency-groups] dev = [...]` to eliminate the deprecation warning emitted during `uv` invocation.

2. **Unit Test Localhost Resolution Normalization**:
   - Updated `test_provider_prefixed_model_forwarded_in_payload` in `tests/ci/models/test_llm_browseruse.py` to replace `localhost` with `127.0.0.1` when resolving `httpserver.url_for('/')`. This prevents IPv6/IPv4 resolution mismatch on macOS causing 503 Service Unavailable errors and reduces test execution time from >40s timeout to ~0.1s.

### Validation
- `uv run ruff check .` -> All checks passed!
- `uv run pyright` -> 0 errors, 0 warnings
- `uv run pytest tests/ci/models/test_llm_browseruse.py` -> 20 passed, 1 skipped in 0.62s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `uv` dev dependencies to PEP 735 dependency groups to remove deprecation warnings, and fixed a test URL bind to avoid IPv6 issues and timeouts on macOS.

- **Dependencies**
  - Replaced `[tool.uv.dev-dependencies]` with `[dependency-groups] dev = [...]` in `pyproject.toml` to align with PEP 735 and silence `uv` warnings.

- **Bug Fixes**
  - In `tests/ci/models/test_llm_browseruse.py`, force `httpserver` base URL to `127.0.0.1` instead of `localhost` to prevent IPv6/IPv4 mismatch and 503s, cutting test timeouts.

<sup>Written for commit 98d4a9c63f6a3e033598099eabbacc850b5bff1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

