### PR TITLE
fix(tools): restore SearchGoogleAction back-compat alias

### DIFF
--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -54,7 +54,7 @@ class SearchAction(BaseModel):
 
 
 # Backward compatibility alias
-SearchAction = SearchAction
+SearchGoogleAction = SearchAction
 
 
 class NavigateAction(BaseModel):

--- a/tests/ci/infrastructure/test_registry_core.py
+++ b/tests/ci/infrastructure/test_registry_core.py
@@ -511,6 +511,13 @@ class TestExistingToolsActions:
 		assert result3.extracted_content is not None
 		assert 'Input text: test input at index: 5' in result3.extracted_content
 
+	async def test_renamed_action_models_keep_old_names_importable(self):
+		"""Renamed action params models must stay importable under their pre-rename names."""
+		from browser_use.tools.views import GoToUrlAction, NavigateAction, SearchAction, SearchGoogleAction
+
+		assert SearchGoogleAction is SearchAction
+		assert GoToUrlAction is NavigateAction
+
 	async def test_pydantic_vs_individual_params_consistency(self, registry, browser_session):
 		"""Test that pydantic and individual parameter patterns produce consistent results"""
 


### PR DESCRIPTION
## What

`browser_use/tools/views.py:57` is a no-op self-assignment where a back-compat alias was intended:

```python
class SearchAction(BaseModel):
	query: str
	engine: str = Field(default='duckduckgo', ...)


# Backward compatibility alias
SearchAction = SearchAction        # <- assigns the class to itself
```

So `SearchGoogleAction` — the name this model had through 0.7.x — is not actually exported, and has been unimportable since `SearchAction` landed in 0.9.0.

The alias two blocks further down does it right, which is what makes the intent unambiguous:

```python
# Backward compatibility alias
GoToUrlAction = NavigateAction
```

And `tests/ci/infrastructure/test_registry_core.py:499` still carries `# Test SearchGoogleAction` above the search assertion — the rename happened, the comment didn't.

## Verification

The rename, traced through published wheels (`class Search*` / `Search* = ...` per version):

| version | `browser_use/{controller,tools}/views.py` |
|---|---|
| 0.5.0 | `class SearchGoogleAction` |
| 0.7.0 | `class SearchGoogleAction` |
| 0.9.0 | `class SearchAction`, `SearchAction = SearchAction`, `GoToUrlAction = NavigateAction` |
| 0.11.4 | same as 0.9.0 |
| this commit's parent (0.13.7) | same as 0.9.0 |

So `SearchGoogleAction` → `SearchAction` happened between 0.7.0 and 0.9.0, and the alias meant to preserve the old name has never worked.

On `main`:

```python
>>> from browser_use.tools.views import SearchAction, GoToUrlAction, NavigateAction
>>> GoToUrlAction is NavigateAction
True
>>> from browser_use.tools.views import SearchGoogleAction
ImportError: cannot import name 'SearchGoogleAction' from 'browser_use.tools.views'
```

With this PR both aliases resolve.

## Tests

Added `TestExistingToolsActions::test_renamed_action_models_keep_old_names_importable` to the existing back-compat test class, covering both aliases so the next rename can't silently break one:

```
$ uv run pytest tests/ci/infrastructure/test_registry_core.py
18 passed in 42.58s
```

(17 on `main`; the new test is the 18th.)

Control experiment — revert only `views.py`, keep the test:

```
$ git stash push -- browser_use/tools/views.py
$ uv run pytest tests/ci/infrastructure/test_registry_core.py -k renamed_action
E   ImportError: cannot import name 'SearchGoogleAction' from 'browser_use.tools.views'
FAILED ...::test_renamed_action_models_keep_old_names_importable
1 failed, 17 deselected
```

`ruff check` (0.14.14, the version pinned in `pyproject.toml`) passes on both files.

One deliberate scoping choice: I did **not** touch the stale `# Test SearchGoogleAction` comment in the test file or the other `PLW0127` self-assignment findings in the tree — happy to fold either in if you'd prefer.

---

*Disclosure: I used an AI coding assistant (Claude Code) while writing this. Every result above — the wheel-by-wheel table, the ImportError, the test counts, the control experiment — is real output from my machine that I verified, not predicted.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `SearchGoogleAction` back-compat alias to `SearchAction` in `browser_use.tools.views`, fixing the ImportError for code importing the old name. Adds a regression test to ensure `SearchGoogleAction` and `GoToUrlAction` remain valid aliases.

<sup>Written for commit f7d8b342725049792a2d86a6e112a3c495f0d12b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

