### PR TITLE
fix: exclude cached tokens from new_prompt_tokens

### DIFF
--- a/browser_use/tokens/service.py
+++ b/browser_use/tokens/service.py
@@ -244,7 +244,7 @@ class TokenCost:
 			)
 
 		return TokenCostCalculated(
-			new_prompt_tokens=usage.prompt_tokens,
+			new_prompt_tokens=uncached_prompt_tokens,
 			new_prompt_cost=uncached_prompt_tokens * (data.input_cost_per_token or 0) * pricing_multiplier,
 			# Cached tokens
 			prompt_read_cached_tokens=usage.prompt_cached_tokens,

--- a/tests/ci/test_token_cost_breakdown.py
+++ b/tests/ci/test_token_cost_breakdown.py
@@ -1,0 +1,91 @@
+import pytest
+
+from browser_use.llm.views import ChatInvokeUsage
+from browser_use.tokens.service import TokenCost
+from browser_use.tokens.views import ModelPricing
+
+INPUT_COST = 0.10 / 1_000_000
+OUTPUT_COST = 0.20 / 1_000_000
+CACHE_READ_COST = 0.02 / 1_000_000
+
+
+def _usage(prompt_tokens: int, cached: int | None, completion_tokens: int = 40) -> ChatInvokeUsage:
+	return ChatInvokeUsage(
+		prompt_tokens=prompt_tokens,
+		prompt_cached_tokens=cached,
+		prompt_cache_creation_tokens=None,
+		prompt_image_tokens=None,
+		completion_tokens=completion_tokens,
+		total_tokens=prompt_tokens + completion_tokens,
+	)
+
+
+@pytest.fixture
+def token_cost(monkeypatch: pytest.MonkeyPatch) -> TokenCost:
+	async def fake_pricing(model_name: str) -> ModelPricing:
+		return ModelPricing(
+			model=model_name,
+			input_cost_per_token=INPUT_COST,
+			output_cost_per_token=OUTPUT_COST,
+			cache_read_input_token_cost=CACHE_READ_COST,
+			cache_creation_input_token_cost=None,
+			max_tokens=None,
+			max_input_tokens=None,
+			max_output_tokens=None,
+		)
+
+	monkeypatch.setattr('browser_use.tokens.service.get_openrouter_model_pricing', fake_pricing)
+	cost = TokenCost(include_cost=True)
+	cost._initialized = True
+	cost._pricing_data = {}
+	return cost
+
+
+async def test_new_prompt_tokens_excludes_cached_tokens(token_cost: TokenCost) -> None:
+	"""new_prompt_tokens is the uncached remainder, so the breakdown sums back to prompt_tokens.
+
+	ChatInvokeUsage.prompt_tokens already includes the cached tokens, and
+	prompt_read_cached_tokens reports them separately. Reporting the full
+	prompt_tokens as "new" counted the cached tokens twice.
+	"""
+	usage = _usage(prompt_tokens=5000, cached=4900)
+
+	result = await token_cost.calculate_cost('deepseek/deepseek-v4-flash', usage)
+
+	assert result is not None
+	assert result.new_prompt_tokens == 100
+	assert result.prompt_read_cached_tokens == 4900
+	assert result.new_prompt_tokens + (result.prompt_read_cached_tokens or 0) == usage.prompt_tokens
+
+
+async def test_new_prompt_tokens_matches_its_own_cost(token_cost: TokenCost) -> None:
+	"""new_prompt_cost is charged on new_prompt_tokens at the input rate."""
+	usage = _usage(prompt_tokens=5000, cached=4900)
+
+	result = await token_cost.calculate_cost('deepseek/deepseek-v4-flash', usage)
+
+	assert result is not None
+	assert result.new_prompt_cost == pytest.approx(result.new_prompt_tokens * INPUT_COST)
+	assert result.prompt_read_cached_cost == pytest.approx(4900 * CACHE_READ_COST)
+
+
+async def test_uncached_request_is_unchanged(token_cost: TokenCost) -> None:
+	"""With no cache hit every prompt token is new."""
+	usage = _usage(prompt_tokens=5000, cached=None)
+
+	result = await token_cost.calculate_cost('deepseek/deepseek-v4-flash', usage)
+
+	assert result is not None
+	assert result.new_prompt_tokens == 5000
+	assert result.new_prompt_cost == pytest.approx(5000 * INPUT_COST)
+
+
+async def test_fully_cached_request_reports_no_new_tokens(token_cost: TokenCost) -> None:
+	"""A fully cached prompt bills nothing at the input rate."""
+	usage = _usage(prompt_tokens=5000, cached=5000)
+
+	result = await token_cost.calculate_cost('deepseek/deepseek-v4-flash', usage)
+
+	assert result is not None
+	assert result.new_prompt_tokens == 0
+	assert result.new_prompt_cost == pytest.approx(0)


### PR DESCRIPTION
`TokenCostCalculated` splits the prompt side of a call into three reported pairs: new (uncached) tokens and their cost, cache-read tokens and their cost, and cache-creation tokens and their cost. `ChatInvokeUsage.prompt_tokens` already includes the cached tokens, as its own docstring says:

> The number of tokens in the prompt (this includes the cached tokens as well. When calculating the cost, subtract the cached tokens from the prompt tokens)

`calculate_cost` does that subtraction for the money (`new_prompt_cost` is charged on `uncached_prompt_tokens`) but not for the count, which was set to the full `usage.prompt_tokens`. So the cached tokens are reported twice, once inside `new_prompt_tokens` and again as `prompt_read_cached_tokens`.

For a 5000-token prompt with a 4900-token cache hit:

```
new_prompt_tokens          5000   (should be 100)
prompt_read_cached_tokens  4900
new + cached               9900   (prompt_tokens is 5000)
```

The field also disagrees with the cost sitting next to it: `new_prompt_cost` is 100 tokens' worth while `new_prompt_tokens` claims 5000, so dividing one by the other gives the wrong effective rate. Cache-heavy agent runs are where the gap is widest.

The fix reports the uncached remainder, which is the quantity `new_prompt_cost` is already computed from. No cost value changes.

Added `tests/ci/test_token_cost_breakdown.py` covering the partition (`new + cached == prompt_tokens`), the count/cost agreement, a fully cached prompt, and an uncached prompt. Verified with `pytest tests/ci/test_token_cost_breakdown.py`: 3 of the 4 fail against the current code and all 4 pass with the fix. The uncached test passes either way. `tests/ci/test_openrouter_token_cost.py` still passes (5 passed).

Note: `browser_use/tokens/service.py` already reports one ASYNC240 from `ruff check` and is not `ruff format` clean on a clean checkout, both unrelated to this line, so I left the rest of the file alone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes token breakdown by excluding cached prompt tokens from new_prompt_tokens. Aligns counts with new_prompt_cost and ensures new + cached == prompt_tokens; costs are unchanged.

- **Bug Fixes**
  - Set new_prompt_tokens to the uncached remainder in browser_use/tokens/service.py.
  - Added tests (tests/ci/test_token_cost_breakdown.py) covering partition, cost alignment, fully cached, and uncached prompts.

<sup>Written for commit a898e352a794c65bc92dce81f35790a08d89e9fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

