### PR TITLE
feat(llm): add OpenAI Responses WebSocket transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ BROWSER_USE_API_KEY=your_bu_api_key_here
 # Model Configuration (optional - use if you want to use other LLM providers)
 # Default LLM model to use
 # OPENAI_API_KEY=your_openai_api_key_here
+# OPENAI_BASE_URL=https://api.openai.com/v1
+# AI_GATEWAY_API_KEY=your_vercel_ai_gateway_key_here
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # AZURE_OPENAI_API_KEY=
 # AZURE_OPENAI_ENDPOINT=

--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -215,6 +215,7 @@ class MessageManager:
 		llm: BaseChatModel | None,
 		settings: MessageCompactionSettings | None,
 		step_info: AgentStepInfo | None = None,
+		session_id: str | None = None,
 	) -> bool:
 		"""Summarize older history into a compact memory block.
 
@@ -270,7 +271,7 @@ class MessageManager:
 
 		messages = [SystemMessage(content=system_prompt), UserMessage(content=compaction_input)]
 		try:
-			response = await llm.ainvoke(messages)
+			response = await llm.ainvoke(messages, session_id=session_id, invocation_scope='compaction')
 			summary = (response.completion or '').strip()
 		except Exception as e:
 			logger.warning(f'Failed to compact messages: {e}')

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -373,6 +373,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self.task = self._enhance_task_with_schema(task, output_model_schema)
 		self.llm = llm
 		self.judge_llm = judge_llm
+		self._additional_session_llms: dict[int, BaseChatModel] = {}
 
 		# Fallback LLM configuration
 		self._fallback_llm: BaseChatModel | None = fallback_llm
@@ -1164,6 +1165,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			llm=compaction_llm,
 			settings=settings,
 			step_info=step_info,
+			session_id=self.session_id,
 		)
 
 	@observe_debug(ignore_input=True, name='get_next_action')
@@ -1609,6 +1611,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if self.judge_llm.provider == 'browser-use':
 			kwargs['request_type'] = 'judge'
 			kwargs['session_id'] = self.session_id
+		elif getattr(self.judge_llm, 'transport', None) in {'responses', 'responses_websocket'}:
+			kwargs['session_id'] = self.session_id
+			kwargs['invocation_scope'] = 'judge'
 
 		try:
 			response = await self.judge_llm.ainvoke(input_messages, **kwargs)
@@ -1943,7 +1948,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		# Build kwargs for ainvoke
 		# Note: ChatBrowserUse will automatically generate action descriptions from output_format schema
-		kwargs: dict = {'output_format': self.AgentOutput, 'session_id': self.session_id}
+		kwargs: dict = {
+			'output_format': self.AgentOutput,
+			'session_id': self.session_id,
+			'invocation_scope': 'agent',
+		}
 
 		try:
 			response = await self.llm.ainvoke(input_messages, **kwargs)
@@ -2787,6 +2796,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					browser_session=self.browser_session,
 					file_system=self.file_system,
 					page_extraction_llm=self.settings.page_extraction_llm,
+					llm_session_id=self.session_id,
 					sensitive_data=self.sensitive_data,
 					available_file_paths=self.available_file_paths,
 					extraction_schema=self.extraction_schema,
@@ -2946,6 +2956,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				self.logger.debug('Using agent LLM for rerun summary')
 			else:
 				self.logger.debug(f'Using provided LLM for rerun summary: {summary_llm.model}')
+			self._additional_session_llms[id(summary_llm)] = summary_llm
 
 			# Build message with prompt and optional screenshot
 			from browser_use.llm.messages import BaseMessage
@@ -2956,7 +2967,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			# Try calling with structured output first
 			self.logger.debug(f'Calling LLM for rerun summary with {len(messages)} message(s)')
 			try:
-				kwargs: dict = {'output_format': RerunSummaryAction}
+				kwargs: dict = {
+					'output_format': RerunSummaryAction,
+					'session_id': self.session_id,
+					'invocation_scope': 'rerun_summary',
+				}
 				response = await summary_llm.ainvoke(messages, **kwargs)
 				summary: RerunSummaryAction = response.completion  # type: ignore[assignment]
 				self.logger.debug(f'LLM response type: {type(summary)}')
@@ -2966,7 +2981,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				# fall back to text response without parsing
 				self.logger.debug(f'Structured output failed: {structured_error}, falling back to text response')
 
-				response = await summary_llm.ainvoke(messages, None)
+				response = await summary_llm.ainvoke(
+					messages,
+					None,
+					session_id=self.session_id,
+					invocation_scope='rerun_summary',
+				)
 				response_text = response.completion
 				self.logger.debug(f'LLM text response: {response_text}')
 
@@ -3075,7 +3095,15 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		try:
 			import asyncio
 
-			response = await asyncio.wait_for(llm.ainvoke([SystemMessage(content=system_prompt), user_message]), timeout=120.0)
+			self._additional_session_llms[id(llm)] = llm
+			response = await asyncio.wait_for(
+				llm.ainvoke(
+					[SystemMessage(content=system_prompt), user_message],
+					session_id=self.session_id,
+					invocation_scope='rerun_ai_step',
+				),
+				timeout=120.0,
+			)
 
 			current_url = await self.browser_session.get_current_page_url()
 			extracted_content = (
@@ -3978,9 +4006,36 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 	def message_manager(self) -> MessageManager:
 		return self._message_manager
 
+	async def _close_llm_sessions(self) -> None:
+		"""Close this agent's persistent LLM sessions without closing shared model instances."""
+		seen_llms: set[int] = set()
+		for llm in (
+			getattr(self, 'llm', None),
+			getattr(self, 'judge_llm', None),
+			getattr(self.settings, 'page_extraction_llm', None),
+			(self.settings.message_compaction.compaction_llm if self.settings.message_compaction is not None else None),
+			getattr(self, '_original_llm', None),
+			getattr(self, '_fallback_llm', None),
+			*getattr(self, '_additional_session_llms', {}).values(),
+		):
+			if llm is None or id(llm) in seen_llms:
+				continue
+			seen_llms.add(id(llm))
+			close_session = getattr(llm, 'close_session', None)
+			if close_session is None:
+				continue
+			try:
+				close_result = close_session(self.session_id)
+				if inspect.isawaitable(close_result):
+					await close_result
+			except Exception as llm_close_error:
+				self.logger.warning(f'Failed to close LLM session: {llm_close_error}')
+
 	async def close(self):
 		"""Close all resources"""
 		try:
+			await self._close_llm_sessions()
+
 			# Only close browser if keep_alive is False (or not set)
 			if self.browser_session is not None:
 				if not self.browser_session.browser_profile.keep_alive:

--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -12,8 +12,7 @@ from pydantic import BaseModel
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.openai.like import ChatOpenAILike
-from browser_use.llm.openai.responses_serializer import ResponsesAPIMessageSerializer
-from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.openai.responses import build_responses_request, get_responses_usage, parse_responses_completion
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
@@ -131,22 +130,7 @@ class ChatAzureOpenAI(ChatOpenAILike):
 
 	def _get_usage_from_responses(self, response: Response) -> ChatInvokeUsage | None:
 		"""Extract usage information from a Responses API response."""
-		if response.usage is None:
-			return None
-
-		# Get cached tokens from input_tokens_details if available
-		cached_tokens = None
-		if response.usage.input_tokens_details is not None:
-			cached_tokens = getattr(response.usage.input_tokens_details, 'cached_tokens', None)
-
-		return ChatInvokeUsage(
-			prompt_tokens=response.usage.input_tokens,
-			prompt_cached_tokens=cached_tokens,
-			prompt_cache_creation_tokens=None,
-			prompt_image_tokens=None,
-			completion_tokens=response.usage.output_tokens,
-			total_tokens=response.usage.total_tokens,
-		)
+		return get_responses_usage(response)
 
 	async def _ainvoke_responses_api(
 		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
@@ -157,92 +141,32 @@ class ChatAzureOpenAI(ChatOpenAILike):
 		This is used for models that require the Responses API (e.g., gpt-5.1-codex-mini)
 		or when use_responses_api is explicitly set to True.
 		"""
-		# Serialize messages to Responses API input format
-		input_messages = ResponsesAPIMessageSerializer.serialize_messages(messages)
-
 		try:
-			model_params: dict[str, Any] = {
-				'model': self.model,
-				'input': input_messages,
-			}
+			model_params = build_responses_request(
+				model=str(self.model),
+				messages=messages,
+				output_format=output_format,
+				temperature=self.temperature,
+				max_output_tokens=self.max_completion_tokens,
+				top_p=self.top_p,
+				service_tier=self.service_tier,
+				reasoning_effort=self.reasoning_effort,
+				is_reasoning_model=self._is_reasoning_model(),
+				add_schema_to_system_prompt=self.add_schema_to_system_prompt,
+				dont_force_structured_output=self.dont_force_structured_output,
+				remove_min_items_from_schema=self.remove_min_items_from_schema,
+				remove_defaults_from_schema=self.remove_defaults_from_schema,
+			)
+			response = await self.get_client().responses.create(**model_params)
+			return parse_responses_completion(
+				response,
+				output_format,
+				model=self.name,
+				max_output_tokens=self.max_completion_tokens,
+			)
 
-			if self.temperature is not None:
-				model_params['temperature'] = self.temperature
-
-			if self.max_completion_tokens is not None:
-				model_params['max_output_tokens'] = self.max_completion_tokens
-
-			if self.top_p is not None:
-				model_params['top_p'] = self.top_p
-
-			if self.service_tier is not None:
-				model_params['service_tier'] = self.service_tier
-
-			# Handle reasoning models
-			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
-				# For reasoning models, use reasoning parameter instead of reasoning_effort
-				model_params['reasoning'] = {'effort': self.reasoning_effort}
-				model_params.pop('temperature', None)
-
-			if output_format is None:
-				# Return string response
-				response = await self.get_client().responses.create(**model_params)
-
-				usage = self._get_usage_from_responses(response)
-				return ChatInvokeCompletion(
-					completion=response.output_text or '',
-					usage=usage,
-					stop_reason=response.status if response.status else None,
-				)
-
-			else:
-				# For structured output, use the text.format parameter
-				json_schema = SchemaOptimizer.create_optimized_json_schema(
-					output_format,
-					remove_min_items=self.remove_min_items_from_schema,
-					remove_defaults=self.remove_defaults_from_schema,
-				)
-
-				model_params['text'] = {
-					'format': {
-						'type': 'json_schema',
-						'name': 'agent_output',
-						'strict': True,
-						'schema': json_schema,
-					}
-				}
-
-				# Add JSON schema to system prompt if requested
-				if self.add_schema_to_system_prompt and input_messages and input_messages[0].get('role') == 'system':
-					schema_text = f'\n<json_schema>\n{json_schema}\n</json_schema>'
-					content = input_messages[0].get('content', '')
-					if isinstance(content, str):
-						input_messages[0]['content'] = content + schema_text
-					elif isinstance(content, list):
-						input_messages[0]['content'] = list(content) + [{'type': 'input_text', 'text': schema_text}]
-					model_params['input'] = input_messages
-
-				if self.dont_force_structured_output:
-					# Remove the text format parameter if not forcing structured output
-					model_params.pop('text', None)
-
-				response = await self.get_client().responses.create(**model_params)
-
-				if not response.output_text:
-					raise ModelProviderError(
-						message='Failed to parse structured output from model response',
-						status_code=500,
-						model=self.name,
-					)
-
-				usage = self._get_usage_from_responses(response)
-				parsed = output_format.model_validate_json(response.output_text)
-
-				return ChatInvokeCompletion(
-					completion=parsed,
-					usage=usage,
-					stop_reason=response.status if response.status else None,
-				)
+		except ModelProviderError:
+			raise
 
 		except RateLimitError as e:
 			raise ModelRateLimitError(message=e.message, model=self.name) from e

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -1,6 +1,8 @@
+import os
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar, overload
+from uuid import uuid4
 
 import httpx
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
@@ -14,6 +16,8 @@ from pydantic import BaseModel
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelOutputTruncatedError, ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
+from browser_use.llm.openai.responses import build_responses_request, parse_responses_completion
+from browser_use.llm.openai.responses_websocket import ResponsesWebSocketTransport
 from browser_use.llm.openai.serializer import OpenAIMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
@@ -26,12 +30,19 @@ class ChatOpenAI(BaseChatModel):
 	"""
 	A wrapper around AsyncOpenAI that implements the BaseLLM protocol.
 
-	This class accepts all AsyncOpenAI parameters while adding model
-	and temperature parameters for the LLM interface (if temperature it not `None`).
+	This class accepts all AsyncOpenAI parameters and supports Chat Completions,
+	HTTP Responses, and persistent Responses WebSocket transports.
+
+	Set ``transport='responses_websocket'`` to send full-context Responses requests
+	over a session-scoped persistent socket. ``websocket_base_url`` may be either a
+	WebSocket API root or a complete ``/responses`` endpoint; when omitted, it is
+	derived from ``base_url`` or the OpenAI API URL.
 	"""
 
 	# Model configuration
 	model: ChatModel | str
+	transport: Literal['chat_completions', 'responses', 'responses_websocket'] = 'chat_completions'
+	responses_store: bool = True
 
 	# Model params
 	temperature: float | None = 0.2
@@ -75,6 +86,10 @@ class ChatOpenAI(BaseChatModel):
 			'gpt-5-nano',
 		]
 	)
+	_responses_websocket_transport: ResponsesWebSocketTransport | None = field(
+		default=None, init=False, repr=False, compare=False
+	)
+	_client: AsyncOpenAI | None = field(default=None, init=False, repr=False, compare=False)
 
 	# Static
 	@property
@@ -113,8 +128,9 @@ class ChatOpenAI(BaseChatModel):
 		Returns:
 			AsyncOpenAI: An instance of the AsyncOpenAI client.
 		"""
-		client_params = self._get_client_params()
-		return AsyncOpenAI(**client_params)
+		if self._client is None:
+			self._client = AsyncOpenAI(**self._get_client_params())
+		return self._client
 
 	@property
 	def name(self) -> str:
@@ -141,6 +157,111 @@ class ChatOpenAI(BaseChatModel):
 
 		return usage
 
+	def _is_reasoning_model(self) -> bool:
+		return bool(
+			self.reasoning_models
+			and any(str(candidate).lower() in str(self.model).lower() for candidate in self.reasoning_models)
+		)
+
+	def _build_responses_request(self, messages: list[BaseMessage], output_format: type[BaseModel] | None) -> dict[str, Any]:
+		return build_responses_request(
+			model=str(self.model),
+			messages=messages,
+			output_format=output_format,
+			temperature=self.temperature,
+			max_output_tokens=self.max_completion_tokens,
+			top_p=self.top_p,
+			service_tier=self.service_tier,
+			reasoning_effort=self.reasoning_effort,
+			is_reasoning_model=self._is_reasoning_model(),
+			add_schema_to_system_prompt=self.add_schema_to_system_prompt,
+			dont_force_structured_output=self.dont_force_structured_output,
+			remove_min_items_from_schema=self.remove_min_items_from_schema,
+			remove_defaults_from_schema=self.remove_defaults_from_schema,
+		)
+
+	def _get_responses_websocket_transport(self) -> ResponsesWebSocketTransport:
+		if self._responses_websocket_transport is None:
+			self._responses_websocket_transport = ResponsesWebSocketTransport(
+				api_key=self.api_key or os.getenv('OPENAI_API_KEY'),
+				organization=self.organization or os.getenv('OPENAI_ORG_ID'),
+				project=self.project or os.getenv('OPENAI_PROJECT_ID'),
+				base_url=self.base_url or os.getenv('OPENAI_BASE_URL'),
+				websocket_base_url=self.websocket_base_url,
+				timeout=self.timeout,
+				default_headers=self.default_headers,
+				default_query=self.default_query,
+				model=self.name,
+			)
+		return self._responses_websocket_transport
+
+	async def _invoke_responses(
+		self,
+		messages: list[BaseMessage],
+		output_format: type[T] | None,
+		**kwargs: Any,
+	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		request = self._build_responses_request(messages, output_format)
+		request['store'] = self.responses_store
+
+		try:
+			if self.transport == 'responses':
+				response = await self.get_client().responses.create(**request)
+			else:
+				session_id = kwargs.get('session_id')
+				ephemeral = not isinstance(session_id, str) or not session_id
+				session_prefix = str(session_id) if not ephemeral else f'ephemeral-{uuid4()}'
+				session_key = f'{session_prefix}:{kwargs.get("invocation_scope", "agent")}'
+				response = None
+				try:
+					for attempt in range(2):
+						try:
+							response = await self._get_responses_websocket_transport().send(
+								session_key=session_key, request=request
+							)
+							break
+						except ConnectionError:
+							if attempt == 1:
+								raise
+					if response is None:
+						raise ModelProviderError(
+							message='Responses WebSocket retry exhausted', status_code=502, model=self.name
+						)
+				finally:
+					if ephemeral:
+						await self.close_session(session_prefix)
+
+			return parse_responses_completion(
+				response,
+				output_format,
+				model=self.name,
+				max_output_tokens=self.max_completion_tokens,
+			)
+		except ModelProviderError:
+			raise
+		except RateLimitError as exc:
+			raise ModelRateLimitError(message=exc.message, model=self.name) from exc
+		except APIStatusError as exc:
+			raise ModelProviderError(message=exc.message, status_code=exc.status_code, model=self.name) from exc
+		except (APIConnectionError, TimeoutError, ConnectionError) as exc:
+			raise ModelProviderError(message=str(exc), status_code=502, model=self.name) from exc
+		except Exception as exc:
+			raise ModelProviderError(message=str(exc), model=self.name) from exc
+
+	async def close_session(self, session_id: str) -> None:
+		"""Close Responses resources owned by one agent session."""
+		if self._responses_websocket_transport is not None:
+			await self._responses_websocket_transport.close_session(session_id)
+
+	async def aclose(self) -> None:
+		"""Close every Responses resource owned by this model instance."""
+		if self._responses_websocket_transport is not None:
+			await self._responses_websocket_transport.close()
+			self._responses_websocket_transport = None
+		if self._client is not None:
+			await self._client.close()
+			self._client = None
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -162,6 +283,13 @@ class ChatOpenAI(BaseChatModel):
 		Returns:
 			Either a string response or an instance of output_format
 		"""
+
+		if self.transport == 'responses':
+			return await self._invoke_responses(messages, output_format, **kwargs)
+		if self.transport == 'responses_websocket':
+			return await self._invoke_responses(messages, output_format, **kwargs)
+		if self.transport != 'chat_completions':
+			raise ModelProviderError(message=f'Unsupported OpenAI transport: {self.transport}', model=self.name)
 
 		openai_messages = OpenAIMessageSerializer.serialize_messages(messages)
 

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -224,9 +224,7 @@ class ChatOpenAI(BaseChatModel):
 							if attempt == 1:
 								raise
 					if response is None:
-						raise ModelProviderError(
-							message='Responses WebSocket retry exhausted', status_code=502, model=self.name
-						)
+						raise ModelProviderError(message='Responses WebSocket retry exhausted', status_code=502, model=self.name)
 				finally:
 					if ephemeral:
 						await self.close_session(session_prefix)

--- a/browser_use/llm/openai/responses.py
+++ b/browser_use/llm/openai/responses.py
@@ -1,0 +1,158 @@
+"""Shared request and response handling for the OpenAI Responses API."""
+
+from typing import Any, TypeVar
+
+from openai.types.responses import Response
+from pydantic import BaseModel, ValidationError
+
+from browser_use.llm.exceptions import ModelOutputTruncatedError, ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.openai.responses_serializer import ResponsesAPIMessageSerializer
+from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
+
+T = TypeVar('T', bound=BaseModel)
+
+
+def build_responses_request(
+	*,
+	model: str,
+	messages: list[BaseMessage],
+	output_format: type[BaseModel] | None,
+	temperature: float | None,
+	max_output_tokens: int | None,
+	top_p: float | None,
+	service_tier: str | None,
+	reasoning_effort: str | None,
+	is_reasoning_model: bool,
+	add_schema_to_system_prompt: bool,
+	dont_force_structured_output: bool,
+	remove_min_items_from_schema: bool,
+	remove_defaults_from_schema: bool,
+) -> dict[str, Any]:
+	"""Build a transport-neutral Responses API request body."""
+	input_messages = ResponsesAPIMessageSerializer.serialize_messages(messages)
+	request: dict[str, Any] = {'model': model, 'input': input_messages}
+
+	if temperature is not None:
+		request['temperature'] = temperature
+	if max_output_tokens is not None:
+		request['max_output_tokens'] = max_output_tokens
+	if top_p is not None:
+		request['top_p'] = top_p
+	if service_tier is not None:
+		request['service_tier'] = service_tier
+	if is_reasoning_model and reasoning_effort is not None:
+		request['reasoning'] = {'effort': reasoning_effort}
+		request.pop('temperature', None)
+
+	if output_format is not None:
+		json_schema = SchemaOptimizer.create_optimized_json_schema(
+			output_format,
+			remove_min_items=remove_min_items_from_schema,
+			remove_defaults=remove_defaults_from_schema,
+		)
+		if not dont_force_structured_output:
+			request['text'] = {
+				'format': {
+					'type': 'json_schema',
+					'name': 'agent_output',
+					'strict': True,
+					'schema': json_schema,
+				}
+			}
+
+		if add_schema_to_system_prompt and input_messages and input_messages[0].get('role') == 'system':
+			schema_text = f'\n<json_schema>\n{json_schema}\n</json_schema>'
+			content = input_messages[0].get('content', '')
+			if isinstance(content, str):
+				input_messages[0]['content'] = content + schema_text
+			elif isinstance(content, list):
+				input_messages[0]['content'] = list(content) + [{'type': 'input_text', 'text': schema_text}]
+
+	return request
+
+
+def get_responses_usage(response: Response) -> ChatInvokeUsage | None:
+	"""Convert Responses API usage into Browser Use usage accounting."""
+	if response.usage is None:
+		return None
+
+	cached_tokens = None
+	if response.usage.input_tokens_details is not None:
+		cached_tokens = getattr(response.usage.input_tokens_details, 'cached_tokens', None)
+
+	return ChatInvokeUsage(
+		prompt_tokens=response.usage.input_tokens,
+		prompt_cached_tokens=cached_tokens,
+		prompt_cache_creation_tokens=None,
+		prompt_image_tokens=None,
+		completion_tokens=response.usage.output_tokens,
+		total_tokens=response.usage.total_tokens,
+	)
+
+
+def parse_responses_completion(
+	response: Response,
+	output_format: type[T] | None,
+	*,
+	model: str,
+	max_output_tokens: int | None,
+) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+	"""Validate a terminal Response and convert it to the common completion type."""
+	if response.status == 'failed':
+		error = response.error
+		message = error.message if error is not None else 'OpenAI Responses API request failed'
+		if error is not None and error.code in {'rate_limit_exceeded', 'rate_limit_error'}:
+			raise ModelRateLimitError(message=message, model=model)
+		raise ModelProviderError(message=message, status_code=502, model=model)
+
+	if response.status == 'incomplete':
+		reason = response.incomplete_details.reason if response.incomplete_details is not None else None
+		if reason == 'max_output_tokens':
+			cap = f'max_output_tokens={max_output_tokens}' if max_output_tokens is not None else "the model's output token limit"
+			raise ModelOutputTruncatedError(
+				message=f'Model output was truncated at {cap}; the response is incomplete.',
+				model=model,
+			)
+		raise ModelProviderError(
+			message=f'OpenAI Responses API returned an incomplete response (reason={reason or "unknown"})',
+			status_code=502,
+			model=model,
+		)
+	if response.status != 'completed':
+		raise ModelProviderError(
+			message=f'OpenAI Responses API returned unexpected status: {response.status or "unknown"}',
+			status_code=502,
+			model=model,
+		)
+
+	usage = get_responses_usage(response)
+	if output_format is None:
+		return ChatInvokeCompletion(
+			completion=response.output_text or '',
+			usage=usage,
+			stop_reason=response.status,
+		)
+
+	if not response.output_text:
+		raise ModelProviderError(
+			message='Failed to parse structured output from model response',
+			status_code=500,
+			model=model,
+		)
+
+	try:
+		completion = output_format.model_validate_json(response.output_text)
+	except ValidationError as exc:
+		raise ModelProviderError(
+			message=str(exc),
+			status_code=500,
+			model=model,
+		) from exc
+
+	return ChatInvokeCompletion(
+		completion=completion,
+		usage=usage,
+		stop_reason=response.status,
+	)

--- a/browser_use/llm/openai/responses_websocket.py
+++ b/browser_use/llm/openai/responses_websocket.py
@@ -222,7 +222,7 @@ class ResponsesWebSocketTransport:
 				if 400 <= exc.status < 500:
 					raise ModelProviderError(message=str(exc), status_code=exc.status, model=self.model) from exc
 				raise ConnectionError(str(exc)) from exc
-			except (aiohttp.ClientError, TimeoutError, ConnectionError, asyncio.TimeoutError) as exc:
+			except (aiohttp.ClientError, TimeoutError, ConnectionError) as exc:
 				await self._close_connection(session)
 				raise ConnectionError(str(exc)) from exc
 			except Exception:

--- a/browser_use/llm/openai/responses_websocket.py
+++ b/browser_use/llm/openai/responses_websocket.py
@@ -1,0 +1,248 @@
+"""Persistent WebSocket transport for the OpenAI Responses API."""
+
+import asyncio
+import json
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+from urllib.parse import urlsplit, urlunsplit
+
+import aiohttp
+import httpx
+from openai.types.responses import Response, ResponseCompletedEvent, ResponseFailedEvent, ResponseIncompleteEvent
+from pydantic import BaseModel, ConfigDict
+
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+
+
+class ResponsesWebSocketErrorBody(BaseModel):
+	"""Error body sent by the Responses WebSocket endpoint."""
+
+	code: str | None = None
+	message: str
+	param: str | None = None
+	type: str | None = None
+
+	model_config = ConfigDict(extra='allow')
+
+
+class ResponsesWebSocketErrorEvent(BaseModel):
+	"""OpenAI's flat error frame, with nested Gateway errors also accepted."""
+
+	type: Literal['error']
+	code: str | None = None
+	message: str | None = None
+	param: str | None = None
+	sequence_number: int | None = None
+	status: int | None = None
+	error: ResponsesWebSocketErrorBody | None = None
+
+	model_config = ConfigDict(extra='allow')
+
+
+@dataclass
+class _ResponsesWebSocketSession:
+	lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+	http_session: aiohttp.ClientSession | None = None
+	websocket: aiohttp.ClientWebSocketResponse | None = None
+	connected_at: float = 0.0
+	model: str | None = None
+
+
+class ResponsesWebSocketTransport:
+	"""Manage one sequential Responses WebSocket connection per agent session."""
+
+	_MAX_CONNECTION_AGE_SECONDS = 55 * 60
+
+	def __init__(
+		self,
+		*,
+		api_key: str | None,
+		organization: str | None,
+		project: str | None,
+		base_url: str | httpx.URL | None,
+		websocket_base_url: str | httpx.URL | None,
+		timeout: float | httpx.Timeout | None,
+		default_headers: Mapping[str, str] | None,
+		default_query: Mapping[str, object] | None,
+		model: str,
+	):
+		self.api_key = api_key
+		self.organization = organization
+		self.project = project
+		self.url = self._responses_websocket_url(websocket_base_url or base_url)
+		self.timeout = self._timeout_seconds(timeout)
+		self.default_headers = dict(default_headers or {})
+		self.default_query = {key: str(value) for key, value in (default_query or {}).items()}
+		self.model = model
+		self._sessions: dict[str, _ResponsesWebSocketSession] = {}
+
+	@staticmethod
+	def _timeout_seconds(timeout: float | httpx.Timeout | None) -> float:
+		if isinstance(timeout, (int, float)):
+			return float(timeout)
+		if isinstance(timeout, httpx.Timeout):
+			return float(timeout.read if timeout.read is not None else 600.0)
+		return 600.0
+
+	@staticmethod
+	def _responses_websocket_url(base_url: str | httpx.URL | None) -> str:
+		raw_url = str(base_url or 'https://api.openai.com/v1').rstrip('/')
+		parts = urlsplit(raw_url)
+		scheme = {'http': 'ws', 'https': 'wss'}.get(parts.scheme, parts.scheme)
+		path = parts.path if parts.path.endswith('/responses') else f'{parts.path}/responses'
+		return urlunsplit((scheme, parts.netloc, path, parts.query, parts.fragment))
+
+	def _headers(self) -> dict[str, str]:
+		headers = dict(self.default_headers)
+		lower_names = {name.lower() for name in headers}
+		if 'authorization' not in lower_names:
+			if not self.api_key:
+				raise ModelProviderError(
+					message='The OPENAI_API_KEY environment variable or api_key parameter is required',
+					status_code=401,
+					model=self.model,
+				)
+			headers['Authorization'] = f'Bearer {self.api_key}'
+		if self.organization and 'openai-organization' not in lower_names:
+			headers['OpenAI-Organization'] = self.organization
+		if self.project and 'openai-project' not in lower_names:
+			headers['OpenAI-Project'] = self.project
+		return headers
+
+	async def _close_connection(self, session: _ResponsesWebSocketSession) -> None:
+		if session.websocket is not None and not session.websocket.closed:
+			await session.websocket.close()
+		session.websocket = None
+		if session.http_session is not None and not session.http_session.closed:
+			await session.http_session.close()
+		session.http_session = None
+		session.connected_at = 0.0
+
+	async def _ensure_connection(self, session: _ResponsesWebSocketSession) -> None:
+		connection_expired = time.monotonic() - session.connected_at >= self._MAX_CONNECTION_AGE_SECONDS
+		if session.websocket is not None and not session.websocket.closed and not connection_expired:
+			return
+
+		await self._close_connection(session)
+		client_timeout = aiohttp.ClientTimeout(total=self.timeout)
+		session.http_session = aiohttp.ClientSession(timeout=client_timeout)
+		try:
+			session.websocket = await session.http_session.ws_connect(
+				self.url,
+				headers=self._headers(),
+				params=self.default_query,
+				heartbeat=30.0,
+				receive_timeout=self.timeout,
+				max_msg_size=16 * 1024 * 1024,
+			)
+		except Exception:
+			await self._close_connection(session)
+			raise
+		session.connected_at = time.monotonic()
+
+	async def _receive_terminal_response(self, websocket: aiohttp.ClientWebSocketResponse) -> Response:
+		while True:
+			message = await websocket.receive()
+			if message.type == aiohttp.WSMsgType.TEXT:
+				try:
+					payload = json.loads(message.data)
+				except json.JSONDecodeError as exc:
+					raise ModelProviderError(
+						message=f'Invalid JSON frame from Responses WebSocket: {exc}',
+						status_code=502,
+						model=self.model,
+					) from exc
+
+				event_type = payload.get('type') if isinstance(payload, dict) else None
+				if event_type == 'response.completed':
+					return ResponseCompletedEvent.model_validate(payload).response
+				if event_type == 'response.failed':
+					return ResponseFailedEvent.model_validate(payload).response
+				if event_type == 'response.incomplete':
+					return ResponseIncompleteEvent.model_validate(payload).response
+				if event_type == 'error':
+					error_event = ResponsesWebSocketErrorEvent.model_validate(payload)
+					error_code = error_event.error.code if error_event.error is not None else error_event.code
+					error_type = error_event.error.type if error_event.error is not None else None
+					error_message = (
+						error_event.error.message
+						if error_event.error is not None
+						else error_event.message or 'OpenAI Responses WebSocket request failed'
+					)
+					if error_code == 'websocket_connection_limit_reached':
+						raise ConnectionError(error_message)
+					is_rate_limit = error_event.status == 429 or any(
+						value is not None and 'rate_limit' in value for value in (error_code, error_type)
+					)
+					if is_rate_limit:
+						raise ModelRateLimitError(message=error_message, model=self.model)
+					raise ModelProviderError(
+						message=error_message,
+						status_code=error_event.status or 502,
+						model=self.model,
+					)
+			elif message.type == aiohttp.WSMsgType.ERROR:
+				raise ConnectionError(str(websocket.exception() or 'Responses WebSocket failed'))
+			elif message.type == aiohttp.WSMsgType.BINARY:
+				raise ModelProviderError(
+					message='Unexpected binary frame from Responses WebSocket',
+					status_code=502,
+					model=self.model,
+				)
+			elif message.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.CLOSING):
+				raise ConnectionError(f'Responses WebSocket closed before a terminal event (code={websocket.close_code})')
+
+	async def send(
+		self,
+		*,
+		session_key: str,
+		request: dict[str, Any],
+	) -> Response:
+		"""Send one full-context request and return its terminal response."""
+		session = self._sessions.setdefault(session_key, _ResponsesWebSocketSession())
+		async with session.lock:
+			request_model = str(request.get('model', ''))
+			if session.model is not None and session.model != request_model:
+				await self._close_connection(session)
+			session.model = request_model
+			try:
+				await self._ensure_connection(session)
+				assert session.websocket is not None
+				await session.websocket.send_json({'type': 'response.create', **request})
+				return await self._receive_terminal_response(session.websocket)
+			except asyncio.CancelledError:
+				await self._close_connection(session)
+				raise
+			except aiohttp.WSServerHandshakeError as exc:
+				await self._close_connection(session)
+				if exc.status == 429:
+					raise ModelRateLimitError(message=str(exc), model=self.model) from exc
+				if 400 <= exc.status < 500:
+					raise ModelProviderError(message=str(exc), status_code=exc.status, model=self.model) from exc
+				raise ConnectionError(str(exc)) from exc
+			except (aiohttp.ClientError, TimeoutError, ConnectionError, asyncio.TimeoutError) as exc:
+				await self._close_connection(session)
+				raise ConnectionError(str(exc)) from exc
+			except Exception:
+				# A malformed or unexpected frame invalidates the one-in-flight stream.
+				# Reconnect before allowing another request on this session.
+				await self._close_connection(session)
+				raise
+
+	async def close_session(self, session_prefix: str) -> None:
+		"""Close all invocation scopes belonging to one agent session."""
+		matching_keys = [key for key in self._sessions if key == session_prefix or key.startswith(f'{session_prefix}:')]
+		for key in matching_keys:
+			session = self._sessions.pop(key)
+			async with session.lock:
+				await self._close_connection(session)
+
+	async def close(self) -> None:
+		"""Close every managed WebSocket session."""
+		sessions = list(self._sessions.values())
+		self._sessions.clear()
+		for session in sessions:
+			async with session.lock:
+				await self._close_connection(session)

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -66,6 +66,7 @@ class Registry(Generic[Context]):
 			'page_url': str,
 			'cdp_client': None,  # CDPClient type from cdp_use, but we don't import it here
 			'page_extraction_llm': BaseChatModel,
+			'llm_session_id': str,
 			'available_file_paths': list,
 			'has_sensitive_data': bool,
 			'file_system': FileSystem,
@@ -117,7 +118,7 @@ class Registry(Generic[Context]):
 					# Handle Optional types - normalize both sides
 					param_type = param.annotation
 					origin = get_origin(param_type)
-					if origin is Union:
+					if origin in (Union, UnionType):
 						args = get_args(param_type)
 						# Find non-None type
 						param_type = next((arg for arg in args if arg is not type(None)), param_type)
@@ -334,6 +335,7 @@ class Registry(Generic[Context]):
 		params: dict,
 		browser_session: BrowserSession | None = None,
 		page_extraction_llm: BaseChatModel | None = None,
+		llm_session_id: str | None = None,
 		file_system: FileSystem | None = None,
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		available_file_paths: list[str] | None = None,
@@ -368,6 +370,7 @@ class Registry(Generic[Context]):
 			special_context = {
 				'browser_session': browser_session,
 				'page_extraction_llm': page_extraction_llm,
+				'llm_session_id': llm_session_id,
 				'available_file_paths': available_file_paths,
 				'has_sensitive_data': action_name == 'input' and bool(sensitive_data),
 				'file_system': file_system,

--- a/browser_use/tools/registry/views.py
+++ b/browser_use/tools/registry/views.py
@@ -168,6 +168,7 @@ class SpecialActionParameters(BaseModel):
 
 	# extra injected config if the action asks for these arg names
 	page_extraction_llm: BaseChatModel | None = None
+	llm_session_id: str | None = None
 	file_system: FileSystem | None = None
 	available_file_paths: list[str] | None = None
 	has_sensitive_data: bool = False

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1062,6 +1062,7 @@ class Tools(Generic[Context]):
 			page_extraction_llm: BaseChatModel,
 			file_system: FileSystem,
 			extraction_schema: dict | None = None,
+			llm_session_id: str | None = None,
 		):
 			# Constants
 			MAX_CHAR_LIMIT = 100000
@@ -1185,6 +1186,8 @@ You will be given a query, a JSON Schema, and the markdown of a webpage that has
 						page_extraction_llm.ainvoke(
 							[SystemMessage(content=system_prompt), UserMessage(content=prompt)],
 							output_format=structured_model,
+							session_id=llm_session_id,
+							invocation_scope='page_extraction',
 						),
 						timeout=120.0,
 					)
@@ -1261,7 +1264,11 @@ You will be given a query and the markdown of a webpage that has been filtered t
 
 			try:
 				response = await asyncio.wait_for(
-					page_extraction_llm.ainvoke([SystemMessage(content=system_prompt), UserMessage(content=prompt)]),
+					page_extraction_llm.ainvoke(
+						[SystemMessage(content=system_prompt), UserMessage(content=prompt)],
+						session_id=llm_session_id,
+						invocation_scope='page_extraction',
+					),
 					timeout=120.0,
 				)
 
@@ -2166,6 +2173,7 @@ Validated Code (after quote fixing):
 		action: ActionModel,
 		browser_session: BrowserSession,
 		page_extraction_llm: BaseChatModel | None = None,
+		llm_session_id: str | None = None,
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		available_file_paths: list[str] | None = None,
 		file_system: FileSystem | None = None,
@@ -2209,6 +2217,7 @@ Validated Code (after quote fixing):
 								params=params,
 								browser_session=browser_session,
 								page_extraction_llm=page_extraction_llm,
+								llm_session_id=llm_session_id,
 								file_system=file_system,
 								sensitive_data=sensitive_data,
 								available_file_paths=available_file_paths,
@@ -2273,6 +2282,7 @@ Validated Code (after quote fixing):
 				special_param_names = {
 					'browser_session',
 					'page_extraction_llm',
+					'llm_session_id',
 					'file_system',
 					'available_file_paths',
 					'sensitive_data',

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -78,11 +78,20 @@ llm = ChatBrowserUse(model='bu-2-0')      # Premium model
 from browser_use import Agent, ChatOpenAI
 
 llm = ChatOpenAI(model="gpt-5")
+
+# Responses API (HTTP or persistent WebSocket)
+llm = ChatOpenAI(model='gpt-5', transport='responses')
+llm = ChatOpenAI(model='gpt-5', transport='responses_websocket')
 ```
 
 **Env:** `OPENAI_API_KEY` | [Available models](https://platform.openai.com/docs/models)
 
-Supports custom `base_url` for OpenAI-compatible APIs.
+- `transport` (default: `'chat_completions'`): `'chat_completions'` | `'responses'` | `'responses_websocket'`
+- `responses_store` (default: `True`): Responses API `store` field
+- `websocket_base_url`: WebSocket root or full `/responses` URL (derived from `base_url` when omitted)
+- `base_url`: OpenAI-compatible HTTP endpoint
+- WebSocket reuses one socket per agent session + invocation scope; closed on `Agent.close()`. Calls without a session use an ephemeral socket.
+- Also reads `OPENAI_BASE_URL`, `OPENAI_ORG_ID`, `OPENAI_PROJECT_ID` when constructor args are omitted
 
 ## Anthropic
 
@@ -211,7 +220,9 @@ llm = ChatOpenRouter(model="anthropic/claude-sonnet-4-6")
 Proxy to multiple providers with automatic fallback:
 
 ```python
-from browser_use import Agent, ChatVercel
+import os
+
+from browser_use import Agent, ChatOpenAI, ChatVercel
 
 llm = ChatVercel(
     model='anthropic/claude-sonnet-4-6',
@@ -221,9 +232,20 @@ llm = ChatVercel(
         }
     },
 )
+
+# Responses WebSocket via ChatOpenAI
+llm = ChatOpenAI(
+    model='openai/gpt-5.2',
+    transport='responses_websocket',
+    api_key=os.environ['AI_GATEWAY_API_KEY'],
+    base_url='https://ai-gateway.vercel.sh/v1',
+    websocket_base_url='wss://ai-gateway.vercel.sh/v1/responses',
+)
 ```
 
 **Env:** `AI_GATEWAY_API_KEY` (or `VERCEL_OIDC_TOKEN` on Vercel) | [Available models](https://vercel.com/ai-gateway/models)
+
+Use `ChatVercel` for the general gateway. Use `ChatOpenAI(transport='responses_websocket')` for the [Responses WebSocket](https://vercel.com/docs/ai-gateway/sdks-and-apis/responses/websockets) endpoint (same pattern works for other bearer-auth OpenAI-compatible gateways).
 
 ## OCI (Oracle)
 

--- a/tests/ci/models/test_azure_responses_api.py
+++ b/tests/ci/models/test_azure_responses_api.py
@@ -3,8 +3,11 @@
 import os
 
 import pytest
+from openai.types.responses import Response
+from pydantic import BaseModel
 
 from browser_use.llm.azure.chat import RESPONSES_API_ONLY_MODELS, ChatAzureOpenAI
+from browser_use.llm.exceptions import ModelOutputTruncatedError
 from browser_use.llm.messages import (
 	AssistantMessage,
 	ContentPartImageParam,
@@ -16,6 +19,44 @@ from browser_use.llm.messages import (
 	UserMessage,
 )
 from browser_use.llm.openai.responses_serializer import ResponsesAPIMessageSerializer
+
+
+class _AzureStructuredOutput(BaseModel):
+	answer: str
+
+
+def _azure_response(text: str, *, status: str = 'completed') -> Response:
+	payload = {
+		'id': 'resp_azure',
+		'created_at': 1.0,
+		'model': 'gpt-5',
+		'object': 'response',
+		'parallel_tool_calls': True,
+		'tool_choice': 'auto',
+		'tools': [],
+		'status': status,
+		'output': [],
+		'usage': {
+			'input_tokens': 4,
+			'input_tokens_details': {'cached_tokens': 1},
+			'output_tokens': 2,
+			'output_tokens_details': {'reasoning_tokens': 0},
+			'total_tokens': 6,
+		},
+	}
+	if status == 'completed':
+		payload['output'] = [
+			{
+				'id': 'msg_azure',
+				'type': 'message',
+				'status': 'completed',
+				'role': 'assistant',
+				'content': [{'type': 'output_text', 'text': text, 'annotations': [], 'logprobs': []}],
+			}
+		]
+	elif status == 'incomplete':
+		payload['incomplete_details'] = {'reason': 'max_output_tokens'}
+	return Response.model_validate(payload)
 
 
 class TestResponsesAPIMessageSerializer:
@@ -201,6 +242,53 @@ class TestChatAzureOpenAIShouldUseResponsesAPI:
 		]
 		for model in expected_models:
 			assert model in RESPONSES_API_ONLY_MODELS, f'{model} should be in RESPONSES_API_ONLY_MODELS'
+
+
+class TestChatAzureOpenAIResponsesParsing:
+	async def test_completed_structured_response_uses_shared_request_and_parser(self, monkeypatch):
+		captured_request = {}
+
+		class FakeResponses:
+			async def create(self, **kwargs):
+				captured_request.update(kwargs)
+				return _azure_response('{"answer":"ok"}')
+
+		class FakeClient:
+			responses = FakeResponses()
+
+		llm = ChatAzureOpenAI(
+			model='gpt-5',
+			api_key='test',
+			azure_endpoint='https://test.openai.azure.com',
+			use_responses_api=True,
+		)
+		monkeypatch.setattr(llm, 'get_client', lambda: FakeClient())
+
+		result = await llm.ainvoke([UserMessage(content='hello')], output_format=_AzureStructuredOutput)
+
+		assert result.completion == _AzureStructuredOutput(answer='ok')
+		assert result.usage is not None and result.usage.prompt_cached_tokens == 1
+		assert captured_request['text']['format']['type'] == 'json_schema'
+		assert captured_request['reasoning'] == {'effort': 'low'}
+
+	async def test_incomplete_response_raises_truncation_error(self, monkeypatch):
+		class FakeResponses:
+			async def create(self, **kwargs):
+				return _azure_response('', status='incomplete')
+
+		class FakeClient:
+			responses = FakeResponses()
+
+		llm = ChatAzureOpenAI(
+			model='gpt-5',
+			api_key='test',
+			azure_endpoint='https://test.openai.azure.com',
+			use_responses_api=True,
+		)
+		monkeypatch.setattr(llm, 'get_client', lambda: FakeClient())
+
+		with pytest.raises(ModelOutputTruncatedError):
+			await llm.ainvoke([UserMessage(content='hello')])
 
 
 class TestChatAzureOpenAIIntegration:

--- a/tests/ci/models/test_openai_responses_parse.py
+++ b/tests/ci/models/test_openai_responses_parse.py
@@ -1,0 +1,63 @@
+"""Tests for shared OpenAI Responses parsing."""
+
+import pytest
+from openai.types.responses import Response
+from pydantic import BaseModel
+
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.openai.responses import parse_responses_completion
+
+
+class _TinyOutput(BaseModel):
+	done: bool
+
+
+def _response(*, status: str = 'completed', text: str = '{"done":true}') -> Response:
+	payload = {
+		'id': 'resp_test',
+		'created_at': 1.0,
+		'model': 'gpt-5.6',
+		'object': 'response',
+		'parallel_tool_calls': True,
+		'tool_choice': 'auto',
+		'tools': [],
+		'status': status,
+		'output': [],
+		'usage': {
+			'input_tokens': 4,
+			'input_tokens_details': {'cached_tokens': 2},
+			'output_tokens': 2,
+			'output_tokens_details': {'reasoning_tokens': 0},
+			'total_tokens': 6,
+		},
+	}
+	if status == 'completed':
+		payload['output'] = [
+			{
+				'id': 'msg_test', 'type': 'message', 'status': 'completed', 'role': 'assistant',
+				'content': [{'type': 'output_text', 'text': text, 'annotations': [], 'logprobs': []}],
+			}
+		]
+	return Response.model_validate(payload)
+
+
+def test_parse_completed_structured_response_and_usage():
+	result = parse_responses_completion(_response(), _TinyOutput, model='gpt-5.6', max_output_tokens=64)
+	assert result.completion == _TinyOutput(done=True)
+	assert result.usage is not None
+	assert result.usage.prompt_cached_tokens == 2
+
+
+def test_structured_response_rejects_trailing_junk():
+	with pytest.raises(ModelProviderError):
+		parse_responses_completion(
+			_response(text='{"done":true} trailing'), _TinyOutput, model='gpt-5.6', max_output_tokens=64
+		)
+
+
+def test_non_completed_status_is_rejected():
+	response = _response()
+	response.status = 'cancelled'
+	response.output = []
+	with pytest.raises(ModelProviderError, match='unexpected status'):
+		parse_responses_completion(response, None, model='gpt-5.6', max_output_tokens=64)

--- a/tests/ci/models/test_openai_responses_parse.py
+++ b/tests/ci/models/test_openai_responses_parse.py
@@ -34,7 +34,10 @@ def _response(*, status: str = 'completed', text: str = '{"done":true}') -> Resp
 	if status == 'completed':
 		payload['output'] = [
 			{
-				'id': 'msg_test', 'type': 'message', 'status': 'completed', 'role': 'assistant',
+				'id': 'msg_test',
+				'type': 'message',
+				'status': 'completed',
+				'role': 'assistant',
 				'content': [{'type': 'output_text', 'text': text, 'annotations': [], 'logprobs': []}],
 			}
 		]
@@ -50,9 +53,7 @@ def test_parse_completed_structured_response_and_usage():
 
 def test_structured_response_rejects_trailing_junk():
 	with pytest.raises(ModelProviderError):
-		parse_responses_completion(
-			_response(text='{"done":true} trailing'), _TinyOutput, model='gpt-5.6', max_output_tokens=64
-		)
+		parse_responses_completion(_response(text='{"done":true} trailing'), _TinyOutput, model='gpt-5.6', max_output_tokens=64)
 
 
 def test_non_completed_status_is_rejected():

--- a/tests/ci/models/test_openai_responses_websocket.py
+++ b/tests/ci/models/test_openai_responses_websocket.py
@@ -1,0 +1,368 @@
+"""Tests for OpenAI HTTP Responses and the full-context WebSocket transport."""
+
+import asyncio
+from typing import Any
+
+import pytest
+from aiohttp import WSMsgType, web
+from openai.types.responses import Response
+from pydantic import BaseModel
+
+from browser_use.llm.exceptions import ModelOutputTruncatedError, ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import SystemMessage, UserMessage
+from browser_use.llm.openai.chat import ChatOpenAI
+
+
+def _response(response_id: str, text: str, *, status: str = 'completed') -> dict[str, Any]:
+	response: dict[str, Any] = {
+		'id': response_id,
+		'created_at': 1.0,
+		'model': 'gpt-5.6',
+		'object': 'response',
+		'parallel_tool_calls': True,
+		'tool_choice': 'auto',
+		'tools': [],
+		'status': status,
+		'output': [],
+		'usage': {
+			'input_tokens': 10,
+			'input_tokens_details': {'cached_tokens': 2},
+			'output_tokens': 3,
+			'output_tokens_details': {'reasoning_tokens': 0},
+			'total_tokens': 13,
+		},
+	}
+	if status == 'completed':
+		response['output'] = [
+			{
+				'id': f'msg_{response_id}',
+				'type': 'message',
+				'status': 'completed',
+				'role': 'assistant',
+				'content': [{'type': 'output_text', 'text': text, 'annotations': [], 'logprobs': []}],
+			}
+		]
+	elif status == 'failed':
+		response['error'] = {'code': 'server_error', 'message': 'request failed'}
+	elif status == 'incomplete':
+		response['incomplete_details'] = {'reason': 'max_output_tokens'}
+	return response
+
+
+def _event(response_id: str, text: str = 'ok', *, status: str = 'completed') -> dict[str, Any]:
+	return {
+		'type': f'response.{status}',
+		'sequence_number': 1,
+		'response': _response(response_id, text, status=status),
+	}
+
+
+@pytest.fixture
+async def responses_websocket_server():
+	state: dict[str, Any] = {
+		'connections': 0,
+		'requests': [],
+		'headers': [],
+		'queries': [],
+		'response_texts': ['first', 'second', 'third'],
+		'malformed_once': False,
+		'hang_once': False,
+		'rate_limit_once': False,
+		'connection_limit_once': False,
+		'nested_error_once': False,
+		'failed_once': False,
+		'incomplete_once': False,
+		'handshake_status_once': None,
+	}
+
+	async def websocket_handler(request: web.Request) -> web.StreamResponse:
+		state['connections'] += 1
+		state['headers'].append(dict(request.headers))
+		state['queries'].append(dict(request.query))
+		if state['handshake_status_once'] is not None:
+			status = state['handshake_status_once']
+			state['handshake_status_once'] = None
+			return web.Response(status=status, text='handshake rejected')
+		websocket = web.WebSocketResponse()
+		await websocket.prepare(request)
+		async for message in websocket:
+			if message.type != WSMsgType.TEXT:
+				continue
+			payload = message.json()
+			state['requests'].append(payload)
+			if state['malformed_once']:
+				state['malformed_once'] = False
+				await websocket.send_str('{not-json')
+				continue
+			if state['hang_once']:
+				state['hang_once'] = False
+				await asyncio.sleep(1)
+				continue
+			if state['rate_limit_once']:
+				state['rate_limit_once'] = False
+				await websocket.send_json(
+					{
+						'type': 'error',
+						'code': 'rate_limit_exceeded',
+						'message': 'slow down',
+						'param': None,
+						'sequence_number': 1,
+					}
+				)
+				continue
+			if state['connection_limit_once']:
+				state['connection_limit_once'] = False
+				await websocket.send_json(
+					{
+						'type': 'error',
+						'code': 'websocket_connection_limit_reached',
+						'message': 'connection reached its lifetime limit',
+						'param': None,
+						'sequence_number': 1,
+					}
+				)
+				continue
+			if state['nested_error_once']:
+				state['nested_error_once'] = False
+				await websocket.send_json(
+					{
+						'type': 'error',
+						'status': 400,
+						'error': {'message': 'nested gateway error', 'type': 'invalid_request_error', 'code': 'bad'},
+					}
+				)
+				continue
+			if state['failed_once']:
+				state['failed_once'] = False
+				await websocket.send_json(_event(f'resp_{len(state["requests"])}', status='failed'))
+				continue
+			if state['incomplete_once']:
+				state['incomplete_once'] = False
+				await websocket.send_json(_event(f'resp_{len(state["requests"])}', status='incomplete'))
+				continue
+			index = len(state['requests'])
+			texts = state['response_texts']
+			await websocket.send_json(_event(f'resp_{index}', texts[min(index - 1, len(texts) - 1)]))
+		return websocket
+
+	app = web.Application()
+	app.router.add_get('/v1/responses', websocket_handler)
+	runner = web.AppRunner(app)
+	await runner.setup()
+	site = web.TCPSite(runner, '127.0.0.1', 0)
+	await site.start()
+	server = site._server
+	assert server is not None
+	port = getattr(server, 'sockets')[0].getsockname()[1]
+	try:
+		yield state, f'http://127.0.0.1:{port}/v1'
+	finally:
+		await runner.cleanup()
+
+
+async def test_reuses_connection_and_resends_full_context(responses_websocket_server):
+	state, websocket_base_url = responses_websocket_server
+	llm = ChatOpenAI(
+		model='gpt-5.6',
+		api_key='test-key',
+		transport='responses_websocket',
+		websocket_base_url=websocket_base_url,
+		default_headers={'X-Test': 'yes'},
+		default_query={'region': 'test'},
+		max_completion_tokens=123,
+	)
+	messages = [SystemMessage(content='system'), UserMessage(content='full state')]
+	try:
+		first = await llm.ainvoke(messages, session_id='agent-1')
+		second = await llm.ainvoke(messages, session_id='agent-1')
+	finally:
+		await llm.aclose()
+
+	assert first.completion == 'first'
+	assert first.usage is not None and first.usage.prompt_cached_tokens == 2
+	assert second.completion == 'second'
+	assert state['connections'] == 1
+	assert state['headers'][0]['Authorization'] == 'Bearer test-key'
+	assert state['headers'][0]['X-Test'] == 'yes'
+	assert state['queries'][0] == {'region': 'test'}
+	assert len(state['requests']) == 2
+	assert all(request['type'] == 'response.create' for request in state['requests'])
+	assert all(request['store'] is True for request in state['requests'])
+	assert all('previous_response_id' not in request for request in state['requests'])
+	assert state['requests'][1]['input'][1]['content'] == 'full state'
+	assert state['requests'][1]['max_output_tokens'] == 123
+	assert state['requests'][1]['reasoning'] == {'effort': 'low'}
+
+
+async def test_store_false_reaches_websocket_request(responses_websocket_server):
+	state, websocket_base_url = responses_websocket_server
+	llm = ChatOpenAI(
+		model='gpt-5.6', transport='responses_websocket', websocket_base_url=websocket_base_url,
+		responses_store=False, default_headers={'Authorization': 'Bearer gateway-key'},
+	)
+	try:
+		await llm.ainvoke([UserMessage(content='hello')], session_id='agent-1')
+	finally:
+		await llm.aclose()
+	assert state['requests'][0]['store'] is False
+	assert state['headers'][0]['Authorization'] == 'Bearer gateway-key'
+
+
+async def test_malformed_frame_closes_socket_before_next_request(responses_websocket_server):
+	state, websocket_base_url = responses_websocket_server
+	llm = ChatOpenAI(
+		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
+	)
+	try:
+		state['malformed_once'] = True
+		with pytest.raises(ModelProviderError, match='Invalid JSON frame'):
+			await llm.ainvoke([UserMessage(content='first')], session_id='agent-1')
+		result = await llm.ainvoke([UserMessage(content='second')], session_id='agent-1')
+	finally:
+		await llm.aclose()
+	assert result.completion == 'second'
+	assert state['connections'] == 2
+
+
+async def test_timeout_reconnects_and_retries_full_context(responses_websocket_server):
+	state, websocket_base_url = responses_websocket_server
+	state['hang_once'] = True
+	llm = ChatOpenAI(
+		model='gpt-5.6', api_key='test-key', transport='responses_websocket',
+		websocket_base_url=websocket_base_url, timeout=0.05,
+	)
+	try:
+		result = await llm.ainvoke([UserMessage(content='full')], session_id='agent-1')
+	finally:
+		await llm.aclose()
+	assert result.completion == 'second'
+	assert state['connections'] == 2
+	assert all('previous_response_id' not in request for request in state['requests'])
+
+
+async def test_connection_lifetime_error_reconnects_and_retries(responses_websocket_server):
+	state, websocket_base_url = responses_websocket_server
+	state['connection_limit_once'] = True
+	llm = ChatOpenAI(
+		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
+	)
+	try:
+		result = await llm.ainvoke([UserMessage(content='full')], session_id='agent-1')
+	finally:
+		await llm.aclose()
+	assert result.completion == 'second'
+	assert state['connections'] == 2
+	assert len(state['requests']) == 2
+	assert all('previous_response_id' not in request for request in state['requests'])
+
+
+async def test_handshake_rate_limit_preserves_rate_limit_error(responses_websocket_server):
+	state, websocket_base_url = responses_websocket_server
+	state['handshake_status_once'] = 429
+	llm = ChatOpenAI(
+		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
+	)
+	try:
+		with pytest.raises(ModelRateLimitError):
+			await llm.ainvoke([UserMessage(content='full')], session_id='agent-1')
+	finally:
+		await llm.aclose()
+	assert state['connections'] == 1
+
+
+async def test_sessions_and_invocation_scopes_are_isolated(responses_websocket_server):
+	state, websocket_base_url = responses_websocket_server
+	llm = ChatOpenAI(
+		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
+	)
+	messages = [UserMessage(content='hello')]
+	try:
+		await llm.ainvoke(messages, session_id='shared', invocation_scope='agent')
+		await llm.ainvoke(messages, session_id='shared', invocation_scope='judge')
+		await llm.ainvoke(messages, session_id='other', invocation_scope='agent')
+		await llm.close_session('shared')
+		await llm.ainvoke(messages, session_id='other', invocation_scope='agent')
+	finally:
+		await llm.aclose()
+	assert state['connections'] == 3
+
+
+async def test_error_and_terminal_failures_map_to_model_errors(responses_websocket_server):
+	state, websocket_base_url = responses_websocket_server
+	llm = ChatOpenAI(
+		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
+	)
+	try:
+		state['rate_limit_once'] = True
+		with pytest.raises(ModelRateLimitError, match='slow down'):
+			await llm.ainvoke([UserMessage(content='rate')], session_id='rate')
+		state['nested_error_once'] = True
+		with pytest.raises(ModelProviderError, match='nested gateway error'):
+			await llm.ainvoke([UserMessage(content='nested')], session_id='nested')
+		state['failed_once'] = True
+		with pytest.raises(ModelProviderError, match='request failed'):
+			await llm.ainvoke([UserMessage(content='failed')], session_id='failed')
+		state['incomplete_once'] = True
+		with pytest.raises(ModelOutputTruncatedError):
+			await llm.ainvoke([UserMessage(content='incomplete')], session_id='incomplete')
+	finally:
+		await llm.aclose()
+
+
+class StructuredResult(BaseModel):
+	answer: str
+
+
+async def test_structured_output_uses_responses_schema(responses_websocket_server):
+	state, websocket_base_url = responses_websocket_server
+	state['response_texts'] = ['{"answer":"ok"}']
+	llm = ChatOpenAI(
+		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
+	)
+	try:
+		result = await llm.ainvoke(
+			[UserMessage(content='return json')], output_format=StructuredResult, session_id='agent-1'
+		)
+	finally:
+		await llm.aclose()
+	assert result.completion == StructuredResult(answer='ok')
+	assert state['requests'][0]['text']['format']['type'] == 'json_schema'
+	assert state['requests'][0]['text']['format']['strict'] is True
+
+
+def test_default_transport_remains_chat_completions():
+	assert ChatOpenAI(model='gpt-4.1-mini').transport == 'chat_completions'
+
+
+def test_websocket_transport_resolves_openai_environment(monkeypatch):
+	monkeypatch.setenv('OPENAI_API_KEY', 'env-key')
+	monkeypatch.setenv('OPENAI_BASE_URL', 'https://gateway.example.test/v1')
+	monkeypatch.setenv('OPENAI_ORG_ID', 'org-test')
+	monkeypatch.setenv('OPENAI_PROJECT_ID', 'project-test')
+	transport = ChatOpenAI(model='gpt-5.6', transport='responses_websocket')._get_responses_websocket_transport()
+	assert transport.url == 'wss://gateway.example.test/v1/responses'
+	assert transport.api_key == 'env-key'
+	assert transport.organization == 'org-test'
+	assert transport.project == 'project-test'
+	assert transport.timeout == 600.0
+
+
+async def test_http_responses_transport_uses_shared_request_parser(monkeypatch):
+	captured_request: dict[str, Any] = {}
+
+	class FakeResponses:
+		async def create(self, **kwargs):
+			captured_request.update(kwargs)
+			return Response.model_validate(_response('resp_http', 'http result'))
+
+	class FakeClient:
+		responses = FakeResponses()
+
+	llm = ChatOpenAI(model='gpt-5.6', api_key='test-key', transport='responses')
+	monkeypatch.setattr(llm, 'get_client', lambda: FakeClient())
+	result = await llm.ainvoke([UserMessage(content='hello')])
+	assert result.completion == 'http result'
+	assert captured_request['model'] == 'gpt-5.6'
+	assert captured_request['store'] is True
+	assert captured_request['input'][0]['content'] == 'hello'
+	assert captured_request['reasoning'] == {'effort': 'low'}

--- a/tests/ci/models/test_openai_responses_websocket.py
+++ b/tests/ci/models/test_openai_responses_websocket.py
@@ -9,7 +9,7 @@ from openai.types.responses import Response
 from pydantic import BaseModel
 
 from browser_use.llm.exceptions import ModelOutputTruncatedError, ModelProviderError, ModelRateLimitError
-from browser_use.llm.messages import SystemMessage, UserMessage
+from browser_use.llm.messages import BaseMessage, SystemMessage, UserMessage
 from browser_use.llm.openai.chat import ChatOpenAI
 
 
@@ -197,8 +197,11 @@ async def test_reuses_connection_and_resends_full_context(responses_websocket_se
 async def test_store_false_reaches_websocket_request(responses_websocket_server):
 	state, websocket_base_url = responses_websocket_server
 	llm = ChatOpenAI(
-		model='gpt-5.6', transport='responses_websocket', websocket_base_url=websocket_base_url,
-		responses_store=False, default_headers={'Authorization': 'Bearer gateway-key'},
+		model='gpt-5.6',
+		transport='responses_websocket',
+		websocket_base_url=websocket_base_url,
+		responses_store=False,
+		default_headers={'Authorization': 'Bearer gateway-key'},
 	)
 	try:
 		await llm.ainvoke([UserMessage(content='hello')], session_id='agent-1')
@@ -210,9 +213,7 @@ async def test_store_false_reaches_websocket_request(responses_websocket_server)
 
 async def test_malformed_frame_closes_socket_before_next_request(responses_websocket_server):
 	state, websocket_base_url = responses_websocket_server
-	llm = ChatOpenAI(
-		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
-	)
+	llm = ChatOpenAI(model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url)
 	try:
 		state['malformed_once'] = True
 		with pytest.raises(ModelProviderError, match='Invalid JSON frame'):
@@ -228,8 +229,11 @@ async def test_timeout_reconnects_and_retries_full_context(responses_websocket_s
 	state, websocket_base_url = responses_websocket_server
 	state['hang_once'] = True
 	llm = ChatOpenAI(
-		model='gpt-5.6', api_key='test-key', transport='responses_websocket',
-		websocket_base_url=websocket_base_url, timeout=0.05,
+		model='gpt-5.6',
+		api_key='test-key',
+		transport='responses_websocket',
+		websocket_base_url=websocket_base_url,
+		timeout=0.05,
 	)
 	try:
 		result = await llm.ainvoke([UserMessage(content='full')], session_id='agent-1')
@@ -243,9 +247,7 @@ async def test_timeout_reconnects_and_retries_full_context(responses_websocket_s
 async def test_connection_lifetime_error_reconnects_and_retries(responses_websocket_server):
 	state, websocket_base_url = responses_websocket_server
 	state['connection_limit_once'] = True
-	llm = ChatOpenAI(
-		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
-	)
+	llm = ChatOpenAI(model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url)
 	try:
 		result = await llm.ainvoke([UserMessage(content='full')], session_id='agent-1')
 	finally:
@@ -259,9 +261,7 @@ async def test_connection_lifetime_error_reconnects_and_retries(responses_websoc
 async def test_handshake_rate_limit_preserves_rate_limit_error(responses_websocket_server):
 	state, websocket_base_url = responses_websocket_server
 	state['handshake_status_once'] = 429
-	llm = ChatOpenAI(
-		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
-	)
+	llm = ChatOpenAI(model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url)
 	try:
 		with pytest.raises(ModelRateLimitError):
 			await llm.ainvoke([UserMessage(content='full')], session_id='agent-1')
@@ -272,10 +272,8 @@ async def test_handshake_rate_limit_preserves_rate_limit_error(responses_websock
 
 async def test_sessions_and_invocation_scopes_are_isolated(responses_websocket_server):
 	state, websocket_base_url = responses_websocket_server
-	llm = ChatOpenAI(
-		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
-	)
-	messages = [UserMessage(content='hello')]
+	llm = ChatOpenAI(model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url)
+	messages: list[BaseMessage] = [UserMessage(content='hello')]
 	try:
 		await llm.ainvoke(messages, session_id='shared', invocation_scope='agent')
 		await llm.ainvoke(messages, session_id='shared', invocation_scope='judge')
@@ -289,9 +287,7 @@ async def test_sessions_and_invocation_scopes_are_isolated(responses_websocket_s
 
 async def test_error_and_terminal_failures_map_to_model_errors(responses_websocket_server):
 	state, websocket_base_url = responses_websocket_server
-	llm = ChatOpenAI(
-		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
-	)
+	llm = ChatOpenAI(model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url)
 	try:
 		state['rate_limit_once'] = True
 		with pytest.raises(ModelRateLimitError, match='slow down'):
@@ -316,13 +312,9 @@ class StructuredResult(BaseModel):
 async def test_structured_output_uses_responses_schema(responses_websocket_server):
 	state, websocket_base_url = responses_websocket_server
 	state['response_texts'] = ['{"answer":"ok"}']
-	llm = ChatOpenAI(
-		model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url
-	)
+	llm = ChatOpenAI(model='gpt-5.6', api_key='test-key', transport='responses_websocket', websocket_base_url=websocket_base_url)
 	try:
-		result = await llm.ainvoke(
-			[UserMessage(content='return json')], output_format=StructuredResult, session_id='agent-1'
-		)
+		result = await llm.ainvoke([UserMessage(content='return json')], output_format=StructuredResult, session_id='agent-1')
 	finally:
 		await llm.aclose()
 	assert result.completion == StructuredResult(answer='ok')

--- a/tests/ci/test_agent_llm_session_cleanup.py
+++ b/tests/ci/test_agent_llm_session_cleanup.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Any
 
 from browser_use.agent.service import Agent
 from browser_use.agent.views import RerunSummaryAction
@@ -32,7 +33,7 @@ async def test_agent_closes_only_its_session_on_each_distinct_model():
 	shared = _SessionModel()
 	compaction = _SessionModel()
 	ai_step = _SessionModel()
-	agent = object.__new__(Agent)
+	agent: Any = object.__new__(Agent)
 	agent.session_id = 'agent-one'
 	agent.llm = shared
 	agent.judge_llm = shared
@@ -53,7 +54,7 @@ async def test_agent_closes_only_its_session_on_each_distinct_model():
 
 async def test_rerun_summary_tracks_custom_llm_for_session_cleanup():
 	custom_summary_llm = _SessionModel()
-	agent = object.__new__(Agent)
+	agent: Any = object.__new__(Agent)
 	agent.session_id = 'agent-one'
 	agent.llm = _SessionModel()
 	agent.browser_session = _BrowserSession()

--- a/tests/ci/test_agent_llm_session_cleanup.py
+++ b/tests/ci/test_agent_llm_session_cleanup.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+from browser_use.agent.service import Agent
+from browser_use.agent.views import RerunSummaryAction
+from browser_use.llm.views import ChatInvokeCompletion
+
+
+class _SessionModel:
+	def __init__(self) -> None:
+		self.closed_sessions: list[str] = []
+		self.model = 'session-model'
+
+	async def close_session(self, session_id: str) -> None:
+		self.closed_sessions.append(session_id)
+
+	async def ainvoke(self, messages, output_format=None, **kwargs):
+		return ChatInvokeCompletion(
+			completion=RerunSummaryAction(summary='done', success=True, completion_status='complete'),
+			usage=None,
+		)
+
+
+class _BrowserSession:
+	id = 'browser-session'
+	agent_focus_target_id = None
+
+	async def take_screenshot(self, **kwargs):
+		return None
+
+
+async def test_agent_closes_only_its_session_on_each_distinct_model():
+	shared = _SessionModel()
+	compaction = _SessionModel()
+	ai_step = _SessionModel()
+	agent = object.__new__(Agent)
+	agent.session_id = 'agent-one'
+	agent.llm = shared
+	agent.judge_llm = shared
+	agent._original_llm = shared
+	agent._fallback_llm = None
+	agent.settings = SimpleNamespace(
+		page_extraction_llm=shared,
+		message_compaction=SimpleNamespace(compaction_llm=compaction),
+	)
+	agent._additional_session_llms = {id(ai_step): ai_step}
+
+	await agent._close_llm_sessions()
+
+	assert shared.closed_sessions == ['agent-one']
+	assert compaction.closed_sessions == ['agent-one']
+	assert ai_step.closed_sessions == ['agent-one']
+
+
+async def test_rerun_summary_tracks_custom_llm_for_session_cleanup():
+	custom_summary_llm = _SessionModel()
+	agent = object.__new__(Agent)
+	agent.session_id = 'agent-one'
+	agent.llm = _SessionModel()
+	agent.browser_session = _BrowserSession()
+	agent._additional_session_llms = {}
+
+	result = await agent._generate_rerun_summary('task', [], custom_summary_llm)
+
+	assert result.error is None
+	assert agent._additional_session_llms[id(custom_summary_llm)] is custom_summary_llm

--- a/tests/ci/test_ai_step.py
+++ b/tests/ci/test_ai_step.py
@@ -9,9 +9,11 @@ from tests.ci.conftest import create_mock_llm
 
 async def test_execute_ai_step_basic():
 	"""Test that _execute_ai_step extracts content with AI"""
+	invocation_kwargs = {}
 
 	# Create mock LLM that returns text response
 	async def custom_ainvoke(*args, **kwargs):
+		invocation_kwargs.update(kwargs)
 		from browser_use.llm.views import ChatInvokeCompletion
 
 		return ChatInvokeCompletion(completion='Extracted: Test content from page', usage=None)
@@ -38,6 +40,8 @@ async def test_execute_ai_step_basic():
 		assert result.extracted_content is not None
 		assert 'Extracted: Test content from page' in result.extracted_content
 		assert result.long_term_memory is not None
+		assert invocation_kwargs['session_id'] == agent.session_id
+		assert invocation_kwargs['invocation_scope'] == 'rerun_ai_step'
 
 	finally:
 		await agent.close()

--- a/tests/ci/test_llm_invocation_scopes.py
+++ b/tests/ci/test_llm_invocation_scopes.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -77,7 +78,7 @@ async def test_rerun_ai_step_uses_agent_session_and_tracks_custom_llm(tmp_path, 
 	llm = AsyncMock()
 	llm.ainvoke.side_effect = invoke
 	llm.model = 'mock-model'
-	agent = object.__new__(Agent)
+	agent: Any = object.__new__(Agent)
 	agent.llm = llm
 	agent.session_id = 'agent-session'
 	agent.browser_session = _FakeBrowserSession()

--- a/tests/ci/test_llm_invocation_scopes.py
+++ b/tests/ci/test_llm_invocation_scopes.py
@@ -1,0 +1,96 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from browser_use.agent.service import Agent
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.tools.service import Tools
+
+
+class _FakeBrowserSession:
+	id = 'browser-session'
+	agent_focus_target_id = None
+	cdp_client = None
+
+	async def get_current_page_url(self) -> str:
+		return 'https://example.test/'
+
+
+@pytest.fixture
+def extracted_markdown(monkeypatch):
+	async def fake_extract_clean_markdown(*, browser_session, extract_links, extract_images=False):
+		return 'Example page content', {
+			'original_html_chars': 100,
+			'initial_markdown_chars': 40,
+			'filtered_chars_removed': 5,
+			'final_filtered_chars': 35,
+		}
+
+	monkeypatch.setattr('browser_use.dom.markdown_extractor.extract_clean_markdown', fake_extract_clean_markdown)
+
+
+@pytest.mark.parametrize('structured', [False, True])
+async def test_extract_threads_agent_session_to_llm(tmp_path, extracted_markdown, structured):
+	captured_kwargs = {}
+
+	async def invoke(messages, output_format=None, **kwargs):
+		captured_kwargs.update(kwargs)
+		completion = output_format.model_validate({'answer': 'ok'}) if output_format is not None else 'ok'
+		return ChatInvokeCompletion(completion=completion, usage=None)
+
+	llm = AsyncMock()
+	llm.ainvoke.side_effect = invoke
+	llm.model = 'mock-model'
+	tools = Tools()
+	output_schema = (
+		{
+			'type': 'object',
+			'properties': {'answer': {'type': 'string'}},
+			'required': ['answer'],
+		}
+		if structured
+		else None
+	)
+
+	result = await tools.extract(
+		query='extract the answer',
+		output_schema=output_schema,
+		browser_session=_FakeBrowserSession(),
+		page_extraction_llm=llm,
+		file_system=FileSystem(str(tmp_path)),
+		llm_session_id='agent-session',
+	)
+
+	assert result.error is None
+	assert captured_kwargs['session_id'] == 'agent-session'
+	assert captured_kwargs['invocation_scope'] == 'page_extraction'
+
+
+async def test_rerun_ai_step_uses_agent_session_and_tracks_custom_llm(tmp_path, extracted_markdown):
+	captured_kwargs = {}
+
+	async def invoke(messages, **kwargs):
+		captured_kwargs.update(kwargs)
+		return ChatInvokeCompletion(completion='analysis', usage=None)
+
+	llm = AsyncMock()
+	llm.ainvoke.side_effect = invoke
+	llm.model = 'mock-model'
+	agent = object.__new__(Agent)
+	agent.llm = llm
+	agent.session_id = 'agent-session'
+	agent.browser_session = _FakeBrowserSession()
+	agent.file_system = FileSystem(str(tmp_path))
+	agent._additional_session_llms = {}
+
+	result = await agent._execute_ai_step(
+		query='analyze the page',
+		include_screenshot=False,
+		ai_step_llm=llm,
+	)
+
+	assert result.error is None
+	assert captured_kwargs['session_id'] == 'agent-session'
+	assert captured_kwargs['invocation_scope'] == 'rerun_ai_step'
+	assert agent._additional_session_llms[id(llm)] is llm

--- a/tests/ci/test_structured_extraction.py
+++ b/tests/ci/test_structured_extraction.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import tempfile
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
@@ -424,8 +425,10 @@ class TestExtractStructured:
 		meta = result.metadata['extraction_result']
 		assert meta['data'] == mock_data
 		assert meta['schema_used'] == output_schema
-		assert extraction_llm.ainvoke.await_args.kwargs['session_id'] == 'agent-test'
-		assert extraction_llm.ainvoke.await_args.kwargs['invocation_scope'] == 'page_extraction'
+		mock_ainvoke = cast(AsyncMock, extraction_llm.ainvoke)
+		assert mock_ainvoke.await_args is not None
+		assert mock_ainvoke.await_args.kwargs['session_id'] == 'agent-test'
+		assert mock_ainvoke.await_args.kwargs['invocation_scope'] == 'page_extraction'
 
 	async def test_freetext_extraction_unchanged(self, browser_session, base_url):
 		"""When output_schema is None, extract returns free-text in <result> tags (backward compat)."""
@@ -451,8 +454,10 @@ class TestExtractStructured:
 		assert '</result>' in result.extracted_content
 		assert '<structured_result>' not in result.extracted_content
 		assert result.metadata is None
-		assert extraction_llm.ainvoke.await_args.kwargs['session_id'] == 'agent-test'
-		assert extraction_llm.ainvoke.await_args.kwargs['invocation_scope'] == 'page_extraction'
+		mock_ainvoke = cast(AsyncMock, extraction_llm.ainvoke)
+		assert mock_ainvoke.await_args is not None
+		assert mock_ainvoke.await_args.kwargs['session_id'] == 'agent-test'
+		assert mock_ainvoke.await_args.kwargs['invocation_scope'] == 'page_extraction'
 
 	async def test_invalid_schema_falls_back_to_freetext(self, browser_session, base_url):
 		"""When output_schema contains unsupported keywords, fall back to free-text gracefully."""

--- a/tests/ci/test_structured_extraction.py
+++ b/tests/ci/test_structured_extraction.py
@@ -404,6 +404,7 @@ class TestExtractStructured:
 				browser_session=browser_session,
 				page_extraction_llm=extraction_llm,
 				file_system=fs,
+				llm_session_id='agent-test',
 			)
 
 		assert isinstance(result, ActionResult)
@@ -423,6 +424,8 @@ class TestExtractStructured:
 		meta = result.metadata['extraction_result']
 		assert meta['data'] == mock_data
 		assert meta['schema_used'] == output_schema
+		assert extraction_llm.ainvoke.await_args.kwargs['session_id'] == 'agent-test'
+		assert extraction_llm.ainvoke.await_args.kwargs['invocation_scope'] == 'page_extraction'
 
 	async def test_freetext_extraction_unchanged(self, browser_session, base_url):
 		"""When output_schema is None, extract returns free-text in <result> tags (backward compat)."""
@@ -439,6 +442,7 @@ class TestExtractStructured:
 				browser_session=browser_session,
 				page_extraction_llm=extraction_llm,
 				file_system=fs,
+				llm_session_id='agent-test',
 			)
 
 		assert isinstance(result, ActionResult)
@@ -447,6 +451,8 @@ class TestExtractStructured:
 		assert '</result>' in result.extracted_content
 		assert '<structured_result>' not in result.extracted_content
 		assert result.metadata is None
+		assert extraction_llm.ainvoke.await_args.kwargs['session_id'] == 'agent-test'
+		assert extraction_llm.ainvoke.await_args.kwargs['invocation_scope'] == 'page_extraction'
 
 	async def test_invalid_schema_falls_back_to_freetext(self, browser_session, base_url):
 		"""When output_schema contains unsupported keywords, fall back to free-text gracefully."""


### PR DESCRIPTION
Adds opt-in OpenAI Responses support over HTTP and persistent WebSocket connections, including OpenAI and Vercel AI Gateway. WebSocket mode reuses session-scoped connections and supports reconnection, structured output, error handling, and agent cleanup.

```python
llm = ChatOpenAI(
    model='gpt-5',
    transport='responses_websocket',
)
```

The existing `chat_completions` transport remains the default, so current `ChatOpenAI` usage is unchanged. Benchmarks showed no major end-to-end difference: 

WebSocket had slightly better TTFB and LLM latency, while total task time, tokens, and cost were broadly similar.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAI Responses to `ChatOpenAI` over HTTP and a persistent WebSocket transport with session- and scope-scoped connections, reconnection, and structured output. Threads agent `session_id` and `invocation_scope` through all LLM calls and closes per-session resources on `Agent.close()`; `chat_completions` behavior is unchanged.

- New Features
  - `ChatOpenAI` supports `transport='responses'` and `transport='responses_websocket'` with `responses_store` and optional `websocket_base_url`; reuses one socket per `session_id` + `invocation_scope`, uses ephemeral sockets when no session, and exposes `close_session`/`aclose`.
  - Shared Responses request/parse in `browser_use.llm.openai.responses`; used by both `ChatOpenAI` and `ChatAzureOpenAI` for consistent structured output, truncation, and usage accounting.
  - Agent adds `invocation_scope` and passes `session_id` through `agent`, `judge`, `compaction`, `page_extraction`, `rerun_ai_step`, and `rerun_summary`; tools accept `llm_session_id` for extraction.
  - New `_close_llm_sessions` closes this agent’s sessions across all involved LLM instances, including ad‑hoc rerun models.
  - Env support for gateways via `OPENAI_BASE_URL`, `OPENAI_ORG_ID`, `OPENAI_PROJECT_ID`; `.env.example` adds `OPENAI_BASE_URL` and `AI_GATEWAY_API_KEY`. Docs show `responses_websocket` usage with Vercel AI Gateway.

- Refactors
  - Centralized Responses request building, parsing, and error handling; simplified Azure code. Cached OpenAI client and clean shutdown of WebSocket and HTTP clients.

<sup>Written for commit 94f94e0ac9b43a24b73bff2d73b7dc714e3c7721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

