### PR TITLE
Add AdaL as a supported skill-install target

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ https://github.com/user-attachments/assets/93714c75-98f4-4cfc-add1-69c38b5138b5
 
 # Quickstart
 
-If you want to use Browser Use in your agent (Claude Code, Codex, Cursor, Hermes, OpenClaw, etc.), paste this prompt, and it sets everything up itself:
+If you want to use Browser Use in your agent (Claude Code, Codex, AdaL, Cursor, Hermes, OpenClaw, etc.), paste this prompt, and it sets everything up itself:
 
 ```text
 Install or upgrade browser-use to the latest stable version with uv using Python 3.12, run `browser-use skill install` to register the skill, and connect it to my browser. If setup or connection fails, follow https://github.com/browser-use/browser-harness/blob/main/install.md.
@@ -162,7 +162,7 @@ Browser Use is also **#1 on the [Odysseys leaderboard](https://odysseysbench.com
 <details>
 <summary><b>Should I use the CLI vs. the Python library?</b></summary>
 
-**Use the CLI** if you already have an agent (Claude Code, Codex, Cursor, Hermes, OpenClaw, etc.) that you want to complete browser tasks for you. The agent installs the skill once (see [Quickstart](#quickstart)) and can then control the browser. Examples:
+**Use the CLI** if you already have an agent (Claude Code, Codex, AdaL, Cursor, Hermes, OpenClaw, etc.) that you want to complete browser tasks for you. The agent installs the skill once (see [Quickstart](#quickstart)) and can then control the browser. Examples:
 - "Upload this video to YouTube"
 - "Compare these three laptops and give me a table with prices"
 - "Fill in this job application with my resume"

--- a/browser_use/skills/install.py
+++ b/browser_use/skills/install.py
@@ -23,6 +23,7 @@ def _home_skill_dir(assistant: str) -> Path:
 
 
 TARGET_DIR_BUILDERS = {
+	'adal': lambda: _home_skill_dir('adal'),
 	'agents': lambda: _home_skill_dir('agents'),
 	'claude': lambda: _home_skill_dir('claude'),
 	'codex': lambda: _home_skill_dir('codex'),

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 BROWSER_USE_REPO_SKILL_URL = 'https://raw.githubusercontent.com/browser-use/browser-use/main/skills/browser-use/SKILL.md'
 EXPECTED_SKILL_INSTALL_PATHS = (
+	Path('.adal') / 'skills' / 'browser-use' / 'SKILL.md',
 	Path('.agents') / 'skills' / 'browser-use' / 'SKILL.md',
 	Path('.claude') / 'skills' / 'browser-use' / 'SKILL.md',
 	Path('.codex') / 'skills' / 'browser-use' / 'SKILL.md',


### PR DESCRIPTION
## Summary

Adds [AdaL](https://sylph.ai) as a recognized skill-install target for `browser-use skill install`.

AdaL is an open-source AI coding agent CLI ([docs](https://docs.sylph.ai)). Its skill loader scans `~/.adal/skills/<name>/SKILL.md` for personal skills — the exact `~/.{assistant}/skills/` convention already used by `claude`, `codex`, `copilot`, and `cursor` via `_home_skill_dir()`.

## Changes

- `browser_use/skills/install.py`: add `'adal': lambda: _home_skill_dir('adal')` to `TARGET_DIR_BUILDERS` (alphabetically placed).
- `README.md`: mention AdaL alongside the other example coding agents in the two "Claude Code, Codex, Cursor, Hermes, OpenClaw, etc." lists.
- `tests/ci/test_browser_use_skill_install_docs.py`: add the new `.adal/skills/browser-use/SKILL.md` path to `EXPECTED_SKILL_INSTALL_PATHS` so `test_browser_use_cli_installs_browser_harness_package_skill` covers the new target.

## Why

`browser-use skill install --target all` (or `--target adal`) currently has no way to write the skill into AdaL's skill directory, even though AdaL follows the identical `~/.{assistant}/skills/<skill>/SKILL.md` layout every other supported assistant uses. This is a one-line, same-pattern addition — no new helper logic, no architecture change.

## Testing

- `ruff check` — passed on both changed Python files
- `ruff format --check` — passed
- `pyright browser_use/skills/install.py` — 0 errors, 0 warnings
- `pytest tests/ci/test_browser_use_skill_install_docs.py` — 3 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add AdaL as a supported target so `browser-use skill install` writes the skill to `~/.adal/skills/browser-use/SKILL.md`. Updates the README to mention AdaL and extends the skill-install path test to include the AdaL path.

<sup>Written for commit 46b359b4e2fc854d7ea53e031d605e1ffcd83a62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

