### PR TITLE
Update Cerebras model IDs and default

### DIFF
--- a/browser_use/llm/cerebras/chat.py
+++ b/browser_use/llm/cerebras/chat.py
@@ -28,7 +28,7 @@ T = TypeVar('T', bound=BaseModel)
 class ChatCerebras(BaseChatModel):
 	"""Cerebras inference wrapper (OpenAI-compatible)."""
 
-	model: str = 'llama3.1-8b'
+	model: str = 'gpt-oss-120b'
 
 	# Generation parameters
 	max_tokens: int | None = 4096

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -79,6 +79,8 @@ anthropic_claude_3_5_haiku_latest: 'BaseChatModel'
 cerebras_llama3_1_8b: 'BaseChatModel'
 cerebras_llama3_3_70b: 'BaseChatModel'
 cerebras_gpt_oss_120b: 'BaseChatModel'
+cerebras_zai_glm_4_7: 'BaseChatModel'
+cerebras_gemma_4_31b: 'BaseChatModel'
 cerebras_llama_4_scout_17b_16e_instruct: 'BaseChatModel'
 cerebras_llama_4_maverick_17b_128e_instruct: 'BaseChatModel'
 cerebras_qwen_3_32b: 'BaseChatModel'
@@ -319,6 +321,8 @@ __all__ += [
 	'cerebras_llama3_1_8b',
 	'cerebras_llama3_3_70b',
 	'cerebras_gpt_oss_120b',
+	'cerebras_zai_glm_4_7',
+	'cerebras_gemma_4_31b',
 	'cerebras_llama_4_scout_17b_16e_instruct',
 	'cerebras_llama_4_maverick_17b_128e_instruct',
 	'cerebras_qwen_3_32b',

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -76,17 +76,9 @@ anthropic_claude_fable_5: 'BaseChatModel'
 anthropic_claude_3_5_sonnet_latest: 'BaseChatModel'
 anthropic_claude_3_5_haiku_latest: 'BaseChatModel'
 
-cerebras_llama3_1_8b: 'BaseChatModel'
-cerebras_llama3_3_70b: 'BaseChatModel'
 cerebras_gpt_oss_120b: 'BaseChatModel'
 cerebras_zai_glm_4_7: 'BaseChatModel'
 cerebras_gemma_4_31b: 'BaseChatModel'
-cerebras_llama_4_scout_17b_16e_instruct: 'BaseChatModel'
-cerebras_llama_4_maverick_17b_128e_instruct: 'BaseChatModel'
-cerebras_qwen_3_32b: 'BaseChatModel'
-cerebras_qwen_3_235b_a22b_instruct_2507: 'BaseChatModel'
-cerebras_qwen_3_235b_a22b_thinking_2507: 'BaseChatModel'
-cerebras_qwen_3_coder_480b: 'BaseChatModel'
 
 bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
@@ -318,17 +310,9 @@ __all__ += [
 	'codestral',
 	'pixtral_large',
 	# Cerebras instances - created on demand
-	'cerebras_llama3_1_8b',
-	'cerebras_llama3_3_70b',
 	'cerebras_gpt_oss_120b',
 	'cerebras_zai_glm_4_7',
 	'cerebras_gemma_4_31b',
-	'cerebras_llama_4_scout_17b_16e_instruct',
-	'cerebras_llama_4_maverick_17b_128e_instruct',
-	'cerebras_qwen_3_32b',
-	'cerebras_qwen_3_235b_a22b_instruct_2507',
-	'cerebras_qwen_3_235b_a22b_thinking_2507',
-	'cerebras_qwen_3_coder_480b',
 	# Browser Use instances - created on demand
 	'bu_latest',
 	'bu_1_0',

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -143,6 +143,8 @@ def get_llm_by_name(model_name: str):
 		model = model_part.replace('llama_4_maverick', 'llama-4-maverick').replace('_', '-')
 	elif 'gpt_oss_120b' in model_part:
 		model = model_part.replace('gpt_oss_120b', 'gpt-oss-120b')
+	elif 'zai_glm_4_7' in model_part:
+		model = model_part.replace('zai_glm_4_7', 'zai-glm-4.7')
 	elif 'qwen_3_32b' in model_part:
 		model = model_part.replace('qwen_3_32b', 'qwen-3-32b')
 	elif 'qwen_3_235b_a22b_instruct' in model_part:

--- a/tests/ci/models/test_llm_model_factory.py
+++ b/tests/ci/models/test_llm_model_factory.py
@@ -1,4 +1,5 @@
 from browser_use.llm.anthropic.chat import ChatAnthropic
+from browser_use.llm.cerebras.chat import ChatCerebras
 from browser_use.llm.models import get_llm_by_name
 
 
@@ -10,3 +11,13 @@ def test_get_llm_by_name_resolves_anthropic_from_env(monkeypatch):
 	assert isinstance(llm, ChatAnthropic)
 	assert llm.model == 'claude-sonnet-4-0'
 	assert llm.api_key == 'anthropic-test-key'
+
+
+def test_get_llm_by_name_preserves_cerebras_zai_glm_version_separator(monkeypatch):
+	monkeypatch.setenv('CEREBRAS_API_KEY', 'cerebras-test-key')
+
+	llm = get_llm_by_name('cerebras_zai_glm_4_7')
+
+	assert isinstance(llm, ChatCerebras)
+	assert llm.model == 'zai-glm-4.7'
+	assert llm.api_key == 'cerebras-test-key'


### PR DESCRIPTION
## Summary

- Adds GLM 4.7 and Gemma 4 aliases and changes the default from retired llama3.1-8b to gpt-oss-120b.
- The current public catalog is `gpt-oss-120b`, `zai-glm-4.7`, and `gemma-4-31b`.

## Why

The previous model ID was retired or the fixed catalog was missing a currently available Cerebras model. This could produce failed requests, stale autocomplete, or misleading examples.

## Validation

- Python syntax parsing, git diff check, and comparison with the live Cerebras model endpoint.
- Source of truth: https://api.cerebras.ai/public/v1/models

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Cerebras model IDs to match the public catalog and switch the default to `gpt-oss-120b`. Add `zai-glm-4.7` and `gemma-4-31b`, remove retired aliases (llama3.*, llama4.*, qwen3.*), and fix `cerebras_zai_glm_4_7` → `zai-glm-4.7` resolution with tests.

<sup>Written for commit ae9d11cc1bb7a606da4fdebdb35cec890fbff6df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

