### PR TITLE
feat(agent): support agent.pause() within tool calls

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2472,7 +2472,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 						await asyncio.wait([task], timeout=0.1)
 					else:
 						start_time = asyncio.get_event_loop().time()
-						await asyncio.wait([task], timeout=0.1)
+						wait_timeout = min(0.1, budget) if budget > 0 else 0.1
+						await asyncio.wait([task], timeout=wait_timeout)
 						if not self.state.paused:
 							budget -= asyncio.get_event_loop().time() - start_time
 						if not task.done() and budget <= 0:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2472,7 +2472,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 						await asyncio.wait([task], timeout=0.1)
 					else:
 						start_time = asyncio.get_event_loop().time()
-						wait_timeout = min(0.1, budget) if budget > 0 else 0.1
+						wait_timeout = max(0.0, min(0.1, budget))
 						await asyncio.wait([task], timeout=wait_timeout)
 						if not self.state.paused:
 							budget -= asyncio.get_event_loop().time() - start_time

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2466,22 +2466,25 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		try:
 			task = asyncio.create_task(self.step(step_info))
 			budget = float(self.settings.step_timeout)
-			while not task.done():
-				if self.state.paused:
-					await asyncio.wait([task], timeout=1.0)
-				else:
-					start_time = asyncio.get_event_loop().time()
-					await asyncio.wait([task], timeout=1.0)
-					if not self.state.paused:
-						budget -= (asyncio.get_event_loop().time() - start_time)
-					if not task.done() and budget <= 0:
-						task.cancel()
-						try:
-							await task
-						except asyncio.CancelledError:
-							pass
-						raise TimeoutError()
-			await task
+			try:
+				while not task.done():
+					if self.state.paused:
+						await asyncio.wait([task], timeout=0.1)
+					else:
+						start_time = asyncio.get_event_loop().time()
+						await asyncio.wait([task], timeout=0.1)
+						if not self.state.paused:
+							budget -= asyncio.get_event_loop().time() - start_time
+						if not task.done() and budget <= 0:
+							raise TimeoutError()
+				await task
+			finally:
+				if not task.done():
+					task.cancel()
+					try:
+						await task
+					except asyncio.CancelledError:
+						pass
 			self.logger.debug(f'✅ Completed step {step + 1}/{max_steps}')
 		except TimeoutError:
 			# Handle step timeout gracefully

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2464,10 +2464,24 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self.logger.debug(f'🚶 Starting step {step + 1}/{max_steps}...')
 
 		try:
-			await asyncio.wait_for(
-				self.step(step_info),
-				timeout=self.settings.step_timeout,
-			)
+			task = asyncio.create_task(self.step(step_info))
+			budget = float(self.settings.step_timeout)
+			while not task.done():
+				if self.state.paused:
+					await asyncio.wait([task], timeout=1.0)
+				else:
+					start_time = asyncio.get_event_loop().time()
+					await asyncio.wait([task], timeout=1.0)
+					if not self.state.paused:
+						budget -= (asyncio.get_event_loop().time() - start_time)
+					if not task.done() and budget <= 0:
+						task.cancel()
+						try:
+							await task
+						except asyncio.CancelledError:
+							pass
+						raise TimeoutError()
+			await task
 			self.logger.debug(f'✅ Completed step {step + 1}/{max_steps}')
 		except TimeoutError:
 			# Handle step timeout gracefully

--- a/tests/ci/test_agent_pause_timeout.py
+++ b/tests/ci/test_agent_pause_timeout.py
@@ -1,0 +1,49 @@
+import asyncio
+import time
+import pytest
+from pydantic import BaseModel
+from browser_use import Agent, Browser, ActionResult, Controller
+
+@pytest.mark.asyncio
+async def test_agent_pause_timeout(mock_llm):
+    """
+    Test that an agent can be paused for longer than the step_timeout
+    and successfully resume without raising a TimeoutError.
+    """
+    controller = Controller()
+
+    @controller.action('Wait and do something')
+    async def custom_pause_action():
+        agent.pause()
+        await asyncio.sleep(4.0)
+        agent.resume()
+        return ActionResult(extracted_content='Success after pause')
+
+    # Force the mock LLM to call the custom tool first, then done.
+    from tests.ci.conftest import create_mock_llm
+    custom_action_json = '{"action": [{"custom_pause_action": {}}]}'
+    mock_llm_with_action = create_mock_llm(actions=[custom_action_json])
+
+    # Extremely short step timeout (2.0s)
+    agent = Agent(
+        task='Test pause functionality. Call the custom tool once.',
+        llm=mock_llm_with_action,
+        controller=controller,
+        browser=Browser(),
+        # Injecting fake max_steps to ensure fast execution
+        max_actions_per_step=1,
+    )
+    # Override timeout setting
+    agent.settings.step_timeout = 2.0
+
+    # Ensure it works without failing
+    start_time = time.time()
+    history = await agent.run(max_steps=2)
+    elapsed = time.time() - start_time
+
+    # We expect elapsed to be > 4 seconds because of the sleep
+    assert elapsed >= 4.0
+    
+    # We expect the agent didn't fail due to TimeoutError
+    assert agent.state.consecutive_failures == 0
+    assert history.is_done() or history.has_errors() == False

--- a/tests/ci/test_agent_pause_timeout.py
+++ b/tests/ci/test_agent_pause_timeout.py
@@ -37,7 +37,7 @@ async def test_agent_pause_timeout(mock_llm):
 		max_actions_per_step=1,
 	)
 	# Override timeout setting
-	agent.settings.step_timeout = 2.0
+	agent.settings.step_timeout = 2
 
 	# Ensure it works without failing
 	start_time = time.time()

--- a/tests/ci/test_agent_pause_timeout.py
+++ b/tests/ci/test_agent_pause_timeout.py
@@ -1,49 +1,52 @@
 import asyncio
 import time
+
 import pytest
-from pydantic import BaseModel
-from browser_use import Agent, Browser, ActionResult, Controller
+
+from browser_use import ActionResult, Agent, Browser, Controller
+
 
 @pytest.mark.asyncio
 async def test_agent_pause_timeout(mock_llm):
-    """
-    Test that an agent can be paused for longer than the step_timeout
-    and successfully resume without raising a TimeoutError.
-    """
-    controller = Controller()
+	"""
+	Test that an agent can be paused for longer than the step_timeout
+	and successfully resume without raising a TimeoutError.
+	"""
+	controller = Controller()
 
-    @controller.action('Wait and do something')
-    async def custom_pause_action():
-        agent.pause()
-        await asyncio.sleep(4.0)
-        agent.resume()
-        return ActionResult(extracted_content='Success after pause')
+	@controller.action('Wait and do something')
+	async def custom_pause_action():
+		agent.pause()
+		await asyncio.sleep(4.0)
+		agent.resume()
+		return ActionResult(extracted_content='Success after pause')
 
-    # Force the mock LLM to call the custom tool first, then done.
-    from tests.ci.conftest import create_mock_llm
-    custom_action_json = '{"action": [{"custom_pause_action": {}}]}'
-    mock_llm_with_action = create_mock_llm(actions=[custom_action_json])
+	# Force the mock LLM to call the custom tool first, then done.
+	from tests.ci.conftest import create_mock_llm
 
-    # Extremely short step timeout (2.0s)
-    agent = Agent(
-        task='Test pause functionality. Call the custom tool once.',
-        llm=mock_llm_with_action,
-        controller=controller,
-        browser=Browser(),
-        # Injecting fake max_steps to ensure fast execution
-        max_actions_per_step=1,
-    )
-    # Override timeout setting
-    agent.settings.step_timeout = 2.0
+	custom_action_json = '{"action": [{"custom_pause_action": {}}]}'
+	mock_llm_with_action = create_mock_llm(actions=[custom_action_json])
 
-    # Ensure it works without failing
-    start_time = time.time()
-    history = await agent.run(max_steps=2)
-    elapsed = time.time() - start_time
+	# Extremely short step timeout (2.0s)
+	agent = Agent(
+		task='Test pause functionality. Call the custom tool once.',
+		llm=mock_llm_with_action,
+		controller=controller,
+		browser=Browser(),
+		# Injecting fake max_steps to ensure fast execution
+		max_actions_per_step=1,
+	)
+	# Override timeout setting
+	agent.settings.step_timeout = 2.0
 
-    # We expect elapsed to be > 4 seconds because of the sleep
-    assert elapsed >= 4.0
-    
-    # We expect the agent didn't fail due to TimeoutError
-    assert agent.state.consecutive_failures == 0
-    assert history.is_done() or history.has_errors() == False
+	# Ensure it works without failing
+	start_time = time.time()
+	history = await agent.run(max_steps=2)
+	elapsed = time.time() - start_time
+
+	# We expect elapsed to be > 4 seconds because of the sleep
+	assert elapsed >= 4.0
+
+	# We expect the agent didn't fail due to TimeoutError
+	assert agent.state.consecutive_failures == 0
+	assert history.is_done() or not history.has_errors()


### PR DESCRIPTION
Fixes #4798

### Background
Currently, the entire agent step execution is wrapped in a wall-clock `asyncio.wait_for`. If a custom tool calls `agent.pause()` to wait for human-in-the-loop input (e.g., 2FA codes, approvals), the step's timeout clock keeps ticking and eventually kills the execution with a `TimeoutError`, breaking the workflow.

### Changes
* Replaced the static `asyncio.wait_for` wrapper inside `Agent._execute_step()` with a dynamic, chunked polling loop.
* The loop evaluates the task status every 1.0s. If the agent's state is paused (`self.state.paused == True`), the step budget is perfectly frozen and time spent waiting for external signals does not count against `step_timeout`.
* If unpaused, the step budget correctly decreases.
* No changes to `pause()`/`resume()` interfaces or the `TimeoutError` contract. The fix is performant and gracefully catches early completions via `asyncio.wait` returning on `FIRST_COMPLETED`.

### Testing
* Added `tests/ci/test_agent_pause_timeout.py` which provisions an aggressively short 2.0s `step_timeout`. A custom tool pauses the agent, sleeps for 4.0s, and resumes. The test successfully passes without a `TimeoutError`, proving that the clock is safely suspended while paused.
