### PR TITLE
Add --help flag to CLI with combined help message.

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -335,6 +335,24 @@ _EMPTY_STDIN_MESSAGE = """browser-use received empty stdin. This CLI executes Py
   PY"""
 
 
+def _build_help_message() -> str:
+	from browser_harness import run
+
+	harness_help = _as_browser_use_cli_text(run.HELP)
+	browser_use_only = """Additional commands and flags (Browser Use specific):
+
+  browser-use install              Install Chromium browser and system dependencies
+  browser-use init                 Scaffold a new project
+  browser-use --mcp                Start MCP server (stdio, full browser tools)
+  browser-use --cli-mcp            Start MCP server (stdio, CLI helpers only)
+  browser-use --template, -t       Same as 'init'
+  browser-use --help, -h           Show this help message
+
+More info: https://github.com/browser-use/browser-use"""
+
+	return f'{harness_help}\n{browser_use_only}'
+
+
 def _command_name(args: list[str]) -> str:
 	if '--cli-mcp' in args:
 		return 'cli-mcp'
@@ -361,6 +379,9 @@ def _dispatch(args: list[str]) -> tuple[int | None, str]:
 	if '--mcp' in args:
 		_run_mcp_server()
 		return 0, 'mcp'
+	if args and args[0] in ('--help', '-h'):
+		print(_build_help_message())
+		return 0, 'help'
 	if args and args[0] == 'install':
 		return _run_install_command(args[1:]), 'install'
 	if args and args[0] == 'init':


### PR DESCRIPTION
Description:

The browser-use CLI currently lacks a --help flag. Users have no way to quickly discover available commands and flags without reading external documentation.

Proposed Solution

Add a --help / -h flag that prints a combined help message showing both the browser-harness base commands and browser-use-specific commands (install, init, --mcp, --cli-mcp, --template).

Example Output

$ browser-use --help
<browser-harness help text>

Additional commands and flags (Browser Use specific):

  browser-use install              Install Chromium browser and system dependencies
  browser-use init                 Scaffold a new project
  browser-use --mcp                Start MCP server (stdio, full browser tools)
  browser-use --cli-mcp            Start MCP server (stdio, CLI helpers only)
  browser-use --template, -t       Same as 'init'
  browser-use --help, -h           Show this help message

More info: https://github.com/browser-use/browser-use

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--help`/`-h` flag to the `browser-use` CLI that prints a single, combined help message. This makes it easy to discover core `browser_harness` commands and Browser Use–specific commands.

- **New Features**
  - `browser-use --help`/`-h` prints merged help: `browser_harness` help plus Browser Use commands (install, init, --mcp, --cli-mcp, --template).
  - Implemented in `_dispatch`; prints help and exits with code 0.

<sup>Written for commit a792de07573fffd4abc77f804ec3df970f8501b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

