### PR TITLE
Recover Anthropic tool arguments when the model serializes its call as text

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -326,7 +326,10 @@ class ChatAnthropic(BaseChatModel):
 				candidates.append(tool_call)
 			for text_candidate in self._json_candidates_from_text(value):
 				try:
-					candidates.append(json.loads(text_candidate))
+					candidate = json.loads(text_candidate)
+					if isinstance(candidate, dict):
+						candidate = self._repair_serialized_fields(candidate)
+					candidates.append(candidate)
 				except (json.JSONDecodeError, TypeError):
 					continue
 

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -316,34 +316,36 @@ class ChatAnthropic(BaseChatModel):
 		if not isinstance(tool_input, dict):
 			return None
 
-		for value in tool_input.values():
-			if not isinstance(value, str):
+		# The malformed Anthropic response puts the complete call in the schema's
+		# `thinking` argument. Do not promote serialized data from arbitrary fields.
+		thinking = tool_input.get('thinking')
+		if not isinstance(thinking, str):
+			return None
+
+		candidates: list[Any] = []
+		tool_call = self._tool_call_from_text(thinking)
+		if tool_call is not None:
+			candidates.append(tool_call)
+		for text_candidate in self._json_candidates_from_text(thinking):
+			try:
+				candidate = json.loads(text_candidate)
+				if isinstance(candidate, dict):
+					candidate = self._repair_serialized_fields(candidate)
+				candidates.append(candidate)
+			except (json.JSONDecodeError, TypeError):
 				continue
 
-			candidates: list[Any] = []
-			tool_call = self._tool_call_from_text(value)
-			if tool_call is not None:
-				candidates.append(tool_call)
-			for text_candidate in self._json_candidates_from_text(value):
-				try:
-					candidate = json.loads(text_candidate)
-					if isinstance(candidate, dict):
-						candidate = self._repair_serialized_fields(candidate)
-					candidates.append(candidate)
-				except (json.JSONDecodeError, TypeError):
-					continue
-
-			for candidate in candidates:
-				try:
-					completion = output_format.model_validate(candidate)
-				except Exception:
-					continue
-				return ChatInvokeCompletion(
-					completion=completion,
-					usage=usage,
-					stop_reason=response.stop_reason,
-					stop_details=self._get_stop_details(response),
-				)
+		for candidate in candidates:
+			try:
+				completion = output_format.model_validate(candidate)
+			except Exception:
+				continue
+			return ChatInvokeCompletion(
+				completion=completion,
+				usage=usage,
+				stop_reason=response.stop_reason,
+				stop_details=self._get_stop_details(response),
+			)
 
 		return None
 

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
@@ -27,6 +28,10 @@ from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
+
+# `<parameter name="x">value</parameter>`, tolerating the mismatched `</x>` closing tag the
+# model sometimes emits instead of `</parameter>`.
+_TEXT_TOOL_CALL_PARAMETER = re.compile(r'<parameter name="([^"]+)">(.*?)(?:</parameter>|</\1>)', re.DOTALL)
 
 
 @dataclass
@@ -279,6 +284,66 @@ class ChatAnthropic(BaseChatModel):
 
 		return list(dict.fromkeys(candidate for candidate in candidates if candidate))
 
+	def _repair_serialized_fields(self, values: dict[str, Any]) -> dict[str, Any]:
+		"""Decode fields the model double-serialized as JSON strings."""
+		for key, value in values.items():
+			if isinstance(value, str) and value.startswith(('[', '{')):
+				try:
+					values[key] = json.loads(value)
+				except json.JSONDecodeError:
+					cleaned = value.replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
+					try:
+						values[key] = json.loads(cleaned)
+					except json.JSONDecodeError:
+						pass
+		return values
+
+	def _tool_call_from_text(self, text: str) -> dict[str, Any] | None:
+		"""Parse arguments out of a tool call the model rendered as text."""
+		values = {name: value.strip() for name, value in _TEXT_TOOL_CALL_PARAMETER.findall(text)}
+		return self._repair_serialized_fields(values) if values else None
+
+	def _completion_from_serialized_tool_input(
+		self, tool_input: Any, output_format: type[T], usage: ChatInvokeUsage | None, response: Any
+	) -> ChatInvokeCompletion[T] | None:
+		"""Recover the output when the model rendered its whole tool call into a string field.
+
+		Claude sometimes calls the tool but fills only the first string property of the schema,
+		with the entire call written out as text (`<parameter name=...>` markup or a JSON object)
+		instead of populating the arguments. That text still carries every field, so parse it out
+		rather than discarding the step.
+		"""
+		if not isinstance(tool_input, dict):
+			return None
+
+		for value in tool_input.values():
+			if not isinstance(value, str):
+				continue
+
+			candidates: list[Any] = []
+			tool_call = self._tool_call_from_text(value)
+			if tool_call is not None:
+				candidates.append(tool_call)
+			for text_candidate in self._json_candidates_from_text(value):
+				try:
+					candidates.append(json.loads(text_candidate))
+				except (json.JSONDecodeError, TypeError):
+					continue
+
+			for candidate in candidates:
+				try:
+					completion = output_format.model_validate(candidate)
+				except Exception:
+					continue
+				return ChatInvokeCompletion(
+					completion=completion,
+					usage=usage,
+					stop_reason=response.stop_reason,
+					stop_details=self._get_stop_details(response),
+				)
+
+		return None
+
 	def _completion_from_text_response(
 		self, response: Any, output_format: type[T], usage: ChatInvokeUsage | None
 	) -> ChatInvokeCompletion[T] | None:
@@ -414,24 +479,21 @@ class ChatAnthropic(BaseChatModel):
 								_input = json.loads(_input)
 							elif isinstance(_input, dict):
 								# Model sometimes double-serializes fields
-								for key, value in _input.items():
-									if isinstance(value, str) and value.startswith(('[', '{')):
-										try:
-											_input[key] = json.loads(value)
-										except json.JSONDecodeError:
-											cleaned = value.replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
-											try:
-												_input[key] = json.loads(cleaned)
-											except json.JSONDecodeError:
-												pass
+								_input = self._repair_serialized_fields(_input)
 							else:
 								raise
-							return ChatInvokeCompletion(
-								completion=output_format.model_validate(_input),
-								usage=usage,
-								stop_reason=response.stop_reason,
-								stop_details=self._get_stop_details(response),
-							)
+							try:
+								return ChatInvokeCompletion(
+									completion=output_format.model_validate(_input),
+									usage=usage,
+									stop_reason=response.stop_reason,
+									stop_details=self._get_stop_details(response),
+								)
+							except Exception:
+								recovered = self._completion_from_serialized_tool_input(_input, output_format, usage, response)
+								if recovered is None:
+									raise
+								return recovered
 
 				if self._requires_auto_tool_choice():
 					text_completion = self._completion_from_text_response(response, output_format, usage)

--- a/tests/ci/test_anthropic_serialized_tool_input.py
+++ b/tests/ci/test_anthropic_serialized_tool_input.py
@@ -86,6 +86,34 @@ async def test_valid_tool_input_is_untouched(httpserver):
 	assert result.completion.action == actions
 
 
+async def test_valid_tool_input_wins_over_conflicting_serialized_thinking(httpserver):
+	"""A valid real action must take priority over a serialized action in thinking."""
+	real_actions = [{'click_element_by_index': {'index': 5}}]
+	serialized_actions = [{'click_element_by_index': {'index': 99}}]
+	serialized = json.dumps({'thinking': 'Conflicting fallback.', 'action': serialized_actions})
+	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(
+		_tool_use_response({'thinking': serialized, 'action': real_actions})
+	)
+
+	result = await _chat(httpserver).ainvoke([UserMessage(content='next step')], output_format=StepOutput)
+
+	assert result.completion.action == real_actions
+	assert result.completion.thinking == serialized
+
+
+async def test_serialized_tool_call_outside_thinking_is_not_recovered(httpserver):
+	"""Only the known malformed `thinking` path may be promoted to structured output."""
+	payload = {'thinking': 'Clicking submit.', 'action': [{'click_element_by_index': {'index': 5}}]}
+	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(
+		_tool_use_response({'thinking': 'No structured action was produced.', 'other': json.dumps(payload)})
+	)
+
+	with pytest.raises(ModelProviderError) as exc_info:
+		await _chat(httpserver).ainvoke([UserMessage(content='next step')], output_format=StepOutput)
+
+	assert 'action' in str(exc_info.value)
+
+
 async def test_unrecoverable_tool_input_still_raises(httpserver):
 	"""Recovery must not mask genuinely malformed output."""
 	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(

--- a/tests/ci/test_anthropic_serialized_tool_input.py
+++ b/tests/ci/test_anthropic_serialized_tool_input.py
@@ -1,0 +1,98 @@
+"""Regression test: when Claude calls the tool but writes the whole call out as text inside a
+single string argument, the arguments must be recovered instead of failing validation with a
+misleading 'Field required' error for the fields that were never populated."""
+
+import json
+
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.anthropic.chat import ChatAnthropic
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.messages import UserMessage
+
+
+class StepOutput(BaseModel):
+	thinking: str
+	action: list[dict]
+
+
+def _tool_use_response(tool_input: dict | str) -> dict:
+	return {
+		'id': 'msg_test',
+		'type': 'message',
+		'role': 'assistant',
+		'model': 'claude-sonnet-5',
+		'content': [{'type': 'tool_use', 'id': 'toolu_test', 'name': 'StepOutput', 'input': tool_input}],
+		'stop_reason': 'tool_use',
+		'stop_sequence': None,
+		'usage': {'input_tokens': 10, 'output_tokens': 20},
+	}
+
+
+def _chat(httpserver) -> ChatAnthropic:
+	return ChatAnthropic(model='claude-sonnet-5', api_key='test-key', base_url=httpserver.url_for('/'))
+
+
+async def test_tool_call_rendered_as_xml_in_string_field_is_recovered(httpserver):
+	"""The model fills only `thinking`, with the complete call as `<parameter name=...>` markup."""
+	actions = [{'click_element_by_index': {'index': 5}}]
+	serialized = (
+		'<invoke name="StepOutput">\n'
+		'<parameter name="thinking">The submit button is at index 5.</parameter>\n'
+		f'<parameter name="action">{json.dumps(actions)}</action>\n'
+		'</invoke>\n'
+	)
+	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(_tool_use_response({'thinking': serialized}))
+
+	result = await _chat(httpserver).ainvoke([UserMessage(content='next step')], output_format=StepOutput)
+
+	assert result.completion.thinking == 'The submit button is at index 5.'
+	assert result.completion.action == actions
+
+
+async def test_tool_call_rendered_as_json_in_string_field_is_recovered(httpserver):
+	"""Same failure mode, but the model writes JSON into the string field instead of markup."""
+	payload = {'thinking': 'Clicking submit.', 'action': [{'click_element_by_index': {'index': 5}}]}
+	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(
+		_tool_use_response({'thinking': f'Here is my response:\n{json.dumps(payload)}'})
+	)
+
+	result = await _chat(httpserver).ainvoke([UserMessage(content='next step')], output_format=StepOutput)
+
+	assert result.completion.action == payload['action']
+
+
+async def test_double_serialized_field_still_repaired(httpserver):
+	"""The pre-existing repair for a single JSON-string field must keep working."""
+	actions = [{'click_element_by_index': {'index': 5}}]
+	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(
+		_tool_use_response({'thinking': 'Clicking submit.', 'action': json.dumps(actions)})
+	)
+
+	result = await _chat(httpserver).ainvoke([UserMessage(content='next step')], output_format=StepOutput)
+
+	assert result.completion.action == actions
+
+
+async def test_valid_tool_input_is_untouched(httpserver):
+	actions = [{'click_element_by_index': {'index': 5}}]
+	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(
+		_tool_use_response({'thinking': 'Clicking submit.', 'action': actions})
+	)
+
+	result = await _chat(httpserver).ainvoke([UserMessage(content='next step')], output_format=StepOutput)
+
+	assert result.completion.action == actions
+
+
+async def test_unrecoverable_tool_input_still_raises(httpserver):
+	"""Recovery must not mask genuinely malformed output."""
+	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(
+		_tool_use_response({'thinking': 'I could not decide what to do next.'})
+	)
+
+	with pytest.raises(ModelProviderError) as exc_info:
+		await _chat(httpserver).ainvoke([UserMessage(content='next step')], output_format=StepOutput)
+
+	assert 'action' in str(exc_info.value)


### PR DESCRIPTION
## Problem

With `claude-sonnet-5`, the model sometimes emits a valid `tool_use` block whose arguments contain the *entire tool call rendered as text* inside the first string property, instead of the actual JSON arguments. Real payload tails from our logs:

```
input_value={'thinking': 'The current...</action>\n</invoke>\n'}
input_value={'thinking': 'The resume ...n>\n</AgentOutput>\n\n'}
```

`AgentOutput` validation then fails with `action / Field required` and the step is lost — even though the text in `thinking` contains every field the schema needs.

The salvage added in 0.13.x can't help, because `_completion_from_text_response()` is only reachable when **no** `tool_use` block exists. Here one does exist, so the `ValidationError` escapes the `for` loop before execution ever reaches the salvage call:

```python
for content_block in response.content:
    if content_block.type == 'tool_use':
        try:
            return ChatInvokeCompletion(completion=output_format.model_validate(content_block.input), ...)
        except Exception as e:
            ...double-serialization repair, then re-validate or raise...

if self._requires_auto_tool_choice():          # unreachable in this failure mode
    text_completion = self._completion_from_text_response(response, output_format, usage)
```

## Fix

Give the `tool_use` validation failure the same last-resort recovery the no-tool_use path already has: before re-raising, parse the arguments back out of the string field, handling both `<parameter name=...>` markup (including the mismatched `</action>`-style closing tags the model emits) and an embedded JSON object. Output that carries no recoverable arguments still raises, so genuinely malformed responses are not masked.

The existing double-serialization repair is extracted into `_repair_serialized_fields()` and reused, since the recovered fields need the same treatment.

## Tests

`tests/ci/test_anthropic_serialized_tool_input.py`, following the `test_llm_output_truncation.py` pattern with `httpserver`:

- markup-serialized call in a string field is recovered
- JSON-serialized call in a string field is recovered
- pre-existing double-serialized-field repair still works
- valid tool input is untouched
- unrecoverable input still raises

The two recovery tests fail on `main` and pass with this change; the other three pass both ways. `tests/ci/models/test_llm_anthropic.py`, `test_llm_model_factory.py`, `test_llm_output_truncation.py`, `test_llm_retries.py` and `test_fallback_llm.py` all still pass (33 passed, 1 skipped). `ruff check`, `ruff format --check` and `pyright` are clean on both files.

## Notes, deliberately left out of this PR

Two related things I ran into while diagnosing this, happy to open separate PRs or issues if you'd like them addressed:

1. **`_requires_auto_tool_choice()` doesn't match `claude-sonnet-5`.** It matches `claude-fable-5` / `claude-mythos-5`, or requires `thinking` to be set explicitly. Sonnet 5 runs adaptive thinking *by default*, so out of the box it gets a forced `tool_choice`. Probing the API with the real `AgentOutput` schema shows what that costs:

   ```
   adaptive thinking + forced tool_choice : blocks=['tool_use']
   adaptive thinking + auto   tool_choice : blocks=['thinking', 'tool_use']
   no thinking config + auto  tool_choice : blocks=['thinking', 'tool_use']
   ```

   Forcing the tool suppresses the thinking block entirely, so the model reasons inside the JSON `thinking` string — which is exactly where the serialized call ends up. Passing `thinking={'type': 'adaptive', 'display': 'summarized'}` flips `_requires_auto_tool_choice()` to `True` and took us from consecutive failing steps to roughly 1 step in 10.

2. **Local validation failures are reported as retryable server errors.** A pydantic `ValidationError` reaches `except Exception as e: raise ModelProviderError(message=str(e), model=self.name)`, which defaults to `status_code=502`. `Agent._try_switch_to_fallback_llm` treats 502 as retryable, so a client-side schema failure logs `⚠️ LLM error (...) but no fallback_llm configured` and points users at fallback config rather than at output-format non-compliance.

Related: #3544 reports the same `action Field required` / `input_value={'thinking': ...}` symptom on DeepSeek, which suggests this failure shape isn't Anthropic-specific.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers lost steps when Anthropic returns a `tool_use` block with its arguments serialized as text by extracting arguments from the `thinking` field after validation fails and re-validating. Prevents `action Field required` errors by parsing `<parameter>` markup or embedded JSON from the `thinking` string.

- **Bug Fixes**
  - On `tool_use` validation failure, recover only from `thinking` by parsing `<parameter name="...">...</parameter>` (tolerates mismatched closing tags like `</action>`) or JSON snippets, then validate. Valid tool input takes priority over conflicting serialized data in `thinking`; unrecoverable inputs still raise.

- **Refactors**
  - Extracted helpers into `_repair_serialized_fields()`, `_tool_call_from_text()`, and `_completion_from_serialized_tool_input()` and reused during recovery.

<sup>Written for commit ef01b9b9c715c5718b218d205dd7f3a3f99f0ca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

