### PR TITLE
docs: replace broken profile sync link

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,11 +235,7 @@ To use your local authentication in production:
 
 **First**, create an API key at [cloud.browser-use.com/new-api-key](https://cloud.browser-use.com/new-api-key) or follow the instruction on [Cloud - Profiles](https://cloud.browser-use.com/dashboard/settings?tab=profiles)
 
-**Then**, sync your local cookies:
-
-```bash  theme={null}
-export BROWSER_USE_API_KEY=your_key && curl -fsSL https://browser-use.com/profile.sh | sh
-```
+**Then**, install `profile-use` for your platform from the [official releases](https://github.com/browser-use/profile-use-releases/releases/latest) and follow the [profile sync guide](https://github.com/browser-use/browser-harness/blob/main/interaction-skills/profile-sync.md) to sync your local cookies.
 
 This opens a browser where you log into your accounts. You'll get a `profile_id`.
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ This open-source library is licensed under the MIT License. For Browser Use serv
 Check out our authentication examples:
 - [Using real browser profiles](https://github.com/browser-use/browser-use/blob/main/examples/browser/real_browser.py) - Reuse your existing Chrome profile with saved logins
 - If you want to use temporary accounts with inbox, choose AgentMail
-- To sync your auth profile with the remote browser, run `curl -fsSL https://browser-use.com/profile.sh | BROWSER_USE_API_KEY=XXXX sh` (replace XXXX with your API key)
+- To sync your auth profile with a remote browser, install `profile-use` for your platform from the [official releases](https://github.com/browser-use/profile-use-releases/releases/latest), then follow the [profile sync guide](https://github.com/browser-use/browser-harness/blob/main/interaction-skills/profile-sync.md).
 
 These examples show how to maintain sessions and handle authentication seamlessly.
 </details>


### PR DESCRIPTION
## Summary

- replace the broken `browser-use.com/profile.sh` command in the README FAQ
- update the matching profile-sync instructions in `AGENTS.md`
- direct users to the official `profile-use` releases and maintained profile-sync guide

## Root cause

The documented `https://browser-use.com/profile.sh` endpoint currently returns HTTP 404, leaving users without a working route to install the profile sync tool.

## Validation

- confirmed the old endpoint returns HTTP 404
- confirmed both replacement links return HTTP 200
- `uv run pre-commit run --all-files`
- `git diff --check`

Fixes #5331

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the broken profile sync command with links to the official `profile-use` releases and the maintained profile-sync guide in README and AGENTS. Fixes the 404 and provides clear, platform-specific steps to install and sync local cookies with a remote browser.

<sup>Written for commit 125338cb259cdf6df89d888f4bfd97e542e5b503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

