### PR TITLE
feat(mcp): migrate MCP integration to mcp 2.x

### DIFF
--- a/browser_use/mcp/cli_mcp.py
+++ b/browser_use/mcp/cli_mcp.py
@@ -92,10 +92,10 @@ class CLIMCPServer:
 							is_error=True,
 						)
 					async with self._exec_lock:
-						output = await asyncio.to_thread(self._execute, code)
-					# _execute swallows exceptions and returns the traceback as text; that is a
-					# failure, not a successful result, so flag it with is_error=True.
-					if 'Traceback (most recent call last)' in output:
+						output, is_error = await asyncio.to_thread(self._execute, code)
+					# _execute reports failure structurally (see its return), so user code that
+					# merely prints a traceback-like string is NOT misclassified as an error.
+					if is_error:
 						return types.CallToolResult(content=[types.TextContent(type='text', text=output)], is_error=True)
 					return types.CallToolResult(content=[types.TextContent(type='text', text=output or '(no output)')])
 				if name == 'browser_screenshot':
@@ -133,13 +133,18 @@ class CLIMCPServer:
 			return
 		ns['ensure_daemon']()
 
-	def _execute(self, code: str, connect: bool = True) -> str:
+	def _execute(self, code: str, connect: bool = True) -> tuple[str, bool]:
 		"""Run code in the persistent namespace, capturing stdout/stderr.
 
 		Runs in a worker thread: harness helpers are synchronous socket IPC. Output is
 		captured because stdout carries the MCP protocol.
+
+		Returns ``(output, is_error)``. Failure is reported structurally via the boolean
+		rather than by scanning the captured text, so user code that prints a
+		traceback-looking string is not mistaken for a real exception.
 		"""
 		buffer = StringIO()
+		is_error = False
 		with redirect_stdout(buffer), redirect_stderr(buffer):
 			try:
 				ns = self._ensure_namespace()
@@ -147,8 +152,9 @@ class CLIMCPServer:
 					self._ensure_daemon(code)
 				exec(code, ns)
 			except BaseException:
+				is_error = True
 				traceback.print_exc(file=buffer)
-		return buffer.getvalue()
+		return buffer.getvalue(), is_error
 
 	def _screenshot(self, full: bool, max_dim: int | None) -> str:
 		buffer = StringIO()

--- a/browser_use/mcp/cli_mcp.py
+++ b/browser_use/mcp/cli_mcp.py
@@ -96,7 +96,8 @@ class CLIMCPServer:
 				max_dim = arguments.get('max_dim')
 				if max_dim is not None and (isinstance(max_dim, bool) or not isinstance(max_dim, int) or max_dim < 1):
 					return types.CallToolResult(
-						content=[types.TextContent(type='text', text="Error: 'max_dim' must be a positive integer")], is_error=True
+						content=[types.TextContent(type='text', text="Error: 'max_dim' must be a positive integer")],
+						is_error=True,
 					)
 				async with self._exec_lock:
 					png = await asyncio.to_thread(self._screenshot, bool(arguments.get('full', False)), max_dim)

--- a/browser_use/mcp/cli_mcp.py
+++ b/browser_use/mcp/cli_mcp.py
@@ -83,26 +83,39 @@ class CLIMCPServer:
 		async def handle_call_tool(ctx: ServerRequestContext, params: types.CallToolRequestParams) -> types.CallToolResult:
 			name = params.name
 			arguments = params.arguments or {}
-			if name == 'browser_exec':
-				code = arguments.get('code')
-				if not isinstance(code, str) or not code.strip():
-					return types.CallToolResult(
-						content=[types.TextContent(type='text', text="Error: 'code' must be a non-empty string")], is_error=True
-					)
-				async with self._exec_lock:
-					output = await asyncio.to_thread(self._execute, code)
-				return types.CallToolResult(content=[types.TextContent(type='text', text=output or '(no output)')])
-			if name == 'browser_screenshot':
-				max_dim = arguments.get('max_dim')
-				if max_dim is not None and (isinstance(max_dim, bool) or not isinstance(max_dim, int) or max_dim < 1):
-					return types.CallToolResult(
-						content=[types.TextContent(type='text', text="Error: 'max_dim' must be a positive integer")],
-						is_error=True,
-					)
-				async with self._exec_lock:
-					png = await asyncio.to_thread(self._screenshot, bool(arguments.get('full', False)), max_dim)
-				return types.CallToolResult(content=[types.ImageContent(type='image', data=png, mime_type='image/png')])
-			return types.CallToolResult(content=[types.TextContent(type='text', text=f'Unknown tool: {name}')], is_error=True)
+			try:
+				if name == 'browser_exec':
+					code = arguments.get('code')
+					if not isinstance(code, str) or not code.strip():
+						return types.CallToolResult(
+							content=[types.TextContent(type='text', text="Error: 'code' must be a non-empty string")],
+							is_error=True,
+						)
+					async with self._exec_lock:
+						output = await asyncio.to_thread(self._execute, code)
+					# _execute swallows exceptions and returns the traceback as text; that is a
+					# failure, not a successful result, so flag it with is_error=True.
+					if 'Traceback (most recent call last)' in output:
+						return types.CallToolResult(content=[types.TextContent(type='text', text=output)], is_error=True)
+					return types.CallToolResult(content=[types.TextContent(type='text', text=output or '(no output)')])
+				if name == 'browser_screenshot':
+					max_dim = arguments.get('max_dim')
+					if max_dim is not None and (isinstance(max_dim, bool) or not isinstance(max_dim, int) or max_dim < 1):
+						return types.CallToolResult(
+							content=[types.TextContent(type='text', text="Error: 'max_dim' must be a positive integer")],
+							is_error=True,
+						)
+					async with self._exec_lock:
+						png = await asyncio.to_thread(self._screenshot, bool(arguments.get('full', False)), max_dim)
+					return types.CallToolResult(content=[types.ImageContent(type='image', data=png, mime_type='image/png')])
+				return types.CallToolResult(content=[types.TextContent(type='text', text=f'Unknown tool: {name}')], is_error=True)
+			except Exception as e:
+				# _screenshot and other unexpected failures (daemon down, capture error,
+				# missing file) must surface as tool errors, not escape the handler.
+				return types.CallToolResult(
+					content=[types.TextContent(type='text', text=f'Error: {e}')],
+					is_error=True,
+				)
 
 		return Server('browser-use', on_list_tools=handle_list_tools, on_call_tool=handle_call_tool)
 

--- a/browser_use/mcp/cli_mcp.py
+++ b/browser_use/mcp/cli_mcp.py
@@ -13,6 +13,7 @@ from typing import Any
 import mcp.server.stdio
 import mcp.types as types
 from mcp.server import NotificationOptions, Server
+from mcp.server.lowlevel.server import ServerRequestContext
 from mcp.server.models import InitializationOptions
 
 from browser_use.utils import get_browser_use_version
@@ -34,10 +35,9 @@ class CLIMCPServer:
 	"""Stateful stdio MCP server wrapping the browser-harness exec model."""
 
 	def __init__(self):
-		self.server: Server = Server('browser-use')
 		self._namespace: dict[str, Any] | None = None
 		self._exec_lock = asyncio.Lock()
-		self._register_handlers()
+		self.server: Server = self._build_server()
 
 	def _tool_definitions(self) -> list[types.Tool]:
 		return [
@@ -50,7 +50,7 @@ class CLIMCPServer:
 					'persists across calls. Returns whatever the code prints. First navigation '
 					'should be new_tab(url).'
 				),
-				inputSchema={
+				input_schema={
 					'type': 'object',
 					'properties': {
 						'code': {'type': 'string', 'description': 'Python code to execute'},
@@ -61,7 +61,7 @@ class CLIMCPServer:
 			types.Tool(
 				name='browser_screenshot',
 				description='Capture the current page and return it as an image. Prefer this over capture_screenshot() in browser_exec.',
-				inputSchema={
+				input_schema={
 					'type': 'object',
 					'properties': {
 						'full': {'type': 'boolean', 'description': 'Capture beyond the viewport (full page)', 'default': False},
@@ -75,29 +75,36 @@ class CLIMCPServer:
 			),
 		]
 
-	def _register_handlers(self):
-		@self.server.list_tools()
-		async def handle_list_tools() -> list[types.Tool]:
-			return self._tool_definitions()
+	def _build_server(self) -> Server:
+		async def handle_list_tools(
+			ctx: ServerRequestContext, params: types.PaginatedRequestParams | None
+		) -> types.ListToolsResult:
+			return types.ListToolsResult(tools=self._tool_definitions())
 
-		@self.server.call_tool()
-		async def handle_call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.TextContent | types.ImageContent]:
-			arguments = arguments or {}
+		async def handle_call_tool(ctx: ServerRequestContext, params: types.CallToolRequestParams) -> types.CallToolResult:
+			name = params.name
+			arguments = params.arguments or {}
 			if name == 'browser_exec':
 				code = arguments.get('code')
 				if not isinstance(code, str) or not code.strip():
-					return [types.TextContent(type='text', text="Error: 'code' must be a non-empty string")]
+					return types.CallToolResult(
+						content=[types.TextContent(type='text', text="Error: 'code' must be a non-empty string")], is_error=True
+					)
 				async with self._exec_lock:
 					output = await asyncio.to_thread(self._execute, code)
-				return [types.TextContent(type='text', text=output or '(no output)')]
+				return types.CallToolResult(content=[types.TextContent(type='text', text=output or '(no output)')])
 			if name == 'browser_screenshot':
 				max_dim = arguments.get('max_dim')
 				if max_dim is not None and (isinstance(max_dim, bool) or not isinstance(max_dim, int) or max_dim < 1):
-					return [types.TextContent(type='text', text="Error: 'max_dim' must be a positive integer")]
+					return types.CallToolResult(
+						content=[types.TextContent(type='text', text="Error: 'max_dim' must be a positive integer")], is_error=True
+					)
 				async with self._exec_lock:
 					png = await asyncio.to_thread(self._screenshot, bool(arguments.get('full', False)), max_dim)
-				return [types.ImageContent(type='image', data=png, mimeType='image/png')]
-			return [types.TextContent(type='text', text=f'Unknown tool: {name}')]
+				return types.CallToolResult(content=[types.ImageContent(type='image', data=png, mime_type='image/png')])
+			return types.CallToolResult(content=[types.TextContent(type='text', text=f'Unknown tool: {name}')], is_error=True)
+
+		return Server('browser-use', on_list_tools=handle_list_tools, on_call_tool=handle_call_tool)
 
 	def _ensure_namespace(self) -> dict[str, Any]:
 		if self._namespace is None:

--- a/browser_use/mcp/cli_mcp.py
+++ b/browser_use/mcp/cli_mcp.py
@@ -12,8 +12,7 @@ from typing import Any
 
 import mcp.server.stdio
 import mcp.types as types
-from mcp.server import NotificationOptions, Server
-from mcp.server.lowlevel.server import ServerRequestContext
+from mcp.server import NotificationOptions, Server, ServerRequestContext
 from mcp.server.models import InitializationOptions
 
 from browser_use.utils import get_browser_use_version

--- a/browser_use/mcp/client.py
+++ b/browser_use/mcp/client.py
@@ -256,10 +256,10 @@ class MCPClient:
 		# Parse tool parameters to create Pydantic model
 		param_fields = {}
 
-		if tool.inputSchema:
+		if tool.input_schema:
 			# MCP tools use JSON Schema for parameters
-			properties = tool.inputSchema.get('properties', {})
-			required = set(tool.inputSchema.get('required', []))
+			properties = tool.input_schema.get('properties', {})
+			required = set(tool.input_schema.get('required', []))
 
 			for param_name, param_schema in properties.items():
 				# Convert JSON Schema type to Python type

--- a/browser_use/mcp/controller.py
+++ b/browser_use/mcp/controller.py
@@ -101,10 +101,10 @@ class MCPToolWrapper:
 		# Parse tool parameters to create Pydantic model
 		param_fields = {}
 
-		if tool.inputSchema:
+		if tool.input_schema:
 			# MCP tools use JSON Schema for parameters
-			properties = tool.inputSchema.get('properties', {})
-			required = set(tool.inputSchema.get('required', []))
+			properties = tool.input_schema.get('properties', {})
+			required = set(tool.input_schema.get('required', []))
 
 			for param_name, param_schema in properties.items():
 				# Convert JSON Schema type to Python type

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -495,9 +495,7 @@ class BrowserUseServer:
 			on_list_prompts=handle_list_prompts,
 		)
 
-	async def _execute_tool(
-		self, tool_name: str, arguments: dict[str, Any]
-	) -> str | list[types.ContentBlock]:
+	async def _execute_tool(self, tool_name: str, arguments: dict[str, Any]) -> str | list[types.ContentBlock]:
 		"""Execute a browser-use tool. Returns str for most tools, or a content list for tools with image output."""
 
 		# Agent-based tools

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -208,6 +208,247 @@ class BrowserUseServer:
 		# Setup handlers and construct the MCP server (handlers are passed to the Server constructor in mcp 2.x)
 		self.server = self._build_server()
 
+	def _tool_definitions(self) -> list[types.Tool]:
+		"""Return the tool schemas advertised by this server."""
+		tools: list[types.Tool] = [
+			# Agent tools
+			# Direct browser control tools
+			types.Tool(
+				name='browser_navigate',
+				description='Navigate to a URL in the browser',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'url': {'type': 'string', 'description': 'The URL to navigate to'},
+						'new_tab': {'type': 'boolean', 'description': 'Whether to open in a new tab', 'default': False},
+					},
+					'required': ['url'],
+				},
+			),
+			types.Tool(
+				name='browser_click',
+				description='Click an element by index or at specific viewport coordinates. Use index for elements from browser_get_state, or coordinate_x/coordinate_y for pixel-precise clicking.',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'index': {
+							'type': 'integer',
+							'description': 'The index of the element to click (from browser_get_state). Provide this OR coordinate_x+coordinate_y.',
+						},
+						'coordinate_x': {
+							'type': 'integer',
+							'description': 'X coordinate in pixels from the left edge of the viewport. Must be used together with coordinate_y. Provide this OR index.',
+						},
+						'coordinate_y': {
+							'type': 'integer',
+							'description': 'Y coordinate in pixels from the top edge of the viewport. Must be used together with coordinate_x. Provide this OR index.',
+						},
+						'new_tab': {
+							'type': 'boolean',
+							'description': 'Whether to open any resulting navigation in a new tab',
+							'default': False,
+						},
+					},
+				},
+			),
+			types.Tool(
+				name='browser_type',
+				description='Type text into an input field. Clears existing text by default; pass text="" to clear only.',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'index': {
+							'type': 'integer',
+							'description': 'The index of the input element (from browser_get_state)',
+						},
+						'text': {
+							'type': 'string',
+							'description': 'The text to type. Pass an empty string ("") to clear the field without typing.',
+						},
+					},
+					'required': ['index', 'text'],
+				},
+			),
+			types.Tool(
+				name='browser_get_state',
+				description='Get the current state of the page including all interactive elements',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'include_screenshot': {
+							'type': 'boolean',
+							'description': 'Whether to include a screenshot of the current page',
+							'default': False,
+						}
+					},
+				},
+			),
+			types.Tool(
+				name='browser_extract_content',
+				description='Extract structured content from the current page based on a query',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'query': {'type': 'string', 'description': 'What information to extract from the page'},
+						'extract_links': {
+							'type': 'boolean',
+							'description': 'Whether to include links in the extraction',
+							'default': False,
+						},
+					},
+					'required': ['query'],
+				},
+			),
+			types.Tool(
+				name='browser_get_html',
+				description='Get the raw HTML of the current page or a specific element by CSS selector',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'selector': {
+							'type': 'string',
+							'description': 'Optional CSS selector to get HTML of a specific element. If omitted, returns full page HTML.',
+						},
+					},
+				},
+			),
+			types.Tool(
+				name='browser_screenshot',
+				description='Take a screenshot of the current page. Returns viewport metadata as text and the screenshot as an image.',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'full_page': {
+							'type': 'boolean',
+							'description': 'Whether to capture the full scrollable page or just the visible viewport',
+							'default': False,
+						},
+					},
+				},
+			),
+			types.Tool(
+				name='browser_scroll',
+				description='Scroll the page',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'direction': {
+							'type': 'string',
+							'enum': ['up', 'down'],
+							'description': 'Direction to scroll',
+							'default': 'down',
+						}
+					},
+				},
+			),
+			types.Tool(
+				name='browser_go_back',
+				description='Go back to the previous page',
+				input_schema={'type': 'object', 'properties': {}},
+			),
+			# Tab management
+			types.Tool(
+				name='browser_list_tabs', description='List all open tabs', input_schema={'type': 'object', 'properties': {}}
+			),
+			types.Tool(
+				name='browser_switch_tab',
+				description='Switch to a different tab',
+				input_schema={
+					'type': 'object',
+					'properties': {'tab_id': {'type': 'string', 'description': '4 Character Tab ID of the tab to switch to'}},
+					'required': ['tab_id'],
+				},
+			),
+			types.Tool(
+				name='browser_close_tab',
+				description='Close a tab',
+				input_schema={
+					'type': 'object',
+					'properties': {'tab_id': {'type': 'string', 'description': '4 Character Tab ID of the tab to close'}},
+					'required': ['tab_id'],
+				},
+			),
+			# types.Tool(
+			# 	name="browser_close",
+			# 	description="Close the browser session",
+			# 	inputSchema={
+			# 		"type": "object",
+			# 		"properties": {}
+			# 	}
+			# ),
+			types.Tool(
+				name='retry_with_browser_use_agent',
+				description='Retry a task using the browser-use agent. Only use this as a last resort if you fail to interact with a page multiple times.',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'task': {
+							'type': 'string',
+							'description': 'The high-level goal and detailed step-by-step description of the task the AI browser agent needs to attempt, along with any relevant data needed to complete the task and info about previous attempts.',
+						},
+						'max_steps': {
+							'type': 'integer',
+							'description': 'Maximum number of steps an agent can take.',
+							'default': 100,
+						},
+						'model': {
+							'type': 'string',
+							'description': 'LLM model to use (e.g., gpt-4o, claude-3-opus-20240229). Defaults to the configured model.',
+						},
+						'allowed_domains': {
+							'type': 'array',
+							'items': {'type': 'string'},
+							'description': (
+								'List of domains the agent is allowed to visit (security feature). '
+								'Omit to use the server-configured profile defaults. '
+								'An empty list is treated the same as omitting the argument and '
+								'will NOT disable server-configured restrictions.'
+							),
+						},
+						'use_vision': {
+							'type': 'boolean',
+							'description': 'Whether to use vision capabilities (screenshots) for the agent',
+							'default': True,
+						},
+					},
+					'required': ['task'],
+				},
+			),
+			# Browser session management tools
+			types.Tool(
+				name='browser_list_sessions',
+				description='List all active browser sessions with their details and last activity time',
+				input_schema={'type': 'object', 'properties': {}},
+			),
+			types.Tool(
+				name='browser_close_session',
+				description='Close a specific browser session by its ID',
+				input_schema={
+					'type': 'object',
+					'properties': {
+						'session_id': {
+							'type': 'string',
+							'description': 'The browser session ID to close (get from browser_list_sessions)',
+						}
+					},
+					'required': ['session_id'],
+				},
+			),
+			types.Tool(
+				name='browser_close_all',
+				description='Close all active browser sessions and clean up resources',
+				input_schema={'type': 'object', 'properties': {}},
+			),
+		]
+		return tools
+
+	@property
+	def _tool_names(self) -> set[str]:
+		"""Names of all tools advertised by this server, for unknown-tool detection."""
+		if not hasattr(self, '_tool_names_cache'):
+			self._tool_names_cache: set[str] = {tool.name for tool in self._tool_definitions()}
+		return self._tool_names_cache
+
 	def _build_server(self) -> Server:
 		"""Build the MCP server, registering request handlers via the Server constructor."""
 
@@ -215,237 +456,7 @@ class BrowserUseServer:
 			ctx: ServerRequestContext, params: types.PaginatedRequestParams | None
 		) -> types.ListToolsResult:
 			"""List all available browser-use tools."""
-			tools: list[types.Tool] = [
-				# Agent tools
-				# Direct browser control tools
-				types.Tool(
-					name='browser_navigate',
-					description='Navigate to a URL in the browser',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'url': {'type': 'string', 'description': 'The URL to navigate to'},
-							'new_tab': {'type': 'boolean', 'description': 'Whether to open in a new tab', 'default': False},
-						},
-						'required': ['url'],
-					},
-				),
-				types.Tool(
-					name='browser_click',
-					description='Click an element by index or at specific viewport coordinates. Use index for elements from browser_get_state, or coordinate_x/coordinate_y for pixel-precise clicking.',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'index': {
-								'type': 'integer',
-								'description': 'The index of the element to click (from browser_get_state). Provide this OR coordinate_x+coordinate_y.',
-							},
-							'coordinate_x': {
-								'type': 'integer',
-								'description': 'X coordinate in pixels from the left edge of the viewport. Must be used together with coordinate_y. Provide this OR index.',
-							},
-							'coordinate_y': {
-								'type': 'integer',
-								'description': 'Y coordinate in pixels from the top edge of the viewport. Must be used together with coordinate_x. Provide this OR index.',
-							},
-							'new_tab': {
-								'type': 'boolean',
-								'description': 'Whether to open any resulting navigation in a new tab',
-								'default': False,
-							},
-						},
-					},
-				),
-				types.Tool(
-					name='browser_type',
-					description='Type text into an input field. Clears existing text by default; pass text="" to clear only.',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'index': {
-								'type': 'integer',
-								'description': 'The index of the input element (from browser_get_state)',
-							},
-							'text': {
-								'type': 'string',
-								'description': 'The text to type. Pass an empty string ("") to clear the field without typing.',
-							},
-						},
-						'required': ['index', 'text'],
-					},
-				),
-				types.Tool(
-					name='browser_get_state',
-					description='Get the current state of the page including all interactive elements',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'include_screenshot': {
-								'type': 'boolean',
-								'description': 'Whether to include a screenshot of the current page',
-								'default': False,
-							}
-						},
-					},
-				),
-				types.Tool(
-					name='browser_extract_content',
-					description='Extract structured content from the current page based on a query',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'query': {'type': 'string', 'description': 'What information to extract from the page'},
-							'extract_links': {
-								'type': 'boolean',
-								'description': 'Whether to include links in the extraction',
-								'default': False,
-							},
-						},
-						'required': ['query'],
-					},
-				),
-				types.Tool(
-					name='browser_get_html',
-					description='Get the raw HTML of the current page or a specific element by CSS selector',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'selector': {
-								'type': 'string',
-								'description': 'Optional CSS selector to get HTML of a specific element. If omitted, returns full page HTML.',
-							},
-						},
-					},
-				),
-				types.Tool(
-					name='browser_screenshot',
-					description='Take a screenshot of the current page. Returns viewport metadata as text and the screenshot as an image.',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'full_page': {
-								'type': 'boolean',
-								'description': 'Whether to capture the full scrollable page or just the visible viewport',
-								'default': False,
-							},
-						},
-					},
-				),
-				types.Tool(
-					name='browser_scroll',
-					description='Scroll the page',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'direction': {
-								'type': 'string',
-								'enum': ['up', 'down'],
-								'description': 'Direction to scroll',
-								'default': 'down',
-							}
-						},
-					},
-				),
-				types.Tool(
-					name='browser_go_back',
-					description='Go back to the previous page',
-					input_schema={'type': 'object', 'properties': {}},
-				),
-				# Tab management
-				types.Tool(
-					name='browser_list_tabs', description='List all open tabs', input_schema={'type': 'object', 'properties': {}}
-				),
-				types.Tool(
-					name='browser_switch_tab',
-					description='Switch to a different tab',
-					input_schema={
-						'type': 'object',
-						'properties': {'tab_id': {'type': 'string', 'description': '4 Character Tab ID of the tab to switch to'}},
-						'required': ['tab_id'],
-					},
-				),
-				types.Tool(
-					name='browser_close_tab',
-					description='Close a tab',
-					input_schema={
-						'type': 'object',
-						'properties': {'tab_id': {'type': 'string', 'description': '4 Character Tab ID of the tab to close'}},
-						'required': ['tab_id'],
-					},
-				),
-				# types.Tool(
-				# 	name="browser_close",
-				# 	description="Close the browser session",
-				# 	inputSchema={
-				# 		"type": "object",
-				# 		"properties": {}
-				# 	}
-				# ),
-				types.Tool(
-					name='retry_with_browser_use_agent',
-					description='Retry a task using the browser-use agent. Only use this as a last resort if you fail to interact with a page multiple times.',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'task': {
-								'type': 'string',
-								'description': 'The high-level goal and detailed step-by-step description of the task the AI browser agent needs to attempt, along with any relevant data needed to complete the task and info about previous attempts.',
-							},
-							'max_steps': {
-								'type': 'integer',
-								'description': 'Maximum number of steps an agent can take.',
-								'default': 100,
-							},
-							'model': {
-								'type': 'string',
-								'description': 'LLM model to use (e.g., gpt-4o, claude-3-opus-20240229). Defaults to the configured model.',
-							},
-							'allowed_domains': {
-								'type': 'array',
-								'items': {'type': 'string'},
-								'description': (
-									'List of domains the agent is allowed to visit (security feature). '
-									'Omit to use the server-configured profile defaults. '
-									'An empty list is treated the same as omitting the argument and '
-									'will NOT disable server-configured restrictions.'
-								),
-							},
-							'use_vision': {
-								'type': 'boolean',
-								'description': 'Whether to use vision capabilities (screenshots) for the agent',
-								'default': True,
-							},
-						},
-						'required': ['task'],
-					},
-				),
-				# Browser session management tools
-				types.Tool(
-					name='browser_list_sessions',
-					description='List all active browser sessions with their details and last activity time',
-					input_schema={'type': 'object', 'properties': {}},
-				),
-				types.Tool(
-					name='browser_close_session',
-					description='Close a specific browser session by its ID',
-					input_schema={
-						'type': 'object',
-						'properties': {
-							'session_id': {
-								'type': 'string',
-								'description': 'The browser session ID to close (get from browser_list_sessions)',
-							}
-						},
-						'required': ['session_id'],
-					},
-				),
-				types.Tool(
-					name='browser_close_all',
-					description='Close all active browser sessions and clean up resources',
-					input_schema={'type': 'object', 'properties': {}},
-				),
-			]
-			return types.ListToolsResult(tools=tools)
+			return types.ListToolsResult(tools=self._tool_definitions())
 
 		async def handle_list_resources(
 			ctx: ServerRequestContext, params: types.PaginatedRequestParams | None
@@ -466,6 +477,14 @@ class BrowserUseServer:
 			start_time = time.time()
 			error_msg = None
 			try:
+				# Short-circuit unknown tools as errors instead of letting _execute_tool
+				# fall through to a plain-string "Unknown tool" that reads as success.
+				if name not in self._tool_names:
+					error_msg = f'Unknown tool: {name}'
+					return types.CallToolResult(
+						content=[types.TextContent(type='text', text=error_msg)],
+						is_error=True,
+					)
 				result = await self._execute_tool(name, arguments or {})
 				if isinstance(result, list):
 					return types.CallToolResult(content=result)

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -133,8 +133,7 @@ _ensure_all_loggers_use_stderr()
 try:
 	import mcp.server.stdio
 	import mcp.types as types
-	from mcp.server import NotificationOptions, Server
-	from mcp.server.lowlevel.server import ServerRequestContext
+	from mcp.server import NotificationOptions, Server, ServerRequestContext
 	from mcp.server.models import InitializationOptions
 
 	MCP_AVAILABLE = True
@@ -498,7 +497,7 @@ class BrowserUseServer:
 
 	async def _execute_tool(
 		self, tool_name: str, arguments: dict[str, Any]
-	) -> str | list[types.TextContent | types.ImageContent]:
+	) -> str | list[types.ContentBlock]:
 		"""Execute a browser-use tool. Returns str for most tools, or a content list for tools with image output."""
 
 		# Agent-based tools
@@ -543,7 +542,7 @@ class BrowserUseServer:
 
 			elif tool_name == 'browser_get_state':
 				state_json, screenshot_b64 = await self._get_browser_state(arguments.get('include_screenshot', False))
-				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=state_json)]
+				content: list[types.ContentBlock] = [types.TextContent(type='text', text=state_json)]
 				if screenshot_b64:
 					content.append(types.ImageContent(type='image', data=screenshot_b64, mime_type='image/png'))
 				return content
@@ -553,7 +552,7 @@ class BrowserUseServer:
 
 			elif tool_name == 'browser_screenshot':
 				meta_json, screenshot_b64 = await self._screenshot(arguments.get('full_page', False))
-				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=meta_json)]
+				content: list[types.ContentBlock] = [types.TextContent(type='text', text=meta_json)]
 				if screenshot_b64:
 					content.append(types.ImageContent(type='image', data=screenshot_b64, mime_type='image/png'))
 				return content

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -134,6 +134,7 @@ try:
 	import mcp.server.stdio
 	import mcp.types as types
 	from mcp.server import NotificationOptions, Server
+	from mcp.server.lowlevel.server import ServerRequestContext
 	from mcp.server.models import InitializationOptions
 
 	MCP_AVAILABLE = True
@@ -191,7 +192,6 @@ class BrowserUseServer:
 		# Ensure all logging goes to stderr (in case new loggers were created)
 		_ensure_all_loggers_use_stderr()
 
-		self.server = Server('browser-use')
 		self.config = load_browser_use_config()
 		self.agent: Agent | None = None
 		self.browser_session: BrowserSession | None = None
@@ -206,22 +206,23 @@ class BrowserUseServer:
 		self.session_timeout_minutes = session_timeout_minutes
 		self._cleanup_task: Any = None
 
-		# Setup handlers
-		self._setup_handlers()
+		# Setup handlers and construct the MCP server (handlers are passed to the Server constructor in mcp 2.x)
+		self.server = self._build_server()
 
-	def _setup_handlers(self):
-		"""Setup MCP server handlers."""
+	def _build_server(self) -> Server:
+		"""Build the MCP server, registering request handlers via the Server constructor."""
 
-		@self.server.list_tools()
-		async def handle_list_tools() -> list[types.Tool]:
+		async def handle_list_tools(
+			ctx: ServerRequestContext, params: types.PaginatedRequestParams | None
+		) -> types.ListToolsResult:
 			"""List all available browser-use tools."""
-			return [
+			tools: list[types.Tool] = [
 				# Agent tools
 				# Direct browser control tools
 				types.Tool(
 					name='browser_navigate',
 					description='Navigate to a URL in the browser',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'url': {'type': 'string', 'description': 'The URL to navigate to'},
@@ -233,7 +234,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_click',
 					description='Click an element by index or at specific viewport coordinates. Use index for elements from browser_get_state, or coordinate_x/coordinate_y for pixel-precise clicking.',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'index': {
@@ -259,7 +260,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_type',
 					description='Type text into an input field. Clears existing text by default; pass text="" to clear only.',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'index': {
@@ -277,7 +278,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_get_state',
 					description='Get the current state of the page including all interactive elements',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'include_screenshot': {
@@ -291,7 +292,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_extract_content',
 					description='Extract structured content from the current page based on a query',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'query': {'type': 'string', 'description': 'What information to extract from the page'},
@@ -307,7 +308,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_get_html',
 					description='Get the raw HTML of the current page or a specific element by CSS selector',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'selector': {
@@ -320,7 +321,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_screenshot',
 					description='Take a screenshot of the current page. Returns viewport metadata as text and the screenshot as an image.',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'full_page': {
@@ -334,7 +335,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_scroll',
 					description='Scroll the page',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'direction': {
@@ -349,16 +350,16 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_go_back',
 					description='Go back to the previous page',
-					inputSchema={'type': 'object', 'properties': {}},
+					input_schema={'type': 'object', 'properties': {}},
 				),
 				# Tab management
 				types.Tool(
-					name='browser_list_tabs', description='List all open tabs', inputSchema={'type': 'object', 'properties': {}}
+					name='browser_list_tabs', description='List all open tabs', input_schema={'type': 'object', 'properties': {}}
 				),
 				types.Tool(
 					name='browser_switch_tab',
 					description='Switch to a different tab',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {'tab_id': {'type': 'string', 'description': '4 Character Tab ID of the tab to switch to'}},
 						'required': ['tab_id'],
@@ -367,7 +368,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_close_tab',
 					description='Close a tab',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {'tab_id': {'type': 'string', 'description': '4 Character Tab ID of the tab to close'}},
 						'required': ['tab_id'],
@@ -384,7 +385,7 @@ class BrowserUseServer:
 				types.Tool(
 					name='retry_with_browser_use_agent',
 					description='Retry a task using the browser-use agent. Only use this as a last resort if you fail to interact with a page multiple times.',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'task': {
@@ -423,12 +424,12 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_list_sessions',
 					description='List all active browser sessions with their details and last activity time',
-					inputSchema={'type': 'object', 'properties': {}},
+					input_schema={'type': 'object', 'properties': {}},
 				),
 				types.Tool(
 					name='browser_close_session',
 					description='Close a specific browser session by its ID',
-					inputSchema={
+					input_schema={
 						'type': 'object',
 						'properties': {
 							'session_id': {
@@ -442,34 +443,38 @@ class BrowserUseServer:
 				types.Tool(
 					name='browser_close_all',
 					description='Close all active browser sessions and clean up resources',
-					inputSchema={'type': 'object', 'properties': {}},
+					input_schema={'type': 'object', 'properties': {}},
 				),
 			]
+			return types.ListToolsResult(tools=tools)
 
-		@self.server.list_resources()
-		async def handle_list_resources() -> list[types.Resource]:
+		async def handle_list_resources(
+			ctx: ServerRequestContext, params: types.PaginatedRequestParams | None
+		) -> types.ListResourcesResult:
 			"""List available resources (none for browser-use)."""
-			return []
+			return types.ListResourcesResult(resources=[])
 
-		@self.server.list_prompts()
-		async def handle_list_prompts() -> list[types.Prompt]:
+		async def handle_list_prompts(
+			ctx: ServerRequestContext, params: types.PaginatedRequestParams | None
+		) -> types.ListPromptsResult:
 			"""List available prompts (none for browser-use)."""
-			return []
+			return types.ListPromptsResult(prompts=[])
 
-		@self.server.call_tool()
-		async def handle_call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.TextContent | types.ImageContent]:
+		async def handle_call_tool(ctx: ServerRequestContext, params: types.CallToolRequestParams) -> types.CallToolResult:
 			"""Handle tool execution."""
+			name = params.name
+			arguments = params.arguments
 			start_time = time.time()
 			error_msg = None
 			try:
 				result = await self._execute_tool(name, arguments or {})
 				if isinstance(result, list):
-					return result
-				return [types.TextContent(type='text', text=result)]
+					return types.CallToolResult(content=result)
+				return types.CallToolResult(content=[types.TextContent(type='text', text=result)])
 			except Exception as e:
 				error_msg = str(e)
 				logger.error(f'Tool execution failed: {e}', exc_info=True)
-				return [types.TextContent(type='text', text=f'Error: {str(e)}')]
+				return types.CallToolResult(content=[types.TextContent(type='text', text=f'Error: {str(e)}')], is_error=True)
 			finally:
 				# Capture telemetry for tool calls
 				duration = time.time() - start_time
@@ -482,6 +487,14 @@ class BrowserUseServer:
 						error_message=error_msg,
 					)
 				)
+
+		return Server(
+			'browser-use',
+			on_list_tools=handle_list_tools,
+			on_call_tool=handle_call_tool,
+			on_list_resources=handle_list_resources,
+			on_list_prompts=handle_list_prompts,
+		)
 
 	async def _execute_tool(
 		self, tool_name: str, arguments: dict[str, Any]
@@ -532,7 +545,7 @@ class BrowserUseServer:
 				state_json, screenshot_b64 = await self._get_browser_state(arguments.get('include_screenshot', False))
 				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=state_json)]
 				if screenshot_b64:
-					content.append(types.ImageContent(type='image', data=screenshot_b64, mimeType='image/png'))
+					content.append(types.ImageContent(type='image', data=screenshot_b64, mime_type='image/png'))
 				return content
 
 			elif tool_name == 'browser_get_html':
@@ -542,7 +555,7 @@ class BrowserUseServer:
 				meta_json, screenshot_b64 = await self._screenshot(arguments.get('full_page', False))
 				content: list[types.TextContent | types.ImageContent] = [types.TextContent(type='text', text=meta_json)]
 				if screenshot_b64:
-					content.append(types.ImageContent(type='image', data=screenshot_b64, mimeType='image/png'))
+					content.append(types.ImageContent(type='image', data=screenshot_b64, mime_type='image/png'))
 				return content
 
 			elif tool_name == 'browser_extract_content':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "posthog==7.7.0",
     "psutil==7.2.2",
     "pydantic==2.12.5",
+    "pydantic-settings==2.12.0",
     "pyobjc==12.1; platform_system == 'darwin'",
     "python-dotenv==1.2.2",
     "requests==2.33.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "google-api-python-client==2.188.0",
     "google-auth==2.48.0",
     "google-auth-oauthlib==1.2.4",
-    "mcp==1.26.0",
+    "mcp>=2.0.0,<3",
     "pypdf==6.10.2",
     "reportlab==4.4.9",
     "cdp-use==1.4.5",

--- a/tests/ci/security/test_mcp_e2e_protocol.py
+++ b/tests/ci/security/test_mcp_e2e_protocol.py
@@ -264,3 +264,69 @@ async def test_browser_use_unknown_tool_is_error_over_wire(browser_use_running: 
 		assert 'Unknown tool' in text
 
 	await browser_use_running.run_session(drive)
+
+
+# ---------------------------------------------------------------------------
+# Execution-exception is_error over the wire
+#
+# The tests above only exercise *validation* errors (blank input, unknown tool),
+# which the handlers return explicitly. The blocking mcp 2.x correctness fix to
+# CLIMCPServer._execute was about a different path: a tool that *raises* during
+# execution (daemon down, exec failure, screenshot error) must still arrive at the
+# client as CallToolResult(is_error=True), not escape the handler or read as success.
+# These cases drive that raised-execution path across the real transport.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cli_daemon_down() -> _RunningServer:
+	"""CLIMCPServer whose daemon cannot start, exercising _execute's structural error.
+
+	The namespace import runs for real; only the daemon entry point (``ensure_daemon``)
+	is replaced with one that raises, so the failure travels through _execute's real
+	``except BaseException`` → structural ``(traceback, True)`` → handler ``is_error``
+	path rather than a stubbed-out _execute.
+	"""
+	srv = CLIMCPServer()
+	ns = srv._ensure_namespace()
+
+	def _failing_ensure_daemon():
+		raise RuntimeError('daemon is down')
+
+	ns['ensure_daemon'] = _failing_ensure_daemon
+	return _RunningServer(srv.server, server_name='browser-use', server_version='0.0.0-test')
+
+
+async def test_cli_exec_raised_exception_is_error_over_wire(cli_daemon_down: _RunningServer) -> None:
+	"""A daemon-down exec failure surfaces as is_error=True across the real transport."""
+
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		result = await session.call_tool('browser_exec', {'code': 'new_tab("http://example.test")'})
+		assert isinstance(result, types.CallToolResult)
+		assert result.is_error is True
+		text = ''.join(getattr(b, 'text', '') for b in result.content)
+		# The real traceback from _execute's except path reached the client.
+		assert 'daemon is down' in text
+
+	await cli_daemon_down.run_session(drive)
+
+
+async def test_browser_use_screenshot_raised_exception_is_error_over_wire() -> None:
+	"""A _screenshot exception is wrapped by the handler's except and returned as is_error."""
+	srv = BrowserUseServer()
+
+	async def _raising_screenshot(full_page: bool = False) -> tuple[str, str | None]:
+		raise RuntimeError('capture failed: no frame')
+
+	srv._screenshot = _raising_screenshot  # type: ignore[method-assign]
+	srv.browser_session = object()  # type: ignore[assignment]  # avoid real browser init
+	running = _RunningServer(srv.server, server_name='browser-use', server_version='0.0.0-test')
+
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		result = await session.call_tool('browser_screenshot', {})
+		assert isinstance(result, types.CallToolResult)
+		assert result.is_error is True
+		text = ''.join(getattr(b, 'text', '') for b in result.content)
+		assert 'capture failed' in text
+
+	await running.run_session(drive)

--- a/tests/ci/security/test_mcp_e2e_protocol.py
+++ b/tests/ci/security/test_mcp_e2e_protocol.py
@@ -1,0 +1,266 @@
+"""Full-stack protocol round-trip tests for the mcp 2.x migration.
+
+Unlike the handler-level contract tests (test_mcp_handler_contract.py), which call
+``server.get_request_handler(...)`` directly and therefore bypass the JSON-RPC
+transport, these tests stand up a *real* client↔server pair over in-memory streams
+(``mcp.shared.memory.create_client_server_memory_streams``) and drive the canonical
+``initialize → list_tools → call_tool → image`` sequence end-to-end.
+
+The point, per issue #5333: "MCP 2.x installs" is not the same claim as "the browser
+tool contract survived the protocol upgrade." Dependency resolution can succeed while
+the server silently advertises the wrong protocol version, drops capabilities, renames
+a schema field, or mangles an image content block on the wire. These tests observe the
+*effective* protocol version, capabilities, and content shapes that an MCP client
+actually receives, so compatibility is scoped from evidence instead of inferred.
+
+No real browser, daemon, or LLM is needed — browser-touching helpers are stubbed out;
+everything under test is the protocol/transport/serialization layer itself.
+"""
+
+from dataclasses import dataclass, field
+
+import anyio
+import mcp.types as types
+import pytest
+from mcp import ClientSession
+from mcp.server import NotificationOptions
+from mcp.server.models import InitializationOptions
+from mcp.shared.memory import create_client_server_memory_streams
+
+from browser_use.mcp.cli_mcp import CLIMCPServer
+from browser_use.mcp.server import BrowserUseServer
+
+# Base64 for b"hello" — a fixed, decodable payload so the image round-trip can assert
+# byte fidelity, not just that *some* string survived.
+FIXED_IMAGE_B64 = 'aGVsbG8='
+
+
+@dataclass
+class RoundTripEvidence:
+	"""Effective protocol facts observed over the wire for one server.
+
+	This is the scoped-compatibility record: rather than asserting "it installed," we
+	capture what the negotiated session actually looks like and assert each fact.
+	"""
+
+	protocol_version: str
+	server_name: str
+	server_version: str
+	tools_capability_present: bool
+	tool_names: list[str] = field(default_factory=list)
+	schemas_by_name: dict[str, dict] = field(default_factory=dict)
+	annotations_by_name: dict[str, types.ToolAnnotations | None] = field(default_factory=dict)
+
+
+class _RunningServer:
+	"""Drives one MCP server through a real initialize + list_tools + call_tool session."""
+
+	def __init__(self, mcp_server, server_name: str, server_version: str, instructions: str | None = None):
+		self._server = mcp_server
+		self._server_name = server_name
+		self._server_version = server_version
+		self._instructions = instructions
+
+	async def run_session(self, drive):
+		"""Run server + client; ``drive(session, evidence)`` performs the client calls."""
+		async with create_client_server_memory_streams() as (client_streams, server_streams):
+			client_read, client_write = client_streams
+			server_read, server_write = server_streams
+
+			async def run_server():
+				await self._server.run(
+					server_read,
+					server_write,
+					InitializationOptions(
+						server_name=self._server_name,
+						server_version=self._server_version,
+						instructions=self._instructions,
+						capabilities=self._server.get_capabilities(
+							notification_options=NotificationOptions(),
+							experimental_capabilities={},
+						),
+					),
+					raise_exceptions=False,
+				)
+
+			async with anyio.create_task_group() as tg:
+				tg.start_soon(run_server)
+				try:
+					async with ClientSession(client_read, client_write) as session:
+						init = await session.initialize()
+						tools = await session.list_tools()
+						evidence = RoundTripEvidence(
+							protocol_version=init.protocol_version,
+							server_name=init.server_info.name,
+							server_version=init.server_info.version,
+							tools_capability_present=init.capabilities.tools is not None,
+							tool_names=sorted(t.name for t in tools.tools),
+							schemas_by_name={t.name: t.input_schema for t in tools.tools},
+							annotations_by_name={t.name: t.annotations for t in tools.tools},
+						)
+						await drive(session, evidence)
+				finally:
+					tg.cancel_scope.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cli_running() -> _RunningServer:
+	"""CLIMCPServer with the daemon-dependent screenshot helper stubbed out."""
+	srv = CLIMCPServer()
+	srv._screenshot = lambda full, max_dim: FIXED_IMAGE_B64  # type: ignore[method-assign]
+	return _RunningServer(srv.server, server_name='browser-use', server_version='0.0.0-test', instructions=srv._instructions())
+
+
+@pytest.fixture
+def browser_use_running() -> _RunningServer:
+	"""BrowserUseServer with browser/LLM-touching internals stubbed out."""
+	srv = BrowserUseServer()
+
+	async def _screenshot_stub(full_page: bool = False) -> tuple[str, str | None]:
+		return ('{"size_bytes": 5}', FIXED_IMAGE_B64)
+
+	srv._screenshot = _screenshot_stub  # type: ignore[method-assign]
+	srv.browser_session = object()  # type: ignore[assignment]  # avoid real browser init
+	return _RunningServer(srv.server, server_name='browser-use', server_version='0.0.0-test')
+
+
+# ---------------------------------------------------------------------------
+# Protocol negotiation (effective version + capabilities)
+# ---------------------------------------------------------------------------
+
+
+async def test_cli_negotiates_protocol_version_and_capabilities(cli_running: _RunningServer) -> None:
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		# A real protocol version string came back from the handshake (not None/empty).
+		assert ev.protocol_version, 'handshake must yield a concrete protocol version'
+		assert isinstance(ev.protocol_version, str)
+		# Server identity round-tripped through initialize.
+		assert ev.server_name == 'browser-use'
+		assert ev.server_version == '0.0.0-test'
+		# The server advertises a tools capability — without it no client would list tools.
+		assert ev.tools_capability_present is True
+
+	await cli_running.run_session(drive)
+
+
+async def test_browser_use_negotiates_protocol_version_and_capabilities(browser_use_running: _RunningServer) -> None:
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		assert ev.protocol_version
+		assert ev.server_name == 'browser-use'
+		assert ev.tools_capability_present is True
+
+	await browser_use_running.run_session(drive)
+
+
+# ---------------------------------------------------------------------------
+# Tool list over the wire (schema names + required fields survive serialization)
+# ---------------------------------------------------------------------------
+
+
+async def test_cli_tool_schemas_survive_wire(cli_running: _RunningServer) -> None:
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		assert ev.tool_names == ['browser_exec', 'browser_screenshot']
+
+		exec_schema = ev.schemas_by_name['browser_exec']
+		assert exec_schema['type'] == 'object'
+		assert 'code' in exec_schema['properties']
+		assert exec_schema['required'] == ['code']
+
+		# The screenshot schema's integer field with a minimum constraint must survive.
+		shot_schema = ev.schemas_by_name['browser_screenshot']
+		max_dim = shot_schema['properties']['max_dim']
+		assert max_dim['type'] == 'integer'
+		assert max_dim['minimum'] == 1
+
+	await cli_running.run_session(drive)
+
+
+async def test_browser_use_tool_schemas_and_annotations_survive_wire(browser_use_running: _RunningServer) -> None:
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		# Every advertised tool carried a populated input_schema across the wire.
+		for name in ev.tool_names:
+			assert ev.schemas_by_name[name], f'tool {name!r} lost its input_schema in transit'
+
+		# The image-producing tool is present with its expected schema shape.
+		assert 'browser_screenshot' in ev.tool_names
+		shot = ev.schemas_by_name['browser_screenshot']
+		assert shot['properties']['full_page']['type'] == 'boolean'
+
+		# The read-only annotation set at decoration time must reach the client.
+		annotations = ev.annotations_by_name['browser_screenshot']
+		assert annotations is not None, 'browser_screenshot lost its ToolAnnotations over the wire'
+		assert annotations.read_only_hint is True
+
+	await browser_use_running.run_session(drive)
+
+
+# ---------------------------------------------------------------------------
+# Call round-trip: text result, image result, and structured is_error
+# ---------------------------------------------------------------------------
+
+
+async def test_cli_text_result_round_trip(cli_running: _RunningServer) -> None:
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		# browser_exec with a real (failing-fast) input: missing/blank code → is_error over the wire.
+		result = await session.call_tool('browser_exec', {'code': '   '})
+		assert isinstance(result, types.CallToolResult)
+		assert result.is_error is True
+		text = ''.join(getattr(b, 'text', '') for b in result.content)
+		assert 'code' in text
+
+	await cli_running.run_session(drive)
+
+
+async def test_cli_image_block_round_trips_with_byte_fidelity(cli_running: _RunningServer) -> None:
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		result = await session.call_tool('browser_screenshot', {})
+		assert result.is_error is not True
+		assert len(result.content) == 1
+		block = result.content[0]
+		# The image content block survived serialization as a real ImageContent...
+		assert isinstance(block, types.ImageContent)
+		# ...with its mime_type intact (this is the field 1.x→2.x is most likely to drop)...
+		assert block.mime_type == 'image/png'
+		# ...and byte-for-byte identical base64 payload.
+		assert block.data == FIXED_IMAGE_B64
+
+	await cli_running.run_session(drive)
+
+
+async def test_browser_use_mixed_text_and_image_blocks_round_trip(browser_use_running: _RunningServer) -> None:
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		result = await session.call_tool('browser_screenshot', {})
+		assert result.is_error is not True
+		texts = [b for b in result.content if isinstance(b, types.TextContent)]
+		images = [b for b in result.content if isinstance(b, types.ImageContent)]
+		assert texts and texts[0].text == '{"size_bytes": 5}'
+		assert images and images[0].data == FIXED_IMAGE_B64
+		assert images[0].mime_type == 'image/png'
+
+	await browser_use_running.run_session(drive)
+
+
+async def test_cli_unknown_tool_is_error_over_wire(cli_running: _RunningServer) -> None:
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		result = await session.call_tool('no_such_tool', {})
+		assert isinstance(result, types.CallToolResult)
+		assert result.is_error is True
+		text = ''.join(getattr(b, 'text', '') for b in result.content)
+		assert 'Unknown tool' in text
+
+	await cli_running.run_session(drive)
+
+
+async def test_browser_use_unknown_tool_is_error_over_wire(browser_use_running: _RunningServer) -> None:
+	async def drive(session: ClientSession, ev: RoundTripEvidence) -> None:
+		result = await session.call_tool('no_such_tool', {})
+		assert result.is_error is True
+		text = ''.join(getattr(b, 'text', '') for b in result.content)
+		assert 'Unknown tool' in text
+
+	await browser_use_running.run_session(drive)

--- a/tests/ci/security/test_mcp_handler_contract.py
+++ b/tests/ci/security/test_mcp_handler_contract.py
@@ -111,6 +111,26 @@ async def test_browser_use_call_tool_success_is_not_error_and_preserves_text(bro
 	assert _text_of(result) == 'did: noop'
 
 
+async def test_browser_use_call_tool_content_list_preserves_text_and_image(browser_use_server: BrowserUseServer) -> None:
+	"""Tools returning a content list (e.g. browser_screenshot) keep text + image blocks."""
+
+	async def screenshot_stub(full_page: bool = False) -> tuple[str, str | None]:
+		return ('{"size_bytes": 5}', 'aGVsbG8=')
+
+	browser_use_server._screenshot = screenshot_stub  # type: ignore[method-assign]
+	# Avoid a real browser session init.
+	browser_use_server.browser_session = object()  # type: ignore[assignment]
+	handler = _call_tool_handler(browser_use_server)
+	params = types.CallToolRequestParams(name='browser_screenshot', arguments={})
+	result = await handler(None, params)
+	assert result.is_error is not True
+	texts = [b for b in result.content if isinstance(b, types.TextContent)]
+	images = [b for b in result.content if isinstance(b, types.ImageContent)]
+	assert texts and texts[0].text == '{"size_bytes": 5}'
+	assert images and images[0].data == 'aGVsbG8='
+	assert images[0].mime_type == 'image/png'
+
+
 # ---------------------------------------------------------------------------
 # CLIMCPServer
 # ---------------------------------------------------------------------------
@@ -152,8 +172,8 @@ async def test_cli_exec_empty_code_is_error(cli_server: CLIMCPServer) -> None:
 
 
 async def test_cli_exec_traceback_is_error(cli_server: CLIMCPServer) -> None:
-	def fake_execute(code: str, connect: bool = True) -> str:
-		return 'Traceback (most recent call last):\n  File "<stdin>", line 1\nZeroDivisionError: division by zero\n'
+	def fake_execute(code: str, connect: bool = True) -> tuple[str, bool]:
+		return ('Traceback (most recent call last):\n  File "<stdin>", line 1\nZeroDivisionError: division by zero\n', True)
 
 	cli_server._execute = fake_execute  # type: ignore[method-assign]
 	handler = _call_tool_handler(cli_server)
@@ -163,9 +183,43 @@ async def test_cli_exec_traceback_is_error(cli_server: CLIMCPServer) -> None:
 	assert 'ZeroDivisionError' in _text_of(result)
 
 
+async def test_cli_exec_traceback_like_output_is_not_error(cli_server: CLIMCPServer) -> None:
+	"""User code that merely *prints* a traceback-looking string is a success.
+
+	The error classification must come from _execute's structural flag, not from
+	scanning captured output for 'Traceback (most recent call last)'.
+	"""
+
+	def fake_execute(code: str, connect: bool = True) -> tuple[str, bool]:
+		# Successful execution whose stdout happens to contain the sentinel string.
+		return ('Traceback (most recent call last):', False)
+
+	cli_server._execute = fake_execute  # type: ignore[method-assign]
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='browser_exec', arguments={'code': 'print("Traceback (most recent call last):")'})
+	result = await handler(None, params)
+	assert result.is_error is not True
+	assert 'Traceback (most recent call last):' in _text_of(result)
+
+
+async def test_cli_exec_real_exception_is_error(cli_server: CLIMCPServer) -> None:
+	"""A real exception inside exec surfaces as an MCP error via the structural flag."""
+
+	def raising_execute(code: str, connect: bool = True) -> tuple[str, bool]:
+		# Mirror what the real _execute does on failure: traceback text + True.
+		return ('Traceback (most recent call last):\nValueError: boom\n', True)
+
+	cli_server._execute = raising_execute  # type: ignore[method-assign]
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='browser_exec', arguments={'code': 'raise ValueError("boom")'})
+	result = await handler(None, params)
+	assert result.is_error is True
+	assert 'ValueError' in _text_of(result)
+
+
 async def test_cli_exec_success_is_not_error(cli_server: CLIMCPServer) -> None:
-	def fake_execute(code: str, connect: bool = True) -> str:
-		return 'hello from the page'
+	def fake_execute(code: str, connect: bool = True) -> tuple[str, bool]:
+		return ('hello from the page', False)
 
 	cli_server._execute = fake_execute  # type: ignore[method-assign]
 	handler = _call_tool_handler(cli_server)
@@ -173,6 +227,31 @@ async def test_cli_exec_success_is_not_error(cli_server: CLIMCPServer) -> None:
 	result = await handler(None, params)
 	assert result.is_error is not True
 	assert _text_of(result) == 'hello from the page'
+
+
+async def test_cli_screenshot_success_preserves_image(cli_server: CLIMCPServer) -> None:
+	"""A successful browser_screenshot returns the base64 payload with image/png."""
+
+	def fake_screenshot(full: bool, max_dim: int | None) -> str:
+		return 'aGVsbG8='  # base64 for "hello"
+
+	cli_server._screenshot = fake_screenshot  # type: ignore[method-assign]
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='browser_screenshot', arguments={})
+	result = await handler(None, params)
+	assert result.is_error is not True
+	assert len(result.content) == 1
+	image = result.content[0]
+	assert isinstance(image, types.ImageContent)
+	assert image.data == 'aGVsbG8='
+	assert image.mime_type == 'image/png'
+
+
+async def test_cli_screenshot_invalid_max_dim_is_error(cli_server: CLIMCPServer) -> None:
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='browser_screenshot', arguments={'max_dim': 0})
+	result = await handler(None, params)
+	assert result.is_error is True
 
 
 async def test_cli_screenshot_that_raises_is_error_not_propagated(cli_server: CLIMCPServer) -> None:

--- a/tests/ci/security/test_mcp_handler_contract.py
+++ b/tests/ci/security/test_mcp_handler_contract.py
@@ -26,6 +26,14 @@ def _list_tools_handler(server: Any) -> Any:
 	return server.server.get_request_handler('tools/list').handler
 
 
+def _list_resources_handler(server: Any) -> Any:
+	return server.server.get_request_handler('resources/list').handler
+
+
+def _list_prompts_handler(server: Any) -> Any:
+	return server.server.get_request_handler('prompts/list').handler
+
+
 def _text_of(result: types.CallToolResult) -> str:
 	return ''.join(getattr(block, 'text', '') for block in result.content)
 
@@ -57,14 +65,14 @@ async def test_browser_use_list_tools_returns_typed_tools_with_schemas(browser_u
 
 
 async def test_browser_use_list_resources_returns_typed_empty(browser_use_server: BrowserUseServer) -> None:
-	handler = browser_use_server.server.get_request_handler('resources/list').handler
+	handler = _list_resources_handler(browser_use_server)
 	result = await handler(None, None)
 	assert isinstance(result, types.ListResourcesResult)
 	assert result.resources == []
 
 
 async def test_browser_use_list_prompts_returns_typed_empty(browser_use_server: BrowserUseServer) -> None:
-	handler = browser_use_server.server.get_request_handler('prompts/list').handler
+	handler = _list_prompts_handler(browser_use_server)
 	result = await handler(None, None)
 	assert isinstance(result, types.ListPromptsResult)
 	assert result.prompts == []

--- a/tests/ci/security/test_mcp_handler_contract.py
+++ b/tests/ci/security/test_mcp_handler_contract.py
@@ -1,0 +1,188 @@
+"""Handler-level regression tests for the mcp 2.x migration.
+
+These tests drive the handlers registered on the underlying ``mcp.server.Server``
+(``server.server.get_request_handler(...)``) rather than calling internal helpers
+directly. They assert the contract the reviewer flagged on PR #5334: failed tool
+calls must be returned as ``CallToolResult(..., is_error=True)`` instead of being
+wrapped as successful results, and the list handlers must return typed results.
+
+No real browser, daemon, or LLM is needed — internal helpers are stubbed out.
+"""
+
+from typing import Any
+
+import mcp.types as types
+import pytest
+
+from browser_use.mcp.cli_mcp import CLIMCPServer
+from browser_use.mcp.server import BrowserUseServer
+
+
+def _call_tool_handler(server: Any) -> Any:
+	return server.server.get_request_handler('tools/call').handler
+
+
+def _list_tools_handler(server: Any) -> Any:
+	return server.server.get_request_handler('tools/list').handler
+
+
+def _text_of(result: types.CallToolResult) -> str:
+	return ''.join(getattr(block, 'text', '') for block in result.content)
+
+
+# ---------------------------------------------------------------------------
+# BrowserUseServer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def browser_use_server() -> BrowserUseServer:
+	return BrowserUseServer()
+
+
+async def test_browser_use_registers_call_and_list_handlers(browser_use_server: BrowserUseServer) -> None:
+	handlers = browser_use_server.server._request_handlers
+	assert 'tools/call' in handlers
+	assert 'tools/list' in handlers
+
+
+async def test_browser_use_list_tools_returns_typed_tools_with_schemas(browser_use_server: BrowserUseServer) -> None:
+	handler = _list_tools_handler(browser_use_server)
+	result = await handler(None, None)
+	assert isinstance(result, types.ListToolsResult)
+	assert len(result.tools) > 0
+	for tool in result.tools:
+		assert isinstance(tool, types.Tool)
+		assert tool.input_schema, f'tool {tool.name!r} must have an input_schema populated'
+
+
+async def test_browser_use_list_resources_returns_typed_empty(browser_use_server: BrowserUseServer) -> None:
+	handler = browser_use_server.server.get_request_handler('resources/list').handler
+	result = await handler(None, None)
+	assert isinstance(result, types.ListResourcesResult)
+	assert result.resources == []
+
+
+async def test_browser_use_list_prompts_returns_typed_empty(browser_use_server: BrowserUseServer) -> None:
+	handler = browser_use_server.server.get_request_handler('prompts/list').handler
+	result = await handler(None, None)
+	assert isinstance(result, types.ListPromptsResult)
+	assert result.prompts == []
+
+
+async def test_browser_use_call_unknown_tool_is_error(browser_use_server: BrowserUseServer) -> None:
+	handler = _call_tool_handler(browser_use_server)
+	params = types.CallToolRequestParams(name='no_such_tool', arguments={})
+	result = await handler(None, params)
+	assert isinstance(result, types.CallToolResult)
+	assert result.is_error is True
+	assert 'Unknown tool' in _text_of(result)
+
+
+async def test_browser_use_call_tool_that_raises_is_error(browser_use_server: BrowserUseServer) -> None:
+	async def raising_stub(tool_name: str, arguments: dict[str, Any]) -> str:
+		raise RuntimeError('boom')
+
+	browser_use_server._execute_tool = raising_stub  # type: ignore[method-assign]
+	handler = _call_tool_handler(browser_use_server)
+	params = types.CallToolRequestParams(name='browser_navigate', arguments={'url': 'https://example.test'})
+	result = await handler(None, params)
+	assert result.is_error is True
+	assert 'boom' in _text_of(result)
+
+
+async def test_browser_use_call_tool_success_is_not_error_and_preserves_text(browser_use_server: BrowserUseServer) -> None:
+	async def ok_stub(task: str, **kwargs: Any) -> str:
+		return f'did: {task}'
+
+	browser_use_server._retry_with_browser_use_agent = ok_stub  # type: ignore[method-assign]
+	handler = _call_tool_handler(browser_use_server)
+	params = types.CallToolRequestParams(name='retry_with_browser_use_agent', arguments={'task': 'noop'})
+	result = await handler(None, params)
+	assert result.is_error is not True
+	assert _text_of(result) == 'did: noop'
+
+
+# ---------------------------------------------------------------------------
+# CLIMCPServer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cli_server() -> CLIMCPServer:
+	return CLIMCPServer()
+
+
+async def test_cli_registers_call_and_list_handlers(cli_server: CLIMCPServer) -> None:
+	handlers = cli_server.server._request_handlers
+	assert 'tools/call' in handlers
+	assert 'tools/list' in handlers
+
+
+async def test_cli_list_tools_returns_both_schemas(cli_server: CLIMCPServer) -> None:
+	handler = _list_tools_handler(cli_server)
+	result = await handler(None, None)
+	assert isinstance(result, types.ListToolsResult)
+	names = {tool.name for tool in result.tools}
+	assert names == {'browser_exec', 'browser_screenshot'}
+	for tool in result.tools:
+		assert tool.input_schema, f'tool {tool.name!r} must have an input_schema populated'
+
+
+async def test_cli_exec_missing_code_is_error(cli_server: CLIMCPServer) -> None:
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='browser_exec', arguments={})
+	result = await handler(None, params)
+	assert result.is_error is True
+
+
+async def test_cli_exec_empty_code_is_error(cli_server: CLIMCPServer) -> None:
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='browser_exec', arguments={'code': '   '})
+	result = await handler(None, params)
+	assert result.is_error is True
+
+
+async def test_cli_exec_traceback_is_error(cli_server: CLIMCPServer) -> None:
+	def fake_execute(code: str, connect: bool = True) -> str:
+		return 'Traceback (most recent call last):\n  File "<stdin>", line 1\nZeroDivisionError: division by zero\n'
+
+	cli_server._execute = fake_execute  # type: ignore[method-assign]
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='browser_exec', arguments={'code': '1/0'})
+	result = await handler(None, params)
+	assert result.is_error is True
+	assert 'ZeroDivisionError' in _text_of(result)
+
+
+async def test_cli_exec_success_is_not_error(cli_server: CLIMCPServer) -> None:
+	def fake_execute(code: str, connect: bool = True) -> str:
+		return 'hello from the page'
+
+	cli_server._execute = fake_execute  # type: ignore[method-assign]
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='browser_exec', arguments={'code': 'print(1)'})
+	result = await handler(None, params)
+	assert result.is_error is not True
+	assert _text_of(result) == 'hello from the page'
+
+
+async def test_cli_screenshot_that_raises_is_error_not_propagated(cli_server: CLIMCPServer) -> None:
+	def fake_screenshot(full: bool, max_dim: int | None) -> str:
+		raise RuntimeError('daemon is down')
+
+	cli_server._screenshot = fake_screenshot  # type: ignore[method-assign]
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='browser_screenshot', arguments={})
+	result = await handler(None, params)
+	assert isinstance(result, types.CallToolResult)
+	assert result.is_error is True
+	assert 'daemon is down' in _text_of(result)
+
+
+async def test_cli_unknown_tool_is_error(cli_server: CLIMCPServer) -> None:
+	handler = _call_tool_handler(cli_server)
+	params = types.CallToolRequestParams(name='no_such_tool', arguments={})
+	result = await handler(None, params)
+	assert result.is_error is True
+	assert 'Unknown tool' in _text_of(result)

--- a/tests/ci/test_mcp_tool_annotations.py
+++ b/tests/ci/test_mcp_tool_annotations.py
@@ -10,6 +10,8 @@ the read-only set: it dispatches the `extract` action through `Tools.act()`
 with a FileSystem handle and can write extraction artifacts.
 """
 
+from typing import Any
+
 import mcp.types as types
 import pytest
 
@@ -38,10 +40,14 @@ def _is_read_only(tool: types.Tool) -> bool:
 	return tool.annotations is not None and tool.annotations.read_only_hint is True
 
 
+def _list_tools_handler(server: Any) -> Any:
+	return server.server.get_request_handler('tools/list').handler
+
+
 async def _list_tools(server: BrowserUseServer) -> list[types.Tool]:
 	# mcp 2.x registers handlers on the Server constructor; they are reachable by
 	# method name via get_request_handler and take (ctx, params).
-	handler = server.server.get_request_handler('tools/list').handler
+	handler = _list_tools_handler(server)
 	list_result = await handler(None, None)
 	assert isinstance(list_result, types.ListToolsResult), f'expected ListToolsResult, got {type(list_result).__name__}'
 	assert len(list_result.tools) > 0, 'tools/list returned an empty catalogue'


### PR DESCRIPTION
Migrates the MCP integration from the hard-pinned `mcp==1.26.0` to `mcp>=2.0.0,<3`.

Closes #5333

## What changed

**`pyproject.toml`** — `mcp==1.26.0` → `mcp>=2.0.0,<3`

**`browser_use/mcp/server.py` & `cli_mcp.py`** — the lowlevel
`@server.list_tools()` / `@server.call_tool()` / `@server.list_resources()` /
`@server.list_prompts()` decorators were removed in mcp 2.0, so handlers are now
registered through the `Server(...)` constructor (`on_list_tools=`,
`on_call_tool=`, …). Handler signatures change to
`(ctx: ServerRequestContext, params)` returning the result models
(`ListToolsResult`, `CallToolResult`, `ListResourcesResult`, `ListPromptsResult`);
`call_tool` reads `params.name` / `params.arguments` and flags failures with
`is_error=True`. `inputSchema=` → `input_schema=`, `mimeType=` → `mime_type=`.

**`browser_use/mcp/client.py` & `controller.py`** — only the camelCase →
snake_case attribute reads changed (`tool.inputSchema` → `tool.input_schema`).
`ClientSession` usage (`list_tools()`, `call_tool()`) is unchanged in 2.0.

The stdio bootstrap (`stdio_server()`, `InitializationOptions`,
`get_capabilities(...)`, `server.run(read, write, init_opts)`) is unchanged —
those APIs are intact in 2.0.

## Testing

Validated against an environment with `mcp==2.0.0` installed:

- `import browser_use.mcp.{server, cli_mcp, client, controller}` — all import cleanly.
- `BrowserUseServer()` constructs and registers `tools/list`, `tools/call`,
  `resources/list`, `prompts/list` in `_request_handlers`.
- `CLIMCPServer()` constructs and registers `tools/list`, `tools/call`.
- Smoke-invoked the registered handlers: `tools/list` returns all 16 tools with
  `input_schema` populated; unknown tool returns `is_error=True`;
  `resources/list` / `prompts/list` return empty.

## Notes for reviewers

Behavior change worth a look: in 1.x the `call_tool` error path returned a bare
content list with no error flag; the 2.0 `CallToolResult` now sets
`is_error=True` on exception / unknown-tool / validation-failure paths so MCP
clients surface them as tool errors. Success paths are unchanged.

The dependency-floor bumps in mcp 2.0 (`pydantic>=2.12`, `anyio>=4.9`,
`typing-extensions>=4.13`, plus new `opentelemetry-api` / `mcp-types`) are
satisfied by the existing constraints.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the MCP integration to `mcp>=2.0.0,<3` with 2.x handler signatures and snake_case models. Previous behavior returned bare content on errors; now tool failures and raised-execution errors return `CallToolResult(is_error=True)`, and image results include `mime_type`. Proves MCP 2.x compatibility end-to-end (addresses #5333).

- Register handlers via `Server(..., on_list_tools, on_call_tool, on_list_resources, on_list_prompts)` using `(ctx, params)` and typed results; content lists use `list[types.ContentBlock]`.
- Use `input_schema`/`mime_type` and `ToolAnnotations.read_only_hint`; clients read `input_schema` and `is_error`.
- Harden error paths: unknown tools short-circuit with `is_error=True`; handler exceptions are caught and returned as errors; CLI `_execute` returns `(output, is_error)` to avoid misclassifying printed tracebacks. New tests assert raised-execution errors reach clients over the live transport.
- Dependencies: bump to `mcp>=2.0.0,<3`; add `pydantic-settings==2.12.0` as a runtime dependency.
- Migration required: replace any `inputSchema`/`mimeType` reads with `input_schema`/`mime_type`.

<sup>Written for commit 7c855168b5010f3a9da6655a6e2ec3f7311c2aea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

