### PR TITLE
fix(utils): harden URL and version parsing

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -658,12 +658,7 @@ def merge_dicts(a: dict, b: dict, path: tuple[str, ...] = ()):
 
 
 def _strip_utf8_bom(raw: bytes) -> bytes:
-	"""Strip a single leading UTF-8 BOM (EF BB BF) from *raw* if present.
-
-	Unlike ``bytes.lstrip``, which removes any combination of the bytes EF/BB/BF,
-	this removes only the exact 3-byte prefix, so a lone 0xEF, 0xBB, or 0xBF (or
-	a partial BOM) is never stripped from the start of the file.
-	"""
+	"""Strip a single leading UTF-8 BOM (EF BB BF) if present, not lone bytes."""
 	return raw.removeprefix(b'\xef\xbb\xbf')
 
 

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -657,6 +657,16 @@ def merge_dicts(a: dict, b: dict, path: tuple[str, ...] = ()):
 	return a
 
 
+def _strip_utf8_bom(raw: bytes) -> bytes:
+	"""Strip a single leading UTF-8 BOM (EF BB BF) from *raw* if present.
+
+	Unlike ``bytes.lstrip``, which removes any combination of the bytes EF/BB/BF,
+	this removes only the exact 3-byte prefix, so a lone 0xEF, 0xBB, or 0xBF (or
+	a partial BOM) is never stripped from the start of the file.
+	"""
+	return raw.removeprefix(b'\xef\xbb\xbf')
+
+
 @cache
 def get_browser_use_version() -> str:
 	"""Get the browser-use package version using the same logic as Agent._set_browser_use_version_and_source"""
@@ -672,7 +682,7 @@ def get_browser_use_version() -> str:
 			import tomllib
 
 			with open(pyproject_path, 'rb') as f:
-				content = f.read().lstrip(b'\xef\xbb\xbf')
+				content = _strip_utf8_bom(f.read())
 			data = tomllib.loads(content.decode('utf-8'))
 			version = data.get('project', {}).get('version')
 			if version is not None:

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -4,6 +4,7 @@ import os
 import platform
 import re
 import signal
+import threading
 import time
 from collections.abc import Callable, Coroutine
 from fnmatch import fnmatch
@@ -46,7 +47,25 @@ def sanitize_url_candidate(url: str) -> str:
 	# "https://example.com/search.\\n2. Next step". Those are task text,
 	# not part of the URL.
 	candidate = re.split(r'\\[nrt]', candidate, maxsplit=1)[0]
-	return re.sub(r'[.,;:!?()\[\]]+$', '', candidate)
+	# Strip trailing sentence punctuation. Closing parentheses/brackets are kept
+	# only when balanced with a matching opener (e.g. Wikipedia URLs ending in
+	# "..._(programming_language)"); unbalanced trailing closers, and any
+	# trailing openers, are stripped so prose punctuation does not bleed in.
+	while candidate:
+		last = candidate[-1]
+		if last in '.,;:!?':
+			candidate = candidate[:-1]
+		elif last in ')]':
+			open_char = '(' if last == ')' else '['
+			if candidate.count(open_char) < candidate.count(last):
+				candidate = candidate[:-1]
+			else:
+				break
+		elif last in '([':
+			candidate = candidate[:-1]
+		else:
+			break
+	return candidate
 
 
 # Lazy import for error types
@@ -471,10 +490,13 @@ def time_execution_async(
 
 def singleton(cls):
 	instance = [None]
+	lock = threading.Lock()
 
 	def wrapper(*args, **kwargs):
 		if instance[0] is None:
-			instance[0] = cls(*args, **kwargs)
+			with lock:
+				if instance[0] is None:
+					instance[0] = cls(*args, **kwargs)
 		return instance[0]
 
 	return wrapper
@@ -642,17 +664,18 @@ def get_browser_use_version() -> str:
 		package_root = Path(__file__).parent.parent
 		pyproject_path = package_root / 'pyproject.toml'
 
-		# Try to read version from pyproject.toml
+		# Try to read version from pyproject.toml via tomllib (parses the TOML
+		# structure so we resolve [project].version rather than the first
+		# ``version =`` line anywhere in the file).
 		if pyproject_path.exists():
-			import re
+			import tomllib
 
-			with open(pyproject_path, encoding='utf-8') as f:
-				content = f.read()
-				match = re.search(r'version\s*=\s*["\']([^"\']+)["\']', content)
-				if match:
-					version = f'{match.group(1)}'
-					os.environ['LIBRARY_VERSION'] = version  # used by bubus event_schema so all Event schemas include versioning
-					return version
+			with open(pyproject_path, 'rb') as f:
+				data = tomllib.load(f)
+			version = data['project']['version']
+			version = f'{version}'
+			os.environ['LIBRARY_VERSION'] = version  # used by bubus event_schema so all Event schemas include versioning
+			return version
 
 		# If pyproject.toml doesn't exist, try getting version from pip
 		from importlib.metadata import version as get_version
@@ -716,8 +739,8 @@ def _browser_use_version_key(version: str) -> tuple[tuple[int, ...], int, int, i
 
 
 @cache
-def get_git_info() -> dict[str, str] | None:
-	"""Get git information if installed from git repository"""
+def _get_git_info_cached() -> dict[str, str] | None:
+	"""Get git information if installed from git repository (cached, do not mutate)."""
 	try:
 		import subprocess
 
@@ -756,6 +779,12 @@ def get_git_info() -> dict[str, str] | None:
 	except Exception as e:
 		logger.debug(f'Error getting git info: {type(e).__name__}: {e}')
 		return None
+
+
+def get_git_info() -> dict[str, str] | None:
+	"""Return a copy of the cached git info so callers cannot mutate the cached dict."""
+	info = _get_git_info_cached()
+	return info.copy() if info else None
 
 
 def _log_pretty_path(path: str | Path | None) -> str:

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -666,18 +666,25 @@ def get_browser_use_version() -> str:
 
 		# Try to read version from pyproject.toml via tomllib (parses the TOML
 		# structure so we resolve [project].version rather than the first
-		# ``version =`` line anywhere in the file).
+		# ``version =`` line anywhere in the file). Strip a UTF-8 BOM first:
+		# tomllib rejects it, but Windows editors commonly save with one.
 		if pyproject_path.exists():
 			import tomllib
 
 			with open(pyproject_path, 'rb') as f:
-				data = tomllib.load(f)
-			version = data['project']['version']
-			version = f'{version}'
-			os.environ['LIBRARY_VERSION'] = version  # used by bubus event_schema so all Event schemas include versioning
-			return version
+				content = f.read().lstrip(b'\xef\xbb\xbf')
+			data = tomllib.loads(content.decode('utf-8'))
+			version = data.get('project', {}).get('version')
+			if version is not None:
+				version = f'{version}'
+				os.environ['LIBRARY_VERSION'] = version  # used by bubus event_schema so all Event schemas include versioning
+				return version
 
-		# If pyproject.toml doesn't exist, try getting version from pip
+			# pyproject.toml parses but declares no [project].version (e.g. a
+			# uv.lock-only layout) - fall through to the installed package below.
+
+		# If pyproject.toml doesn't exist (or declares no version), try getting
+		# version from pip
 		from importlib.metadata import version as get_version
 
 		version = str(get_version('browser-use'))

--- a/tests/ci/infrastructure/test_version_check.py
+++ b/tests/ci/infrastructure/test_version_check.py
@@ -72,27 +72,13 @@ def test_later_release_candidate_is_newer():
 
 
 def test_strip_utf8_bom_only_removes_a_full_bom_prefix():
-	"""A full UTF-8 BOM (EF BB BF) is stripped; partial or lone BOM bytes are not.
-
-	Regression guard: ``bytes.lstrip(b'\\xef\\xbb\\xbf')`` would strip any
-	combination of those bytes, silently corrupting files that start with a lone
-	0xEF, 0xBB, or 0xBF instead of the exact 3-byte BOM.
-	"""
-	# A full BOM prefix is removed so real content (e.g. a TOML header) survives.
+	"""A full UTF-8 BOM (EF BB BF) is stripped; partial or lone BOM bytes are not."""
 	assert _strip_utf8_bom(b'\xef\xbb\xbf[project]\nversion = "1.0"') == b'[project]\nversion = "1.0"'
-
-	# Partial BOMs are NOT a BOM and must be left intact.
 	assert _strip_utf8_bom(b'\xef\xbb[project]') == b'\xef\xbb[project]'
 	assert _strip_utf8_bom(b'\xbb\xbf[project]') == b'\xbb\xbf[project]'
-
-	# A lone 0xEF, 0xBB, or 0xBF byte must never be stripped.
 	assert _strip_utf8_bom(b'\xef[project]') == b'\xef[project]'
 	assert _strip_utf8_bom(b'\xbb[project]') == b'\xbb[project]'
 	assert _strip_utf8_bom(b'\xbf[project]') == b'\xbf[project]'
-
-	# Only a single prefix is stripped (removeprefix, not lstrip-style sweeping).
 	assert _strip_utf8_bom(b'\xef\xbb\xbf\xef\xbb\xbf') == b'\xef\xbb\xbf'
-
-	# No BOM present: bytes are unchanged; empty input stays empty.
 	assert _strip_utf8_bom(b'[project]\nversion = "1.0"') == b'[project]\nversion = "1.0"'
 	assert _strip_utf8_bom(b'') == b''

--- a/tests/ci/infrastructure/test_version_check.py
+++ b/tests/ci/infrastructure/test_version_check.py
@@ -1,3 +1,4 @@
+import tomllib
 from pathlib import Path
 
 from browser_use.utils import _is_newer_browser_use_version, get_browser_use_version
@@ -19,6 +20,43 @@ def test_get_browser_use_version_reads_project_version_from_pyproject_toml(monke
 	assert version == expected
 	assert version != 'unknown'
 	assert os.environ.get('LIBRARY_VERSION') == expected
+
+
+def test_get_browser_use_version_handles_utf8_bom_in_pyproject_toml(monkeypatch):
+	"""A UTF-8 BOM (as Windows editors save) must not make version detection return 'unknown'."""
+
+	get_browser_use_version.cache_clear()
+	monkeypatch.delenv('LIBRARY_VERSION', raising=False)
+	pyproject = Path(__file__).parent.parent.parent.parent / 'pyproject.toml'
+	original = pyproject.read_bytes()
+	expected = tomllib.loads(original.decode('utf-8'))['project']['version']
+	try:
+		pyproject.write_bytes(b'\xef\xbb\xbf' + original)
+		version = get_browser_use_version()
+	finally:
+		pyproject.write_bytes(original)
+		get_browser_use_version.cache_clear()
+	assert version == expected
+	assert version != 'unknown'
+
+
+def test_get_browser_use_version_falls_back_when_pyproject_has_no_project_version(monkeypatch):
+	"""A parseable pyproject.toml without [project].version must fall back to installed metadata."""
+	from importlib.metadata import version as get_version
+
+	get_browser_use_version.cache_clear()
+	monkeypatch.delenv('LIBRARY_VERSION', raising=False)
+	pyproject = Path(__file__).parent.parent.parent.parent / 'pyproject.toml'
+	original = pyproject.read_bytes()
+	expected = get_version('browser-use')
+	try:
+		pyproject.write_bytes(b'[tool.ruff]\ntarget-version = "py311"\n')
+		version = get_browser_use_version()
+	finally:
+		pyproject.write_bytes(original)
+		get_browser_use_version.cache_clear()
+	assert version == expected
+	assert version != 'unknown'
 
 
 def test_prerelease_is_newer_than_previous_stable():

--- a/tests/ci/infrastructure/test_version_check.py
+++ b/tests/ci/infrastructure/test_version_check.py
@@ -1,4 +1,24 @@
-from browser_use.utils import _is_newer_browser_use_version
+from pathlib import Path
+
+from browser_use.utils import _is_newer_browser_use_version, get_browser_use_version
+
+
+def test_get_browser_use_version_reads_project_version_from_pyproject_toml(monkeypatch):
+	"""Ensure tomllib-based parsing returns the [project] version and sets LIBRARY_VERSION."""
+	import os
+
+	get_browser_use_version.cache_clear()
+	monkeypatch.delenv('LIBRARY_VERSION', raising=False)
+	version = get_browser_use_version()
+	pyproject = Path(__file__).parent.parent.parent.parent / 'pyproject.toml'
+	assert pyproject.exists()
+	import tomllib
+
+	with open(pyproject, 'rb') as f:
+		expected = tomllib.load(f)['project']['version']
+	assert version == expected
+	assert version != 'unknown'
+	assert os.environ.get('LIBRARY_VERSION') == expected
 
 
 def test_prerelease_is_newer_than_previous_stable():

--- a/tests/ci/infrastructure/test_version_check.py
+++ b/tests/ci/infrastructure/test_version_check.py
@@ -1,7 +1,7 @@
 import tomllib
 from pathlib import Path
 
-from browser_use.utils import _is_newer_browser_use_version, get_browser_use_version
+from browser_use.utils import _is_newer_browser_use_version, _strip_utf8_bom, get_browser_use_version
 
 
 def test_get_browser_use_version_reads_project_version_from_pyproject_toml(monkeypatch):
@@ -69,3 +69,30 @@ def test_stable_release_is_newer_than_same_release_candidate():
 
 def test_later_release_candidate_is_newer():
 	assert _is_newer_browser_use_version('0.13.0rc4', '0.13.0rc3') is True
+
+
+def test_strip_utf8_bom_only_removes_a_full_bom_prefix():
+	"""A full UTF-8 BOM (EF BB BF) is stripped; partial or lone BOM bytes are not.
+
+	Regression guard: ``bytes.lstrip(b'\\xef\\xbb\\xbf')`` would strip any
+	combination of those bytes, silently corrupting files that start with a lone
+	0xEF, 0xBB, or 0xBF instead of the exact 3-byte BOM.
+	"""
+	# A full BOM prefix is removed so real content (e.g. a TOML header) survives.
+	assert _strip_utf8_bom(b'\xef\xbb\xbf[project]\nversion = "1.0"') == b'[project]\nversion = "1.0"'
+
+	# Partial BOMs are NOT a BOM and must be left intact.
+	assert _strip_utf8_bom(b'\xef\xbb[project]') == b'\xef\xbb[project]'
+	assert _strip_utf8_bom(b'\xbb\xbf[project]') == b'\xbb\xbf[project]'
+
+	# A lone 0xEF, 0xBB, or 0xBF byte must never be stripped.
+	assert _strip_utf8_bom(b'\xef[project]') == b'\xef[project]'
+	assert _strip_utf8_bom(b'\xbb[project]') == b'\xbb[project]'
+	assert _strip_utf8_bom(b'\xbf[project]') == b'\xbf[project]'
+
+	# Only a single prefix is stripped (removeprefix, not lstrip-style sweeping).
+	assert _strip_utf8_bom(b'\xef\xbb\xbf\xef\xbb\xbf') == b'\xef\xbb\xbf'
+
+	# No BOM present: bytes are unchanged; empty input stays empty.
+	assert _strip_utf8_bom(b'[project]\nversion = "1.0"') == b'[project]\nversion = "1.0"'
+	assert _strip_utf8_bom(b'') == b''

--- a/tests/ci/test_sanitize_url_candidate.py
+++ b/tests/ci/test_sanitize_url_candidate.py
@@ -1,0 +1,64 @@
+from browser_use.utils import sanitize_url_candidate
+
+
+def test_balanced_trailing_parenthesis_preserved():
+	"""A Wikipedia-style URL with a balanced trailing ``)`` is preserved."""
+	url = 'https://en.wikipedia.org/wiki/Python_(programming_language)'
+	assert sanitize_url_candidate(url) == url
+
+
+def test_balanced_trailing_bracket_preserved():
+	"""A URL with a balanced trailing ``]`` is preserved."""
+	url = 'https://example.com/path/[item]'
+	assert sanitize_url_candidate(url) == url
+
+
+def test_unbalanced_trailing_parenthesis_stripped():
+	"""A trailing ``)`` with no matching ``(`` is stripped."""
+	assert sanitize_url_candidate('https://example.com/foo)') == 'https://example.com/foo'
+
+
+def test_unbalanced_trailing_bracket_stripped():
+	"""A trailing ``]`` with no matching ``[`` is stripped."""
+	assert sanitize_url_candidate('https://example.com/bar]') == 'https://example.com/bar'
+
+
+def test_nested_balanced_parens_preserved():
+	"""Nested balanced parentheses are kept intact."""
+	url = 'https://example.com/(a(b)c)'
+	assert sanitize_url_candidate(url) == url
+
+
+def test_extra_closing_paren_stripped():
+	"""Only the unbalanced trailing ``)`` is stripped; balanced ones remain."""
+	assert sanitize_url_candidate('https://example.com/(foo))') == 'https://example.com/(foo)'
+
+
+def test_trailing_punctuation_stripped():
+	"""Trailing ``.,;:!?`` are stripped."""
+	for suffix in '.,;:!?':
+		assert sanitize_url_candidate(f'https://example.com/foo{suffix}') == 'https://example.com/foo'
+
+
+def test_punctuation_after_balanced_paren_stripped():
+	"""Trailing punctuation after a balanced ``)`` is stripped, ``)`` kept."""
+	assert sanitize_url_candidate('https://en.wikipedia.org/wiki/Python_(programming_language).') == (
+		'https://en.wikipedia.org/wiki/Python_(programming_language)'
+	)
+
+
+def test_escaped_newline_truncation_unchanged():
+	"""Escaped-newline prose truncation still happens before balance handling."""
+	# The split on escaped newlines keeps everything before the first \\n, then
+	# the trailing ``.`` is stripped as punctuation.
+	assert sanitize_url_candidate('https://example.com/search.\\n2. Next step') == 'https://example.com/search'
+
+
+def test_empty_input():
+	"""Empty input returns empty string."""
+	assert sanitize_url_candidate('') == ''
+
+
+def test_whitespace_only_input():
+	"""Whitespace-only input returns empty string after strip."""
+	assert sanitize_url_candidate('   ') == ''


### PR DESCRIPTION
## Summary

Hardening for URL candidate sanitization and version/git info parsing:

- **`sanitize_url_candidate`** — balance-aware trailing stripping: preserves balanced `()`/`[]` (e.g. Wikipedia-style URLs ending in `..._(programming_language)`) while still stripping unbalanced trailing closers/openers and trailing `.`, `,`, `;`, `:`, `!`, `?`
- **`get_browser_use_version`** — resolves `[project].version` via `tomllib` instead of a naive first-match regex over the file contents; reads the TOML in binary mode as `tomllib` requires
- **`get_git_info`** — split into a cached private helper (`_get_git_info_cached`) plus a public wrapper returning a **copy**, so callers can no longer mutate the cached dict
- **`singleton`** — double-checked locking with `threading.Lock()` to avoid duplicate instance creation under concurrent first access

## Tests

- New `tests/ci/test_sanitize_url_candidate.py` (11 tests): balanced/unbalanced/nested parens & brackets, trailing punctuation, escaped-newline truncation, empty input
- New coverage in `tests/ci/infrastructure/test_version_check.py`: asserts `[project].version` resolution and `LIBRARY_VERSION` propagation

Verified locally: `pytest tests/ci/test_sanitize_url_candidate.py tests/ci/infrastructure/test_version_check.py` → **15 passed**.

## Notes

This PR was **split out of #5303** (which has been closed) to keep changes small and reviewable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens URL sanitization and version/git parsing for correctness and thread safety. Preserves balanced parentheses in URLs, parses version via `tomllib` with exact UTF-8 BOM handling and fallback, prevents cached git info mutation, and makes the singleton thread-safe.

- **Bug Fixes**
  - `sanitize_url_candidate`: preserve balanced ()/[]; strip unbalanced closers and trailing . , ; : ! ?; keep escaped-newline truncation.
  - `get_browser_use_version`: read `[project].version` via `tomllib`; strip only a full UTF-8 BOM via `_strip_utf8_bom`; fall back to installed metadata when missing; set `LIBRARY_VERSION`.

- **Refactors**
  - `get_git_info`: split into cached helper and public wrapper that returns a copy to avoid mutation.
  - `singleton`: add double-checked locking to prevent duplicate instances under concurrent first access.
  - Docs: trim `_strip_utf8_bom` docstring and related test comments (no behavior change).

<sup>Written for commit b69eb5a0e375b3a793f567f740b3b7db6462468f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

