### PR TITLE
test(ci): Windows path execution tests for skill install docs

### DIFF
--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -42,6 +42,19 @@ def _fake_browser_harness_tools(tmp_path: Path, skill_text: str) -> Path:
 		encoding='utf-8',
 	)
 	browser_harness.chmod(0o755)
+
+	if sys.platform == 'win32':
+		uv_bat = bin_dir / 'uv.bat'
+		uv_bat.write_text(
+			f'@echo off\n"{sys.executable}" "{uv}" %*\n',
+			encoding='utf-8',
+		)
+		harness_bat = bin_dir / 'browser-harness.bat'
+		harness_bat.write_text(
+			f'@echo off\n"{sys.executable}" "{browser_harness}" %*\n',
+			encoding='utf-8',
+		)
+
 	return bin_dir
 
 
@@ -67,6 +80,8 @@ def test_browser_use_cli_installs_browser_harness_package_skill(tmp_path):
 	uv_args = tmp_path / 'uv-args.txt'
 	env = os.environ.copy()
 	env['HOME'] = str(home)
+	if sys.platform == 'win32':
+		env['USERPROFILE'] = env['HOME']
 	env['PATH'] = os.pathsep.join(part for part in (str(bin_dir), env.get('PATH', '')) if part)
 	env['PYTHONPATH'] = os.pathsep.join(part for part in (str(ROOT), env.get('PYTHONPATH', '')) if part)
 	env['UV_TOOL_INSTALL_ARGS_FILE'] = str(uv_args)
@@ -101,6 +116,8 @@ def test_browser_use_cli_validates_destination_before_installing_harness(tmp_pat
 	uv_args = tmp_path / 'uv-args.txt'
 	env = os.environ.copy()
 	env['HOME'] = str(tmp_path / 'home')
+	if sys.platform == 'win32':
+		env['USERPROFILE'] = env['HOME']
 	env['PATH'] = os.pathsep.join(part for part in (str(bin_dir), env.get('PATH', '')) if part)
 	env['PYTHONPATH'] = os.pathsep.join(part for part in (str(ROOT), env.get('PYTHONPATH', '')) if part)
 	env['UV_TOOL_INSTALL_ARGS_FILE'] = str(uv_args)


### PR DESCRIPTION
## Summary

Makes the skill-install doc tests executable on Windows:

- Create `.bat` shims for the fake `uv` / `browser-harness` executables so subprocess resolution works on Windows
- Forward `USERPROFILE` alongside `HOME` in the test environment, matching how Windows tools locate the user profile directory

The three tests now run on Windows CI as well as POSIX. Verified locally on Windows: `pytest tests/ci/test_browser_use_skill_install_docs.py` → **3 passed**.

## Notes

This PR was **split out of #5303** (which has been closed) to keep changes small and reviewable. Test-only change; no library code touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Windows CI for the skill-install doc tests so they run correctly on Windows. All three tests now pass on Windows and POSIX.

- **Bug Fixes**
  - Added Windows `.bat` shims for fake `uv` and `browser-harness` so PATH execution works.
  - Forward `USERPROFILE` alongside `HOME` in the test env to match Windows profile lookup.

<sup>Written for commit 216481ac8844ea60684f5a403d4d45d9e3a70bcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

