### PR TITLE
ci: add name to test discovery step for readability

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,8 @@ jobs:
         with:
           # Force fresh checkout to avoid any caching issues
           fetch-depth: 1
-      - id: lsgrep
+      - name: Discover CI test files for matrix
+        id: lsgrep
         run: |
           echo "🔍 Discovering test files at $(date)"
           echo "Git commit: $(git rev-parse HEAD)"


### PR DESCRIPTION
## Problem

In `.github/workflows/test.yaml`, the `lsgrep` step that builds the CI test matrix is a long unnamed `run` block, so the Actions UI shows a generic label.

## Changes

Semantics are unchanged: same `id: lsgrep`, same `TEST_FILENAMES` output, and the same job/step output wiring.

- Add `name: Discover CI test files for matrix` to the existing `lsgrep` step

## Test plan
- [ ] Confirm `find_tests.outputs.TEST_FILENAMES` still comes from `steps.lsgrep.outputs.TEST_FILENAMES`
- [ ] Confirm the discovery command is unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the name "Discover CI test files for matrix" to the CI test discovery step in `.github/workflows/test.yaml` so the Actions UI shows a clear label. No behavior changes: step still uses `id: lsgrep` and emits `TEST_FILENAMES`.

<sup>Written for commit 7514a85978dade917f4b2744585846cd1deb8d54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

