### PR TITLE
fix: remove stale action context generic

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -8,7 +8,7 @@ import tempfile
 import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Literal, cast
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
@@ -124,13 +124,10 @@ def log_response(response: AgentOutput, registry=None, logger=None) -> None:
 		logger.info(f'  \033[34m🎯 Next goal: {next_goal}\033[0m')
 
 
-Context = TypeVar('Context')
-
-
 AgentHookFunc = Callable[['Agent'], Awaitable[None]]
 
 
-class Agent(Generic[Context, AgentStructuredOutput]):
+class Agent(Generic[AgentStructuredOutput]):
 	@time_execution_sync('--init')
 	def __init__(
 		self,
@@ -140,8 +137,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		browser_profile: BrowserProfile | None = None,
 		browser_session: BrowserSession | None = None,
 		browser: Browser | None = None,  # Alias for browser_session
-		tools: Tools[Context] | None = None,
-		controller: Tools[Context] | None = None,  # Alias for tools
+		tools: Tools | None = None,
+		controller: Tools | None = None,  # Alias for tools
 		# Skills integration
 		skill_ids: list[str | Literal['*']] | None = None,
 		skills: list[str | Literal['*']] | None = None,  # Alias for skill_ids

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -25,7 +25,6 @@ from urllib.parse import urlparse
 
 from bubus import EventBus
 from pydantic import BaseModel, ValidationError, create_model
-from typing_extensions import TypeVar
 from uuid_extensions import uuid7str
 
 from browser_use.agent.cloud_events import (
@@ -80,7 +79,6 @@ from browser_use.utils import (
 	sanitize_url_candidate,
 )
 
-Context = TypeVar('Context')
 AgentHookFunc = Callable[['Agent'], Awaitable[None]]
 AgentNewStepCallback = (
 	Callable[[BrowserStateSummary, AgentOutput, int], None] | Callable[[BrowserStateSummary, AgentOutput, int], Awaitable[None]]
@@ -4233,7 +4231,7 @@ def _normalize_initial_action(action_name: str, params: Any) -> tuple[str, Any]:
 	return action_name, params
 
 
-class Agent(Generic[Context, AgentStructuredOutput]):
+class Agent(Generic[AgentStructuredOutput]):
 	"""Browser Use-style Agent backed by the Rust browser-use-terminal core."""
 
 	def __init__(
@@ -4243,8 +4241,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		browser_profile: BrowserProfile | None = None,
 		browser_session: BrowserSession | None = None,
 		browser: BrowserSession | None = None,
-		tools: Tools[Context] | None = None,
-		controller: Tools[Context] | None = None,
+		tools: Tools | None = None,
+		controller: Tools | None = None,
 		skill_ids: list[str | Literal['*']] | None = None,
 		skills: list[str | Literal['*']] | None = None,
 		skill_service: Any | None = None,

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Callable
 from inspect import Parameter, iscoroutinefunction, signature
 from types import UnionType
-from typing import Any, Generic, Optional, TypeVar, Union, get_args, get_origin
+from typing import Any, Optional, Union, get_args, get_origin
 
 import pyotp
 from pydantic import BaseModel, Field, RootModel, create_model
@@ -25,12 +25,10 @@ from browser_use.tools.registry.views import (
 )
 from browser_use.utils import is_new_tab_page, match_url_with_domain_pattern, time_execution_async
 
-Context = TypeVar('Context')
-
 logger = logging.getLogger(__name__)
 
 
-class Registry(Generic[Context]):
+class Registry:
 	"""Service for registering and managing actions"""
 
 	def __init__(self, exclude_actions: list[str] | None = None):
@@ -61,7 +59,6 @@ class Registry(Generic[Context]):
 		# but each driver should decide what is relevant to expose the action methods,
 		# e.g. CDP client, 2fa code getters, sensitive_data wrappers, other context, etc.
 		return {
-			'context': None,  # Context is a TypeVar, so we can't validate type
 			'browser_session': BrowserSession,
 			'page_url': str,
 			'cdp_client': None,  # CDPClient type from cdp_use, but we don't import it here

--- a/browser_use/tools/registry/views.py
+++ b/browser_use/tools/registry/views.py
@@ -151,12 +151,6 @@ class SpecialActionParameters(BaseModel):
 
 	model_config = ConfigDict(arbitrary_types_allowed=True)
 
-	# optional user-provided context object passed down from Agent(context=...)
-	# e.g. can contain anything, external db connections, file handles, queues, runtime config objects, etc.
-	# that you might want to be able to access quickly from within many of your actions
-	# browser-use code doesn't use this at all, we just pass it down to your actions for convenience
-	context: Any | None = None
-
 	# browser-use session object, can be used to create new tabs, navigate, access CDP
 	browser_session: BrowserSession | None = None
 

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -3,7 +3,7 @@ import json
 import logging
 import math
 import os
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 import anyio
 
@@ -69,8 +69,6 @@ ClickElementEvent.model_rebuild()
 TypeTextEvent.model_rebuild()
 ScrollEvent.model_rebuild()
 UploadFileEvent.model_rebuild()
-
-Context = TypeVar('Context')
 
 T = TypeVar('T', bound=BaseModel)
 
@@ -438,14 +436,14 @@ def _is_autocomplete_field(node: EnhancedDOMTreeNode) -> bool:
 	return False
 
 
-class Tools(Generic[Context]):
+class Tools:
 	def __init__(
 		self,
 		exclude_actions: list[str] | None = None,
 		output_model: type[T] | None = None,
 		display_files_in_done_text: bool = True,
 	):
-		self.registry = Registry[Context](exclude_actions if exclude_actions is not None else [])
+		self.registry = Registry(exclude_actions if exclude_actions is not None else [])
 		self.display_files_in_done_text = display_files_in_done_text
 		self._output_model: type[BaseModel] | None = output_model
 		self._coordinate_clicking_enabled: bool = False

--- a/tests/ci/infrastructure/test_registry_core.py
+++ b/tests/ci/infrastructure/test_registry_core.py
@@ -36,12 +36,6 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-class TestContext:
-	"""Simple context for testing"""
-
-	pass
-
-
 # Test parameter models
 class SimpleParams(BaseActionModel):
 	"""Simple parameter model"""
@@ -90,7 +84,7 @@ def mock_llm():
 @pytest.fixture(scope='function')
 def registry():
 	"""Create a fresh registry for each test"""
-	return Registry[TestContext]()
+	return Registry()
 
 
 @pytest.fixture(scope='function')
@@ -128,6 +122,20 @@ class TestActionRegistryParameterPatterns:
 		assert isinstance(result, ActionResult)
 		assert result.extracted_content is not None
 		assert 'Text: hello, Number: 42' in result.extracted_content
+
+	async def test_context_is_a_regular_action_parameter(self, registry):
+		"""The removed Agent context injection no longer reserves the context parameter name."""
+
+		@registry.action('Echo context')
+		async def echo_context(context: str):
+			return ActionResult(extracted_content=context)
+
+		action = registry.registry.actions['echo_context']
+		assert 'context' in action.param_model.model_fields
+
+		result = await registry.execute_action('echo_context', {'context': 'supplied by the action'})
+
+		assert result.extracted_content == 'supplied by the action'
 
 	async def test_individual_parameters_with_browser(self, registry, browser_session, base_url):
 		"""Test action with individual parameters plus browser_session injection"""
@@ -454,7 +462,7 @@ class TestRegistryEdgeCases:
 	async def test_excluded_actions(self, browser_session):
 		"""Test that excluded actions are not registered"""
 
-		registry_with_exclusions = Registry[TestContext](exclude_actions=['excluded_action'])
+		registry_with_exclusions = Registry(exclude_actions=['excluded_action'])
 
 		@registry_with_exclusions.action('Excluded action')
 		async def excluded_action(text: str):

--- a/tests/ci/infrastructure/test_registry_validation.py
+++ b/tests/ci/infrastructure/test_registry_validation.py
@@ -391,10 +391,6 @@ class TestParamsModelArgsAndKwargs:
 		from browser_use.tools.registry.service import Registry
 		from browser_use.tools.registry.views import ActionModel
 
-		# Simple context for testing
-		class TestContext:
-			pass
-
 		class MockBrowserSession:
 			async def get_current_page(self):
 				return None
@@ -402,7 +398,7 @@ class TestParamsModelArgsAndKwargs:
 		browser_session = MockBrowserSession()
 
 		# Create registry
-		registry = Registry[TestContext]()
+		registry = Registry()
 
 		# Model that doesn't include browser_session (renamed to avoid pytest collecting it)
 		class CellActionParams(ActionModel):

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -100,17 +100,17 @@ def test_beta_agent_generic_subscription_matches_browser_use():
 	class Answer(BaseModel):
 		answer: str
 
-	browser_use_alias = BrowserUseAgent[dict, Answer]
-	beta_alias = BetaAgent[dict, Answer]
-	service_alias = ServiceAgent[dict, Answer]
+	browser_use_alias = BrowserUseAgent[Answer]
+	beta_alias = BetaAgent[Answer]
+	service_alias = ServiceAgent[Answer]
 
-	assert get_args(beta_alias) == get_args(browser_use_alias) == (dict, Answer)
-	assert get_args(service_alias) == (dict, Answer)
+	assert get_args(beta_alias) == get_args(browser_use_alias) == (Answer,)
+	assert get_args(service_alias) == (Answer,)
 	assert get_origin(beta_alias) is BetaAgent
 	assert get_origin(service_alias) is BrowserUseAgent
 
-	with pytest.raises(TypeError, match='Too few arguments'):
-		BetaAgent[Answer]
+	with pytest.raises(TypeError, match='Too many arguments'):
+		BetaAgent[dict, Answer]
 
 
 def test_beta_agent_constructor_signature_matches_browser_use_order(tmp_path):
@@ -180,17 +180,14 @@ def test_beta_agent_constructor_type_hints_match_browser_use_core_params():
 	):
 		assert beta_hints[name] == browser_use_hints[name]
 
-	def assert_tools_context_hint(annotation):
+	def assert_tools_hint(annotation):
 		inner = [arg for arg in get_args(annotation) if arg is not type(None)]
 		assert len(inner) == 1
-		assert get_origin(inner[0]) is Tools
-		type_args = get_args(inner[0])
-		assert len(type_args) == 1
-		assert type_args[0].__name__ == 'Context'
+		assert inner[0] is Tools
 
 	for name in ('tools', 'controller'):
-		assert_tools_context_hint(browser_use_hints[name])
-		assert_tools_context_hint(beta_hints[name])
+		assert_tools_hint(browser_use_hints[name])
+		assert_tools_hint(beta_hints[name])
 
 	assert 'kwargs' not in beta_hints
 	assert 'return' not in beta_hints


### PR DESCRIPTION
Fixes #5188

Remove the Context generic and special-action parameter that stopped being propagated in #2831. `context` is now treated as a regular action input, while the structured-output generic remains; the beta adapter and its type-parity tests stay aligned.

Tests:
- `uv run --no-sync pytest tests/ci/infrastructure/test_registry_validation.py -q`
- `uv run --no-sync pytest tests/ci/test_beta_agent.py -q`
- `uv run --no-sync pyright browser_use/agent/service.py browser_use/tools/service.py browser_use/tools/registry/service.py browser_use/tools/registry/views.py tests/ci/infrastructure/test_registry_core.py tests/ci/infrastructure/test_registry_validation.py`
- `uv run --no-sync pre-commit run --files browser_use/agent/service.py browser_use/beta/service.py browser_use/tools/service.py browser_use/tools/registry/service.py browser_use/tools/registry/views.py tests/ci/infrastructure/test_registry_core.py tests/ci/infrastructure/test_registry_validation.py tests/ci/test_beta_agent.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the stale `Context` generic and special `context` injection across Agent, Tools, and Registry, making `context` a regular action input. Keeps the structured-output generic and updates the beta adapter and tests for single-argument agents.

- **Refactors**
  - Dropped `Context` TypeVar and special `context` parameter handling.
  - `Agent` now uses `Agent[AgentStructuredOutput]` only; `Tools` and `Registry` are non-generic.
  - Removed `context` from `SpecialActionParameters`; verified `context` works as a normal action parameter.
  - Updated beta adapter and type-parity tests to match the new single-generic `Agent`.

- **Migration**
  - Change `Agent[MyContext, MyOutput]` to `Agent[MyOutput]`.
  - Change `Tools[MyContext]()` and `Registry[MyContext]()` to `Tools()` and `Registry()`.
  - If actions need context, include a `context` field in the action params or function signature and pass it explicitly.

<sup>Written for commit 6217647b84cc615633d4b7fc8b22d1e6efa7cfab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

