### PR TITLE
fix: preserve explicit empty accessibility names in DOM identity hashing

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -850,7 +850,7 @@ class EnhancedDOMTreeNode:
 		attributes_string = ''.join(f'{k}={v}' for k, v in sorted(filtered_attrs.items()))
 
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		combined_string = f'{parent_branch_path_string}|{attributes_string}{ax_name}'
@@ -878,7 +878,7 @@ class EnhancedDOMTreeNode:
 		# Include accessibility name (ax_name) if available - this helps distinguish
 		# elements that have identical structure and attributes but different visible text
 		ax_name = ''
-		if self.ax_node and self.ax_node.name:
+		if self.ax_node and self.ax_node.name is not None:
 			ax_name = f'|ax_name={self.ax_node.name}'
 
 		# Combine all for final hash
@@ -1024,7 +1024,7 @@ class DOMInteractedElement:
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
 		# Extract accessibility name if available
 		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
+		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name is not None:
 			ax_name = enhanced_dom_tree.ax_node.name
 
 		return cls(

--- a/tests/ci/test_dom_ax_name_empty_string.py
+++ b/tests/ci/test_dom_ax_name_empty_string.py
@@ -1,0 +1,87 @@
+"""Regression coverage for empty-string accessibility names (issue #5041).
+
+An element can have an explicit empty accessible name (e.g. aria-label=""),
+which is a distinct, valid state from having no accessibility node at all.
+`if ax_node.name:` treats both states the same because "" is falsy in
+Python, silently collapsing them to None. This corrupts DOM identity hashing
+and element matching, since two elements with different (but both empty)
+accessible-name states would otherwise hash identically to elements that
+have no ax_node whatsoever.
+"""
+
+from browser_use.dom.views import (
+	DOMInteractedElement,
+	DOMRect,
+	EnhancedAXNode,
+	EnhancedDOMTreeNode,
+	EnhancedSnapshotNode,
+	NodeType,
+)
+
+
+def _node(*, ax_name: str | None, node_id: int = 1, backend_node_id: int = 1) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=node_id,
+		backend_node_id=backend_node_id,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes={},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=DOMRect(x=0, y=0, width=100, height=30),
+		target_id='target-1',
+		frame_id=None,
+		session_id='session-1',
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=[],
+		ax_node=EnhancedAXNode(
+			ax_node_id='1',
+			ignored=False,
+			role='button',
+			name=ax_name,
+			description=None,
+			properties=None,
+			child_ids=None,
+		)
+		if ax_name is not None
+		else None,
+		snapshot_node=EnhancedSnapshotNode(
+			is_clickable=None,
+			cursor_style='auto',
+			bounds=DOMRect(x=0, y=0, width=100, height=30),
+			clientRects=DOMRect(x=0, y=0, width=100, height=30),
+			scrollRects=None,
+			computed_styles={},
+			paint_order=None,
+			stacking_contexts=None,
+		),
+	)
+
+
+def test_load_from_enhanced_dom_tree_preserves_explicit_empty_ax_name():
+	node_with_empty_name = _node(ax_name='')
+	node_with_no_ax_node = _node(ax_name=None)
+
+	interacted_empty = DOMInteractedElement.load_from_enhanced_dom_tree(node_with_empty_name)
+	interacted_none = DOMInteractedElement.load_from_enhanced_dom_tree(node_with_no_ax_node)
+
+	assert interacted_empty.ax_name == '', 'explicit empty accessible name must be preserved, not collapsed to None'
+	assert interacted_none.ax_name is None
+
+
+def test_stable_hash_distinguishes_empty_ax_name_from_missing_ax_node():
+	node_with_empty_name = _node(ax_name='')
+	node_with_no_ax_node = _node(ax_name=None)
+
+	assert node_with_empty_name.compute_stable_hash() != node_with_no_ax_node.compute_stable_hash()
+
+
+def test_element_hash_distinguishes_empty_ax_name_from_missing_ax_node():
+	node_with_empty_name = _node(ax_name='')
+	node_with_no_ax_node = _node(ax_name=None)
+
+	assert hash(node_with_empty_name) != hash(node_with_no_ax_node)


### PR DESCRIPTION
## Summary
Fixes #5041.

`DOMInteractedElement.load_from_enhanced_dom_tree`, `EnhancedDOMTreeNode.__hash__`, and `EnhancedDOMTreeNode.compute_stable_hash` (`browser_use/dom/views.py`) all read the accessibility name with `if ax_node.name:`. Since `""` is falsy in Python, an element with an *explicit* empty accessible name (e.g. `aria-label=""`) was silently collapsed to `None` — the same state as an element with no `ax_node` at all. This conflates two distinct DOM states and corrupts the identity hash used for element re-matching (e.g. history rerun).

Changed all three sites to `is not None` so an explicitly empty accessible name is preserved and correctly distinguished from "no accessibility node."

## Test plan
- Added `tests/ci/test_dom_ax_name_empty_string.py`, verified it fails against the pre-fix code and passes after the fix.
- `uv run pytest -vxs tests/ci/test_dom_ax_name_empty_string.py` — 3 passed
- `uv run pytest -vxs tests/ci/test_ax_name_matching.py` — 10 passed (no regressions in existing ax_name matching coverage)
- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run pyright browser_use/dom/views.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves explicit empty accessibility names (e.g. `aria-label=""`) so they don’t get collapsed to None, fixing DOM identity hashing and element re-matching.

- **Bug Fixes**
  - Use `is not None` instead of truthiness checks for `ax_node.name` in `compute_stable_hash`, `__hash__`, and `load_from_enhanced_dom_tree`.
  - Add regression tests to ensure empty-string names are kept and produce distinct hashes from missing AX nodes.

<sup>Written for commit 52139d7ced7758bcaf30fe5e063234e22f0cadf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

