### PR TITLE
fix: prevent redact_sensitive_string from cascading into its own placeholders

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -74,10 +74,24 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 
 
 def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
-	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
-	for key, secret in sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True):
-		value = value.replace(secret, f'<secret>{key}</secret>')
-	return value
+	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks.
+
+	Matches are found in a single pass over the original string so that a secret whose value
+	happens to contain text like "secret" (which appears in the `<secret>...</secret>` placeholder)
+	can never be re-matched inside a placeholder that was just inserted for another secret.
+	"""
+	# Skip empty secret values - matching them would be meaningless and re.escape('') matches everywhere
+	items = sorted(
+		((key, secret) for key, secret in sensitive_values.items() if secret),
+		key=lambda item: len(item[1]),
+		reverse=True,
+	)
+	if not items:
+		return value
+
+	key_by_secret = {secret: key for key, secret in items}
+	pattern = re.compile('|'.join(re.escape(secret) for _, secret in items))
+	return pattern.sub(lambda match: f'<secret>{key_by_secret[match.group(0)]}</secret>', value)
 
 
 def _get_openai_bad_request_error() -> type | None:

--- a/tests/ci/test_redact_sensitive_string.py
+++ b/tests/ci/test_redact_sensitive_string.py
@@ -1,0 +1,50 @@
+"""Regression coverage for redact_sensitive_string cascade leaks (issue #5248).
+
+redact_sensitive_string used to replace secrets one at a time by scanning the
+*already partially redacted* string on every pass. Since the placeholder text
+`<secret>{key}</secret>` itself contains the literal word "secret", any later
+secret whose value contained the substring "secret" would be re-matched
+inside a placeholder that had just been inserted, corrupting it into a
+malformed / nested tag and leaking structure.
+"""
+
+from browser_use.utils import redact_sensitive_string
+
+
+def test_redact_sensitive_string_does_not_corrupt_placeholder_with_secret_substring():
+	sensitive = {
+		'api_key': 'secret-token-abc',
+		'db_pass': 'secret',
+	}
+	value = 'key=secret-token-abc pass=secret'
+
+	result = redact_sensitive_string(value, sensitive)
+
+	assert result == 'key=<secret>api_key</secret> pass=<secret>db_pass</secret>'
+	# No nested/corrupted tags left behind
+	assert '</sec<secret>' not in result
+
+
+def test_redact_sensitive_string_longest_match_wins_for_overlapping_secrets():
+	sensitive = {'short': 'ab', 'long': 'abcdef'}
+	value = 'value=abcdef'
+
+	result = redact_sensitive_string(value, sensitive)
+
+	assert result == 'value=<secret>long</secret>'
+
+
+def test_redact_sensitive_string_leaves_unmatched_text_untouched():
+	sensitive = {'api_key': 'abc123'}
+	value = 'nothing sensitive here'
+
+	assert redact_sensitive_string(value, sensitive) == value
+
+
+def test_redact_sensitive_string_ignores_empty_secret_values():
+	sensitive = {'unset': '', 'api_key': 'abc123'}
+	value = 'key=abc123'
+
+	result = redact_sensitive_string(value, sensitive)
+
+	assert result == 'key=<secret>api_key</secret>'


### PR DESCRIPTION
## Summary
Fixes #5248.

`redact_sensitive_string` (`browser_use/utils.py`) replaced secrets one at a time with sequential `str.replace()` calls, rescanning the *whole string* on every pass. Since the placeholder text `<secret>{key}</secret>` itself contains the literal word "secret", any later secret whose value contained the substring "secret" would get re-matched **inside a placeholder that was just inserted** for an earlier secret — corrupting it into a malformed/nested tag and leaking structure, e.g.:

```
key=secret-token-abc pass=secret
```
redacted with `{"api_key": "secret-token-abc", "db_pass": "secret"}` produced:
```
key=<<secret>db_pass</secret>>api_key</<secret>db_pass</secret>> pass=<secret>db_pass</secret>
```
instead of the expected:
```
key=<secret>api_key</secret> pass=<secret>db_pass</secret>
```

## Fix
Switched to a single-pass `re.sub` over the *original* string using an alternation of all secret values (longest first, so overlapping/substring secrets still resolve to the longest match — preserving the original "longest matches first" intent). Because the scan only ever runs once over the original text, an already-inserted placeholder can never be rescanned or corrupted by a later secret.

## Test plan
- Added `tests/ci/test_redact_sensitive_string.py`, including the exact repro from the issue; verified it fails against the pre-fix code (reproducing the corrupted nested-tag output) and passes after the fix.
- `uv run pytest -vxs tests/ci/test_redact_sensitive_string.py` — 4 passed
- `uv run pytest -vxs tests/ci/security/test_sensitive_data.py` — 14 passed (no regressions in existing sensitive-data redaction coverage)
- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run pyright browser_use/utils.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `redact_sensitive_string` from matching inside its own `<secret>` placeholders, fixing malformed/nested tags and ensuring correct longest-match redaction. Fixes #5248.

- **Bug Fixes**
  - Use a single-pass `re.sub` over the original string with a combined pattern of all secrets (longest first) so placeholders are never rescanned.
  - Skip empty secret values and add regression tests covering cascade corruption, overlapping secrets, and no-op cases.

<sup>Written for commit 0e3ca5f23cc1222d7bc4d795236836a3e041e2ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

