### PR TITLE
fix: add readOnlyHint annotations to read-only MCP tools

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -287,6 +287,7 @@ class BrowserUseServer:
 							}
 						},
 					},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_extract_content',
@@ -303,6 +304,7 @@ class BrowserUseServer:
 						},
 						'required': ['query'],
 					},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_get_html',
@@ -316,6 +318,7 @@ class BrowserUseServer:
 							},
 						},
 					},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_screenshot',
@@ -330,6 +333,7 @@ class BrowserUseServer:
 							},
 						},
 					},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_scroll',
@@ -353,7 +357,10 @@ class BrowserUseServer:
 				),
 				# Tab management
 				types.Tool(
-					name='browser_list_tabs', description='List all open tabs', inputSchema={'type': 'object', 'properties': {}}
+					name='browser_list_tabs',
+					description='List all open tabs',
+					inputSchema={'type': 'object', 'properties': {}},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_switch_tab',
@@ -424,6 +431,7 @@ class BrowserUseServer:
 					name='browser_list_sessions',
 					description='List all active browser sessions with their details and last activity time',
 					inputSchema={'type': 'object', 'properties': {}},
+					annotations=types.ToolAnnotations(readOnlyHint=True),
 				),
 				types.Tool(
 					name='browser_close_session',

--- a/tests/ci/test_mcp_readonly_tool_annotations.py
+++ b/tests/ci/test_mcp_readonly_tool_annotations.py
@@ -1,0 +1,65 @@
+"""Regression coverage for missing MCP tool annotations (issue #5239).
+
+`tools/list` on the native Browser Use MCP server returned no annotations at
+all, including for genuinely read-only operations like `browser_get_state`.
+Some MCP hosts (e.g. Codex CLI running non-interactively with
+`approval_policy=never`) require `readOnlyHint=true` before they'll auto-run
+a tool call instead of cancelling it, so unannotated read-only tools could
+never be used in those hosts.
+"""
+
+from mcp import types
+
+from browser_use.mcp.server import BrowserUseServer
+
+READ_ONLY_TOOLS = {
+	'browser_get_state',
+	'browser_extract_content',
+	'browser_get_html',
+	'browser_screenshot',
+	'browser_list_tabs',
+	'browser_list_sessions',
+}
+
+MUTATING_TOOLS = {
+	'browser_navigate',
+	'browser_click',
+	'browser_type',
+	'browser_scroll',
+	'browser_go_back',
+	'browser_switch_tab',
+	'browser_close_tab',
+	'retry_with_browser_use_agent',
+	'browser_close_session',
+	'browser_close_all',
+}
+
+
+async def _list_tools() -> dict[str, types.Tool]:
+	server = BrowserUseServer()
+	handler = server.server.request_handlers[types.ListToolsRequest]
+	result = await handler(types.ListToolsRequest(method='tools/list'))
+	tools = result.root.tools  # type: ignore[union-attr]
+	return {tool.name: tool for tool in tools}
+
+
+async def test_all_expected_tools_are_present():
+	tools = await _list_tools()
+	assert READ_ONLY_TOOLS | MUTATING_TOOLS <= tools.keys()
+
+
+async def test_read_only_tools_have_read_only_hint():
+	tools = await _list_tools()
+	for name in READ_ONLY_TOOLS:
+		annotations = tools[name].annotations
+		assert annotations is not None, f'{name} is read-only but has no annotations at all'
+		assert annotations.readOnlyHint is True, f'{name} is read-only but readOnlyHint is {annotations.readOnlyHint!r}'
+
+
+async def test_mutating_tools_are_not_marked_read_only():
+	tools = await _list_tools()
+	for name in MUTATING_TOOLS:
+		annotations = tools[name].annotations
+		assert annotations is None or annotations.readOnlyHint is not True, (
+			f'{name} mutates browser/session state and must not claim readOnlyHint=true'
+		)


### PR DESCRIPTION
## Summary
Fixes #5239.

`tools/list` on the native Browser Use MCP server (`browser-use --mcp`, `browser_use/mcp/server.py`) returned no MCP annotations at all — including for genuinely read-only operations like `browser_get_state`, `browser_screenshot`, `browser_list_tabs`, and `browser_list_sessions`.

Some MCP hosts key off `annotations.readOnlyHint` to decide whether a tool call can be auto-approved. The issue reports that Codex CLI, run non-interactively with `approval_policy=never`, cancelled `browser_get_state` calls with `user cancelled MCP tool call` because the tool had no `readOnlyHint=true` annotation — even though the tool never mutates browser or session state. A transparent proxy that added the annotation fixed it.

## Fix
Added `annotations=types.ToolAnnotations(readOnlyHint=True)` to the 6 tools in `handle_list_tools` that genuinely don't mutate browser/page/session state:
- `browser_get_state`
- `browser_extract_content`
- `browser_get_html`
- `browser_screenshot`
- `browser_list_tabs`
- `browser_list_sessions`

Left navigation/interaction/session-mutation tools (`browser_navigate`, `browser_click`, `browser_type`, `browser_scroll`, `browser_go_back`, `browser_switch_tab`, `browser_close_tab`, `retry_with_browser_use_agent`, `browser_close_session`, `browser_close_all`) unannotated, since they do change state.

## Test plan
- Added `tests/ci/test_mcp_readonly_tool_annotations.py`, invoking the registered `tools/list` handler directly; verified it fails against the pre-fix code (no annotations present) and passes after the fix.
- `uv run pytest -vxs tests/ci/test_mcp_readonly_tool_annotations.py` — 3 passed
- `uv run pytest -vxs tests/ci/security/test_mcp_allowed_domains.py tests/ci/test_mcp_readonly_tool_annotations.py` — 6 passed (no regressions in existing MCP server coverage)
- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run pyright browser_use/mcp/server.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark read-only MCP tools with `annotations.readOnlyHint=true` so hosts can auto-approve them. Fixes #5239 and restores non-interactive runs (e.g., Codex CLI with `approval_policy=never`).

- **Bug Fixes**
  - Added `readOnlyHint=True` to these tools in `handle_list_tools` (`browser_use/mcp/server.py`): `browser_get_state`, `browser_extract_content`, `browser_get_html`, `browser_screenshot`, `browser_list_tabs`, `browser_list_sessions`. Left mutating tools unannotated.
  - Added `tests/ci/test_mcp_readonly_tool_annotations.py` to assert read-only tools expose `readOnlyHint` via `tools/list` and mutating tools do not.

<sup>Written for commit 8514239d3e3d559f0e2fe4b10d735e50d113e1a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

