### PR TITLE
fix: report MCP tool execution exceptions with isError=true

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -457,7 +457,9 @@ class BrowserUseServer:
 			return []
 
 		@self.server.call_tool()
-		async def handle_call_tool(name: str, arguments: dict[str, Any] | None) -> list[types.TextContent | types.ImageContent]:
+		async def handle_call_tool(
+			name: str, arguments: dict[str, Any] | None
+		) -> list[types.TextContent | types.ImageContent] | types.CallToolResult:
 			"""Handle tool execution."""
 			start_time = time.time()
 			error_msg = None
@@ -469,7 +471,12 @@ class BrowserUseServer:
 			except Exception as e:
 				error_msg = str(e)
 				logger.error(f'Tool execution failed: {e}', exc_info=True)
-				return [types.TextContent(type='text', text=f'Error: {str(e)}')]
+				# Return isError=True so MCP hosts can distinguish a failed tool execution
+				# from a successful one that merely returned text describing an error.
+				return types.CallToolResult(
+					content=[types.TextContent(type='text', text=f'Error: {str(e)}')],
+					isError=True,
+				)
 			finally:
 				# Capture telemetry for tool calls
 				duration = time.time() - start_time

--- a/tests/ci/test_mcp_tool_exception_iserror.py
+++ b/tests/ci/test_mcp_tool_exception_iserror.py
@@ -1,0 +1,54 @@
+"""Regression coverage for MCP tool exceptions reported as isError=false (issue #5252).
+
+`handle_call_tool` caught exceptions from `_execute_tool` and returned a plain
+`list[TextContent]` describing the error. The low-level MCP SDK wraps a
+returned content list into `CallToolResult(..., isError=False)` unconditionally,
+so callers (and MCP hosts like Codex, which key off `isError` to classify a
+tool call as failed) saw exceptions -- including CDP connection failures -- as
+successful tool calls with error text embedded in the content.
+"""
+
+from mcp import types
+
+from browser_use.mcp.server import BrowserUseServer
+
+
+async def _call_tool(server: BrowserUseServer, name: str, arguments: dict) -> types.CallToolResult:
+	handler = server.server.request_handlers[types.CallToolRequest]
+	request = types.CallToolRequest(
+		method='tools/call',
+		params=types.CallToolRequestParams(name=name, arguments=arguments),
+	)
+	result = await handler(request)
+	assert isinstance(result.root, types.CallToolResult)
+	return result.root
+
+
+async def test_tool_execution_exception_sets_iserror_true():
+	server = BrowserUseServer()
+
+	async def boom(name: str, arguments: dict) -> str:
+		raise RuntimeError('Failed to establish CDP connection to browser: no close frame received or sent')
+
+	server._execute_tool = boom  # type: ignore[method-assign]
+
+	result = await _call_tool(server, 'browser_type', {'index': 999999, 'text': 'x'})
+
+	assert result.isError is True
+	assert len(result.content) == 1
+	assert isinstance(result.content[0], types.TextContent)
+	assert 'Failed to establish CDP connection' in result.content[0].text
+
+
+async def test_successful_tool_execution_keeps_iserror_false():
+	server = BrowserUseServer()
+
+	async def ok(name: str, arguments: dict) -> str:
+		return 'done'
+
+	server._execute_tool = ok  # type: ignore[method-assign]
+
+	result = await _call_tool(server, 'browser_get_state', {})
+
+	assert result.isError is False
+	assert result.content[0].text == 'done'  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary
Partially addresses #5252 — the caught-exception path only (see Scope below).

`handle_call_tool` (`browser_use/mcp/server.py`) caught exceptions raised while executing a tool — e.g. CDP connection failures — and returned a plain `list[TextContent]` describing the error. The low-level MCP SDK unconditionally wraps any returned content list into `CallToolResult(..., isError=False)`, so callers saw these failures as **successful** tool calls with the error text embedded in the content, e.g.:

```json
{"content": [{"type": "text", "text": "Error: Failed to establish CDP connection..."}], "isError": false}
```

The MCP spec expects tool execution failures to be reported via `CallToolResult(isError=True)` so conforming hosts (e.g. Codex, per the issue) can correctly classify and surface them as failed tool calls rather than completed ones.

## Fix
The except block in `handle_call_tool` now returns an explicit `types.CallToolResult(content=[...], isError=True)`. The low-level SDK's `call_tool` decorator already special-cases a returned `CallToolResult` and passes it through unchanged (confirmed by reading `mcp.server.lowlevel.server.Server.call_tool`), so this is enough to flip the signal without touching the SDK.

## Scope
The issue also flags "semantic action failures" — action handlers that return a **string** describing a failure (e.g. `Element with index N not found`) which then get wrapped as ordinary successful content. That's a broader, fuzzier change (it would mean inspecting return strings across every action handler to distinguish failure text from legitimate content), so this PR intentionally covers only the unambiguous part: exceptions caught by `handle_call_tool` itself. Left the issue open rather than using a closing keyword, since the semantic-failure part is still unresolved.

## Test plan
- Added `tests/ci/test_mcp_tool_exception_iserror.py`, reproducing the exact failure mode from the issue (a CDP connection error raised from `_execute_tool`); verified it fails against the pre-fix code (`isError=False`) and passes after the fix (`isError=True`), plus a control case confirming successful calls still report `isError=False`.
- `uv run pytest -vxs tests/ci/test_mcp_tool_exception_iserror.py` — 2 passed
- `uv run pytest -vxs tests/ci/security/test_mcp_allowed_domains.py tests/ci/test_mcp_tool_exception_iserror.py` — 5 passed (no regressions in existing MCP server coverage)
- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run pyright browser_use/mcp/server.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report MCP tool execution exceptions with `isError=true` so hosts correctly mark failed tool calls instead of treating them as successful with error text. Covers the caught-exception path in `handle_call_tool` (part of #5252).

- **Bug Fixes**
  - In `browser_use/mcp/server.py`, `handle_call_tool` now returns `types.CallToolResult(..., isError=True)` on exceptions, preserving the failure signal expected by MCP hosts.
  - Added `tests/ci/test_mcp_tool_exception_iserror.py` to verify exception cases set `isError=true` and successful calls keep `isError=false`.

<sup>Written for commit fe7945a8ece69df138c06ec323906cf12b2a1190. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

