### PR TITLE
fix(agent): skip local paths during start URL detection

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -78,6 +78,7 @@ from browser_use.utils import (
 	check_latest_browser_use_version,
 	get_browser_use_version,
 	is_placeholder_url,
+	is_url_candidate_from_local_path,
 	sanitize_url_candidate,
 	time_execution_async,
 	time_execution_sync,
@@ -2376,7 +2377,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		found_urls = []
 		matched_spans: list[tuple[int, int]] = []
-		for pattern in patterns:
+		for pattern_index, pattern in enumerate(patterns):
 			matches = re.finditer(pattern, task_without_emails)
 			for match in matches:
 				url = match.group(0)
@@ -2386,6 +2387,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				if any(match.start() < end and match.end() > start for start, end in matched_spans):
 					continue
 				matched_spans.append((match.start(), match.end()))
+				if pattern_index == 1 and is_url_candidate_from_local_path(task_without_emails, match.start()):
+					continue
 
 				# Remove trailing punctuation that's not part of URLs
 				url = sanitize_url_candidate(url)

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -79,6 +79,7 @@ from browser_use.utils import (
 	get_browser_use_version,
 	has_url_negation,
 	is_placeholder_url,
+	is_url_candidate_from_local_path,
 	sanitize_url_candidate,
 	time_execution_async,
 	time_execution_sync,
@@ -2375,7 +2376,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		found_urls = []
 		matched_spans: list[tuple[int, int]] = []
-		for pattern in patterns:
+		for pattern_index, pattern in enumerate(patterns):
 			matches = re.finditer(pattern, task_without_emails)
 			for match in matches:
 				url = match.group(0)
@@ -2385,6 +2386,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				if any(match.start() < end and match.end() > start for start, end in matched_spans):
 					continue
 				matched_spans.append((match.start(), match.end()))
+				if pattern_index == 1 and is_url_candidate_from_local_path(task_without_emails, match.start()):
+					continue
 
 				# Remove trailing punctuation that's not part of URLs
 				url = sanitize_url_candidate(url)

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -77,6 +77,7 @@ from browser_use.utils import (
 	get_browser_use_version,
 	get_git_info,
 	is_placeholder_url,
+	is_url_candidate_from_local_path,
 	sanitize_url_candidate,
 )
 
@@ -1464,12 +1465,14 @@ def _extract_start_url(task: str) -> str | None:
 
 	found_urls = []
 	matched_spans: list[tuple[int, int]] = []
-	for pattern in patterns:
+	for pattern_index, pattern in enumerate(patterns):
 		for match in re.finditer(pattern, task_without_emails):
 			# Skip fragments of URLs already matched by an earlier pattern
 			if any(match.start() < end and match.end() > start for start, end in matched_spans):
 				continue
 			matched_spans.append((match.start(), match.end()))
+			if pattern_index == 1 and is_url_candidate_from_local_path(task_without_emails, match.start()):
+				continue
 			url = sanitize_url_candidate(match.group(0))
 			url_lower = url.lower()
 			has_scheme = url_lower.startswith(('http://', 'https://', 'file://'))

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -78,6 +78,7 @@ from browser_use.utils import (
 	get_git_info,
 	has_url_negation,
 	is_placeholder_url,
+	is_url_candidate_from_local_path,
 	sanitize_url_candidate,
 )
 
@@ -1463,12 +1464,14 @@ def _extract_start_url(task: str) -> str | None:
 	}
 	found_urls = []
 	matched_spans: list[tuple[int, int]] = []
-	for pattern in patterns:
+	for pattern_index, pattern in enumerate(patterns):
 		for match in re.finditer(pattern, task_without_emails):
 			# Skip fragments of URLs already matched by an earlier pattern
 			if any(match.start() < end and match.end() > start for start, end in matched_spans):
 				continue
 			matched_spans.append((match.start(), match.end()))
+			if pattern_index == 1 and is_url_candidate_from_local_path(task_without_emails, match.start()):
+				continue
 			url = sanitize_url_candidate(match.group(0))
 			url_lower = url.lower()
 			has_scheme = url_lower.startswith(('http://', 'https://', 'file://'))

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -52,9 +52,12 @@ def sanitize_url_candidate(url: str) -> str:
 def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
 	"""Return whether a bare-domain match is embedded in a local path token."""
 	prefix = task[:candidate_start]
-	token_start = max(prefix.rfind(separator) for separator in (' ', '\t', '\r', '\n')) + 1
-	path_prefix = prefix[token_start:].lstrip('`\'"(<[{')
+	path_prefix = (re.search(r'\S*$', prefix).group(0) if prefix else '').lstrip('`\'"(<[{')
 	if '/' in path_prefix or '\\' in path_prefix:
+		return True
+	if re.fullmatch(r'[A-Za-z]:[^/\\]*', path_prefix):
+		return True
+	if candidate_start > 0 and task[candidate_start - 1] == '_':
 		return True
 
 	# Quoted or bracketed paths can contain whitespace, so the current token may

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -69,7 +69,10 @@ def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
 		opener_index = prefix.rfind(opener)
 		if opener_index < 0 or task.find(closer, candidate_start) < 0:
 			continue
-		if opener != closer and opener_index < prefix.rfind(closer):
+		if opener == closer:
+			if prefix.count(opener) % 2 == 0:
+				continue
+		elif opener_index < prefix.rfind(closer):
 			continue
 		delimited_prefix = prefix[opener_index + 1 :]
 		if '/' in delimited_prefix or '\\' in delimited_prefix:

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -52,7 +52,10 @@ def sanitize_url_candidate(url: str) -> str:
 def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
 	"""Return whether a bare-domain match is embedded in a local path token."""
 	prefix = task[:candidate_start]
-	path_prefix = (re.search(r'\S*$', prefix).group(0) if prefix else '').lstrip('`\'"(<[{')
+	token_start = len(prefix)
+	while token_start > 0 and not prefix[token_start - 1].isspace():
+		token_start -= 1
+	path_prefix = prefix[token_start:].lstrip('`\'"(<[{')
 	if '/' in path_prefix or '\\' in path_prefix:
 		return True
 	if re.fullmatch(r'[A-Za-z]:[^/\\]*', path_prefix):

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -49,6 +49,14 @@ def sanitize_url_candidate(url: str) -> str:
 	return re.sub(r'[.,;:!?()\[\]]+$', '', candidate)
 
 
+def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
+	"""Return whether a bare-domain match is embedded in a local path token."""
+	prefix = task[:candidate_start]
+	token_start = max(prefix.rfind(separator) for separator in (' ', '\t', '\r', '\n')) + 1
+	path_prefix = prefix[token_start:].lstrip('`\'"(<[{')
+	return '/' in path_prefix or '\\' in path_prefix
+
+
 # Lazy import for error types
 # Use sentinel to avoid retrying import when package is not installed
 _IMPORT_NOT_FOUND: type = type('_ImportNotFound', (), {})

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -54,7 +54,22 @@ def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
 	prefix = task[:candidate_start]
 	token_start = max(prefix.rfind(separator) for separator in (' ', '\t', '\r', '\n')) + 1
 	path_prefix = prefix[token_start:].lstrip('`\'"(<[{')
-	return '/' in path_prefix or '\\' in path_prefix
+	if '/' in path_prefix or '\\' in path_prefix:
+		return True
+
+	# Quoted or bracketed paths can contain whitespace, so the current token may
+	# only contain the filename suffix (for example, "/tmp/customer file.com").
+	for opener, closer in (('"', '"'), ("'", "'"), ('`', '`'), ('(', ')'), ('[', ']'), ('{', '}')):
+		opener_index = prefix.rfind(opener)
+		if opener_index < 0 or task.find(closer, candidate_start) < 0:
+			continue
+		if opener != closer and opener_index < prefix.rfind(closer):
+			continue
+		delimited_prefix = prefix[opener_index + 1 :]
+		if '/' in delimited_prefix or '\\' in delimited_prefix:
+			return True
+
+	return False
 
 
 # Lazy import for error types

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -84,7 +84,10 @@ def has_url_negation(context: str) -> bool:
 def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
 	"""Return whether a bare-domain match is embedded in a local path token."""
 	prefix = task[:candidate_start]
-	path_prefix = (re.search(r'\S*$', prefix).group(0) if prefix else '').lstrip('`\'"(<[{')
+	token_start = len(prefix)
+	while token_start > 0 and not prefix[token_start - 1].isspace():
+		token_start -= 1
+	path_prefix = prefix[token_start:].lstrip('`\'"(<[{')
 	if '/' in path_prefix or '\\' in path_prefix:
 		return True
 	if re.fullmatch(r'[A-Za-z]:[^/\\]*', path_prefix):

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -86,7 +86,22 @@ def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
 	prefix = task[:candidate_start]
 	token_start = max(prefix.rfind(separator) for separator in (' ', '\t', '\r', '\n')) + 1
 	path_prefix = prefix[token_start:].lstrip('`\'"(<[{')
-	return '/' in path_prefix or '\\' in path_prefix
+	if '/' in path_prefix or '\\' in path_prefix:
+		return True
+
+	# Quoted or bracketed paths can contain whitespace, so the current token may
+	# only contain the filename suffix (for example, "/tmp/customer file.com").
+	for opener, closer in (('"', '"'), ("'", "'"), ('`', '`'), ('(', ')'), ('[', ']'), ('{', '}')):
+		opener_index = prefix.rfind(opener)
+		if opener_index < 0 or task.find(closer, candidate_start) < 0:
+			continue
+		if opener != closer and opener_index < prefix.rfind(closer):
+			continue
+		delimited_prefix = prefix[opener_index + 1 :]
+		if '/' in delimited_prefix or '\\' in delimited_prefix:
+			return True
+
+	return False
 
 
 # Lazy import for error types

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -101,7 +101,10 @@ def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
 		opener_index = prefix.rfind(opener)
 		if opener_index < 0 or task.find(closer, candidate_start) < 0:
 			continue
-		if opener != closer and opener_index < prefix.rfind(closer):
+		if opener == closer:
+			if prefix.count(opener) % 2 == 0:
+				continue
+		elif opener_index < prefix.rfind(closer):
 			continue
 		delimited_prefix = prefix[opener_index + 1 :]
 		if '/' in delimited_prefix or '\\' in delimited_prefix:

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -81,6 +81,14 @@ def has_url_negation(context: str) -> bool:
 	return URL_NEGATION_PATTERN.search(context) is not None
 
 
+def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
+	"""Return whether a bare-domain match is embedded in a local path token."""
+	prefix = task[:candidate_start]
+	token_start = max(prefix.rfind(separator) for separator in (' ', '\t', '\r', '\n')) + 1
+	path_prefix = prefix[token_start:].lstrip('`\'"(<[{')
+	return '/' in path_prefix or '\\' in path_prefix
+
+
 # Lazy import for error types
 # Use sentinel to avoid retrying import when package is not installed
 _IMPORT_NOT_FOUND: type = type('_ImportNotFound', (), {})

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -98,11 +98,16 @@ def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
 	# Quoted or bracketed paths can contain whitespace, so the current token may
 	# only contain the filename suffix (for example, "/tmp/customer file.com").
 	for opener, closer in (('"', '"'), ("'", "'"), ('`', '`'), ('(', ')'), ('[', ']'), ('{', '}')):
-		opener_index = prefix.rfind(opener)
+		opener_indices = [index for index, char in enumerate(prefix) if char == opener]
+		if opener == closer:
+			opener_indices = [
+				index for index in opener_indices if (len(prefix[:index]) - len(prefix[:index].rstrip('\\'))) % 2 == 0
+			]
+		opener_index = opener_indices[-1] if opener_indices else -1
 		if opener_index < 0 or task.find(closer, candidate_start) < 0:
 			continue
 		if opener == closer:
-			if prefix.count(opener) % 2 == 0:
+			if len(opener_indices) % 2 == 0:
 				continue
 		elif opener_index < prefix.rfind(closer):
 			continue

--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -84,9 +84,12 @@ def has_url_negation(context: str) -> bool:
 def is_url_candidate_from_local_path(task: str, candidate_start: int) -> bool:
 	"""Return whether a bare-domain match is embedded in a local path token."""
 	prefix = task[:candidate_start]
-	token_start = max(prefix.rfind(separator) for separator in (' ', '\t', '\r', '\n')) + 1
-	path_prefix = prefix[token_start:].lstrip('`\'"(<[{')
+	path_prefix = (re.search(r'\S*$', prefix).group(0) if prefix else '').lstrip('`\'"(<[{')
 	if '/' in path_prefix or '\\' in path_prefix:
+		return True
+	if re.fullmatch(r'[A-Za-z]:[^/\\]*', path_prefix):
+		return True
+	if candidate_start > 0 and task[candidate_start - 1] == '_':
 		return True
 
 	# Quoted or bracketed paths can contain whitespace, so the current token may

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -4306,12 +4306,19 @@ def test_beta_agent_exposes_task_helper_methods():
 		'[/app/example.com]',
 		'`../uploads/example.ai`',
 		r'C:\uploads\example.org',
+		'customer_example.com',
+		r'C:customer_example.com',
 		'"/tmp/customer file.example.com"',
 		"'/tmp/customer/example file.com'",
 		r'"C:\Users\me\customer file.org"',
 	):
 		assert agent._extract_start_url(f'Upload {local_path}.') is None
 		assert browser_use_agent._extract_start_url(f'Upload {local_path}.') is None
+	for separator in ('\f', '\v', '\u2003'):
+		assert agent._extract_start_url(f'Inspect /tmp/a.com{separator}then open example.org.') == 'https://example.org'
+		assert (
+			browser_use_agent._extract_start_url(f'Inspect /tmp/a.com{separator}then open example.org.') == 'https://example.org'
+		)
 	numbered_task = '1. Navigate to https://elibrary.ferc.gov/eLibrary/search.\\n2. Ensure "General Search" is selected.'
 	assert agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'
 	assert browser_use_agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -4301,6 +4301,14 @@ def test_beta_agent_exposes_task_helper_methods():
 	assert agent._extract_start_url('Open https://example.com/report.pdf and summarize it.') is None
 	assert agent._extract_start_url('Use https://XXX.XX as a placeholder in the table.') is None
 	assert browser_use_agent._extract_start_url('Use https://XXX.XX as a placeholder in the table.') is None
+	for local_path in (
+		'/app/customer_example.com',
+		'[/app/example.com]',
+		'`../uploads/example.ai`',
+		r'C:\uploads\example.org',
+	):
+		assert agent._extract_start_url(f'Upload {local_path}.') is None
+		assert browser_use_agent._extract_start_url(f'Upload {local_path}.') is None
 	numbered_task = '1. Navigate to https://elibrary.ferc.gov/eLibrary/search.\\n2. Ensure "General Search" is selected.'
 	assert agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'
 	assert browser_use_agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -4323,6 +4323,9 @@ def test_beta_agent_exposes_task_helper_methods():
 		assert (
 			browser_use_agent._extract_start_url(f'Inspect /tmp/a.com{separator}then open example.org.') == 'https://example.org'
 		)
+	quoted_then_url = 'Inspect "local/path" and compare A/B, then open example.com "in a new tab".'
+	assert agent._extract_start_url(quoted_then_url) == 'https://example.com'
+	assert browser_use_agent._extract_start_url(quoted_then_url) == 'https://example.com'
 	numbered_task = '1. Navigate to https://elibrary.ferc.gov/eLibrary/search.\\n2. Ensure "General Search" is selected.'
 	assert agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'
 	assert browser_use_agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -4310,12 +4310,19 @@ def test_beta_agent_exposes_task_helper_methods():
 		'[/app/example.com]',
 		'`../uploads/example.ai`',
 		r'C:\uploads\example.org',
+		'customer_example.com',
+		r'C:customer_example.com',
 		'"/tmp/customer file.example.com"',
 		"'/tmp/customer/example file.com'",
 		r'"C:\Users\me\customer file.org"',
 	):
 		assert agent._extract_start_url(f'Upload {local_path}.') is None
 		assert browser_use_agent._extract_start_url(f'Upload {local_path}.') is None
+	for separator in ('\f', '\v', '\u2003'):
+		assert agent._extract_start_url(f'Inspect /tmp/a.com{separator}then open example.org.') == 'https://example.org'
+		assert (
+			browser_use_agent._extract_start_url(f'Inspect /tmp/a.com{separator}then open example.org.') == 'https://example.org'
+		)
 	numbered_task = '1. Navigate to https://elibrary.ferc.gov/eLibrary/search.\\n2. Ensure "General Search" is selected.'
 	assert agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'
 	assert browser_use_agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -4313,6 +4313,8 @@ def test_beta_agent_exposes_task_helper_methods():
 		'customer_example.com',
 		r'C:customer_example.com',
 		'"/tmp/customer file.example.com"',
+		'"/tmp/customer \\"quoted file.example.com"',
+		'"/tmp/customer \\\\\\"quoted file.example.com"',
 		"'/tmp/customer/example file.com'",
 		r'"C:\Users\me\customer file.org"',
 	):
@@ -4326,6 +4328,9 @@ def test_beta_agent_exposes_task_helper_methods():
 	quoted_then_url = 'Inspect "local/path" and compare A/B, then open example.com "in a new tab".'
 	assert agent._extract_start_url(quoted_then_url) == 'https://example.com'
 	assert browser_use_agent._extract_start_url(quoted_then_url) == 'https://example.com'
+	even_backslashes_close_quote = 'Inspect "/tmp/customer \\\\" then open example.com.'
+	assert agent._extract_start_url(even_backslashes_close_quote) == 'https://example.com'
+	assert browser_use_agent._extract_start_url(even_backslashes_close_quote) == 'https://example.com'
 	numbered_task = '1. Navigate to https://elibrary.ferc.gov/eLibrary/search.\\n2. Ensure "General Search" is selected.'
 	assert agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'
 	assert browser_use_agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -4305,6 +4305,14 @@ def test_beta_agent_exposes_task_helper_methods():
 	assert agent._extract_start_url('Open https://example.com/report.pdf and summarize it.') is None
 	assert agent._extract_start_url('Use https://XXX.XX as a placeholder in the table.') is None
 	assert browser_use_agent._extract_start_url('Use https://XXX.XX as a placeholder in the table.') is None
+	for local_path in (
+		'/app/customer_example.com',
+		'[/app/example.com]',
+		'`../uploads/example.ai`',
+		r'C:\uploads\example.org',
+	):
+		assert agent._extract_start_url(f'Upload {local_path}.') is None
+		assert browser_use_agent._extract_start_url(f'Upload {local_path}.') is None
 	numbered_task = '1. Navigate to https://elibrary.ferc.gov/eLibrary/search.\\n2. Ensure "General Search" is selected.'
 	assert agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'
 	assert browser_use_agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -4319,6 +4319,9 @@ def test_beta_agent_exposes_task_helper_methods():
 		assert (
 			browser_use_agent._extract_start_url(f'Inspect /tmp/a.com{separator}then open example.org.') == 'https://example.org'
 		)
+	quoted_then_url = 'Inspect "local/path" and compare A/B, then open example.com "in a new tab".'
+	assert agent._extract_start_url(quoted_then_url) == 'https://example.com'
+	assert browser_use_agent._extract_start_url(quoted_then_url) == 'https://example.com'
 	numbered_task = '1. Navigate to https://elibrary.ferc.gov/eLibrary/search.\\n2. Ensure "General Search" is selected.'
 	assert agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'
 	assert browser_use_agent._extract_start_url(numbered_task) == 'https://elibrary.ferc.gov/eLibrary/search'

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -4310,6 +4310,9 @@ def test_beta_agent_exposes_task_helper_methods():
 		'[/app/example.com]',
 		'`../uploads/example.ai`',
 		r'C:\uploads\example.org',
+		'"/tmp/customer file.example.com"',
+		"'/tmp/customer/example file.com'",
+		r'"C:\Users\me\customer file.org"',
 	):
 		assert agent._extract_start_url(f'Upload {local_path}.') is None
 		assert browser_use_agent._extract_start_url(f'Upload {local_path}.') is None

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -4306,6 +4306,9 @@ def test_beta_agent_exposes_task_helper_methods():
 		'[/app/example.com]',
 		'`../uploads/example.ai`',
 		r'C:\uploads\example.org',
+		'"/tmp/customer file.example.com"',
+		"'/tmp/customer/example file.com'",
+		r'"C:\Users\me\customer file.org"',
 	):
 		assert agent._extract_start_url(f'Upload {local_path}.') is None
 		assert browser_use_agent._extract_start_url(f'Upload {local_path}.') is None


### PR DESCRIPTION
## Problem

With `directly_open_url=True`, the agent scans task text and injects an initial navigation before the model acts. The bare-domain regex can match a domain-like filename inside a local path, so tasks such as `Upload /app/customer_example.com` force-navigate to `https://example.com`. This is the same root cause reported for HTML uploads in #4794; current main now excludes bare `.html` candidates, but `.com`, `.ai`, `.org`, and other domain-like local filenames still reproduce in both the classic and beta agents.

## Fix

Before accepting a bare-domain match, check the current whitespace-delimited token for the local path prefix before the match. A preceding `/` or `\` means the candidate came from a POSIX, relative, or Windows path and is skipped. The guard is shared by the classic and beta implementations and applies only to the bare-domain pattern, so explicit `http://`, `https://`, and `file://` URLs retain their existing behavior.

This is a focused current-main alternative to #4983: it does not modify the unrelated downloadable-extension policy or removed Rust-agent files.

## Validation

- Added classic + beta regression coverage for absolute, relative, quoted/bracketed, and Windows local paths.
- `tests/ci/test_beta_agent.py`: 202 passed.
- Full pre-commit suite, including Ruff and Pyright: passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips bare-domain matches that come from local file paths during start URL detection, so tasks like "Upload /app/example.com" no longer auto-navigate to the wrong domain. Prevents this for Windows drive prefixes, underscored filenames, and quoted/bracketed paths with spaces, including escaped quotes, while avoiding full-text regex scans.

- **Bug Fixes**
  - Added `is_url_candidate_from_local_path`, a token-based guard that detects path prefixes (`/`, `\`, `C:`) and underscores before the match, and pairs quotes/brackets to handle delimited paths with spaces, including escaped quotes.
  - Applied the guard only to the bare-domain pattern in classic and beta `_extract_start_url`; `http://`, `https://`, and `file://` URLs are unchanged. Expanded tests cover POSIX/Windows/relative paths, escaped quotes, uncommon whitespace separators, and preserving detection of later real domains.

<sup>Written for commit e2259adebd5015096f63ebe5f90039b9aa8785a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

