### PR TITLE
fix(llm): consolidate Anthropic cache_control into TTL-aware helper

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -13,7 +13,7 @@ from anthropic import (
 	RateLimitError,
 	omit,
 )
-from anthropic.types import CacheControlEphemeralParam, Message, ToolParam
+from anthropic.types import Message, ToolParam
 from anthropic.types.model_param import ModelParam
 from anthropic.types.text_block import TextBlock
 from anthropic.types.tool_choice_tool_param import ToolChoiceToolParam
@@ -429,7 +429,7 @@ class ChatAnthropic(BaseChatModel):
 					name=tool_name,
 					description=f'Extract information in the format of {tool_name}',
 					input_schema=schema,
-					cache_control=CacheControlEphemeralParam(type='ephemeral'),
+					cache_control=AnthropicMessageSerializer._serialize_cache_control(True),
 				)
 
 				if self._requires_auto_tool_choice():

--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -1,5 +1,5 @@
 import json
-from typing import overload
+from typing import Literal, overload
 
 from anthropic.types import (
 	Base64ImageSourceParam,
@@ -61,10 +61,17 @@ class AnthropicMessageSerializer:
 		return media_type, data  # type: ignore
 
 	@staticmethod
-	def _serialize_cache_control(use_cache: bool) -> CacheControlEphemeralParam | None:
-		"""Serialize cache control."""
+	def _serialize_cache_control(use_cache: bool, ttl: Literal['5m', '1h'] | None = None) -> CacheControlEphemeralParam | None:
+		"""Serialize cache control.
+
+		Anthropic applies a 5-minute TTL when none is specified, which is the default.
+		Pass ``ttl='1h'`` to opt into the cheaper 1-hour cache, useful when inter-request
+		gaps exceed five minutes.
+		"""
 		if use_cache:
-			return CacheControlEphemeralParam(type='ephemeral')
+			if ttl is None:
+				return CacheControlEphemeralParam(type='ephemeral')
+			return CacheControlEphemeralParam(type='ephemeral', ttl=ttl)
 		return None
 
 	@staticmethod
@@ -125,7 +132,13 @@ class AnthropicMessageSerializer:
 		"""Serialize content to Anthropic format."""
 		if isinstance(content, str):
 			if use_cache:
-				return [TextBlockParam(text=content, type='text', cache_control=CacheControlEphemeralParam(type='ephemeral'))]
+				return [
+					TextBlockParam(
+						text=content,
+						type='text',
+						cache_control=AnthropicMessageSerializer._serialize_cache_control(True),
+					)
+				]
 			else:
 				return content
 

--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -1,5 +1,5 @@
 import json
-from typing import overload
+from typing import Literal, overload
 
 from anthropic.types import (
 	Base64ImageSourceParam,
@@ -51,10 +51,17 @@ class AnthropicMessageSerializer:
 		return media_type, data  # type: ignore
 
 	@staticmethod
-	def _serialize_cache_control(use_cache: bool) -> CacheControlEphemeralParam | None:
-		"""Serialize cache control."""
+	def _serialize_cache_control(use_cache: bool, ttl: Literal['5m', '1h'] | None = None) -> CacheControlEphemeralParam | None:
+		"""Serialize cache control.
+
+		Anthropic applies a 5-minute TTL when none is specified, which is the default.
+		Pass ``ttl='1h'`` to opt into the cheaper 1-hour cache, useful when inter-request
+		gaps exceed five minutes.
+		"""
 		if use_cache:
-			return CacheControlEphemeralParam(type='ephemeral')
+			if ttl is None:
+				return CacheControlEphemeralParam(type='ephemeral')
+			return CacheControlEphemeralParam(type='ephemeral', ttl=ttl)
 		return None
 
 	@staticmethod
@@ -115,7 +122,13 @@ class AnthropicMessageSerializer:
 		"""Serialize content to Anthropic format."""
 		if isinstance(content, str):
 			if use_cache:
-				return [TextBlockParam(text=content, type='text', cache_control=CacheControlEphemeralParam(type='ephemeral'))]
+				return [
+					TextBlockParam(
+						text=content,
+						type='text',
+						cache_control=AnthropicMessageSerializer._serialize_cache_control(True),
+					)
+				]
 			else:
 				return content
 

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -10,7 +10,7 @@ from anthropic import (
 	RateLimitError,
 	omit,
 )
-from anthropic.types import CacheControlEphemeralParam, Message, ToolParam
+from anthropic.types import Message, ToolParam
 from anthropic.types.text_block import TextBlock
 from anthropic.types.tool_choice_tool_param import ToolChoiceToolParam
 from pydantic import BaseModel
@@ -213,7 +213,7 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 					name=tool_name,
 					description=f'Extract information in the format of {tool_name}',
 					input_schema=schema,
-					cache_control=CacheControlEphemeralParam(type='ephemeral'),
+					cache_control=AnthropicMessageSerializer._serialize_cache_control(True),
 				)
 
 				# Force the model to use this tool

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -10,7 +10,7 @@ from anthropic import (
 	RateLimitError,
 	omit,
 )
-from anthropic.types import CacheControlEphemeralParam, Message, ToolParam
+from anthropic.types import Message, ToolParam
 from anthropic.types.text_block import TextBlock
 from anthropic.types.tool_choice_tool_param import ToolChoiceToolParam
 from pydantic import BaseModel
@@ -214,7 +214,7 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 					name=tool_name,
 					description=f'Extract information in the format of {tool_name}',
 					input_schema=schema,
-					cache_control=CacheControlEphemeralParam(type='ephemeral'),
+					cache_control=AnthropicMessageSerializer._serialize_cache_control(True),
 				)
 
 				# Force the model to use this tool

--- a/browser_use/llm/tests/test_anthropic_cache.py
+++ b/browser_use/llm/tests/test_anthropic_cache.py
@@ -263,6 +263,17 @@ class TestAnthropicCache:
 		for msg in cleaned_messages:
 			assert not msg.cache
 
+	def test_cache_control_ttl(self):
+		"""Test that _serialize_cache_control emits the requested TTL."""
+		# Default: no ttl field, so Anthropic applies the 5-minute TTL
+		assert AnthropicMessageSerializer._serialize_cache_control(True) == {'type': 'ephemeral'}
+		# Explicit 5-minute and 1-hour TTLs
+		assert AnthropicMessageSerializer._serialize_cache_control(True, ttl='5m') == {'type': 'ephemeral', 'ttl': '5m'}
+		assert AnthropicMessageSerializer._serialize_cache_control(True, ttl='1h') == {'type': 'ephemeral', 'ttl': '1h'}
+		# Caching disabled never emits cache_control
+		assert AnthropicMessageSerializer._serialize_cache_control(False) is None
+		assert AnthropicMessageSerializer._serialize_cache_control(False, ttl='1h') is None
+
 	def test_max_4_cache_blocks(self):
 		"""Test that the max number of cache blocks is 4."""
 		agent = Agent(task='Hello, world!', llm=ChatAnthropic(''))


### PR DESCRIPTION
Closes #5321

## What

Consolidates every `CacheControlEphemeralParam` construction site in the Anthropic provider behind the serializer's `_serialize_cache_control` helper, and makes that helper TTL-aware:

- `browser_use/llm/anthropic/serializer.py` — `_serialize_cache_control(use_cache, ttl=None)` now accepts `ttl: Literal['5m', '1h']`. With no `ttl` it emits exactly what it always did (`{"type": "ephemeral"}` → Anthropic's 5-minute cache), so the default path is byte-for-byte unchanged.
- `serializer.py` string-content path and both providers' structured-output `ToolParam` paths (`anthropic/chat.py`, `aws/chat_anthropic.py`) previously constructed `CacheControlEphemeralParam(type='ephemeral')` directly, bypassing the helper. All three now route through it — the "three places that construct it" from the issue are now one.

## Why this shape

The issue offered two options: consolidate through a single TTL-aware helper, or drop the 1h fields from the usage model. I went with consolidation because:

- The 1h usage path (`prompt_cache_creation_1h_tokens` and its cost calculation in `tokens/service.py`) is already fully plumbed and correct — it just never had a producer. Removing it would be a public API break on `ChatInvokeUsage` for a field that is now reachable.
- With the helper in place, opting into the 1-hour cache is a one-line `ttl='1h'` at any cache site, and any future TTL work has exactly one place to touch.

The reporter's measured data (1h arm ~40% cheaper on 5min–1hr gaps, but browser steps landing inside the 5-minute window) says 5m remains the right default, so nothing changes behavior by default. The new test `test_cache_control_ttl` locks in both the default and the explicit `'5m'`/`'1h'` emissions.

## Tests

- `browser_use/llm/tests/test_anthropic_cache.py` — 17 passed (includes new `test_cache_control_ttl`)
- `ruff check` clean on all four touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates all Anthropic `CacheControlEphemeralParam` construction behind a TTL-aware helper without changing defaults. Previously three sites built the param directly; now `_serialize_cache_control(use_cache, ttl)` centralizes it, enabling an optional 1-hour TTL while keeping the 5-minute default byte-for-byte.

- Routes the serializer string-content path and both providers' `ToolParam.cache_control` through `AnthropicMessageSerializer._serialize_cache_control(...)`.
- Adds `test_cache_control_ttl` asserting default behavior and explicit `'5m'`/`'1h'` emissions; no migration required.

<sup>Written for commit cd0a4c77a2cf7ae7a93a79edb6b1a4cf65217053. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

