### PR TITLE
fix(browser): exclude chrome-extension targets from page target list

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -188,7 +188,10 @@ class SessionManager:
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
+			# chrome-extension:// targets are browser-internal UI (extensions, devtools
+			# panels) and must never be treated as agent-visible pages - otherwise agent
+			# focus can switch to a target the agent cannot meaningfully control.
+			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
 				page_targets.append(target)
 		return page_targets
 

--- a/tests/ci/browser/test_session_manager.py
+++ b/tests/ci/browser/test_session_manager.py
@@ -1,0 +1,62 @@
+"""Unit tests for SessionManager target/session bookkeeping.
+
+These tests exercise the pure bookkeeping logic of SessionManager without
+spinning up a real browser or CDP connection.
+"""
+
+import logging
+
+import pytest
+
+from browser_use.browser.session import Target
+from browser_use.browser.session_manager import SessionManager
+
+
+class _FakeBrowserSession:
+	def __init__(self):
+		self.logger = logging.getLogger('test_session_manager')
+
+
+@pytest.fixture
+def session_manager():
+	sm = SessionManager(_FakeBrowserSession())
+	sm._targets = {
+		'page-a': Target(target_id='page-a', target_type='page', url='https://example.com/'),
+		'page-b': Target(target_id='page-b', target_type='tab', url='https://example.org/'),
+		'newtab': Target(target_id='newtab', target_type='page', url='about:blank'),
+		'ext': Target(target_id='ext', target_type='page', url='chrome-extension://abc123/panel.html'),
+		'ext-bg': Target(target_id='ext-bg', target_type='tab', url='chrome-extension://abc123/background.html'),
+		'iframe': Target(target_id='iframe', target_type='iframe', url='https://example.com/embed'),
+		'worker': Target(target_id='worker', target_type='worker', url='https://example.com/worker.js'),
+	}
+	return sm
+
+
+def test_get_all_page_targets_excludes_chrome_extension(session_manager):
+	"""Chrome extension targets must never be surfaced as agent-visible pages.
+
+	Regression test for #4133: agent focus could switch to chrome-extension://
+	targets because get_all_page_targets() only filtered on target type.
+	"""
+	targets = session_manager.get_all_page_targets()
+
+	urls = [t.url for t in targets]
+	assert 'chrome-extension://abc123/panel.html' not in urls
+	assert 'chrome-extension://abc123/background.html' not in urls
+
+
+def test_get_all_page_targets_keeps_real_pages(session_manager):
+	"""Normal pages, tabs, and new-tab pages are still returned."""
+	targets = session_manager.get_all_page_targets()
+
+	urls = {t.url for t in targets}
+	assert urls == {'https://example.com/', 'https://example.org/', 'about:blank'}
+
+
+def test_get_all_page_targets_excludes_non_page_types(session_manager):
+	"""Iframes and workers are still filtered out by target type."""
+	targets = session_manager.get_all_page_targets()
+
+	urls = {t.url for t in targets}
+	assert 'https://example.com/embed' not in urls
+	assert 'https://example.com/worker.js' not in urls

--- a/tests/ci/browser/test_session_manager.py
+++ b/tests/ci/browser/test_session_manager.py
@@ -19,7 +19,7 @@ class _FakeBrowserSession:
 
 @pytest.fixture
 def session_manager():
-	sm = SessionManager(_FakeBrowserSession())
+	sm = SessionManager(_FakeBrowserSession())  # type: ignore[arg-type]
 	sm._targets = {
 		'page-a': Target(target_id='page-a', target_type='page', url='https://example.com/'),
 		'page-b': Target(target_id='page-b', target_type='tab', url='https://example.org/'),


### PR DESCRIPTION
Closes #4133

## Problem

`SessionManager.get_all_page_targets()` filtered targets only by `target_type in ('page', 'tab')`. Chrome extension targets (e.g. `chrome-extension://...` panels/background pages) are surfaced by CDP as `page` targets, so the agent's focus could switch to a target it cannot meaningfully control — the browser's own extension UI.

## Fix

Exclude `chrome-extension://` URLs from `get_all_page_targets()`, matching the existing default behavior of `BrowserSession._is_valid_target()`, which already refuses `chrome-extension://` targets unless `include_chrome_extensions=True` is explicitly requested.

## Tests

Added `tests/ci/browser/test_session_manager.py` with three focused unit tests:

- chrome-extension `page`/`tab` targets are excluded
- real pages, tabs, and `about:blank` new-tab pages are still returned
- iframes/workers remain filtered by target type

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Excludes `chrome-extension://` targets from the page target list so the agent never switches focus to extension UI. Previously these targets were included; now only real pages and `about:blank` tabs are returned.

- Filtered `get_all_page_targets()` to skip `chrome-extension://` for `page`/`tab`, aligning with `BrowserSession._is_valid_target()`.
- Added tests to verify exclusions and kept pages; silenced Pyright arg-type on the fake session (`# type: ignore[arg-type]`).

<sup>Written for commit 6d94094cf44fbc8e3af5dd14e376a9592e1b6328. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

