### PR TITLE
fix(dom): preserve explicitly empty accessibility names

### DIFF
--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -1022,10 +1022,10 @@ class DOMInteractedElement:
 
 	@classmethod
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
-		# Extract accessibility name if available
-		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
-			ax_name = enhanced_dom_tree.ax_node.name
+		# Extract accessibility name if available. ax_node.name is str | None:
+		# preserve an explicitly empty name ("") rather than collapsing it to None,
+		# so the two states (attribute missing vs. intentionally empty) stay distinct.
+		ax_name = enhanced_dom_tree.ax_node.name if enhanced_dom_tree.ax_node else None
 
 		return cls(
 			node_id=enhanced_dom_tree.node_id,

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -1026,10 +1026,10 @@ class DOMInteractedElement:
 
 	@classmethod
 	def load_from_enhanced_dom_tree(cls, enhanced_dom_tree: EnhancedDOMTreeNode) -> 'DOMInteractedElement':
-		# Extract accessibility name if available
-		ax_name = None
-		if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
-			ax_name = enhanced_dom_tree.ax_node.name
+		# Extract accessibility name if available. ax_node.name is str | None:
+		# preserve an explicitly empty name ("") rather than collapsing it to None,
+		# so the two states (attribute missing vs. intentionally empty) stay distinct.
+		ax_name = enhanced_dom_tree.ax_node.name if enhanced_dom_tree.ax_node else None
 
 		return cls(
 			node_id=enhanced_dom_tree.node_id,

--- a/tests/ci/browser/test_dom_views.py
+++ b/tests/ci/browser/test_dom_views.py
@@ -1,0 +1,86 @@
+"""Unit tests for DOM view models that don't need a live browser.
+
+Covers pure data transformations in browser_use/dom/views.py, notably
+DOMInteractedElement.load_from_enhanced_dom_tree preserving explicitly
+empty accessibility names (regression for #5271).
+"""
+
+from browser_use.dom.views import (
+	DOMInteractedElement,
+	EnhancedAXNode,
+	EnhancedDOMTreeNode,
+	NodeType,
+)
+
+
+def _make_tree_node(ax_node: EnhancedAXNode | None) -> EnhancedDOMTreeNode:
+	"""Build a minimal EnhancedDOMTreeNode with only the fields the loader touches."""
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=100,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='button',
+		node_value='',
+		attributes={'aria-label': ''},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id='frame-1',
+		session_id='session-1',
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=None,
+	)
+
+
+def _make_ax_node(name: str | None) -> EnhancedAXNode:
+	return EnhancedAXNode(
+		ax_node_id='ax-1',
+		ignored=False,
+		role='button',
+		name=name,
+		description=None,
+		properties=None,
+		child_ids=None,
+	)
+
+
+def test_load_preserves_explicitly_empty_ax_name():
+	"""An explicitly empty accessibility name ("") must survive the round-trip.
+
+	Regression for #5271: the old truthiness check collapsed "" to None,
+	conflating "attribute missing" with "attribute intentionally empty".
+	"""
+	node = _make_tree_node(ax_node=_make_ax_node(name=''))
+	interacted = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+
+	assert interacted.ax_name == ''
+
+
+def test_load_keeps_none_when_ax_name_missing():
+	"""When the AX node has no name attribute, ax_name stays None."""
+	node = _make_tree_node(ax_node=_make_ax_node(name=None))
+	interacted = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+
+	assert interacted.ax_name is None
+
+
+def test_load_keeps_real_ax_name():
+	"""A populated accessibility name is preserved."""
+	node = _make_tree_node(ax_node=_make_ax_node(name='Submit order'))
+	interacted = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+
+	assert interacted.ax_name == 'Submit order'
+
+
+def test_load_without_ax_node():
+	"""No AX node at all -> ax_name is None."""
+	node = _make_tree_node(ax_node=None)
+	interacted = DOMInteractedElement.load_from_enhanced_dom_tree(node)
+
+	assert interacted.ax_name is None


### PR DESCRIPTION
Closes #5271

## Problem

`DOMInteractedElement.load_from_enhanced_dom_tree()` used an implicit truthiness check on the accessibility name:

```python
if enhanced_dom_tree.ax_node and enhanced_dom_tree.ax_node.name:
    ax_name = enhanced_dom_tree.ax_node.name
```

An explicitly empty accessibility name (`aria-label=""`) evaluates to falsy, so it was collapsed to `None`. That conflates two distinct states:

- the attribute does not exist → `None`
- the attribute exists but is intentionally empty → `""`

This can confuse downstream DOM matching / agent interaction logic.

## Fix

When the AX node exists, take `ax_node.name` as-is (`str | None`), so `None` stays `None` and `""` is preserved:

```python
ax_name = enhanced_dom_tree.ax_node.name if enhanced_dom_tree.ax_node else None
```

## Tests

Added `tests/ci/browser/test_dom_views.py` with four focused unit tests:

- explicitly empty `ax_name` (`""`) survives the round-trip
- missing name attribute stays `None`
- real accessibility names are preserved
- no AX node at all → `None`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5271 by preserving explicitly empty accessibility names (`aria-label=""`) when loading DOM elements. Previously `''` collapsed to `None`, conflating missing and intentionally empty names; now `ax_node.name` is taken as-is so missing stays `None` and empty stays `""`, preventing incorrect DOM matching and interaction. Adds tests covering empty, missing, and present names, plus no AX node.

<sup>Written for commit 728eb81c57d87501a1ba69920d69e7cf034b7718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

