### PR TITLE
fix(cli): guide legacy 'tab' subcommand to CLI 3.0 helpers

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -209,6 +209,7 @@ _LEGACY_HINTS: dict[str, str] = {
 	'screenshot': 'print(capture_screenshot())',
 	'eval': 'print(js("document.title"))',
 	'cookies': 'print(cdp("Network.getCookies"))',
+	'tab': '# list tabs with list_tabs(); switch with switch_tab(target); close with close_tab(target)',
 	'python': '# the CLI runs Python directly now — pipe it on stdin as shown below',
 	'run': '# write the steps as Python using the pre-imported helpers shown below',
 	'connect': '# connecting is automatic — the default flow attaches to your running Chrome',

--- a/tests/ci/test_browser_use_cli.py
+++ b/tests/ci/test_browser_use_cli.py
@@ -27,6 +27,16 @@ def test_browser_use_doctor_help_prints_browser_use_usage():
 	assert result.stderr == ''
 
 
+def test_legacy_tab_command_prints_migration_hint():
+	result = _run_browser_use_cli('tab', 'list')
+
+	assert result.returncode == 2
+	assert "The browser-use CLI changed in 3.0, and 'tab' was removed." in result.stderr
+	assert 'list_tabs()' in result.stderr
+	assert 'switch_tab(target)' in result.stderr
+	assert 'close_tab(target)' in result.stderr
+
+
 def test_normalize_captured_cli_output_handles_string_system_exit(capsys):
 	from browser_use.cli import _normalize_captured_cli_output
 

--- a/tests/ci/test_browser_use_cli.py
+++ b/tests/ci/test_browser_use_cli.py
@@ -36,6 +36,16 @@ def test_browser_use_module_entrypoint_matches_cli_entrypoint():
 	assert module_result.stderr == cli_result.stderr == ''
 
 
+def test_legacy_tab_command_prints_migration_hint():
+	result = _run_browser_use_cli('tab', 'list')
+
+	assert result.returncode == 2
+	assert "The browser-use CLI changed in 3.0, and 'tab' was removed." in result.stderr
+	assert 'list_tabs()' in result.stderr
+	assert 'switch_tab(target)' in result.stderr
+	assert 'close_tab(target)' in result.stderr
+
+
 def test_normalize_captured_cli_output_handles_string_system_exit(capsys):
 	from browser_use.cli import _normalize_captured_cli_output
 


### PR DESCRIPTION
## Summary

`browser-use tab list` (and `tab new` / `tab switch` / `tab close`) are still advertised as live commands in `skills/remote-browser/SKILL.md`, but the pre-3.0 subcommands were removed in the CLI 3.0 rewrite. `tab` was missing from `_LEGACY_HINTS`, so the harness swallowed it and printed only a bare `Usage:` block with no explanation and exit code 1.

This maps `tab` in `_LEGACY_HINTS` the same way every other removed subcommand is handled, so users now get a migration hint pointing at the CLI 3.0 helpers:

```
browser-use <<'PY'
print(list_tabs())
switch_tab(target)
close_tab(target)
PY
```

Closes #4790.

## Notes

Supersedes #4823, which targeted the removed argparse CLI — `browser_use/skill_cli/main.py` and its `build_parser()` no longer exist on main, so that diff cannot apply.

## Test plan

- `pytest tests/ci/test_browser_use_cli.py` — 4 passed (includes new `test_legacy_tab_command_prints_migration_hint`)
- `uvx ruff@0.12.10 format --check` and `ruff check` on both changed files — clean (verified with the CI-pinned ruff version)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guides the legacy `tab` subcommand in the `browser-use` CLI to CLI 3.0 helpers, replacing the bare usage error. Previously `tab` printed a usage block and exited 1; now it prints a hint to use `list_tabs()`, `switch_tab(target)`, and `close_tab(target)`, and exits 2 like other legacy commands.

- Adds `'tab'` to `_LEGACY_HINTS` to cover `tab list/new/switch/close`.
- Adds a test verifying the hint text and exit code.

<sup>Written for commit d4d611feed697144c5eb846e9118131c3bc8d2ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

