### PR TITLE
fix(tools): thread user-provided context through Agent, Tools, and Registry

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -210,6 +210,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_clickable_elements_length: int = 40000,
 		_url_shortening_limit: int = 25,
 		enable_signal_handler: bool = True,
+		context: Context | None = None,
 		**kwargs,
 	):
 		# Validate llm_screenshot_size
@@ -317,7 +318,21 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		else:
 			# Exclude screenshot tool when use_vision is not auto
 			exclude_actions = ['screenshot'] if use_vision != 'auto' else []
-			self.tools = Tools(exclude_actions=exclude_actions, display_files_in_done_text=display_files_in_done_text)
+			self.tools = Tools(
+				exclude_actions=exclude_actions,
+				display_files_in_done_text=display_files_in_done_text,
+				context=context,
+			)
+
+		# Optional user-provided context object forwarded to actions that declare a
+		# `context` parameter (see SpecialActionParameters). Apply it even when the
+		# caller supplied their own Tools/controller instance.
+		self.context = context
+		if context is not None:
+			self.tools.context = context
+			registry = getattr(self.tools, 'registry', None)
+			if registry is not None:
+				registry.context = context
 
 		# Enforce screenshot exclusion when use_vision != 'auto', even if user passed custom tools
 		if use_vision != 'auto':

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -209,6 +209,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_clickable_elements_length: int = 40000,
 		_url_shortening_limit: int = 25,
 		enable_signal_handler: bool = True,
+		context: Context | None = None,
 		**kwargs,
 	):
 		# Validate llm_screenshot_size
@@ -316,7 +317,21 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		else:
 			# Exclude screenshot tool when use_vision is not auto
 			exclude_actions = ['screenshot'] if use_vision != 'auto' else []
-			self.tools = Tools(exclude_actions=exclude_actions, display_files_in_done_text=display_files_in_done_text)
+			self.tools = Tools(
+				exclude_actions=exclude_actions,
+				display_files_in_done_text=display_files_in_done_text,
+				context=context,
+			)
+
+		# Optional user-provided context object forwarded to actions that declare a
+		# `context` parameter (see SpecialActionParameters). Apply it even when the
+		# caller supplied their own Tools/controller instance.
+		self.context = context
+		if context is not None:
+			self.tools.context = context
+			registry = getattr(self.tools, 'registry', None)
+			if registry is not None:
+				registry.context = context
 
 		# Enforce screenshot exclusion when use_vision != 'auto', even if user passed custom tools
 		if use_vision != 'auto':

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -1,4 +1,4 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import ast
 import asyncio
@@ -1176,8 +1176,8 @@ def _warn_sensitive_data_domain_constraints(
 		return
 	if not allowed_domains:
 		logger.warning(
-			'âš ï¸ Agent(sensitive_data=â€¢â€¢â€¢â€¢â€¢â€¢â€¢â€¢) was provided but Browser(allowed_domains=[...]) is not locked down! âš ï¸\n'
-			'          â˜ ï¸ If the agent visits a malicious website and encounters a prompt-injection attack, your sensitive_data may be exposed!\n\n'
+			'⚠️ Agent(sensitive_data=••••••••) was provided but Browser(allowed_domains=[...]) is not locked down! ⚠️\n'
+			'          ☠️ If the agent visits a malicious website and encounters a prompt-injection attack, your sensitive_data may be exposed!\n\n'
 			'   \n'
 		)
 		return
@@ -1186,7 +1186,7 @@ def _warn_sensitive_data_domain_constraints(
 			continue
 		if not any(_sensitive_domain_is_allowed(domain_pattern, allowed_domain) for allowed_domain in allowed_domains):
 			logger.warning(
-				f'âš ï¸ Domain pattern "{domain_pattern}" in sensitive_data is not covered by any pattern in allowed_domains={allowed_domains}\n'
+				f'⚠️ Domain pattern "{domain_pattern}" in sensitive_data is not covered by any pattern in allowed_domains={allowed_domains}\n'
 				f'   This may be a security risk as credentials could be used on unintended domains.'
 			)
 
@@ -4434,7 +4434,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		)
 		if self.settings.save_conversation_path:
 			self.settings.save_conversation_path = Path(self.settings.save_conversation_path).expanduser().resolve()
-			self.logger.info(f'ðŸ’¬ Saving conversation to {_log_pretty_path(self.settings.save_conversation_path)}')
+			self.logger.info(f'💬 Saving conversation to {_log_pretty_path(self.settings.save_conversation_path)}')
 		self._setup_action_models()
 		self._verify_and_setup_llm()
 		logger.debug(
@@ -4486,7 +4486,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if self.directly_open_url and not self.state.follow_up_task and not initial_actions:
 			self.initial_url = _extract_start_url(task)
 			if self.initial_url:
-				self.logger.info(f'ðŸ”— Found URL in task: {self.initial_url}, adding as initial action...')
+				self.logger.info(f'🔗 Found URL in task: {self.initial_url}, adding as initial action...')
 				initial_actions = [{'navigate': {'url': self.initial_url, 'new_tab': False}}]
 		self.initial_action_payloads = list(initial_actions or [])
 		self.initial_actions = (
@@ -4586,12 +4586,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	async def _log_agent_run(self) -> None:
 		"""Log Browser Use run metadata for the Rust-backed wrapper."""
-		self.logger.info(f'\033[34mðŸŽ¯ Task: {self.task}\033[0m')
-		self.logger.debug(f'ðŸ¤– Browser-Use Library Version {self.version} ({self.source})')
+		self.logger.info(f'\033[34m🎯 Task: {self.task}\033[0m')
+		self.logger.debug(f'🤖 Browser-Use Library Version {self.version} ({self.source})')
 		latest_version = await check_latest_browser_use_version()
 		if latest_version and latest_version != self.version:
 			self.logger.info(
-				f'ðŸ“¦ Newer version available: {latest_version} (current: {self.version}). Upgrade with: uv add browser-use=={latest_version}'
+				f'📦 Newer version available: {latest_version} (current: {self.version}). Upgrade with: uv add browser-use=={latest_version}'
 			)
 
 	def _log_agent_setup(self) -> None:
@@ -4738,11 +4738,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		judge_log = '\n'
 		if self_reported_success is True and judgement.verdict is False:
-			judge_log += 'âš ï¸  \033[33mAgent reported success but judge thinks task failed\033[0m\n'
+			judge_log += '⚠️  \033[33mAgent reported success but judge thinks task failed\033[0m\n'
 
 		verdict_color = '\033[32m' if judgement.verdict else '\033[31m'
-		verdict_text = 'âœ… PASS' if judgement.verdict else 'âŒ FAIL'
-		judge_log += f'âš–ï¸  {verdict_color}Judge Verdict: {verdict_text}\033[0m\n'
+		verdict_text = '✅ PASS' if judgement.verdict else '❌ FAIL'
+		judge_log += f'⚖️  {verdict_color}Judge Verdict: {verdict_text}\033[0m\n'
 		if judgement.failure_reason:
 			judge_log += f'   Failure Reason: {judgement.failure_reason}\n'
 		if judgement.reached_captcha:
@@ -5435,7 +5435,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		focus_target_id = getattr(agent_focus, 'target_id', None)
 		if isinstance(focus_target_id, str) and focus_target_id:
 			target_id = focus_target_id[-2:]
-		return logging.getLogger(f'browser_use.AgentðŸ…° {self.task_id[-4:]} â‡¢ ðŸ…‘ {str(browser_session_id)[-4:]} ðŸ…£ {target_id}')
+		return logging.getLogger(f'browser_use.Agent🅰 {self.task_id[-4:]} ⇢ 🅑 {str(browser_session_id)[-4:]} 🅣 {target_id}')
 
 	@property
 	def browser_profile(self) -> Any:
@@ -5737,7 +5737,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		"""Get model output, retrying once when the model returns no usable action."""
 		model_output = await self.get_model_output(input_messages)
 		action_count = len(model_output.action) if getattr(model_output, 'action', None) else 0
-		self.logger.debug(f'âœ… Step {self.state.n_steps}: Got LLM response with {action_count} actions')
+		self.logger.debug(f'✅ Step {self.state.n_steps}: Got LLM response with {action_count} actions')
 
 		def has_empty_actions(output: AgentOutput) -> bool:
 			actions = getattr(output, 'action', None)
@@ -5860,21 +5860,21 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		await self._check_and_update_downloads('after executing actions')
 		if self.state.last_result and len(self.state.last_result) == 1 and self.state.last_result[-1].error:
 			self.state.consecutive_failures += 1
-			self.logger.debug(f'ðŸ”„ Step {self.state.n_steps}: Consecutive failures: {self.state.consecutive_failures}')
+			self.logger.debug(f'🔄 Step {self.state.n_steps}: Consecutive failures: {self.state.consecutive_failures}')
 			return
 		if self.state.consecutive_failures > 0:
 			self.state.consecutive_failures = 0
-			self.logger.debug(f'ðŸ”„ Step {self.state.n_steps}: Consecutive failures reset to: {self.state.consecutive_failures}')
+			self.logger.debug(f'🔄 Step {self.state.n_steps}: Consecutive failures reset to: {self.state.consecutive_failures}')
 		if self.state.last_result and self.state.last_result[-1].is_done:
 			success = self.state.last_result[-1].success
 			if success:
-				self.logger.info(f'\nðŸ“„ \033[32m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
+				self.logger.info(f'\n📄 \033[32m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
 			else:
-				self.logger.info(f'\nðŸ“„ \033[31m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
+				self.logger.info(f'\n📄 \033[31m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
 			if self.state.last_result[-1].attachments:
 				total_attachments = len(self.state.last_result[-1].attachments)
 				for index, file_path in enumerate(self.state.last_result[-1].attachments):
-					self.logger.info(f'ðŸ‘‰ Attachment {index + 1 if total_attachments > 1 else ""}: {file_path}')
+					self.logger.info(f'👉 Attachment {index + 1 if total_attachments > 1 else ""}: {file_path}')
 
 	async def _handle_step_error(self, error: Exception) -> None:
 		"""Convert a step exception into Browser Use-style state.last_result."""
@@ -5883,7 +5883,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			return
 		include_trace = self.logger.isEnabledFor(logging.DEBUG)
 		error_msg = AgentError.format_error(error, include_trace=include_trace)
-		prefix = f'âŒ Result failed {self.state.consecutive_failures + 1}/{self.settings.max_failures + int(self.settings.final_response_after_failure)} times:\n '
+		prefix = f'❌ Result failed {self.state.consecutive_failures + 1}/{self.settings.max_failures + int(self.settings.final_response_after_failure)} times:\n '
 		self.state.consecutive_failures += 1
 		if 'Could not parse response' in error_msg or 'tool_use_failed' in error_msg:
 			logger.error(f'Model: {getattr(self.llm, "model", None)} failed')
@@ -5985,9 +5985,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		Registered Python custom actions (e.g. ``@agent.tools.registry.action``)
 		cannot be executed by the Rust terminal, so they are dispatched locally
-		through ``Registry.execute_action`` â€” which injects the agent's ``context``
+		through ``Registry.execute_action`` — which injects the agent's ``context``
 		into any action that declares a ``context`` parameter. This makes the
-		beta agent honor the documented ``Agent(context=...)`` â†’ custom-action
+		beta agent honor the documented ``Agent(context=...)`` → custom-action
 		contract instead of silently dropping the context on custom actions.
 		"""
 		payloads: list[dict[str, Any]] = []
@@ -6075,7 +6075,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		"""Execute configured Browser Use initial actions through the Rust-backed action path."""
 		if not self.initial_actions or self.state.follow_up_task or self._initial_actions_executed:
 			return
-		self.logger.debug(f'âš¡ Executing {len(self.initial_actions)} initial actions...')
+		self.logger.debug(f'⚡ Executing {len(self.initial_actions)} initial actions...')
 		result = await self._execute_direct_initial_navigation_actions()
 		if result is None:
 			if not allow_terminal_run:
@@ -6133,7 +6133,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				metadata=metadata,
 			)
 		)
-		self.logger.debug('ðŸ“ Saved initial actions to history as step 0')
+		self.logger.debug('📝 Saved initial actions to history as step 0')
 		self.logger.debug('Initial actions completed')
 
 	async def _execute_direct_initial_navigation_actions(self) -> list[ActionResult] | None:
@@ -6323,20 +6323,20 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	def pause(self) -> None:
 		"""Pause the Rust-backed agent before the next terminal run."""
-		print('\n\nâ¸ï¸ Paused the agent and left the browser open.\n\tPress [Enter] to resume or [Ctrl+C] again to quit.')
+		print('\n\n⏸️ Paused the agent and left the browser open.\n\tPress [Enter] to resume or [Ctrl+C] again to quit.')
 		self.state.paused = True
 		self._external_pause_event.clear()
 
 	def resume(self) -> None:
 		"""Resume a paused Rust-backed agent."""
 		print('----------------------------------------------------------------------')
-		print('â–¶ï¸  Resuming agent execution where it left off...\n')
+		print('▶️  Resuming agent execution where it left off...\n')
 		self.state.paused = False
 		self._external_pause_event.set()
 
 	def stop(self) -> None:
 		"""Stop the Rust-backed agent before the next terminal run."""
-		self.logger.info('â¹ï¸ Agent stopping')
+		self.logger.info('⏹️ Agent stopping')
 		self.state.stopped = True
 		self._external_pause_event.set()
 		if self._sdk_client is not None:
@@ -6406,7 +6406,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 	async def log_completion(self) -> None:
 		"""Log Browser Use-style task completion."""
 		if self.history.is_successful():
-			self.logger.info('âœ… Task completed successfully')
+			self.logger.info('✅ Task completed successfully')
 
 	def run_sync(
 		self,

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5982,9 +5982,20 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		The Rust terminal owns browser actions, so non-`done` action batches are
 		serialized as a follow-up instruction for the active Rust session. A
 		standalone `done` action preserves Browser Use's local completion semantics.
+
+		Registered Python custom actions (e.g. ``@agent.tools.registry.action``)
+		cannot be executed by the Rust terminal, so they are dispatched locally
+		through ``Registry.execute_action`` — which injects the agent's ``context``
+		into any action that declares a ``context`` parameter. This makes the
+		beta agent honor the documented ``Agent(context=...)`` → custom-action
+		contract instead of silently dropping the context on custom actions.
 		"""
-		payloads = []
+		payloads: list[dict[str, Any]] = []
+		local_results: list[ActionResult] = []
 		total_actions = len(actions)
+		# Module that defines built-in browser actions; anything registered from
+		# elsewhere is a user-supplied custom action that Rust cannot run.
+		builtin_module = Tools.__module__
 		for index, action in enumerate(actions):
 			payload = _action_payload(action)
 			if index > 0 and payload.get('done') is not None:
@@ -5992,12 +6003,44 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					f'Done action is allowed only as a single action - stopped after action {index} / {total_actions}.'
 				)
 				break
+			# Route registered custom Python actions through the local registry so
+			# they receive the agent context. Built-in browser actions go to Rust.
+			action_name = next(iter(payload), None)
+			if action_name and action_name != 'done' and self._is_custom_action(action_name, builtin_module):
+				try:
+					# Only forward a session whose CDP client is actually connected;
+					# an unconnected session would crash custom actions that use it.
+					connected_session = getattr(self, 'browser_session', None)
+					if connected_session is not None and not getattr(connected_session, '_cdp_client_root', None):
+						connected_session = None
+					result = await self.tools.registry.execute_action(
+						action_name=action_name,
+						params=payload.get(action_name) or {},
+						browser_session=connected_session,
+						page_extraction_llm=getattr(self, 'page_extraction_llm', None),
+						file_system=getattr(self, 'file_system', None),
+						sensitive_data=self.sensitive_data,
+						available_file_paths=self.available_file_paths,
+						extraction_schema=self.extraction_schema,
+					)
+					if isinstance(result, ActionResult):
+						local_results.append(result)
+					else:
+						local_results.append(ActionResult(extracted_content=str(result)))
+				except Exception as e:  # noqa: BLE001
+					local_results.append(ActionResult(error=f'Custom action {action_name} failed: {e}'))
+				# Custom actions are executed locally; do not forward to Rust.
+				if payload.get('done') is not None:
+					break
+				continue
 			payloads.append(payload)
 			if payload.get('done') is not None:
 				break
+		if local_results and not payloads:
+			return local_results
 		if not payloads:
-			return []
-		if len(payloads) == 1:
+			return local_results
+		if len(payloads) == 1 and not local_results:
 			done_result = _done_action_result(payloads[0])
 			if done_result is not None:
 				return [done_result]
@@ -6005,14 +6048,28 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_steps = max(1, len(payloads))
 		if self.terminal_session_id:
 			history = await self.follow_up(instruction, max_steps=max_steps)
-			return history.action_results()
-		original_task = self.task
-		self.task = f'{self.task}\n\n{instruction}'
-		try:
-			history = await self.run(max_steps=max_steps)
-		finally:
-			self.task = original_task
-		return history.action_results()
+			rust_results = history.action_results()
+		else:
+			original_task = self.task
+			self.task = f'{self.task}\n\n{instruction}'
+			try:
+				history = await self.run(max_steps=max_steps)
+			finally:
+				self.task = original_task
+			rust_results = history.action_results()
+		return local_results + rust_results
+
+	def _is_custom_action(self, action_name: str, builtin_module: str | None) -> bool:
+		"""True if ``action_name`` is a registered Python action that is not a built-in browser action."""
+		action = self.tools.registry.registry.actions.get(action_name)
+		if action is None:
+			return False
+		if builtin_module is None:
+			return True
+		# Built-in browser actions are defined in the Tools module itself; MCP- and
+		# user-registered actions come from other modules.
+		func_module = getattr(action.function, '__module__', '')
+		return func_module != builtin_module
 
 	async def _execute_initial_actions(self, *, allow_terminal_run: bool = True) -> None:
 		"""Execute configured Browser Use initial actions through the Rust-backed action path."""

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+﻿from __future__ import annotations
 
 import ast
 import asyncio
@@ -1176,8 +1176,8 @@ def _warn_sensitive_data_domain_constraints(
 		return
 	if not allowed_domains:
 		logger.warning(
-			'⚠️ Agent(sensitive_data=••••••••) was provided but Browser(allowed_domains=[...]) is not locked down! ⚠️\n'
-			'          ☠️ If the agent visits a malicious website and encounters a prompt-injection attack, your sensitive_data may be exposed!\n\n'
+			'âš ï¸ Agent(sensitive_data=â€¢â€¢â€¢â€¢â€¢â€¢â€¢â€¢) was provided but Browser(allowed_domains=[...]) is not locked down! âš ï¸\n'
+			'          â˜ ï¸ If the agent visits a malicious website and encounters a prompt-injection attack, your sensitive_data may be exposed!\n\n'
 			'   \n'
 		)
 		return
@@ -1186,7 +1186,7 @@ def _warn_sensitive_data_domain_constraints(
 			continue
 		if not any(_sensitive_domain_is_allowed(domain_pattern, allowed_domain) for allowed_domain in allowed_domains):
 			logger.warning(
-				f'⚠️ Domain pattern "{domain_pattern}" in sensitive_data is not covered by any pattern in allowed_domains={allowed_domains}\n'
+				f'âš ï¸ Domain pattern "{domain_pattern}" in sensitive_data is not covered by any pattern in allowed_domains={allowed_domains}\n'
 				f'   This may be a security risk as credentials could be used on unintended domains.'
 			)
 
@@ -4434,7 +4434,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		)
 		if self.settings.save_conversation_path:
 			self.settings.save_conversation_path = Path(self.settings.save_conversation_path).expanduser().resolve()
-			self.logger.info(f'💬 Saving conversation to {_log_pretty_path(self.settings.save_conversation_path)}')
+			self.logger.info(f'ðŸ’¬ Saving conversation to {_log_pretty_path(self.settings.save_conversation_path)}')
 		self._setup_action_models()
 		self._verify_and_setup_llm()
 		logger.debug(
@@ -4486,7 +4486,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if self.directly_open_url and not self.state.follow_up_task and not initial_actions:
 			self.initial_url = _extract_start_url(task)
 			if self.initial_url:
-				self.logger.info(f'🔗 Found URL in task: {self.initial_url}, adding as initial action...')
+				self.logger.info(f'ðŸ”— Found URL in task: {self.initial_url}, adding as initial action...')
 				initial_actions = [{'navigate': {'url': self.initial_url, 'new_tab': False}}]
 		self.initial_action_payloads = list(initial_actions or [])
 		self.initial_actions = (
@@ -4586,12 +4586,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	async def _log_agent_run(self) -> None:
 		"""Log Browser Use run metadata for the Rust-backed wrapper."""
-		self.logger.info(f'\033[34m🎯 Task: {self.task}\033[0m')
-		self.logger.debug(f'🤖 Browser-Use Library Version {self.version} ({self.source})')
+		self.logger.info(f'\033[34mðŸŽ¯ Task: {self.task}\033[0m')
+		self.logger.debug(f'ðŸ¤– Browser-Use Library Version {self.version} ({self.source})')
 		latest_version = await check_latest_browser_use_version()
 		if latest_version and latest_version != self.version:
 			self.logger.info(
-				f'📦 Newer version available: {latest_version} (current: {self.version}). Upgrade with: uv add browser-use=={latest_version}'
+				f'ðŸ“¦ Newer version available: {latest_version} (current: {self.version}). Upgrade with: uv add browser-use=={latest_version}'
 			)
 
 	def _log_agent_setup(self) -> None:
@@ -4738,11 +4738,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		judge_log = '\n'
 		if self_reported_success is True and judgement.verdict is False:
-			judge_log += '⚠️  \033[33mAgent reported success but judge thinks task failed\033[0m\n'
+			judge_log += 'âš ï¸  \033[33mAgent reported success but judge thinks task failed\033[0m\n'
 
 		verdict_color = '\033[32m' if judgement.verdict else '\033[31m'
-		verdict_text = '✅ PASS' if judgement.verdict else '❌ FAIL'
-		judge_log += f'⚖️  {verdict_color}Judge Verdict: {verdict_text}\033[0m\n'
+		verdict_text = 'âœ… PASS' if judgement.verdict else 'âŒ FAIL'
+		judge_log += f'âš–ï¸  {verdict_color}Judge Verdict: {verdict_text}\033[0m\n'
 		if judgement.failure_reason:
 			judge_log += f'   Failure Reason: {judgement.failure_reason}\n'
 		if judgement.reached_captcha:
@@ -5435,7 +5435,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		focus_target_id = getattr(agent_focus, 'target_id', None)
 		if isinstance(focus_target_id, str) and focus_target_id:
 			target_id = focus_target_id[-2:]
-		return logging.getLogger(f'browser_use.Agent🅰 {self.task_id[-4:]} ⇢ 🅑 {str(browser_session_id)[-4:]} 🅣 {target_id}')
+		return logging.getLogger(f'browser_use.AgentðŸ…° {self.task_id[-4:]} â‡¢ ðŸ…‘ {str(browser_session_id)[-4:]} ðŸ…£ {target_id}')
 
 	@property
 	def browser_profile(self) -> Any:
@@ -5737,7 +5737,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		"""Get model output, retrying once when the model returns no usable action."""
 		model_output = await self.get_model_output(input_messages)
 		action_count = len(model_output.action) if getattr(model_output, 'action', None) else 0
-		self.logger.debug(f'✅ Step {self.state.n_steps}: Got LLM response with {action_count} actions')
+		self.logger.debug(f'âœ… Step {self.state.n_steps}: Got LLM response with {action_count} actions')
 
 		def has_empty_actions(output: AgentOutput) -> bool:
 			actions = getattr(output, 'action', None)
@@ -5860,21 +5860,21 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		await self._check_and_update_downloads('after executing actions')
 		if self.state.last_result and len(self.state.last_result) == 1 and self.state.last_result[-1].error:
 			self.state.consecutive_failures += 1
-			self.logger.debug(f'🔄 Step {self.state.n_steps}: Consecutive failures: {self.state.consecutive_failures}')
+			self.logger.debug(f'ðŸ”„ Step {self.state.n_steps}: Consecutive failures: {self.state.consecutive_failures}')
 			return
 		if self.state.consecutive_failures > 0:
 			self.state.consecutive_failures = 0
-			self.logger.debug(f'🔄 Step {self.state.n_steps}: Consecutive failures reset to: {self.state.consecutive_failures}')
+			self.logger.debug(f'ðŸ”„ Step {self.state.n_steps}: Consecutive failures reset to: {self.state.consecutive_failures}')
 		if self.state.last_result and self.state.last_result[-1].is_done:
 			success = self.state.last_result[-1].success
 			if success:
-				self.logger.info(f'\n📄 \033[32m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
+				self.logger.info(f'\nðŸ“„ \033[32m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
 			else:
-				self.logger.info(f'\n📄 \033[31m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
+				self.logger.info(f'\nðŸ“„ \033[31m Final Result:\033[0m \n{self.state.last_result[-1].extracted_content}\n\n')
 			if self.state.last_result[-1].attachments:
 				total_attachments = len(self.state.last_result[-1].attachments)
 				for index, file_path in enumerate(self.state.last_result[-1].attachments):
-					self.logger.info(f'👉 Attachment {index + 1 if total_attachments > 1 else ""}: {file_path}')
+					self.logger.info(f'ðŸ‘‰ Attachment {index + 1 if total_attachments > 1 else ""}: {file_path}')
 
 	async def _handle_step_error(self, error: Exception) -> None:
 		"""Convert a step exception into Browser Use-style state.last_result."""
@@ -5883,7 +5883,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			return
 		include_trace = self.logger.isEnabledFor(logging.DEBUG)
 		error_msg = AgentError.format_error(error, include_trace=include_trace)
-		prefix = f'❌ Result failed {self.state.consecutive_failures + 1}/{self.settings.max_failures + int(self.settings.final_response_after_failure)} times:\n '
+		prefix = f'âŒ Result failed {self.state.consecutive_failures + 1}/{self.settings.max_failures + int(self.settings.final_response_after_failure)} times:\n '
 		self.state.consecutive_failures += 1
 		if 'Could not parse response' in error_msg or 'tool_use_failed' in error_msg:
 			logger.error(f'Model: {getattr(self.llm, "model", None)} failed')
@@ -5985,9 +5985,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		Registered Python custom actions (e.g. ``@agent.tools.registry.action``)
 		cannot be executed by the Rust terminal, so they are dispatched locally
-		through ``Registry.execute_action`` — which injects the agent's ``context``
+		through ``Registry.execute_action`` â€” which injects the agent's ``context``
 		into any action that declares a ``context`` parameter. This makes the
-		beta agent honor the documented ``Agent(context=...)`` → custom-action
+		beta agent honor the documented ``Agent(context=...)`` â†’ custom-action
 		contract instead of silently dropping the context on custom actions.
 		"""
 		payloads: list[dict[str, Any]] = []
@@ -6027,7 +6027,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 						local_results.append(result)
 					else:
 						local_results.append(ActionResult(extracted_content=str(result)))
-				except Exception as e:  # noqa: BLE001
+				except Exception as e:
 					local_results.append(ActionResult(error=f'Custom action {action_name} failed: {e}'))
 				# Custom actions are executed locally; do not forward to Rust.
 				if payload.get('done') is not None:
@@ -6075,7 +6075,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		"""Execute configured Browser Use initial actions through the Rust-backed action path."""
 		if not self.initial_actions or self.state.follow_up_task or self._initial_actions_executed:
 			return
-		self.logger.debug(f'⚡ Executing {len(self.initial_actions)} initial actions...')
+		self.logger.debug(f'âš¡ Executing {len(self.initial_actions)} initial actions...')
 		result = await self._execute_direct_initial_navigation_actions()
 		if result is None:
 			if not allow_terminal_run:
@@ -6133,7 +6133,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				metadata=metadata,
 			)
 		)
-		self.logger.debug('📝 Saved initial actions to history as step 0')
+		self.logger.debug('ðŸ“ Saved initial actions to history as step 0')
 		self.logger.debug('Initial actions completed')
 
 	async def _execute_direct_initial_navigation_actions(self) -> list[ActionResult] | None:
@@ -6323,20 +6323,20 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	def pause(self) -> None:
 		"""Pause the Rust-backed agent before the next terminal run."""
-		print('\n\n⏸️ Paused the agent and left the browser open.\n\tPress [Enter] to resume or [Ctrl+C] again to quit.')
+		print('\n\nâ¸ï¸ Paused the agent and left the browser open.\n\tPress [Enter] to resume or [Ctrl+C] again to quit.')
 		self.state.paused = True
 		self._external_pause_event.clear()
 
 	def resume(self) -> None:
 		"""Resume a paused Rust-backed agent."""
 		print('----------------------------------------------------------------------')
-		print('▶️  Resuming agent execution where it left off...\n')
+		print('â–¶ï¸  Resuming agent execution where it left off...\n')
 		self.state.paused = False
 		self._external_pause_event.set()
 
 	def stop(self) -> None:
 		"""Stop the Rust-backed agent before the next terminal run."""
-		self.logger.info('⏹️ Agent stopping')
+		self.logger.info('â¹ï¸ Agent stopping')
 		self.state.stopped = True
 		self._external_pause_event.set()
 		if self._sdk_client is not None:
@@ -6406,7 +6406,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 	async def log_completion(self) -> None:
 		"""Log Browser Use-style task completion."""
 		if self.history.is_successful():
-			self.logger.info('✅ Task completed successfully')
+			self.logger.info('âœ… Task completed successfully')
 
 	def run_sync(
 		self,

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -4111,11 +4111,22 @@ def _resolve_tools(
 	output_model_schema: type[BaseModel] | None,
 	use_vision: bool | Literal['auto'],
 	display_files_in_done_text: bool,
+	context: Context | None = None,
 ) -> Any:
 	resolved_tools = tools if tools is not None else controller
 	if resolved_tools is None:
 		exclude_actions = ['screenshot'] if use_vision is False else []
-		resolved_tools = Tools(exclude_actions=exclude_actions, display_files_in_done_text=display_files_in_done_text)
+		resolved_tools = Tools(
+			exclude_actions=exclude_actions,
+			display_files_in_done_text=display_files_in_done_text,
+			context=context,
+		)
+	elif context is not None:
+		# Forward the user-provided context even when a custom Tools/controller was supplied.
+		resolved_tools.context = context
+		registry = getattr(resolved_tools, 'registry', None)
+		if registry is not None:
+			registry.context = context
 	if output_model_schema is not None and hasattr(resolved_tools, 'use_structured_output_action'):
 		resolved_tools.use_structured_output_action(output_model_schema)
 	return resolved_tools
@@ -4299,6 +4310,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_clickable_elements_length: int = 40000,
 		_url_shortening_limit: int = 25,
 		enable_signal_handler: bool = True,
+		context: Context | None = None,
 		**kwargs,
 	):
 		if llm_screenshot_size is not None:
@@ -4352,7 +4364,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			output_model_schema,
 			use_vision,
 			display_files_in_done_text,
+			context,
 		)
+		self.context = context
 		if skills and skill_ids:
 			raise ValueError('Cannot specify both "skills" and "skill_ids" parameters. Use "skills" for the cleaner API.')
 		skill_ids = skills or skill_ids

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5983,9 +5983,20 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		The Rust terminal owns browser actions, so non-`done` action batches are
 		serialized as a follow-up instruction for the active Rust session. A
 		standalone `done` action preserves Browser Use's local completion semantics.
+
+		Registered Python custom actions (e.g. ``@agent.tools.registry.action``)
+		cannot be executed by the Rust terminal, so they are dispatched locally
+		through ``Registry.execute_action`` — which injects the agent's ``context``
+		into any action that declares a ``context`` parameter. This makes the
+		beta agent honor the documented ``Agent(context=...)`` → custom-action
+		contract instead of silently dropping the context on custom actions.
 		"""
-		payloads = []
+		payloads: list[dict[str, Any]] = []
+		local_results: list[ActionResult] = []
 		total_actions = len(actions)
+		# Module that defines built-in browser actions; anything registered from
+		# elsewhere is a user-supplied custom action that Rust cannot run.
+		builtin_module = self.tools.registry.__module__
 		for index, action in enumerate(actions):
 			payload = _action_payload(action)
 			if index > 0 and payload.get('done') is not None:
@@ -5993,12 +6004,44 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					f'Done action is allowed only as a single action - stopped after action {index} / {total_actions}.'
 				)
 				break
+			# Route registered custom Python actions through the local registry so
+			# they receive the agent context. Built-in browser actions go to Rust.
+			action_name = next(iter(payload), None)
+			if action_name and action_name != 'done' and self._is_custom_action(action_name, builtin_module):
+				try:
+					# Only forward a session whose CDP client is actually connected;
+					# an unconnected session would crash custom actions that use it.
+					connected_session = getattr(self, 'browser_session', None)
+					if connected_session is not None and not connected_session._cdp_client_root:
+						connected_session = None
+					result = await self.tools.registry.execute_action(
+						action_name=action_name,
+						params=payload.get(action_name) or {},
+						browser_session=connected_session,
+						page_extraction_llm=getattr(self, 'page_extraction_llm', None),
+						file_system=getattr(self, 'file_system', None),
+						sensitive_data=self.sensitive_data,
+						available_file_paths=self.available_file_paths,
+						extraction_schema=self.extraction_schema,
+					)
+					if isinstance(result, ActionResult):
+						local_results.append(result)
+					else:
+						local_results.append(ActionResult(extracted_content=str(result)))
+				except Exception as e:  # noqa: BLE001
+					local_results.append(ActionResult(error=f'Custom action {action_name} failed: {e}'))
+				# Custom actions are executed locally; do not forward to Rust.
+				if payload.get('done') is not None:
+					break
+				continue
 			payloads.append(payload)
 			if payload.get('done') is not None:
 				break
+		if local_results and not payloads:
+			return local_results
 		if not payloads:
-			return []
-		if len(payloads) == 1:
+			return local_results
+		if len(payloads) == 1 and not local_results:
 			done_result = _done_action_result(payloads[0])
 			if done_result is not None:
 				return [done_result]
@@ -6006,14 +6049,28 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_steps = max(1, len(payloads))
 		if self.terminal_session_id:
 			history = await self.follow_up(instruction, max_steps=max_steps)
-			return history.action_results()
-		original_task = self.task
-		self.task = f'{self.task}\n\n{instruction}'
-		try:
-			history = await self.run(max_steps=max_steps)
-		finally:
-			self.task = original_task
-		return history.action_results()
+			rust_results = history.action_results()
+		else:
+			original_task = self.task
+			self.task = f'{self.task}\n\n{instruction}'
+			try:
+				history = await self.run(max_steps=max_steps)
+			finally:
+				self.task = original_task
+			rust_results = history.action_results()
+		return local_results + rust_results
+
+	def _is_custom_action(self, action_name: str, builtin_module: str | None) -> bool:
+		"""True if ``action_name`` is a registered Python action that is not a built-in browser action."""
+		action = self.tools.registry.registry.actions.get(action_name)
+		if action is None:
+			return False
+		if builtin_module is None:
+			return True
+		# Built-in browser actions are defined in the registry module itself;
+		# user-registered actions come from other modules.
+		func_module = getattr(action.function, '__module__', '')
+		return func_module != builtin_module
 
 	async def _execute_initial_actions(self, *, allow_terminal_run: bool = True) -> None:
 		"""Execute configured Browser Use initial actions through the Rust-backed action path."""

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -4112,11 +4112,22 @@ def _resolve_tools(
 	output_model_schema: type[BaseModel] | None,
 	use_vision: bool | Literal['auto'],
 	display_files_in_done_text: bool,
+	context: Context | None = None,
 ) -> Any:
 	resolved_tools = tools if tools is not None else controller
 	if resolved_tools is None:
 		exclude_actions = ['screenshot'] if use_vision is False else []
-		resolved_tools = Tools(exclude_actions=exclude_actions, display_files_in_done_text=display_files_in_done_text)
+		resolved_tools = Tools(
+			exclude_actions=exclude_actions,
+			display_files_in_done_text=display_files_in_done_text,
+			context=context,
+		)
+	elif context is not None:
+		# Forward the user-provided context even when a custom Tools/controller was supplied.
+		resolved_tools.context = context
+		registry = getattr(resolved_tools, 'registry', None)
+		if registry is not None:
+			registry.context = context
 	if output_model_schema is not None and hasattr(resolved_tools, 'use_structured_output_action'):
 		resolved_tools.use_structured_output_action(output_model_schema)
 	return resolved_tools
@@ -4300,6 +4311,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		max_clickable_elements_length: int = 40000,
 		_url_shortening_limit: int = 25,
 		enable_signal_handler: bool = True,
+		context: Context | None = None,
 		**kwargs,
 	):
 		if llm_screenshot_size is not None:
@@ -4353,7 +4365,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			output_model_schema,
 			use_vision,
 			display_files_in_done_text,
+			context,
 		)
+		self.context = context
 		if skills and skill_ids:
 			raise ValueError('Cannot specify both "skills" and "skill_ids" parameters. Use "skills" for the cleaner API.')
 		skill_ids = skills or skill_ids

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -33,11 +33,15 @@ logger = logging.getLogger(__name__)
 class Registry(Generic[Context]):
 	"""Service for registering and managing actions"""
 
-	def __init__(self, exclude_actions: list[str] | None = None):
+	def __init__(self, exclude_actions: list[str] | None = None, context: Context | None = None):
 		self.registry = ActionRegistry()
 		self.telemetry = ProductTelemetry()
 		# Create a new list to avoid mutable default argument issues
 		self.exclude_actions = list(exclude_actions) if exclude_actions is not None else []
+		# Optional user-provided context object passed down from Agent(context=...).
+		# browser-use doesn't use this at all, it is only forwarded to actions that
+		# declare a `context` parameter (see SpecialActionParameters).
+		self.context = context
 
 	def exclude_action(self, action_name: str) -> None:
 		"""Exclude an action from the registry after initialization.
@@ -221,6 +225,11 @@ class Registry(Generic[Context]):
 								raise ValueError(f'Action {func.__name__} requires available_file_paths but none provided.')
 							elif param.name == 'file_system':
 								raise ValueError(f'Action {func.__name__} requires file_system but none provided.')
+							elif param.name == 'context':
+								raise ValueError(
+									f'Action {func.__name__} requires context but none provided. '
+									f'Pass context=... to Agent() or Tools().'
+								)
 							else:
 								raise ValueError(f"{func.__name__}() missing required special parameter '{param.name}'")
 						call_args.append(value)
@@ -240,6 +249,11 @@ class Registry(Generic[Context]):
 							raise ValueError(f'Action {func.__name__} requires available_file_paths but none provided.')
 						elif param.name == 'file_system':
 							raise ValueError(f'Action {func.__name__} requires file_system but none provided.')
+						elif param.name == 'context':
+							raise ValueError(
+								f'Action {func.__name__} requires context but none provided. '
+								f'Pass context=... to Agent() or Tools().'
+							)
 						else:
 							raise ValueError(f"{func.__name__}() missing required special parameter '{param.name}'")
 				else:
@@ -366,6 +380,7 @@ class Registry(Generic[Context]):
 
 			# Build special context dict
 			special_context = {
+				'context': self.context,
 				'browser_session': browser_session,
 				'page_extraction_llm': page_extraction_llm,
 				'available_file_paths': available_file_paths,

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -401,8 +401,10 @@ class Registry(Generic[Context]):
 				except Exception:
 					special_context['page_url'] = None
 
-				# Add cdp_client
-				special_context['cdp_client'] = browser_session.cdp_client
+				# Add cdp_client, but only when the browser is actually connected:
+				# BrowserSession.cdp_client asserts, and test doubles may not define the attr.
+				cdp_root = getattr(browser_session, '_cdp_client_root', None)
+				special_context['cdp_client'] = browser_session.cdp_client if cdp_root else None
 
 			# All functions are now normalized to accept kwargs only
 			# Call with params and unpacked special context

--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -402,7 +402,7 @@ class Registry(Generic[Context]):
 					special_context['page_url'] = None
 
 				# Add cdp_client
-				special_context['cdp_client'] = browser_session.cdp_client
+				special_context['cdp_client'] = browser_session.cdp_client if browser_session._cdp_client_root else None
 
 			# All functions are now normalized to accept kwargs only
 			# Call with params and unpacked special context

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -444,8 +444,10 @@ class Tools(Generic[Context]):
 		exclude_actions: list[str] | None = None,
 		output_model: type[T] | None = None,
 		display_files_in_done_text: bool = True,
+		context: Context | None = None,
 	):
-		self.registry = Registry[Context](exclude_actions if exclude_actions is not None else [])
+		self.registry = Registry[Context](exclude_actions if exclude_actions is not None else [], context=context)
+		self.context = context
 		self.display_files_in_done_text = display_files_in_done_text
 		self._output_model: type[BaseModel] | None = output_model
 		self._coordinate_clicking_enabled: bool = False

--- a/tests/ci/infrastructure/test_registry_action_parameter_injection.py
+++ b/tests/ci/infrastructure/test_registry_action_parameter_injection.py
@@ -392,3 +392,66 @@ class TestBrowserContext:
 		result = await registry.execute_action('special_params_only', {}, browser_session=browser_session)
 		assert 'Page URL:' in result.extracted_content
 		assert base_url in result.extracted_content
+
+
+class TestContextInjection:
+	"""Tests for the user-provided `context` special parameter.
+
+	SpecialActionParameters documents `context` as an optional user-provided object
+	passed down from Agent(context=...) to every action. These tests verify the
+	Registry actually injects it (see #5188).
+	"""
+
+	class FakeContext:
+		def __init__(self):
+			self.received: list[object] = []
+
+	class OtherContext:
+		pass
+
+	@pytest.mark.asyncio
+	async def test_context_injected_into_action(self):
+		from browser_use.agent.views import ActionResult
+		from browser_use.tools.registry.service import Registry
+
+		context = self.FakeContext()
+		registry = Registry(context=context)
+
+		@registry.action('Action that reads user-provided context')
+		async def read_context(context: TestContextInjection.FakeContext):
+			context.received.append('called')
+			return ActionResult(extracted_content='ok')
+
+		result = await registry.execute_action('read_context', {})
+		assert result.extracted_content == 'ok'
+		assert context.received == ['called'], 'action should receive the exact context object'
+
+	@pytest.mark.asyncio
+	async def test_context_not_injected_when_omitted(self):
+		from browser_use.agent.views import ActionResult
+		from browser_use.tools.registry.service import Registry
+
+		registry = Registry()
+
+		# Action that does not declare context must still work (extra kwarg filtered)
+		@registry.action('Action without context')
+		async def plain_action():
+			return ActionResult(extracted_content='no context')
+
+		# Action declaring optional context receives None when none was provided
+		@registry.action('Action with optional context')
+		async def optional_context_action(context: TestContextInjection.OtherContext | None = None):
+			assert context is None
+			return ActionResult(extracted_content='optional context ok')
+
+		assert (await registry.execute_action('plain_action', {})).extracted_content == 'no context'
+		assert (await registry.execute_action('optional_context_action', {})).extracted_content == 'optional context ok'
+
+	@pytest.mark.asyncio
+	async def test_tools_forwards_context_to_registry(self):
+		from browser_use.tools.service import Tools
+
+		context = self.FakeContext()
+		tools = Tools(context=context)
+		assert tools.context is context
+		assert tools.registry.context is context

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -7905,3 +7905,45 @@ def test_rust_history_surfaces_terminal_session_interrupted_message():
 	assert history.is_done() is False
 	assert history.errors() == ['Rust terminal session was interrupted: interrupted by send_input']
 	assert history.action_results()[-1].error == 'Rust terminal session was interrupted: interrupted by send_input'
+
+
+def test_beta_agent_multi_act_routes_custom_action_with_context():
+	"""Custom Python actions must receive the agent's context object.
+
+	Regression for Cubic review on PR #5355: the beta Agent previously serialized
+	all non-`done` actions to a Rust instruction, so a registered Python action
+	declaring `context` could never receive the object provided to `Agent(context=...)`.
+	"""
+	from browser_use.agent.views import ActionResult
+	from browser_use.beta import Agent
+
+	class LLM:
+		model = 'gpt-test'
+
+	class MyContext:
+		value = 'injected'
+
+	received: dict[str, Any] = {}
+
+	agent = Agent(
+		task='use tools',
+		llm=LLM(),
+		context=MyContext(),
+	)
+
+	@agent.tools.registry.action('use context')
+	async def use_context(context: MyContext) -> ActionResult:
+		received['context'] = context
+		return ActionResult(extracted_content=f'got {context.value}')
+
+	# Rebuild the action model now that the custom action is registered.
+	agent.ActionModel = agent.tools.registry.create_action_model()
+
+	# Build a payload action the way the model output would.
+	action = agent.ActionModel(use_context={})
+
+	results = asyncio.get_event_loop().run_until_complete(agent.multi_act([action]))
+
+	assert len(results) == 1
+	assert results[0].extracted_content == 'got injected'
+	assert received['context'] is agent.context

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -7920,7 +7920,7 @@ def test_rust_history_surfaces_terminal_session_interrupted_message():
 	assert history.action_results()[-1].error == 'Rust terminal session was interrupted: interrupted by send_input'
 
 
-def test_beta_agent_multi_act_routes_custom_action_with_context():
+async def test_beta_agent_multi_act_routes_custom_action_with_context():
 	"""Custom Python actions must receive the agent's context object.
 
 	Regression for Cubic review on PR #5355: the beta Agent previously serialized
@@ -7955,7 +7955,7 @@ def test_beta_agent_multi_act_routes_custom_action_with_context():
 	# Build a payload action the way the model output would.
 	action = agent.ActionModel(use_context={})
 
-	results = asyncio.get_event_loop().run_until_complete(agent.multi_act([action]))
+	results = await agent.multi_act([action])
 
 	assert len(results) == 1
 	assert results[0].extracted_content == 'got injected'

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -7918,3 +7918,45 @@ def test_rust_history_surfaces_terminal_session_interrupted_message():
 	assert history.is_done() is False
 	assert history.errors() == ['Rust terminal session was interrupted: interrupted by send_input']
 	assert history.action_results()[-1].error == 'Rust terminal session was interrupted: interrupted by send_input'
+
+
+def test_beta_agent_multi_act_routes_custom_action_with_context():
+	"""Custom Python actions must receive the agent's context object.
+
+	Regression for Cubic review on PR #5355: the beta Agent previously serialized
+	all non-`done` actions to a Rust instruction, so a registered Python action
+	declaring `context` could never receive the object provided to `Agent(context=...)`.
+	"""
+	from browser_use.agent.views import ActionResult
+	from browser_use.beta import Agent
+
+	class LLM:
+		model = 'gpt-test'
+
+	class MyContext:
+		value = 'injected'
+
+	received: dict[str, Any] = {}
+
+	agent = Agent(
+		task='use tools',
+		llm=LLM(),
+		context=MyContext(),
+	)
+
+	@agent.tools.registry.action('use context')
+	async def use_context(context: MyContext) -> ActionResult:
+		received['context'] = context
+		return ActionResult(extracted_content=f'got {context.value}')
+
+	# Rebuild the action model now that the custom action is registered.
+	agent.ActionModel = agent.tools.registry.create_action_model()
+
+	# Build a payload action the way the model output would.
+	action = agent.ActionModel(use_context={})
+
+	results = asyncio.get_event_loop().run_until_complete(agent.multi_act([action]))
+
+	assert len(results) == 1
+	assert results[0].extracted_content == 'got injected'
+	assert received['context'] is agent.context


### PR DESCRIPTION
## Summary

`Context` is declared as a TypeVar on `Agent`, `Tools`, and `Registry`, and `SpecialActionParameters` documents a `context` field that is supposed to be "passed down from `Agent(context=...)`" to every action — but the parameter never existed on any constructor and was never injected, so `Agent[...]` showed up as `Agent[Unknown, Unknown]` and actions declaring a `context` parameter could never receive it.

This PR makes the documented behavior real:

- `Agent.__init__` gains `context: Context | None = None` and stores `self.context`.
- `Tools.__init__` gains `context: Context | None = None` and forwards it to its `Registry`.
- `Registry.__init__` gains `context: Context | None = None`, stores `self.context`, and injects it into `special_context` in `execute_action`, so any action that declares a `context` parameter receives the exact object the caller provided.
- When a caller supplies their own `Tools`/`controller` instance, the Agent still applies its `context` onto that instance so the wiring holds regardless of how tools were constructed.
- The same `context` parameter is mirrored on the beta (Rust-backed) `Agent` and `_resolve_tools` for API parity.
- Actions that require `context` but get none now raise a clear error naming `Agent()`/`Tools()`.

## Example

```python
class MyContext:
    db: DatabaseConnection = ...

async def run():
    agent = Agent[MyContext, None](
        task='...',
        context=MyContext(...),
    )

    @agent.tools.registry.action('use my db')
    async def use_db(context: MyContext):
        rows = await context.db.query(...)
        return ActionResult(extracted_content='done')
```

## Test plan

- `tests/ci/infrastructure/test_registry_action_parameter_injection.py::TestContextInjection` — 3 new tests: action receives the exact context object; omitted context stays `None` and actions without a `context` param are unaffected; `Tools` forwards its context to the registry.
- End-to-end check: `Agent(context=...)` → `self.tools.registry.context` → action injection, including the custom-`Tools` path and beta `Agent` parity.
- `tests/ci/infrastructure` + `tests/ci/test_registry_empty_url_domain_filter.py`: 91 passed, 8 skipped (1 pre-existing Windows browser-navigation flake, passes in isolation).
- `uvx ruff@0.12.10 check` and `format --check` clean on all changed files (LF-normalized).

Closes #5188

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Threads user-provided context from `Agent(context=...)` through Tools and Registry so actions that declare a `context` parameter receive the same object. In the beta Agent, registered Python actions now execute locally via the Registry instead of being serialized to Rust, fixing the lost-context behavior and avoiding unconnected CDP client leaks.

- `Agent`, `Tools`, and `Registry` accept an optional `context` and forward it, including when callers supply custom Tools/controller instances.
- `Registry.execute_action` injects `context` into `special_context` and raises a clear error when an action requires context but none is provided.
- Beta `multi_act` dispatches registered Python actions through the local registry, merges their results with Rust action results, and only passes a `browser_session` when its CDP client is connected.
- Minor cleanup: normalized indentation and dropped a stale `noqa`.

<sup>Written for commit 101c69a00daa98753f75925f9ac6c97243cd0daf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

