### PR TITLE
fix(utils): stop redact_sensitive_string placeholder cascade

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -5,6 +5,7 @@ import platform
 import re
 import signal
 import time
+import uuid
 from collections.abc import Callable, Coroutine
 from fnmatch import fnmatch
 from functools import cache, wraps
@@ -74,9 +75,28 @@ def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]
 
 
 def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
-	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
-	for key, secret in sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True):
-		value = value.replace(secret, f'<secret>{key}</secret>')
+	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks.
+
+	Each secret is first replaced with a unique per-call sentinel and only restored to the
+	``<secret>{key}</secret>`` placeholder in a final pass. Because the sentinels are opaque
+	to every secret value, a secret that is a substring of the placeholder markup (e.g. a
+	value containing the word "secret") can never be re-matched inside an already-redacted
+	span, which previously produced corrupted, nested tags.
+	"""
+	if not sensitive_values:
+		return value
+
+	nonce = uuid.uuid4().hex
+	sentinels: dict[str, str] = {}
+	for i, (key, secret) in enumerate(sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True)):
+		if not secret:
+			continue
+		sentinel = f'\x00<redacted-{nonce}-{i}>{key}</redacted-{nonce}-{i}>\x00'
+		value = value.replace(secret, sentinel)
+		sentinels[sentinel] = f'<secret>{key}</secret>'
+
+	for sentinel, placeholder in sentinels.items():
+		value = value.replace(sentinel, placeholder)
 	return value
 
 

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -9,7 +9,7 @@ from browser_use.filesystem.file_system import FileSystem
 from browser_use.llm import SystemMessage, UserMessage
 from browser_use.llm.messages import ContentPartTextParam
 from browser_use.tools.registry.service import Registry
-from browser_use.utils import is_new_tab_page, match_url_with_domain_pattern
+from browser_use.utils import is_new_tab_page, match_url_with_domain_pattern, redact_sensitive_string
 
 
 class SensitiveParams(BaseModel):
@@ -588,3 +588,79 @@ def test_password_field_without_type_attribute():
 	attrs_str = DOMTreeSerializer._build_attributes_string(node, list(DEFAULT_INCLUDE_ATTRIBUTES), '')
 
 	assert value in attrs_str, 'Input without type attribute should preserve its value'
+
+
+# ─── Tests for redact_sensitive_string placeholder cascade ───────────────────
+
+
+def _assert_well_formed_placeholders(text: str) -> None:
+	"""Assert every <secret> tag is a well-formed, non-nested pair."""
+	import re
+
+	opens = [m.start() for m in re.finditer(r'<secret>', text)]
+	closes = [m.start() for m in re.finditer(r'</secret>', text)]
+	assert len(opens) == len(closes), f'Unbalanced placeholder tags in: {text!r}'
+	for open_pos, close_pos in zip(opens, closes):
+		assert open_pos < close_pos, f'Placeholder close before open in: {text!r}'
+		assert not any(open_pos < o < close_pos for o in opens), f'Nested placeholder in: {text!r}'
+
+
+def test_redact_sensitive_string_basic():
+	"""Sanity: plain secrets are masked once with well-formed placeholders."""
+	result = redact_sensitive_string('user john pw supersecret', {'user': 'john', 'pw': 'supersecret'})
+	assert result == 'user <secret>user</secret> pw <secret>pw</secret>'
+	_assert_well_formed_placeholders(result)
+
+
+def test_redact_sensitive_string_no_secrets():
+	"""Empty mapping leaves the value untouched."""
+	value = 'nothing sensitive here'
+	assert redact_sensitive_string(value, {}) == value
+
+
+def test_redact_sensitive_string_multiple_occurrences():
+	"""Every occurrence of a secret is masked."""
+	result = redact_sensitive_string('a tok b tok', {'t': 'tok'})
+	assert result == 'a <secret>t</secret> b <secret>t</secret>'
+	_assert_well_formed_placeholders(result)
+
+
+def test_redact_sensitive_string_secret_value_contains_secret_word():
+	"""GH-5248: a secret whose value contains 'secret' must not corrupt earlier placeholders."""
+	sensitive = {'api_key': 'secret-token-abc', 'db_pass': 'secret'}
+	value = 'key=secret-token-abc pass=secret'
+	result = redact_sensitive_string(value, sensitive)
+	assert result == 'key=<secret>api_key</secret> pass=<secret>db_pass</secret>'
+	_assert_well_formed_placeholders(result)
+
+
+def test_redact_sensitive_string_secret_is_placeholder_substring():
+	"""GH-5135: a shorter secret that is a substring of the placeholder markup must not cascade."""
+	sensitive = {'password': 'supersecret', 'type': 'secret'}
+	value = 'leaked supersecret token'
+	result = redact_sensitive_string(value, sensitive)
+	assert result == 'leaked <secret>password</secret> token'
+	_assert_well_formed_placeholders(result)
+
+
+def test_redact_sensitive_string_substring_secrets_both_real():
+	"""When the shorter secret also appears standalone, it is masked without touching the longer one."""
+	sensitive = {'full': 'supersecret', 'part': 'secret'}
+	result = redact_sensitive_string('x supersecret y secret z', sensitive)
+	assert result == 'x <secret>full</secret> y <secret>part</secret> z'
+	_assert_well_formed_placeholders(result)
+
+
+def test_redact_sensitive_string_longest_first_still_holds():
+	"""Longest-match-first behavior is preserved: the shorter substring is not masked inside the longer secret."""
+	sensitive = {'full': 'supersecret', 'part': 'secret'}
+	result = redact_sensitive_string('token=supersecret', sensitive)
+	assert result == 'token=<secret>full</secret>'
+	_assert_well_formed_placeholders(result)
+
+
+def test_redact_sensitive_string_skips_empty_secrets():
+	"""Empty secret values are ignored instead of corrupting the string."""
+	result = redact_sensitive_string('keep me', {'a': '', 'b': 'me'})
+	assert result == 'keep <secret>b</secret>'
+	_assert_well_formed_placeholders(result)


### PR DESCRIPTION
## Fix: `redact_sensitive_string` placeholder cascade corruption

Closes #5248 and #5135.

### Problem

`redact_sensitive_string` replaces sensitive values one secret at a time with
`str.replace`. When one secret's value contains the text of an already-emitted
`<secret>...</secret>` placeholder (e.g. a short secret like `"secret"` or
`"type"` that substring-matches another secret's placeholder), the placeholder
itself gets re-redacted on a later iteration, producing corrupted output like:

```text
key=<<secret>db_pass</secret>>api_key</<secret>db_pass</secret>> pass=<secret>db_pass</secret>
```

instead of:

```text
key=<secret>api_key</secret> pass=<secret>db_pass</secret>
```

Both #5248 and #5135 are the same root cause:
- #5248 repro: `{"api_key": "secret-token-abc", "db_pass": "secret"}` with value `"key=secret-token-abc pass=secret"`.
- #5135 repro: `{"password": "supersecret", "type": "secret"}` with value `"leaked supersecret token"` — `"type"` matches inside the placeholder text.

### Fix

A sentinel-based two-pass approach in `browser_use/utils.py`:

1. Iterate secrets longest-first (preserving the existing whole-string
   semantics — longer matches still win over substring collisions).
2. Replace each occurrence of a secret with a unique transient sentinel
   containing a `uuid4` nonce (control-char-wrapped, so it can never collide
   with real content or other placeholders).
3. In a final pass, restore every sentinel to its canonical `<secret>key</secret>`
   placeholder.

Empty secrets are skipped, matching `collect_sensitive_data_values` behavior.

### Tests

Added 8 tests in `tests/ci/security/test_sensitive_data.py`:

- `test_redact_sensitive_string_basic`
- `test_redact_sensitive_string_no_secrets`
- `test_redact_sensitive_string_multiple_occurrences`
- `test_redact_sensitive_string_secret_value_contains_secret_word` (GH-5248)
- `test_redact_sensitive_string_secret_is_placeholder_substring` (GH-5135)
- `test_redact_sensitive_string_substring_secrets_both_real`
- `test_redact_sensitive_string_longest_first_still_holds`
- `test_redact_sensitive_string_skips_empty_secrets`

Plus a `_assert_well_formed_placeholders` helper that verifies placeholders are
balanced and non-nested.

### Verification

- Targeted run: 8/8 passed.
- `tests/ci/security/` + `tests/ci/infrastructure/test_url_shortening.py`: 111 passed.
- `uvx ruff@0.12.10 check` — all checks passed; `format --check` — clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes redaction placeholder cascade in redact_sensitive_string. Replaces secrets with unique sentinels before emitting <secret>key</secret> placeholders to prevent corrupted tags while preserving longest-first behavior.

- **Bug Fixes**
  - Implemented a two-pass sentinel approach with a per-call nonce to avoid re-redaction and substring collisions.
  - Skips empty secrets and retains longest-first ordering.

- **Tests**
  - Added 8 tests covering cascade edge cases, multiple occurrences, empty secrets, and placeholder well-formedness.

<sup>Written for commit 6568307697f8eb176ff8a5e87781639caff6b990. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

