### PR TITLE
fix(cli): restore browser-use.com/cli/install.sh bootstrap installer

### DIFF
--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -131,6 +131,14 @@ ensure_uv() {
 	fi
 }
 
+ensure_uv_tool_bin_on_path() {
+	local uv_tool_bin
+	uv_tool_bin=$(uv tool dir --bin 2>/dev/null || true)
+	if [ -n "$uv_tool_bin" ]; then
+		export PATH="$uv_tool_bin:$PATH"
+	fi
+}
+
 # =============================================================================
 # browser-use installation
 # =============================================================================
@@ -145,10 +153,12 @@ install_browser_use() {
 		uv tool install --upgrade "$PACKAGE"
 	fi
 
+	ensure_uv_tool_bin_on_path
+
 	if command -v browser-use >/dev/null 2>&1; then
 		log_success "browser-use installed ($(browser-use --version 2>/dev/null || echo 'version unknown'))"
 	else
-		log_warn "browser-use installed, but not on PATH. Add $UV_BIN_DIR to your PATH and re-open your shell."
+		log_warn "browser-use installed, but not on PATH. Add the uv tool bin directory to your PATH and re-open your shell."
 		export PATH="$UV_BIN_DIR:$PATH"
 	fi
 }
@@ -183,7 +193,7 @@ print_next_steps() {
 	echo "      print(page_info())"
 	echo "      PY"
 	echo ""
-	echo "  Recommended:    browser-use skill install"
+	echo "  Recommended:    browser-use skill install${BROWSER_USE_BRANCH:+ --no-install}"
 	echo "  Docs: https://github.com/browser-use/browser-use"
 	echo "  The 'browser-use' command may require a fresh terminal if your"
 	echo "  PATH was just updated."

--- a/browser_use/skill_cli/install.sh
+++ b/browser_use/skill_cli/install.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Browser-Use Bootstrap Installer
+#
+# Usage:
+#   curl -fsSL https://browser-use.com/cli/install.sh | bash
+#
+# For development testing against a specific branch:
+#   curl -fsSL <raw-url> | BROWSER_USE_BRANCH=<branch-name> bash
+#
+# This installer sets up the current browser-use CLI (installed via uv) and
+# downloads Chromium, so the `browser-use` command works out of the box.
+
+set -euo pipefail
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+UV_INSTALL_URL="https://astral.sh/uv/install.sh"
+UV_BIN_DIR="$HOME/.local/bin"
+PACKAGE="browser-use"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# =============================================================================
+# Logging functions
+# =============================================================================
+
+log_info() {
+	echo -e "${BLUE}i${NC} $1"
+}
+
+log_success() {
+	echo -e "${GREEN}ok${NC} $1"
+}
+
+log_warn() {
+	echo -e "${YELLOW}!${NC} $1"
+}
+
+log_error() {
+	echo -e "${RED}x${NC} $1"
+}
+
+# =============================================================================
+# Argument parsing
+# =============================================================================
+
+parse_args() {
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		--help | -h)
+			echo "Browser-Use Installer"
+			echo ""
+			echo "Usage: install.sh [OPTIONS]"
+			echo ""
+			echo "Options:"
+			echo "  --help, -h        Show this help"
+			echo ""
+			echo "Installs uv (if needed), the browser-use CLI, and Chromium."
+			echo ""
+			echo "Environment:"
+			echo "  BROWSER_USE_BRANCH  Install from a specific git branch instead of PyPI"
+			exit 0
+			;;
+		*)
+			log_warn "Unknown argument: $1 (ignored)"
+			shift
+			;;
+		esac
+	done
+}
+
+# =============================================================================
+# Platform detection
+# =============================================================================
+
+detect_platform() {
+	local os
+	os=$(uname -s | tr '[:upper:]' '[:lower:]')
+
+	case "$os" in
+	linux*)
+		PLATFORM="linux"
+		;;
+	darwin*)
+		PLATFORM="macos"
+		;;
+	msys* | mingw* | cygwin*)
+		PLATFORM="windows"
+		;;
+	*)
+		log_error "Unsupported OS: $os"
+		exit 1
+		;;
+	esac
+
+	log_info "Detected platform: $PLATFORM"
+}
+
+# =============================================================================
+# uv management
+# =============================================================================
+
+ensure_uv() {
+	if command -v uv >/dev/null 2>&1; then
+		log_success "uv found ($(uv --version))"
+		return 0
+	fi
+
+	log_info "uv not found. Installing uv..."
+	if ! command -v curl >/dev/null 2>&1; then
+		log_error "curl is required to install uv. Install curl first and re-run this script."
+		exit 1
+	fi
+
+	curl -LsSf "$UV_INSTALL_URL" | sh
+
+	if [ -x "$UV_BIN_DIR/uv" ]; then
+		export PATH="$UV_BIN_DIR:$PATH"
+		log_success "uv installed ($(uv --version))"
+	else
+		log_error "uv installation failed. Please install it manually: https://docs.astral.sh/uv/"
+		exit 1
+	fi
+}
+
+# =============================================================================
+# browser-use installation
+# =============================================================================
+
+install_browser_use() {
+	log_info "Installing $PACKAGE..."
+
+	if [ -n "${BROWSER_USE_BRANCH:-}" ]; then
+		log_info "Installing from branch: $BROWSER_USE_BRANCH"
+		uv tool install --upgrade --from "git+https://github.com/browser-use/browser-use@${BROWSER_USE_BRANCH}" "$PACKAGE"
+	else
+		uv tool install --upgrade "$PACKAGE"
+	fi
+
+	if command -v browser-use >/dev/null 2>&1; then
+		log_success "browser-use installed ($(browser-use --version 2>/dev/null || echo 'version unknown'))"
+	else
+		log_warn "browser-use installed, but not on PATH. Add $UV_BIN_DIR to your PATH and re-open your shell."
+		export PATH="$UV_BIN_DIR:$PATH"
+	fi
+}
+
+# =============================================================================
+# Chromium installation
+# =============================================================================
+
+install_chromium() {
+	log_info "Installing Chromium browser and system dependencies..."
+	if browser-use install; then
+		log_success "Chromium installed."
+	else
+		log_warn "Chromium installation failed. Run 'browser-use install' manually to retry."
+	fi
+}
+
+# =============================================================================
+# Next steps
+# =============================================================================
+
+print_next_steps() {
+	echo ""
+	echo "================================================================"
+	echo "  Browser-Use is ready!"
+	echo "================================================================"
+	echo ""
+	echo "  Health check:   browser-use --doctor"
+	echo "  Try it out:"
+	echo "      browser-use <<'PY'"
+	echo "      new_tab(\"https://news.ycombinator.com\")"
+	echo "      print(page_info())"
+	echo "      PY"
+	echo ""
+	echo "  Recommended:    browser-use skill install"
+	echo "  Docs: https://github.com/browser-use/browser-use"
+	echo "  The 'browser-use' command may require a fresh terminal if your"
+	echo "  PATH was just updated."
+	echo "================================================================"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	parse_args "$@"
+	detect_platform
+	ensure_uv
+	install_browser_use
+	install_chromium
+	print_next_steps
+}
+
+main "$@"


### PR DESCRIPTION
## What

Restores a working bootstrap installer at `browser_use/skill_cli/install.sh`, the exact file `https://browser-use.com/cli/install.sh` redirects to. This fixes the 404 reported in #5131 without any website-side change:

```
curl -fsSL https://browser-use.com/cli/install.sh | bash
```

## Root cause

`browser-use.com/cli/install.sh` is a redirect to `https://raw.githubusercontent.com/browser-use/browser-use/main/browser_use/skill_cli/install.sh`. Commit `bfaad696b` ("remove old CLI", 2026-06-29) deleted the entire `browser_use/skill_cli/` package — including `install.sh` — so the redirect target now 404s. The sibling URL `/terminal/install.sh` still works because it points at the separate `browser-use/terminal` repo, which installs a different product (`browser-use-terminal`).

Verified URL chain today:
- `https://browser-use.com/cli/install.sh` → 404 (redirect target missing)
- `https://browser-use.com/terminal/install.sh` → 200 (lives in `browser-use/terminal`)

## What the restored script does

The old script was a 549-line installer for the removed skill CLI. The new one is a small, modern bootstrap for the **current** CLI:

1. Detects platform (linux/macos/windows-git-bash)
2. Ensures `uv` is installed (astral installer, `~/.local/bin` added to session PATH)
3. Installs/upgrades the `browser-use` CLI via `uv tool install --upgrade browser-use`
4. Runs `browser-use install` to fetch Chromium (warns, doesn't abort, if it fails)
5. Prints next steps (`browser-use --doctor`, stdin-python quickstart, `browser-use skill install`)

`BROWSER_USE_BRANCH=<branch>` is still supported for testing the installer against a git branch, mirroring the old script's dev workflow.

## Testing

- `bash -n` syntax check passes
- `bash install.sh --help` exits 0
- Full end-to-end run on Windows Git Bash: uv found → `uv tool install --upgrade browser-use` → `browser-use install` (Chromium) → next steps printed

## Related observation (not changed here)

`skills/remote-browser/SKILL.md` still links to `browser_use/skill_cli/README.md`, which the same deletion removed. Happy to fix that in a follow-up if desired.

Fixes #5131

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the bootstrap installer at `browser_use/skill_cli/install.sh` that `https://browser-use.com/cli/install.sh` redirects to, fixing the 404 caused by the old CLI installer's deletion.

- Ensures `uv` is present and adds its tool bin directory to PATH via `uv tool dir --bin`.
- Installs or upgrades `browser-use` with `uv tool install --upgrade` and sets the script executable.
- Runs `browser-use install` to fetch Chromium, supports `BROWSER_USE_BRANCH`, and recommends `browser-use skill install --no-install` so branch builds aren't replaced.

<sup>Written for commit a3774b15e94b16cb8122bbc39e65cc321d1cc680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

