### PR TITLE
fix(mcp): keep browser launch working when downloads dir cannot be created

### DIFF
--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -35,6 +35,23 @@ if TYPE_CHECKING:
 	pass
 
 
+def _ensure_downloads_directory(downloads_path: str | Path) -> Path | None:
+	"""Ensure the downloads directory exists, or return None if it cannot be created.
+
+	On some platforms (e.g. Windows virtualized/redirected folders such as
+	OneDrive-backed Downloads), ``Path.mkdir(parents=True, exist_ok=True)``
+	raises ``OSError`` even though the parent reports as an existing directory.
+	Callers should treat a ``None`` result as a non-fatal condition and skip
+	download tracking instead of failing the browser launch.
+	"""
+	try:
+		expanded_path = Path(downloads_path).expanduser().resolve()
+		expanded_path.mkdir(parents=True, exist_ok=True)
+		return expanded_path
+	except OSError:
+		return None
+
+
 _NETWORK_DOWNLOAD_FILE_EXTENSIONS = {
 	'pdf',
 	'doc',
@@ -186,8 +203,12 @@ class DownloadsWatchdog(BaseWatchdog):
 		# Ensure downloads directory exists
 		downloads_path = self.browser_session.browser_profile.downloads_path
 		if downloads_path:
-			expanded_path = Path(downloads_path).expanduser().resolve()
-			expanded_path.mkdir(parents=True, exist_ok=True)
+			expanded_path = _ensure_downloads_directory(downloads_path)
+			if expanded_path is None:
+				self.logger.warning(
+					f'[DownloadsWatchdog] Could not create downloads directory, skipping download tracking: {downloads_path}'
+				)
+				return
 			self.logger.debug(f'[DownloadsWatchdog] Ensured downloads directory exists: {expanded_path}')
 
 			# Capture initial files to detect new downloads reliably

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import logging
 import os
 import re
 import tempfile
@@ -443,25 +442,21 @@ class DownloadsWatchdog(BaseWatchdog):
 						self.logger.debug('[DownloadsWatchdog] No filePath in progress event; detecting via filesystem')
 						downloads_dir = self._resolved_downloads_dir
 						if downloads_dir is not None and downloads_dir.exists():
-								for f in downloads_dir.iterdir():
-									if (
-										f.is_file()
-										and not f.name.startswith('.')
-										and f.name not in self._initial_downloads_snapshot
-									):
-										# Check file has content before processing
-										if f.stat().st_size > 4:
-											# Found a new file! Add to snapshot immediately to prevent duplicate detection
-											self._initial_downloads_snapshot.add(f.name)
-											self.logger.debug(f'[DownloadsWatchdog] Detected new download: {f.name}')
-											self._track_download(str(f))
-											# Mark as handled
-											try:
-												if guid in self._cdp_downloads_info:
-													self._cdp_downloads_info[guid]['handled'] = True
-											except (KeyError, AttributeError):
-												pass
-											break
+							for f in downloads_dir.iterdir():
+								if f.is_file() and not f.name.startswith('.') and f.name not in self._initial_downloads_snapshot:
+									# Check file has content before processing
+									if f.stat().st_size > 4:
+										# Found a new file! Add to snapshot immediately to prevent duplicate detection
+										self._initial_downloads_snapshot.add(f.name)
+										self.logger.debug(f'[DownloadsWatchdog] Detected new download: {f.name}')
+										self._track_download(str(f))
+										# Mark as handled
+										try:
+											if guid in self._cdp_downloads_info:
+												self._cdp_downloads_info[guid]['handled'] = True
+										except (KeyError, AttributeError):
+											pass
+										break
 				else:
 					# Remote browser: do not touch local filesystem. Fallback to downloadPath+suggestedFilename
 					info = self._cdp_downloads_info.get(guid, {})

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import logging
 import os
 import re
 import tempfile
@@ -154,6 +155,11 @@ class DownloadsWatchdog(BaseWatchdog):
 	_network_monitored_targets: set[str] = PrivateAttr(default_factory=set)  # Track targets with network monitoring enabled
 	_detected_downloads: set[str] = PrivateAttr(default_factory=set)  # Track detected download URLs to avoid duplicates
 	_network_callback_registered: bool = PrivateAttr(default=False)  # Track if global network callback is registered
+	# Resolved, writable downloads directory for this session, or None if it
+	# cannot be created (e.g. OneDrive-redirected virtualized folder on Windows).
+	# Set once in on_BrowserLaunchEvent; all download paths consult it so a
+	# directory that failed at launch is not re-attempted on every download.
+	_resolved_downloads_dir: Path | None = PrivateAttr(default=None)
 
 	# Direct callback support for download waiting (bypasses event bus for synchronization)
 	_download_start_callbacks: list[Any] = PrivateAttr(default_factory=list)  # Callbacks for download start
@@ -205,10 +211,15 @@ class DownloadsWatchdog(BaseWatchdog):
 		if downloads_path:
 			expanded_path = _ensure_downloads_directory(downloads_path)
 			if expanded_path is None:
+				# Directory cannot be created (virtualized/redirected on Windows).
+				# Cache None so every downstream download path degrades gracefully
+				# instead of re-attempting the same failing mkdir on each download.
+				self._resolved_downloads_dir = None
 				self.logger.warning(
-					f'[DownloadsWatchdog] Could not create downloads directory, skipping download tracking: {downloads_path}'
+					f'[DownloadsWatchdog] Could not create downloads directory, download tracking disabled: {downloads_path}'
 				)
 				return
+			self._resolved_downloads_dir = expanded_path
 			self.logger.debug(f'[DownloadsWatchdog] Ensured downloads directory exists: {expanded_path}')
 
 			# Capture initial files to detect new downloads reliably
@@ -430,10 +441,8 @@ class DownloadsWatchdog(BaseWatchdog):
 					else:
 						# No filePath provided - detect by comparing with initial snapshot
 						self.logger.debug('[DownloadsWatchdog] No filePath in progress event; detecting via filesystem')
-						downloads_path = self.browser_session.browser_profile.downloads_path
-						if downloads_path:
-							downloads_dir = Path(downloads_path).expanduser().resolve()
-							if downloads_dir.exists():
+						downloads_dir = self._resolved_downloads_dir
+						if downloads_dir is not None and downloads_dir.exists():
 								for f in downloads_dir.iterdir():
 									if (
 										f.is_file()
@@ -503,6 +512,12 @@ class DownloadsWatchdog(BaseWatchdog):
 				# logger.info(f'[DownloadsWatchdog] No downloads path configured, skipping target: {target_id}')
 				return  # No downloads path configured
 
+			# If the directory could not be created at launch, don't configure
+			# CDP download behavior with an unusable path.
+			if self._resolved_downloads_dir is None:
+				self.logger.debug('[DownloadsWatchdog] Downloads directory unavailable, skipping CDP download setup')
+				return
+
 			# Check if we already have a download listener on this session
 			# to prevent duplicate listeners from being added
 			# Note: Since download listeners are set up once per browser session, not per target,
@@ -519,12 +534,9 @@ class DownloadsWatchdog(BaseWatchdog):
 				cdp_client = self.browser_session.cdp_client
 
 				# Set download behavior to allow downloads and enable events
-				downloads_path = self.browser_session.browser_profile.downloads_path
-				if not downloads_path:
-					self.logger.warning('[DownloadsWatchdog] No downloads path configured, skipping CDP download setup')
-					return
-				# Ensure path is properly expanded (~ -> absolute path)
-				expanded_downloads_path = Path(downloads_path).expanduser().resolve()
+				# Use the session-resolved path so a virtualized/redirected
+				# directory that failed to materialize is never passed to CDP.
+				expanded_downloads_path = self._resolved_downloads_dir
 				await cdp_client.send.Browser.setDownloadBehavior(
 					params={
 						'behavior': 'allow',
@@ -799,8 +811,13 @@ class DownloadsWatchdog(BaseWatchdog):
 					else:
 						filename = 'download'
 
-			# Ensure downloads directory exists
-			downloads_dir = str(self.browser_session.browser_profile.downloads_path)
+			# Use the session-resolved downloads directory. If it could not be
+			# created (virtualized/redirected folder), skip the download rather
+			# than re-attempting mkdir on every request.
+			downloads_dir = str(self._resolved_downloads_dir) if self._resolved_downloads_dir else None
+			if not downloads_dir:
+				self.logger.warning('[DownloadsWatchdog] Downloads directory unavailable, skipping download')
+				return None
 			os.makedirs(downloads_dir, exist_ok=True)
 
 			# Generate unique filename if file exists
@@ -1363,7 +1380,10 @@ class DownloadsWatchdog(BaseWatchdog):
 				return existing_path
 
 			# Generate unique filename if file exists from previous run
-			downloads_dir = str(self.browser_session.browser_profile.downloads_path)
+			downloads_dir = str(self._resolved_downloads_dir) if self._resolved_downloads_dir else None
+			if not downloads_dir:
+				self.logger.warning('[DownloadsWatchdog] Downloads directory unavailable, cannot save PDF')
+				return None
 			os.makedirs(downloads_dir, exist_ok=True)
 			final_filename = pdf_filename
 			existing_files = os.listdir(downloads_dir)
@@ -1426,7 +1446,10 @@ class DownloadsWatchdog(BaseWatchdog):
 
 				if download_result and download_result.get('data') and len(download_result['data']) > 0:
 					# Ensure downloads directory exists
-					downloads_dir = str(self.browser_session.browser_profile.downloads_path)
+					downloads_dir = str(self._resolved_downloads_dir) if self._resolved_downloads_dir else None
+					if not downloads_dir:
+						self.logger.error('[DownloadsWatchdog] Downloads directory unavailable, cannot save PDF')
+						return None
 					os.makedirs(downloads_dir, exist_ok=True)
 					download_path = os.path.join(downloads_dir, final_filename)
 					if not self._is_path_contained(download_path, downloads_dir):

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -590,7 +590,7 @@ class BrowserUseServer:
 
 		# Merge profile config with defaults and overrides
 		profile_data = {
-			'downloads_path': str(Path.home() / 'Downloads' / 'browser-use-mcp'),
+			'downloads_path': str(Path.home() / '.browser-use-mcp' / 'downloads'),
 			'wait_between_actions': 0.5,
 			'keep_alive': True,
 			'user_data_dir': '~/.config/browseruse/profiles/default',

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -597,7 +597,7 @@ class BrowserUseServer:
 
 		# Merge profile config with defaults and overrides
 		profile_data = {
-			'downloads_path': str(Path.home() / 'Downloads' / 'browser-use-mcp'),
+			'downloads_path': str(Path.home() / '.browser-use-mcp' / 'downloads'),
 			'wait_between_actions': 0.5,
 			'keep_alive': True,
 			'user_data_dir': '~/.config/browseruse/profiles/default',

--- a/tests/ci/test_downloads_dir_unavailable.py
+++ b/tests/ci/test_downloads_dir_unavailable.py
@@ -1,0 +1,110 @@
+"""Regression test for downloads when the directory cannot be created.
+
+On some platforms (virtualized/redirected folders such as OneDrive-backed
+Downloads on Windows) ``Path.mkdir`` raises ``OSError`` even though the parent
+reports as existing. PR #5358 originally only skipped the initial snapshot
+capture in that case; CDP setup, ``download_file_from_url``, and
+``trigger_pdf_download`` still used the unusable path and re-attempted
+``os.makedirs`` on every download.
+
+This test drives ``DownloadsWatchdog`` with a broken directory and asserts that
+downloads degrade cleanly (return None) instead of raising or repeatedly
+touching the filesystem.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from browser_use.browser.watchdogs.downloads_watchdog import DownloadsWatchdog
+
+
+class _FakeBrowserProfile:
+    """Browser profile whose downloads directory raises on mkdir."""
+
+    downloads_path = '\\\\\\nonsense\\\\uncreatable\\\\downloads'
+    auto_download_pdfs = False
+
+
+def _make_broken_watchdog() -> tuple[DownloadsWatchdog, list[str]]:
+    """Build a watchdog whose resolved downloads dir is None (launch failed)."""
+    mkdir_calls: list[str] = []
+
+    browser_session = SimpleNamespace(
+        logger=SimpleNamespace(warning=lambda *a, **k: None, debug=lambda *a, **k: None, error=lambda *a, **k: None),
+        is_local=True,
+        id='broken-session-0001',
+        browser_profile=_FakeBrowserProfile(),
+        cdp_client=SimpleNamespace(send=AsyncMock()),
+        session_manager=None,
+    )
+    event_bus = SimpleNamespace(dispatch=lambda *a, **k: None)
+    wd = DownloadsWatchdog.model_construct(browser_session=browser_session, event_bus=event_bus)
+
+    # Record any os.makedirs attempts so we can assert none happened.
+    real_makedirs = __import__('os').makedirs
+
+    def tracking_makedirs(path: str, exist_ok: bool = False) -> None:
+        mkdir_calls.append(str(path))
+        return real_makedirs(path, exist_ok=exist_ok)
+
+    return wd, mkdir_calls
+
+
+@pytest.mark.asyncio
+async def test_download_file_from_url_skips_when_dir_unavailable(tmp_path) -> None:
+    wd, mkdir_calls = _make_broken_watchdog()
+    assert wd._resolved_downloads_dir is None
+
+    # Simulate on_BrowserLaunchEvent having failed to create the directory.
+    real_makedirs = __import__('os').makedirs
+
+    def tracking_makedirs(path: str, exist_ok: bool = False) -> None:
+        mkdir_calls.append(str(path))
+        return real_makedirs(path, exist_ok=exist_ok)
+
+    with (
+        patch(
+            'browser_use.browser.watchdogs.downloads_watchdog._ensure_downloads_directory',
+            return_value=None,
+        ),
+        patch('os.makedirs', side_effect=tracking_makedirs),
+    ):
+        await wd.on_BrowserLaunchEvent(SimpleNamespace())
+        assert wd._resolved_downloads_dir is None
+
+        result = await wd.download_file_from_url(
+            url='https://example.com/report.pdf',
+            target_id='FAKE_TARGET',
+            content_type='application/pdf',
+            suggested_filename='report.pdf',
+        )
+
+    assert result is None
+    assert mkdir_calls == [], f'os.makedirs should not be called when directory unavailable: {mkdir_calls}'
+
+
+@pytest.mark.asyncio
+async def test_attach_to_target_skips_cdp_setup_when_dir_unavailable(tmp_path) -> None:
+    wd, _ = _make_broken_watchdog()
+
+    # Simulate on_BrowserLaunchEvent having failed to create the directory.
+    with patch(
+        'browser_use.browser.watchdogs.downloads_watchdog._ensure_downloads_directory',
+        return_value=None,
+    ):
+        await wd.on_BrowserLaunchEvent(SimpleNamespace())
+
+    assert wd._resolved_downloads_dir is None
+
+    # attach_to_target must not configure CDP with the broken path.
+    await wd.attach_to_target('FAKE_TARGET')
+
+    set_download_behavior = wd.browser_session.cdp_client.send.Browser.setDownloadBehavior
+    set_download_behavior.assert_not_called()
+    assert wd._download_cdp_session_setup is False

--- a/tests/ci/test_downloads_dir_unavailable.py
+++ b/tests/ci/test_downloads_dir_unavailable.py
@@ -14,97 +14,97 @@ touching the filesystem.
 
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from browser_use.browser.events import BrowserLaunchEvent
 from browser_use.browser.watchdogs.downloads_watchdog import DownloadsWatchdog
 
 
 class _FakeBrowserProfile:
-    """Browser profile whose downloads directory raises on mkdir."""
+	"""Browser profile whose downloads directory raises on mkdir."""
 
-    downloads_path = '\\\\\\nonsense\\\\uncreatable\\\\downloads'
-    auto_download_pdfs = False
+	downloads_path = '\\\\\\nonsense\\\\uncreatable\\\\downloads'
+	auto_download_pdfs = False
 
 
 def _make_broken_watchdog() -> tuple[DownloadsWatchdog, list[str]]:
-    """Build a watchdog whose resolved downloads dir is None (launch failed)."""
-    mkdir_calls: list[str] = []
+	"""Build a watchdog whose resolved downloads dir is None (launch failed)."""
+	mkdir_calls: list[str] = []
 
-    browser_session = SimpleNamespace(
-        logger=SimpleNamespace(warning=lambda *a, **k: None, debug=lambda *a, **k: None, error=lambda *a, **k: None),
-        is_local=True,
-        id='broken-session-0001',
-        browser_profile=_FakeBrowserProfile(),
-        cdp_client=SimpleNamespace(send=AsyncMock()),
-        session_manager=None,
-    )
-    event_bus = SimpleNamespace(dispatch=lambda *a, **k: None)
-    wd = DownloadsWatchdog.model_construct(browser_session=browser_session, event_bus=event_bus)
+	browser_session = SimpleNamespace(
+		logger=SimpleNamespace(warning=lambda *a, **k: None, debug=lambda *a, **k: None, error=lambda *a, **k: None),
+		is_local=True,
+		id='broken-session-0001',
+		browser_profile=_FakeBrowserProfile(),
+		cdp_client=SimpleNamespace(send=AsyncMock()),
+		session_manager=None,
+	)
+	event_bus = SimpleNamespace(dispatch=lambda *a, **k: None)
+	wd = DownloadsWatchdog.model_construct(browser_session=browser_session, event_bus=event_bus)
 
-    # Record any os.makedirs attempts so we can assert none happened.
-    real_makedirs = __import__('os').makedirs
+	# Record any os.makedirs attempts so we can assert none happened.
+	real_makedirs = __import__('os').makedirs
 
-    def tracking_makedirs(path: str, exist_ok: bool = False) -> None:
-        mkdir_calls.append(str(path))
-        return real_makedirs(path, exist_ok=exist_ok)
+	def tracking_makedirs(path: str, exist_ok: bool = False) -> None:
+		mkdir_calls.append(str(path))
+		return real_makedirs(path, exist_ok=exist_ok)
 
-    return wd, mkdir_calls
+	return wd, mkdir_calls
 
 
 @pytest.mark.asyncio
 async def test_download_file_from_url_skips_when_dir_unavailable(tmp_path) -> None:
-    wd, mkdir_calls = _make_broken_watchdog()
-    assert wd._resolved_downloads_dir is None
+	wd, mkdir_calls = _make_broken_watchdog()
+	assert wd._resolved_downloads_dir is None
 
-    # Simulate on_BrowserLaunchEvent having failed to create the directory.
-    real_makedirs = __import__('os').makedirs
+	# Simulate on_BrowserLaunchEvent having failed to create the directory.
+	real_makedirs = __import__('os').makedirs
 
-    def tracking_makedirs(path: str, exist_ok: bool = False) -> None:
-        mkdir_calls.append(str(path))
-        return real_makedirs(path, exist_ok=exist_ok)
+	def tracking_makedirs(path: str, exist_ok: bool = False) -> None:
+		mkdir_calls.append(str(path))
+		return real_makedirs(path, exist_ok=exist_ok)
 
-    with (
-        patch(
-            'browser_use.browser.watchdogs.downloads_watchdog._ensure_downloads_directory',
-            return_value=None,
-        ),
-        patch('os.makedirs', side_effect=tracking_makedirs),
-    ):
-        await wd.on_BrowserLaunchEvent(SimpleNamespace())
-        assert wd._resolved_downloads_dir is None
+	with (
+		patch(
+			'browser_use.browser.watchdogs.downloads_watchdog._ensure_downloads_directory',
+			return_value=None,
+		),
+		patch('os.makedirs', side_effect=tracking_makedirs),
+	):
+		await wd.on_BrowserLaunchEvent(BrowserLaunchEvent())
+		assert wd._resolved_downloads_dir is None
 
-        result = await wd.download_file_from_url(
-            url='https://example.com/report.pdf',
-            target_id='FAKE_TARGET',
-            content_type='application/pdf',
-            suggested_filename='report.pdf',
-        )
+		result = await wd.download_file_from_url(
+			url='https://example.com/report.pdf',
+			target_id='FAKE_TARGET',
+			content_type='application/pdf',
+			suggested_filename='report.pdf',
+		)
 
-    assert result is None
-    assert mkdir_calls == [], f'os.makedirs should not be called when directory unavailable: {mkdir_calls}'
+	assert result is None
+	assert mkdir_calls == [], f'os.makedirs should not be called when directory unavailable: {mkdir_calls}'
 
 
 @pytest.mark.asyncio
 async def test_attach_to_target_skips_cdp_setup_when_dir_unavailable(tmp_path) -> None:
-    wd, _ = _make_broken_watchdog()
+	wd, _ = _make_broken_watchdog()
 
-    # Simulate on_BrowserLaunchEvent having failed to create the directory.
-    with patch(
-        'browser_use.browser.watchdogs.downloads_watchdog._ensure_downloads_directory',
-        return_value=None,
-    ):
-        await wd.on_BrowserLaunchEvent(SimpleNamespace())
+	# Simulate on_BrowserLaunchEvent having failed to create the directory.
+	with patch(
+		'browser_use.browser.watchdogs.downloads_watchdog._ensure_downloads_directory',
+		return_value=None,
+	):
+		await wd.on_BrowserLaunchEvent(BrowserLaunchEvent())
 
-    assert wd._resolved_downloads_dir is None
+	assert wd._resolved_downloads_dir is None
 
-    # attach_to_target must not configure CDP with the broken path.
-    await wd.attach_to_target('FAKE_TARGET')
+	# attach_to_target must not configure CDP with the broken path.
+	await wd.attach_to_target('FAKE_TARGET')
 
-    set_download_behavior = wd.browser_session.cdp_client.send.Browser.setDownloadBehavior
-    set_download_behavior.assert_not_called()
-    assert wd._download_cdp_session_setup is False
+	set_download_behavior = cast(Any, wd.browser_session.cdp_client.send).Browser.setDownloadBehavior
+	set_download_behavior.assert_not_called()
+	assert wd._download_cdp_session_setup is False

--- a/tests/ci/test_downloads_watchdog.py
+++ b/tests/ci/test_downloads_watchdog.py
@@ -1,4 +1,7 @@
-from browser_use.browser.watchdogs.downloads_watchdog import _should_auto_download_network_response
+from browser_use.browser.watchdogs.downloads_watchdog import (
+	_ensure_downloads_directory,
+	_should_auto_download_network_response,
+)
 
 
 def test_downloads_watchdog_skips_generic_text_attachment_without_file_url():
@@ -49,3 +52,28 @@ def test_downloads_watchdog_keeps_attachment_without_known_extension():
 		is_download_attachment=True,
 		suggested_filename='statement',
 	)
+
+
+def test_ensure_downloads_directory_creates_missing_dir(tmp_path):
+	downloads_dir = tmp_path / 'downloads' / 'nested'
+	result = _ensure_downloads_directory(downloads_dir)
+	assert result == downloads_dir.resolve()
+	assert downloads_dir.is_dir()
+
+
+def test_ensure_downloads_directory_accepts_existing_dir(tmp_path):
+	downloads_dir = tmp_path / 'downloads'
+	downloads_dir.mkdir()
+	result = _ensure_downloads_directory(downloads_dir)
+	assert result == downloads_dir.resolve()
+	assert downloads_dir.is_dir()
+
+
+def test_ensure_downloads_directory_returns_none_when_uncreatable(tmp_path):
+	# Parent path is occupied by a regular file, so no directory tree can be
+	# created under it (mirrors Windows virtualized folders that reject
+	# child creation with OSError despite parents=True).
+	blocker = tmp_path / 'blocker'
+	blocker.write_text('not a directory')
+	result = _ensure_downloads_directory(blocker / 'sub' / 'downloads')
+	assert result is None

--- a/tests/ci/test_remote_download_complete_callback.py
+++ b/tests/ci/test_remote_download_complete_callback.py
@@ -69,7 +69,11 @@ def _make_watchdog(tmp_path) -> tuple[DownloadsWatchdog, _ProgressCapture]:
 	# mechanism here, so stub dispatch() to a no-op.
 	event_bus = SimpleNamespace(dispatch=lambda *a, **k: None)
 
-	wd = DownloadsWatchdog.model_construct(browser_session=browser_session, event_bus=event_bus)
+	wd = DownloadsWatchdog.model_construct(
+		browser_session=browser_session,
+		event_bus=event_bus,
+		_resolved_downloads_dir=tmp_path,
+	)
 	return wd, progress_capture
 
 


### PR DESCRIPTION
## What

Fixes #4580 — `browser_navigate` (and every other MCP tool) failed with `Error: [WinError 2] The system cannot find the file specified: 'C:\Users\<user>\Downloads\browser-use-mcp'` on Windows.

## Why

The MCP server defaults `downloads_path` to `~/Downloads/browser-use-mcp`. On many Windows machines `Downloads` is a **virtualized/redirected Known Folder** (OneDrive "known folder move" or similar): `os.path.isdir()` returns `True`, the folder is readable, but the OS **rejects creating entries inside it** — `mkdir(parents=True, exist_ok=True)` raises `FileNotFoundError [WinError 2]` even though the parent exists.

The downloads watchdog did:

```python
expanded_path = Path(downloads_path).expanduser().resolve()
expanded_path.mkdir(parents=True, exist_ok=True)  # raises on Windows virtualized Downloads
```

That exception propagated through `on_BrowserLaunchEvent` → `BrowserStartEvent`, so **the entire browser session failed to start**, and every MCP tool call returned the `[WinError 2]` error. The watchdog is otherwise defensive (it catches and logs other setup failures), so this one unguarded `mkdir` was the odd one out.

## Changes

1. **`browser_use/mcp/server.py`** — default `downloads_path` to `~/.browser-use-mcp/downloads` instead of `~/Downloads/browser-use-mcp`. Keeps the persistent app-dir intent and parallels the existing `file_system_path` default (`~/.browser-use-mcp`).
2. **`browser_use/browser/watchdogs/downloads_watchdog.py`** — extract `_ensure_downloads_directory()` (module-level, pure). On `OSError` it returns `None`; the watchdog logs a warning and skips download tracking instead of failing the launch. Browser still starts; users on virtualized Downloads simply get download tracking disabled rather than a broken session.

## Tests

Added 3 unit tests in `tests/ci/test_downloads_watchdog.py`:

- `_ensure_downloads_directory` creates a missing nested dir
- accepts an existing dir
- returns `None` (no raise) when the parent path is occupied by a regular file — the portable analogue of the Windows virtualized-folder failure

Verified on the affected machine (Windows, virtualized `~/Downloads`): before the fix, `BrowserSession.start()` crashed with the `FileNotFoundError`; after, the session starts, the warning is logged, and `browser_navigate` completes successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents MCP browser launches from failing when the downloads directory can't be created. Previously launches aborted on `~/Downloads/browser-use-mcp` (e.g., Windows virtualized Downloads); now the default is safer and download tracking is disabled if the directory is unavailable.

- Default `downloads_path` to `~/.browser-use-mcp/downloads` (was `~/Downloads/browser-use-mcp`).
- Add `_ensure_downloads_directory()`; on `OSError` it logs a warning and starts the browser instead of aborting.
- Cache a session `_resolved_downloads_dir` and use it everywhere: skip CDP download setup when `None`, use it in the filesystem fallback, and have `download_file_from_url` and `trigger_pdf_download` return `None` rather than retrying `mkdir`.
- Add regression tests for an unavailable directory and update existing watchdog and remote download callback tests.

<sup>Written for commit 6f4459be573a367b04f280a3c40715d10d6f728d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

