### PR TITLE
fix(agent): build the empty-action fallback through the action model union

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1684,18 +1684,39 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
-				action_instance = self.ActionModel()
-				setattr(
-					action_instance,
-					'done',
-					{
-						'success': False,
-						'text': 'No next action returned by LLM!',
-					},
-				)
-				model_output.action = [action_instance]
+				model_output.action = [self._build_fallback_done_action()]
 
 		return model_output
+
+	def _build_fallback_done_action(self) -> ActionModel:
+		"""Build the `done` action used to terminate when the LLM returns no actions.
+
+		`self.ActionModel` is a union of single-action models (see `Registry.create_action_model`),
+		so it must be constructed with its payload — instantiating it empty and assigning the
+		payload afterwards raises a ValidationError.
+
+		The `done` param model varies with configuration: `DoneAction` (which has `text`) normally,
+		or `StructuredOutputAction` (which has `data` and no `text`) when an output schema is set,
+		so the payload is derived from the registered param model instead of being hardcoded.
+		"""
+		params: dict[str, Any] = {'success': False}
+
+		done_action = self.tools.registry.registry.actions.get('done')
+		fields = done_action.param_model.model_fields if done_action else {}
+
+		if 'text' in fields:
+			params['text'] = 'No next action returned by LLM!'
+
+		if 'data' in fields:
+			# Structured output: `data` is typed to the caller's schema, which cannot be
+			# synthesised here without inventing values the agent never observed. Emit an empty
+			# shell so the fallback still builds — executing it surfaces a normal ActionResult
+			# error rather than an uncaught exception out of the recovery path.
+			annotation = fields['data'].annotation
+			if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+				params['data'] = annotation.model_construct()
+
+		return self.ActionModel(**{'done': params})
 
 	async def _handle_post_llm_processing(
 		self,

--- a/tests/ci/test_empty_action_fallback.py
+++ b/tests/ci/test_empty_action_fallback.py
@@ -12,14 +12,12 @@ flat all-optional model.
 """
 
 import tempfile
-from unittest.mock import AsyncMock
 
 from pydantic import BaseModel
 
 from browser_use import Agent
 from browser_use.filesystem.file_system import FileSystem
-from browser_use.llm import BaseChatModel
-from browser_use.llm.views import ChatInvokeCompletion
+from tests.ci.conftest import create_mock_llm
 
 EMPTY_ACTION_RESPONSE = """
 {
@@ -42,33 +40,9 @@ VALID_ACTION_RESPONSE = """
 """
 
 
-def create_mock_llm(responses: list[str]) -> BaseChatModel:
-	"""Create a mock LLM that returns `responses` in order, repeating the last one when exhausted."""
-	llm = AsyncMock(spec=BaseChatModel)
-	llm.model = 'mock-llm'
-	llm.provider = 'mock'
-	llm.name = 'mock-llm'
-	llm.model_name = 'mock-llm'
-	llm._verified_api_keys = True
-
-	call_index = 0
-
-	async def mock_ainvoke(*args, **kwargs):
-		nonlocal call_index
-		output_format = kwargs.get('output_format') or (args[1] if len(args) >= 2 else None)
-		assert output_format is not None, 'Agent should always request structured output'
-
-		payload = responses[min(call_index, len(responses) - 1)]
-		call_index += 1
-		return ChatInvokeCompletion(completion=output_format.model_validate_json(payload), usage=None)
-
-	llm.ainvoke = mock_ainvoke
-	return llm
-
-
 async def test_persistently_empty_actions_fall_back_to_done():
 	"""Two empty responses in a row should yield a done action, not raise."""
-	agent = Agent(task='test task', llm=create_mock_llm([EMPTY_ACTION_RESPONSE]))
+	agent = Agent(task='test task', llm=create_mock_llm([EMPTY_ACTION_RESPONSE, EMPTY_ACTION_RESPONSE]))
 
 	model_output = await agent._get_model_output_with_retry([])
 
@@ -93,7 +67,7 @@ async def test_persistently_empty_actions_do_not_raise_with_structured_output():
 
 	agent = Agent(
 		task='test task',
-		llm=create_mock_llm([EMPTY_ACTION_RESPONSE]),
+		llm=create_mock_llm([EMPTY_ACTION_RESPONSE, EMPTY_ACTION_RESPONSE]),
 		output_model_schema=Output,
 	)
 
@@ -111,7 +85,7 @@ async def test_fallback_done_action_is_executable():
 	`Tools.act` re-validates the action against its registered param model, so an action that
 	constructs but fails that validation would still break the run.
 	"""
-	agent = Agent(task='test task', llm=create_mock_llm([EMPTY_ACTION_RESPONSE]))
+	agent = Agent(task='test task', llm=create_mock_llm([EMPTY_ACTION_RESPONSE, EMPTY_ACTION_RESPONSE]))
 	model_output = await agent._get_model_output_with_retry([])
 
 	file_system = FileSystem(tempfile.mkdtemp())

--- a/tests/ci/test_empty_action_fallback.py
+++ b/tests/ci/test_empty_action_fallback.py
@@ -1,0 +1,149 @@
+"""
+Tests for Agent's empty-action recovery path.
+
+When the LLM returns no actions, `Agent._get_model_output_with_retry()` retries once and,
+if the retry is also empty, substitutes a `done` action so the agent terminates cleanly
+instead of raising.
+
+Regression coverage for the case where that fallback was built by instantiating
+`self.ActionModel()` with no arguments — which raises `ValidationError`, because
+`Registry.create_action_model()` returns a union of single-action models rather than a
+flat all-optional model.
+"""
+
+import tempfile
+from unittest.mock import AsyncMock
+
+from pydantic import BaseModel
+
+from browser_use import Agent
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.llm import BaseChatModel
+from browser_use.llm.views import ChatInvokeCompletion
+
+EMPTY_ACTION_RESPONSE = """
+{
+	"thinking": "null",
+	"evaluation_previous_goal": "Nothing yet",
+	"memory": "Nothing yet",
+	"next_goal": "Decide what to do",
+	"action": []
+}
+"""
+
+VALID_ACTION_RESPONSE = """
+{
+	"thinking": "null",
+	"evaluation_previous_goal": "Nothing yet",
+	"memory": "Nothing yet",
+	"next_goal": "Finish",
+	"action": [{"done": {"text": "all good", "success": true}}]
+}
+"""
+
+
+def create_mock_llm(responses: list[str]) -> BaseChatModel:
+	"""Create a mock LLM that returns `responses` in order, repeating the last one when exhausted."""
+	llm = AsyncMock(spec=BaseChatModel)
+	llm.model = 'mock-llm'
+	llm.provider = 'mock'
+	llm.name = 'mock-llm'
+	llm.model_name = 'mock-llm'
+	llm._verified_api_keys = True
+
+	call_index = 0
+
+	async def mock_ainvoke(*args, **kwargs):
+		nonlocal call_index
+		output_format = kwargs.get('output_format') or (args[1] if len(args) >= 2 else None)
+		assert output_format is not None, 'Agent should always request structured output'
+
+		payload = responses[min(call_index, len(responses) - 1)]
+		call_index += 1
+		return ChatInvokeCompletion(completion=output_format.model_validate_json(payload), usage=None)
+
+	llm.ainvoke = mock_ainvoke
+	return llm
+
+
+async def test_persistently_empty_actions_fall_back_to_done():
+	"""Two empty responses in a row should yield a done action, not raise."""
+	agent = Agent(task='test task', llm=create_mock_llm([EMPTY_ACTION_RESPONSE]))
+
+	model_output = await agent._get_model_output_with_retry([])
+
+	assert len(model_output.action) == 1
+	action_dump = model_output.action[0].model_dump(exclude_unset=True)
+	assert next(iter(action_dump)) == 'done', 'fallback action must be a done action'
+	assert action_dump['done']['success'] is False
+	assert action_dump['done']['text'] == 'No next action returned by LLM!'
+
+
+async def test_persistently_empty_actions_do_not_raise_with_structured_output():
+	"""The recovery path must not raise when done uses StructuredOutputAction, which has no `text`.
+
+	A structured `done` requires `data` typed to the caller's schema, which cannot be synthesised
+	without inventing values the agent never observed. So the fallback builds an empty shell: the
+	recovery path returns normally instead of raising, and executing the action surfaces an
+	ordinary ActionResult error rather than an uncaught exception escaping into step().
+	"""
+
+	class Output(BaseModel):
+		answer: str
+
+	agent = Agent(
+		task='test task',
+		llm=create_mock_llm([EMPTY_ACTION_RESPONSE]),
+		output_model_schema=Output,
+	)
+
+	model_output = await agent._get_model_output_with_retry([])
+
+	assert len(model_output.action) == 1
+	action_dump = model_output.action[0].model_dump(exclude_unset=True)
+	assert next(iter(action_dump)) == 'done', 'fallback action must be a done action'
+	assert action_dump['done']['success'] is False
+
+
+async def test_fallback_done_action_is_executable():
+	"""The fallback must survive execution, not merely construction.
+
+	`Tools.act` re-validates the action against its registered param model, so an action that
+	constructs but fails that validation would still break the run.
+	"""
+	agent = Agent(task='test task', llm=create_mock_llm([EMPTY_ACTION_RESPONSE]))
+	model_output = await agent._get_model_output_with_retry([])
+
+	file_system = FileSystem(tempfile.mkdtemp())
+	result = await agent.tools.act(
+		action=model_output.action[0],
+		browser_session=None,  # type: ignore[arg-type] - the done handler does not request a browser session
+		file_system=file_system,
+	)
+
+	assert result.error is None
+	assert result.is_done is True
+	assert result.success is False
+	assert result.extracted_content == 'No next action returned by LLM!'
+
+
+async def test_empty_action_recovers_on_retry():
+	"""An empty first response followed by a valid one should use the retried action, not the fallback."""
+	agent = Agent(task='test task', llm=create_mock_llm([EMPTY_ACTION_RESPONSE, VALID_ACTION_RESPONSE]))
+
+	model_output = await agent._get_model_output_with_retry([])
+
+	assert len(model_output.action) == 1
+	action_dump = model_output.action[0].model_dump(exclude_unset=True)
+	assert action_dump['done']['text'] == 'all good'
+	assert action_dump['done']['success'] is True
+
+
+async def test_non_empty_action_is_returned_unchanged():
+	"""A valid first response should not trigger the retry path at all."""
+	agent = Agent(task='test task', llm=create_mock_llm([VALID_ACTION_RESPONSE]))
+
+	model_output = await agent._get_model_output_with_retry([])
+
+	assert len(model_output.action) == 1
+	assert model_output.action[0].model_dump(exclude_unset=True)['done']['text'] == 'all good'


### PR DESCRIPTION
Fixes #5360.

## Problem

`Agent._get_model_output_with_retry()` retries once when the LLM returns no actions. If the retry is also empty, it is supposed to substitute a `done` action so the run terminates cleanly. Instead it raises:

```
WARNING  [Agent] Model returned empty action. Retrying...
WARNING  [Agent] Model still returned empty after retry. Inserting safe noop action.
pydantic_core._pydantic_core.ValidationError: 24 validation errors for ActionModelUnion
  Input should be a valid dictionary or instance of DoneActionModel [type=model_type, input_value=PydanticUndefined, ...]
  ... (24 total)
```

The fallback was written as:

```python
action_instance = self.ActionModel()
setattr(action_instance, 'done', {'success': False, 'text': 'No next action returned by LLM!'})
```

`self.ActionModel` comes from `Registry.create_action_model()` (`browser_use/tools/registry/service.py:517`), which builds one `create_model(...)` per registered action and wraps them in a `RootModel` union. A root-model union has no all-optional shape, so `self.ActionModel()` with no arguments cannot validate — every union member reports `PydanticUndefined` against its expected type.

The exception propagates out of `_get_next_action()` into `step()`'s handler, where `_handle_step_error()` treats it as a generic step failure. So the last-resort safety net not only fails to insert the `done`, it burns a `consecutive_failures` and ends the run with a pydantic wall instead of the intended readable message.

This looks like a regression from `e89e7884`, which changed `create_action_model()` to emit a union of single-action models. The fallback was written when `ActionModel` was still a flat all-optional model where `ActionModel()` was valid.

Worth noting: **the beta agent already does this correctly.** `browser_use/beta/service.py:5745` constructs through the single-action model, keeping the old pattern only as an unreachable `except` branch:

```python
try:
    done_action = self.DoneActionModel(done={'success': False, 'text': 'No next action returned by LLM!'})
except Exception:
    done_action = self.ActionModel()   # the pattern this PR removes from agent/service.py
    setattr(done_action, 'done', {...})
```

and `tests/ci/test_beta_agent.py:6897` asserts that behaviour. `browser_use/agent/service.py` was never given the same treatment.

## Why it matters

This path fires whenever a model returns an empty action list twice in a row — most commonly with smaller, local, or quantised models, and with providers that intermittently return an empty tool call. It is precisely the situation the fallback exists to absorb, and it is the situation in which it fails.

## Fix

Construct the action **with** its payload rather than instantiating empty and mutating:

```python
model_output.action = [self._build_fallback_done_action()]
```

`_build_fallback_done_action()` derives the payload from the registered `done` param model rather than hardcoding it, because that model varies with configuration:

- **`DoneAction`** (default) has a required `text` field.
- **`StructuredOutputAction`** (when `output_model_schema` is set) has no `text` at all, and requires `data` typed to the caller's schema.

A hardcoded `{'success': False, 'text': ...}` payload — the fix I originally proposed in the issue — would still raise for structured-output agents, on `data` being missing. Deriving from `model_fields` covers both shapes.

`self.ActionModel(**{'done': params})` uses dict unpacking to match the existing construction pattern at `agent/service.py:3980` (`_convert_initial_actions`), which also keeps pyright happy about the dynamic field name.

### On the structured-output case — please read

I want to be precise about what this does and does not fix, because I got it wrong once already while writing it.

For a structured-output agent there is **no valid `done` the fallback can synthesise**: `data` is typed to the caller's schema and filling it would mean inventing values the agent never observed. The fallback emits an empty shell, which means:

- the recovery path returns normally instead of raising, so nothing escapes into `step()` — this is the part that is fixed;
- executing that action surfaces an ordinary `ActionResult(error=...)` from `Tools.act`'s param re-validation, rather than a `done`.

That is a strict improvement over today (uncaught exception → handled action error), but it is not a complete answer for structured output. I initially wrote a test that only asserted construction, which passed while execution was still broken — hence the added `test_fallback_done_action_is_executable`, which pins the plain path end-to-end through `Tools.act`. Happy to take direction if you would rather structured output degrade some other way; I did not want to guess at semantics for the caller's schema.

## Tests

New `tests/ci/test_empty_action_fallback.py`:

| Test | On `main` | With this PR |
|---|---|---|
| `test_persistently_empty_actions_fall_back_to_done` | ❌ `ValidationError` | ✅ |
| `test_persistently_empty_actions_do_not_raise_with_structured_output` | ❌ `ValidationError` | ✅ |
| `test_fallback_done_action_is_executable` | ❌ `ValidationError` | ✅ |
| `test_empty_action_recovers_on_retry` | ✅ | ✅ |
| `test_non_empty_action_is_returned_unchanged` | ✅ | ✅ |

Verified by running the new file against a clean `main` worktree: `3 failed, 2 passed`. The two that pass on `main` are deliberate — they pin the surrounding behaviour (retry succeeds, no retry needed) so the fix is shown not to disturb it.

## Verification

```
tests/ci/test_empty_action_fallback.py                        5 passed
tests/ci (full suite)                     1 failed, 478 passed, 33 skipped

uv run ruff check    All checks passed
uv run ruff format   unchanged
uv run pyright       0 errors, 0 warnings
```

The one full-suite failure is `test_beta_agent_constructor_type_hints_match_browser_use_core_params`, asserting `get_origin(inner[0]) is Tools` and failing with `assert <class Tools> is <class Tools>`. It is **pre-existing and unrelated** — a clean `main` worktree produces the identical `1 failed, 478 passed, 33 skipped` on the same test, and it passes when run in isolation, so it looks like cross-test class-identity pollution rather than anything to do with this change. Flagging it in case it is not already known.

## Not in scope

`browser_use/beta/service.py:5747` still carries the old `self.ActionModel()` + `setattr` pattern inside its `except Exception:` branch. It is unreachable in practice because the `try` above it succeeds, but it is the same latent bug, and beta's version also hardcodes `text` so it shares the structured-output gap described above. Happy to follow up separately — I left it out to keep this reviewable, since `beta/service.py` is a parallel implementation with its own test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the agent’s empty-action fallback by constructing a `done` action through the action-model union, preventing pydantic `ValidationError` and letting runs end cleanly when the LLM returns no actions twice.

- **Bug Fixes**
  - Build the fallback via `_build_fallback_done_action()` and `self.ActionModel(**{'done': params})`.
  - Derive params from the registered `done` model to support both `DoneAction` (with `text`) and structured-output `done` (with `data`).
  - For structured output, emit an empty `data` shell so recovery returns normally; executing the action yields an `ActionResult` error instead of an exception.

- **Refactors**
  - Tests now use the shared `create_mock_llm` fixture; persistent-empty tests pass the empty response twice to match the fixture’s fallthrough behavior.

<sup>Written for commit 47d9f04ac6684f22a02326aac91067971e71a451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

