### PR TITLE
fix: clean up temp .zip in _extract_extension on failure

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1222,15 +1222,24 @@ async function initialize(checkInitialized, magic) {{
 				zip_data = f.read()
 
 			# Write ZIP data to temp file and extract
+			temp_zip_path = None
+			try:
+				with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
+					temp_zip.write(zip_data)
+					temp_zip.flush()
+					temp_zip_path = temp_zip.name
 
-			with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
-				temp_zip.write(zip_data)
-				temp_zip.flush()
-
-				with zipfile.ZipFile(temp_zip.name, 'r') as zip_ref:
+				with zipfile.ZipFile(temp_zip_path, 'r') as zip_ref:
 					zip_ref.extractall(extract_dir)
-
-				os.unlink(temp_zip.name)
+			finally:
+				# Close the temp file (with block exit) before unlinking so the
+				# unlink does not hit a still-open handle (PermissionError on
+				# Windows), and always clean up even when extraction fails.
+				if temp_zip_path is not None:
+					try:
+						os.unlink(temp_zip_path)
+					except FileNotFoundError:
+						pass
 
 	def detect_display_configuration(self) -> None:
 		"""

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1234,15 +1234,24 @@ async function initialize(checkInitialized, magic) {{
 				zip_data = f.read()
 
 			# Write ZIP data to temp file and extract
+			temp_zip_path = None
+			try:
+				with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
+					temp_zip.write(zip_data)
+					temp_zip.flush()
+					temp_zip_path = temp_zip.name
 
-			with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
-				temp_zip.write(zip_data)
-				temp_zip.flush()
-
-				with zipfile.ZipFile(temp_zip.name, 'r') as zip_ref:
+				with zipfile.ZipFile(temp_zip_path, 'r') as zip_ref:
 					zip_ref.extractall(extract_dir)
-
-				os.unlink(temp_zip.name)
+			finally:
+				# Close the temp file (with block exit) before unlinking so the
+				# unlink does not hit a still-open handle (PermissionError on
+				# Windows), and always clean up even when extraction fails.
+				if temp_zip_path is not None:
+					try:
+						os.unlink(temp_zip_path)
+					except FileNotFoundError:
+						pass
 
 	def detect_display_configuration(self) -> None:
 		"""

--- a/tests/ci/test_extension_extract.py
+++ b/tests/ci/test_extension_extract.py
@@ -1,0 +1,112 @@
+"""Tests for _extract_extension temp .zip file cleanup."""
+
+import io
+import os
+import tempfile as _tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+
+
+def _make_crx(zip_data: bytes) -> bytes:
+	"""Build a minimal CRX v3 file: 'Cr24' magic + empty header + zip data."""
+	header = b'Cr24' + (3).to_bytes(4, 'little') + (0).to_bytes(4, 'little')
+	return header + zip_data
+
+
+def _valid_crx() -> bytes:
+	buf = io.BytesIO()
+	with zipfile.ZipFile(buf, 'w') as zf:
+		zf.writestr('manifest.json', '{"name": "test-ext", "version": "1.0.0"}')
+	return _make_crx(buf.getvalue())
+
+
+@pytest.fixture
+def profile() -> BrowserProfile:
+	return BrowserProfile(headless=True)
+
+
+def _force_crx_header_path(monkeypatch, crx_path):
+	"""Force _extract_extension down the CRX-header-skip branch.
+
+	Modern zipfile can read most CRX files directly thanks to its
+	prepended-data handling, which bypasses the temp-file extraction path
+	entirely. Some layouts (CRX v2, unusual headers, older Pythons) cannot,
+	so the header-skip branch is the one that must not leak temp files.
+	This wrapper simulates that case deterministically.
+	"""
+	real_zipfile = zipfile.ZipFile
+
+	def selective_zipfile(file, *args, **kwargs):
+		if isinstance(file, (str, os.PathLike)) and Path(file) == crx_path:
+			raise zipfile.BadZipFile('forced: direct CRX read not supported')
+		return real_zipfile(file, *args, **kwargs)
+
+	monkeypatch.setattr(zipfile, 'ZipFile', selective_zipfile)
+
+
+class TestExtractExtensionTempZipCleanup:
+	def test_successful_extraction_removes_temp_zip(self, tmp_path, monkeypatch, profile):
+		"""A valid CRX extracts and leaves no temp .zip behind."""
+		monkeypatch.setattr(_tempfile, 'tempdir', str(tmp_path))
+
+		crx_path = tmp_path / 'ext.crx'
+		crx_path.write_bytes(_valid_crx())
+		extract_dir = tmp_path / 'extracted'
+		_force_crx_header_path(monkeypatch, crx_path)
+
+		profile._extract_extension(crx_path, extract_dir)
+
+		assert (extract_dir / 'manifest.json').exists()
+		assert list(tmp_path.glob('*.zip')) == []
+
+	def test_failed_extraction_does_not_leak_temp_zip(self, tmp_path, monkeypatch, profile):
+		"""A CRX whose embedded zip is corrupt raises and leaves no temp .zip."""
+		monkeypatch.setattr(_tempfile, 'tempdir', str(tmp_path))
+
+		crx_path = tmp_path / 'ext.crx'
+		crx_path.write_bytes(_make_crx(b'this is not a zip archive'))
+		extract_dir = tmp_path / 'extracted'
+
+		with pytest.raises(Exception):
+			profile._extract_extension(crx_path, extract_dir)
+
+		assert list(tmp_path.glob('*.zip')) == []
+
+	def test_temp_zip_unlinked_after_handle_closed(self, tmp_path, monkeypatch, profile):
+		"""Temp file handle must be closed before unlink (Windows-safe ordering)."""
+		monkeypatch.setattr(_tempfile, 'tempdir', str(tmp_path))
+		real_ntf = _tempfile.NamedTemporaryFile
+		opened = []
+
+		def tracking_ntf(*args, **kwargs):
+			f = real_ntf(*args, **kwargs)
+			opened.append(f)
+			return f
+
+		monkeypatch.setattr(_tempfile, 'NamedTemporaryFile', tracking_ntf)
+		real_unlink = os.unlink
+
+		def guarded_unlink(path):
+			# Unlinking a still-open file raises PermissionError on Windows;
+			# assert the implementation never does that.
+			assert all(f.closed for f in opened), (
+				'os.unlink called while the temp zip handle is still open; '
+				'on Windows this raises PermissionError'
+			)
+			return real_unlink(path)
+
+		monkeypatch.setattr(os, 'unlink', guarded_unlink)
+
+		crx_path = tmp_path / 'ext.crx'
+		crx_path.write_bytes(_valid_crx())
+		extract_dir = tmp_path / 'extracted'
+		_force_crx_header_path(monkeypatch, crx_path)
+
+		profile._extract_extension(crx_path, extract_dir)
+
+		assert (extract_dir / 'manifest.json').exists()
+		assert list(tmp_path.glob('*.zip')) == []

--- a/tests/ci/test_extension_extract.py
+++ b/tests/ci/test_extension_extract.py
@@ -94,8 +94,7 @@ class TestExtractExtensionTempZipCleanup:
 			# Unlinking a still-open file raises PermissionError on Windows;
 			# assert the implementation never does that.
 			assert all(f.closed for f in opened), (
-				'os.unlink called while the temp zip handle is still open; '
-				'on Windows this raises PermissionError'
+				'os.unlink called while the temp zip handle is still open; on Windows this raises PermissionError'
 			)
 			return real_unlink(path)
 


### PR DESCRIPTION
## Summary

`_extract_extension` writes the CRX zip payload to a `NamedTemporaryFile(suffix='.zip', delete=False)` and only unlinks it on the happy path. Two problems:

1. **Temp file leak on failure** — if the embedded zip data fails to extract (corrupt data, disk full, etc.), the exception propagates before `os.unlink` runs, leaving a `.zip` file behind in the system temp dir forever.
2. **`PermissionError` on Windows** — the unlink runs while the `NamedTemporaryFile` handle is still open. On Windows this raises `WinError 32` ("The process cannot access the file because it is being used by another process"), which surfaces as a spurious `⚠️ Failed to setup ... extension` warning.

## Fix

- Move the unlink into a `finally` block so cleanup always runs, even when extraction fails.
- Close the temp file (exit the `with` block) *before* unlinking so the handle is no longer open.
- Suppress `FileNotFoundError` in cleanup so a racing removal cannot mask the original extraction error.

## Test plan

New `tests/ci/test_extension_extract.py` covers:

- **Success path**: valid CRX v3 extracts `manifest.json` and leaves no temp `.zip`.
- **Failure path**: corrupt embedded zip raises and leaves no temp `.zip` (was leaking).
- **Ordering**: asserts the temp handle is closed before `os.unlink` is called (Windows-safe).

All three fail on the old code (including the real `WinError 32` on Windows), all pass with the fix. Neighboring `test_extension_config.py` and `test_chrome_profile_helpers.py` still pass (20 tests).

Fixes #5364

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes temp `.zip` cleanup in `_extract_extension` so extraction failures no longer leak files and Windows no longer raises PermissionError (WinError 32) from unlinking an open handle.

- Moves the unlink into a `finally` block and closes the handle before unlinking, so cleanup runs on both success and failure.
- Ignores `FileNotFoundError` during cleanup so a racing removal can't mask the original extraction error.
- Adds tests covering the success path, the failure path, and close-before-unlink ordering.

Fixes #5364.

<sup>Written for commit 69e2d513a5471be9eee8d816d15fa91a8ae92e9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

