### PR TITLE
fix: report actual wait duration instead of the requested one

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -596,14 +596,13 @@ class Tools(Generic[Context]):
 
 		@self.registry.action('Wait for x seconds.')
 		async def wait(seconds: int = 3):
-			# Cap wait time at maximum 30 seconds
-			# Reduce the wait time by 3 seconds to account for the llm call which takes at least 3 seconds
-			# So if the model decides to wait for 5 seconds, the llm call took at least 3 seconds, so we only need to wait for 2 seconds
-			# Note by Mert: the above doesnt make sense because we do the LLM call right after this or this could be followed by another action after which we would like to wait
-			# so I revert this.
+			# Cap wait time at 30 seconds and skip a 1-second offset for the LLM call.
 			actual_seconds = min(max(seconds - 1, 0), 30)
-			memory = f'Waited for {seconds} seconds'
-			logger.info(f'🕒 waited for {seconds} second{"" if seconds == 1 else "s"}')
+			if actual_seconds == 30 and seconds > 30:
+				memory = f'Waited for {actual_seconds} seconds (capped from the requested {seconds})'
+			else:
+				memory = f'Waited for {actual_seconds} seconds'
+			logger.info(f'🕒 waited for {actual_seconds} second{"" if actual_seconds == 1 else "s"}')
 			await asyncio.sleep(actual_seconds)
 			return ActionResult(extracted_content=memory, long_term_memory=memory)
 

--- a/tests/ci/test_wait_reports_actual_duration.py
+++ b/tests/ci/test_wait_reports_actual_duration.py
@@ -1,0 +1,65 @@
+"""Tests for #5362: the wait action reports the duration it actually slept.
+
+The wait action sleeps `min(max(seconds - 1, 0), 30)` but previously reported
+the *requested* duration to the LLM, so a 120 s request slept 30 s while the
+agent was told it had waited two minutes, and the 30 s cap was invisible.
+
+These tests drive the registered wait action with a stubbed asyncio.sleep so
+no real waiting happens, and assert that the reported memory reflects the
+actual sleep (including the cap when one was applied).
+"""
+
+from browser_use.tools.service import Tools
+
+
+async def _run_wait(seconds):
+	tools = Tools()
+	action = tools.registry.registry.actions['wait']
+	return await action.function(seconds=seconds)
+
+
+async def test_wait_reports_actual_duration(monkeypatch):
+	"""A 3 s request sleeps 2 s (after the 1 s offset) and must report 2 s."""
+	sleeps = []
+
+	async def fake_sleep(seconds):
+		sleeps.append(seconds)
+
+	monkeypatch.setattr('asyncio.sleep', fake_sleep)
+
+	result = await _run_wait(3)
+
+	assert sleeps == [2]
+	assert result.long_term_memory == 'Waited for 2 seconds'
+	assert result.extracted_content == 'Waited for 2 seconds'
+
+
+async def test_wait_reports_cap_when_capped(monkeypatch):
+	"""A 120 s request is capped to a 30 s sleep and the cap must be reported."""
+	sleeps = []
+
+	async def fake_sleep(seconds):
+		sleeps.append(seconds)
+
+	monkeypatch.setattr('asyncio.sleep', fake_sleep)
+
+	result = await _run_wait(120)
+
+	assert sleeps == [30]
+	assert result.long_term_memory == 'Waited for 30 seconds (capped from the requested 120)'
+	assert result.extracted_content == 'Waited for 30 seconds (capped from the requested 120)'
+
+
+async def test_wait_without_cap_has_no_cap_message(monkeypatch):
+	"""A request under the cap must not include a cap note."""
+	sleeps = []
+
+	async def fake_sleep(seconds):
+		sleeps.append(seconds)
+
+	monkeypatch.setattr('asyncio.sleep', fake_sleep)
+
+	result = await _run_wait(30)
+
+	assert sleeps == [29]
+	assert result.long_term_memory == 'Waited for 29 seconds'


### PR DESCRIPTION
Fixes #5362

The `wait` action slept `min(max(seconds - 1, 0), 30)` but reported the *requested* duration to the LLM. Measured on the old code:

```
wait(seconds=3)   -> slept  2.00s, told the LLM: 'Waited for 3 seconds'
wait(seconds=120) -> slept 30.00s, told the LLM: 'Waited for 120 seconds'
```

A 120 s request slept 30 s while the agent concluded it had already waited two minutes — a plausible path into a premature `done(success=False)` or an unnecessary reload. The 30 s cap was invisible to the model.

## Changes

- `long_term_memory` and `extracted_content` now report the **actual** sleep (`actual_seconds`), not the requested value.
- When the request is capped at 30 s, the model is told so: `Waited for 30 seconds (capped from the requested 120)`.
- The `INFO` log line prints the actual duration.
- Replaced the stale comment block (it described a 3-second adjustment the code never made; the code subtracts 1, and that offset is left unchanged — the reporter flagged the `- 1` itself as a behavioural call for maintainers, so I only fixed the reporting).

## Tests

New `tests/ci/test_wait_reports_actual_duration.py` drives the registered wait action with a stubbed `asyncio.sleep` (no real waiting):

- `test_wait_reports_actual_duration` — 3 s request sleeps 2 s, reports 2 s.
- `test_wait_reports_cap_when_capped` — 120 s request sleeps 30 s, reports the cap.
- `test_wait_without_cap_has_no_cap_message` — 30 s request (29 s actual) has no cap note.

All 3 fail on the old code and pass on the fix. Regression: `test_tools.py` (incl. the existing `test_wait_action`, which asserts `'Waited for'` and the ≤2.5 s timing) — 19/19 green. `ruff check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report the actual wait duration in the wait action's feedback so the model sees accurate timing and avoids premature or redundant steps. Previously the action slept `min(max(seconds - 1, 0), 30)` but reported the requested value to the LLM.

- Return the actual slept seconds in `extracted_content` and `long_term_memory`; when capped at 30 s, include `Waited for 30 seconds (capped from the requested 120)`.
- Update the INFO log to the actual duration and replace the stale comment; the 1 s offset and 30 s cap behavior remain unchanged.

<sup>Written for commit ebb40828bb65360fe009e054614d9aa6e058bf21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

