### PR TITLE
fix: bound evaluate inline image payloads

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -109,6 +109,10 @@ _DEFAULT_PDF_FOOTER_TEMPLATE = (
 # BROWSER_USE_ACTION_TIMEOUT_S env var or tools.act(action_timeout=...).
 _ACTION_TIMEOUT_FALLBACK_S = 180.0
 
+_EVALUATE_MAX_IMAGES = 4
+_EVALUATE_MAX_IMAGE_CHARS = 256_000
+_EVALUATE_MAX_RESULT_CHARS = 20_000
+
 
 def _parse_env_action_timeout(raw: str | None) -> float:
 	"""Parse BROWSER_USE_ACTION_TIMEOUT_S defensively.
@@ -1882,21 +1886,27 @@ Validated Code (after quote fixing):
 
 				image_pattern = r'(data:image/[^;]+;base64,[A-Za-z0-9+/=]+)'
 				found_images = re.findall(image_pattern, result_text)
+				kept_images = [image for image in found_images if len(image) <= _EVALUATE_MAX_IMAGE_CHARS][:_EVALUATE_MAX_IMAGES]
+				dropped_image_count = len(found_images) - len(kept_images)
 
 				metadata = None
-				if found_images:
+				if kept_images:
 					# Store images in metadata so they can be added as ContentPartImageParam
-					metadata = {'images': found_images}
+					metadata = {'images': kept_images}
 
-					# Replace image data in result text with shorter placeholder
-					modified_text = result_text
-					for i, img_data in enumerate(found_images, 1):
-						placeholder = '[Image]'
-						modified_text = modified_text.replace(img_data, placeholder)
-					result_text = modified_text
+				# Replace image data in result text with shorter placeholder
+				modified_text = result_text
+				for img_data in found_images:
+					modified_text = modified_text.replace(img_data, '[Image]')
+				result_text = modified_text
+
+				if dropped_image_count:
+					result_text += (
+						f'\n... [{dropped_image_count} image(s) omitted: too large or over the limit of {_EVALUATE_MAX_IMAGES}]'
+					)
 
 				# Apply length limit with better truncation (after image extraction)
-				if len(result_text) > 20000:
+				if len(result_text) > _EVALUATE_MAX_RESULT_CHARS:
 					result_text = result_text[:19950] + '\n... [Truncated after 20000 characters]'
 
 				# Don't log the code - it's already visible in the user's cell

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1889,10 +1889,16 @@ Validated Code (after quote fixing):
 				kept_images = [image for image in found_images if len(image) <= _EVALUATE_MAX_IMAGE_CHARS][:_EVALUATE_MAX_IMAGES]
 				dropped_image_count = len(found_images) - len(kept_images)
 
-				metadata = None
+				images = None
 				if kept_images:
-					# Store images in metadata so they can be added as ContentPartImageParam
-					metadata = {'images': kept_images}
+					# Return images in the format consumed by the message manager.
+					images = [
+						{
+							'name': f'evaluate_image_{index}.{image.split("/", 1)[1].split(";", 1)[0]}',
+							'data': image.split(',', 1)[1],
+						}
+						for index, image in enumerate(kept_images, 1)
+					]
 
 				# Replace image data in result text with shorter placeholder
 				modified_text = result_text
@@ -1900,14 +1906,19 @@ Validated Code (after quote fixing):
 					modified_text = modified_text.replace(img_data, '[Image]')
 				result_text = modified_text
 
+				omission_report = ''
 				if dropped_image_count:
-					result_text += (
+					omission_report = (
 						f'\n... [{dropped_image_count} image(s) omitted: too large or over the limit of {_EVALUATE_MAX_IMAGES}]'
 					)
 
 				# Apply length limit with better truncation (after image extraction)
 				if len(result_text) > _EVALUATE_MAX_RESULT_CHARS:
-					result_text = result_text[:19950] + '\n... [Truncated after 20000 characters]'
+					truncation_marker = f'\n... [Truncated after {_EVALUATE_MAX_RESULT_CHARS} characters]'
+					suffix = omission_report + truncation_marker
+					result_text = result_text[: max(0, _EVALUATE_MAX_RESULT_CHARS - len(suffix))] + suffix
+				else:
+					result_text += omission_report
 
 				# Don't log the code - it's already visible in the user's cell
 				logger.debug(f'JavaScript executed successfully, result length: {len(result_text)}')
@@ -1927,7 +1938,7 @@ Validated Code (after quote fixing):
 					extracted_content=result_text,
 					long_term_memory=memory,
 					include_extracted_content_only_once=include_extracted_content_only_once,
-					metadata=metadata,
+					images=images,
 				)
 
 			except Exception as e:

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -146,10 +146,39 @@ class TestToolsIntegration:
 			browser_session=browser_session,
 		)
 
-		images = (result.metadata or {}).get('images', [])
+		images = result.images or []
 		assert len(images) == 4
-		assert all(len(image) <= 256000 for image in images)
+		assert all(image['name'].startswith('evaluate_image_') for image in images)
+		assert all(len(image['data']) <= 256000 for image in images)
+		assert all(image['data'].startswith(('B',)) for image in images)
 		assert '[2 image(s) omitted' in result.extracted_content
+
+	async def test_evaluate_preserves_omission_report_at_result_limit(self, tools, browser_session, monkeypatch):
+		"""Test that image omission details survive result truncation."""
+		from browser_use.tools import service as tools_service
+
+		monkeypatch.setattr(tools_service, '_EVALUATE_MAX_RESULT_CHARS', 1000)
+		result = await tools.evaluate(
+			code="""(() => {
+				const largeImage = 'data:image/png;base64,' + 'A'.repeat(256001);
+				return 'x'.repeat(2000) + largeImage;
+			})()""",
+			browser_session=browser_session,
+		)
+
+		assert len(result.extracted_content) <= 1000
+		assert '[1 image(s) omitted' in result.extracted_content
+		assert '[Truncated after 1000 characters]' in result.extracted_content
+
+	async def test_evaluate_uses_configured_result_limit(self, tools, browser_session, monkeypatch):
+		"""Test that both truncation and its marker use the configured result limit."""
+		from browser_use.tools import service as tools_service
+
+		monkeypatch.setattr(tools_service, '_EVALUATE_MAX_RESULT_CHARS', 321)
+		result = await tools.evaluate(code="'x'.repeat(1000)", browser_session=browser_session)
+
+		assert len(result.extracted_content) <= 321
+		assert '[Truncated after 321 characters]' in result.extracted_content
 
 	async def test_wait_action(self, tools, browser_session):
 		"""Test that the wait action correctly waits for the specified duration."""

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -133,6 +133,24 @@ class TestToolsIntegration:
 		assert 'Custom action executed with: test_value on' in result.extracted_content
 		assert f'{base_url}/page1' in result.extracted_content
 
+	async def test_evaluate_limits_inline_images(self, tools, browser_session):
+		"""Test that evaluate bounds inline image data returned by page JavaScript."""
+		result = await tools.evaluate(
+			code="""(() => {
+				const largeImage = 'data:image/png;base64,' + 'A'.repeat(256001);
+				const smallImage = 'data:image/png;base64,' + 'B'.repeat(10);
+				return '<img src="' + largeImage + '">' + Array.from(
+					{length: 5}, () => '<img src="' + smallImage + '">'
+				).join('');
+			})()""",
+			browser_session=browser_session,
+		)
+
+		images = (result.metadata or {}).get('images', [])
+		assert len(images) == 4
+		assert all(len(image) <= 256000 for image in images)
+		assert '[2 image(s) omitted' in result.extracted_content
+
 	async def test_wait_action(self, tools, browser_session):
 		"""Test that the wait action correctly waits for the specified duration."""
 


### PR DESCRIPTION
## Summary
- Bound evaluate() inline image payloads to four images of at most 256,000 characters each.
- Replace omitted image data with placeholders and report omitted images in the result text.
- Add a regression test covering oversized and excess inline images.

Fixes #5367

## Tests
- uv run pytest -q tests/ci/test_tools.py — 17 passed
- ./bin/lint.sh — ruff, pre-commit, and pyright passed
- uv run pytest -q tests/ci/test_rerun_ai_summary.py::test_generate_rerun_summary_with_errors — passed after one transient failure during the full suite
- Full tests/ci rerun completed without the transient failure recurring