### PR TITLE
fix(dom): remove unused ready-state call

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -403,13 +403,6 @@ class DomService:
 	async def _get_all_trees(self, target_id: TargetID) -> TargetAllTrees:
 		cdp_session = await self.browser_session.get_or_create_cdp_session(target_id=target_id, focus=False)
 
-		# Wait for the page to be ready first
-		try:
-			ready_state = await cdp_session.cdp_client.send.Runtime.evaluate(
-				params={'expression': 'document.readyState'}, session_id=cdp_session.session_id
-			)
-		except Exception as e:
-			pass  # Page might not be ready yet
 		# DEBUG: Log before capturing snapshot
 		self.logger.debug(f'🔍 DEBUG: Capturing DOM snapshot for target {target_id}')
 

--- a/tests/ci/browser/test_dom_service_cdp_calls.py
+++ b/tests/ci/browser/test_dom_service_cdp_calls.py
@@ -1,0 +1,63 @@
+"""Regression tests for CDP calls made while building the DOM tree."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from browser_use.dom.service import DomService
+
+
+class RecordingRuntime:
+	def __init__(self) -> None:
+		self.expressions: list[str] = []
+
+	async def evaluate(self, params: dict[str, Any], session_id: str) -> dict[str, Any]:
+		self.expressions.append(params['expression'])
+		if 'scrollData' in params['expression']:
+			return {'result': {'value': {}}}
+		return {'result': {'value': None}}
+
+
+class StubDOMSnapshot:
+	async def captureSnapshot(self, params: dict[str, Any], session_id: str) -> dict[str, Any]:
+		return {'documents': []}
+
+
+class StubDOM:
+	async def getDocument(self, params: dict[str, Any], session_id: str) -> dict[str, Any]:
+		return {}
+
+
+async def test_get_all_trees_does_not_probe_unused_document_ready_state(monkeypatch) -> None:
+	"""Building the DOM should not make a CDP call whose result is ignored."""
+	runtime = RecordingRuntime()
+	cdp_session = SimpleNamespace(
+		session_id='session-1',
+		cdp_client=SimpleNamespace(
+			send=SimpleNamespace(Runtime=runtime, DOMSnapshot=StubDOMSnapshot(), DOM=StubDOM()),
+		),
+	)
+
+	async def get_cdp_session(*_args: Any, **_kwargs: Any):
+		return cdp_session
+
+	browser_session = cast(
+		Any,
+		SimpleNamespace(
+			logger=SimpleNamespace(debug=lambda *_args: None, warning=lambda *_args: None),
+			get_or_create_cdp_session=get_cdp_session,
+		),
+	)
+	service = DomService(browser_session)
+
+	async def get_ax_tree(_target_id: str) -> dict[str, Any]:
+		return {'nodes': []}
+
+	async def get_viewport_ratio(_target_id: str) -> float:
+		return 1.0
+
+	monkeypatch.setattr(service, '_get_ax_tree_for_all_frames', get_ax_tree)
+	monkeypatch.setattr(service, '_get_viewport_ratio', get_viewport_ratio)
+
+	await service._get_all_trees(cast(Any, 'target-1'))
+
+	assert 'document.readyState' not in runtime.expressions


### PR DESCRIPTION
## What changed

Removed an unused `document.readyState` CDP call from DOM tree building.

The call did not wait for the page and its result was never used. This removes one unnecessary browser round-trip from every DOM build.

Added a regression test that records the CDP expressions and checks that the unused call is not made.

Fixes #5363.

## Tests

- `uv run pytest -q tests/ci/browser/test_dom*.py tests/ci/test_dom*.py` — 31 passed
- `uv run pre-commit run --all-files --show-diff-on-failure` — passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an unused CDP `document.readyState` evaluation from DOM tree building to eliminate an extra browser round-trip and speed up DOM builds. Added a regression test that records CDP expressions to ensure the probe is never called.

<sup>Written for commit 9d66cda7b2427354131ab79339226c2f86185ca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

