### PR TITLE
fix: include exception details in coordinate click and add missing error logs

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -493,7 +493,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 					try:
 						await asyncio.wait_for(self._click_element_node_impl(element_node), timeout=10.0)
 					except Exception as e:
-						pass
+						self.logger.debug(f'Fallback click for page typing failed: {e}')
 					await self._type_to_page(event.text)
 					# Log with sensitive data protection
 					if event.is_sensitive:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -668,7 +668,11 @@ class Tools(Generic[Context]):
 				tabs_before = {t.target_id for t in await browser_session.get_tabs()}
 
 				# Highlight the coordinate being clicked (truly non-blocking)
-				asyncio.create_task(browser_session.highlight_coordinate_click(actual_x, actual_y))
+				create_task_with_error_handling(
+					browser_session.highlight_coordinate_click(actual_x, actual_y),
+					name='highlight_coordinate_click',
+					suppress_exceptions=True,
+				)
 
 				# Dispatch ClickCoordinateEvent - handler will check for safety and click
 				event = browser_session.event_bus.dispatch(
@@ -694,7 +698,7 @@ class Tools(Generic[Context]):
 			except BrowserError as e:
 				return handle_browser_error(e)
 			except Exception as e:
-				error_msg = f'Failed to click at coordinates ({params.coordinate_x}, {params.coordinate_y}).'
+				error_msg = f'Failed to click at coordinates ({params.coordinate_x}, {params.coordinate_y}): {e}'
 				return ActionResult(error=error_msg)
 
 		async def _click_by_index(


### PR DESCRIPTION
Fixes #5365. \n\nThis PR fixes two small diagnosability issues:\n1. It includes the actual exception message in the `ActionResult` error when a coordinate click fails, so the LLM and user know *why* it failed.\n2. It replaces a raw `asyncio.create_task` with the safer `create_task_with_error_handling` for highlight tasks.\n3. It logs the exception trace in the typing fallback recovery handler.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the actual exception when coordinate clicks fail, add a debug log for typing fallback failures, and run the highlight task with safe error handling to avoid unhandled errors.

- **Bug Fixes**
  - Include exception details in coordinate click errors instead of a generic message.
  - Use `create_task_with_error_handling` for `highlight_coordinate_click` with `suppress_exceptions=True`.
  - Log a debug message when the fallback click during typing recovery fails.

<sup>Written for commit 40010b3680d7ee9b885c6c2148f2b0e761044672. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

