### PR TITLE
fix(tools): cap evaluate image extraction by occurrence count

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1898,20 +1898,42 @@ Validated Code (after quote fixing):
 				found_images = re.findall(image_pattern, result_text)
 
 				metadata = None
+				dropped_count = 0
 				if found_images:
-					# Store images in metadata so they can be added as ContentPartImageParam
-					metadata = {'images': found_images}
+					# Cap images sent to the model: house screenshot budget is 10 images,
+					# and each base64 image must fit comfortably in a single message.
+					MAX_IMAGES = 10
+					MAX_IMAGE_CHARS = 100000
 
-					# Replace image data in result text with shorter placeholder
+					# Cap by occurrence, not by unique value: 12 identical inline
+					# images still consume 12 slots of the 10-image budget.
+					size_ok = [img for img in found_images if len(img) <= MAX_IMAGE_CHARS]
+					kept_images = size_ok[:MAX_IMAGES]
+					dropped_count = len(found_images) - len(kept_images)
+
+					# Store kept images in metadata so they can be added as ContentPartImageParam
+					if kept_images:
+						metadata = {'images': kept_images}
+
+					# Replace every image in result text with a shorter placeholder;
+					# dropped images get an explicit marker so the model knows they were omitted.
+					# Dedupe only for replacement efficiency; counting stays occurrence-based.
 					modified_text = result_text
-					for i, img_data in enumerate(found_images, 1):
-						placeholder = '[Image]'
+					for img_data in dict.fromkeys(found_images):
+						placeholder = '[Image]' if img_data in kept_images else '[Image omitted]'
 						modified_text = modified_text.replace(img_data, placeholder)
 					result_text = modified_text
 
 				# Apply length limit with better truncation (after image extraction)
 				if len(result_text) > 20000:
 					result_text = result_text[:19950] + '\n... [Truncated after 20000 characters]'
+
+				# Tell the model about any omitted images; appended after truncation so it survives.
+				if dropped_count:
+					result_text += (
+						f'\n... [{dropped_count} image(s) omitted: '
+						f'over the cap of {MAX_IMAGES} images / {MAX_IMAGE_CHARS} chars each]'
+					)
 
 				# Don't log the code - it's already visible in the user's cell
 				logger.debug(f'JavaScript executed successfully, result length: {len(result_text)}')

--- a/tests/ci/test_evaluate_image_cap.py
+++ b/tests/ci/test_evaluate_image_cap.py
@@ -1,0 +1,83 @@
+"""Tests for bounded image extraction in the evaluate action.
+
+Root cause of #5367: evaluate() extracts data:image/...;base64 URIs from the JavaScript
+result into metadata['images'] BEFORE the 20,000-char text truncation, so a single evaluate
+call can forward an arbitrarily large image payload to the next LLM request.
+
+The fix caps the number of images (10, matching the max_images screenshot budget) and the size
+of each (100_000 base64 chars, roughly 75 KB decoded). Anything beyond the cap is dropped,
+replaced with an [Image omitted] placeholder in the text, and counted in an omission note
+appended AFTER the truncation so the model knows images were omitted.
+"""
+
+import asyncio
+
+from browser_use.tools.service import Tools
+
+
+def _make_fake_session(js_result: str):
+	"""Build a fake CDP session whose Runtime.evaluate returns js_result."""
+
+	class Send:
+		class Runtime:
+			@staticmethod
+			async def evaluate(params=None, session_id=None):
+				return {'result': {'value': js_result}}
+
+	class Client:
+		send = Send()
+
+	class CdpSession:
+		cdp_client = Client()
+		session_id = 's'
+
+	class FakeSession:
+		async def get_or_create_cdp_session(self):
+			return CdpSession()
+
+	return FakeSession()
+
+
+def _run_evaluate(js_result: str):
+	"""Drive the evaluate action against a fake session and return the ActionResult."""
+	evaluate = Tools().registry.registry.actions['evaluate'].function
+	return asyncio.run(evaluate(code='return document.body.innerHTML', browser_session=_make_fake_session(js_result)))
+
+
+class TestEvaluateImageCap:
+	def test_oversized_single_image_is_dropped_and_noted(self):
+		"""One ~300 KB base64 image exceeds the per-image cap -> dropped, noted, payload bounded."""
+		big = 'A' * 300_000
+		js_result = f'<img src="data:image/png;base64,{big}">'
+
+		result = _run_evaluate(js_result)
+
+		images = (result.metadata or {}).get('images', [])
+		assert images == [], f'expected the oversized image to be dropped, got {len(images)} image(s)'
+		assert 'image(s) omitted' in result.extracted_content
+		# Raw base64 must not leak into the text result either
+		assert 'data:image' not in result.extracted_content
+
+	def test_image_count_capped(self):
+		"""12 small images -> only 10 kept, the remaining 2 dropped and noted."""
+		images = ''.join(f'<img src="data:image/png;base64,{"B" * 10_000}">' for _ in range(12))
+		js_result = f'<div>{images}</div>'
+
+		result = _run_evaluate(js_result)
+
+		kept = (result.metadata or {}).get('images', [])
+		assert len(kept) == 10
+		assert '2 image(s) omitted' in result.extracted_content
+		assert 'data:image' not in result.extracted_content
+
+	def test_small_image_passthrough_unchanged(self):
+		"""A small inline image is still extracted and placeholder'd as before (regression guard)."""
+		js_result = '<img src="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=">'
+
+		result = _run_evaluate(js_result)
+
+		images = (result.metadata or {}).get('images', [])
+		assert len(images) == 1
+		assert images[0] == 'data:image/svg+xml;base64,PHN2Zz48L3N2Zz4='
+		assert '[Image]' in result.extracted_content
+		assert 'omitted' not in result.extracted_content


### PR DESCRIPTION
Fixes #5367

## Problem
\evaluate()\ extracts \data:image/...;base64\ URIs from the JavaScript result into metadata **before** the 20,000-char text truncation, so a single evaluate call can forward an arbitrarily large image payload to the next LLM request.

## Fix
Cap the images extracted from evaluate results:
- Keep only the first **10** images (matching the \max_images\ screenshot budget) that fit within **100,000 base64 chars** each (~75 KB decoded).
- Drop everything beyond the cap, replace it with an \[Image omitted]\ placeholder in the text, and append an omission note *after* truncation so the model knows images were dropped.
- The cap counts **occurrences, not unique values**: 12 identical inline images consume 12 of the 10-image budget (previously \dict.fromkeys\ collapsed them to 1 and the cap was never reached).

## Tests
New \	ests/ci/test_evaluate_image_cap.py\:
- oversized single image → dropped, noted, no base64 leaks into text
- 12 small images → 10 kept, 2 omitted and noted
- small inline image → passthrough unchanged (regression guard)

All 3 pass locally; full \	ests/ci/\ run: 76 passed, 3 skipped, 1 pre-existing Windows path-format failure (\	est_path_configuration\, fails on pristine main too).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps inline image extraction in `evaluate()` so a single call can't forward an arbitrarily large base64 payload to the next request. Previously all inline images were extracted before the 20,000-char truncation; now only the first 10 that fit within 100,000 base64 chars each are kept.

- Kept images are replaced in the text with `[Image]`; dropped ones with `[Image omitted]`.
- The cap counts occurrences, not unique values, so 12 identical images consume 12 of the 10-image budget.
- An omission note is appended after truncation so it survives the cut.
- Adds `tests/ci/test_evaluate_image_cap.py` covering oversized images, count capping, and small-image passthrough.

<sup>Written for commit 4ef5111055d45f98cc492282a19aec793612168c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

