### PR TITLE
fix: reject embedded-wildcard domain patterns like www*.com

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -525,7 +525,7 @@ def match_url_with_domain_pattern(url: str, domain_pattern: str, log_warnings: b
 
 	Supports optional glob patterns and schemes:
 	- *.example.com will match sub.example.com and example.com
-	- *google.com will match google.com, agoogle.com, and www.google.com
+	- Only a leading "*." subdomain wildcard is supported; other placements (e.g. *google.com, www*.com) are rejected as unsafe and never match
 	- http*://example.com will match http://example.com, https://example.com
 	- chrome-extension://* will match chrome-extension://aaaaaaaaaaaa and chrome-extension://bbbbbbbbbbbbb
 
@@ -596,8 +596,11 @@ def match_url_with_domain_pattern(url: str, domain_pattern: str, log_warnings: b
 					logger.error(f'⛔️ Wildcard TLDs like in pattern=[{domain_pattern}] are not supported for security')
 				return False  # Don't match unsafe patterns
 
-			# Then check for embedded wildcards
-			bare_domain = pattern_domain.replace('*.', '')
+			# Then check for embedded wildcards. Only a *leading* "*." is the sanctioned
+			# subdomain wildcard, so strip just that one before checking. Using replace()
+			# stripped every "*." occurrence, so a pattern like "www*.com" slipped through
+			# this guard and then fnmatch matched it against e.g. "www.attacker.com".
+			bare_domain = pattern_domain[2:] if pattern_domain.startswith('*.') else pattern_domain
 			if '*' in bare_domain:
 				if log_warnings:
 					logger = logging.getLogger(__name__)

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -144,6 +144,12 @@ def test_unsafe_domain_patterns():
 	assert match_url_with_domain_pattern('https://google.com', 'g*e.com') is False
 	assert match_url_with_domain_pattern('https://google.com', '*com*') is False
 
+	# A "*" that happens to be followed by "." must not slip past the embedded-wildcard
+	# guard: "www*.com" previously matched arbitrary hosts like "www.attacker.com".
+	assert match_url_with_domain_pattern('https://www.attacker.com', 'www*.com') is False
+	assert match_url_with_domain_pattern('https://sub.attacker.example.com', 'sub*.example.com') is False
+	assert match_url_with_domain_pattern('https://a.example.com', 'a*.example.com') is False
+
 	# Test with patterns that have multiple asterisks in different positions
 	assert match_url_with_domain_pattern('https://subdomain.example.com', '*domain*example*') is False
 	assert match_url_with_domain_pattern('https://sub.domain.example.com', '*.*.example.com') is False


### PR DESCRIPTION
## What

`match_url_with_domain_pattern` (marked SECURITY CRITICAL, drives `allowed_domains`) rejects embedded-wildcard patterns so only `*.domain` subdomain wildcards are honored. The guard strips the sanctioned wildcard and rejects anything with a leftover `*`:

```python
bare_domain = pattern_domain.replace('*.', '')
if '*' in bare_domain:
    return False
```

`str.replace` strips every `*.` occurrence, so a pattern whose `*` is immediately followed by a `.` slips past the guard. `www*.com` becomes `wwwcom` (no `*` left), passes the check, and then `fnmatch(domain, 'www*.com')` matches across dots:

```python
match_url_with_domain_pattern('https://www.attacker.com', 'www*.com')  # -> True
```

The structurally identical `g*e.com` is correctly rejected (its `*` is not followed by `.`), so the allowlist widens inconsistently. A user who writes `allowed_domains=['www*.com']` silently allows navigation to arbitrary `www*.com` hosts, including attacker-controlled ones.

## Fix

Strip only a leading `*.` before the embedded-wildcard check. `www*.com`, `sub*.example.com` and `a*.example.com` are then rejected like every other embedded-wildcard pattern, while `*.domain` still matches.

I checked the change against the existing `test_unsafe_domain_patterns` assertions (all still pass) and added regression cases for the `*` followed by `.` shape. Also fixed the docstring, which listed `*google.com` as supported even though the code (and `test_unsafe_domain_patterns`) rejects it as unsafe.

Note: `is_unsafe_pattern` in the same file has the same `.replace('*.', '')` shape, but it has no callers anywhere, so I left it alone. Glad to fix it too if you want.

I could not run the full `tests/ci` suite locally (no uv env set up), so I extracted the patched function and ran it directly against the old and new cases to confirm the behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Security fix to reject embedded wildcard domain patterns like `www*.com` by only allowing a leading `*.` in `match_url_with_domain_pattern`. Prevents unintended allowlisting of attacker-controlled hosts.

- **Bug Fixes**
  - Strip only a leading `*.` before the embedded-wildcard check; reject any remaining `*` (e.g., `www*.com`, `sub*.example.com`, `a*.example.com`).
  - Added regression tests for the above patterns.
  - Updated docstring to clarify that only a leading `*.` subdomain wildcard is supported; patterns like `*google.com` are unsafe and do not match.

<sup>Written for commit a2c17749b75ad3b1cf835335ff278a5f0bc6a71e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

