### PR TITLE
fix(tokens): normalize cache tokens per adapter and fix new_prompt_tokens

### DIFF
--- a/browser_use/llm/aws/chat_bedrock.py
+++ b/browser_use/llm/aws/chat_bedrock.py
@@ -135,12 +135,18 @@ class ChatAWSBedrock(BaseChatModel):
 			return None
 
 		usage_data = response['usage']
+		input_tokens = usage_data.get('inputTokens', 0) or 0
+		# Bedrock Converse reports cache tokens separately from inputTokens when
+		# prompt caching is enabled; don't drop them. Mirror the Anthropic adapters'
+		# convention: fold cache-read into prompt_tokens, keep cache-creation apart.
+		cache_read = usage_data.get('cacheReadInputTokens')
+		cache_write = usage_data.get('cacheWriteInputTokens')
 		return ChatInvokeUsage(
-			prompt_tokens=usage_data.get('inputTokens', 0),
+			prompt_tokens=input_tokens + (int(cache_read) if cache_read is not None else 0),
 			completion_tokens=usage_data.get('outputTokens', 0),
 			total_tokens=usage_data.get('totalTokens', 0),
-			prompt_cached_tokens=None,  # Bedrock doesn't provide this
-			prompt_cache_creation_tokens=None,
+			prompt_cached_tokens=int(cache_read) if cache_read is not None else None,
+			prompt_cache_creation_tokens=int(cache_write) if cache_write is not None else None,
 			prompt_image_tokens=None,
 		)
 

--- a/browser_use/llm/litellm/chat.py
+++ b/browser_use/llm/litellm/chat.py
@@ -75,7 +75,7 @@ class ChatLiteLLM(BaseChatModel):
 		if usage is None:
 			return None
 
-		prompt_tokens = getattr(usage, 'prompt_tokens', 0) or 0
+		raw_prompt_tokens = getattr(usage, 'prompt_tokens', 0) or 0
 		completion_tokens = getattr(usage, 'completion_tokens', 0) or 0
 
 		prompt_cached = getattr(usage, 'cache_read_input_tokens', None)
@@ -86,13 +86,24 @@ class ChatLiteLLM(BaseChatModel):
 			if details:
 				prompt_cached = getattr(details, 'cached_tokens', None)
 
+		prompt_cached_int = int(prompt_cached) if prompt_cached is not None else None
+		cache_creation_int = int(cache_creation) if cache_creation is not None else None
+
+		# Normalize to the same convention the Anthropic adapters use: prompt_tokens =
+		# real input + cache-read, with cache-creation tracked separately. LiteLLM's
+		# Anthropic usage rolls cache-creation *into* prompt_tokens, so strip it here;
+		# otherwise the cost basis (prompt_tokens - cache-read) still counts the
+		# cache-creation tokens as new. On other LiteLLM providers cache_creation is
+		# None, so this is a no-op.
+		prompt_tokens = max(0, raw_prompt_tokens - (cache_creation_int or 0))
+
 		return ChatInvokeUsage(
 			prompt_tokens=prompt_tokens,
-			prompt_cached_tokens=int(prompt_cached) if prompt_cached is not None else None,
-			prompt_cache_creation_tokens=int(cache_creation) if cache_creation is not None else None,
+			prompt_cached_tokens=prompt_cached_int,
+			prompt_cache_creation_tokens=cache_creation_int,
 			prompt_image_tokens=None,
 			completion_tokens=completion_tokens,
-			total_tokens=prompt_tokens + completion_tokens,
+			total_tokens=raw_prompt_tokens + completion_tokens,
 		)
 
 	@overload
@@ -119,7 +130,7 @@ class ChatLiteLLM(BaseChatModel):
 	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
 		from litellm import acompletion  # type: ignore[reportMissingImports]
 		from litellm.exceptions import APIConnectionError, APIError, RateLimitError, Timeout  # type: ignore[reportMissingImports]
-		from litellm.types.utils import ModelResponse  # type: ignore[reportMissingImports]
+		from litellm.types.utils import Choices, ModelResponse  # type: ignore[reportMissingImports]
 
 		litellm_messages = LiteLLMMessageSerializer.serialize(messages)
 
@@ -193,6 +204,9 @@ class ChatLiteLLM(BaseChatModel):
 				status_code=502,
 				model=self.name,
 			)
+		# A non-streaming completion always yields Choices (with .message), never
+		# StreamingChoices (with .delta); narrow it so attribute access is typed.
+		assert isinstance(choice, Choices)
 
 		content = choice.message.content or ''
 		usage = self._parse_usage(response)

--- a/browser_use/tokens/service.py
+++ b/browser_use/tokens/service.py
@@ -227,7 +227,10 @@ class TokenCost:
 		if data is None:
 			return None
 
-		uncached_prompt_tokens = usage.prompt_tokens - (usage.prompt_cached_tokens or 0)
+		# Genuinely-new (uncached) input tokens = prompt_tokens minus the cache-read
+		# tokens they include. Clamped at 0 so malformed usage where cached_tokens
+		# exceeds prompt_tokens can't produce a negative count or cost.
+		uncached_prompt_tokens = max(0, usage.prompt_tokens - (usage.prompt_cached_tokens or 0))
 		pricing_multiplier = usage.pricing_multiplier or 1.0
 
 		cache_creation_5m_tokens = usage.prompt_cache_creation_5m_tokens
@@ -244,7 +247,7 @@ class TokenCost:
 			)
 
 		return TokenCostCalculated(
-			new_prompt_tokens=usage.prompt_tokens,
+			new_prompt_tokens=uncached_prompt_tokens,
 			new_prompt_cost=uncached_prompt_tokens * (data.input_cost_per_token or 0) * pricing_multiplier,
 			# Cached tokens
 			prompt_read_cached_tokens=usage.prompt_cached_tokens,

--- a/tests/ci/test_new_prompt_tokens_normalization.py
+++ b/tests/ci/test_new_prompt_tokens_normalization.py
@@ -1,0 +1,133 @@
+"""Invariant tests for cache-token normalization and new_prompt_tokens.
+
+Follow-up to the closed browser-use#5319: `new_prompt_tokens` returned the raw,
+cache-inclusive prompt count while the cost basis used prompt_tokens minus
+cache-read. Per the maintainer's guidance, each adapter now normalizes to the
+convention the Anthropic adapters already use -- prompt_tokens = real input +
+cache-read, with cache-creation tracked separately -- and new_prompt_tokens is
+computed against that basis, clamped so malformed usage can't go negative.
+"""
+
+import types
+
+import pytest
+
+from browser_use.llm.views import ChatInvokeUsage
+from browser_use.tokens.service import TokenCost
+from browser_use.tokens.views import ModelPricing
+
+INPUT_COST = 0.10 / 1_000_000
+OUTPUT_COST = 0.20 / 1_000_000
+CACHE_READ_COST = 0.02 / 1_000_000
+CACHE_CREATION_COST = 0.12 / 1_000_000
+
+
+@pytest.fixture
+def token_cost(monkeypatch: pytest.MonkeyPatch) -> TokenCost:
+	async def fake_pricing(model_name: str) -> ModelPricing:
+		return ModelPricing(
+			model=model_name,
+			input_cost_per_token=INPUT_COST,
+			output_cost_per_token=OUTPUT_COST,
+			cache_read_input_token_cost=CACHE_READ_COST,
+			cache_creation_input_token_cost=CACHE_CREATION_COST,
+			max_tokens=None,
+			max_input_tokens=None,
+			max_output_tokens=None,
+		)
+
+	monkeypatch.setattr('browser_use.tokens.service.get_openrouter_model_pricing', fake_pricing)
+	cost = TokenCost(include_cost=True)
+	cost._initialized = True
+	cost._pricing_data = {}
+	return cost
+
+
+def _usage(prompt_tokens: int, cached: int | None = None, creation: int | None = None, completion_tokens: int = 40):
+	return ChatInvokeUsage(
+		prompt_tokens=prompt_tokens,
+		prompt_cached_tokens=cached,
+		prompt_cache_creation_tokens=creation,
+		prompt_image_tokens=None,
+		completion_tokens=completion_tokens,
+		total_tokens=prompt_tokens + completion_tokens,
+	)
+
+
+# --- service.calculate_cost invariants ---------------------------------------
+
+
+async def test_new_prompt_tokens_excludes_cache_read(token_cost: TokenCost):
+	# Normalized usage: 100 real input + 20 cache-read -> prompt_tokens 120.
+	result = await token_cost.calculate_cost('gpt-4o', _usage(120, cached=20))
+	assert result is not None
+	assert result.new_prompt_tokens == 100  # not the raw inclusive 120
+	assert result.new_prompt_cost == pytest.approx(100 * INPUT_COST)
+	assert result.prompt_read_cached_tokens == 20
+
+
+async def test_cache_creation_not_counted_as_new(token_cost: TokenCost):
+	# The maintainer's example after adapter normalization: input 100 + read 20
+	# = prompt_tokens 120, with creation 30 tracked separately (not in prompt_tokens).
+	result = await token_cost.calculate_cost('claude', _usage(120, cached=20, creation=30))
+	assert result is not None
+	assert result.new_prompt_tokens == 100
+	assert result.prompt_read_cached_tokens == 20
+	assert result.prompt_cached_creation_tokens == 30
+	# new + read + creation reconstructs the 150 tokens LiteLLM originally reported.
+	assert result.new_prompt_tokens + result.prompt_read_cached_tokens + result.prompt_cached_creation_tokens == 150
+
+
+async def test_negative_guard_when_cached_exceeds_prompt(token_cost: TokenCost):
+	result = await token_cost.calculate_cost('gpt-4o', _usage(50, cached=80))
+	assert result is not None
+	assert result.new_prompt_tokens == 0
+	assert result.new_prompt_cost == 0
+
+
+async def test_no_cache_is_all_new(token_cost: TokenCost):
+	result = await token_cost.calculate_cost('gpt-4o', _usage(100))
+	assert result is not None
+	assert result.new_prompt_tokens == 100
+
+
+# --- adapter normalization ----------------------------------------------------
+
+
+def test_litellm_adapter_strips_cache_creation_from_prompt_tokens():
+	chat = pytest.importorskip('browser_use.llm.litellm.chat')
+	# LiteLLM-Anthropic rolls cache-creation into prompt_tokens: 100 input + 20 read
+	# + 30 creation = 150.
+	response = types.SimpleNamespace(
+		usage=types.SimpleNamespace(
+			prompt_tokens=150,
+			completion_tokens=40,
+			cache_read_input_tokens=20,
+			cache_creation_input_tokens=30,
+		)
+	)
+	usage = chat.ChatLiteLLM._parse_usage(response)
+	assert usage is not None
+	assert usage.prompt_tokens == 120  # creation stripped -> input + read
+	assert usage.prompt_cached_tokens == 20
+	assert usage.prompt_cache_creation_tokens == 30
+
+
+def test_bedrock_adapter_populates_cache_tokens():
+	chat = pytest.importorskip('browser_use.llm.aws.chat_bedrock')
+	response = {
+		'usage': {
+			'inputTokens': 100,
+			'outputTokens': 40,
+			'totalTokens': 190,
+			'cacheReadInputTokens': 20,
+			'cacheWriteInputTokens': 30,
+		}
+	}
+	# _get_usage only reads `response`, so an unbound call is fine and avoids
+	# constructing a real Bedrock client.
+	usage = chat.ChatAWSBedrock._get_usage(None, response)
+	assert usage is not None
+	assert usage.prompt_tokens == 120  # input + cache-read (Anthropic convention)
+	assert usage.prompt_cached_tokens == 20
+	assert usage.prompt_cache_creation_tokens == 30


### PR DESCRIPTION
Follow-up to #5319 (closed). Thanks @MagMueller for the detailed audit - this implements the adapter-boundary normalization you outlined, so `new_prompt_tokens` matches the cost basis across providers rather than presenting a partial one-liner.

### Problem
`new_prompt_tokens` returned the raw, cache-inclusive prompt count while cost used `prompt_tokens - cache_read`, and the adapters disagreed on what `prompt_tokens` contains. The concrete LiteLLM-Anthropic case you gave: input 100 + cache-read 20 + cache-creation 30 arrives as `prompt_tokens=150`; subtracting only reads reported **130** new (should be **100**).

### Fix - normalize every adapter to one convention
The Anthropic adapters already use `prompt_tokens = real input + cache-read`, with cache-creation tracked separately. This brings the others in line:

- **litellm**: LiteLLM-Anthropic rolls cache-creation *into* `prompt_tokens`; strip it so the cost basis counts only genuinely-new tokens.
- **aws/bedrock**: stop dropping Bedrock Converse's `cacheReadInputTokens` / `cacheWriteInputTokens`; populate them and fold cache-read into `prompt_tokens`.
- **tokens/service**: `new_prompt_tokens` now uses the uncached basis, clamped at 0 so malformed usage (cached > prompt) can't go negative.

Result for your example: **100 new, 20 read, 30 creation** (= the real 150), instead of 130 new.

### Tests
`tests/ci/test_new_prompt_tokens_normalization.py`: the service invariants (new = prompt − read, negative guard, creation-not-counted-as-new) plus per-adapter normalization (the LiteLLM 150 → 120 strip and the Bedrock cache-field population).

Note on Bedrock: I assumed `inputTokens` **excludes** cache-read (so `prompt_tokens = inputTokens + cacheRead`, matching the Anthropic adapters). Happy to adjust if your Bedrock usage samples say otherwise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize cache-token accounting across adapters and fix `new_prompt_tokens` to use uncached prompt tokens. Aligns cost calculations with provider usage and prevents overcounting.

- **Bug Fixes**
  - `litellm`: strip cache-creation from `prompt_tokens`; keep cache-read in `prompt_cached_tokens`; preserve provider totals via `total_tokens = raw_prompt_tokens + completion_tokens`.
  - `aws/bedrock`: populate `cacheReadInputTokens`/`cacheWriteInputTokens` and fold cache-read into `prompt_tokens`.
  - `tokens/service`: compute `new_prompt_tokens = max(0, prompt_tokens - prompt_cached_tokens)` and use it for input cost.
  - Added tests for service invariants and adapter normalization; the 100 input + 20 read + 30 creation case now reports 100 new (not 130).

<sup>Written for commit d57679d932873807d9b4b7116dc6c95656f910c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

