### PR TITLE
perf: remove discarded DOM readiness probe

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -403,13 +403,6 @@ class DomService:
 	async def _get_all_trees(self, target_id: TargetID) -> TargetAllTrees:
 		cdp_session = await self.browser_session.get_or_create_cdp_session(target_id=target_id, focus=False)
 
-		# Wait for the page to be ready first
-		try:
-			ready_state = await cdp_session.cdp_client.send.Runtime.evaluate(
-				params={'expression': 'document.readyState'}, session_id=cdp_session.session_id
-			)
-		except Exception as e:
-			pass  # Page might not be ready yet
 		# DEBUG: Log before capturing snapshot
 		self.logger.debug(f'🔍 DEBUG: Capturing DOM snapshot for target {target_id}')
 


### PR DESCRIPTION
## Summary
- remove the discarded document.readyState CDP evaluation from DOM capture

## Problem
_get_all_trees() paid for one Runtime.evaluate round-trip on every DOM build, but discarded the result and never waited or gated snapshot capture. The comment implied a readiness guarantee that was not provided.

## Solution
Remove the dead probe and misleading comment. Existing snapshot and scroll logic is unchanged.

## Tests
- python -m compileall -q browser_use/dom/service.py
- git diff --check passed

## Scope and risk
One dead-code removal in DOM capture. This does not alter navigation or snapshot ordering; it removes a no-op network round trip.

Closes #5363

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the discarded document.readyState evaluation in DOM capture, eliminating an extra CDP Runtime.evaluate round trip. No changes to snapshot or scroll logic; this removes a misleading comment and slightly improves performance.

<sup>Written for commit 09610da77727ac1074026fc4b84baef5d1034334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

