### PR TITLE
fix: prevent temp file leak on crx extraction failure

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1230,6 +1230,7 @@ async function initialize(checkInitialized, magic) {{
 				with zipfile.ZipFile(temp_zip.name, 'r') as zip_ref:
 					zip_ref.extractall(extract_dir)
 			finally:
+				temp_zip.close()  # idempotent; ensures handle is released on write errors
 				with contextlib.suppress(OSError):
 					os.unlink(temp_zip.name)
 

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1180,6 +1180,7 @@ async function initialize(checkInitialized, magic) {{
 
 	def _extract_extension(self, crx_path: Path, extract_dir: Path) -> None:
 		"""Extract .crx file to directory."""
+		import contextlib
 		import os
 		import zipfile
 
@@ -1222,15 +1223,15 @@ async function initialize(checkInitialized, magic) {{
 				zip_data = f.read()
 
 			# Write ZIP data to temp file and extract
-
-			with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
+			temp_zip = tempfile.NamedTemporaryFile(suffix='.zip', delete=False)
+			try:
 				temp_zip.write(zip_data)
-				temp_zip.flush()
-
+				temp_zip.close()  # close before opening by name, required on Windows
 				with zipfile.ZipFile(temp_zip.name, 'r') as zip_ref:
 					zip_ref.extractall(extract_dir)
-
-				os.unlink(temp_zip.name)
+			finally:
+				with contextlib.suppress(OSError):
+					os.unlink(temp_zip.name)
 
 	def detect_display_configuration(self) -> None:
 		"""


### PR DESCRIPTION
Fixes #5364.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops leaking temporary files when extracting CRX extensions by always closing and cleaning up the temp ZIP on errors (fixes #5364). Also fixes Windows extraction by closing the temp file before opening it by name.

- **Bug Fixes**
  - Close the temp file handle in finally before unlink, so cleanup works even if the write fails; ignore unlink errors.
  - Close `NamedTemporaryFile` before passing its path to `ZipFile` on Windows.

<sup>Written for commit fb2d37181f0cc2c5abaf50b4826b1f3a447c91ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

