### PR TITLE
fix: ensure failed actions return errors instead of successes

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -782,7 +782,7 @@ class Tools(Generic[Context]):
 			if node is None:
 				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(error=msg)
 
 			# Highlight the element being typed into (truly non-blocking)
 			create_task_with_error_handling(
@@ -1447,6 +1447,9 @@ You will be given a query and the markdown of a webpage that has been filtered t
 						except Exception as e:
 							logger.warning(f'Fractional scroll failed: {e}')
 
+					if completed_scrolls == 0:
+						return ActionResult(error='Failed to execute scroll action: all scroll attempts failed')
+
 					if params.pages == 1.0:
 						long_term_memory = f'Scrolled {direction} {target} {viewport_height}px'.replace('  ', ' ')
 					else:
@@ -1500,14 +1503,17 @@ You will be given a query and the markdown of a webpage that has been filtered t
 				msg = f'🔍  {memory}'
 				logger.info(msg)
 				return ActionResult(extracted_content=memory, long_term_memory=memory)
+			except BrowserError as e:
+				if 'Text not found' in str(e):
+					msg = f"Text '{text}' not found or not visible on page"
+					logger.info(msg)
+					return ActionResult(
+						extracted_content=msg,
+						long_term_memory=f"Tried scrolling to text '{text}' but it was not found",
+					)
+				return handle_browser_error(e)
 			except Exception as e:
-				# Text not found
-				msg = f"Text '{text}' not found or not visible on page"
-				logger.info(msg)
-				return ActionResult(
-					extracted_content=msg,
-					long_term_memory=f"Tried scrolling to text '{text}' but it was not found",
-				)
+				return ActionResult(error=f'Failed to execute scroll_to_text action: {e}')
 
 		@self.registry.action(
 			'Take a screenshot of the current viewport. If file_name is provided, saves to that file and returns the path. '

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1504,7 +1504,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 				logger.info(msg)
 				return ActionResult(extracted_content=memory, long_term_memory=memory)
 			except BrowserError as e:
-				if 'Text not found' in str(e):
+				if e.details and 'text' in e.details:
 					msg = f"Text '{text}' not found or not visible on page"
 					logger.info(msg)
 					return ActionResult(


### PR DESCRIPTION
Fixes #5361. \n\nThis PR fixes three cases where actions that completely failed were silently returning success:\n1. `scroll`: Now tracks failed scrolls and correctly returns an error when no scrolls succeeded, rather than silently returning a successful ActionResult.\n2. `input`: Now properly returns an error `ActionResult(error=msg)` rather than a success `ActionResult(extracted_content=msg)` if the element index is not found.\n3. `scroll_to_text`: Differentiates between 'Text not found' (expected) and CDP/transport exceptions (unexpected) which now properly return an `error`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure failed actions return errors so callers can detect and handle failures reliably. Fixes #5361.

- **Bug Fixes**
  - `input`: When the element index isn’t found, return `ActionResult(error=msg)` instead of a success with `extracted_content`.
  - `scroll`: If all scroll attempts fail, return `ActionResult(error=...)`.
  - `scroll_to_text`: Use a structured `BrowserError.details` check to treat “text not found” as expected with a clear message; return errors for other browser/transport exceptions.

<sup>Written for commit 5bedbe6750eea3d7175d0381df916a43f072ce90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

