### PR TITLE
fix: empty action recovery raises ValidationError

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1684,15 +1684,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
-				action_instance = self.ActionModel()
-				setattr(
-					action_instance,
-					'done',
-					{
+				action_instance = self.ActionModel.model_validate({
+					'done': {
 						'success': False,
 						'text': 'No next action returned by LLM!',
-					},
-				)
+					}
+				})
 				model_output.action = [action_instance]
 
 		return model_output

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1684,14 +1684,15 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
-				action_instance = self.ActionModel.model_validate(
-					{
-						'done': {
-							'success': False,
-							'text': 'No next action returned by LLM!',
-						}
-					}
-				)
+				# Build a done action compatible with both DoneAction (text) and
+				# StructuredOutputAction (data) so the fallback works regardless
+				# of whether output_model_schema is configured.
+				done_params: dict = {'success': False}
+				if self.output_model_schema is not None:
+					done_params['data'] = self.output_model_schema.model_construct()
+				else:
+					done_params['text'] = 'No next action returned by LLM!'
+				action_instance = self.DoneActionModel.model_validate({'done': done_params})
 				model_output.action = [action_instance]
 
 		return model_output

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1684,12 +1684,14 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
-				action_instance = self.ActionModel.model_validate({
-					'done': {
-						'success': False,
-						'text': 'No next action returned by LLM!',
+				action_instance = self.ActionModel.model_validate(
+					{
+						'done': {
+							'success': False,
+							'text': 'No next action returned by LLM!',
+						}
 					}
-				})
+				)
 				model_output.action = [action_instance]
 
 		return model_output


### PR DESCRIPTION
Fixes #5360. \n\nThis PR fixes a bug where the recovery path for a model returning zero actions would crash with a ValidationError, rather than properly inserting the fallback 'done' action. This was caused by an outdated initialization of the `ActionModelUnion`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5360. When the model returns no actions, we now insert a validated fallback `done` action using `DoneActionModel.model_validate`, choosing `data` when `output_model_schema` is set (StructuredOutput) or `text` otherwise, so the agent safely no-ops instead of raising a ValidationError.

<sup>Written for commit 7c82ac7b303c79117ab67b8d6f0d343e9319d443. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

