### PR TITLE
docs: show the hosted agent API call in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ Browser Use is also **#1 on the [Odysseys leaderboard](https://odysseysbench.com
 - 1000+ integrations (Gmail, Slack, Notion, and more)
 - Persistent filesystem and memory
 
+```sh
+curl -X POST https://api.browser-use.com/api/v4/runs \
+  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"task": "Your task"}'
+```
+
 <br/>
 
 ## Integrations, hosting, custom tools, MCP, and more on our [Docs ↗](https://docs.browser-use.com)


### PR DESCRIPTION
## Summary

The "Fully-Hosted Cloud Agent" block sells the hosted agent but never shows it. Adds the one call
that runs it, right under the bullets:

```sh
curl -X POST https://api.browser-use.com/api/v4/runs \
  -H "X-Browser-Use-API-Key: $BROWSER_USE_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"task": "Your task"}'
```

`task` is the only required field. Same snippet is going into the BrowserCode README
(browser-use/browsercode#145) — v4 is the BrowserCode agent, which is the Cloud v4 line in the plot
above this section.

## Test plan

Ran the snippet verbatim against production with a real key: created a run
(`{"id":"f20575b6-...","status":"queued","model":"gpt-5.6-luna",...}`), cancelled immediately,
$0.00 spent.

Ran it verbatim with `BROWSER_USE_API_KEY` unset: curl drops a valueless header rather than sending
an empty one, so it lands on the missing-API-key 401. browser-use/cloud#5397 rewrites that 401 to
name the one-click key-creation URL, so this should land after that deploys.

`pre-commit run --files README.md` — passed (codespell + the file hygiene hooks; the Python hooks
have no files to check).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a curl example to the README to show how to start the Fully-Hosted Cloud Agent via POST to https://api.browser-use.com/api/v4/runs. The snippet uses the `X-Browser-Use-API-Key` header and `Content-Type: application/json`; `task` is the only required field.

<sup>Written for commit 455fd424e26e29a57ce604f190cecdf867884ba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

