### PR TITLE
fix: preserve CHROME_DEFAULT_ARGS order when ignore_default_args is a list

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -896,7 +896,10 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		"""Get the list of all Chrome CLI launch args for this profile (compiled from defaults, user-provided, and system-specific)."""
 
 		if isinstance(self.ignore_default_args, list):
-			default_args = set(CHROME_DEFAULT_ARGS) - set(self.ignore_default_args)
+			# Keep CHROME_DEFAULT_ARGS order. Set subtraction is order-unstable
+			# across processes/hash seeds and can shuffle Chrome CLI flags.
+			ignored_args = set(self.ignore_default_args)
+			default_args = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_args]
 		elif self.ignore_default_args is True:
 			default_args = []
 		elif not self.ignore_default_args:

--- a/tests/ci/browser/test_get_args_default_order.py
+++ b/tests/ci/browser/test_get_args_default_order.py
@@ -16,11 +16,7 @@ def _default_args_in_order(args: list[str], ignore: list[str]) -> tuple[list[str
 	original token. We only track whole-token defaults that survive unchanged.
 	"""
 	ignored = set(ignore)
-	expected = [
-		arg
-		for arg in CHROME_DEFAULT_ARGS
-		if arg not in ignored and not arg.startswith('--disable-features=')
-	]
+	expected = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored and not arg.startswith('--disable-features=')]
 	# Preserve first-seen order from the final args list, restricted to expected defaults.
 	seen: list[str] = []
 	expected_set = set(expected)

--- a/tests/ci/browser/test_get_args_default_order.py
+++ b/tests/ci/browser/test_get_args_default_order.py
@@ -1,0 +1,99 @@
+"""Regression: ignore_default_args as a list must preserve CHROME_DEFAULT_ARGS order."""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from browser_use.browser.profile import CHROME_DEFAULT_ARGS, BrowserProfile
+
+
+def _default_args_in_order(args: list[str], ignore: list[str]) -> tuple[list[str], list[str]]:
+	"""Return (seen_in_args, expected) for whole-token CHROME_DEFAULT_ARGS entries.
+
+	`--disable-features=...` is merged later in get_args(), so it may not appear as the
+	original token. We only track whole-token defaults that survive unchanged.
+	"""
+	ignored = set(ignore)
+	expected = [
+		arg
+		for arg in CHROME_DEFAULT_ARGS
+		if arg not in ignored and not arg.startswith('--disable-features=')
+	]
+	# Preserve first-seen order from the final args list, restricted to expected defaults.
+	seen: list[str] = []
+	expected_set = set(expected)
+	for arg in args:
+		if arg in expected_set and arg not in seen:
+			seen.append(arg)
+	return seen, expected
+
+
+class TestGetArgsDefaultOrder:
+	def test_ignore_default_args_list_preserves_chrome_default_order(self):
+		"""List ignore mode should filter defaults without set-driven reordering."""
+		ignore = ['--disable-popup-blocking', '--metrics-recording-only']
+		assert all(arg in CHROME_DEFAULT_ARGS for arg in ignore)
+
+		profile = BrowserProfile(
+			ignore_default_args=ignore,
+			user_data_dir=tempfile.mkdtemp(prefix='test-default-order-'),
+			headless=True,
+			enable_default_extensions=False,
+		)
+		profile.detect_display_configuration()
+		args = profile.get_args()
+
+		seen, expected = _default_args_in_order(args, ignore)
+		assert seen == expected
+		for ignored in ignore:
+			assert ignored not in args
+
+	def test_ignore_default_args_list_order_stable_across_hash_seeds(self):
+		"""Order must not depend on PYTHONHASHSEED (set iteration used to shuffle it)."""
+		repo_root = Path(__file__).resolve().parents[3]
+		script = r"""
+import tempfile
+from browser_use.browser.profile import CHROME_DEFAULT_ARGS, BrowserProfile
+
+ignore = ['--disable-popup-blocking']
+profile = BrowserProfile(
+    ignore_default_args=ignore,
+    user_data_dir=tempfile.mkdtemp(prefix='test-hashseed-'),
+    headless=True,
+    enable_default_extensions=False,
+)
+profile.detect_display_configuration()
+args = profile.get_args()
+ignored = set(ignore)
+expected = [
+    a for a in CHROME_DEFAULT_ARGS
+    if a not in ignored and not a.startswith('--disable-features=')
+]
+seen = []
+expected_set = set(expected)
+for arg in args:
+    if arg in expected_set and arg not in seen:
+        seen.append(arg)
+assert seen == expected, (seen, expected)
+print('\n'.join(seen))
+"""
+		env_base = os.environ.copy()
+		env_base['PYTHONPATH'] = str(repo_root) + os.pathsep + env_base.get('PYTHONPATH', '')
+
+		outputs = []
+		for seed in ('0', '1', '42', '12345'):
+			env = env_base.copy()
+			env['PYTHONHASHSEED'] = seed
+			proc = subprocess.run(
+				[sys.executable, '-c', script],
+				env=env,
+				capture_output=True,
+				text=True,
+				check=False,
+			)
+			assert proc.returncode == 0, proc.stderr
+			outputs.append(proc.stdout)
+
+		assert len(set(outputs)) == 1, f'get_args order varied across PYTHONHASHSEED values:\n{outputs}'


### PR DESCRIPTION
## Summary
`BrowserProfile.get_args()` used set subtraction when `ignore_default_args` was a list. That drops ignored flags correctly, but set iteration order is not stable across processes / `PYTHONHASHSEED`, so the remaining default Chrome CLI flags could be reordered.

## Change
Filter `CHROME_DEFAULT_ARGS` with a list comprehension so ignored entries are removed while the original order is kept.

## Reproduction
1. Build a profile with `ignore_default_args=['--disable-popup-blocking']`.
2. Call `get_args()` under different `PYTHONHASHSEED` values.
3. Before this change, the remaining default-arg order could differ between seeds.
4. After this change, the remaining defaults keep `CHROME_DEFAULT_ARGS` order.

## Verification
Ran focused local checks against this branch:

- order-preserving filter with two ignored defaults
- stability across `PYTHONHASHSEED` in `{0,1,42,12345}`
- reproduced the old set-subtraction path producing 4 different orders across those seeds
- existing disable-security / `--disable-features` merge behavior still looks correct

Commands used:

```bash
PYTHONPATH=. python3 - <<'PY'
# focused order + hash-seed checks (see tests/ci/browser/test_get_args_default_order.py)
PY
```

Also added `tests/ci/browser/test_get_args_default_order.py`.

## Notes
Scope is only the list-ignore path in `get_args()`.

Fixes #5397

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the order of Chrome default launch flags in `BrowserProfile.get_args()` when `ignore_default_args` is a list by filtering `CHROME_DEFAULT_ARGS` in order instead of using set subtraction. Prevents nondeterministic reordering across processes and `PYTHONHASHSEED` values, with a regression test to lock the expected order (fixes #5397).

<sup>Written for commit 9343d30a1959e79e47606732d6e1102b1a258eea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

