### PR TITLE
fix(browser): preserve default argument order when filtering

### DIFF
--- a/tests/ci/browser/test_profile_args.py
+++ b/tests/ci/browser/test_profile_args.py
@@ -1,0 +1,18 @@
+from browser_use.browser.profile import CHROME_DEFAULT_ARGS, BrowserProfile
+
+
+def test_ignore_default_args_preserves_default_order(tmp_path):
+	ignored_arg = '--disable-popup-blocking'
+	profile = BrowserProfile(
+		user_data_dir=tmp_path,
+		ignore_default_args=[ignored_arg],
+		enable_default_extensions=False,
+	)
+
+	expected_default_args = [
+		arg for arg in CHROME_DEFAULT_ARGS if arg != ignored_arg and not arg.startswith('--disable-features=')
+	]
+	actual_args = profile.get_args()
+	actual_default_args = [arg for arg in actual_args if arg in expected_default_args]
+
+	assert actual_default_args == expected_default_args

--- a/tests/ci/browser/test_profile_args.py
+++ b/tests/ci/browser/test_profile_args.py
@@ -15,4 +15,5 @@ def test_ignore_default_args_preserves_default_order(tmp_path):
 	actual_args = profile.get_args()
 	actual_default_args = [arg for arg in actual_args if arg in expected_default_args]
 
+	assert ignored_arg not in actual_args
 	assert actual_default_args == expected_default_args


### PR DESCRIPTION
## Summary

- preserve the ordering of `CHROME_DEFAULT_ARGS` when `ignore_default_args` is a list
- keep set-based membership checks without converting the ordered defaults to a set
- add regression coverage for the filtered argument sequence

## Root cause

`BrowserProfile.get_args()` used a set difference to remove ignored defaults. The difference discarded the source list's ordering, so the Chrome launch argument sequence changed across Python hash seeds.

## Impact

Filtering a default argument now leaves every remaining default in its declared order, making browser launch configuration deterministic across processes.

## Validation

- `uv run pytest -q tests/ci/browser/test_profile_args.py`
- `uv run pre-commit run --files browser_use/browser/profile.py tests/ci/browser/test_profile_args.py`
- smoke-tested the resulting order with `PYTHONHASHSEED=1`, `2`, and `3`

Closes #5397

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-deterministic Chrome launch arg order when `ignore_default_args` is a list by preserving the declared order of defaults. Previously we used a set difference that reordered flags; now we use an order-preserving filter for deterministic startup flags.

- Replace set difference with an order-preserving filter: build a set from the ignore list for O(1) checks, then iterate `CHROME_DEFAULT_ARGS` in sequence.
- Add a regression test to ensure ignored args are removed and remaining defaults keep their original order.

<sup>Written for commit 94ec9cfaa728c90db6988b1368a1bc3b983d7e0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

