### PR TITLE
fix: stop restoring deleted storage-state cookies

### DIFF
--- a/browser_use/browser/watchdogs/storage_state_watchdog.py
+++ b/browser_use/browser/watchdogs/storage_state_watchdog.py
@@ -325,14 +325,9 @@ class StorageStateWatchdog(BaseWatchdog):
 		"""Merge two storage states, with new values taking precedence."""
 		merged = existing.copy()
 
-		# Merge cookies
-		existing_cookies = {(c['name'], c['domain'], c['path']): c for c in existing.get('cookies', [])}
-
-		for cookie in new.get('cookies', []):
-			key = (cookie['name'], cookie['domain'], cookie['path'])
-			existing_cookies[key] = cookie
-
-		merged['cookies'] = list(existing_cookies.values())
+		# Storage.getCookies returns the browser's complete cookie snapshot. Treat it
+		# as authoritative so deleted cookies are not resurrected from the old file.
+		merged['cookies'] = list(new.get('cookies', []))
 
 		# Merge origins
 		existing_origins = {origin['origin']: origin for origin in existing.get('origins', [])}

--- a/tests/ci/test_storage_state_watchdog.py
+++ b/tests/ci/test_storage_state_watchdog.py
@@ -105,3 +105,23 @@ async def test_save_storage_state_reads_existing_file_as_utf8(tmp_path: Path, mo
 	saved_state = json.loads(original_read_text(storage_path, encoding='utf-8'))
 	saved_cookies = {cookie['name']: cookie['value'] for cookie in saved_state['cookies']}
 	assert saved_cookies == {'greeting': unicode_value, 'current': 'new-value'}
+
+
+def test_merge_storage_states_does_not_restore_deleted_cookies() -> None:
+	existing = {
+		'cookies': [
+			{'name': 'session', 'value': 'old-token', 'domain': 'example.com', 'path': '/'},
+			{'name': 'theme', 'value': 'light', 'domain': 'example.com', 'path': '/'},
+		],
+		'origins': [{'origin': 'https://previous.example', 'localStorage': [{'name': 'key', 'value': 'value'}]}],
+	}
+	current = {
+		'cookies': [{'name': 'theme', 'value': 'dark', 'domain': 'example.com', 'path': '/'}],
+		'origins': [],
+	}
+
+	merged = StorageStateWatchdog._merge_storage_states(existing, current)
+
+	assert merged['cookies'] == current['cookies']
+	assert merged['origins'] == existing['origins']
+

--- a/tests/ci/test_storage_state_watchdog.py
+++ b/tests/ci/test_storage_state_watchdog.py
@@ -104,7 +104,7 @@ async def test_save_storage_state_reads_existing_file_as_utf8(tmp_path: Path, mo
 	assert encodings == ['utf-8']
 	saved_state = json.loads(original_read_text(storage_path, encoding='utf-8'))
 	saved_cookies = {cookie['name']: cookie['value'] for cookie in saved_state['cookies']}
-	assert saved_cookies == {'greeting': unicode_value, 'current': 'new-value'}
+	assert saved_cookies == {'current': 'new-value'}
 
 
 def test_merge_storage_states_does_not_restore_deleted_cookies() -> None:
@@ -124,4 +124,5 @@ def test_merge_storage_states_does_not_restore_deleted_cookies() -> None:
 
 	assert merged['cookies'] == current['cookies']
 	assert merged['origins'] == existing['origins']
+
 

--- a/tests/ci/test_storage_state_watchdog.py
+++ b/tests/ci/test_storage_state_watchdog.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
 
 import anyio
@@ -39,10 +40,10 @@ async def test_load_storage_state_reads_utf8(tmp_path: Path, monkeypatch: pytest
 		encoding='utf-8',
 	)
 
-	encodings: list[str | None] = []
+	encodings: list[Optional[str]] = []
 	original_read_text = anyio.Path.read_text
 
-	async def track_encoding(path: anyio.Path, encoding: str | None = None, errors: str | None = None) -> str:
+	async def track_encoding(path: anyio.Path, encoding: Optional[str] = None, errors: Optional[str] = None) -> str:
 		encodings.append(encoding)
 		return await original_read_text(path, encoding=encoding, errors=errors)
 
@@ -77,10 +78,10 @@ async def test_save_storage_state_reads_existing_file_as_utf8(tmp_path: Path, mo
 		encoding='utf-8',
 	)
 
-	encodings: list[str | None] = []
+	encodings: list[Optional[str]] = []
 	original_read_text = Path.read_text
 
-	def track_encoding(path: Path, encoding: str | None = None, errors: str | None = None) -> str:
+	def track_encoding(path: Path, encoding: Optional[str] = None, errors: Optional[str] = None) -> str:
 		if path == storage_path.resolve():
 			encodings.append(encoding)
 		return original_read_text(path, encoding=encoding, errors=errors)

--- a/tests/ci/test_storage_state_watchdog.py
+++ b/tests/ci/test_storage_state_watchdog.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
 
 import anyio
@@ -40,10 +39,10 @@ async def test_load_storage_state_reads_utf8(tmp_path: Path, monkeypatch: pytest
 		encoding='utf-8',
 	)
 
-	encodings: list[Optional[str]] = []
+	encodings: list[str | None] = []
 	original_read_text = anyio.Path.read_text
 
-	async def track_encoding(path: anyio.Path, encoding: Optional[str] = None, errors: Optional[str] = None) -> str:
+	async def track_encoding(path: anyio.Path, encoding: str | None = None, errors: str | None = None) -> str:
 		encodings.append(encoding)
 		return await original_read_text(path, encoding=encoding, errors=errors)
 
@@ -78,10 +77,10 @@ async def test_save_storage_state_reads_existing_file_as_utf8(tmp_path: Path, mo
 		encoding='utf-8',
 	)
 
-	encodings: list[Optional[str]] = []
+	encodings: list[str | None] = []
 	original_read_text = Path.read_text
 
-	def track_encoding(path: Path, encoding: Optional[str] = None, errors: Optional[str] = None) -> str:
+	def track_encoding(path: Path, encoding: str | None = None, errors: str | None = None) -> str:
 		if path == storage_path.resolve():
 			encodings.append(encoding)
 		return original_read_text(path, encoding=encoding, errors=errors)

--- a/tests/ci/test_storage_state_watchdog.py
+++ b/tests/ci/test_storage_state_watchdog.py
@@ -124,5 +124,3 @@ def test_merge_storage_states_does_not_restore_deleted_cookies() -> None:
 
 	assert merged['cookies'] == current['cookies']
 	assert merged['origins'] == existing['origins']
-
-


### PR DESCRIPTION
## Why

`StorageStateWatchdog` merges the current browser state into an existing `storage_state.json` file. The current implementation also retains cookies that are present only in the old file.

`Storage.getCookies` returns the complete browser cookie snapshot, so a cookie missing from that result has been removed from the browser. Keeping the old value can restore a deleted session cookie on the next Browser Use startup, including after a logout.

## What changed

- Treat the current CDP cookie list as authoritative when saving storage state.
- Keep the existing origin merge behavior unchanged.
- Add a regression test covering removal of an old session cookie while preserving origin state.

## Validation

- `pytest -q tests/ci/test_storage_state_watchdog.py`
- `ruff check browser_use/browser/watchdogs/storage_state_watchdog.py tests/ci/test_storage_state_watchdog.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops restoring deleted cookies when saving browser storage state. Previously, cookies present only in the old `storage_state.json` were retained; now `Storage.getCookies` is the authoritative source, so cookies removed from the browser are not resurrected on the next startup, including after logout.

- Preserves existing origin merge behavior; existing origins remain unless overridden by the new state.
- Adds regression coverage confirming deleted session cookies are not restored and origins are preserved.

<sup>Written for commit 43802b922f65b5ba5dc22671b574d17426745b4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

