### PR TITLE
fix(agent): honor zero message compaction threshold

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -238,7 +238,7 @@ class MessageManager:
 		# Char floor gate
 		history_items = self.state.agent_history_items
 		full_history_text = '\n'.join(item.to_string() for item in history_items).strip()
-		trigger_char_count = settings.trigger_char_count or 40000
+		trigger_char_count = settings.trigger_char_count if settings.trigger_char_count is not None else 40000
 		if len(full_history_text) < trigger_char_count:
 			return False
 

--- a/tests/ci/test_message_compaction.py
+++ b/tests/ci/test_message_compaction.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from browser_use.agent.message_manager.service import MessageManager
+from browser_use.agent.views import AgentStepInfo, MessageCompactionSettings
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.llm import BaseChatModel, SystemMessage
+from browser_use.llm.views import ChatInvokeCompletion
+
+
+@pytest.mark.asyncio
+async def test_zero_trigger_char_count_compacts_when_step_interval_is_reached(tmp_path: Path):
+	manager = MessageManager(
+		task='test task',
+		system_message=SystemMessage(content='system'),
+		file_system=FileSystem(tmp_path),
+	)
+	llm = AsyncMock(spec=BaseChatModel)
+	llm.ainvoke.return_value = ChatInvokeCompletion(completion='Compacted history', usage=None)
+	settings = MessageCompactionSettings(compact_every_n_steps=1, trigger_char_count=0)
+
+	compacted = await manager.maybe_compact_messages(
+		llm=llm,
+		settings=settings,
+		step_info=AgentStepInfo(step_number=1, max_steps=10),
+	)
+
+	assert compacted is True
+	llm.ainvoke.assert_awaited_once()
+	assert manager.state.compacted_memory == 'Compacted history'


### PR DESCRIPTION
## Summary

- preserve an explicit `trigger_char_count=0` instead of replacing it with the 40,000-character default
- add a regression test proving compaction runs once the configured step interval is reached

## Problem

`MessageCompactionSettings` already resolves an omitted threshold to the default value. The runtime check used a truthiness fallback, so an explicit zero was also replaced with 40,000. This prevented callers from removing the character floor and using only the step cadence to trigger compaction.

## Validation

- `uv run pytest tests/ci/test_message_compaction.py tests/ci/test_message_manager_state_isolation.py -q`
- `uv run ruff check browser_use/agent/message_manager/service.py tests/ci/test_message_compaction.py`
- `uv run ruff format --check browser_use/agent/message_manager/service.py tests/ci/test_message_compaction.py`
- `pyright --threads 6 browser_use/agent/message_manager/service.py tests/ci/test_message_compaction.py`
- changed-file pre-commit hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor an explicit zero message compaction threshold so compaction can be driven solely by step cadence. Fixes a fallback that replaced 0 with the 40,000 default and adds a regression test to confirm compaction runs at the configured step interval.

- **Bug Fixes**
  - Preserve `trigger_char_count=0` by checking for `None` instead of truthiness.
  - Added a test ensuring compaction occurs when `compact_every_n_steps` is reached with `trigger_char_count=0`.

<sup>Written for commit f39f50530357198cfc09a4304927b6f2ad06e039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

