### PR TITLE
fix: relax openai version pin

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1684,15 +1684,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
-				action_instance = self.ActionModel()
-				setattr(
-					action_instance,
-					'done',
-					{
+				action_instance = self.ActionModel.model_validate({
+					'done': {
 						'success': False,
 						'text': 'No next action returned by LLM!',
-					},
-				)
+					}
+				})
 				model_output.action = [action_instance]
 
 		return model_output

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1684,12 +1684,14 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
-				action_instance = self.ActionModel.model_validate({
-					'done': {
-						'success': False,
-						'text': 'No next action returned by LLM!',
+				action_instance = self.ActionModel.model_validate(
+					{
+						'done': {
+							'success': False,
+							'text': 'No next action returned by LLM!',
+						}
 					}
-				})
+				)
 				model_output.action = [action_instance]
 
 		return model_output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "google-genai==1.65.0",
-    "openai==2.16.0",
+    "openai>=2.16.0,<3",
     "anthropic==0.76.0",
     "groq==1.0.0",
     "ollama==0.6.1",


### PR DESCRIPTION
Fixes #4285. This relaxes the strict `openai==2.16.0` pin to `openai>=2.16.0,<3` so that downstream packages like `openai-agents` (which require a newer OpenAI SDK version) can be successfully installed alongside `browser-use`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relaxes the `openai` dependency to `>=2.16.0,<3` to avoid downstream version conflicts and fixes a ValidationError when inserting a fallback noop action after retries. Fixes #4285.

- **Dependencies**
  - Update `openai` pin from `==2.16.0` to `>=2.16.0,<3` to allow newer 2.x versions and unblock installs with packages like `openai-agents`.

- **Bug Fixes**
  - Build the fallback `done` action via `self.ActionModel.model_validate({...})` to avoid Pydantic ValidationError when the model returns no action.

<sup>Written for commit 880c26cb7c8323917cbbaacdb5ae61fd4e1f2bca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

