### PR TITLE
feat: add hover action for CSS :hover / JS mouseenter reveal (#4964)

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -138,6 +138,15 @@ class ClickCoordinateEvent(BaseEvent[dict]):
 
 	coordinate_x: int
 	coordinate_y: int
+
+
+class HoverElementEvent(ElementSelectedEvent[dict[str, Any] | None]):
+	"""Move the mouse over an element without clicking, to trigger CSS :hover states and
+	JS mouseenter/mouseover listeners (dropdown menus, tooltips, hover-reveal UI)."""
+
+	node: 'EnhancedDOMTreeNode'
+
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverElementEvent', 15.0))  # seconds
 	button: Literal['left', 'right', 'middle'] = 'left'
 	force: bool = False  # If True, skip safety checks (file input, print, select)
 
@@ -634,7 +643,7 @@ class CaptchaSolverFinishedEvent(BaseEvent):
 
 # Note: Model rebuilding for forward references is handled in the importing modules
 # Events with 'EnhancedDOMTreeNode' forward references (ClickElementEvent, TypeTextEvent,
-# ScrollEvent, UploadFileEvent) need model_rebuild() called after imports are complete
+# ScrollEvent, UploadFileEvent, HoverElementEvent) need model_rebuild() called after imports are complete
 
 
 def _check_event_names_dont_overlap():

--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -138,6 +138,10 @@ class ClickCoordinateEvent(BaseEvent[dict]):
 
 	coordinate_x: int
 	coordinate_y: int
+	button: Literal['left', 'right', 'middle'] = 'left'
+	force: bool = False  # If True, skip safety checks (file input, print, select)
+
+	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ClickCoordinateEvent', 15.0))  # seconds
 
 
 class HoverElementEvent(ElementSelectedEvent[dict[str, Any] | None]):
@@ -147,10 +151,6 @@ class HoverElementEvent(ElementSelectedEvent[dict[str, Any] | None]):
 	node: 'EnhancedDOMTreeNode'
 
 	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_HoverElementEvent', 15.0))  # seconds
-	button: Literal['left', 'right', 'middle'] = 'left'
-	force: bool = False  # If True, skip safety checks (file input, print, select)
-
-	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_ClickCoordinateEvent', 15.0))  # seconds
 
 
 class TypeTextEvent(ElementSelectedEvent[dict | None]):

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -13,6 +13,7 @@ from browser_use.browser.events import (
 	GetDropdownOptionsEvent,
 	GoBackEvent,
 	GoForwardEvent,
+	HoverElementEvent,
 	RefreshEvent,
 	ScrollEvent,
 	ScrollToTextEvent,
@@ -36,6 +37,7 @@ SelectDropdownOptionEvent.model_rebuild()
 TypeTextEvent.model_rebuild()
 ScrollEvent.model_rebuild()
 UploadFileEvent.model_rebuild()
+HoverElementEvent.model_rebuild()
 
 
 class DefaultActionWatchdog(BaseWatchdog):
@@ -1059,6 +1061,92 @@ class DefaultActionWatchdog(BaseWatchdog):
 			raise BrowserError(
 				message=f'Failed to click element: {str(e)}',
 				long_term_memory=error_detail,
+			)
+
+	async def on_HoverElementEvent(self, event: HoverElementEvent) -> dict | None:
+		"""Handle hover request with CDP. Moves the mouse over the element without clicking."""
+		try:
+			if not self.browser_session.agent_focus_target_id:
+				error_msg = 'Cannot execute hover: browser session is corrupted (target_id=None). Session may have crashed.'
+				self.logger.error(f'{error_msg}')
+				raise BrowserError(error_msg)
+
+			element_node = event.node
+			index_for_logging = self.browser_session.get_selector_index(element_node)
+
+			hover_metadata = await self._hover_element_node_impl(element_node)
+
+			self.logger.debug(f'🖱️ Hovered element index {index_for_logging}: {element_node.node_name}')
+			return hover_metadata
+		except Exception:
+			raise
+
+	async def _hover_element_node_impl(self, element_node) -> dict | None:
+		"""
+		Move the mouse over an element using pure CDP, without pressing/releasing any button.
+
+		Triggers CSS :hover rules and JS mouseenter/mouseover/mousemove listeners the same
+		way a real cursor movement would - useful for hover-revealed dropdowns, tooltips,
+		and menus that a plain click can't reach.
+
+		Args:
+			element_node: The DOM element to hover over
+		"""
+		try:
+			selector_index = self.browser_session.get_selector_index(element_node)
+
+			# Get CDP client for the element's frame
+			cdp_session = await self.browser_session.cdp_client_for_node(element_node)
+			session_id = cdp_session.session_id
+			backend_node_id = element_node.backend_node_id
+
+			# Get viewport dimensions to clamp the hover point on-screen
+			layout_metrics = await cdp_session.cdp_client.send.Page.getLayoutMetrics(session_id=session_id)
+			viewport_width = layout_metrics['layoutViewport']['clientWidth']
+			viewport_height = layout_metrics['layoutViewport']['clientHeight']
+
+			# Scroll element into view before computing coordinates
+			try:
+				await cdp_session.cdp_client.send.DOM.scrollIntoViewIfNeeded(
+					params={'backendNodeId': backend_node_id}, session_id=session_id
+				)
+				await asyncio.sleep(0.05)
+			except Exception as e:
+				self.logger.debug(f'Failed to scroll element into view before hover: {e}')
+
+			element_rect = await self.browser_session.get_element_coordinates(backend_node_id, cdp_session)
+			if not element_rect:
+				msg = f'Could not determine coordinates for element index {selector_index} - unable to hover.'
+				self.logger.warning(f'⚠️ {msg}')
+				return {'validation_error': msg}
+
+			center_x = element_rect.x + element_rect.width / 2
+			center_y = element_rect.y + element_rect.height / 2
+
+			# Keep the hover point within the viewport
+			center_x = max(0, min(viewport_width - 1, center_x))
+			center_y = max(0, min(viewport_height - 1, center_y))
+
+			self.logger.debug(f'🖱️ Moving mouse over element x: {center_x}px y: {center_y}px ...')
+			await cdp_session.cdp_client.send.Input.dispatchMouseEvent(
+				params={
+					'type': 'mouseMoved',
+					'x': center_x,
+					'y': center_y,
+				},
+				session_id=session_id,
+			)
+
+			# Give the page a beat to run CSS :hover / JS mouseenter handlers and render
+			# any hover-revealed content (dropdown, tooltip) before the next action runs.
+			await asyncio.sleep(0.15)
+
+			return {'x': center_x, 'y': center_y}
+		except Exception as e:
+			selector_index = self.browser_session.get_selector_index(element_node)
+			raise BrowserError(
+				message=f'Failed to hover element: {str(e)}',
+				long_term_memory=f'Failed to hover element index={selector_index}. The element may not be visible or interactable.',
 			)
 
 	async def _click_on_coordinate(self, coordinate_x: int, coordinate_y: int, force: bool = False) -> dict | None:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -21,6 +21,7 @@ from browser_use.browser.events import (
 	CloseTabEvent,
 	GetDropdownOptionsEvent,
 	GoBackEvent,
+	HoverElementEvent,
 	NavigateToUrlEvent,
 	ScrollEvent,
 	ScrollToTextEvent,
@@ -45,6 +46,7 @@ from browser_use.tools.views import (
 	ExtractAction,
 	FindElementsAction,
 	GetDropdownOptionsAction,
+	HoverElementAction,
 	InputTextAction,
 	NavigateAction,
 	NoParamsAction,
@@ -68,6 +70,7 @@ logger = logging.getLogger(__name__)
 ClickElementEvent.model_rebuild()
 TypeTextEvent.model_rebuild()
 ScrollEvent.model_rebuild()
+HoverElementEvent.model_rebuild()
 UploadFileEvent.model_rebuild()
 
 Context = TypeVar('Context')
@@ -855,6 +858,45 @@ class Tools(Generic[Context]):
 				# Log the full error for debugging
 				logger.error(f'Failed to dispatch TypeTextEvent: {type(e).__name__}: {e}')
 				error_msg = f'Failed to type text into element {params.index}: {e}'
+				return ActionResult(error=error_msg)
+
+		@self.registry.action(
+			'Move the mouse over an element by index without clicking. Use to reveal CSS :hover '
+			'menus, tooltips, or dropdowns that only appear on hover - then read the updated '
+			'browser state to interact with the revealed content.',
+			param_model=HoverElementAction,
+		)
+		async def hover(params: HoverElementAction, browser_session: BrowserSession):
+			node = await browser_session.get_element_by_index(params.index)
+			if node is None:
+				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
+				logger.warning(f'⚠️ {msg}')
+				return ActionResult(extracted_content=msg)
+
+			# Highlight the element being hovered (truly non-blocking)
+			create_task_with_error_handling(
+				browser_session.highlight_interaction_element(node), name='highlight_hover_element', suppress_exceptions=True
+			)
+
+			try:
+				event = browser_session.event_bus.dispatch(HoverElementEvent(node=node))
+				await event
+				hover_metadata = await event.event_result(raise_if_any=True, raise_if_none=False)
+
+				if isinstance(hover_metadata, dict) and 'validation_error' in hover_metadata:
+					return ActionResult(error=hover_metadata['validation_error'])
+
+				msg = f'Hovered element {get_click_description(node)}'
+				logger.debug(f'🖱️ {msg}')
+				return ActionResult(
+					extracted_content=msg,
+					long_term_memory=msg,
+					metadata=hover_metadata if isinstance(hover_metadata, dict) else None,
+				)
+			except BrowserError as e:
+				return handle_browser_error(e)
+			except Exception as e:
+				error_msg = f'Failed to hover element {params.index}: {str(e)}'
 				return ActionResult(error=error_msg)
 
 		@self.registry.action(

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -865,6 +865,7 @@ class Tools(Generic[Context]):
 			'menus, tooltips, or dropdowns that only appear on hover - then read the updated '
 			'browser state to interact with the revealed content.',
 			param_model=HoverElementAction,
+			terminates_sequence=True,
 		)
 		async def hover(params: HoverElementAction, browser_session: BrowserSession):
 			node = await browser_session.get_element_by_index(params.index)

--- a/browser_use/tools/views.py
+++ b/browser_use/tools/views.py
@@ -80,6 +80,10 @@ class ClickElementActionIndexOnly(BaseModel):
 	index: int = Field(ge=1, description='Element index from browser_state')
 
 
+class HoverElementAction(BaseModel):
+	index: int = Field(ge=1, description='Element index from browser_state')
+
+
 class InputTextAction(BaseModel):
 	index: int = Field(ge=0, description='from browser_state')
 	text: str = Field(description='Text to enter. With clear=True, text="" clears the field without typing.')

--- a/tests/ci/browser/test_hover_action.py
+++ b/tests/ci/browser/test_hover_action.py
@@ -1,0 +1,122 @@
+"""Tests for the hover action (CSS :hover / JS mouseenter reveal)."""
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile, ViewportSize
+from browser_use.browser.session import BrowserSession
+from browser_use.tools.service import Tools
+from browser_use.tools.views import HoverElementAction
+
+
+@pytest.fixture
+async def browser_session():
+	"""Create a simple headless browser session for hover tests."""
+	session = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=True,
+			window_size=ViewportSize(width=1280, height=1000),
+		)
+	)
+	await session.start()
+	yield session
+	await session.kill()
+
+
+HOVER_PAGE_HTML = """
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+	.menu { position: relative; display: inline-block; }
+	.dropdown {
+		display: none;
+		position: absolute;
+		border: 1px solid black;
+	}
+	.menu:hover .dropdown { display: block; }
+</style>
+</head>
+<body>
+	<div class="menu" id="menu-trigger" tabindex="0">
+		Products
+		<div class="dropdown" id="dropdown-content">
+			<a href="/a">Item A</a>
+			<a href="/b">Item B</a>
+		</div>
+	</div>
+	<script>
+		document.getElementById('menu-trigger').addEventListener('mouseenter', function () {
+			window.__hoverFired = true;
+		});
+	</script>
+</body>
+</html>
+"""
+
+
+class TestHoverAction:
+	"""Verify the `hover` tool triggers CSS :hover state and JS mouseenter listeners."""
+
+	async def test_hover_reveals_css_dropdown(self, httpserver, browser_session: BrowserSession):
+		"""Hovering the trigger should make the CSS-only dropdown visible."""
+		httpserver.expect_request('/hover-test').respond_with_data(HOVER_PAGE_HTML, content_type='text/html')
+		url = httpserver.url_for('/hover-test')
+
+		await browser_session.navigate_to(url)
+
+		browser_state = await browser_session.get_browser_state_summary(include_screenshot=False)
+		assert browser_state.dom_state is not None
+
+		# Find the hover trigger by its element id in the selector map
+		trigger_index = None
+		for idx, element in browser_state.dom_state.selector_map.items():
+			if element.attributes and element.attributes.get('id') == 'menu-trigger':
+				trigger_index = idx
+				break
+
+		assert trigger_index is not None, 'Could not find #menu-trigger element in selector map'
+
+		tools = Tools()
+		hover_action = tools.registry.registry.actions['hover']
+		result = await hover_action.function(
+			params=HoverElementAction(index=trigger_index),
+			browser_session=browser_session,
+		)
+
+		assert result.error is None, f'Hover action failed: {result.error}'
+
+		# Verify the JS mouseenter listener fired
+		cdp_session = await browser_session.get_or_create_cdp_session()
+		eval_result = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': 'window.__hoverFired === true'},
+			session_id=cdp_session.session_id,
+		)
+		assert eval_result.get('result', {}).get('value') is True, 'mouseenter listener did not fire on hover'
+
+		# Verify the CSS-revealed dropdown is now visible (display != none)
+		eval_display = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': "getComputedStyle(document.getElementById('dropdown-content')).display"},
+			session_id=cdp_session.session_id,
+		)
+		assert eval_display.get('result', {}).get('value') != 'none', 'CSS :hover dropdown did not become visible'
+
+	async def test_hover_invalid_index_returns_helpful_message(self, httpserver, browser_session: BrowserSession):
+		"""Hovering a stale/invalid index should return a clear message, not raise."""
+		httpserver.expect_request('/hover-empty').respond_with_data(
+			'<html><body><p>no interactive elements</p></body></html>', content_type='text/html'
+		)
+		url = httpserver.url_for('/hover-empty')
+		await browser_session.navigate_to(url)
+		await browser_session.get_browser_state_summary(include_screenshot=False)
+
+		tools = Tools()
+		hover_action = tools.registry.registry.actions['hover']
+		result = await hover_action.function(
+			params=HoverElementAction(index=999),
+			browser_session=browser_session,
+		)
+
+		assert result.error is None
+		assert 'not available' in (result.extracted_content or '')


### PR DESCRIPTION
Add hover action for CSS :hover / JS mouseenter reveal

Adds a hover tool that moves the mouse over an element by index without clicking, so the agent can reach dropdown menus, tooltips, and other hover-revealed UI that today's click action can't trigger and that isn't even visible in the DOM until hovered (#4964).

Implementation reuses the existing scroll-into-view and coordinate logic from click, then dispatches a single CDP mouseMoved event — deliberately stops short of press/release so it can never accidentally click.

Tested against a real page with a CSS-only dropdown and a JS mouseenter listener; both fire correctly. Full test suite passes.

Before:
<img width="1108" height="563" alt="hover_before" src="https://github.com/user-attachments/assets/003f26e6-6ec1-4d5c-a7ba-2d2b44bfa4d5" />

After:
<img width="1108" height="563" alt="hover_after" src="https://github.com/user-attachments/assets/806b0a85-3cef-47e5-9d2b-45d41f003f23" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `hover` action that moves the mouse over an element by index without clicking to reveal CSS :hover and JS mouseenter UI. Previously, click couldn’t trigger hover-only dropdowns or tooltips; now a single CDP `mouseMoved` fires handlers, never presses/releases, and the action terminates the sequence.

- **Details for review**
  - Introduces `HoverElementEvent` and `HoverElementAction`; rebuilds models, scrolls into view, centers, clamps to viewport, and returns `{ x, y }` metadata.
  - Registers `hover` in `Tools` with `terminates_sequence=true`; highlights the target and returns helpful messages for stale indices or validation errors for unknown coordinates.
  - Separates hover from click handling so hover never routes through click paths.
  - Adds tests to verify CSS dropdown reveal, JS `mouseenter` firing, and invalid index behavior.

<sup>Written for commit e9fd8450868a46fbaf4ebc9688443169ebf03926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

