### PR TITLE
fix: update openai version pin to 2.28.0

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1684,15 +1684,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
-				action_instance = self.ActionModel()
-				setattr(
-					action_instance,
-					'done',
-					{
+				action_instance = self.ActionModel.model_validate({
+					'done': {
 						'success': False,
 						'text': 'No next action returned by LLM!',
-					},
-				)
+					}
+				})
 				model_output.action = [action_instance]
 
 		return model_output

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1684,12 +1684,14 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
-				action_instance = self.ActionModel.model_validate({
-					'done': {
-						'success': False,
-						'text': 'No next action returned by LLM!',
+				action_instance = self.ActionModel.model_validate(
+					{
+						'done': {
+							'success': False,
+							'text': 'No next action returned by LLM!',
+						}
 					}
-				})
+				)
 				model_output.action = [action_instance]
 
 		return model_output

--- a/examples/custom-functions/cua.py
+++ b/examples/custom-functions/cua.py
@@ -259,6 +259,7 @@ async def openai_cua_fallback(params: OpenAICUAAction, browser_session: BrowserS
 		computer_call = computer_calls[0] if computer_calls else None
 		if not computer_call:
 			raise Exception('No computer calls found in CUA response')
+		assert computer_call is not None  # type narrowing for pyright
 
 		action = computer_call.action
 		print(f'🎬 Executing CUA action: {action.type} - {action}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "google-genai==1.65.0",
-    "openai==2.16.0",
+    "openai>=2.16.0,<3",
     "anthropic==0.76.0",
     "groq==1.0.0",
     "ollama==0.6.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "google-genai==1.65.0",
-    "openai>=2.16.0,<3",
+    "openai==2.28.0",
     "anthropic==0.76.0",
     "groq==1.0.0",
     "ollama==0.6.1",

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -183,7 +183,7 @@ def test_beta_agent_constructor_type_hints_match_browser_use_core_params():
 	def assert_tools_context_hint(annotation):
 		inner = [arg for arg in get_args(annotation) if arg is not type(None)]
 		assert len(inner) == 1
-		assert get_origin(inner[0]) is Tools
+		assert get_origin(inner[0]) == Tools
 		type_args = get_args(inner[0])
 		assert len(type_args) == 1
 		assert type_args[0].__name__ == 'Context'


### PR DESCRIPTION
Fixes #4285. Updated openai to 2.28.0 to resolve downstream dependency conflicts, as requested by maintainer. Also fixed a brittle identity test assertion in `test_beta_agent.py` that was failing on the newer pydantic/typing_extensions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `openai` to 2.28.0 to resolve downstream dependency conflicts (fixes #4285) and hardens the agent’s empty-action fallback. Also stabilizes typing checks under newer `pydantic`/`typing_extensions` and pyright.

- **Dependencies**
  - Bump `openai` to `2.28.0` in `pyproject.toml`.

- **Bug Fixes**
  - Use `ActionModel.model_validate` to insert a safe noop when the model returns no actions, preventing ValidationError.
  - Update test to use `get_origin(inner[0]) == Tools` instead of identity comparison.
  - Add assert to narrow `computer_call` in the CUA example to satisfy pyright.

<sup>Written for commit 142510c52173d5ccbef543aabdced1bb0e9c6ffd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

