### PR TITLE
fix(browser): clean up temp zip file in CRX extraction fallback

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import sys
 import tempfile
@@ -1225,12 +1226,14 @@ async function initialize(checkInitialized, magic) {{
 
 			with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
 				temp_zip.write(zip_data)
-				temp_zip.flush()
+				temp_zip_path = temp_zip.name
 
-				with zipfile.ZipFile(temp_zip.name, 'r') as zip_ref:
+			try:
+				with zipfile.ZipFile(temp_zip_path, 'r') as zip_ref:
 					zip_ref.extractall(extract_dir)
-
-				os.unlink(temp_zip.name)
+			finally:
+				with contextlib.suppress(OSError):
+					os.unlink(temp_zip_path)
 
 	def detect_display_configuration(self) -> None:
 		"""

--- a/tests/ci/test_extract_extension.py
+++ b/tests/ci/test_extract_extension.py
@@ -1,0 +1,68 @@
+"""Regression tests for BrowserProfile._extract_extension CRX fallback path.
+
+See https://github.com/browser-use/browser-use/issues/5364 - when the raw CRX
+can't be opened as a zip directly, the header-stripping fallback writes the
+payload to a NamedTemporaryFile and must always clean it up, even when the
+stripped payload itself isn't a valid zip (e.g. truncated download, unknown
+CRX version, corrupted header offset).
+"""
+
+import glob
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+
+
+def _make_headered_non_zip_crx(version: int = 3, header_len: int = 0) -> bytes:
+	"""Build a CRX-shaped file whose payload is not a valid zip at all.
+
+	This forces the direct `zipfile.ZipFile(crx_path)` open to raise
+	BadZipFile (so the header-stripping fallback in `_extract_extension`
+	is entered), AND makes the header-stripped payload also fail to open
+	as a zip, which is the scenario that used to leak the temp file.
+	"""
+	payload = b'not a zip file at all, no end-of-central-directory signature here'
+	if version == 2:
+		pubkey_len = 0
+		sig_len = 0
+		header = (2).to_bytes(4, 'little') + pubkey_len.to_bytes(4, 'little') + sig_len.to_bytes(4, 'little')
+	else:
+		header = (3).to_bytes(4, 'little') + header_len.to_bytes(4, 'little') + (b'\x00' * header_len)
+	return b'Cr24' + header + payload
+
+
+class TestExtractExtensionCrxFallback:
+	def test_no_temp_zip_leaked_when_fallback_payload_is_invalid(self, tmp_path: Path):
+		"""When both the direct and header-stripped opens fail, no .zip temp file should remain."""
+		profile = BrowserProfile(headless=True)
+
+		crx_path = tmp_path / 'broken.crx'
+		crx_path.write_bytes(_make_headered_non_zip_crx())
+		extract_dir = tmp_path / 'extracted'
+
+		tempdir = tempfile.gettempdir()
+		before = set(glob.glob(os.path.join(tempdir, '*.zip')))
+
+		with pytest.raises(Exception):
+			profile._extract_extension(crx_path, extract_dir)
+
+		after = set(glob.glob(os.path.join(tempdir, '*.zip')))
+		leaked = after - before
+		assert not leaked, f'_extract_extension leaked temp file(s) on failure: {leaked}'
+
+	def test_raises_instead_of_permission_error_on_cleanup(self, tmp_path: Path):
+		"""The failure raised should come from the zip extraction itself, not from cleanup."""
+		profile = BrowserProfile(headless=True)
+
+		crx_path = tmp_path / 'broken.crx'
+		crx_path.write_bytes(_make_headered_non_zip_crx())
+		extract_dir = tmp_path / 'extracted'
+
+		import zipfile
+
+		with pytest.raises(zipfile.BadZipFile):
+			profile._extract_extension(crx_path, extract_dir)


### PR DESCRIPTION
## Summary

`BrowserProfile._extract_extension()`'s CRX-header-stripping fallback path has two bugs:

1. **Temp file leak on failure**: `os.unlink(temp_zip.name)` is the last statement in the `with tempfile.NamedTemporaryFile(...)` block, reached only if extraction succeeds. If the header-stripped payload isn't a valid zip (truncated download, corrupted header offset, unsupported CRX version), the exception skips cleanup entirely and the temp `.zip` is leaked on disk permanently.
2. **Delete-while-open**: the `os.unlink()` call runs while the `NamedTemporaryFile` handle is still open (inside its own `with` block). On Windows this raises `PermissionError`, since an open file can't be deleted there.

Fixes #5364.

## Fix

Close the temp file before reopening it for extraction, then wrap the extraction in `try/finally` so cleanup always runs regardless of outcome or platform.

## Testing

- Added `tests/ci/test_extract_extension.py`: constructs a synthetic CRX whose header-stripped payload isn't a valid zip. Verified this test fails against the original code (actual leaked `.zip` file on disk) and passes with the fix.
- Ran `ruff format --check`, `ruff check`, and `pyright` on the changed file — all clean.
- Ran the existing extension-related suite (`tests/ci/test_extension_config.py`, `tests/ci/test_chrome_profile_helpers.py`) — all pass.
- End-to-end: launched a real headless `BrowserSession` with `enable_default_extensions=True`, which downloads and extracts the 3 real default extensions (uBlock Origin Lite, "I still don't care about cookies", Force Background Tab) and navigates a page successfully — no regression.
- End-to-end (bug repro): simulated a corrupted/truncated CRX download for a real default extension id and ran it through the actual `_setup_default_extensions` → `_extract_extension` production path with a real browser launch. With the fix: warning logged, browser launches fine, no leaked temp file. With the original code (same scenario): identical behavior except a `.zip` temp file is left behind in the OS temp directory.

Note: for the 3 currently-shipped default extensions, the direct `zipfile.ZipFile(crx_path)` open succeeds without hitting this fallback branch at all (Python's zipfile tolerates the CRX header prefix). This fallback is only exercised for malformed/truncated downloads or non-standard CRX headers — which is exactly the scenario reproduced above and described in #5364.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CRX extraction fallback to always clean up the temp `.zip` and avoid delete-while-open, preventing leaked files and Windows PermissionError. Adds regression tests to ensure correct cleanup and error reporting. Fixes #5364.

- **Bug Fixes**
  - Close the temp file before extraction and always remove it with try/finally using `contextlib.suppress`.
  - Added regression tests that simulate invalid CRX payloads to verify no temp `.zip` is leaked and `BadZipFile` is raised.

<sup>Written for commit ca969c44d12a8bc8912bf8c7585339b89b8fe435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

