### PR TITLE
fix(tools): scroll no longer reports success when every attempt fails

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1451,6 +1451,11 @@ You will be given a query and the markdown of a webpage that has been filtered t
 						except Exception as e:
 							logger.warning(f'Fractional scroll failed: {e}')
 
+					if completed_scrolls == 0:
+						target_suffix = f' {target}' if target else ''
+						error_msg = f'Failed to scroll {direction}{target_suffix}: all scroll attempts failed'
+						return ActionResult(error=error_msg)
+
 					if params.pages == 1.0:
 						long_term_memory = f'Scrolled {direction} {target} {viewport_height}px'.replace('  ', ' ')
 					else:

--- a/tests/ci/test_action_ScrollEvent_failure.py
+++ b/tests/ci/test_action_ScrollEvent_failure.py
@@ -1,0 +1,34 @@
+"""Regression test: a failed ScrollEvent dispatch must not be reported as a successful scroll.
+
+Prior to the fix, `scroll()`'s pages>=1.0 branch caught every per-attempt exception,
+logged a warning, and then unconditionally returned a success ActionResult (with a
+hardcoded "Scrolled down {viewport_height}px" message for the default pages=1.0 case),
+even when zero scroll attempts actually completed.
+"""
+
+from browser_use.tools.service import Tools
+from browser_use.tools.views import ScrollAction
+
+
+async def test_scroll_returns_error_when_no_active_target(browser_session):
+	"""`on_ScrollEvent` raises BrowserError('No active target for scrolling') when
+	`agent_focus_target_id` is unset — a real failure condition, not a mock — and
+	`scroll()` must surface that as an error, not a fabricated success message.
+	"""
+	tools = Tools()
+	ActionModel = tools.registry.create_action_model()
+	action = ActionModel(**{'scroll': ScrollAction(down=True).model_dump()})
+
+	original_target_id = browser_session.agent_focus_target_id
+	browser_session.agent_focus_target_id = None
+	try:
+		result = await tools.act(action, browser_session=browser_session)
+	finally:
+		browser_session.agent_focus_target_id = original_target_id
+
+	assert result.error is not None, (
+		f'scroll() reported success ({result.extracted_content!r}) despite every scroll attempt failing'
+	)
+	assert 'Scrolled' not in (result.extracted_content or ''), (
+		f'scroll() fabricated a success message despite failing: {result.extracted_content!r}'
+	)


### PR DESCRIPTION
## Summary

`scroll()`'s `pages >= 1.0` branch (the default call shape — `pages` defaults to `1.0`) wraps each per-page `ScrollEvent` dispatch in its own `try/except` that only logs a warning on failure and continues. After the loop, the function unconditionally returns a success `ActionResult` — for the default `pages == 1.0` case it's a hardcoded `f'Scrolled {direction} {target} {viewport_height}px'` message — without ever checking whether `completed_scrolls` is actually greater than zero.

**Concrete failure scenario:** if the underlying scroll dispatch fails (no active target, an iframe/target swap mid-action, a page that blocks programmatic scroll — e.g. `on_ScrollEvent` raises `BrowserError('No active target for scrolling')`), the agent calls `scroll(down=True)` and gets back a success result with `error=None`. The page hasn't moved, but the agent believes it has and keeps acting on stale content — a silent no-op that doesn't even trip the failure/loop-detection counters, since `result.error` is never set.

## Fix

Return an `ActionResult(error=...)` when `completed_scrolls == 0` instead of falling through to the hardcoded success message. No change to the partial-success case (some pages scrolled, some didn't) — that already reports the real `completed_scrolls` count honestly.

## Testing

- Added `tests/ci/test_action_ScrollEvent_failure.py`: uses a real `BrowserSession` and forces a genuine failure by clearing `agent_focus_target_id`, which makes `on_ScrollEvent` raise `BrowserError('No active target for scrolling')` for real (no mocking). Verified this test fails against the original code — actual assertion output: `scroll() reported success ('🔍 Scrolled down 1000px') despite every scroll attempt failing` — and passes with the fix.
- `ruff format --check`, `ruff check`, `pyright` — all clean on the changed files.
- Ran `tests/ci/test_tools.py`, `tests/ci/test_multi_act_guards.py`, `tests/ci/test_action_loop_detection.py` alongside the new test — 69 passed, no regressions.
- End-to-end: launched a real headless browser, navigated to a real page, and confirmed (1) a normal scroll still succeeds exactly as before (no regression to the happy path), and (2) forcing the same real failure condition returns `error='Failed to scroll down: all scroll attempts failed'` instead of a fabricated success message.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where `scroll()` returned success even when all scroll attempts failed. Now it returns an error so the agent doesn’t act on stale content.

- **Bug Fixes**
  - In the `pages >= 1.0` path, return `ActionResult(error=...)` when `completed_scrolls == 0` instead of a success message.
  - Added `tests/ci/test_action_ScrollEvent_failure.py` to reproduce a real failure (no active target) and assert an error is returned.
  - Partial successes are unchanged; normal scrolls still succeed.

<sup>Written for commit 465dced47b9d466dcfcd59967a7d0f9c86c3d152. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

