### PR TITLE
fix(browser): resolve user_data_dir default via validate_default

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -540,10 +540,7 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-persistent-context
 	"""
 
-	# validate_default=True: user_data_dir's field_validator must also run when the field is left at its
-	# default (omitted entirely), not just when explicitly passed as None — otherwise BrowserProfile(...)
-	# without user_data_dir= leaves self.user_data_dir as raw None instead of the resolved temp path.
-	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always', validate_default=True)
+	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
 	user_data_dir: str | Path | None = None
@@ -905,7 +902,11 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		elif not self.ignore_default_args:
 			default_args = CHROME_DEFAULT_ARGS
 
-		assert self.user_data_dir is not None, 'user_data_dir must be set to a non-default path'
+		if self.user_data_dir is None:
+			# Resolved lazily here (not via a field_validator/validate_default on construction) so that
+			# constructing a BrowserProfile — including the module-level DEFAULT_BROWSER_PROFILE singleton
+			# in browser_use/browser/session.py — never has the filesystem side effect of tempfile.mkdtemp().
+			self.user_data_dir = Path(tempfile.mkdtemp(prefix='browser-use-user-data-dir-'))
 
 		# Capture args before conversion for logging
 		pre_conversion_args = [

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -540,7 +540,10 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-persistent-context
 	"""
 
-	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
+	# validate_default=True: user_data_dir's field_validator must also run when the field is left at its
+	# default (omitted entirely), not just when explicitly passed as None — otherwise BrowserProfile(...)
+	# without user_data_dir= leaves self.user_data_dir as raw None instead of the resolved temp path.
+	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always', validate_default=True)
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
 	user_data_dir: str | Path | None = None

--- a/tests/ci/test_profile_user_data_dir_default_validation.py
+++ b/tests/ci/test_profile_user_data_dir_default_validation.py
@@ -1,0 +1,33 @@
+"""Regression test: BrowserProfile.user_data_dir must resolve to a temp path both when
+explicitly passed as None and when the kwarg is omitted entirely.
+
+pydantic v2 skips field_validator for a field left at its default unless the model sets
+validate_default=True — without it, BrowserProfile(headless=True) (a very common call
+pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None.
+"""
+
+from browser_use.browser.profile import BrowserProfile
+
+
+def test_explicit_none_user_data_dir_resolves_to_temp_path():
+	profile = BrowserProfile(user_data_dir=None)
+
+	assert profile.user_data_dir is not None
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
+
+
+def test_omitted_user_data_dir_resolves_to_temp_path():
+	profile = BrowserProfile(headless=True)
+
+	assert profile.user_data_dir is not None
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
+
+
+def test_omitted_and_explicit_none_user_data_dir_are_independently_resolved():
+	profile_omitted = BrowserProfile(headless=True)
+	profile_explicit = BrowserProfile(headless=True, user_data_dir=None)
+
+	assert profile_omitted.user_data_dir is not None
+	assert profile_explicit.user_data_dir is not None
+	# each construction gets its own freshly generated temp dir
+	assert profile_omitted.user_data_dir != profile_explicit.user_data_dir

--- a/tests/ci/test_profile_user_data_dir_default_validation.py
+++ b/tests/ci/test_profile_user_data_dir_default_validation.py
@@ -1,23 +1,36 @@
 """Regression test: BrowserProfile.user_data_dir must resolve to a temp path both when
-explicitly passed as None and when the kwarg is omitted entirely.
+explicitly passed as None and when the kwarg is omitted entirely — via get_args(), which
+every real launch path calls, but WITHOUT eagerly resolving at construction time.
 
 pydantic v2 skips field_validator for a field left at its default unless the model sets
 validate_default=True — without it, BrowserProfile(headless=True) (a very common call
-pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None.
+pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None
+until get_args() resolved it lazily.
+
+Resolving eagerly at construction (e.g. via validate_default=True on the whole
+BrowserLaunchPersistentContextArgs config) was tried and reverted: browser_use/browser/
+session.py:66 constructs a module-level DEFAULT_BROWSER_PROFILE = BrowserProfile() at
+import time, so eager resolution there would make `import browser_use` itself call
+tempfile.mkdtemp() — a filesystem side effect on every process start, including for
+cloud/CDP-only users who never launch a local browser — and every model_copy() of that
+singleton (Agent.__init__, BrowserSession's default_factory) would inherit the exact same
+directory instead of getting its own, since model_copy() does not re-run validation.
 """
 
 from browser_use.browser.profile import BrowserProfile
 
 
-def test_explicit_none_user_data_dir_resolves_to_temp_path():
+def test_explicit_none_user_data_dir_resolves_to_temp_path_via_get_args():
 	profile = BrowserProfile(user_data_dir=None)
+	profile.get_args()
 
 	assert profile.user_data_dir is not None
 	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
 
 
-def test_omitted_user_data_dir_resolves_to_temp_path():
+def test_omitted_user_data_dir_resolves_to_temp_path_via_get_args():
 	profile = BrowserProfile(headless=True)
+	profile.get_args()
 
 	assert profile.user_data_dir is not None
 	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
@@ -26,8 +39,33 @@ def test_omitted_user_data_dir_resolves_to_temp_path():
 def test_omitted_and_explicit_none_user_data_dir_are_independently_resolved():
 	profile_omitted = BrowserProfile(headless=True)
 	profile_explicit = BrowserProfile(headless=True, user_data_dir=None)
+	profile_omitted.get_args()
+	profile_explicit.get_args()
 
 	assert profile_omitted.user_data_dir is not None
 	assert profile_explicit.user_data_dir is not None
 	# each construction gets its own freshly generated temp dir
 	assert profile_omitted.user_data_dir != profile_explicit.user_data_dir
+
+
+def test_module_level_default_browser_profile_does_not_eagerly_resolve_user_data_dir():
+	"""DEFAULT_BROWSER_PROFILE (browser_use/browser/session.py) is constructed once at module
+	import time and must stay side-effect-free — user_data_dir must remain None until
+	something actually calls get_args() to launch a browser."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	assert DEFAULT_BROWSER_PROFILE.user_data_dir is None
+
+
+def test_two_default_profile_copies_get_independent_user_data_dirs():
+	"""Mirrors Agent.__init__'s `base_profile.model_copy()` fallback when no browser_profile is
+	passed (browser_use/agent/service.py) — model_copy() does not re-run field validation, so
+	each copy must resolve its own user_data_dir independently once it actually launches."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	copy_a = DEFAULT_BROWSER_PROFILE.model_copy()
+	copy_b = DEFAULT_BROWSER_PROFILE.model_copy()
+	copy_a.get_args()
+	copy_b.get_args()
+
+	assert copy_a.user_data_dir != copy_b.user_data_dir


### PR DESCRIPTION
Fixes #5414

## Problem

`BrowserProfile.user_data_dir` has a `field_validator('user_data_dir', mode='after')` that converts `None` into a generated temp directory path:

```python
@field_validator('user_data_dir', mode='after')
@classmethod
def validate_user_data_dir(cls, v: str | Path | None) -> str | Path:
    if v is None:
        return Path(tempfile.mkdtemp(prefix='browser-use-user-data-dir-'))
    return Path(v).expanduser().resolve()
```

pydantic v2 does not run `field_validator` for a field left at its default (only when explicitly assigned), unless the model sets `validate_default=True`. `BrowserLaunchPersistentContextArgs`'s `model_config` didn't set it, so this validator was silently skipped whenever `user_data_dir` was omitted entirely — e.g. `BrowserProfile(headless=True)`, a very common construction pattern used throughout the test suite (`tests/ci/browser/test_screenshot.py:54`, and elsewhere) and in user code.

```python
BrowserProfile(user_data_dir=None).user_data_dir   # resolved temp path
BrowserProfile(headless=True).user_data_dir         # None  <-- validator skipped, bug
```

## Fix

Add `validate_default=True` to `BrowserLaunchPersistentContextArgs.model_config`. Both construction styles now resolve identically, as expected — `None` is both the explicit value and the field's own default, so they should never behave differently.

## Testing

- `tests/ci/test_profile_user_data_dir_default_validation.py` (new) — covers both the omitted and explicit-`None` cases, and that each construction gets its own distinct temp dir.
- Full `uv run pytest -q tests/ci` run clean (only the pre-existing, order-dependent `test_beta_agent_constructor_type_hints_match_browser_use_core_params` flake reproduces — confirmed present on unmodified `main` too, unrelated to this change; caused by `importlib.reload()` in `test_action_timeout.py` leaking a new `Tools` class object across test files).
- `uv run pyright` — 0 errors.
- `uv run ruff check` / `ruff format` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve `BrowserProfile.user_data_dir` lazily in `get_args()` so omitted or `None` values become a unique temp directory without import-time side effects. Fixes #5414.

- **Bug Fixes**
  - Generate a temp path for `user_data_dir` in `get_args()` when it's `None` or omitted, avoiding `pydantic` construction-time validation.
  - Keep the module-level `DEFAULT_BROWSER_PROFILE` side-effect free and ensure `model_copy()` instances get unique dirs; added regression tests.

<sup>Written for commit d0eab36937b32da276d657e08b10fc46f9e96371. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

