### PR TITLE
feat(browser): honor BROWSER_USE_HEADLESS in BrowserProfile

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -702,6 +702,17 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	profile_directory: str = 'Default'  # e.g. 'Profile 1', 'Profile 2', 'Custom Profile', etc.
 
+	use_system_keychain: bool | None = Field(
+		default=None,
+		description=(
+			'Whether Chromium may use the OS credential store (macOS Keychain / Linux libsecret) to decrypt '
+			'saved passwords/cookies. None (default) = auto: resolved in model_post_init before the profile is '
+			'possibly copied to a temp dir. Disabled for profiles fully managed by browser-use (temp dirs and the '
+			'default browser-use profile) so automation never triggers an OS credential prompt; enabled for a '
+			'real, user-supplied user_data_dir (e.g. an existing Chrome profile) so its saved logins stay readable.'
+		),
+	)
+
 	# these can be found in BrowserLaunchArgs, BrowserLaunchPersistentContextArgs, BrowserNewContextArgs, BrowserConnectArgs:
 	# save_recording_path: alias of record_video_dir
 	# save_har_path: alias of record_har_path
@@ -832,6 +843,14 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	def model_post_init(self, __context: Any) -> None:
 		"""Called after model initialization to set up display configuration."""
+		if self.use_system_keychain is None:
+			# resolve auto mode before user_data_dir's field_validator (only guaranteed to have run when
+			# the field was explicitly passed — see #5414) and _copy_profile() may rewrite it to a temp copy
+			is_browser_use_managed_profile = self.user_data_dir is None or (
+				'browser-use-user-data-dir-' in str(self.user_data_dir).lower()
+				or Path(self.user_data_dir).expanduser().resolve() == CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR.resolve()
+			)
+			self.use_system_keychain = not is_browser_use_managed_profile
 		self.detect_display_configuration()
 		self._copy_profile()
 
@@ -912,6 +931,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			f'--profile-directory={self.profile_directory}',
 			*(CHROME_DOCKER_ARGS if (CONFIG.IN_DOCKER or not self.chromium_sandbox) else []),
 			*(CHROME_HEADLESS_ARGS if self.headless else []),
+			*([] if self.use_system_keychain else ['--use-mock-keychain', '--password-store=basic']),
 			*(CHROME_DISABLE_SECURITY_ARGS if self.disable_security else []),
 			*(CHROME_DETERMINISTIC_RENDERING_ARGS if self.deterministic_rendering else []),
 			*(

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -540,10 +540,7 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-persistent-context
 	"""
 
-	# validate_default=True: user_data_dir's field_validator must also run when the field is left at its
-	# default (omitted entirely), not just when explicitly passed as None — otherwise BrowserProfile(...)
-	# without user_data_dir= leaves self.user_data_dir as raw None instead of the resolved temp path.
-	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always', validate_default=True)
+	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
 	user_data_dir: str | Path | None = None
@@ -905,7 +902,11 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		elif not self.ignore_default_args:
 			default_args = CHROME_DEFAULT_ARGS
 
-		assert self.user_data_dir is not None, 'user_data_dir must be set to a non-default path'
+		if self.user_data_dir is None:
+			# Resolved lazily here (not via a field_validator/validate_default on construction) so that
+			# constructing a BrowserProfile — including the module-level DEFAULT_BROWSER_PROFILE singleton
+			# in browser_use/browser/session.py — never has the filesystem side effect of tempfile.mkdtemp().
+			self.user_data_dir = Path(tempfile.mkdtemp(prefix='browser-use-user-data-dir-'))
 
 		# Capture args before conversion for logging
 		pre_conversion_args = [

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -25,6 +25,14 @@ def _get_enable_default_extensions_default() -> bool:
 	return True
 
 
+def _get_headless_default() -> bool | None:
+	"""Get the default value for headless from the BROWSER_USE_HEADLESS env var, or None to fall back to display detection."""
+	env_val = os.getenv('BROWSER_USE_HEADLESS')
+	if env_val is not None:
+		return env_val.lower() not in ('0', 'false', 'no', 'off', '')
+	return None
+
+
 CHROME_DEBUG_PORT = 9242  # use a non-default port to avoid conflicts with other tools / devs using 9222
 DOMAIN_OPTIMIZATION_THRESHOLD = 100  # Convert domain lists to sets for O(1) lookup when >= this size
 CHROME_PROFILE_TRANSIENT_FILE_PATTERNS = (
@@ -419,7 +427,10 @@ class BrowserLaunchArgs(BaseModel):
 		validation_alias=AliasChoices('browser_binary_path', 'chrome_binary_path'),
 		description='Path to the chromium-based browser executable to use.',
 	)
-	headless: bool | None = Field(default=None, description='Whether to run the browser in headless or windowed mode.')
+	headless: bool | None = Field(
+		default_factory=_get_headless_default,
+		description='Whether to run the browser in headless or windowed mode. Defaults to BROWSER_USE_HEADLESS env var if set, otherwise auto-detected from display availability.',
+	)
 	args: list[CliArgStr] = Field(
 		default_factory=list, description='List of *extra* CLI args to pass to the browser when launching.'
 	)
@@ -456,8 +467,21 @@ class BrowserLaunchArgs(BaseModel):
 
 	@model_validator(mode='after')
 	def validate_devtools_headless(self) -> Self:
-		"""Cannot open devtools when headless is True"""
-		assert not (self.headless and self.devtools), 'headless=True and devtools=True cannot both be set at the same time'
+		"""Cannot open devtools when headless is True.
+
+		An explicit headless=True still conflicts with devtools=True and raises. A headless value that
+		only came from the BROWSER_USE_HEADLESS env var (not passed explicitly) yields to an explicit
+		devtools=True instead of raising, since the user never wrote headless=True themselves.
+		"""
+		if self.headless and self.devtools:
+			if 'headless' not in self.model_fields_set:
+				logger.warning(
+					'⚠️ BROWSER_USE_HEADLESS is set but devtools=True was passed explicitly. '
+					'devtools takes priority. Setting headless=False.'
+				)
+				self.headless = False
+			else:
+				assert False, 'headless=True and devtools=True cannot both be set at the same time'
 		return self
 
 	@model_validator(mode='after')

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -540,7 +540,10 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-persistent-context
 	"""
 
-	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
+	# validate_default=True: user_data_dir's field_validator must also run when the field is left at its
+	# default (omitted entirely), not just when explicitly passed as None — otherwise BrowserProfile(...)
+	# without user_data_dir= leaves self.user_data_dir as raw None instead of the resolved temp path.
+	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always', validate_default=True)
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
 	user_data_dir: str | Path | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "uuid7==0.1.0",
     "google-genai==1.65.0",
     "openai==2.16.0",
-    "anthropic==0.76.0",
+    "anthropic==0.121.0",
     "groq==1.0.0",
     "ollama==0.6.1",
     "google-api-python-client==2.188.0",

--- a/tests/ci/conftest.py
+++ b/tests/ci/conftest.py
@@ -163,6 +163,7 @@ async def browser_session():
 			user_data_dir=None,  # Use temporary directory
 			keep_alive=True,
 			enable_default_extensions=True,  # Enable extensions during tests
+			use_system_keychain=False,  # tests must never touch the OS credential store
 		)
 	)
 	await session.start()

--- a/tests/ci/test_browser_profile_keychain.py
+++ b/tests/ci/test_browser_profile_keychain.py
@@ -1,0 +1,52 @@
+"""Tests for BrowserProfile.use_system_keychain and its effect on get_args()."""
+
+from browser_use.browser.profile import CONFIG, BrowserProfile
+
+
+def test_temporary_profile_avoids_system_keychain_by_default():
+	profile = BrowserProfile(user_data_dir=None)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_default_browser_use_profile_avoids_system_keychain_by_default():
+	profile = BrowserProfile(headless=True, user_data_dir=CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR, keep_alive=False)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_real_user_supplied_profile_keeps_system_keychain_by_default(tmp_path):
+	profile = BrowserProfile(user_data_dir=tmp_path / 'my-real-profile')
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' not in args
+	assert '--password-store=basic' not in args
+
+
+def test_explicit_use_system_keychain_true_overrides_temporary_profile_default():
+	profile = BrowserProfile(user_data_dir=None, use_system_keychain=True)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' not in args
+	assert '--password-store=basic' not in args
+
+
+def test_explicit_use_system_keychain_false_overrides_real_profile_default(tmp_path):
+	profile = BrowserProfile(user_data_dir=tmp_path / 'my-real-profile', use_system_keychain=False)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_omitted_user_data_dir_still_avoids_system_keychain():
+	"""use_system_keychain's auto-detection must not rely on user_data_dir's field_validator having
+	already run (see #5414) — BrowserProfile(headless=True) with no explicit user_data_dir= is a very
+	common call pattern and must not be treated as a real user profile."""
+	profile = BrowserProfile(headless=True)
+
+	assert profile.use_system_keychain is False

--- a/tests/ci/test_browser_profile_keychain.py
+++ b/tests/ci/test_browser_profile_keychain.py
@@ -1,6 +1,6 @@
 """Tests for BrowserProfile.use_system_keychain and its effect on get_args()."""
 
-from browser_use.browser.profile import CONFIG, BrowserProfile
+from browser_use.browser.profile import CONFIG, BrowserChannel, BrowserProfile
 
 
 def test_temporary_profile_avoids_system_keychain_by_default():
@@ -23,6 +23,27 @@ def test_real_user_supplied_profile_keeps_system_keychain_by_default(tmp_path):
 	profile = BrowserProfile(user_data_dir=tmp_path / 'my-real-profile')
 	args = profile.get_args()
 
+	assert '--use-mock-keychain' not in args
+	assert '--password-store=basic' not in args
+
+
+def test_real_chrome_profile_keeps_system_keychain_after_copy_profile_rewrites_user_data_dir(tmp_path):
+	"""use_system_keychain must be decided from the ORIGINAL real user_data_dir before _copy_profile()
+	rewrites it to a browser-use-managed-looking temp dir — and must stay True afterward, so a copied
+	real Chrome profile's OS-keychain-encrypted cookies/passwords stay decryptable. The path here has
+	no 'chrome' substring and channel=CHROME is what makes _copy_profile() actually perform the copy
+	(is_chrome True), unlike test_real_user_supplied_profile_keeps_system_keychain_by_default's path,
+	which has no 'chrome' substring/executable_path/CHROME channel and so never exercises the copy."""
+	real_profile_dir = tmp_path / 'my-real-profile'
+	real_profile_dir.mkdir()
+
+	profile = BrowserProfile(user_data_dir=real_profile_dir, channel=BrowserChannel.CHROME)
+
+	# _copy_profile() must have actually rewritten user_data_dir to a temp copy (proving the copy ran).
+	assert str(profile.user_data_dir) != str(real_profile_dir)
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir).lower()
+
+	args = profile.get_args()
 	assert '--use-mock-keychain' not in args
 	assert '--password-store=basic' not in args
 

--- a/tests/ci/test_browser_profile_keychain.py
+++ b/tests/ci/test_browser_profile_keychain.py
@@ -48,6 +48,24 @@ def test_real_chrome_profile_keeps_system_keychain_after_copy_profile_rewrites_u
 	assert '--password-store=basic' not in args
 
 
+def test_default_browser_use_profile_avoids_system_keychain_with_non_default_channel():
+	"""Pins an ordering dependency: model_post_init resolves use_system_keychain BEFORE the
+	model_validator(mode='after') warn_user_data_dir_non_default_version rewrites a user_data_dir
+	equal to CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR to a sibling '.../default-{channel}' dir (only
+	triggered by a non-default channel — test_default_browser_use_profile_avoids_system_keychain_by_default
+	uses the default channel, so that rewrite validator never fires there and this ordering goes
+	unexercised). If model_post_init ever ran after that rewrite, the sibling path would match neither
+	the None check, the temp-dir substring, nor an exact equal to BROWSER_USE_DEFAULT_USER_DATA_DIR, so
+	use_system_keychain would flip to True — silently reintroducing OS keychain prompts for a
+	browser-use-managed profile."""
+	profile = BrowserProfile(user_data_dir=CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR, channel=BrowserChannel.CHROME)
+	args = profile.get_args()
+
+	assert profile.use_system_keychain is False
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
 def test_explicit_use_system_keychain_true_overrides_temporary_profile_default():
 	profile = BrowserProfile(user_data_dir=None, use_system_keychain=True)
 	args = profile.get_args()

--- a/tests/ci/test_headless_config.py
+++ b/tests/ci/test_headless_config.py
@@ -1,0 +1,155 @@
+"""Tests for the BROWSER_USE_HEADLESS environment variable (see issue #5420).
+
+Mirrors tests/ci/test_extension_config.py's pattern for BROWSER_USE_DISABLE_EXTENSIONS.
+"""
+
+import os
+
+import pytest
+
+
+class TestHeadlessEnvVar:
+	"""Test BROWSER_USE_HEADLESS environment variable."""
+
+	def test_default_value_is_none(self):
+		"""Without env var set, _get_headless_default should return None (fall back to display detection)."""
+		original = os.environ.pop('BROWSER_USE_HEADLESS', None)
+		try:
+			from browser_use.browser.profile import _get_headless_default
+
+			assert _get_headless_default() is None
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+
+	@pytest.mark.parametrize(
+		'env_value,expected_headless',
+		[
+			('true', True),
+			('True', True),
+			('TRUE', True),
+			('1', True),
+			('yes', True),
+			('on', True),
+			('false', False),
+			('False', False),
+			('FALSE', False),
+			('0', False),
+			('no', False),
+			('off', False),
+			('', False),
+		],
+	)
+	def test_env_var_values(self, env_value: str, expected_headless: bool):
+		"""Test various env var values are parsed correctly."""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = env_value
+			from browser_use.browser.profile import _get_headless_default
+
+			result = _get_headless_default()
+			assert result is expected_headless, (
+				f"Expected headless={expected_headless} for BROWSER_USE_HEADLESS='{env_value}', got {result}"
+			)
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_browser_profile_uses_env_var(self):
+		"""Test that BrowserProfile picks up the env var."""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = 'true'
+
+			from browser_use.browser.profile import BrowserProfile
+
+			profile = BrowserProfile()
+			assert profile.headless is True, 'BrowserProfile should be headless when BROWSER_USE_HEADLESS=true'
+
+			os.environ['BROWSER_USE_HEADLESS'] = 'false'
+			profile2 = BrowserProfile()
+			assert profile2.headless is False, 'BrowserProfile should be headful when BROWSER_USE_HEADLESS=false'
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_explicit_param_overrides_env_var(self):
+		"""Test that an explicit headless= parameter overrides the env var."""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = 'true'
+
+			from browser_use.browser.profile import BrowserProfile
+
+			profile = BrowserProfile(headless=False)
+			assert profile.headless is False, 'Explicit headless=False should override BROWSER_USE_HEADLESS=true'
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_browser_session_uses_env_var(self):
+		"""Test that BrowserSession picks up the env var via BrowserProfile.
+
+		BrowserSession.__init__ filters None values out of the kwargs it forwards to BrowserProfile,
+		so an unpassed headless= must still reach the field's default_factory rather than being
+		overridden with an explicit None - this is a distinct code path from BrowserProfile() directly.
+		"""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = 'true'
+
+			from browser_use.browser import BrowserSession
+
+			session = BrowserSession()
+			assert session.browser_profile.headless is True, 'BrowserSession should be headless when BROWSER_USE_HEADLESS=true'
+
+			session2 = BrowserSession(headless=False)
+			assert session2.browser_profile.headless is False, 'Explicit headless=False should override the env var'
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_env_var_headless_yields_to_explicit_devtools(self):
+		"""Regression test: BROWSER_USE_HEADLESS=true must not make BrowserProfile(devtools=True) raise.
+
+		default_factory populates the headless field before validate_devtools_headless (mode='after')
+		runs, so a naive implementation would turn a previously-valid BrowserProfile(devtools=True) call
+		into an AssertionError as soon as the env var is set. devtools takes priority: headless is forced
+		back to False instead of raising, since the caller never wrote headless=True themselves.
+		"""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = 'true'
+
+			from browser_use.browser.profile import BrowserProfile
+
+			profile = BrowserProfile(devtools=True)
+			assert profile.headless is False
+			assert profile.devtools is True
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_explicit_headless_true_still_conflicts_with_devtools(self):
+		"""An explicit headless=True (not from the env var) must still raise with devtools=True, unchanged."""
+		original = os.environ.pop('BROWSER_USE_HEADLESS', None)
+		try:
+			from pydantic import ValidationError
+
+			from browser_use.browser.profile import BrowserProfile
+
+			with pytest.raises(ValidationError, match='headless=True and devtools=True cannot both be set'):
+				BrowserProfile(headless=True, devtools=True)
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original

--- a/tests/ci/test_profile_user_data_dir_default_validation.py
+++ b/tests/ci/test_profile_user_data_dir_default_validation.py
@@ -1,0 +1,33 @@
+"""Regression test: BrowserProfile.user_data_dir must resolve to a temp path both when
+explicitly passed as None and when the kwarg is omitted entirely.
+
+pydantic v2 skips field_validator for a field left at its default unless the model sets
+validate_default=True — without it, BrowserProfile(headless=True) (a very common call
+pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None.
+"""
+
+from browser_use.browser.profile import BrowserProfile
+
+
+def test_explicit_none_user_data_dir_resolves_to_temp_path():
+	profile = BrowserProfile(user_data_dir=None)
+
+	assert profile.user_data_dir is not None
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
+
+
+def test_omitted_user_data_dir_resolves_to_temp_path():
+	profile = BrowserProfile(headless=True)
+
+	assert profile.user_data_dir is not None
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
+
+
+def test_omitted_and_explicit_none_user_data_dir_are_independently_resolved():
+	profile_omitted = BrowserProfile(headless=True)
+	profile_explicit = BrowserProfile(headless=True, user_data_dir=None)
+
+	assert profile_omitted.user_data_dir is not None
+	assert profile_explicit.user_data_dir is not None
+	# each construction gets its own freshly generated temp dir
+	assert profile_omitted.user_data_dir != profile_explicit.user_data_dir

--- a/tests/ci/test_profile_user_data_dir_default_validation.py
+++ b/tests/ci/test_profile_user_data_dir_default_validation.py
@@ -1,23 +1,36 @@
 """Regression test: BrowserProfile.user_data_dir must resolve to a temp path both when
-explicitly passed as None and when the kwarg is omitted entirely.
+explicitly passed as None and when the kwarg is omitted entirely — via get_args(), which
+every real launch path calls, but WITHOUT eagerly resolving at construction time.
 
 pydantic v2 skips field_validator for a field left at its default unless the model sets
 validate_default=True — without it, BrowserProfile(headless=True) (a very common call
-pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None.
+pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None
+until get_args() resolved it lazily.
+
+Resolving eagerly at construction (e.g. via validate_default=True on the whole
+BrowserLaunchPersistentContextArgs config) was tried and reverted: browser_use/browser/
+session.py:66 constructs a module-level DEFAULT_BROWSER_PROFILE = BrowserProfile() at
+import time, so eager resolution there would make `import browser_use` itself call
+tempfile.mkdtemp() — a filesystem side effect on every process start, including for
+cloud/CDP-only users who never launch a local browser — and every model_copy() of that
+singleton (Agent.__init__, BrowserSession's default_factory) would inherit the exact same
+directory instead of getting its own, since model_copy() does not re-run validation.
 """
 
 from browser_use.browser.profile import BrowserProfile
 
 
-def test_explicit_none_user_data_dir_resolves_to_temp_path():
+def test_explicit_none_user_data_dir_resolves_to_temp_path_via_get_args():
 	profile = BrowserProfile(user_data_dir=None)
+	profile.get_args()
 
 	assert profile.user_data_dir is not None
 	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
 
 
-def test_omitted_user_data_dir_resolves_to_temp_path():
+def test_omitted_user_data_dir_resolves_to_temp_path_via_get_args():
 	profile = BrowserProfile(headless=True)
+	profile.get_args()
 
 	assert profile.user_data_dir is not None
 	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
@@ -26,8 +39,33 @@ def test_omitted_user_data_dir_resolves_to_temp_path():
 def test_omitted_and_explicit_none_user_data_dir_are_independently_resolved():
 	profile_omitted = BrowserProfile(headless=True)
 	profile_explicit = BrowserProfile(headless=True, user_data_dir=None)
+	profile_omitted.get_args()
+	profile_explicit.get_args()
 
 	assert profile_omitted.user_data_dir is not None
 	assert profile_explicit.user_data_dir is not None
 	# each construction gets its own freshly generated temp dir
 	assert profile_omitted.user_data_dir != profile_explicit.user_data_dir
+
+
+def test_module_level_default_browser_profile_does_not_eagerly_resolve_user_data_dir():
+	"""DEFAULT_BROWSER_PROFILE (browser_use/browser/session.py) is constructed once at module
+	import time and must stay side-effect-free — user_data_dir must remain None until
+	something actually calls get_args() to launch a browser."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	assert DEFAULT_BROWSER_PROFILE.user_data_dir is None
+
+
+def test_two_default_profile_copies_get_independent_user_data_dirs():
+	"""Mirrors Agent.__init__'s `base_profile.model_copy()` fallback when no browser_profile is
+	passed (browser_use/agent/service.py) — model_copy() does not re-run field validation, so
+	each copy must resolve its own user_data_dir independently once it actually launches."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	copy_a = DEFAULT_BROWSER_PROFILE.model_copy()
+	copy_b = DEFAULT_BROWSER_PROFILE.model_copy()
+	copy_a.get_args()
+	copy_b.get_args()
+
+	assert copy_a.user_data_dir != copy_b.user_data_dir


### PR DESCRIPTION
Closes #5420.

## Problem

`BROWSER_USE_HEADLESS` was declared under `# MCP-specific env vars` (`config.py:230`) and applied only inside `_load_config()` (`:472-473`), whose only consumer is `mcp/server.py`. Direct library usage (`Agent(...)`, `BrowserSession(...)`, `BrowserProfile(...)`) silently ignored it — no error, no warning.

`BrowserProfile.headless` defaults to `None`, resolved via display detection (`profile.py:1269-1271`), so the same code goes headless on `ubuntu-latest` (no display) and headful on a dev machine with a monitor — e.g. a plain `pytest tests/ci` run pops real Chromium windows on a desktop, since most tests never pass `headless=` explicitly. There was no way to force one behavior across a process without touching call sites.

## Change

`BROWSER_USE_DISABLE_EXTENSIONS` already does exactly this in both the MCP path (`config.py:502-503`) and the direct profile path (`profile.py:19-25`, wired via `default_factory` on `:638`). `headless` just fell out of that pattern. This PR adds `_get_headless_default()`, mirroring the existing helper, and wires it into the `headless` field via `default_factory`.

Priority: constructor argument > `BROWSER_USE_HEADLESS` > display detection. `None` preserves today's behavior for anyone not setting the env var. The MCP config path (`config.py:472-473`) is untouched — `mcp/server.py` always passes `headless` explicitly into `profile_data`, so `default_factory` never runs on that path.

## Edge case found while implementing

`default_factory` populates a field *before* `@model_validator(mode='after')` runs. That means `BrowserProfile(devtools=True)` would start raising `ValidationError` (`validate_devtools_headless`, `profile.py:457-461`) as soon as `BROWSER_USE_HEADLESS=true` is set in the environment — even though the caller never wrote `headless=True` themselves. Confirmed this empirically with an isolated pydantic model before touching the real field.

Resolved it the same way `validate_highlight_elements_conflict` already resolves an analogous same-file conflict: when the conflict is between an *env-derived* `headless` and an explicit `devtools=True`, `devtools` wins — logs a warning and sets `headless=False` — instead of raising. An explicit `headless=True` (checked via `self.model_fields_set`) still raises exactly as before, so nothing changes for existing callers who set both explicitly.

## Testing

New `tests/ci/test_headless_config.py` (mirrors `tests/ci/test_extension_config.py`'s pattern), 19 tests covering:
- `_get_headless_default()` value parsing (same truthy/falsy string set as the extensions helper)
- `BrowserProfile()` / `BrowserSession()` pick up the env var
- explicit `headless=` overrides the env var in both
- regression: `BROWSER_USE_HEADLESS=true` + `BrowserProfile(devtools=True)` no longer raises
- unchanged: `BrowserProfile(headless=True, devtools=True)` still raises

```
uv run pytest -vxs tests/ci/test_headless_config.py tests/ci/test_extension_config.py tests/ci/test_browser_profile_keychain.py tests/ci/test_profile_user_data_dir_default_validation.py
uv run pyright
uv run ruff check --fix && uv run ruff format
uv run pre-commit run --all-files
```
All green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `BrowserProfile` and `BrowserSession` honor the BROWSER_USE_HEADLESS env var so you can force headless/headful consistently across environments. Also prevents OS keychain prompts for managed profiles and resolves user_data_dir lazily to avoid side effects.

- **New Features**
  - Headless default comes from BROWSER_USE_HEADLESS (via default_factory).
  - Precedence: explicit param > env var > display detection.
  - Applies to both `BrowserProfile` and `BrowserSession`.

- **Bug Fixes**
  - If headless is set by env and devtools=True is passed, devtools wins and headless is forced to False (no error).
  - Avoid OS keychain prompts for browser-use-managed profiles by auto-setting use_system_keychain=False and adding mock-keychain flags; real user profiles keep system keychain.
  - Resolve user_data_dir only in get_args to avoid tempfile side effects at import and ensure each instance gets a unique temp dir.

<sup>Written for commit 4ed1a779e6e99913071c9181ff41cabd60f0eb34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

