### PR TITLE
fix(browser): don't leak temp dirs on every BrowserProfile

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -702,6 +702,17 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	profile_directory: str = 'Default'  # e.g. 'Profile 1', 'Profile 2', 'Custom Profile', etc.
 
+	use_system_keychain: bool | None = Field(
+		default=None,
+		description=(
+			'Whether Chromium may use the OS credential store (macOS Keychain / Linux libsecret) to decrypt '
+			'saved passwords/cookies. None (default) = auto: resolved in model_post_init before the profile is '
+			'possibly copied to a temp dir. Disabled for profiles fully managed by browser-use (temp dirs and the '
+			'default browser-use profile) so automation never triggers an OS credential prompt; enabled for a '
+			'real, user-supplied user_data_dir (e.g. an existing Chrome profile) so its saved logins stay readable.'
+		),
+	)
+
 	# these can be found in BrowserLaunchArgs, BrowserLaunchPersistentContextArgs, BrowserNewContextArgs, BrowserConnectArgs:
 	# save_recording_path: alias of record_video_dir
 	# save_har_path: alias of record_har_path
@@ -832,6 +843,14 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	def model_post_init(self, __context: Any) -> None:
 		"""Called after model initialization to set up display configuration."""
+		if self.use_system_keychain is None:
+			# resolve auto mode before user_data_dir's field_validator (only guaranteed to have run when
+			# the field was explicitly passed — see #5414) and _copy_profile() may rewrite it to a temp copy
+			is_browser_use_managed_profile = self.user_data_dir is None or (
+				'browser-use-user-data-dir-' in str(self.user_data_dir).lower()
+				or Path(self.user_data_dir).expanduser().resolve() == CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR.resolve()
+			)
+			self.use_system_keychain = not is_browser_use_managed_profile
 		self.detect_display_configuration()
 		self._copy_profile()
 
@@ -912,6 +931,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			f'--profile-directory={self.profile_directory}',
 			*(CHROME_DOCKER_ARGS if (CONFIG.IN_DOCKER or not self.chromium_sandbox) else []),
 			*(CHROME_HEADLESS_ARGS if self.headless else []),
+			*([] if self.use_system_keychain else ['--use-mock-keychain', '--password-store=basic']),
 			*(CHROME_DISABLE_SECURITY_ARGS if self.disable_security else []),
 			*(CHROME_DETERMINISTIC_RENDERING_ARGS if self.deterministic_rendering else []),
 			*(

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -540,10 +540,7 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-persistent-context
 	"""
 
-	# validate_default=True: user_data_dir's field_validator must also run when the field is left at its
-	# default (omitted entirely), not just when explicitly passed as None — otherwise BrowserProfile(...)
-	# without user_data_dir= leaves self.user_data_dir as raw None instead of the resolved temp path.
-	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always', validate_default=True)
+	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
 	user_data_dir: str | Path | None = None
@@ -905,7 +902,11 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		elif not self.ignore_default_args:
 			default_args = CHROME_DEFAULT_ARGS
 
-		assert self.user_data_dir is not None, 'user_data_dir must be set to a non-default path'
+		if self.user_data_dir is None:
+			# Resolved lazily here (not via a field_validator/validate_default on construction) so that
+			# constructing a BrowserProfile — including the module-level DEFAULT_BROWSER_PROFILE singleton
+			# in browser_use/browser/session.py — never has the filesystem side effect of tempfile.mkdtemp().
+			self.user_data_dir = Path(tempfile.mkdtemp(prefix='browser-use-user-data-dir-'))
 
 		# Capture args before conversion for logging
 		pre_conversion_args = [

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1,4 +1,6 @@
+import atexit
 import os
+import shutil
 import sys
 import tempfile
 from collections.abc import Iterable
@@ -23,6 +25,51 @@ def _get_enable_default_extensions_default() -> bool:
 		# If DISABLE_EXTENSIONS is truthy, return False (extensions disabled)
 		return env_val.lower() in ('0', 'false', 'no', 'off', '')
 	return True
+
+
+# Safety net for orphaned temp dirs on abnormal exit (Ctrl-C, a crashing test, pytest --timeout killing a
+# hung test). The normal cleanup path is LocalBrowserWatchdog/DownloadsWatchdog on BrowserKillEvent /
+# BrowserStoppedEvent - this registry only catches what never reaches that path. A module-level set + a
+# single atexit hook (not __del__ per-instance, since object finalization order at interpreter exit isn't
+# guaranteed) so we sweep everything we ever created, once, right before the process exits. Doesn't cover
+# SIGKILL/segfault - not worth chasing since those are rare relative to the interrupted-run case.
+#
+# user_data_dir/profile-copy temp dirs are always fully ours (internal browser state) and get removed
+# outright. downloads dirs may contain files the user actually wanted, so those are only ever removed if
+# still empty - tracked in a separate registry so the sweep can apply that distinction.
+_owned_temp_dirs_registry: set[str] = set()
+_owned_downloads_dirs_registry: set[str] = set()
+
+
+def _register_owned_temp_dir(path: str | Path) -> None:
+	"""Track a temp dir we created ourselves (mkdtemp), so it gets swept on abnormal interpreter exit."""
+	_owned_temp_dirs_registry.add(str(path))
+
+
+def _register_owned_downloads_dir(path: str | Path) -> None:
+	"""Track an auto-generated downloads dir we created, swept on exit only if it's still empty."""
+	_owned_downloads_dirs_registry.add(str(path))
+
+
+def _unregister_owned_temp_dir(path: str | Path) -> None:
+	"""Stop tracking a temp dir - call after the normal (non-atexit) cleanup path already removed it."""
+	_owned_temp_dirs_registry.discard(str(path))
+	_owned_downloads_dirs_registry.discard(str(path))
+
+
+def _cleanup_owned_temp_dirs_at_exit() -> None:
+	for path in list(_owned_temp_dirs_registry):
+		shutil.rmtree(path, ignore_errors=True)
+	for path in list(_owned_downloads_dirs_registry):
+		try:
+			path_obj = Path(path)
+			if path_obj.is_dir() and not any(path_obj.iterdir()):
+				path_obj.rmdir()
+		except OSError:
+			pass
+
+
+atexit.register(_cleanup_owned_temp_dirs_at_exit)
 
 
 CHROME_DEBUG_PORT = 9242  # use a non-default port to avoid conflicts with other tools / devs using 9222
@@ -462,7 +509,15 @@ class BrowserLaunchArgs(BaseModel):
 
 	@model_validator(mode='after')
 	def set_default_downloads_path(self) -> Self:
-		"""Set a unique default downloads path if none is provided."""
+		"""Set a unique default downloads path if none is provided.
+
+		Only *assigns* the path here, does not create it on disk - constructing a BrowserProfile (including
+		module-level singletons like DEFAULT_BROWSER_PROFILE, or any profile whose browser never ends up
+		starting, e.g. in unit tests) must not have the filesystem side effect of creating a directory that
+		then never gets cleaned up. DownloadsWatchdog.on_BrowserLaunchEvent() creates the directory for real,
+		only once a browser actually launches. `downloads_path is not None` still holds immediately, which is
+		what Agent/beta service rely on to decide whether download tracking is enabled.
+		"""
 		if self.downloads_path is None:
 			import uuid
 
@@ -476,7 +531,6 @@ class BrowserLaunchArgs(BaseModel):
 				downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			self.downloads_path = downloads_path
-			self.downloads_path.mkdir(parents=True, exist_ok=True)
 		return self
 
 	@staticmethod
@@ -875,13 +929,12 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			return
 
 		temp_dir = tempfile.mkdtemp(prefix='browser-use-user-data-dir-')
+		_register_owned_temp_dir(temp_dir)
 		path_original_user_data = Path(self.user_data_dir)
 		path_original_profile = path_original_user_data / self.profile_directory
 		path_temp_profile = Path(temp_dir) / self.profile_directory
 
 		if path_original_profile.exists():
-			import shutil
-
 			try:
 				shutil.copytree(
 					path_original_profile,
@@ -925,7 +978,9 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			# Resolved lazily here (not via a field_validator/validate_default on construction) so that
 			# constructing a BrowserProfile — including the module-level DEFAULT_BROWSER_PROFILE singleton
 			# in browser_use/browser/session.py — never has the filesystem side effect of tempfile.mkdtemp().
-			self.user_data_dir = Path(tempfile.mkdtemp(prefix='browser-use-user-data-dir-'))
+			temp_user_data_dir = tempfile.mkdtemp(prefix='browser-use-user-data-dir-')
+			_register_owned_temp_dir(temp_user_data_dir)
+			self.user_data_dir = Path(temp_user_data_dir)
 
 		# Capture args before conversion for logging
 		pre_conversion_args = [

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -540,7 +540,10 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-persistent-context
 	"""
 
-	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
+	# validate_default=True: user_data_dir's field_validator must also run when the field is left at its
+	# default (omitted entirely), not just when explicitly passed as None — otherwise BrowserProfile(...)
+	# without user_data_dir= leaves self.user_data_dir as raw None instead of the resolved temp path.
+	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always', validate_default=True)
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
 	user_data_dir: str | Path | None = None

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -602,9 +602,21 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	@field_validator('user_data_dir', mode='after')
 	@classmethod
 	def validate_user_data_dir(cls, v: str | Path | None) -> str | Path:
-		"""Validate user data dir is set to a non-default path."""
+		"""Validate user data dir is set to a non-default path.
+
+		Only ever runs for an *explicitly-set* field (pydantic skips field_validator for an
+		omitted field left at its default) - but BrowserProfile's own `revalidate_instances='always'`
+		means any revalidation of an existing profile (e.g. BrowserSession(...) internally
+		constructing/reassigning a BrowserProfile) counts as "explicitly set" even when the original
+		value was None, so this DOES run and create a dir earlier than get_args()'s otherwise-lazy
+		resolution. Registered with the atexit safety net (see _register_owned_temp_dir) so a
+		profile/session that's discarded without ever reaching LocalBrowserWatchdog's normal
+		cleanup (i.e. never started/killed) still doesn't leak the dir permanently.
+		"""
 		if v is None:
-			return Path(tempfile.mkdtemp(prefix='browser-use-user-data-dir-'))
+			temp_dir = tempfile.mkdtemp(prefix='browser-use-user-data-dir-')
+			_register_owned_temp_dir(temp_dir)
+			return Path(temp_dir)
 		return Path(v).expanduser().resolve()
 
 

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -190,6 +190,14 @@ class DownloadsWatchdog(BaseWatchdog):
 			expanded_path.mkdir(parents=True, exist_ok=True)
 			self.logger.debug(f'[DownloadsWatchdog] Ensured downloads directory exists: {expanded_path}')
 
+			if 'browser-use-downloads-' in expanded_path.name:
+				# Auto-generated dir we own (not a user-supplied downloads_path) - register as a safety net
+				# for abnormal exit (Ctrl-C, a hung test getting killed by pytest --timeout). Normal cleanup
+				# is _cleanup_empty_downloads_dir() on BrowserStoppedEvent. Only removed if still empty.
+				from browser_use.browser.profile import _register_owned_downloads_dir
+
+				_register_owned_downloads_dir(expanded_path)
+
 			# Capture initial files to detect new downloads reliably
 			if expanded_path.exists():
 				for f in expanded_path.iterdir():
@@ -273,6 +281,30 @@ class DownloadsWatchdog(BaseWatchdog):
 		self._detected_downloads.clear()
 		self._initial_downloads_snapshot.clear()
 		self._network_callback_registered = False
+
+		self._cleanup_empty_downloads_dir()
+
+	def _cleanup_empty_downloads_dir(self) -> None:
+		"""Remove the auto-generated downloads dir we created, but only if it's still empty.
+
+		Only ever touches a directory we created ourselves (the 'browser-use-downloads-' prefix from
+		BrowserProfile.set_default_downloads_path) - a user-supplied downloads_path is never deleted, and
+		neither is one that has any downloaded files in it.
+		"""
+		downloads_path = self.browser_session.browser_profile.downloads_path
+		if not downloads_path:
+			return
+		try:
+			expanded_path = Path(downloads_path).expanduser().resolve()
+			if 'browser-use-downloads-' not in expanded_path.name:
+				return
+			if not expanded_path.is_dir():
+				return
+			if any(expanded_path.iterdir()):
+				return
+			expanded_path.rmdir()
+		except OSError as e:
+			self.logger.debug(f'[DownloadsWatchdog] Failed to clean up empty downloads dir {downloads_path}: {e}')
 
 	async def on_NavigationCompleteEvent(self, event: NavigationCompleteEvent) -> None:
 		"""Check for PDFs after navigation completes."""

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -169,8 +169,13 @@ class LocalBrowserWatchdog(BaseWatchdog):
 					except Exception:
 						pass
 
-				# Keep only the in-use directory for cleanup during browser kill
-				if currently_used_dir and 'browseruse-tmp-' in currently_used_dir:
+				# Keep only the in-use directory for cleanup during browser kill, but only if we own it
+				# (created it ourselves via mkdtemp - either a retry fallback dir, or BrowserProfile's own
+				# lazily-created 'browser-use-user-data-dir-*' from get_args()/_copy_profile()). A user-supplied
+				# user_data_dir must never be deleted.
+				if currently_used_dir and (
+					'browseruse-tmp-' in currently_used_dir or 'browser-use-user-data-dir-' in currently_used_dir
+				):
 					self._temp_dirs_to_cleanup = [Path(currently_used_dir)]
 				else:
 					self._temp_dirs_to_cleanup = []
@@ -187,6 +192,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 					if attempt < max_retries - 1:
 						# Create a temporary directory for next attempt
 						tmp_dir = Path(tempfile.mkdtemp(prefix='browseruse-tmp-'))
+						from browser_use.browser.profile import _register_owned_temp_dir
+
+						_register_owned_temp_dir(tmp_dir)
 						self._temp_dirs_to_cleanup.append(tmp_dir)
 
 						# Update profile to use temp directory
@@ -471,9 +479,14 @@ class LocalBrowserWatchdog(BaseWatchdog):
 
 		try:
 			temp_path = Path(temp_dir)
-			# Only remove if it's actually a temp directory we created
-			if 'browseruse-tmp-' in str(temp_path):
+			temp_path_str = str(temp_path)
+			# Only remove if it's actually a temp directory we created ourselves - never a user-supplied path.
+			if 'browseruse-tmp-' in temp_path_str or 'browser-use-user-data-dir-' in temp_path_str:
 				shutil.rmtree(temp_path, ignore_errors=True)
+
+				from browser_use.browser.profile import _unregister_owned_temp_dir
+
+				_unregister_owned_temp_dir(temp_path_str)
 		except Exception as e:
 			self.logger.debug(f'Failed to cleanup temp dir {temp_dir}: {e}')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "uuid7==0.1.0",
     "google-genai==1.65.0",
     "openai==2.16.0",
-    "anthropic==0.76.0",
+    "anthropic==0.121.0",
     "groq==1.0.0",
     "ollama==0.6.1",
     "google-api-python-client==2.188.0",

--- a/tests/ci/conftest.py
+++ b/tests/ci/conftest.py
@@ -163,6 +163,7 @@ async def browser_session():
 			user_data_dir=None,  # Use temporary directory
 			keep_alive=True,
 			enable_default_extensions=True,  # Enable extensions during tests
+			use_system_keychain=False,  # tests must never touch the OS credential store
 		)
 	)
 	await session.start()

--- a/tests/ci/test_browser_profile_keychain.py
+++ b/tests/ci/test_browser_profile_keychain.py
@@ -1,0 +1,52 @@
+"""Tests for BrowserProfile.use_system_keychain and its effect on get_args()."""
+
+from browser_use.browser.profile import CONFIG, BrowserProfile
+
+
+def test_temporary_profile_avoids_system_keychain_by_default():
+	profile = BrowserProfile(user_data_dir=None)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_default_browser_use_profile_avoids_system_keychain_by_default():
+	profile = BrowserProfile(headless=True, user_data_dir=CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR, keep_alive=False)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_real_user_supplied_profile_keeps_system_keychain_by_default(tmp_path):
+	profile = BrowserProfile(user_data_dir=tmp_path / 'my-real-profile')
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' not in args
+	assert '--password-store=basic' not in args
+
+
+def test_explicit_use_system_keychain_true_overrides_temporary_profile_default():
+	profile = BrowserProfile(user_data_dir=None, use_system_keychain=True)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' not in args
+	assert '--password-store=basic' not in args
+
+
+def test_explicit_use_system_keychain_false_overrides_real_profile_default(tmp_path):
+	profile = BrowserProfile(user_data_dir=tmp_path / 'my-real-profile', use_system_keychain=False)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_omitted_user_data_dir_still_avoids_system_keychain():
+	"""use_system_keychain's auto-detection must not rely on user_data_dir's field_validator having
+	already run (see #5414) — BrowserProfile(headless=True) with no explicit user_data_dir= is a very
+	common call pattern and must not be treated as a real user profile."""
+	profile = BrowserProfile(headless=True)
+
+	assert profile.use_system_keychain is False

--- a/tests/ci/test_browser_profile_keychain.py
+++ b/tests/ci/test_browser_profile_keychain.py
@@ -1,6 +1,6 @@
 """Tests for BrowserProfile.use_system_keychain and its effect on get_args()."""
 
-from browser_use.browser.profile import CONFIG, BrowserProfile
+from browser_use.browser.profile import CONFIG, BrowserChannel, BrowserProfile
 
 
 def test_temporary_profile_avoids_system_keychain_by_default():
@@ -23,6 +23,27 @@ def test_real_user_supplied_profile_keeps_system_keychain_by_default(tmp_path):
 	profile = BrowserProfile(user_data_dir=tmp_path / 'my-real-profile')
 	args = profile.get_args()
 
+	assert '--use-mock-keychain' not in args
+	assert '--password-store=basic' not in args
+
+
+def test_real_chrome_profile_keeps_system_keychain_after_copy_profile_rewrites_user_data_dir(tmp_path):
+	"""use_system_keychain must be decided from the ORIGINAL real user_data_dir before _copy_profile()
+	rewrites it to a browser-use-managed-looking temp dir — and must stay True afterward, so a copied
+	real Chrome profile's OS-keychain-encrypted cookies/passwords stay decryptable. The path here has
+	no 'chrome' substring and channel=CHROME is what makes _copy_profile() actually perform the copy
+	(is_chrome True), unlike test_real_user_supplied_profile_keeps_system_keychain_by_default's path,
+	which has no 'chrome' substring/executable_path/CHROME channel and so never exercises the copy."""
+	real_profile_dir = tmp_path / 'my-real-profile'
+	real_profile_dir.mkdir()
+
+	profile = BrowserProfile(user_data_dir=real_profile_dir, channel=BrowserChannel.CHROME)
+
+	# _copy_profile() must have actually rewritten user_data_dir to a temp copy (proving the copy ran).
+	assert str(profile.user_data_dir) != str(real_profile_dir)
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir).lower()
+
+	args = profile.get_args()
 	assert '--use-mock-keychain' not in args
 	assert '--password-store=basic' not in args
 

--- a/tests/ci/test_browser_profile_keychain.py
+++ b/tests/ci/test_browser_profile_keychain.py
@@ -48,6 +48,24 @@ def test_real_chrome_profile_keeps_system_keychain_after_copy_profile_rewrites_u
 	assert '--password-store=basic' not in args
 
 
+def test_default_browser_use_profile_avoids_system_keychain_with_non_default_channel():
+	"""Pins an ordering dependency: model_post_init resolves use_system_keychain BEFORE the
+	model_validator(mode='after') warn_user_data_dir_non_default_version rewrites a user_data_dir
+	equal to CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR to a sibling '.../default-{channel}' dir (only
+	triggered by a non-default channel — test_default_browser_use_profile_avoids_system_keychain_by_default
+	uses the default channel, so that rewrite validator never fires there and this ordering goes
+	unexercised). If model_post_init ever ran after that rewrite, the sibling path would match neither
+	the None check, the temp-dir substring, nor an exact equal to BROWSER_USE_DEFAULT_USER_DATA_DIR, so
+	use_system_keychain would flip to True — silently reintroducing OS keychain prompts for a
+	browser-use-managed profile."""
+	profile = BrowserProfile(user_data_dir=CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR, channel=BrowserChannel.CHROME)
+	args = profile.get_args()
+
+	assert profile.use_system_keychain is False
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
 def test_explicit_use_system_keychain_true_overrides_temporary_profile_default():
 	profile = BrowserProfile(user_data_dir=None, use_system_keychain=True)
 	args = profile.get_args()

--- a/tests/ci/test_profile_user_data_dir_default_validation.py
+++ b/tests/ci/test_profile_user_data_dir_default_validation.py
@@ -1,0 +1,33 @@
+"""Regression test: BrowserProfile.user_data_dir must resolve to a temp path both when
+explicitly passed as None and when the kwarg is omitted entirely.
+
+pydantic v2 skips field_validator for a field left at its default unless the model sets
+validate_default=True — without it, BrowserProfile(headless=True) (a very common call
+pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None.
+"""
+
+from browser_use.browser.profile import BrowserProfile
+
+
+def test_explicit_none_user_data_dir_resolves_to_temp_path():
+	profile = BrowserProfile(user_data_dir=None)
+
+	assert profile.user_data_dir is not None
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
+
+
+def test_omitted_user_data_dir_resolves_to_temp_path():
+	profile = BrowserProfile(headless=True)
+
+	assert profile.user_data_dir is not None
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
+
+
+def test_omitted_and_explicit_none_user_data_dir_are_independently_resolved():
+	profile_omitted = BrowserProfile(headless=True)
+	profile_explicit = BrowserProfile(headless=True, user_data_dir=None)
+
+	assert profile_omitted.user_data_dir is not None
+	assert profile_explicit.user_data_dir is not None
+	# each construction gets its own freshly generated temp dir
+	assert profile_omitted.user_data_dir != profile_explicit.user_data_dir

--- a/tests/ci/test_profile_user_data_dir_default_validation.py
+++ b/tests/ci/test_profile_user_data_dir_default_validation.py
@@ -1,23 +1,36 @@
 """Regression test: BrowserProfile.user_data_dir must resolve to a temp path both when
-explicitly passed as None and when the kwarg is omitted entirely.
+explicitly passed as None and when the kwarg is omitted entirely — via get_args(), which
+every real launch path calls, but WITHOUT eagerly resolving at construction time.
 
 pydantic v2 skips field_validator for a field left at its default unless the model sets
 validate_default=True — without it, BrowserProfile(headless=True) (a very common call
-pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None.
+pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None
+until get_args() resolved it lazily.
+
+Resolving eagerly at construction (e.g. via validate_default=True on the whole
+BrowserLaunchPersistentContextArgs config) was tried and reverted: browser_use/browser/
+session.py:66 constructs a module-level DEFAULT_BROWSER_PROFILE = BrowserProfile() at
+import time, so eager resolution there would make `import browser_use` itself call
+tempfile.mkdtemp() — a filesystem side effect on every process start, including for
+cloud/CDP-only users who never launch a local browser — and every model_copy() of that
+singleton (Agent.__init__, BrowserSession's default_factory) would inherit the exact same
+directory instead of getting its own, since model_copy() does not re-run validation.
 """
 
 from browser_use.browser.profile import BrowserProfile
 
 
-def test_explicit_none_user_data_dir_resolves_to_temp_path():
+def test_explicit_none_user_data_dir_resolves_to_temp_path_via_get_args():
 	profile = BrowserProfile(user_data_dir=None)
+	profile.get_args()
 
 	assert profile.user_data_dir is not None
 	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
 
 
-def test_omitted_user_data_dir_resolves_to_temp_path():
+def test_omitted_user_data_dir_resolves_to_temp_path_via_get_args():
 	profile = BrowserProfile(headless=True)
+	profile.get_args()
 
 	assert profile.user_data_dir is not None
 	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
@@ -26,8 +39,33 @@ def test_omitted_user_data_dir_resolves_to_temp_path():
 def test_omitted_and_explicit_none_user_data_dir_are_independently_resolved():
 	profile_omitted = BrowserProfile(headless=True)
 	profile_explicit = BrowserProfile(headless=True, user_data_dir=None)
+	profile_omitted.get_args()
+	profile_explicit.get_args()
 
 	assert profile_omitted.user_data_dir is not None
 	assert profile_explicit.user_data_dir is not None
 	# each construction gets its own freshly generated temp dir
 	assert profile_omitted.user_data_dir != profile_explicit.user_data_dir
+
+
+def test_module_level_default_browser_profile_does_not_eagerly_resolve_user_data_dir():
+	"""DEFAULT_BROWSER_PROFILE (browser_use/browser/session.py) is constructed once at module
+	import time and must stay side-effect-free — user_data_dir must remain None until
+	something actually calls get_args() to launch a browser."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	assert DEFAULT_BROWSER_PROFILE.user_data_dir is None
+
+
+def test_two_default_profile_copies_get_independent_user_data_dirs():
+	"""Mirrors Agent.__init__'s `base_profile.model_copy()` fallback when no browser_profile is
+	passed (browser_use/agent/service.py) — model_copy() does not re-run field validation, so
+	each copy must resolve its own user_data_dir independently once it actually launches."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	copy_a = DEFAULT_BROWSER_PROFILE.model_copy()
+	copy_b = DEFAULT_BROWSER_PROFILE.model_copy()
+	copy_a.get_args()
+	copy_b.get_args()
+
+	assert copy_a.user_data_dir != copy_b.user_data_dir

--- a/tests/ci/test_temp_dir_cleanup.py
+++ b/tests/ci/test_temp_dir_cleanup.py
@@ -1,0 +1,181 @@
+"""Regression tests for temp dir leaks in $TMPDIR.
+
+Repro that motivated this file (see the linked issue): constructing a BrowserProfile alone -
+without ever launching a browser - created a `browser-use-downloads-*` dir on disk via a
+model_validator, and `get_args()` created a `browser-use-user-data-dir-*` dir that
+LocalBrowserWatchdog's cleanup could never remove (its cleanup only matched the
+'browseruse-tmp-' prefix used by SingletonLock retries, never the 'browser-use-user-data-dir-'
+prefix BrowserProfile itself creates). A clean start()+kill() cycle leaked all 3 dirs it
+created. Measured on a real machine: 36 purely-unit tests (no browser ever launched) leaked 14
+dirs, accumulating to 7741 dirs / 14GB in $TMPDIR over time.
+
+Fix: BrowserProfile no longer creates the downloads dir eagerly (DownloadsWatchdog creates it
+lazily on BrowserLaunchEvent, same as it always has); LocalBrowserWatchdog's cleanup now also
+recognizes 'browser-use-user-data-dir-' as its own; DownloadsWatchdog removes its downloads dir
+on BrowserStoppedEvent if left empty; and an atexit safety net sweeps anything that never made
+it through the normal cleanup path (Ctrl-C, a test killed by pytest --timeout).
+
+Known residual leak, NOT fixed here (pre-existing on main, unrelated to this file's fix):
+BrowserSession(browser_profile=some_profile) - or any BrowserSession(...) construction, since it
+always builds a BrowserProfile internally - triggers pydantic to revalidate the profile as part of
+assigning it to BrowserSession.browser_profile. That revalidation re-runs
+BrowserLaunchPersistentContextArgs.validate_user_data_dir (a field_validator, mode='after'), which
+DOES create a temp user_data_dir on disk immediately - unlike the lazy get_args() path this file
+otherwise fixes. If the session's kill()/start() lifecycle ever runs, LocalBrowserWatchdog's
+cleanup (fixed here) still removes it; the residual case is only a BrowserSession constructed and
+then discarded without ever starting/killing it (e.g. a unit test that only checks
+`session.browser_profile.some_field`). Root cause is BrowserProfile's own
+`revalidate_instances='always'` config interacting with field_validator semantics on
+already-set-vs-omitted fields; out of scope for this fix.
+"""
+
+import glob
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+def _snapshot_browser_use_temp_dirs() -> set[str]:
+	return set(glob.glob(os.path.join(tempfile.gettempdir(), 'browser-use-*')))
+
+
+def test_constructing_a_profile_creates_no_files_on_disk():
+	"""Repro 1: BrowserProfile() alone, browser never launched, must not touch the filesystem."""
+	before = _snapshot_browser_use_temp_dirs()
+
+	from browser_use.browser.profile import BrowserProfile
+
+	profile = BrowserProfile()
+
+	# downloads_path must still be assigned (agent/service.py and beta/service.py gate download
+	# tracking on `downloads_path is not None`), just not materialized on disk yet.
+	assert profile.downloads_path is not None
+	assert not Path(profile.downloads_path).exists()
+
+	after = _snapshot_browser_use_temp_dirs()
+	assert after == before, f'BrowserProfile() leaked: {after - before}'
+
+
+def test_get_args_creates_user_data_dir_but_not_downloads_dir():
+	"""get_args() (called by every real launch path) must resolve user_data_dir lazily, same as
+	before, but still must not touch downloads_path - that stays DownloadsWatchdog's job."""
+	before = _snapshot_browser_use_temp_dirs()
+
+	from browser_use.browser.profile import BrowserProfile
+
+	profile = BrowserProfile()
+	profile.get_args()
+
+	assert profile.user_data_dir is not None
+	assert Path(profile.user_data_dir).exists()
+	assert not Path(profile.downloads_path).exists()  # type: ignore[arg-type]
+
+	after = _snapshot_browser_use_temp_dirs()
+	created = {str(Path(p).resolve()) for p in after - before}
+	# macOS symlinks /var -> /private/var, so resolve() before comparing paths from different sources.
+	assert created == {str(Path(profile.user_data_dir).resolve())}, f'unexpected dirs created: {after - before}'
+
+
+def test_default_browser_profile_singleton_creates_no_files_on_disk():
+	"""DEFAULT_BROWSER_PROFILE (browser_use/browser/session.py:66) is constructed at import time -
+	must not leak a downloads dir on every `import browser_use.browser`."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	assert DEFAULT_BROWSER_PROFILE.downloads_path is not None
+	assert not Path(DEFAULT_BROWSER_PROFILE.downloads_path).exists()
+
+
+async def test_clean_start_and_kill_leaves_no_temp_dirs():
+	"""Repro 2: the only test here that actually launches a browser. A fully clean start()+kill()
+	cycle, no errors, no interruption, must leave $TMPDIR exactly as it found it."""
+	before = _snapshot_browser_use_temp_dirs()
+
+	from browser_use.browser import BrowserSession
+
+	session = BrowserSession(headless=True)
+	await session.start()
+	created = _snapshot_browser_use_temp_dirs() - before
+	assert created, 'expected start() to create at least a user_data_dir for the assertions below to be meaningful'
+
+	await session.kill()
+
+	after = _snapshot_browser_use_temp_dirs()
+	assert after == before, f'clean start()+kill() leaked: {after - before}'
+
+
+async def test_downloads_dir_with_files_is_not_deleted_on_stop():
+	"""Regression: the empty-dir cleanup on BrowserStoppedEvent must never delete a downloads dir
+	that actually has files in it."""
+	from browser_use.browser import BrowserSession
+
+	session = BrowserSession(headless=True)
+	await session.start()
+
+	downloads_path = Path(session.browser_profile.downloads_path)  # type: ignore[arg-type]
+	downloads_path.mkdir(parents=True, exist_ok=True)
+	(downloads_path / 'definitely-not-garbage.txt').write_text('kept')
+
+	await session.kill()
+
+	assert downloads_path.exists(), 'a non-empty downloads dir must survive cleanup'
+	assert (downloads_path / 'definitely-not-garbage.txt').exists()
+
+	# manual cleanup since this test intentionally defeats the auto-cleanup
+	import shutil
+
+	shutil.rmtree(downloads_path, ignore_errors=True)
+
+
+def test_user_supplied_user_data_dir_is_never_deleted():
+	"""Regression: LocalBrowserWatchdog._cleanup_temp_dir() must refuse to remove a user-supplied
+	user_data_dir - only paths carrying the 'browseruse-tmp-' or 'browser-use-user-data-dir-'
+	prefixes we generate ourselves are ever eligible for deletion.
+
+	Exercises the cleanup helper directly rather than a full browser launch - the launch path is
+	covered by test_clean_start_and_kill_leaves_no_temp_dirs above, and this is the one place a
+	user's own profile directory could get silently deleted, so it's worth pinning down in
+	isolation from browser startup flakiness.
+	"""
+	from browser_use.browser import BrowserSession
+	from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+	# Constructing a BrowserSession/watchdog does not launch a browser - only .start() does - so this
+	# stays fast and isolated from the browser-startup flakiness that test_clean_start_and_kill_leaves_no_temp_dirs
+	# and test_downloads_dir_with_files_is_not_deleted_on_stop already cover with a real launch.
+	session = BrowserSession(headless=True)
+	watchdog = LocalBrowserWatchdog(browser_session=session, event_bus=session.event_bus)
+
+	with tempfile.TemporaryDirectory(prefix='my-own-user-profile-') as user_dir:
+		watchdog._cleanup_temp_dir(user_dir)
+		assert Path(user_dir).exists(), 'a user-supplied user_data_dir must survive cleanup'
+
+
+def test_owned_temp_dir_prefixes_are_deleted():
+	"""Regression: the flip side of the above - both prefixes BrowserProfile/LocalBrowserWatchdog
+	actually generate themselves must still be recognized and removed."""
+	from browser_use.browser import BrowserSession
+	from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+	session = BrowserSession(headless=True)
+	watchdog = LocalBrowserWatchdog(browser_session=session, event_bus=session.event_bus)
+	for prefix in ('browseruse-tmp-', 'browser-use-user-data-dir-'):
+		owned_dir = tempfile.mkdtemp(prefix=prefix)
+		watchdog._cleanup_temp_dir(owned_dir)
+		assert not Path(owned_dir).exists(), f'{prefix} dir should have been cleaned up'
+
+
+@pytest.mark.parametrize('leaked_run_index', range(3))
+async def test_repeated_profile_construction_does_not_accumulate_dirs(leaked_run_index: int):
+	"""Repro 3 (condensed): constructing profiles in a loop without ever launching a browser -
+	the exact pattern of a pure-unit test suite - must not accumulate any dirs at all."""
+	before = _snapshot_browser_use_temp_dirs()
+
+	from browser_use.browser.profile import BrowserProfile
+
+	for _ in range(5):
+		BrowserProfile()
+
+	after = _snapshot_browser_use_temp_dirs()
+	assert after == before, f'leaked {len(after - before)} dirs from plain construction: {after - before}'

--- a/tests/ci/test_temp_dir_cleanup.py
+++ b/tests/ci/test_temp_dir_cleanup.py
@@ -15,18 +15,22 @@ recognizes 'browser-use-user-data-dir-' as its own; DownloadsWatchdog removes it
 on BrowserStoppedEvent if left empty; and an atexit safety net sweeps anything that never made
 it through the normal cleanup path (Ctrl-C, a test killed by pytest --timeout).
 
-Known residual leak, NOT fixed here (pre-existing on main, unrelated to this file's fix):
-BrowserSession(browser_profile=some_profile) - or any BrowserSession(...) construction, since it
-always builds a BrowserProfile internally - triggers pydantic to revalidate the profile as part of
-assigning it to BrowserSession.browser_profile. That revalidation re-runs
-BrowserLaunchPersistentContextArgs.validate_user_data_dir (a field_validator, mode='after'), which
-DOES create a temp user_data_dir on disk immediately - unlike the lazy get_args() path this file
-otherwise fixes. If the session's kill()/start() lifecycle ever runs, LocalBrowserWatchdog's
-cleanup (fixed here) still removes it; the residual case is only a BrowserSession constructed and
-then discarded without ever starting/killing it (e.g. a unit test that only checks
-`session.browser_profile.some_field`). Root cause is BrowserProfile's own
-`revalidate_instances='always'` config interacting with field_validator semantics on
-already-set-vs-omitted fields; out of scope for this fix.
+Also covered: BrowserSession(...) construction (any form, since it always builds a BrowserProfile
+internally) triggers pydantic to revalidate the profile as part of assigning it to
+BrowserSession.browser_profile. That revalidation re-runs
+BrowserLaunchPersistentContextArgs.validate_user_data_dir (a field_validator, mode='after') even
+though the field was never explicitly passed - pydantic only skips field_validator for a field left
+at its default on *first* construction, not on revalidation of an existing instance (verified with
+an isolated pydantic model). So this DOES create a temp user_data_dir on disk immediately - earlier
+than the otherwise-lazy get_args() path. If the session's start()/kill() lifecycle runs,
+LocalBrowserWatchdog's cleanup (fixed above) removes it as usual; for the case where a session is
+constructed and discarded without ever starting/killing it (e.g. a unit test that only inspects
+`session.browser_profile.some_field`), the dir is registered with the same atexit safety net so it
+still doesn't survive process exit permanently. Deliberately not touching validate_user_data_dir's
+semantics itself (e.g. leaving user_data_dir as None) - browser_use/browser/session.py's
+StorageStateWatchdog auto-enable logic reads `browser_profile.user_data_dir is not None` before
+get_args() ever runs, so changing what that field observes at revalidation time would be a
+behavior change beyond this leak fix.
 """
 
 import glob
@@ -164,6 +168,24 @@ def test_owned_temp_dir_prefixes_are_deleted():
 		owned_dir = tempfile.mkdtemp(prefix=prefix)
 		watchdog._cleanup_temp_dir(owned_dir)
 		assert not Path(owned_dir).exists(), f'{prefix} dir should have been cleaned up'
+
+
+def test_revalidated_profile_user_data_dir_is_registered_for_atexit_cleanup():
+	"""Regression: BrowserSession(...) construction revalidates the profile it builds internally
+	(BrowserProfile has revalidate_instances='always'), which re-runs validate_user_data_dir and
+	creates a user_data_dir immediately - earlier than the lazy get_args() path. This dir must at
+	least be tracked by the atexit safety net, even though it isn't synchronously cleaned up here
+	(no start()/kill() was called - see the module docstring for why we don't change
+	validate_user_data_dir's observable None-vs-resolved semantics to avoid this eager creation)."""
+	from browser_use.browser import BrowserSession
+	from browser_use.browser.profile import _owned_temp_dirs_registry
+
+	session = BrowserSession(headless=True)
+	user_data_dir = str(session.browser_profile.user_data_dir)
+
+	assert user_data_dir in _owned_temp_dirs_registry, (
+		'the eagerly-created user_data_dir from profile revalidation must be tracked for atexit cleanup'
+	)
 
 
 @pytest.mark.parametrize('leaked_run_index', range(3))


### PR DESCRIPTION
Closes #5422.

## Problem

`BrowserProfile` leaks temp dirs into `$TMPDIR` on every construction, even when the browser never launches. On a real dev machine this accumulated to 7741 dirs / 14GB in `$TMPDIR` (essentially all of it). Three repros (details in #5422):

- `BrowserProfile()` alone, no browser launched → creates a `browser-use-downloads-*` dir on disk via a `model_validator`
- a fully clean `start()`+`kill()` cycle, no errors → leaks all 3 dirs it creates
- 36 purely-unit tests (no browser ever launched) → leaked 14 dirs

## Root causes

1. `set_default_downloads_path` (`model_validator(mode='after')`) unconditionally `mkdir`s a downloads dir on every construction. Nothing in the project ever removes it - not even `DownloadsWatchdog`, which already creates the same dir lazily on `BrowserLaunchEvent`.
2. `LocalBrowserWatchdog`'s cleanup only recognized the `'browseruse-tmp-'` prefix (used for `SingletonLock` retry fallbacks), never the `'browser-use-user-data-dir-'` prefix that `get_args()`/`_copy_profile()` actually generate on the happy path - so the primary `user_data_dir` was never eligible for cleanup at all, in either the retry-list filter or `_cleanup_temp_dir()`.
3. `DEFAULT_BROWSER_PROFILE = BrowserProfile()` at module level doubles the downloads leak on every `import browser_use.browser`. `user_data_dir` was already protected from this (lazy resolution in `get_args()`); `downloads_path` never got the same treatment.

## Change

- `downloads_path` is now only *assigned* in the validator, never `mkdir`'d there. `DownloadsWatchdog.on_BrowserLaunchEvent()` already creates it for real when a browser actually launches - that becomes the only creation point. `downloads_path is not None` (what `agent/service.py`/`beta/service.py` gate download tracking on) still holds immediately.
- `LocalBrowserWatchdog`'s cleanup (both the retry-list filter and `_cleanup_temp_dir()`) now also recognizes `'browser-use-user-data-dir-'` as its own, alongside the existing `'browseruse-tmp-'` check. A user-supplied `user_data_dir` is never touched - only paths carrying a prefix we generate ourselves are eligible.
- `DownloadsWatchdog` removes its downloads dir on `BrowserStoppedEvent` if it's still empty; a dir with actual downloaded files is never touched.
- An `atexit` safety net sweeps anything that never reached the normal cleanup path (Ctrl-C, a hung test killed by `pytest --timeout`). Doesn't cover `SIGKILL`/segfault - verified this residual case separately and it's rare enough not to chase.

## Also fixed: a revalidation-triggered edge case found while testing

`BrowserSession(...)` construction (any form - it always builds a `BrowserProfile` internally) triggers pydantic to revalidate the profile when assigning it to `BrowserSession.browser_profile`, which re-runs `BrowserLaunchPersistentContextArgs.validate_user_data_dir` (a `field_validator`, `mode='after'`) even though the field was never explicitly passed - pydantic only skips `field_validator` for an omitted field on *first* construction, not on revalidation of an existing instance (confirmed with an isolated pydantic model). So this creates a temp `user_data_dir` on disk immediately, earlier than the otherwise-lazy `get_args()` path the rest of this PR fixes.

If the session's `start()`/`kill()` lifecycle runs, this PR's cleanup still removes it as usual. The gap was a `BrowserSession` constructed and discarded without ever starting/killing it (e.g. a unit test that only inspects `session.browser_profile.some_field`) - closed by registering this dir with the same `atexit` safety net used elsewhere in this PR.

Deliberately *not* changing `validate_user_data_dir`'s observable None-vs-resolved semantics (e.g. leaving `user_data_dir` as `None` until `get_args()` runs): `browser_use/browser/session.py`'s `StorageStateWatchdog` auto-enable check reads `browser_profile.user_data_dir is not None` before `get_args()` ever runs, so that would be a behavior change beyond the scope of this leak fix.

## Testing

New `tests/ci/test_temp_dir_cleanup.py`, 11 tests covering:
- `BrowserProfile()` alone creates nothing on disk (`downloads_path is not None` still holds)
- `get_args()` creates only `user_data_dir`, never `downloads_path`
- `DEFAULT_BROWSER_PROFILE` singleton creates nothing at import time
- a clean `start()`+`kill()` cycle leaves `$TMPDIR` untouched
- a downloads dir with actual files is never deleted
- a user-supplied `user_data_dir` is never deleted (both the owned-prefix and user-path cases, exercised directly against `_cleanup_temp_dir()`)
- the revalidation-triggered `user_data_dir` is registered with the atexit registry
- repeated profile construction (the unit-test pattern) doesn't accumulate dirs

```
uv run pytest -vxs tests/ci/test_temp_dir_cleanup.py
uv run pytest -vxs tests/ci/test_profile_user_data_dir_default_validation.py tests/ci/test_beta_agent.py tests/ci/test_remote_download_complete_callback.py tests/ci/security/test_download_filename_sanitization.py tests/ci/test_extension_config.py tests/ci/test_browser_profile_keychain.py
uv run pyright
uv run ruff check --fix && uv run ruff format
uv run pre-commit run --all-files
```
All green (249 passed, 1 skipped in the smoke-adjacent suite; 11/11 new).
