### PR TITLE
fix(tests): stop importlib.reload()-ing tools.service in action-timeout test

### DIFF
--- a/tests/ci/test_action_timeout.py
+++ b/tests/ci/test_action_timeout.py
@@ -132,45 +132,28 @@ def test_default_action_timeout_accommodates_extract_action():
 	)
 
 
-@pytest.fixture
-def _restore_service_module():
-	"""Reload browser_use.tools.service without any env override on teardown.
-
-	Tests in this file intentionally reload the module with BROWSER_USE_ACTION_TIMEOUT_S
-	set to various values; without this fixture, the last reload's default leaks into
-	every later test in the same worker.
-	"""
-	import importlib
-	import os
-
-	import browser_use.tools.service as svc_module
-
-	yield svc_module
-	os.environ.pop('BROWSER_USE_ACTION_TIMEOUT_S', None)
-	importlib.reload(svc_module)
-
-
-def test_malformed_env_timeout_does_not_break_import(monkeypatch, _restore_service_module):
+def test_malformed_env_timeout_does_not_break_import():
 	"""Bad BROWSER_USE_ACTION_TIMEOUT_S values must fall back, not crash or misbehave.
 
 	Covers three failure modes:
 	- Non-numeric / empty (ValueError from float()): would crash module import.
 	- NaN: parses fine but makes asyncio.wait_for time out immediately for every action.
 	- Infinity / negative / zero: parses fine but effectively disables the hang guard.
-	"""
-	import importlib
 
-	svc_module = _restore_service_module
+	Exercises _parse_env_action_timeout() directly (the function _DEFAULT_ACTION_TIMEOUT_S
+	is computed from at import time) rather than importlib.reload()-ing the module: reload
+	rebinds browser_use.tools.service.Tools to a new class object, but every module that
+	already did `from browser_use.tools.service import Tools` (agent/service.py,
+	beta/service.py, mcp/client.py, ...) keeps pointing at the old one - silently breaking
+	`is`/isinstance checks against Tools for the rest of the pytest process.
+	"""
+	from browser_use.tools.service import _parse_env_action_timeout
 
 	bad_values = ('', 'not-a-number', 'abc', 'nan', 'NaN', 'inf', '-inf', '0', '-5')
 	for bad_value in bad_values:
-		monkeypatch.setenv('BROWSER_USE_ACTION_TIMEOUT_S', bad_value)
-		reloaded = importlib.reload(svc_module)
-		assert reloaded._DEFAULT_ACTION_TIMEOUT_S == 180.0, (
-			f'Expected fallback 180.0 for bad env {bad_value!r}, got {reloaded._DEFAULT_ACTION_TIMEOUT_S}'
+		assert _parse_env_action_timeout(bad_value) == 180.0, (
+			f'Expected fallback 180.0 for bad env {bad_value!r}, got {_parse_env_action_timeout(bad_value)}'
 		)
 
 	# Valid finite positive values still take effect.
-	monkeypatch.setenv('BROWSER_USE_ACTION_TIMEOUT_S', '45')
-	reloaded = importlib.reload(svc_module)
-	assert reloaded._DEFAULT_ACTION_TIMEOUT_S == 45.0
+	assert _parse_env_action_timeout('45') == 45.0


### PR DESCRIPTION
Closes #5425.

## Problem

`test_malformed_env_timeout_does_not_break_import` in `tests/ci/test_action_timeout.py` called `importlib.reload(browser_use.tools.service)` ten times to exercise different malformed `BROWSER_USE_ACTION_TIMEOUT_S` values. Each reload rebinds `browser_use.tools.service.Tools` to a brand new class object. Several other modules already hold `from browser_use.tools.service import Tools` references taken before any reload runs (`agent/service.py`, `beta/service.py`, `mcp/client.py`, `mcp/server.py`, `integrations/gmail/actions.py`, `__init__.py`) — those keep pointing at the pre-reload class forever, since a plain `from x import y` binds by value, not by live reference.

This desyncs `Tools` identity for the rest of the pytest **process** (not just this test): any test that runs afterward and compares a freshly-imported `Tools` against one obtained through `agent.tools` or a constructor type hint sees two different-but-identically-named classes. Confirmed via direct reproduction (see issue) and via bisecting the full `tests/ci` file list — `test_action_timeout.py` is the sole trigger for two failures in `tests/ci/test_beta_agent.py` (`test_beta_agent_constructor_type_hints_match_browser_use_core_params`, `test_beta_agent_initializes_tools_and_action_models`) whenever it runs earlier in the same process. Both tests are 100% green in isolation, which is why this stayed hidden — the fixture's own teardown `reload()` doesn't restore the original object either, it just creates yet another new one.

## Fix

`browser_use/tools/service.py` already exposes the exact function this test needs: `_parse_env_action_timeout(raw: str | None) -> float`, the pure function `_DEFAULT_ACTION_TIMEOUT_S` is computed from at import time. Call it directly for each malformed value instead of reloading the module. No `sys.modules` mutation, no fixture needed, same coverage (all bad values fall back to 180.0, a valid value like `'45'` takes effect).

## Testing

```
uv run pytest -q tests/ci/test_action_timeout.py tests/ci/test_beta_agent.py
uv run pytest -q tests/ci
uv run pyright browser_use/tools/service.py tests/ci/test_action_timeout.py
uv run ruff check --fix && uv run ruff format
```
Full `tests/ci` run: 1112 passed, 34 skipped (previously 2 failed when run in full, order-dependent). `test_action_timeout.py` + `test_beta_agent.py` together: 206 passed, 1 skipped.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced reload-based testing with direct calls to `_parse_env_action_timeout` to avoid `Tools` class identity leaks from reloading `browser_use.tools.service`. This removes order-dependent failures and keeps timeout parsing covered.

- **Bug Fixes**
  - Root cause: reloading `browser_use.tools.service` created new `Tools` classes while other modules kept old references, breaking `is`/`isinstance` in later tests.
  - Change: removed the reload fixture; call `_parse_env_action_timeout()` for bad inputs and a valid value.
  - Outcome: no `sys.modules` churn; stable `Tools` identity; same behavior (bad values fall back to 180.0; valid values apply); full suite no longer order-dependent.

<sup>Written for commit 818bcf1141fbf5beeebab1dce6dafd3ae7cd8e92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

