### PR TITLE
fix(examples/cua): guard against a computer call with no action

### DIFF
--- a/examples/custom-functions/cua.py
+++ b/examples/custom-functions/cua.py
@@ -261,6 +261,9 @@ async def openai_cua_fallback(params: OpenAICUAAction, browser_session: BrowserS
 			raise Exception('No computer calls found in CUA response')
 
 		action = computer_call.action
+		if action is None:
+			raise Exception('CUA response contained a computer call with no action')
+
 		print(f'🎬 Executing CUA action: {action.type} - {action}')
 
 		action_result = await handle_model_action(browser_session, action)


### PR DESCRIPTION
https://github.com/browser-use/browser-use/blob/main/examples/custom-functions/cua.py#L263-L264 dereferences `computer_call.action` without checking it:

```python
action = computer_call.action
print(f"🎬 Executing CUA action: {action.type} - {action}")
```

`ResponseComputerToolCall.action` is typed `ActionClick | ActionDoubleClick | ActionDrag | ActionKeypress | ActionMove | ActionScreenshot | ActionScroll | ActionType | ActionWait | None` in the OpenAI SDK, so `action.type` raises `AttributeError` when a computer call comes back without one.

## Fix

An explicit `None` check, symmetric to the `computer_call` guard directly above it:

```python
action = computer_call.action
if action is None:
    raise Exception("CUA response contained a computer call with no action")
```

The `raise` stays inside the existing `try`, so the surrounding `except Exception` still converts it into `ActionResult(error=...)` — same failure mode as the neighbouring guard, just with a clear message instead of an `AttributeError`.

## Why this is worth merging

This is currently **the only pyright error on `main`**, and it fails two CI jobs, since `type-checker` and `code-style` share one pyright run:

```console
$ uv run pyright
examples/custom-functions/cua.py:264:44 - error: "type" is not a known attribute of "None" (reportOptionalMemberAccess)
1 error, 0 warnings, 0 informations
```

Verified on a clean checkout of `main` (reproduces) and with this patch applied (clean).

## Verification

| check | result |
|---|---|
| `pyright` on clean `main` | 1 error (reproduces) |
| `pyright` with this patch | **0 errors** |
| `pre-commit run --all-files` | **all Passed** |
| `pytest tests/ci` | 1118 passed, 34 skipped |

Scope: one file, +3 lines. No behavior change on the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cwy7NdLXDwg3wEpUpT8vEx

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a None check for `computer_call.action` in `examples/custom-functions/cua.py`. Prevents an AttributeError when a computer call has no action and clears the only `pyright` error on `main`.

- **Bug Fixes**
  - Raise a clear exception when `action is None`; existing try/except converts it to `ActionResult(error=...)`.
  - Mirrors the guard for missing `computer_call`.
  - No change on the happy path; unblocks CI by resolving `pyright` type-checking.

<sup>Written for commit 7c9ebf45df08df2d000e1078905dbde1a5622a56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

