### PR TITLE
fix(browser): clean up leaked temp/user-data/download dirs

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1,4 +1,6 @@
+import atexit
 import os
+import shutil
 import sys
 import tempfile
 from collections.abc import Iterable
@@ -23,6 +25,59 @@ def _get_enable_default_extensions_default() -> bool:
 		# If DISABLE_EXTENSIONS is truthy, return False (extensions disabled)
 		return env_val.lower() in ('0', 'false', 'no', 'off', '')
 	return True
+
+
+def _get_headless_default() -> bool | None:
+	"""Get the default value for headless from the BROWSER_USE_HEADLESS env var, or None to fall back to display detection."""
+	env_val = os.getenv('BROWSER_USE_HEADLESS')
+	if env_val is not None:
+		return env_val.lower() not in ('0', 'false', 'no', 'off', '')
+	return None
+
+
+# Safety net for orphaned temp dirs on abnormal exit (Ctrl-C, a crashing test, pytest --timeout killing a
+# hung test). The normal cleanup path is LocalBrowserWatchdog/DownloadsWatchdog on BrowserKillEvent /
+# BrowserStoppedEvent - this registry only catches what never reaches that path. A module-level set + a
+# single atexit hook (not __del__ per-instance, since object finalization order at interpreter exit isn't
+# guaranteed) so we sweep everything we ever created, once, right before the process exits. Doesn't cover
+# SIGKILL/segfault - not worth chasing since those are rare relative to the interrupted-run case.
+#
+# user_data_dir/profile-copy temp dirs are always fully ours (internal browser state) and get removed
+# outright. downloads dirs may contain files the user actually wanted, so those are only ever removed if
+# still empty - tracked in a separate registry so the sweep can apply that distinction.
+_owned_temp_dirs_registry: set[str] = set()
+_owned_downloads_dirs_registry: set[str] = set()
+
+
+def _register_owned_temp_dir(path: str | Path) -> None:
+	"""Track a temp dir we created ourselves (mkdtemp), so it gets swept on abnormal interpreter exit."""
+	_owned_temp_dirs_registry.add(str(path))
+
+
+def _register_owned_downloads_dir(path: str | Path) -> None:
+	"""Track an auto-generated downloads dir we created, swept on exit only if it's still empty."""
+	_owned_downloads_dirs_registry.add(str(path))
+
+
+def _unregister_owned_temp_dir(path: str | Path) -> None:
+	"""Stop tracking a temp dir - call after the normal (non-atexit) cleanup path already removed it."""
+	_owned_temp_dirs_registry.discard(str(path))
+	_owned_downloads_dirs_registry.discard(str(path))
+
+
+def _cleanup_owned_temp_dirs_at_exit() -> None:
+	for path in list(_owned_temp_dirs_registry):
+		shutil.rmtree(path, ignore_errors=True)
+	for path in list(_owned_downloads_dirs_registry):
+		try:
+			path_obj = Path(path)
+			if path_obj.is_dir() and not any(path_obj.iterdir()):
+				path_obj.rmdir()
+		except OSError:
+			pass
+
+
+atexit.register(_cleanup_owned_temp_dirs_at_exit)
 
 
 CHROME_DEBUG_PORT = 9242  # use a non-default port to avoid conflicts with other tools / devs using 9222
@@ -89,6 +144,27 @@ CHROME_DISABLED_COMPONENTS = [
 def _ignore_chrome_profile_transient_files(_src: str, names: list[str]) -> set[str]:
 	"""Skip Chrome lock/journal files that should not be copied into a temp profile."""
 	return {name for name in names if any(fnmatch(name, pattern) for pattern in CHROME_PROFILE_TRANSIENT_FILE_PATTERNS)}
+
+
+def _is_empty_dir_under_system_temp(path: str | Path) -> bool:
+	"""Whether path is inside the OS temp dir AND doesn't exist yet or has no Chrome profile files in
+	it. Used to auto-detect a caller-supplied tempfile.mkdtemp() user_data_dir (not just
+	BrowserProfile's own 'browser-use-user-data-dir-*' prefix) as browser-use-managed for the
+	use_system_keychain heuristic. Requiring both conditions (not just emptiness) keeps a real user
+	profile that happens to not be initialized yet - but lives at a real, non-temp path - correctly
+	classified as a real profile."""
+	try:
+		resolved = Path(path).expanduser().resolve()
+		temp_root = Path(tempfile.gettempdir()).resolve()
+	except OSError:
+		return False
+	if resolved != temp_root and temp_root not in resolved.parents:
+		return False
+	if not resolved.exists():
+		return True
+	if not resolved.is_dir():
+		return False
+	return not any(resolved.iterdir())
 
 
 def _is_chrome_profile_lock_error(error: BaseException) -> bool:
@@ -419,7 +495,10 @@ class BrowserLaunchArgs(BaseModel):
 		validation_alias=AliasChoices('browser_binary_path', 'chrome_binary_path'),
 		description='Path to the chromium-based browser executable to use.',
 	)
-	headless: bool | None = Field(default=None, description='Whether to run the browser in headless or windowed mode.')
+	headless: bool | None = Field(
+		default_factory=_get_headless_default,
+		description='Whether to run the browser in headless or windowed mode. Defaults to BROWSER_USE_HEADLESS env var if set, otherwise auto-detected from display availability.',
+	)
 	args: list[CliArgStr] = Field(
 		default_factory=list, description='List of *extra* CLI args to pass to the browser when launching.'
 	)
@@ -456,13 +535,34 @@ class BrowserLaunchArgs(BaseModel):
 
 	@model_validator(mode='after')
 	def validate_devtools_headless(self) -> Self:
-		"""Cannot open devtools when headless is True"""
-		assert not (self.headless and self.devtools), 'headless=True and devtools=True cannot both be set at the same time'
+		"""Cannot open devtools when headless is True.
+
+		An explicit headless=True still conflicts with devtools=True and raises. A headless value that
+		only came from the BROWSER_USE_HEADLESS env var (not passed explicitly) yields to an explicit
+		devtools=True instead of raising, since the user never wrote headless=True themselves.
+		"""
+		if self.headless and self.devtools:
+			if 'headless' not in self.model_fields_set:
+				logger.warning(
+					'⚠️ BROWSER_USE_HEADLESS is set but devtools=True was passed explicitly. '
+					'devtools takes priority. Setting headless=False.'
+				)
+				self.headless = False
+			else:
+				assert False, 'headless=True and devtools=True cannot both be set at the same time'
 		return self
 
 	@model_validator(mode='after')
 	def set_default_downloads_path(self) -> Self:
-		"""Set a unique default downloads path if none is provided."""
+		"""Set a unique default downloads path if none is provided.
+
+		Only *assigns* the path here, does not create it on disk - constructing a BrowserProfile (including
+		module-level singletons like DEFAULT_BROWSER_PROFILE, or any profile whose browser never ends up
+		starting, e.g. in unit tests) must not have the filesystem side effect of creating a directory that
+		then never gets cleaned up. DownloadsWatchdog.on_BrowserLaunchEvent() creates the directory for real,
+		only once a browser actually launches. `downloads_path is not None` still holds immediately, which is
+		what Agent/beta service rely on to decide whether download tracking is enabled.
+		"""
 		if self.downloads_path is None:
 			import uuid
 
@@ -476,7 +576,6 @@ class BrowserLaunchArgs(BaseModel):
 				downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			self.downloads_path = downloads_path
-			self.downloads_path.mkdir(parents=True, exist_ok=True)
 		return self
 
 	@staticmethod
@@ -548,9 +647,21 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	@field_validator('user_data_dir', mode='after')
 	@classmethod
 	def validate_user_data_dir(cls, v: str | Path | None) -> str | Path:
-		"""Validate user data dir is set to a non-default path."""
+		"""Validate user data dir is set to a non-default path.
+
+		Only ever runs for an *explicitly-set* field (pydantic skips field_validator for an
+		omitted field left at its default) - but BrowserProfile's own `revalidate_instances='always'`
+		means any revalidation of an existing profile (e.g. BrowserSession(...) internally
+		constructing/reassigning a BrowserProfile) counts as "explicitly set" even when the original
+		value was None, so this DOES run and create a dir earlier than get_args()'s otherwise-lazy
+		resolution. Registered with the atexit safety net (see _register_owned_temp_dir) so a
+		profile/session that's discarded without ever reaching LocalBrowserWatchdog's normal
+		cleanup (i.e. never started/killed) still doesn't leak the dir permanently.
+		"""
 		if v is None:
-			return Path(tempfile.mkdtemp(prefix='browser-use-user-data-dir-'))
+			temp_dir = tempfile.mkdtemp(prefix='browser-use-user-data-dir-')
+			_register_owned_temp_dir(temp_dir)
+			return Path(temp_dir)
 		return Path(v).expanduser().resolve()
 
 
@@ -702,6 +813,17 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	profile_directory: str = 'Default'  # e.g. 'Profile 1', 'Profile 2', 'Custom Profile', etc.
 
+	use_system_keychain: bool | None = Field(
+		default=None,
+		description=(
+			'Whether Chromium may use the OS credential store (macOS Keychain / Linux libsecret) to decrypt '
+			'saved passwords/cookies. None (default) = auto: resolved in model_post_init before the profile is '
+			'possibly copied to a temp dir. Disabled for profiles fully managed by browser-use (temp dirs and the '
+			'default browser-use profile) so automation never triggers an OS credential prompt; enabled for a '
+			'real, user-supplied user_data_dir (e.g. an existing Chrome profile) so its saved logins stay readable.'
+		),
+	)
+
 	# these can be found in BrowserLaunchArgs, BrowserLaunchPersistentContextArgs, BrowserNewContextArgs, BrowserConnectArgs:
 	# save_recording_path: alias of record_video_dir
 	# save_har_path: alias of record_har_path
@@ -832,6 +954,15 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	def model_post_init(self, __context: Any) -> None:
 		"""Called after model initialization to set up display configuration."""
+		if self.use_system_keychain is None:
+			# resolve auto mode before user_data_dir's field_validator (only guaranteed to have run when
+			# the field was explicitly passed — see #5414) and _copy_profile() may rewrite it to a temp copy
+			is_browser_use_managed_profile = self.user_data_dir is None or (
+				'browser-use-user-data-dir-' in str(self.user_data_dir).lower()
+				or Path(self.user_data_dir).expanduser().resolve() == CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR.resolve()
+				or _is_empty_dir_under_system_temp(self.user_data_dir)
+			)
+			self.use_system_keychain = not is_browser_use_managed_profile
 		self.detect_display_configuration()
 		self._copy_profile()
 
@@ -856,13 +987,12 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			return
 
 		temp_dir = tempfile.mkdtemp(prefix='browser-use-user-data-dir-')
+		_register_owned_temp_dir(temp_dir)
 		path_original_user_data = Path(self.user_data_dir)
 		path_original_profile = path_original_user_data / self.profile_directory
 		path_temp_profile = Path(temp_dir) / self.profile_directory
 
 		if path_original_profile.exists():
-			import shutil
-
 			try:
 				shutil.copytree(
 					path_original_profile,
@@ -902,7 +1032,13 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		elif not self.ignore_default_args:
 			default_args = CHROME_DEFAULT_ARGS
 
-		assert self.user_data_dir is not None, 'user_data_dir must be set to a non-default path'
+		if self.user_data_dir is None:
+			# Resolved lazily here (not via a field_validator/validate_default on construction) so that
+			# constructing a BrowserProfile — including the module-level DEFAULT_BROWSER_PROFILE singleton
+			# in browser_use/browser/session.py — never has the filesystem side effect of tempfile.mkdtemp().
+			temp_user_data_dir = tempfile.mkdtemp(prefix='browser-use-user-data-dir-')
+			_register_owned_temp_dir(temp_user_data_dir)
+			self.user_data_dir = Path(temp_user_data_dir)
 
 		# Capture args before conversion for logging
 		pre_conversion_args = [
@@ -912,6 +1048,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			f'--profile-directory={self.profile_directory}',
 			*(CHROME_DOCKER_ARGS if (CONFIG.IN_DOCKER or not self.chromium_sandbox) else []),
 			*(CHROME_HEADLESS_ARGS if self.headless else []),
+			*([] if self.use_system_keychain else ['--use-mock-keychain', '--password-store=basic']),
 			*(CHROME_DISABLE_SECURITY_ARGS if self.disable_security else []),
 			*(CHROME_DETERMINISTIC_RENDERING_ARGS if self.deterministic_rendering else []),
 			*(

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -190,6 +190,14 @@ class DownloadsWatchdog(BaseWatchdog):
 			expanded_path.mkdir(parents=True, exist_ok=True)
 			self.logger.debug(f'[DownloadsWatchdog] Ensured downloads directory exists: {expanded_path}')
 
+			if 'browser-use-downloads-' in expanded_path.name:
+				# Auto-generated dir we own (not a user-supplied downloads_path) - register as a safety net
+				# for abnormal exit (Ctrl-C, a hung test getting killed by pytest --timeout). Normal cleanup
+				# is _cleanup_empty_downloads_dir() on BrowserStoppedEvent. Only removed if still empty.
+				from browser_use.browser.profile import _register_owned_downloads_dir
+
+				_register_owned_downloads_dir(expanded_path)
+
 			# Capture initial files to detect new downloads reliably
 			if expanded_path.exists():
 				for f in expanded_path.iterdir():
@@ -273,6 +281,30 @@ class DownloadsWatchdog(BaseWatchdog):
 		self._detected_downloads.clear()
 		self._initial_downloads_snapshot.clear()
 		self._network_callback_registered = False
+
+		self._cleanup_empty_downloads_dir()
+
+	def _cleanup_empty_downloads_dir(self) -> None:
+		"""Remove the auto-generated downloads dir we created, but only if it's still empty.
+
+		Only ever touches a directory we created ourselves (the 'browser-use-downloads-' prefix from
+		BrowserProfile.set_default_downloads_path) - a user-supplied downloads_path is never deleted, and
+		neither is one that has any downloaded files in it.
+		"""
+		downloads_path = self.browser_session.browser_profile.downloads_path
+		if not downloads_path:
+			return
+		try:
+			expanded_path = Path(downloads_path).expanduser().resolve()
+			if 'browser-use-downloads-' not in expanded_path.name:
+				return
+			if not expanded_path.is_dir():
+				return
+			if any(expanded_path.iterdir()):
+				return
+			expanded_path.rmdir()
+		except OSError as e:
+			self.logger.debug(f'[DownloadsWatchdog] Failed to clean up empty downloads dir {downloads_path}: {e}')
 
 	async def on_NavigationCompleteEvent(self, event: NavigationCompleteEvent) -> None:
 		"""Check for PDFs after navigation completes."""

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -169,8 +169,13 @@ class LocalBrowserWatchdog(BaseWatchdog):
 					except Exception:
 						pass
 
-				# Keep only the in-use directory for cleanup during browser kill
-				if currently_used_dir and 'browseruse-tmp-' in currently_used_dir:
+				# Keep only the in-use directory for cleanup during browser kill, but only if we own it
+				# (created it ourselves via mkdtemp - either a retry fallback dir, or BrowserProfile's own
+				# lazily-created 'browser-use-user-data-dir-*' from get_args()/_copy_profile()). A user-supplied
+				# user_data_dir must never be deleted.
+				if currently_used_dir and (
+					'browseruse-tmp-' in currently_used_dir or 'browser-use-user-data-dir-' in currently_used_dir
+				):
 					self._temp_dirs_to_cleanup = [Path(currently_used_dir)]
 				else:
 					self._temp_dirs_to_cleanup = []
@@ -187,6 +192,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 					if attempt < max_retries - 1:
 						# Create a temporary directory for next attempt
 						tmp_dir = Path(tempfile.mkdtemp(prefix='browseruse-tmp-'))
+						from browser_use.browser.profile import _register_owned_temp_dir
+
+						_register_owned_temp_dir(tmp_dir)
 						self._temp_dirs_to_cleanup.append(tmp_dir)
 
 						# Update profile to use temp directory
@@ -471,9 +479,14 @@ class LocalBrowserWatchdog(BaseWatchdog):
 
 		try:
 			temp_path = Path(temp_dir)
-			# Only remove if it's actually a temp directory we created
-			if 'browseruse-tmp-' in str(temp_path):
+			temp_path_str = str(temp_path)
+			# Only remove if it's actually a temp directory we created ourselves - never a user-supplied path.
+			if 'browseruse-tmp-' in temp_path_str or 'browser-use-user-data-dir-' in temp_path_str:
 				shutil.rmtree(temp_path, ignore_errors=True)
+
+				from browser_use.browser.profile import _unregister_owned_temp_dir
+
+				_unregister_owned_temp_dir(temp_path_str)
 		except Exception as e:
 			self.logger.debug(f'Failed to cleanup temp dir {temp_dir}: {e}')
 

--- a/tests/ci/test_temp_dir_cleanup.py
+++ b/tests/ci/test_temp_dir_cleanup.py
@@ -1,0 +1,268 @@
+"""Regression tests for temp dir leaks in $TMPDIR.
+
+Repro that motivated this file (see the linked issue): constructing a BrowserProfile alone -
+without ever launching a browser - created a `browser-use-downloads-*` dir on disk via a
+model_validator, and `get_args()` created a `browser-use-user-data-dir-*` dir that
+LocalBrowserWatchdog's cleanup could never remove (its cleanup only matched the
+'browseruse-tmp-' prefix used by SingletonLock retries, never the 'browser-use-user-data-dir-'
+prefix BrowserProfile itself creates). A clean start()+kill() cycle leaked all 3 dirs it
+created. Measured on a real machine: 36 purely-unit tests (no browser ever launched) leaked 14
+dirs, accumulating to 7741 dirs / 14GB in $TMPDIR over time.
+
+Fix: BrowserProfile no longer creates the downloads dir eagerly (DownloadsWatchdog creates it
+lazily on BrowserLaunchEvent, same as it always has); LocalBrowserWatchdog's cleanup now also
+recognizes 'browser-use-user-data-dir-' as its own; DownloadsWatchdog removes its downloads dir
+on BrowserStoppedEvent if left empty; and an atexit safety net sweeps anything that never made
+it through the normal cleanup path (Ctrl-C, a test killed by pytest --timeout).
+
+Also covered: BrowserSession(...) construction (any form, since it always builds a BrowserProfile
+internally) triggers pydantic to revalidate the profile as part of assigning it to
+BrowserSession.browser_profile. That revalidation re-runs
+BrowserLaunchPersistentContextArgs.validate_user_data_dir (a field_validator, mode='after') even
+though the field was never explicitly passed - pydantic only skips field_validator for a field left
+at its default on *first* construction, not on revalidation of an existing instance (verified with
+an isolated pydantic model). So this DOES create a temp user_data_dir on disk immediately - earlier
+than the otherwise-lazy get_args() path. If the session's start()/kill() lifecycle runs,
+LocalBrowserWatchdog's cleanup (fixed above) removes it as usual; for the case where a session is
+constructed and discarded without ever starting/killing it (e.g. a unit test that only inspects
+`session.browser_profile.some_field`), the dir is registered with the same atexit safety net so it
+still doesn't survive process exit permanently. Deliberately not touching validate_user_data_dir's
+semantics itself (e.g. leaving user_data_dir as None) - browser_use/browser/session.py's
+StorageStateWatchdog auto-enable logic reads `browser_profile.user_data_dir is not None` before
+get_args() ever runs, so changing what that field observes at revalidation time would be a
+behavior change beyond this leak fix.
+"""
+
+import glob
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_tmpdir(tmp_path, monkeypatch):
+	"""Give each test a private $TMPDIR so a concurrent xdist worker can't pollute the snapshots.
+
+	_snapshot_browser_use_temp_dirs() globs the whole temp root, so under `pytest -n` a sibling
+	worker creating its own browser-use-* dir between a test's before/after snapshots shows up as
+	a phantom leak. Redirecting $TMPDIR keeps every assertion's meaning intact - a genuinely leaked
+	dir still lands in this test's own root and still shows up in the delta - while making the
+	observation window private to this process.
+
+	The tradeoff: a snapshot delta taken here can only see leaks that land in the redirected root,
+	so a production site that binds the temp root at import time (or otherwise ignores a later
+	$TMPDIR change) would leak into the *real* system temp dir, outside the observation window.
+	test_temp_paths_track_the_live_temp_root_not_an_import_time_one covers that gap directly.
+	"""
+	monkeypatch.setenv('TMPDIR', str(tmp_path))
+	# tempfile caches the resolved dir in a module global, so setenv alone is a no-op. monkeypatch
+	# restores the original cached value on teardown, which is what the next test should observe.
+	monkeypatch.setattr(tempfile, 'tempdir', None)
+
+
+def _snapshot_browser_use_temp_dirs() -> set[str]:
+	return set(glob.glob(os.path.join(tempfile.gettempdir(), 'browser-use-*')))
+
+
+def test_temp_paths_track_the_live_temp_root_not_an_import_time_one(tmp_path, monkeypatch):
+	"""Guards the blind spot the autouse redirect creates.
+
+	Every snapshot-delta test here globs `tempfile.gettempdir()`, which under _isolated_tmpdir is
+	the private tmp_path. So a production site that resolves the temp root once - at import time,
+	or by caching gettempdir() - would put its dirs in the *real* system temp root, entirely
+	outside that before/after window, and every one of those tests would still pass. That is the
+	module docstring's original failure mode (7741 dirs / 14GB in the user's real $TMPDIR).
+
+	Detecting import-time binding requires observing from a context where the two roots *differ*:
+	asserting from an unredirected test would compare gettempdir() against itself and hold by
+	construction. So this redirects to a root of its own and asserts the freshly built profile
+	tracks it. A path bound to any earlier root fails here, which is precisely what a snapshot
+	delta cannot see.
+
+	Asserts on paths attributable to the profile it just built rather than on a glob delta - the
+	raw delta is what made these tests flaky under `pytest -n`, since a sibling worker's dirs land
+	in the same root.
+	"""
+	private_root = tmp_path / 'live-temp-root'
+	private_root.mkdir()
+	monkeypatch.setenv('TMPDIR', str(private_root))
+	monkeypatch.setattr(tempfile, 'tempdir', None)
+
+	from browser_use.browser.profile import BrowserProfile
+
+	profile = BrowserProfile()
+
+	assert profile.downloads_path is not None
+	assert not Path(profile.downloads_path).exists(), (
+		f'BrowserProfile() eagerly created its downloads dir: {profile.downloads_path}'
+	)
+	assert Path(profile.downloads_path).resolve().parent == private_root.resolve(), (
+		f'downloads_path is bound to a stale temp root, not the live one: {profile.downloads_path}'
+	)
+
+	# get_args() is the lazy path that materializes user_data_dir - it must track the live root too.
+	profile.get_args()
+	assert profile.user_data_dir is not None
+	assert Path(profile.user_data_dir).resolve().parent == private_root.resolve(), (
+		f'user_data_dir is bound to a stale temp root, not the live one: {profile.user_data_dir}'
+	)
+
+
+def test_constructing_a_profile_creates_no_files_on_disk():
+	"""Repro 1: BrowserProfile() alone, browser never launched, must not touch the filesystem."""
+	before = _snapshot_browser_use_temp_dirs()
+
+	from browser_use.browser.profile import BrowserProfile
+
+	profile = BrowserProfile()
+
+	# downloads_path must still be assigned (agent/service.py and beta/service.py gate download
+	# tracking on `downloads_path is not None`), just not materialized on disk yet.
+	assert profile.downloads_path is not None
+	assert not Path(profile.downloads_path).exists()
+
+	after = _snapshot_browser_use_temp_dirs()
+	assert after == before, f'BrowserProfile() leaked: {after - before}'
+
+
+def test_get_args_creates_user_data_dir_but_not_downloads_dir():
+	"""get_args() (called by every real launch path) must resolve user_data_dir lazily, same as
+	before, but still must not touch downloads_path - that stays DownloadsWatchdog's job."""
+	before = _snapshot_browser_use_temp_dirs()
+
+	from browser_use.browser.profile import BrowserProfile
+
+	profile = BrowserProfile()
+	profile.get_args()
+
+	assert profile.user_data_dir is not None
+	assert Path(profile.user_data_dir).exists()
+	assert not Path(profile.downloads_path).exists()  # type: ignore[arg-type]
+
+	after = _snapshot_browser_use_temp_dirs()
+	created = {str(Path(p).resolve()) for p in after - before}
+	# macOS symlinks /var -> /private/var, so resolve() before comparing paths from different sources.
+	assert created == {str(Path(profile.user_data_dir).resolve())}, f'unexpected dirs created: {after - before}'
+
+
+def test_default_browser_profile_singleton_creates_no_files_on_disk():
+	"""DEFAULT_BROWSER_PROFILE (browser_use/browser/session.py:66) is constructed at import time -
+	must not leak a downloads dir on every `import browser_use.browser`."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	assert DEFAULT_BROWSER_PROFILE.downloads_path is not None
+	assert not Path(DEFAULT_BROWSER_PROFILE.downloads_path).exists()
+
+
+async def test_clean_start_and_kill_leaves_no_temp_dirs():
+	"""Repro 2: the only test here that actually launches a browser. A fully clean start()+kill()
+	cycle, no errors, no interruption, must leave $TMPDIR exactly as it found it."""
+	before = _snapshot_browser_use_temp_dirs()
+
+	from browser_use.browser import BrowserSession
+
+	session = BrowserSession(headless=True)
+	await session.start()
+	created = _snapshot_browser_use_temp_dirs() - before
+	assert created, 'expected start() to create at least a user_data_dir for the assertions below to be meaningful'
+
+	await session.kill()
+
+	after = _snapshot_browser_use_temp_dirs()
+	assert after == before, f'clean start()+kill() leaked: {after - before}'
+
+
+async def test_downloads_dir_with_files_is_not_deleted_on_stop():
+	"""Regression: the empty-dir cleanup on BrowserStoppedEvent must never delete a downloads dir
+	that actually has files in it."""
+	from browser_use.browser import BrowserSession
+
+	session = BrowserSession(headless=True)
+	await session.start()
+
+	downloads_path = Path(session.browser_profile.downloads_path)  # type: ignore[arg-type]
+	downloads_path.mkdir(parents=True, exist_ok=True)
+	(downloads_path / 'definitely-not-garbage.txt').write_text('kept')
+
+	await session.kill()
+
+	assert downloads_path.exists(), 'a non-empty downloads dir must survive cleanup'
+	assert (downloads_path / 'definitely-not-garbage.txt').exists()
+
+	# manual cleanup since this test intentionally defeats the auto-cleanup
+	import shutil
+
+	shutil.rmtree(downloads_path, ignore_errors=True)
+
+
+def test_user_supplied_user_data_dir_is_never_deleted():
+	"""Regression: LocalBrowserWatchdog._cleanup_temp_dir() must refuse to remove a user-supplied
+	user_data_dir - only paths carrying the 'browseruse-tmp-' or 'browser-use-user-data-dir-'
+	prefixes we generate ourselves are ever eligible for deletion.
+
+	Exercises the cleanup helper directly rather than a full browser launch - the launch path is
+	covered by test_clean_start_and_kill_leaves_no_temp_dirs above, and this is the one place a
+	user's own profile directory could get silently deleted, so it's worth pinning down in
+	isolation from browser startup flakiness.
+	"""
+	from browser_use.browser import BrowserSession
+	from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+	# Constructing a BrowserSession/watchdog does not launch a browser - only .start() does - so this
+	# stays fast and isolated from the browser-startup flakiness that test_clean_start_and_kill_leaves_no_temp_dirs
+	# and test_downloads_dir_with_files_is_not_deleted_on_stop already cover with a real launch.
+	session = BrowserSession(headless=True)
+	watchdog = LocalBrowserWatchdog(browser_session=session, event_bus=session.event_bus)
+
+	with tempfile.TemporaryDirectory(prefix='my-own-user-profile-') as user_dir:
+		watchdog._cleanup_temp_dir(user_dir)
+		assert Path(user_dir).exists(), 'a user-supplied user_data_dir must survive cleanup'
+
+
+def test_owned_temp_dir_prefixes_are_deleted():
+	"""Regression: the flip side of the above - both prefixes BrowserProfile/LocalBrowserWatchdog
+	actually generate themselves must still be recognized and removed."""
+	from browser_use.browser import BrowserSession
+	from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+	session = BrowserSession(headless=True)
+	watchdog = LocalBrowserWatchdog(browser_session=session, event_bus=session.event_bus)
+	for prefix in ('browseruse-tmp-', 'browser-use-user-data-dir-'):
+		owned_dir = tempfile.mkdtemp(prefix=prefix)
+		watchdog._cleanup_temp_dir(owned_dir)
+		assert not Path(owned_dir).exists(), f'{prefix} dir should have been cleaned up'
+
+
+def test_revalidated_profile_user_data_dir_is_registered_for_atexit_cleanup():
+	"""Regression: BrowserSession(...) construction revalidates the profile it builds internally
+	(BrowserProfile has revalidate_instances='always'), which re-runs validate_user_data_dir and
+	creates a user_data_dir immediately - earlier than the lazy get_args() path. This dir must at
+	least be tracked by the atexit safety net, even though it isn't synchronously cleaned up here
+	(no start()/kill() was called - see the module docstring for why we don't change
+	validate_user_data_dir's observable None-vs-resolved semantics to avoid this eager creation)."""
+	from browser_use.browser import BrowserSession
+	from browser_use.browser.profile import _owned_temp_dirs_registry
+
+	session = BrowserSession(headless=True)
+	user_data_dir = str(session.browser_profile.user_data_dir)
+
+	assert user_data_dir in _owned_temp_dirs_registry, (
+		'the eagerly-created user_data_dir from profile revalidation must be tracked for atexit cleanup'
+	)
+
+
+@pytest.mark.parametrize('leaked_run_index', range(3))
+async def test_repeated_profile_construction_does_not_accumulate_dirs(leaked_run_index: int):
+	"""Repro 3 (condensed): constructing profiles in a loop without ever launching a browser -
+	the exact pattern of a pure-unit test suite - must not accumulate any dirs at all."""
+	before = _snapshot_browser_use_temp_dirs()
+
+	from browser_use.browser.profile import BrowserProfile
+
+	for _ in range(5):
+		BrowserProfile()
+
+	after = _snapshot_browser_use_temp_dirs()
+	assert after == before, f'leaked {len(after - before)} dirs from plain construction: {after - before}'


### PR DESCRIPTION
## Problem

`BrowserProfile` creates a fresh `mkdtemp()` `user_data_dir` per session and eagerly creates `downloads_path`, but nothing ever removes them once the session ends. Every run of the library (including in CI, examples, and tests) leaks a `browser-use-*` directory into the system temp root.

## Fix

- Track owned temp/`user_data_dir`/downloads dirs in module-level registries; clean them up via `atexit` and when the browser stops.
- Make `downloads_path` lazy — the validator no longer eagerly `mkdir`s it.
- Only clean up dirs `browser-use` itself created and that are still empty, so a user explicitly pointing at an existing profile/downloads dir is left untouched.

## Tests

`tests/ci/test_temp_dir_cleanup.py` covers the leak (before/after snapshot of the system temp root) and the cleanup path.

Each test gets its own private `$TMPDIR` via an autouse fixture, so the snapshot-based leak assertions stay valid under `pytest -n` (xdist) — otherwise a concurrent worker's own `browser-use-*` dir would show up as a phantom leak in this test's delta.

Full `tests/ci` suite: 1080 passed, 34 skipped, 0 failed. `ruff check`, `ruff format --check`, and `pyright` all clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leaked `browser-use-*` temp directories by tracking and cleaning up session `user_data_dir` and auto-created downloads folders. Downloads dirs are now created lazily, and a safety net cleans leftovers on abnormal exits.

- **Bug Fixes**
  - Track owned temp and downloads dirs; clean on browser stop and via `atexit`.
  - Create `downloads_path` only on browser launch; delete only if still empty.
  - Extend cleanup to `'browser-use-user-data-dir-*'`; never delete user-supplied paths.
  - Tests cover before/after temp snapshots, isolated `$TMPDIR` under `pytest -n`, and retention of non-empty downloads dirs.

- **New Features**
  - `headless` defaults from `BROWSER_USE_HEADLESS`; explicit `devtools=True` overrides the env-derived default.
  - Auto-detect `use_system_keychain`; for browser-use-managed profiles pass `--use-mock-keychain` and `--password-store=basic`.

<sup>Written for commit ca4fa858ccc966da9de782620bcbc0e55fcffefe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

