### PR TITLE
fix(browser): avoid OS keychain prompts for browser-use-managed profiles

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -91,6 +91,27 @@ def _ignore_chrome_profile_transient_files(_src: str, names: list[str]) -> set[s
 	return {name for name in names if any(fnmatch(name, pattern) for pattern in CHROME_PROFILE_TRANSIENT_FILE_PATTERNS)}
 
 
+def _is_empty_dir_under_system_temp(path: str | Path) -> bool:
+	"""Whether path is inside the OS temp dir AND doesn't exist yet or has no Chrome profile files in
+	it. Used to auto-detect a caller-supplied tempfile.mkdtemp() user_data_dir (not just
+	BrowserProfile's own 'browser-use-user-data-dir-*' prefix) as browser-use-managed for the
+	use_system_keychain heuristic. Requiring both conditions (not just emptiness) keeps a real user
+	profile that happens to not be initialized yet - but lives at a real, non-temp path - correctly
+	classified as a real profile."""
+	try:
+		resolved = Path(path).expanduser().resolve()
+		temp_root = Path(tempfile.gettempdir()).resolve()
+	except OSError:
+		return False
+	if resolved != temp_root and temp_root not in resolved.parents:
+		return False
+	if not resolved.exists():
+		return True
+	if not resolved.is_dir():
+		return False
+	return not any(resolved.iterdir())
+
+
 def _is_chrome_profile_lock_error(error: BaseException) -> bool:
 	"""Detect Windows sharing violations or permission errors raised while copying a Chrome profile."""
 	if isinstance(error, PermissionError):
@@ -702,6 +723,17 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	profile_directory: str = 'Default'  # e.g. 'Profile 1', 'Profile 2', 'Custom Profile', etc.
 
+	use_system_keychain: bool | None = Field(
+		default=None,
+		description=(
+			'Whether Chromium may use the OS credential store (macOS Keychain / Linux libsecret) to decrypt '
+			'saved passwords/cookies. None (default) = auto: resolved in model_post_init before the profile is '
+			'possibly copied to a temp dir. Disabled for profiles fully managed by browser-use (temp dirs and the '
+			'default browser-use profile) so automation never triggers an OS credential prompt; enabled for a '
+			'real, user-supplied user_data_dir (e.g. an existing Chrome profile) so its saved logins stay readable.'
+		),
+	)
+
 	# these can be found in BrowserLaunchArgs, BrowserLaunchPersistentContextArgs, BrowserNewContextArgs, BrowserConnectArgs:
 	# save_recording_path: alias of record_video_dir
 	# save_har_path: alias of record_har_path
@@ -832,6 +864,15 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 
 	def model_post_init(self, __context: Any) -> None:
 		"""Called after model initialization to set up display configuration."""
+		if self.use_system_keychain is None:
+			# resolve auto mode before user_data_dir's field_validator (only guaranteed to have run when
+			# the field was explicitly passed — see #5414) and _copy_profile() may rewrite it to a temp copy
+			is_browser_use_managed_profile = self.user_data_dir is None or (
+				'browser-use-user-data-dir-' in str(self.user_data_dir).lower()
+				or Path(self.user_data_dir).expanduser().resolve() == CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR.resolve()
+				or _is_empty_dir_under_system_temp(self.user_data_dir)
+			)
+			self.use_system_keychain = not is_browser_use_managed_profile
 		self.detect_display_configuration()
 		self._copy_profile()
 
@@ -912,6 +953,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 			f'--profile-directory={self.profile_directory}',
 			*(CHROME_DOCKER_ARGS if (CONFIG.IN_DOCKER or not self.chromium_sandbox) else []),
 			*(CHROME_HEADLESS_ARGS if self.headless else []),
+			*([] if self.use_system_keychain else ['--use-mock-keychain', '--password-store=basic']),
 			*(CHROME_DISABLE_SECURITY_ARGS if self.disable_security else []),
 			*(CHROME_DETERMINISTIC_RENDERING_ARGS if self.deterministic_rendering else []),
 			*(

--- a/tests/ci/conftest.py
+++ b/tests/ci/conftest.py
@@ -163,6 +163,7 @@ async def browser_session():
 			user_data_dir=None,  # Use temporary directory
 			keep_alive=True,
 			enable_default_extensions=True,  # Enable extensions during tests
+			use_system_keychain=False,  # tests must never touch the OS credential store
 		)
 	)
 	await session.start()

--- a/tests/ci/test_browser_profile_keychain.py
+++ b/tests/ci/test_browser_profile_keychain.py
@@ -1,0 +1,123 @@
+"""Tests for BrowserProfile.use_system_keychain and its effect on get_args()."""
+
+import shutil
+from pathlib import Path
+
+from browser_use.browser.profile import CONFIG, BrowserChannel, BrowserProfile
+
+
+def test_temporary_profile_avoids_system_keychain_by_default():
+	profile = BrowserProfile(user_data_dir=None)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_default_browser_use_profile_avoids_system_keychain_by_default():
+	profile = BrowserProfile(headless=True, user_data_dir=CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR, keep_alive=False)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_real_user_supplied_profile_keeps_system_keychain_by_default():
+	"""A real user profile must keep system keychain even before it has any files on disk yet - the
+	distinguishing signal is a real (non-temp) path, not whether it's been initialized. Uses a path
+	outside the OS temp dir rather than pytest's tmp_path, since an empty dir inside the temp dir is
+	exactly what the caller-supplied-mkdtemp case looks like (see
+	test_caller_supplied_empty_temp_dir_avoids_system_keychain)."""
+	real_profile_dir = Path('~/.browser-use-test-real-profile-uninitialized').expanduser()
+	try:
+		profile = BrowserProfile(user_data_dir=real_profile_dir)
+		args = profile.get_args()
+
+		assert '--use-mock-keychain' not in args
+		assert '--password-store=basic' not in args
+	finally:
+		shutil.rmtree(real_profile_dir, ignore_errors=True)
+
+
+def test_caller_supplied_empty_temp_dir_avoids_system_keychain(tmp_path):
+	"""Regression: a caller-supplied tempfile.mkdtemp()-style dir (not BrowserProfile's own
+	'browser-use-user-data-dir-*' prefix) must still be treated as browser-use-managed when it's
+	empty or doesn't exist yet AND lives inside the OS temp dir - there's nothing in it to decrypt.
+	Misclassifying this as a real profile left system keychain enabled, causing Chromium to hang
+	indefinitely at startup trying to reach the OS credential store in headless/CI environments
+	(issue #5424, a duplicate of this one)."""
+	empty_dir = tmp_path / 'some-other-prefix-abc123'
+	profile = BrowserProfile(headless=True, user_data_dir=empty_dir)
+
+	assert profile.use_system_keychain is False
+
+
+def test_real_chrome_profile_keeps_system_keychain_after_copy_profile_rewrites_user_data_dir():
+	"""use_system_keychain must be decided from the ORIGINAL real user_data_dir before _copy_profile()
+	rewrites it to a browser-use-managed-looking temp dir — and must stay True afterward, so a copied
+	real Chrome profile's OS-keychain-encrypted cookies/passwords stay decryptable. The path here has
+	no 'chrome' substring and channel=CHROME is what makes _copy_profile() actually perform the copy
+	(is_chrome True), unlike test_real_user_supplied_profile_keeps_system_keychain_by_default's path,
+	which has no 'chrome' substring/executable_path/CHROME channel and so never exercises the copy.
+
+	Uses a real (non-temp) path rather than pytest's tmp_path: a real user profile that happens to be
+	empty/not-yet-initialized must still be classified as real when it lives at a real path - only an
+	empty directory that's ALSO inside the OS temp dir is treated as browser-use-managed (see
+	test_caller_supplied_empty_temp_dir_avoids_system_keychain)."""
+	real_profile_dir = Path('~/.browser-use-test-real-profile-5417').expanduser()
+	real_profile_dir.mkdir(exist_ok=True)
+	try:
+		profile = BrowserProfile(user_data_dir=real_profile_dir, channel=BrowserChannel.CHROME)
+
+		# _copy_profile() must have actually rewritten user_data_dir to a temp copy (proving the copy ran).
+		assert str(profile.user_data_dir) != str(real_profile_dir)
+		assert 'browser-use-user-data-dir-' in str(profile.user_data_dir).lower()
+
+		args = profile.get_args()
+		assert '--use-mock-keychain' not in args
+		assert '--password-store=basic' not in args
+	finally:
+		shutil.rmtree(real_profile_dir, ignore_errors=True)
+
+
+def test_default_browser_use_profile_avoids_system_keychain_with_non_default_channel():
+	"""Pins an ordering dependency: model_post_init resolves use_system_keychain BEFORE the
+	model_validator(mode='after') warn_user_data_dir_non_default_version rewrites a user_data_dir
+	equal to CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR to a sibling '.../default-{channel}' dir (only
+	triggered by a non-default channel — test_default_browser_use_profile_avoids_system_keychain_by_default
+	uses the default channel, so that rewrite validator never fires there and this ordering goes
+	unexercised). If model_post_init ever ran after that rewrite, the sibling path would match neither
+	the None check, the temp-dir substring, nor an exact equal to BROWSER_USE_DEFAULT_USER_DATA_DIR, so
+	use_system_keychain would flip to True — silently reintroducing OS keychain prompts for a
+	browser-use-managed profile."""
+	profile = BrowserProfile(user_data_dir=CONFIG.BROWSER_USE_DEFAULT_USER_DATA_DIR, channel=BrowserChannel.CHROME)
+	args = profile.get_args()
+
+	assert profile.use_system_keychain is False
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_explicit_use_system_keychain_true_overrides_temporary_profile_default():
+	profile = BrowserProfile(user_data_dir=None, use_system_keychain=True)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' not in args
+	assert '--password-store=basic' not in args
+
+
+def test_explicit_use_system_keychain_false_overrides_real_profile_default(tmp_path):
+	profile = BrowserProfile(user_data_dir=tmp_path / 'my-real-profile', use_system_keychain=False)
+	args = profile.get_args()
+
+	assert '--use-mock-keychain' in args
+	assert '--password-store=basic' in args
+
+
+def test_omitted_user_data_dir_still_avoids_system_keychain():
+	"""use_system_keychain's auto-detection must not rely on user_data_dir's field_validator having
+	already run (see #5414) — BrowserProfile(headless=True) with no explicit user_data_dir= is a very
+	common call pattern and must not be treated as a real user profile."""
+	profile = BrowserProfile(headless=True)
+
+	assert profile.use_system_keychain is False


### PR DESCRIPTION
Re-opens #5417 (closed without merge; source branch was deleted) as a clean PR against current `main`.

## Problem

#3225 removed `--use-mock-keychain` / `--password-store=basic` from `CHROME_DEFAULT_ARGS` globally, to let Chromium decrypt saved passwords/cookies in a real, user-supplied Chrome profile. That fix is still correct for that scenario.

The side effect: every browser-use-managed profile (temp dirs, and the default browser-use profile under `~/.config/browseruse/profiles/default`) now behaves like a real user profile w.r.t. keychain access too, even though there's nothing saved in it to decrypt. On macOS (or Linux with a keyring daemon registered), Chromium's profile init synchronously tries to reach the OS credential store; in headless/CI environments with no way to answer that prompt, it hangs indefinitely at startup instead of opening its CDP port, until BrowserSession's internal 30s watchdog timeout fires.

Fixes #5415.

## Fix

Adds `use_system_keychain: bool | None` (default `None` = auto), resolved in `model_post_init` before `_copy_profile()` may rewrite `user_data_dir` to a temp copy: disabled for browser-use-managed profiles (temp dirs and the default profile dir), enabled for a real, user-supplied `user_data_dir` — preserving the #3225 behavior for that case while fixing it for every other profile.

The heuristic also treats any empty/nonexistent `user_data_dir` under the OS temp dir as managed, not just `BrowserProfile`'s own `browser-use-user-data-dir-*` prefix — a caller-supplied `mkdtemp()` dir (common in tests/CI) was previously misclassified as a real profile.

## Verification

Reproduced the hang directly: launched the same Chromium binary with an identical argument list twice, differing only in these two flags — without them the CDP port never opens even after 8s; with them it responds within ~1s. Also sampled the stuck process and found every thread blocked in `SecKeychainFindGenericPassword -> mach_msg`. 15/15 repro attempts succeed after this fix (previously hung on attempt 1/1).

## Tests

`tests/ci/test_browser_profile_keychain.py` — 9 tests, all passing. `ruff check`, `ruff format --check`, `pyright` clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OS keychain prompts for browser-use-managed profiles so Chromium doesn’t hang at startup in headless/CI. Keeps real user profiles using the system keychain so saved passwords and cookies still decrypt.

- **Bug Fixes**
  - Added `use_system_keychain` (bool | None, default auto) and resolve it before any profile copy.
  - Auto-disables for temp dirs, the default browser-use profile, and empty/nonexistent dirs under the OS temp dir.
  - Stays enabled for real, user-supplied `user_data_dir` paths.
  - When disabled, passes `--use-mock-keychain` and `--password-store=basic` to Chrome.
  - Tests cover auto-detection, overrides, copy-path ordering, and CI sets `use_system_keychain=False`.

<sup>Written for commit a4fd408f3f595faaf908ce218b0354e97d2423ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

