### PR TITLE
feat(browser): honor BROWSER_USE_HEADLESS in BrowserProfile

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -25,6 +25,14 @@ def _get_enable_default_extensions_default() -> bool:
 	return True
 
 
+def _get_headless_default() -> bool | None:
+	"""Get the default value for headless from the BROWSER_USE_HEADLESS env var, or None to fall back to display detection."""
+	env_val = os.getenv('BROWSER_USE_HEADLESS')
+	if env_val is not None:
+		return env_val.lower() not in ('0', 'false', 'no', 'off', '')
+	return None
+
+
 CHROME_DEBUG_PORT = 9242  # use a non-default port to avoid conflicts with other tools / devs using 9222
 DOMAIN_OPTIMIZATION_THRESHOLD = 100  # Convert domain lists to sets for O(1) lookup when >= this size
 CHROME_PROFILE_TRANSIENT_FILE_PATTERNS = (
@@ -419,7 +427,10 @@ class BrowserLaunchArgs(BaseModel):
 		validation_alias=AliasChoices('browser_binary_path', 'chrome_binary_path'),
 		description='Path to the chromium-based browser executable to use.',
 	)
-	headless: bool | None = Field(default=None, description='Whether to run the browser in headless or windowed mode.')
+	headless: bool | None = Field(
+		default_factory=_get_headless_default,
+		description='Whether to run the browser in headless or windowed mode. Defaults to BROWSER_USE_HEADLESS env var if set, otherwise auto-detected from display availability.',
+	)
 	args: list[CliArgStr] = Field(
 		default_factory=list, description='List of *extra* CLI args to pass to the browser when launching.'
 	)
@@ -456,8 +467,21 @@ class BrowserLaunchArgs(BaseModel):
 
 	@model_validator(mode='after')
 	def validate_devtools_headless(self) -> Self:
-		"""Cannot open devtools when headless is True"""
-		assert not (self.headless and self.devtools), 'headless=True and devtools=True cannot both be set at the same time'
+		"""Cannot open devtools when headless is True.
+
+		An explicit headless=True still conflicts with devtools=True and raises. A headless value that
+		only came from the BROWSER_USE_HEADLESS env var (not passed explicitly) yields to an explicit
+		devtools=True instead of raising, since the user never wrote headless=True themselves.
+		"""
+		if self.headless and self.devtools:
+			if 'headless' not in self.model_fields_set:
+				logger.warning(
+					'⚠️ BROWSER_USE_HEADLESS is set but devtools=True was passed explicitly. '
+					'devtools takes priority. Setting headless=False.'
+				)
+				self.headless = False
+			else:
+				assert False, 'headless=True and devtools=True cannot both be set at the same time'
 		return self
 
 	@model_validator(mode='after')

--- a/tests/ci/test_headless_config.py
+++ b/tests/ci/test_headless_config.py
@@ -1,0 +1,155 @@
+"""Tests for the BROWSER_USE_HEADLESS environment variable (see issue #5420).
+
+Mirrors tests/ci/test_extension_config.py's pattern for BROWSER_USE_DISABLE_EXTENSIONS.
+"""
+
+import os
+
+import pytest
+
+
+class TestHeadlessEnvVar:
+	"""Test BROWSER_USE_HEADLESS environment variable."""
+
+	def test_default_value_is_none(self):
+		"""Without env var set, _get_headless_default should return None (fall back to display detection)."""
+		original = os.environ.pop('BROWSER_USE_HEADLESS', None)
+		try:
+			from browser_use.browser.profile import _get_headless_default
+
+			assert _get_headless_default() is None
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+
+	@pytest.mark.parametrize(
+		'env_value,expected_headless',
+		[
+			('true', True),
+			('True', True),
+			('TRUE', True),
+			('1', True),
+			('yes', True),
+			('on', True),
+			('false', False),
+			('False', False),
+			('FALSE', False),
+			('0', False),
+			('no', False),
+			('off', False),
+			('', False),
+		],
+	)
+	def test_env_var_values(self, env_value: str, expected_headless: bool):
+		"""Test various env var values are parsed correctly."""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = env_value
+			from browser_use.browser.profile import _get_headless_default
+
+			result = _get_headless_default()
+			assert result is expected_headless, (
+				f"Expected headless={expected_headless} for BROWSER_USE_HEADLESS='{env_value}', got {result}"
+			)
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_browser_profile_uses_env_var(self):
+		"""Test that BrowserProfile picks up the env var."""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = 'true'
+
+			from browser_use.browser.profile import BrowserProfile
+
+			profile = BrowserProfile()
+			assert profile.headless is True, 'BrowserProfile should be headless when BROWSER_USE_HEADLESS=true'
+
+			os.environ['BROWSER_USE_HEADLESS'] = 'false'
+			profile2 = BrowserProfile()
+			assert profile2.headless is False, 'BrowserProfile should be headful when BROWSER_USE_HEADLESS=false'
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_explicit_param_overrides_env_var(self):
+		"""Test that an explicit headless= parameter overrides the env var."""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = 'true'
+
+			from browser_use.browser.profile import BrowserProfile
+
+			profile = BrowserProfile(headless=False)
+			assert profile.headless is False, 'Explicit headless=False should override BROWSER_USE_HEADLESS=true'
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_browser_session_uses_env_var(self):
+		"""Test that BrowserSession picks up the env var via BrowserProfile.
+
+		BrowserSession.__init__ filters None values out of the kwargs it forwards to BrowserProfile,
+		so an unpassed headless= must still reach the field's default_factory rather than being
+		overridden with an explicit None - this is a distinct code path from BrowserProfile() directly.
+		"""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = 'true'
+
+			from browser_use.browser import BrowserSession
+
+			session = BrowserSession()
+			assert session.browser_profile.headless is True, 'BrowserSession should be headless when BROWSER_USE_HEADLESS=true'
+
+			session2 = BrowserSession(headless=False)
+			assert session2.browser_profile.headless is False, 'Explicit headless=False should override the env var'
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_env_var_headless_yields_to_explicit_devtools(self):
+		"""Regression test: BROWSER_USE_HEADLESS=true must not make BrowserProfile(devtools=True) raise.
+
+		default_factory populates the headless field before validate_devtools_headless (mode='after')
+		runs, so a naive implementation would turn a previously-valid BrowserProfile(devtools=True) call
+		into an AssertionError as soon as the env var is set. devtools takes priority: headless is forced
+		back to False instead of raising, since the caller never wrote headless=True themselves.
+		"""
+		original = os.environ.get('BROWSER_USE_HEADLESS')
+		try:
+			os.environ['BROWSER_USE_HEADLESS'] = 'true'
+
+			from browser_use.browser.profile import BrowserProfile
+
+			profile = BrowserProfile(devtools=True)
+			assert profile.headless is False
+			assert profile.devtools is True
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original
+			else:
+				os.environ.pop('BROWSER_USE_HEADLESS', None)
+
+	def test_explicit_headless_true_still_conflicts_with_devtools(self):
+		"""An explicit headless=True (not from the env var) must still raise with devtools=True, unchanged."""
+		original = os.environ.pop('BROWSER_USE_HEADLESS', None)
+		try:
+			from pydantic import ValidationError
+
+			from browser_use.browser.profile import BrowserProfile
+
+			with pytest.raises(ValidationError, match='headless=True and devtools=True cannot both be set'):
+				BrowserProfile(headless=True, devtools=True)
+		finally:
+			if original is not None:
+				os.environ['BROWSER_USE_HEADLESS'] = original


### PR DESCRIPTION
Re-opens #5421 (closed without merge; source branch was deleted) as a clean PR against current `main`.

## Problem

`BROWSER_USE_HEADLESS` was declared under "MCP-specific env vars" (`config.py:230`) and applied only in `_load_config()`, whose only consumer is `mcp/server.py`. Direct library usage (`Agent(...)`, `BrowserSession(...)`, `BrowserProfile(...)`) silently ignored it — no error, no warning.

Practical effect: `BrowserProfile.headless` defaults to `None`, resolved via display detection, so the same code goes headless on `ubuntu-latest` (no display) and headful on a dev machine with a monitor, popping real Chromium windows during a plain `pytest` run. There was no way to force one behavior across a process without touching call sites.

Closes #5420.

## Fix

`BROWSER_USE_DISABLE_EXTENSIONS` already does this in both the MCP path and the direct profile path, wired via `default_factory`. `headless` just fell out of that pattern; `_get_headless_default()` mirrors the existing helper.

Wiring `headless` via `default_factory` surfaced a real edge case: `default_factory` populates the field before `@model_validator(mode='after')` runs, so `BrowserProfile(devtools=True)` would start raising `ValidationError` as soon as `BROWSER_USE_HEADLESS=true` is set in the environment, even though the caller never wrote `headless=True`. Resolved the same way `validate_highlight_elements_conflict` already resolves a similar conflict in this file: an env-derived `headless` yields to an explicit `devtools=True` (logs a warning, sets `headless=False`), while an explicit `headless=True` still raises exactly as before.

Priority: constructor argument > `BROWSER_USE_HEADLESS` > display detection. `None` preserves today's behavior for anyone not setting the env var; the MCP config path is untouched.

## Note on overlap with #5429

This PR's `profile.py` diff was developed alongside #5429 (temp-dir leak fix) in the same working branch, so both touch `profile.py` in the same general area. If #5429 merges first, this PR will need a straightforward rebase — the two changes are logically independent (env-var-driven `headless` default vs. temp-dir lifecycle) and don't touch the same lines.

## Tests

`tests/ci/test_headless_config.py` — 19 tests, all passing. `ruff check`, `ruff format --check`, `pyright` clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the `BROWSER_USE_HEADLESS` env var in `BrowserProfile` and `BrowserSession` to make headless behavior consistent across CI and local dev. Prevents accidental Chromium windows during tests (fixes #5420).

- **Bug Fixes**
  - Read `headless` via a `default_factory` that uses `BROWSER_USE_HEADLESS` (mirrors `BROWSER_USE_DISABLE_EXTENSIONS`).
  - Precedence: explicit arg > env var > display detection; if `devtools=True` and headless only comes from env, prefer devtools and set `headless=False` with a warning; explicit `headless=True` + `devtools=True` still errors.
  - Added `tests/ci/test_headless_config.py` (19 tests).

<sup>Written for commit b864f4092af963eac102fec36aa9a88fe4eb1579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

