### PR TITLE
fix(browser): resolve user_data_dir lazily in get_args, not at construction

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -902,7 +902,11 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		elif not self.ignore_default_args:
 			default_args = CHROME_DEFAULT_ARGS
 
-		assert self.user_data_dir is not None, 'user_data_dir must be set to a non-default path'
+		if self.user_data_dir is None:
+			# Resolved lazily here (not via a field_validator/validate_default on construction) so that
+			# constructing a BrowserProfile — including the module-level DEFAULT_BROWSER_PROFILE singleton
+			# in browser_use/browser/session.py — never has the filesystem side effect of tempfile.mkdtemp().
+			self.user_data_dir = Path(tempfile.mkdtemp(prefix='browser-use-user-data-dir-'))
 
 		# Capture args before conversion for logging
 		pre_conversion_args = [

--- a/tests/ci/test_profile_user_data_dir_default_validation.py
+++ b/tests/ci/test_profile_user_data_dir_default_validation.py
@@ -1,0 +1,71 @@
+"""Regression test: BrowserProfile.user_data_dir must resolve to a temp path both when
+explicitly passed as None and when the kwarg is omitted entirely — via get_args(), which
+every real launch path calls, but WITHOUT eagerly resolving at construction time.
+
+pydantic v2 skips field_validator for a field left at its default unless the model sets
+validate_default=True — without it, BrowserProfile(headless=True) (a very common call
+pattern, see e.g. tests/ci/browser/test_screenshot.py) left user_data_dir as raw None
+until get_args() resolved it lazily.
+
+Resolving eagerly at construction (e.g. via validate_default=True on the whole
+BrowserLaunchPersistentContextArgs config) was tried and reverted: browser_use/browser/
+session.py:66 constructs a module-level DEFAULT_BROWSER_PROFILE = BrowserProfile() at
+import time, so eager resolution there would make `import browser_use` itself call
+tempfile.mkdtemp() — a filesystem side effect on every process start, including for
+cloud/CDP-only users who never launch a local browser — and every model_copy() of that
+singleton (Agent.__init__, BrowserSession's default_factory) would inherit the exact same
+directory instead of getting its own, since model_copy() does not re-run validation.
+"""
+
+from browser_use.browser.profile import BrowserProfile
+
+
+def test_explicit_none_user_data_dir_resolves_to_temp_path_via_get_args():
+	profile = BrowserProfile(user_data_dir=None)
+	profile.get_args()
+
+	assert profile.user_data_dir is not None
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
+
+
+def test_omitted_user_data_dir_resolves_to_temp_path_via_get_args():
+	profile = BrowserProfile(headless=True)
+	profile.get_args()
+
+	assert profile.user_data_dir is not None
+	assert 'browser-use-user-data-dir-' in str(profile.user_data_dir)
+
+
+def test_omitted_and_explicit_none_user_data_dir_are_independently_resolved():
+	profile_omitted = BrowserProfile(headless=True)
+	profile_explicit = BrowserProfile(headless=True, user_data_dir=None)
+	profile_omitted.get_args()
+	profile_explicit.get_args()
+
+	assert profile_omitted.user_data_dir is not None
+	assert profile_explicit.user_data_dir is not None
+	# each construction gets its own freshly generated temp dir
+	assert profile_omitted.user_data_dir != profile_explicit.user_data_dir
+
+
+def test_module_level_default_browser_profile_does_not_eagerly_resolve_user_data_dir():
+	"""DEFAULT_BROWSER_PROFILE (browser_use/browser/session.py) is constructed once at module
+	import time and must stay side-effect-free — user_data_dir must remain None until
+	something actually calls get_args() to launch a browser."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	assert DEFAULT_BROWSER_PROFILE.user_data_dir is None
+
+
+def test_two_default_profile_copies_get_independent_user_data_dirs():
+	"""Mirrors Agent.__init__'s `base_profile.model_copy()` fallback when no browser_profile is
+	passed (browser_use/agent/service.py) — model_copy() does not re-run field validation, so
+	each copy must resolve its own user_data_dir independently once it actually launches."""
+	from browser_use.browser.session import DEFAULT_BROWSER_PROFILE
+
+	copy_a = DEFAULT_BROWSER_PROFILE.model_copy()
+	copy_b = DEFAULT_BROWSER_PROFILE.model_copy()
+	copy_a.get_args()
+	copy_b.get_args()
+
+	assert copy_a.user_data_dir != copy_b.user_data_dir


### PR DESCRIPTION
Re-opens #5416 (closed without merge; source branch was deleted) as a clean PR against current `main`.

## Problem

`BrowserProfile`'s `user_data_dir` field_validator (`mode='after'`) only ran when the field was explicitly passed, not when left at its default — pydantic v2 skips `field_validator` on defaults unless `validate_default` is set. `BrowserProfile(headless=True)`, a very common construction pattern used throughout the test suite and examples, left `self.user_data_dir` as raw `None` instead of the resolved temp path the validator is meant to guarantee.

Fixes #5414.

## Fix

Resolving eagerly at construction (e.g. via `validate_default=True` on the whole `BrowserLaunchPersistentContextArgs` config) was tried and reverted: `browser_use/browser/session.py` constructs a module-level `DEFAULT_BROWSER_PROFILE = BrowserProfile()` at import time, so eager resolution there would make `import browser_use` itself call `tempfile.mkdtemp()` — a filesystem side effect on every process start, including for cloud/CDP-only users who never launch a local browser — and every `model_copy()` of that singleton (`Agent.__init__`, `BrowserSession`'s `default_factory`) would inherit the exact same directory instead of getting its own, since `model_copy()` does not re-run validation.

Resolve `user_data_dir` lazily inside `get_args()` instead — the one place every real launch path already calls before starting a browser.

## Note on overlap with #5429

This PR's `profile.py` diff was developed alongside #5429 (temp-dir leak fix) in the same working branch — #5429 already includes this same lazy-resolution logic in `get_args()`, since the leak fix's cleanup registry needed to hook the same spot. If #5429 merges first, this PR becomes redundant / trivially satisfied and can be closed; if this one merges first, #5429 will need a small rebase. Keeping it open per the "no orphaned closed PRs" cleanup — happy to close in favor of whichever lands first.

## Tests

`tests/ci/test_profile_user_data_dir_default_validation.py` — 5 tests, all passing. `ruff check`, `ruff format --check`, `pyright` clean on the changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazily resolve `BrowserProfile.user_data_dir` in `get_args()` so a unique temp dir is set only when launching, fixing None defaults and avoiding import-time side effects via `DEFAULT_BROWSER_PROFILE`. Fixes #5414.

- **Bug Fixes**
  - Resolve `user_data_dir` when `None` inside `get_args()`; no eager default validation.
  - Avoid calling `tempfile.mkdtemp()` on `import browser_use` and prevent shared dirs across `model_copy()` calls.
  - Added regression tests for omitted/explicit `None` cases and default-profile copies.

<sup>Written for commit dd1e9ac4ec03c53e93b44a028cf480d18e1666c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

