### PR TITLE
fix(test): keep xdist distribution in the local test runner

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -6,4 +6,5 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPT_DIR/.." || exit 1
 
-exec uv run pytest --numprocesses auto tests/ci $1 $2 $3
+# Keep xdist local to this entry point; CI runs each test file in its own job.
+exec uv run pytest --numprocesses auto --dist=loadscope tests/ci $1 $2 $3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ markers = [
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
-addopts = "-svx --strict-markers --tb=short --dist=loadscope"
+addopts = "-svx --strict-markers --tb=short"
 log_cli = true
 log_cli_format = "%(levelname)-8s [%(name)s] %(message)s"
 filterwarnings = [


### PR DESCRIPTION
Closes #5427

## Summary

`pyproject.toml` configured `--dist=loadscope` globally, but pytest-xdist was not enabled by the default test command. That made the option a silent no-op for normal pytest runs while suggesting that tests were being distributed across workers.

This change:

- removes the unused `--dist=loadscope` flag from the global pytest `addopts`;
- keeps `--numprocesses auto --dist=loadscope` in `bin/test.sh`, where the project's local test entry point already enables xdist;
- leaves the per-file GitHub Actions jobs on the normal single-process pytest path.

This keeps the existing fixture-aware scheduling for the local suite without implicitly enabling xdist for every invocation or CI runner.

## Validation

- `uv run pytest tests/ci/test_variable_substitution.py -q` — 9 passed
- `uv run pytest tests/ci/test_variable_substitution.py -n 2 --dist=loadscope -q` — 9 passed with 2 workers and LoadScopeScheduling
- pre-commit hooks — passed (pyright skipped because the current Windows environment reports the existing `browser_use/logging_config.py` `os.mkfifo`/`os.O_NONBLOCK` errors)
- `git diff --check`

AI assistance was used for the implementation and validation. I reviewed the final diff and am responsible for the changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes `pytest-xdist` to the local test runner to avoid a misleading global flag. Previously `pyproject.toml` set `--dist=loadscope` without enabling `pytest-xdist`, which had no effect; now only the local test script enables distribution and default `pytest` runs stay single-process.

- Remove `--dist=loadscope` from `pyproject.toml` `addopts`.
- Run `pytest` with `--numprocesses auto --dist=loadscope` in `bin/test.sh`; CI continues single-process per file.
- No migration required.

<sup>Written for commit 4206ec8a1daea6687c1526ee83ae4189fcabaab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

