### PR TITLE
fix(browser): exclude chrome-extension:// targets from get_all_page_targets()

### DIFF
--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -183,12 +183,18 @@ class SessionManager:
 	def get_all_page_targets(self) -> list:
 		"""Get all page/tab targets using owned data.
 
+		Excludes chrome-extension:// targets (e.g. extension side panels, options
+		pages, or popups opened as a tab) -- these are internal extension surfaces,
+		not pages the agent is meant to see or navigate to. Real pages/tabs are the
+		only targets that should be exposed as "available tabs" or used for crash
+		recovery focus selection.
+
 		Returns:
 			List of Target objects for all page/tab targets
 		"""
 		page_targets = []
 		for target in self._targets.values():
-			if target.target_type in ('page', 'tab'):
+			if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
 				page_targets.append(target)
 		return page_targets
 

--- a/tests/ci/browser/test_extension_target_filtering.py
+++ b/tests/ci/browser/test_extension_target_filtering.py
@@ -1,0 +1,61 @@
+"""Regression test for https://github.com/browser-use/browser-use/issues/4133
+
+SessionManager.get_all_page_targets() filtered targets by CDP target_type only,
+so a chrome-extension:// page (a side panel, an options page, or a popup opened
+as its own tab) passed straight through as a normal "page"/"tab" target. That
+target then leaked into BrowserSession.get_tabs() -- the "Available tabs" list
+shown to the LLM -- and into crash-recovery focus selection, so the agent could
+end up believing it was looking at, or switch its own focus to, an internal
+extension surface instead of a real page.
+
+BrowserSession._is_valid_target() already excludes chrome-extension:// URLs by
+default (include_chrome_extensions=False) for every other target-discovery path
+in the codebase; get_all_page_targets() was the one path missing that filter.
+"""
+
+from browser_use.browser.session import BrowserSession, Target
+from browser_use.browser.session_manager import SessionManager
+
+
+def _make_session_manager() -> SessionManager:
+	# BrowserSession() with no cdp_url/executable just builds the object and its
+	# attributes -- it does not launch or connect to a browser.
+	session = BrowserSession()
+	return SessionManager(session)
+
+
+def test_get_all_page_targets_excludes_chrome_extension_pages():
+	manager = _make_session_manager()
+
+	real_page = Target(target_id='PAGE1', target_type='page', url='https://example.com/', title='Example')
+	extension_page = Target(
+		target_id='EXT1',
+		target_type='page',
+		url='chrome-extension://abcdefghijklmnopabcdefghijklmnop/panel.html',
+		title='Extension Panel',
+	)
+	manager._targets[real_page.target_id] = real_page
+	manager._targets[extension_page.target_id] = extension_page
+
+	page_targets = manager.get_all_page_targets()
+
+	assert page_targets == [real_page]
+
+
+async def test_get_tabs_excludes_chrome_extension_pages():
+	session = BrowserSession()
+	session.session_manager = SessionManager(session)
+
+	real_page = Target(target_id='PAGE1', target_type='page', url='https://example.com/', title='Example')
+	extension_page = Target(
+		target_id='EXT1',
+		target_type='tab',
+		url='chrome-extension://abcdefghijklmnopabcdefghijklmnop/panel.html',
+		title='Extension Panel',
+	)
+	session.session_manager._targets[real_page.target_id] = real_page
+	session.session_manager._targets[extension_page.target_id] = extension_page
+
+	tabs = await session.get_tabs()
+
+	assert [tab.url for tab in tabs] == ['https://example.com/']


### PR DESCRIPTION
## Bug

Fixes #4133.

`SessionManager.get_all_page_targets()` (`browser_use/browser/session_manager.py`) filtered CDP targets by `target_type` only:

```python
def get_all_page_targets(self) -> list:
    page_targets = []
    for target in self._targets.values():
        if target.target_type in ('page', 'tab'):
            page_targets.append(target)
    return page_targets
```

If an extension's own page (a side panel, an options page, or a popup opened as its own tab) is reported by CDP as a `page`/`tab` target with a `chrome-extension://` URL, it passes straight through unfiltered.

That single method backs several call sites in `browser_use/browser/session.py`, so the extension page leaks into:
- `BrowserSession.get_tabs()` — the "Available tabs" list that gets serialized into the LLM's context every step
- `SessionManager._recover_agent_focus()` — which does `page_targets[-1]` on crash/detach recovery, so if the extension page happens to be the most-recently-created target, the agent's focus gets switched onto it instead of a real page
- Initial `connect()` target selection

This is inconsistent with the rest of the codebase: `BrowserSession._is_valid_target()` already excludes `chrome-extension://` URLs by default (`include_chrome_extensions=False`) everywhere else targets are discovered (`_cdp_get_all_pages()`, `get_all_frames()`, etc). `get_all_page_targets()` was the one path missing that filter.

## Live repro

Every real Chrome/Chromium session ships built-in component extensions exposing a `background_page`/`service_worker` target with a `chrome-extension://` URL. Opening that extension's own HTML page as a new tab creates a real CDP target with `target_type == 'page'` — the exact scenario the issue describes for a side panel/options page/popup-as-tab.

Before the fix, with a real headless `BrowserSession`, one real page open (`https://example.com/`), and one extension page opened as a second tab:

```
--- BrowserSession.get_tabs() (this is what the LLM sees as 'Available tabs') ---
  target_id=... url='https://example.com/' title='example.com'
  target_id=... url='chrome-extension://nkeimhogjdpnpccoofpliimaahmaaome/background.html' title='chrome-extension://.../background.html'
extension pages leaked into tab list: 1
```

After the fix, same setup:

```
--- BrowserSession.get_tabs() (this is what the LLM sees as 'Available tabs') ---
  target_id=... url='https://example.com/' title='example.com'
extension pages leaked into tab list: 0
```

## Fix

Apply the same `chrome-extension://` exclusion `_is_valid_target()` already uses elsewhere:

```python
if target.target_type in ('page', 'tab') and not target.url.startswith('chrome-extension://'):
```

## Testing

- Added `tests/ci/browser/test_extension_target_filtering.py`: two regression tests using real `Target`/`SessionManager`/`BrowserSession` objects (no mocking) asserting `get_all_page_targets()` and `get_tabs()` both exclude `chrome-extension://` targets.
  - Verified both fail against the original code (confirms the bug) and pass against the fix.
- `uv run ruff format --check` / `uv run ruff check` — clean on touched files.
- `uv run pyright` — 0 errors, 0 warnings on touched files.
- `uv run pytest tests/ci/browser/test_tabs.py tests/ci/browser/test_extension_target_filtering.py tests/ci/browser/test_cdp_headers.py tests/ci/browser/test_navigation_readiness.py` — 17/17 passed, no regressions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `chrome-extension://` pages from `SessionManager.get_all_page_targets()` to keep extension surfaces out of available tabs and crash-recovery focus. Aligns with `BrowserSession._is_valid_target()` filtering. Fixes #4133.

- **Bug Fixes**
  - Include only `page`/`tab` targets whose URL does not start with `chrome-extension://`.
  - Prevents leaks into `BrowserSession.get_tabs()` and focus selection in `_recover_agent_focus()`.
  - Adds regression tests covering `get_all_page_targets()` and `get_tabs()`.

<sup>Written for commit 43cc97d8f3d27e4ed562321cb2b025840f35c857. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

