### PR TITLE
fix(browser): preserve CHROME_DEFAULT_ARGS order when ignore_default_args is a list

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -896,7 +896,8 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		"""Get the list of all Chrome CLI launch args for this profile (compiled from defaults, user-provided, and system-specific)."""
 
 		if isinstance(self.ignore_default_args, list):
-			default_args = set(CHROME_DEFAULT_ARGS) - set(self.ignore_default_args)
+			ignored_args = set(self.ignore_default_args)
+			default_args = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_args]
 		elif self.ignore_default_args is True:
 			default_args = []
 		elif not self.ignore_default_args:

--- a/tests/ci/browser/test_profile_get_args.py
+++ b/tests/ci/browser/test_profile_get_args.py
@@ -1,0 +1,34 @@
+"""Regression test for https://github.com/browser-use/browser-use/issues/5397
+
+BrowserProfile.get_args() converted CHROME_DEFAULT_ARGS to a `set` when
+ignore_default_args was passed as a list, so the order of the remaining
+default args depended on Python's per-process string hash seed instead of
+their declared order in CHROME_DEFAULT_ARGS.
+"""
+
+from browser_use.browser.profile import CHROME_DEFAULT_ARGS, BrowserProfile
+
+
+def _extract_default_args(profile_args: list[str], ignored: set[str]) -> list[str]:
+	"""The subset of profile_args that came from CHROME_DEFAULT_ARGS, in the order returned."""
+	default_arg_set = set(CHROME_DEFAULT_ARGS) - ignored
+	return [arg for arg in profile_args if arg in default_arg_set]
+
+
+def test_ignore_default_args_preserves_declared_order():
+	"""Removing an entry from CHROME_DEFAULT_ARGS via ignore_default_args must not
+	reorder the remaining entries. The old implementation went through `set(...)
+	- set(...)`, whose iteration order depends on Python's per-process string hash
+	seed rather than the declared order of CHROME_DEFAULT_ARGS -- for a list this
+	long, a hash-seed-dependent ordering would essentially never match the
+	declared order by chance, so this assertion reliably catches the regression."""
+	ignored = ['--disable-popup-blocking']
+	profile = BrowserProfile(user_data_dir='/tmp/browser-use-test-profile', ignore_default_args=ignored)
+
+	args = profile.get_args()
+
+	assert '--disable-popup-blocking' not in args
+
+	remaining_defaults = _extract_default_args(args, set(ignored))
+	expected_order = [arg for arg in CHROME_DEFAULT_ARGS if arg not in set(ignored)]
+	assert remaining_defaults == expected_order


### PR DESCRIPTION
## Bug

Fixes #5397.

`BrowserProfile.get_args()` computes the remaining default Chrome args as:

```python
default_args = set(CHROME_DEFAULT_ARGS) - set(self.ignore_default_args)
```

`set` iteration order in CPython depends on string hashes, which are randomized per-process by default (`PYTHONHASHSEED` is random unless explicitly fixed). So the exact same `BrowserProfile` config can produce Chrome launch args in a different order on every run.

## Live repro

Same profile (`ignore_default_args=['--disable-popup-blocking']`), only `PYTHONHASHSEED` changed between runs:

```
$ PYTHONHASHSEED=1 python repro.py | md5sum   # <different order>
$ PYTHONHASHSEED=2 python repro.py | md5sum   # <different order>
$ PYTHONHASHSEED=3 python repro.py | md5sum   # <different order>
```

Full argument lists for seeds 1/2/3 come out in three different orders (e.g. `--disable-speech-api` first vs. `--disable-ipc-flooding-protection` first vs. `--no-first-run` first) despite identical `BrowserProfile` construction.

## Fix

Filter the original list instead of round-tripping through a set, so `CHROME_DEFAULT_ARGS`'s declared order is preserved once the ignored entries are removed:

```python
ignored_args = set(self.ignore_default_args)
default_args = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_args]
```

After the fix, the same repro produces an identical md5 across `PYTHONHASHSEED=1/2/3`.

## Testing

- Added `tests/ci/browser/test_profile_get_args.py::test_ignore_default_args_preserves_declared_order`, asserting the remaining default args come back in the same order as `CHROME_DEFAULT_ARGS` (minus the ignored entry).
  - Confirmed it fails against the original code (ran it 5x in separate `pytest` invocations, each gets a fresh random hash seed — failed all 5 times) and passes against the fix.
- `uv run ruff check` / `uv run ruff format --check` — clean on touched files.
- `uv run pyright` — 0 errors, 0 warnings on touched files.
- `uv run pytest tests/ci/browser/test_profile_get_args.py tests/ci/browser/test_profile_copy.py tests/ci/test_chrome_profile_helpers.py tests/ci/browser/test_session_start.py` — 15/15 passed, no regressions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the order of Chrome default args when `ignore_default_args` is a list, preventing nondeterministic CLI arg ordering across runs. Fixes #5397.

- **Bug Fixes**
  - Filter `CHROME_DEFAULT_ARGS` by list comprehension instead of set diff to keep declared order.
  - Added regression test `tests/ci/browser/test_profile_get_args.py::test_ignore_default_args_preserves_declared_order`.

<sup>Written for commit 4efae60a8d0a3aa8626ab9daf02bc7119ff4e178. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

