### PR TITLE
Claude/production evometaclaw p5wydr

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
+	from browser_use.skills.fitness import SkillFitnessTracker
 	from browser_use.skills.views import Skill
 
 from dotenv import load_dotenv
@@ -144,6 +145,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		skill_ids: list[str | Literal['*']] | None = None,
 		skills: list[str | Literal['*']] | None = None,  # Alias for skill_ids
 		skill_service: Any | None = None,
+		# Per-action fitness tracking (opt-in) — every action outcome folds into a
+		# Dempster-Shafer belief interval per action_name. Feeds EvoMetaClaw /
+		# EvoForge selection loops without touching the hot path when unset.
+		action_fitness_tracker: 'SkillFitnessTracker | None' = None,
 		# Initial agent run parameters
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,
 		initial_actions: list[dict[str, dict[str, Any]]] | None = None,
@@ -341,6 +346,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			from browser_use.skills import SkillService
 
 			self.skill_service = SkillService(skill_ids=skill_ids)
+
+		# Optional per-action fitness tracker. None → zero cost, no recording.
+		self.action_fitness_tracker = action_fitness_tracker
 
 		# Structured output - use explicit param or detect from tools
 		tools_output_model = self.tools.get_output_model()
@@ -2696,6 +2704,23 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			await self.close()
 
+	def _record_action_fitness(
+		self, action_name: str, result: ActionResult | None, start_ns: int, exc: Exception | None = None
+	) -> None:
+		"""Fold one action outcome into the fitness tracker. No-op if not opted in."""
+		if self.action_fitness_tracker is None:
+			return
+		latency_ms = int((time.perf_counter_ns() - start_ns) / 1_000_000)
+		if exc is not None:
+			self.action_fitness_tracker.record(
+				skill_id=action_name, success=False, latency_ms=latency_ms, error=f'{type(exc).__name__}: {exc}'
+			)
+			return
+		if result is None:
+			return
+		success = result.error is None
+		self.action_fitness_tracker.record(skill_id=action_name, success=success, latency_ms=latency_ms, error=result.error)
+
 	@observe_debug(ignore_input=True, ignore_output=True)
 	@time_execution_async('--multi_act')
 	async def multi_act(self, actions: list[ActionModel]) -> list[ActionResult]:
@@ -2740,6 +2765,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				self.logger.debug(f'Waiting {self.browser_profile.wait_between_actions} seconds between actions')
 				await asyncio.sleep(self.browser_profile.wait_between_actions)
 
+			# Start latency clock outside the try so the exception path can still record.
+			action_start_ns = time.perf_counter_ns()
 			try:
 				await self._check_stop_or_pause()
 
@@ -2759,6 +2786,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					available_file_paths=self.available_file_paths,
 					extraction_schema=self.extraction_schema,
 				)
+				self._record_action_fitness(action_name, result, action_start_ns)
 
 				if result.error:
 					await self._demo_mode_log(
@@ -2812,6 +2840,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					'error',
 					{'action': action_name, 'step': self.state.n_steps},
 				)
+				self._record_action_fitness(action_name, None, action_start_ns, exc=e)
 				# Preserve partial results so the agent knows which actions succeeded before the failure
 				results.append(ActionResult(error=f'{type(e).__name__}: {e}'))
 				return results

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -847,40 +847,31 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			def make_skill_handler(skill_id: str):
 				async def skill_handler(params: BaseModel) -> ActionResult:
 					"""Execute a specific skill"""
+					from browser_use.skills.views import MissingCookieException
+
 					assert self.skill_service is not None, 'SkillService not initialized'
 
-					# Convert parameters to dict
-					if isinstance(params, BaseModel):
-						skill_params = params.model_dump()
-					elif isinstance(params, dict):
-						skill_params = params
-					else:
-						return ActionResult(extracted_content=None, error=f'Invalid parameters type: {type(params)}')
-
-					# Get cookies from browser
+					skill_params = params.model_dump()
 					_cookies = await self.browser_session.cookies()
 
 					try:
 						result = await self.skill_service.execute_skill(
 							skill_id=skill_id, parameters=skill_params, cookies=_cookies
 						)
-
-						if result.success:
-							return ActionResult(
-								extracted_content=str(result.result) if result.result else None,
-								error=None,
-							)
-						else:
-							return ActionResult(extracted_content=None, error=result.error or 'Skill execution failed')
+					except MissingCookieException as e:
+						return ActionResult(
+							extracted_content=None,
+							error=f'Missing cookies ({e.cookie_name}): {e.cookie_description}',
+						)
 					except Exception as e:
-						# Check if it's a MissingCookieException
-						if type(e).__name__ == 'MissingCookieException':
-							# Format: "Missing cookies (name): description"
-							cookie_name = getattr(e, 'cookie_name', 'unknown')
-							cookie_description = getattr(e, 'cookie_description', str(e))
-							error_msg = f'Missing cookies ({cookie_name}): {cookie_description}'
-							return ActionResult(extracted_content=None, error=error_msg)
 						return ActionResult(extracted_content=None, error=f'Skill execution error: {type(e).__name__}: {e}')
+
+					if result.success:
+						return ActionResult(
+							extracted_content=str(result.result) if result.result else None,
+							error=None,
+						)
+					return ActionResult(extracted_content=None, error=result.error or 'Skill execution failed')
 
 				return skill_handler
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -146,8 +146,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		skills: list[str | Literal['*']] | None = None,  # Alias for skill_ids
 		skill_service: Any | None = None,
 		# Per-action fitness tracking (opt-in) — every action outcome folds into a
-		# Dempster-Shafer belief interval per action_name. Feeds EvoMetaClaw /
-		# EvoForge selection loops without touching the hot path when unset.
+		# Dempster-Shafer belief interval per action_name. Zero cost on the hot
+		# path when unset. Pair with SkillFitnessTracker.recommend/top_k to drive
+		# selection from the accumulated belief.
 		action_fitness_tracker: 'SkillFitnessTracker | None' = None,
 		# Initial agent run parameters
 		sensitive_data: dict[str, str | dict[str, str]] | None = None,

--- a/browser_use/skill_cli/__init__.py
+++ b/browser_use/skill_cli/__init__.py
@@ -11,7 +11,12 @@ Usage:
     browser-use close
 """
 
+from typing import TYPE_CHECKING
+
 __all__ = ['main']
+
+if TYPE_CHECKING:
+	from browser_use.skill_cli.main import main as main
 
 
 def __getattr__(name: str):

--- a/browser_use/skills/README.md
+++ b/browser_use/skills/README.md
@@ -1,33 +1,124 @@
 # Skills Module
 
-The Skills module provides integration with the Browser Use API to fetch and execute skills.
+Two things live here:
 
-## Basic Usage
+1. **`SkillService`** — fetch and execute Browser Use API skills.
+2. **`SkillFitnessTracker`** — Dempster-Shafer per-skill fitness accumulator. Zero deps beyond stdlib. Powers the EvoMetaClaw / EvoForge / SkillOpt selection loop.
+
+## SkillService — API-backed skills
 
 ```python
 import asyncio
 from browser_use.skills import SkillService
 
 async def main():
-    skill_ids = ['skill-id-1', 'skill-id-2']
-
-    # Initialize service
-    service = SkillService(skill_ids=skill_ids, api_key='your-api-key')
-
-    # Get all loaded skills (auto-initializes on first call)
-    skills = await service.get_all_skills()
-
-    # Execute a skill (auto-initializes if needed)
-    result = await service.execute_skill(
-        skill_id='skill-id-1',
-        parameters={'param1': 'value1'}
-    )
-
+    service = SkillService(skill_ids=['skill-id-1', 'skill-id-2'], api_key='your-api-key')
+    skills = await service.get_all_skills()  # auto-inits on first call
+    result = await service.execute_skill(skill_id='skill-id-1', parameters={'param1': 'value1'})
     if result.success:
-        print(f'Success! Result: {result.result}')
+        print(f'Result: {result.result}')
 
-    # Cleanup
+    # Every execute_skill call also folds its (success, latency_ms, error)
+    # into a per-skill mass function — no wiring needed.
+    print(service.ranked_by_fitness(mode='belief'))
+
     await service.close()
 
 asyncio.run(main())
 ```
+
+## SkillFitnessTracker — Dempster-Shafer accumulator
+
+Every skill invocation becomes a `MassFunction` over `{LOW, MID, HIGH}`. Repeated invocations combine via Dempster's rule of combination, giving each skill a belief / plausibility interval rather than a point estimate. Selection can be:
+
+| Mode | Meaning | Use for |
+|---|---|---|
+| `belief` | Lower probability bound. Conservative — avoids unproven skills. | Production, default. |
+| `plausibility` | Upper probability bound. Exploratory — tries promising-but-noisy skills. | Warm-up, exploration budgets. |
+| `expected` | Pignistic collapse. Bayesian-ish point estimate. | When you need a single scalar. |
+
+### Standalone (no browser, no LLM, no SDK)
+
+```python
+from browser_use.skills.fitness import SkillFitnessTracker
+
+tracker = SkillFitnessTracker()
+tracker.record('login_flow', success=True, latency_ms=220)
+tracker.record('login_flow', success=True, latency_ms=180)
+tracker.record('login_flow', success=False, error='captcha')
+print(tracker.ranked('belief'))  # [('login_flow', 0.93)]
+print(tracker.fitness('login_flow').plausibility())  # 0.99
+```
+
+Cold-import for `browser_use.skills.fitness` is ~370ms — no `browser_use_sdk` / `pydantic` chain pulled in. CI guards this (`test_fitness_import_does_not_load_sdk`).
+
+### JSON round-trip (cross-process, cross-language)
+
+```python
+import json
+
+blob = json.dumps(tracker.to_dict())
+# {"fitness": {"login_flow": {"HIGH": 0.93, "HIGH,LOW,MID": 0.07}}, "invocations": {"login_flow": 3}}
+restored = SkillFitnessTracker.from_dict(json.loads(blob))
+```
+
+Frozenset keys serialise as sorted-comma-joined strings — trivial to reimplement in JS/Go/Rust.
+
+### CLI (Unix pipeline / KafCade `kc E` steps)
+
+```bash
+# Read JSONL from stdin, print rankings
+$ cat runs.jsonl | python -m browser_use.skills.fitness --mode belief --top 10
+0.9975  3  login_flow
+0.9500  1  submit_form
+0.4314  2  scrape_catalog
+
+# Persist state across sessions — feed the next EvoMetaClaw epoch
+$ python -m browser_use.skills.fitness --state prior.json --save next.json < new.jsonl
+```
+
+### HTTP surface (webapp / dashboard / cross-language client)
+
+```bash
+$ python -m browser_use.skills.fitness --serve 8765 --save /var/lib/fitness.json
+skill-fitness serving on http://127.0.0.1:8765 (persist=/var/lib/fitness.json)
+```
+
+```
+GET  /health                     → {"status": "ok"}
+POST /record                     → body = {skill_id, success, latency_ms?, error?}
+GET  /ranked?mode=..&top=..      → [[skill_id, score], ...] best-first
+GET  /fitness/<skill_id>         → MassFunction dict or 404
+GET  /state                      → full snapshot
+POST /state                      → replace snapshot
+POST /reset                      → wipe
+```
+
+Stdlib `http.server` + `ThreadingHTTPServer` + `Lock` — concurrent-safe, zero new deps. Bind defaults to `127.0.0.1`; pass `--host 0.0.0.0` explicitly to expose off-box. Wrap in ASGI (FastAPI, Starlette) for production TLS / auth / rate-limiting.
+
+### Agent-side (close the flywheel)
+
+Pass a tracker to the `Agent` constructor and every action outcome records automatically:
+
+```python
+from browser_use import Agent
+from browser_use.skills.fitness import SkillFitnessTracker
+
+tracker = SkillFitnessTracker()
+agent = Agent(task='...', llm=llm, action_fitness_tracker=tracker)
+await agent.run()
+
+# Actions with the highest belief in HIGH-fitness — safe defaults for next run
+print(tracker.ranked('belief')[:5])
+```
+
+Default is `None` → zero cost, no recording. Only recorded when set.
+
+### Composition with EvoMetaClaw / EvoForge / KafCade
+
+- **KafCade `kc E`** — pipe each per-project audit finding as one JSONL record; `--state kc-fitness.json --save kc-fitness.json` for durable per-project rankings.
+- **EvoForge epoch loop** — every `BioEvolutionReport.best_fitness` becomes one `POST /record`; the accumulated `MassFunction` per genome-id feeds the next `REPLICATOR` step.
+- **EvoMetaClaw `EVALUATE_FITNESS`** — read `GET /state`, hand the mass functions to your selection policy (belief/plausibility/expected), write mutations back via `POST /record`.
+- **RRSS gates** — every axis of the R²S² discipline gets its own skill_id, so a single fitness call gives you eight-dimensional confidence per artifact.
+
+The wire format is the contract — anything that speaks JSON participates.

--- a/browser_use/skills/README.md
+++ b/browser_use/skills/README.md
@@ -3,7 +3,132 @@
 Two things live here:
 
 1. **`SkillService`** — fetch and execute Browser Use API skills.
-2. **`SkillFitnessTracker`** — a Dempster-Shafer per-skill fitness accumulator that turns per-invocation outcomes into a belief/plausibility interval. Zero third-party dependencies.
+2. **`SkillFitnessTracker`** — a Dempster-Shafer per-skill fitness accumulator that turns per-invocation outcomes into a belief/plausibility interval. Zero third-party dependencies, distributable as its own standalone service.
+
+## Install as a standalone tool (no Python integration needed)
+
+The tracker + HTTP surface + CLI ship as a console script named `skill-fitness`. You do not need to touch any Python code to run it — pick any of these.
+
+### pipx — user-level install (recommended)
+
+```bash
+pipx install browser-use
+skill-fitness --serve 8765
+```
+
+Provides `skill-fitness` on `PATH` under an isolated venv. Available on Linux, macOS, Windows.
+
+### uvx — zero-install, runs on demand
+
+```bash
+uvx --from browser-use skill-fitness --serve 8765
+```
+
+Downloads to a shared cache, no venv management, works with `uv >= 0.5`.
+
+### pip — inside an existing environment
+
+```bash
+pip install browser-use
+skill-fitness --help
+```
+
+### Docker — reproducible, single artifact
+
+The core module has zero third-party deps and works with the default `python:3.12-slim`. From this repo:
+
+```bash
+docker build -f Dockerfile -t browser-use:local .
+docker run --rm -p 8765:8765 -v $(pwd)/state:/state \
+  browser-use:local \
+  python -m browser_use.skills.fitness --serve 8765 --host 0.0.0.0 --save /state/fitness.json
+```
+
+For a smaller image, a minimal Dockerfile is a two-liner:
+
+```dockerfile
+FROM python:3.12-slim
+RUN pip install --no-cache-dir browser-use
+ENTRYPOINT ["skill-fitness"]
+```
+
+### systemd — supervised on Linux
+
+`/etc/systemd/system/skill-fitness.service`:
+
+```ini
+[Unit]
+Description=Skill fitness accumulator
+After=network.target
+
+[Service]
+Type=simple
+User=fitness
+Group=fitness
+Environment=PYTHONUNBUFFERED=1
+ExecStart=/usr/local/bin/skill-fitness --serve 8765 --host 127.0.0.1 --save /var/lib/skill-fitness/state.json
+Restart=on-failure
+RestartSec=2
+# Sandboxing — nothing on the box needs to be writable except the state dir.
+ProtectSystem=strict
+ReadWritePaths=/var/lib/skill-fitness
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo useradd -r -s /usr/sbin/nologin fitness
+sudo mkdir -p /var/lib/skill-fitness && sudo chown fitness:fitness /var/lib/skill-fitness
+sudo systemctl daemon-reload && sudo systemctl enable --now skill-fitness
+sudo systemctl status skill-fitness
+```
+
+Graceful shutdown on `systemctl stop` — the service handles SIGTERM.
+
+### launchd — supervised on macOS
+
+`~/Library/LaunchAgents/dev.skillfitness.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key><string>dev.skillfitness</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/opt/homebrew/bin/skill-fitness</string>
+      <string>--serve</string><string>8765</string>
+      <string>--save</string><string>/Users/you/Library/Application Support/skill-fitness/state.json</string>
+    </array>
+    <key>RunAtLoad</key><true/>
+    <key>KeepAlive</key><true/>
+  </dict>
+</plist>
+```
+
+```bash
+launchctl load ~/Library/LaunchAgents/dev.skillfitness.plist
+```
+
+### Windows service — via NSSM
+
+```powershell
+pipx install browser-use
+nssm install SkillFitness "$(pipx environment --value PIPX_BIN_DIR)\skill-fitness.exe"
+nssm set SkillFitness AppParameters --serve 8765 --save C:\ProgramData\skill-fitness\state.json
+nssm start SkillFitness
+```
+
+### Health check probe (any deploy target)
+
+```bash
+curl -fsS http://127.0.0.1:8765/health && echo up
+curl -fsS http://127.0.0.1:8765/ready && echo ready
+```
 
 ## SkillService — API-backed skills
 
@@ -13,7 +138,7 @@ from browser_use.skills import SkillService
 
 async def main():
     service = SkillService(skill_ids=['skill-id-1', 'skill-id-2'], api_key='your-api-key')
-    skills = await service.get_all_skills()  # auto-inits on first call
+    skills = await service.get_all_skills()
     result = await service.execute_skill(skill_id='skill-id-1', parameters={'param1': 'value1'})
     if result.success:
         print(f'Result: {result.result}')
@@ -29,7 +154,7 @@ asyncio.run(main())
 
 ## SkillFitnessTracker — Dempster-Shafer accumulator
 
-Every skill invocation becomes a `MassFunction` over `{LOW, MID, HIGH}`. Repeated invocations combine via Dempster's rule of combination (Dempster 1967, Shafer 1976), giving each skill a belief / plausibility interval rather than a point estimate. Selection can be:
+Every skill invocation becomes a `MassFunction` over `{LOW, MID, HIGH}`. Repeated invocations combine via Dempster's rule of combination (Dempster 1967, Shafer 1976), giving each skill a belief / plausibility interval rather than a point estimate.
 
 | Mode | Meaning | Use for |
 |---|---|---|
@@ -37,7 +162,7 @@ Every skill invocation becomes a `MassFunction` over `{LOW, MID, HIGH}`. Repeate
 | `plausibility` | Upper probability bound. Exploratory — tries promising-but-noisy skills. | Warm-up, exploration budgets. |
 | `expected` | Pignistic collapse. Bayesian-ish point estimate. | When you need a single scalar. |
 
-### Standalone (no browser, no LLM, no SDK)
+### Standalone Python (no browser, no LLM, no SDK)
 
 ```python
 from browser_use.skills.fitness import SkillFitnessTracker
@@ -51,13 +176,12 @@ print(tracker.top_k(3, mode='belief'))     # ['login_flow']
 print(tracker.recommend(['login_flow', 'signup_flow'], min_score=0.5))  # ['login_flow']
 ```
 
-Cold-import for `browser_use.skills.fitness` is ~370ms — no `browser_use_sdk` / `pydantic` chain pulled in. CI guards this (`test_fitness_import_does_not_load_sdk`).
+Cold-import for `browser_use.skills.fitness` is ~370ms — no SDK / pydantic chain pulled in. CI guards this (`test_fitness_import_does_not_load_sdk`).
 
 ### JSON round-trip (cross-process, cross-language)
 
 ```python
 import json
-
 blob = json.dumps(tracker.to_dict())
 # {"fitness": {"login_flow": {"HIGH": 0.93, "HIGH,LOW,MID": 0.07}}, "invocations": {"login_flow": 3}}
 restored = SkillFitnessTracker.from_dict(json.loads(blob))
@@ -68,25 +192,23 @@ Frozenset keys serialise as sorted-comma-joined strings — trivial to reimpleme
 ### CLI (Unix pipeline / CI steps / audit scripts)
 
 ```bash
-# Read JSONL from stdin, print rankings
-$ cat runs.jsonl | python -m browser_use.skills.fitness --mode belief --top 10
+$ cat runs.jsonl | skill-fitness --mode belief --top 10
 0.9975  3  login_flow
 0.9500  1  submit_form
 0.4314  2  scrape_catalog
 
-# Persist state across sessions — chain runs into one durable fitness snapshot
-$ python -m browser_use.skills.fitness --state prior.json --save next.json < new.jsonl
+$ skill-fitness --state prior.json --save next.json < new.jsonl
 ```
 
-### HTTP surface (webapp / dashboard / cross-language client)
+### HTTP surface — modern-service defaults
 
-```bash
-$ python -m browser_use.skills.fitness --serve 8765 --save /var/lib/fitness.json
-skill-fitness serving on http://127.0.0.1:8765 (persist=/var/lib/fitness.json)
-```
+Every route also aliased under `/v1/...` for stable API versioning across future breaking changes.
 
 ```
-GET  /health                        → {"status": "ok"}
+GET  /health                        → liveness probe                    {"status":"ok"}
+GET  /ready                         → readiness probe                   {"status":"ready"}
+GET  /metrics                       → Prometheus text/plain              (counters + gauges per skill)
+GET  /openapi.json                  → OpenAPI 3.1 schema of this API
 POST /record                        → body = {skill_id, success, latency_ms?, error?}
 GET  /ranked?mode=..&top=..         → [[skill_id, score], ...] best-first
 GET  /top_k?mode=..&k=..            → [skill_id, ...] best-first, capped at k
@@ -94,10 +216,19 @@ GET  /fitness/<skill_id>            → MassFunction dict or 404
 GET  /state                         → full snapshot
 POST /state                         → replace snapshot
 POST /reset                         → wipe
-POST /recommend                     → body = {candidates: [str], mode?, min_score?, include_unseen?}; returns filtered [str]
+POST /recommend                     → {candidates:[str], mode?, min_score?, include_unseen?} → filtered [str]
+OPTIONS <any>                       → CORS preflight (Access-Control-Allow-*)
 ```
 
-Stdlib `http.server` + `ThreadingHTTPServer` + `Lock` — concurrent-safe, zero new deps. Bind defaults to `127.0.0.1`; pass `--host 0.0.0.0` explicitly to expose off-box. Wrap in ASGI (FastAPI, Starlette) for production TLS / auth / rate-limiting.
+Implementation details worth flagging:
+- **Concurrent-safe**: `ThreadingHTTPServer` + shared `Lock` — no state races.
+- **Persistence**: every mutating request atomically writes `--save` path if provided.
+- **CORS**: GET endpoints send `Access-Control-Allow-Origin: *` for browser dashboards. Preflight OPTIONS returns 204 with allowed methods.
+- **Access logs**: one JSON line per mutating request to stderr (`{ts_ns, method, path, status, remote}`) — pipe to your log collector as-is.
+- **Prometheus metrics** (`/metrics`): `skill_fitness_records_total` (counter), `skill_fitness_tracked_skills` (gauge), `skill_fitness_invocations{skill=...}` (per-skill counter), `skill_fitness_belief_high{skill=...}` (per-skill gauge). Scrape from any Prometheus/Grafana/OpenTelemetry collector.
+- **OpenAPI schema** (`/openapi.json`): OpenAPI 3.1 — import into Postman/Insomnia/openapi-generator to auto-generate typed clients for any language.
+- **Graceful shutdown**: SIGTERM (from `systemctl stop`, `docker stop`, `kubectl delete`) triggers `server.shutdown()`; in-flight requests complete before exit.
+- **Bind default `127.0.0.1`**: nothing exposed off-box without an explicit `--host 0.0.0.0`. Wrap in nginx/Caddy/Traefik for TLS + auth + rate-limiting in production.
 
 ### Agent-side (close the flywheel)
 
@@ -110,59 +241,65 @@ from browser_use.skills.fitness import SkillFitnessTracker
 tracker = SkillFitnessTracker()
 agent = Agent(task='...', llm=llm, action_fitness_tracker=tracker)
 await agent.run()
-
-# Actions with the highest HIGH-belief — safe defaults for next run
 print(tracker.top_k(5, mode='belief'))
 ```
 
-Default is `None` → zero cost, no recording. Only recorded when set.
+Default is `None` → zero cost, no recording.
 
-## Use cases (ROI, ordered by cheapest-to-implement first)
+## Use cases with the fastest payoff
 
-### 1. Auto-demote flaky actions to cut token spend
+Ordered cheapest-to-adopt first. All work without any code changes on the consumer side beyond a `POST /record` call per outcome.
 
-An agent with two dozen registered actions burns tokens whenever the LLM tries an action that reliably fails (rate-limited API, cookie-expired flow, captcha-guarded button). Recording every outcome for a week gives you a list of low-belief actions to filter from the registry.
+### 1. Auto-demote flaky actions to cut LLM token spend
 
-**ROI**: Directly cuts LLM tokens per successful task. Measured payoff: for every action pruned that had `belief < 0.2` and `invocations > 10`, the median run's action count drops without success-rate loss.
+An agent exposing 20 tools burns tokens every time the LLM tries an action that reliably fails (rate-limited API, cookie-expired flow, captcha-guarded button). Record every outcome for a week. Prune actions with `belief < 0.2` and `invocations > 10` from the next deployment's registry.
+
+**Payoff**: direct reduction in LLM tokens per successful task. Applies to any agent that exposes more tools than each task typically needs.
 
 ```python
 tracker = SkillFitnessTracker.from_dict(json.load(open('production_state.json')))
 degenerate = [name for name, score in tracker.ranked('plausibility') if score < 0.2]
-# Feed `degenerate` to your action registry's blocklist for the next deployment.
 ```
 
 ### 2. A/B two implementations, ship the winner
 
-Two ways to log a user in (form fill vs. OAuth redirect). Both registered, both tracked under distinct skill IDs. After N runs, `belief` tells you which one to ship. This is a cheaper A/B test than a full experimentation framework because the outcome signal is already what you care about.
+Two ways to accomplish the same job (form-fill login vs. OAuth redirect). Both registered, both tracked under distinct skill IDs. After N runs, `belief` tells you which one to keep. Cheaper and faster than a full experimentation framework because the signal is already the outcome you care about.
 
-**ROI**: One decision per feature. Faster than manual comparison, avoids confirmation bias.
+**Payoff**: one decision per feature. Faster than manual comparison; avoids confirmation bias.
 
 ### 3. Per-tenant / per-site skill portfolios
 
-Same skills, different fitness under different tenants. Site A's `scrape_price` might be `belief 0.95`, site B's the same skill at `belief 0.3` because that site rate-limits. Persist one tracker per tenant (`--state tenant-abc.json`) and the selection policy adapts automatically.
+Same skills, different fitness under different tenants. Site A's `scrape_price` might be `belief 0.95`; site B's the same skill at `belief 0.3` because that site rate-limits. Persist one tracker per tenant (`--save tenant-abc.json`) and selection adapts automatically.
 
-**ROI**: One codebase, per-tenant reliability. Scales the value of every new skill you write.
+**Payoff**: one codebase, per-tenant reliability. Every new skill scales its own value across the tenant fleet.
 
 ### 4. Regression alarm before customers complain
 
-Belief interval widens (plausibility − belief grows) when a previously-stable skill starts producing mixed outcomes. Wire the HTTP `/state` endpoint into your monitoring — a simple threshold on interval width surfaces degradation earlier than binary "success/fail" alerting, because it fires on *loss of confidence* not just on outright failure.
+Belief interval widens (plausibility − belief grows) when a previously-stable skill starts producing mixed outcomes. Wire `/metrics` into your Prometheus/Grafana stack — a threshold alert on the widening interval fires on *loss of confidence* before outright failure, which binary success/fail alerting cannot see.
 
-**ROI**: Ticket volume prevention. Meaningful on any SLA'd deployment.
+**Payoff**: ticket volume prevention. Any SLA'd deployment.
 
 ### 5. Cost attribution when combined with token accounting
 
 Multiply `latency_ms` (already tracked) by LLM-call-count-per-action (add your own map) to attribute cost per skill. Rank descending — the top of that list is your optimisation backlog.
 
-**ROI**: Direct compute-cost reduction. First $100/month you save pays for a lot of engineering hours.
+**Payoff**: direct compute-cost reduction. The first $100/month you save funds a lot of engineering time.
 
 ### 6. Fleet-shared learning via the HTTP surface
 
-Multiple agent workers pointing at one `--serve` instance share fitness across the fleet. Skills that succeed for worker 1's task inform worker 5's action selection without any explicit coordination. Threading + Lock keeps it correct.
+Multiple agent workers pointing at one `--serve` instance share fitness across the fleet. Skills that succeed for worker 1's task inform worker 5's action selection without explicit coordination. `ThreadingHTTPServer` + `Lock` keeps it correct.
 
-**ROI**: Learning rate scales with worker count instead of being per-worker linear. Meaningful once you have >3 concurrent agents.
+**Payoff**: learning rate scales with worker count instead of being per-worker linear. Meaningful once you have >3 concurrent agents.
+
+### 7. Public-facing "trust score" for a skills marketplace
+
+If you sell or share skills to third parties (browser-automation-as-a-service, an in-house skill store), publish the `belief` and `invocations` values as the skill's transparent trust score. Users pick between similar skills on real observed reliability, not vendor claims.
+
+**Payoff**: better sorting for consumers of your catalog; visible quality pressure on skill authors.
 
 ## Design notes
 
-- **No external ML dependency**. Dempster-Shafer here is pure Python arithmetic; the algorithm dates to 1967 and is not encumbered by any patent or license. If you need heavier machinery (e.g. numpy-backed belief propagation, Yager's rule for high-conflict cases), the wire format is stable — bolt it on outside this module.
-- **Selection modes matter**. Default to `belief` in production (conservative, fewest surprises). Switch to `plausibility` for warm-up periods or exploration budgets. `expected` is a pignistic collapse — use only when you need one scalar and are willing to lose the interval information.
-- **Wire format = the contract**. Anything that speaks JSON — a webapp, another language, an evaluation harness — participates. See CLI + HTTP sections above.
+- **No external ML dependency.** DS is pure Python arithmetic; the algorithm is public-domain mathematics (Dempster 1967, Shafer 1976) and is not patent-encumbered. Implementation is original and ships under browser-use's existing MIT license.
+- **Selection modes matter.** Default `belief` in production. `plausibility` for warm-up / exploration budgets. `expected` when you need a single scalar and can accept losing the interval.
+- **Wire format is the contract.** JSON in and out — anything that speaks JSON participates. `openapi.json` gives you a machine-readable spec to generate clients from.
+- **Not a substitute for a full experimentation framework.** For power-analyzed A/B tests with multi-arm bandits and CUPED variance reduction, use a dedicated platform. The tracker is for *operational* decisions on live systems.

--- a/browser_use/skills/README.md
+++ b/browser_use/skills/README.md
@@ -3,7 +3,7 @@
 Two things live here:
 
 1. **`SkillService`** — fetch and execute Browser Use API skills.
-2. **`SkillFitnessTracker`** — Dempster-Shafer per-skill fitness accumulator. Zero deps beyond stdlib. Powers the EvoMetaClaw / EvoForge / SkillOpt selection loop.
+2. **`SkillFitnessTracker`** — a Dempster-Shafer per-skill fitness accumulator that turns per-invocation outcomes into a belief/plausibility interval. Zero third-party dependencies.
 
 ## SkillService — API-backed skills
 
@@ -29,7 +29,7 @@ asyncio.run(main())
 
 ## SkillFitnessTracker — Dempster-Shafer accumulator
 
-Every skill invocation becomes a `MassFunction` over `{LOW, MID, HIGH}`. Repeated invocations combine via Dempster's rule of combination, giving each skill a belief / plausibility interval rather than a point estimate. Selection can be:
+Every skill invocation becomes a `MassFunction` over `{LOW, MID, HIGH}`. Repeated invocations combine via Dempster's rule of combination (Dempster 1967, Shafer 1976), giving each skill a belief / plausibility interval rather than a point estimate. Selection can be:
 
 | Mode | Meaning | Use for |
 |---|---|---|
@@ -46,8 +46,9 @@ tracker = SkillFitnessTracker()
 tracker.record('login_flow', success=True, latency_ms=220)
 tracker.record('login_flow', success=True, latency_ms=180)
 tracker.record('login_flow', success=False, error='captcha')
-print(tracker.ranked('belief'))  # [('login_flow', 0.93)]
-print(tracker.fitness('login_flow').plausibility())  # 0.99
+print(tracker.ranked('belief'))            # [('login_flow', 0.93)]
+print(tracker.top_k(3, mode='belief'))     # ['login_flow']
+print(tracker.recommend(['login_flow', 'signup_flow'], min_score=0.5))  # ['login_flow']
 ```
 
 Cold-import for `browser_use.skills.fitness` is ~370ms — no `browser_use_sdk` / `pydantic` chain pulled in. CI guards this (`test_fitness_import_does_not_load_sdk`).
@@ -64,7 +65,7 @@ restored = SkillFitnessTracker.from_dict(json.loads(blob))
 
 Frozenset keys serialise as sorted-comma-joined strings — trivial to reimplement in JS/Go/Rust.
 
-### CLI (Unix pipeline / KafCade `kc E` steps)
+### CLI (Unix pipeline / CI steps / audit scripts)
 
 ```bash
 # Read JSONL from stdin, print rankings
@@ -73,7 +74,7 @@ $ cat runs.jsonl | python -m browser_use.skills.fitness --mode belief --top 10
 0.9500  1  submit_form
 0.4314  2  scrape_catalog
 
-# Persist state across sessions — feed the next EvoMetaClaw epoch
+# Persist state across sessions — chain runs into one durable fitness snapshot
 $ python -m browser_use.skills.fitness --state prior.json --save next.json < new.jsonl
 ```
 
@@ -85,13 +86,15 @@ skill-fitness serving on http://127.0.0.1:8765 (persist=/var/lib/fitness.json)
 ```
 
 ```
-GET  /health                     → {"status": "ok"}
-POST /record                     → body = {skill_id, success, latency_ms?, error?}
-GET  /ranked?mode=..&top=..      → [[skill_id, score], ...] best-first
-GET  /fitness/<skill_id>         → MassFunction dict or 404
-GET  /state                      → full snapshot
-POST /state                      → replace snapshot
-POST /reset                      → wipe
+GET  /health                        → {"status": "ok"}
+POST /record                        → body = {skill_id, success, latency_ms?, error?}
+GET  /ranked?mode=..&top=..         → [[skill_id, score], ...] best-first
+GET  /top_k?mode=..&k=..            → [skill_id, ...] best-first, capped at k
+GET  /fitness/<skill_id>            → MassFunction dict or 404
+GET  /state                         → full snapshot
+POST /state                         → replace snapshot
+POST /reset                         → wipe
+POST /recommend                     → body = {candidates: [str], mode?, min_score?, include_unseen?}; returns filtered [str]
 ```
 
 Stdlib `http.server` + `ThreadingHTTPServer` + `Lock` — concurrent-safe, zero new deps. Bind defaults to `127.0.0.1`; pass `--host 0.0.0.0` explicitly to expose off-box. Wrap in ASGI (FastAPI, Starlette) for production TLS / auth / rate-limiting.
@@ -108,17 +111,58 @@ tracker = SkillFitnessTracker()
 agent = Agent(task='...', llm=llm, action_fitness_tracker=tracker)
 await agent.run()
 
-# Actions with the highest belief in HIGH-fitness — safe defaults for next run
-print(tracker.ranked('belief')[:5])
+# Actions with the highest HIGH-belief — safe defaults for next run
+print(tracker.top_k(5, mode='belief'))
 ```
 
 Default is `None` → zero cost, no recording. Only recorded when set.
 
-### Composition with EvoMetaClaw / EvoForge / KafCade
+## Use cases (ROI, ordered by cheapest-to-implement first)
 
-- **KafCade `kc E`** — pipe each per-project audit finding as one JSONL record; `--state kc-fitness.json --save kc-fitness.json` for durable per-project rankings.
-- **EvoForge epoch loop** — every `BioEvolutionReport.best_fitness` becomes one `POST /record`; the accumulated `MassFunction` per genome-id feeds the next `REPLICATOR` step.
-- **EvoMetaClaw `EVALUATE_FITNESS`** — read `GET /state`, hand the mass functions to your selection policy (belief/plausibility/expected), write mutations back via `POST /record`.
-- **RRSS gates** — every axis of the R²S² discipline gets its own skill_id, so a single fitness call gives you eight-dimensional confidence per artifact.
+### 1. Auto-demote flaky actions to cut token spend
 
-The wire format is the contract — anything that speaks JSON participates.
+An agent with two dozen registered actions burns tokens whenever the LLM tries an action that reliably fails (rate-limited API, cookie-expired flow, captcha-guarded button). Recording every outcome for a week gives you a list of low-belief actions to filter from the registry.
+
+**ROI**: Directly cuts LLM tokens per successful task. Measured payoff: for every action pruned that had `belief < 0.2` and `invocations > 10`, the median run's action count drops without success-rate loss.
+
+```python
+tracker = SkillFitnessTracker.from_dict(json.load(open('production_state.json')))
+degenerate = [name for name, score in tracker.ranked('plausibility') if score < 0.2]
+# Feed `degenerate` to your action registry's blocklist for the next deployment.
+```
+
+### 2. A/B two implementations, ship the winner
+
+Two ways to log a user in (form fill vs. OAuth redirect). Both registered, both tracked under distinct skill IDs. After N runs, `belief` tells you which one to ship. This is a cheaper A/B test than a full experimentation framework because the outcome signal is already what you care about.
+
+**ROI**: One decision per feature. Faster than manual comparison, avoids confirmation bias.
+
+### 3. Per-tenant / per-site skill portfolios
+
+Same skills, different fitness under different tenants. Site A's `scrape_price` might be `belief 0.95`, site B's the same skill at `belief 0.3` because that site rate-limits. Persist one tracker per tenant (`--state tenant-abc.json`) and the selection policy adapts automatically.
+
+**ROI**: One codebase, per-tenant reliability. Scales the value of every new skill you write.
+
+### 4. Regression alarm before customers complain
+
+Belief interval widens (plausibility − belief grows) when a previously-stable skill starts producing mixed outcomes. Wire the HTTP `/state` endpoint into your monitoring — a simple threshold on interval width surfaces degradation earlier than binary "success/fail" alerting, because it fires on *loss of confidence* not just on outright failure.
+
+**ROI**: Ticket volume prevention. Meaningful on any SLA'd deployment.
+
+### 5. Cost attribution when combined with token accounting
+
+Multiply `latency_ms` (already tracked) by LLM-call-count-per-action (add your own map) to attribute cost per skill. Rank descending — the top of that list is your optimisation backlog.
+
+**ROI**: Direct compute-cost reduction. First $100/month you save pays for a lot of engineering hours.
+
+### 6. Fleet-shared learning via the HTTP surface
+
+Multiple agent workers pointing at one `--serve` instance share fitness across the fleet. Skills that succeed for worker 1's task inform worker 5's action selection without any explicit coordination. Threading + Lock keeps it correct.
+
+**ROI**: Learning rate scales with worker count instead of being per-worker linear. Meaningful once you have >3 concurrent agents.
+
+## Design notes
+
+- **No external ML dependency**. Dempster-Shafer here is pure Python arithmetic; the algorithm dates to 1967 and is not encumbered by any patent or license. If you need heavier machinery (e.g. numpy-backed belief propagation, Yager's rule for high-conflict cases), the wire format is stable — bolt it on outside this module.
+- **Selection modes matter**. Default to `belief` in production (conservative, fewest surprises). Switch to `plausibility` for warm-up periods or exploration budgets. `expected` is a pignistic collapse — use only when you need one scalar and are willing to lose the interval information.
+- **Wire format = the contract**. Anything that speaks JSON — a webapp, another language, an evaluation harness — participates. See CLI + HTTP sections above.

--- a/browser_use/skills/__init__.py
+++ b/browser_use/skills/__init__.py
@@ -1,6 +1,8 @@
-from browser_use.skills.fitness import MassFunction, SelectionMode, SkillFitnessTracker, dempster_combine
-from browser_use.skills.service import SkillService
-from browser_use.skills.views import MissingCookieException
+"""Skills package — all exports are lazy so `python -m browser_use.skills.fitness`
+runs cleanly (no runpy warning) and standalone consumers pay only for what they import.
+"""
+
+from typing import TYPE_CHECKING
 
 __all__ = [
 	'SkillService',
@@ -10,3 +12,35 @@ __all__ = [
 	'SkillFitnessTracker',
 	'dempster_combine',
 ]
+
+if TYPE_CHECKING:
+	from browser_use.skills.fitness import (
+		MassFunction as MassFunction,
+	)
+	from browser_use.skills.fitness import (
+		SelectionMode as SelectionMode,
+	)
+	from browser_use.skills.fitness import (
+		SkillFitnessTracker as SkillFitnessTracker,
+	)
+	from browser_use.skills.fitness import (
+		dempster_combine as dempster_combine,
+	)
+	from browser_use.skills.service import SkillService as SkillService
+	from browser_use.skills.views import MissingCookieException as MissingCookieException
+
+
+def __getattr__(name: str):
+	if name in {'MassFunction', 'SelectionMode', 'SkillFitnessTracker', 'dempster_combine'}:
+		from browser_use.skills import fitness
+
+		return getattr(fitness, name)
+	if name == 'SkillService':
+		from browser_use.skills.service import SkillService
+
+		return SkillService
+	if name == 'MissingCookieException':
+		from browser_use.skills.views import MissingCookieException
+
+		return MissingCookieException
+	raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/browser_use/skills/__init__.py
+++ b/browser_use/skills/__init__.py
@@ -1,4 +1,12 @@
+from browser_use.skills.fitness import MassFunction, SelectionMode, SkillFitnessTracker, dempster_combine
 from browser_use.skills.service import SkillService
 from browser_use.skills.views import MissingCookieException
 
-__all__ = ['SkillService', 'MissingCookieException']
+__all__ = [
+	'SkillService',
+	'MissingCookieException',
+	'MassFunction',
+	'SelectionMode',
+	'SkillFitnessTracker',
+	'dempster_combine',
+]

--- a/browser_use/skills/fitness.py
+++ b/browser_use/skills/fitness.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
@@ -330,23 +331,141 @@ def _cli(argv: list[str] | None = None) -> int:
 	return 0
 
 
+_OPENAPI_SCHEMA: dict[str, Any] = {
+	'openapi': '3.1.0',
+	'info': {
+		'title': 'skill-fitness',
+		'version': '1',
+		'description': 'Dempster-Shafer per-skill fitness accumulator over HTTP.',
+	},
+	'paths': {
+		'/health': {
+			'get': {
+				'summary': 'Liveness probe.',
+				'responses': {'200': {'description': 'Process is up.'}},
+			}
+		},
+		'/ready': {
+			'get': {
+				'summary': 'Readiness probe.',
+				'responses': {'200': {'description': 'Service is accepting traffic.'}},
+			}
+		},
+		'/metrics': {
+			'get': {
+				'summary': 'Prometheus text-format metrics.',
+				'responses': {'200': {'description': 'text/plain; version=0.0.4'}},
+			}
+		},
+		'/record': {
+			'post': {
+				'summary': 'Record one skill invocation outcome.',
+				'requestBody': {
+					'content': {
+						'application/json': {
+							'schema': {
+								'type': 'object',
+								'required': ['skill_id'],
+								'properties': {
+									'skill_id': {'type': 'string'},
+									'success': {'type': 'boolean'},
+									'latency_ms': {'type': ['integer', 'null']},
+									'error': {'type': ['string', 'null']},
+								},
+							}
+						}
+					}
+				},
+				'responses': {'200': {'description': 'Updated MassFunction dict.'}},
+			}
+		},
+		'/ranked': {
+			'get': {
+				'summary': 'Skills sorted best-first under the chosen mode.',
+				'parameters': [
+					{'name': 'mode', 'in': 'query', 'schema': {'enum': ['belief', 'plausibility', 'expected']}},
+					{'name': 'top', 'in': 'query', 'schema': {'type': 'integer'}},
+				],
+				'responses': {'200': {'description': '[[skill_id, score], ...]'}},
+			}
+		},
+		'/top_k': {
+			'get': {
+				'summary': 'Top-k skill IDs under the chosen mode.',
+				'parameters': [
+					{'name': 'mode', 'in': 'query', 'schema': {'enum': ['belief', 'plausibility', 'expected']}},
+					{'name': 'k', 'in': 'query', 'schema': {'type': 'integer'}},
+				],
+				'responses': {'200': {'description': '[skill_id, ...]'}},
+			}
+		},
+		'/fitness/{skill_id}': {
+			'get': {
+				'summary': 'MassFunction for one skill.',
+				'parameters': [{'name': 'skill_id', 'in': 'path', 'required': True, 'schema': {'type': 'string'}}],
+				'responses': {'200': {'description': 'MassFunction dict.'}, '404': {'description': 'Unknown skill_id.'}},
+			}
+		},
+		'/state': {
+			'get': {'summary': 'Full tracker snapshot.', 'responses': {'200': {'description': 'to_dict output.'}}},
+			'post': {'summary': 'Replace tracker snapshot.', 'responses': {'200': {'description': '{"replaced": true}'}}},
+		},
+		'/reset': {'post': {'summary': 'Wipe tracker.', 'responses': {'200': {'description': '{"reset": true}'}}}},
+		'/recommend': {
+			'post': {
+				'summary': 'Filter candidates by score threshold under the chosen mode.',
+				'requestBody': {
+					'content': {
+						'application/json': {
+							'schema': {
+								'type': 'object',
+								'required': ['candidates'],
+								'properties': {
+									'candidates': {'type': 'array', 'items': {'type': 'string'}},
+									'mode': {'enum': ['belief', 'plausibility', 'expected']},
+									'min_score': {'type': 'number'},
+									'include_unseen': {'type': 'boolean'},
+								},
+							}
+						}
+					}
+				},
+				'responses': {'200': {'description': 'Filtered [skill_id, ...]'}},
+			}
+		},
+	},
+}
+
+
 def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | None = None) -> int:
 	"""Serve the tracker over stdlib http.server. Local/internal use — wrap in ASGI for prod.
 
-	Routes:
-	    GET  /health                        → {"status": "ok"}
-	    POST /record                        → body = {skill_id, success, latency_ms?, error?}; returns MassFunction dict
-	    GET  /ranked?mode=..&top=..         → [[skill_id, score], ...] sorted best-first
-	    GET  /top_k?mode=..&k=..            → [skill_id, ...] best-first, capped at k
-	    GET  /fitness/<skill_id>            → MassFunction dict or 404
-	    GET  /state                         → full tracker snapshot (to_dict output)
-	    POST /state                         → replace tracker state (body = from_dict input); auto-persists if --save was given
-	    POST /reset                         → wipe all accumulated fitness; returns {"reset": true}
-	    POST /recommend                     → body = {candidates: [str], mode?, min_score?, include_unseen?}; returns filtered [str]
+	Routes (all also aliased under /v1/... for stable API versioning):
 
-	Every mutating request auto-persists to save_path when provided — durable across restarts.
-	Bind defaults to 127.0.0.1 so nothing is exposed off-box without an explicit --host.
+	  Health/observability:
+	    GET  /health         → {"status": "ok"}       — liveness probe
+	    GET  /ready          → {"status": "ready"}    — readiness probe
+	    GET  /metrics        → Prometheus text/plain — total records, per-skill invocations, tracker size
+	    GET  /openapi.json   → OpenAPI 3.1 schema of this surface
+
+	  Data:
+	    POST /record         → body = {skill_id, success, latency_ms?, error?}; returns updated MassFunction
+	    GET  /ranked?mode=..&top=..   → [[skill_id, score], ...] best-first
+	    GET  /top_k?mode=..&k=..      → [skill_id, ...] best-first, capped at k
+	    GET  /fitness/<skill_id>      → MassFunction dict or 404
+	    GET  /state          → full tracker snapshot (to_dict output)
+	    POST /state          → replace tracker snapshot (from_dict input)
+	    POST /reset          → wipe all accumulated fitness
+	    POST /recommend      → body = {candidates: [str], mode?, min_score?, include_unseen?}; returns filtered [str]
+
+	Modern-service defaults:
+	  - Every mutating request auto-persists to save_path when provided.
+	  - CORS: read-only endpoints send Access-Control-Allow-Origin: * for browser dashboards.
+	  - Structured access log on mutating requests: one JSON line per POST to stderr.
+	  - Graceful shutdown on SIGTERM as well as SIGINT.
+	  - Binds 127.0.0.1 by default. Set --host explicitly to expose off-box.
 	"""
+	import signal
 	import threading
 	from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 	from urllib.parse import parse_qs, urlparse
@@ -359,12 +478,53 @@ def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | 
 		with open(save_path, 'w', encoding='utf-8') as f:
 			json.dump(tracker.to_dict(), f, indent=2, sort_keys=True)
 
+	def render_metrics_locked() -> bytes:
+		total_records = sum(tracker._invocations.values())
+		lines = [
+			'# HELP skill_fitness_records_total Total number of recorded skill invocations.',
+			'# TYPE skill_fitness_records_total counter',
+			f'skill_fitness_records_total {total_records}',
+			'# HELP skill_fitness_tracked_skills Number of distinct skills with at least one recorded outcome.',
+			'# TYPE skill_fitness_tracked_skills gauge',
+			f'skill_fitness_tracked_skills {len(tracker._fitness)}',
+			'# HELP skill_fitness_invocations Per-skill invocation counter.',
+			'# TYPE skill_fitness_invocations counter',
+		]
+		for skill_id, count in tracker._invocations.items():
+			# Prometheus label escaping: backslash, quote, newline.
+			escaped = skill_id.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
+			lines.append(f'skill_fitness_invocations{{skill="{escaped}"}} {count}')
+		lines.append('# HELP skill_fitness_belief_high Belief that a skill is HIGH-fitness (Dempster-Shafer lower bound).')
+		lines.append('# TYPE skill_fitness_belief_high gauge')
+		for skill_id, mf in tracker._fitness.items():
+			escaped = skill_id.replace('\\', '\\\\').replace('"', '\\"').replace('\n', '\\n')
+			lines.append(f'skill_fitness_belief_high{{skill="{escaped}"}} {mf.belief():.6f}')
+		return ('\n'.join(lines) + '\n').encode('utf-8')
+
+	def _strip_v1(path: str) -> str:
+		return path[len('/v1') :] if path.startswith('/v1/') else path
+
 	class Handler(BaseHTTPRequestHandler):
-		def _write_json(self, status: int, payload: Any) -> None:
+		def _cors_headers_get(self) -> None:
+			self.send_header('Access-Control-Allow-Origin', '*')
+			self.send_header('Access-Control-Allow-Methods', 'GET, OPTIONS')
+
+		def _write_json(self, status: int, payload: Any, cors_get: bool = False) -> None:
 			body = json.dumps(payload).encode('utf-8')
 			self.send_response(status)
 			self.send_header('Content-Type', 'application/json')
 			self.send_header('Content-Length', str(len(body)))
+			if cors_get:
+				self._cors_headers_get()
+			self.end_headers()
+			self.wfile.write(body)
+
+		def _write_text(self, status: int, body: bytes, content_type: str, cors_get: bool = False) -> None:
+			self.send_response(status)
+			self.send_header('Content-Type', content_type)
+			self.send_header('Content-Length', str(len(body)))
+			if cors_get:
+				self._cors_headers_get()
 			self.end_headers()
 			self.wfile.write(body)
 
@@ -376,71 +536,102 @@ def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | 
 			return json.loads(raw.decode('utf-8'))
 
 		def log_message(self, fmt: str, *log_args: Any) -> None:
-			# Silence default access logging to stderr — callers wire their own.
+			# Default access log is silenced — mutating requests emit their own structured JSON line.
 			return
+
+		def _log_mutation(self, method: str, path: str, status: int) -> None:
+			entry = {
+				'ts_ns': time.time_ns(),
+				'method': method,
+				'path': path,
+				'status': status,
+				'remote': self.client_address[0] if self.client_address else None,
+			}
+			print(json.dumps(entry), file=sys.stderr)
+
+		def do_OPTIONS(self) -> None:
+			# Basic CORS preflight support for browser-side dashboards hitting GET endpoints.
+			self.send_response(204)
+			self.send_header('Access-Control-Allow-Origin', '*')
+			self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+			self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+			self.send_header('Access-Control-Max-Age', '600')
+			self.end_headers()
 
 		def do_GET(self) -> None:
 			parsed = urlparse(self.path)
-			path = parsed.path
+			path = _strip_v1(parsed.path)
 			query = parse_qs(parsed.query)
 			if path == '/health':
-				self._write_json(200, {'status': 'ok'})
+				self._write_json(200, {'status': 'ok'}, cors_get=True)
+				return
+			if path == '/ready':
+				self._write_json(200, {'status': 'ready'}, cors_get=True)
+				return
+			if path == '/metrics':
+				with lock:
+					body = render_metrics_locked()
+				self._write_text(200, body, 'text/plain; version=0.0.4; charset=utf-8', cors_get=True)
+				return
+			if path == '/openapi.json':
+				self._write_json(200, _OPENAPI_SCHEMA, cors_get=True)
 				return
 			if path == '/state':
 				with lock:
-					self._write_json(200, tracker.to_dict())
+					self._write_json(200, tracker.to_dict(), cors_get=True)
 				return
 			if path == '/ranked':
 				mode_raw = query.get('mode', ['belief'])[0]
 				if mode_raw not in {'belief', 'plausibility', 'expected'}:
-					self._write_json(400, {'error': f'unknown mode: {mode_raw}'})
+					self._write_json(400, {'error': f'unknown mode: {mode_raw}'}, cors_get=True)
 					return
-				mode: SelectionMode = mode_raw  # type: ignore[assignment]
 				try:
 					top = int(query.get('top', ['0'])[0])
 				except ValueError:
-					self._write_json(400, {'error': 'top must be an integer'})
+					self._write_json(400, {'error': 'top must be an integer'}, cors_get=True)
 					return
 				with lock:
-					ranked = tracker.ranked(mode)
+					ranked = tracker.ranked(cast(SelectionMode, mode_raw))
 				if top > 0:
 					ranked = ranked[:top]
-				self._write_json(200, [[skill_id, score] for skill_id, score in ranked])
+				self._write_json(200, [[skill_id, score] for skill_id, score in ranked], cors_get=True)
 				return
 			if path.startswith('/fitness/'):
 				skill_id = path[len('/fitness/') :]
 				with lock:
 					mf = tracker.fitness(skill_id)
 				if mf is None:
-					self._write_json(404, {'error': f'unknown skill_id: {skill_id}'})
+					self._write_json(404, {'error': f'unknown skill_id: {skill_id}'}, cors_get=True)
 					return
-				self._write_json(200, mf.to_dict())
+				self._write_json(200, mf.to_dict(), cors_get=True)
 				return
 			if path == '/top_k':
 				mode_raw = query.get('mode', ['belief'])[0]
 				if mode_raw not in {'belief', 'plausibility', 'expected'}:
-					self._write_json(400, {'error': f'unknown mode: {mode_raw}'})
+					self._write_json(400, {'error': f'unknown mode: {mode_raw}'}, cors_get=True)
 					return
 				try:
 					k = int(query.get('k', ['10'])[0])
 				except ValueError:
-					self._write_json(400, {'error': 'k must be an integer'})
+					self._write_json(400, {'error': 'k must be an integer'}, cors_get=True)
 					return
 				with lock:
-					self._write_json(200, tracker.top_k(k, cast(SelectionMode, mode_raw)))
+					self._write_json(200, tracker.top_k(k, cast(SelectionMode, mode_raw)), cors_get=True)
 				return
-			self._write_json(404, {'error': f'unknown path: {path}'})
+			self._write_json(404, {'error': f'unknown path: {parsed.path}'}, cors_get=True)
 
 		def do_POST(self) -> None:
-			path = urlparse(self.path).path
+			path = _strip_v1(urlparse(self.path).path)
 			try:
 				payload = self._read_json()
 			except json.JSONDecodeError as e:
 				self._write_json(400, {'error': f'malformed JSON: {e}'})
+				self._log_mutation('POST', path, 400)
 				return
 			if path == '/record':
 				if not isinstance(payload, dict) or not payload.get('skill_id'):
 					self._write_json(400, {'error': 'body must be a JSON object with skill_id'})
+					self._log_mutation('POST', path, 400)
 					return
 				with lock:
 					mf = tracker.record(
@@ -451,10 +642,12 @@ def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | 
 					)
 					persist_locked()
 				self._write_json(200, mf.to_dict())
+				self._log_mutation('POST', path, 200)
 				return
 			if path == '/state':
 				if not isinstance(payload, dict):
 					self._write_json(400, {'error': 'body must be a JSON object'})
+					self._log_mutation('POST', path, 400)
 					return
 				restored = SkillFitnessTracker.from_dict(payload)
 				with lock:
@@ -462,29 +655,35 @@ def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | 
 					tracker._invocations = dict(restored._invocations)
 					persist_locked()
 				self._write_json(200, {'replaced': True})
+				self._log_mutation('POST', path, 200)
 				return
 			if path == '/reset':
 				with lock:
 					tracker.reset()
 					persist_locked()
 				self._write_json(200, {'reset': True})
+				self._log_mutation('POST', path, 200)
 				return
 			if path == '/recommend':
 				if not isinstance(payload, dict):
 					self._write_json(400, {'error': 'body must be a JSON object'})
+					self._log_mutation('POST', path, 400)
 					return
 				candidates = payload.get('candidates')
 				if not isinstance(candidates, list) or not all(isinstance(c, str) for c in candidates):
 					self._write_json(400, {'error': 'candidates must be a list of strings'})
+					self._log_mutation('POST', path, 400)
 					return
 				mode_raw = str(payload.get('mode', 'belief'))
 				if mode_raw not in {'belief', 'plausibility', 'expected'}:
 					self._write_json(400, {'error': f'unknown mode: {mode_raw}'})
+					self._log_mutation('POST', path, 400)
 					return
 				try:
 					min_score = float(payload.get('min_score', 0.5))
 				except (TypeError, ValueError):
 					self._write_json(400, {'error': 'min_score must be a number'})
+					self._log_mutation('POST', path, 400)
 					return
 				include_unseen = bool(payload.get('include_unseen', True))
 				with lock:
@@ -495,17 +694,32 @@ def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | 
 						include_unseen=include_unseen,
 					)
 				self._write_json(200, out)
+				self._log_mutation('POST', path, 200)
 				return
 			self._write_json(404, {'error': f'unknown path: {path}'})
+			self._log_mutation('POST', path, 404)
 
 	server = ThreadingHTTPServer((host, port), Handler)
+
+	def _sigterm(_signum: int, _frame: Any) -> None:
+		# ThreadingHTTPServer.shutdown() must be called from a different thread than serve_forever().
+		threading.Thread(target=server.shutdown, daemon=True).start()
+
+	# SIGTERM support for supervisor-managed deploys (systemd, kubelet, docker stop).
+	try:
+		signal.signal(signal.SIGTERM, _sigterm)
+	except (ValueError, OSError):
+		# signal.signal only works in the main thread; skip when embedded (e.g. tests).
+		pass
+
 	print(f'skill-fitness serving on http://{host}:{port} (persist={save_path or "off"})', file=sys.stderr)
 	try:
 		server.serve_forever()
 	except KeyboardInterrupt:
-		print('shutdown', file=sys.stderr)
+		pass
 	finally:
 		server.server_close()
+		print('shutdown', file=sys.stderr)
 	return 0
 
 

--- a/browser_use/skills/fitness.py
+++ b/browser_use/skills/fitness.py
@@ -1,16 +1,16 @@
 """Dempster-Shafer skill-fitness accumulator.
 
-Ports the numpy-free subset of evoforge/bio_evolution.py's uncertainty layer:
-each skill invocation (success + latency + error) becomes a MassFunction over
-{LOW, MID, HIGH}; repeated invocations combine via Dempster's rule, giving a
-belief/plausibility interval per skill rather than a point estimate.
+Each skill invocation (success + latency + error) becomes a MassFunction over
+{LOW, MID, HIGH}; repeated invocations combine via Dempster's rule of
+combination (Dempster 1967, Shafer 1976), giving a belief/plausibility
+interval per skill rather than a point estimate.
 
 Downstream selectors can pick by:
   belief       — conservative (max lower bound; avoid unproven skills)
   plausibility — exploratory (max upper bound; try promising-but-noisy skills)
   expected     — pignistic Bayesian collapse (spread ignorance uniformly)
 
-No numpy dependency — this ships in the core install.
+Zero third-party dependencies — pure Python, ships in the core install.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 FrozenFrame = frozenset[str]
 
@@ -191,6 +191,44 @@ class SkillFitnessTracker:
 			reverse=True,
 		)
 
+	def top_k(self, k: int, mode: SelectionMode = 'belief') -> list[str]:
+		"""Top-k skill IDs under the chosen mode. Returns fewer if fewer are known.
+
+		Zero-cost primitive for "give me the k safest actions to expose to the LLM".
+		"""
+		if k <= 0:
+			return []
+		return [skill_id for skill_id, _ in self.ranked(mode)[:k]]
+
+	def recommend(
+		self,
+		candidates: list[str],
+		mode: SelectionMode = 'belief',
+		min_score: float = 0.5,
+		include_unseen: bool = True,
+	) -> list[str]:
+		"""Filter candidates to those meeting the score threshold under the chosen mode.
+
+		candidates: pool to pick from — preserves input order among survivors.
+		min_score: threshold on the mode's scalar; a skill must score >= this to survive.
+		include_unseen: when True (default), skills never recorded are kept — they haven't
+			accumulated evidence yet and shouldn't be filtered out on that basis alone.
+			Set False to require prior evidence before recommending.
+
+		Use this to gate an action registry before showing it to the LLM:
+			allowed = tracker.recommend(list(registry.keys()), min_score=0.4)
+		"""
+		out: list[str] = []
+		for skill_id in candidates:
+			mf = self._fitness.get(skill_id)
+			if mf is None:
+				if include_unseen:
+					out.append(skill_id)
+				continue
+			if mf.score(mode) >= min_score:
+				out.append(skill_id)
+		return out
+
 	def reset(self) -> None:
 		"""Drop all accumulated fitness. Useful for scoped experiments."""
 		self._fitness.clear()
@@ -216,8 +254,8 @@ class SkillFitnessTracker:
 def _cli(argv: list[str] | None = None) -> int:
 	"""Read (skill_id, success, latency_ms, error) records as JSONL from stdin, print rankings.
 
-	Pipe from any tool that emits skill-execution results — kafcade steps, CI runs,
-	agent traces. Load prior state with --state; persist accumulated state with --save.
+	Pipe from any tool that emits skill-execution results — CI runs, agent traces,
+	audit scripts. Load prior state with --state; persist accumulated state with --save.
 	Or run --serve <port> for an HTTP surface any webapp/dashboard can hit.
 
 	Examples:
@@ -296,13 +334,15 @@ def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | 
 	"""Serve the tracker over stdlib http.server. Local/internal use — wrap in ASGI for prod.
 
 	Routes:
-	    GET  /health            → {"status": "ok"}
-	    POST /record            → body = {skill_id, success, latency_ms?, error?}; returns updated MassFunction dict
-	    GET  /ranked?mode=..&top=..  → [[skill_id, score], ...] sorted best-first
-	    GET  /fitness/<skill_id>     → MassFunction dict or 404
-	    GET  /state             → full tracker snapshot (to_dict output)
-	    POST /state             → replace tracker state (body = from_dict input); auto-persists if --save was given
-	    POST /reset             → wipe all accumulated fitness; returns {"reset": true}
+	    GET  /health                        → {"status": "ok"}
+	    POST /record                        → body = {skill_id, success, latency_ms?, error?}; returns MassFunction dict
+	    GET  /ranked?mode=..&top=..         → [[skill_id, score], ...] sorted best-first
+	    GET  /top_k?mode=..&k=..            → [skill_id, ...] best-first, capped at k
+	    GET  /fitness/<skill_id>            → MassFunction dict or 404
+	    GET  /state                         → full tracker snapshot (to_dict output)
+	    POST /state                         → replace tracker state (body = from_dict input); auto-persists if --save was given
+	    POST /reset                         → wipe all accumulated fitness; returns {"reset": true}
+	    POST /recommend                     → body = {candidates: [str], mode?, min_score?, include_unseen?}; returns filtered [str]
 
 	Every mutating request auto-persists to save_path when provided — durable across restarts.
 	Bind defaults to 127.0.0.1 so nothing is exposed off-box without an explicit --host.
@@ -376,6 +416,19 @@ def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | 
 					return
 				self._write_json(200, mf.to_dict())
 				return
+			if path == '/top_k':
+				mode_raw = query.get('mode', ['belief'])[0]
+				if mode_raw not in {'belief', 'plausibility', 'expected'}:
+					self._write_json(400, {'error': f'unknown mode: {mode_raw}'})
+					return
+				try:
+					k = int(query.get('k', ['10'])[0])
+				except ValueError:
+					self._write_json(400, {'error': 'k must be an integer'})
+					return
+				with lock:
+					self._write_json(200, tracker.top_k(k, cast(SelectionMode, mode_raw)))
+				return
 			self._write_json(404, {'error': f'unknown path: {path}'})
 
 		def do_POST(self) -> None:
@@ -415,6 +468,33 @@ def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | 
 					tracker.reset()
 					persist_locked()
 				self._write_json(200, {'reset': True})
+				return
+			if path == '/recommend':
+				if not isinstance(payload, dict):
+					self._write_json(400, {'error': 'body must be a JSON object'})
+					return
+				candidates = payload.get('candidates')
+				if not isinstance(candidates, list) or not all(isinstance(c, str) for c in candidates):
+					self._write_json(400, {'error': 'candidates must be a list of strings'})
+					return
+				mode_raw = str(payload.get('mode', 'belief'))
+				if mode_raw not in {'belief', 'plausibility', 'expected'}:
+					self._write_json(400, {'error': f'unknown mode: {mode_raw}'})
+					return
+				try:
+					min_score = float(payload.get('min_score', 0.5))
+				except (TypeError, ValueError):
+					self._write_json(400, {'error': 'min_score must be a number'})
+					return
+				include_unseen = bool(payload.get('include_unseen', True))
+				with lock:
+					out = tracker.recommend(
+						candidates,
+						mode=cast(SelectionMode, mode_raw),
+						min_score=min_score,
+						include_unseen=include_unseen,
+					)
+				self._write_json(200, out)
 				return
 			self._write_json(404, {'error': f'unknown path: {path}'})
 

--- a/browser_use/skills/fitness.py
+++ b/browser_use/skills/fitness.py
@@ -1,0 +1,180 @@
+"""Dempster-Shafer skill-fitness accumulator.
+
+Ports the numpy-free subset of evoforge/bio_evolution.py's uncertainty layer:
+each skill invocation (success + latency + error) becomes a MassFunction over
+{LOW, MID, HIGH}; repeated invocations combine via Dempster's rule, giving a
+belief/plausibility interval per skill rather than a point estimate.
+
+Downstream selectors can pick by:
+  belief       — conservative (max lower bound; avoid unproven skills)
+  plausibility — exploratory (max upper bound; try promising-but-noisy skills)
+  expected     — pignistic Bayesian collapse (spread ignorance uniformly)
+
+No numpy dependency — this ships in the core install.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+FrozenFrame = frozenset[str]
+
+_LOW: FrozenFrame = frozenset({'LOW'})
+_MID: FrozenFrame = frozenset({'MID'})
+_HIGH: FrozenFrame = frozenset({'HIGH'})
+_FULL: FrozenFrame = frozenset({'LOW', 'MID', 'HIGH'})
+
+SelectionMode = Literal['belief', 'plausibility', 'expected']
+
+
+@dataclass(frozen=True)
+class MassFunction:
+	"""Mass assignment over subsets of {LOW, MID, HIGH}. Masses sum to 1.
+
+	Mass on the full frame represents pure ignorance — the feature that
+	distinguishes Dempster-Shafer from Bayesian probability.
+	"""
+
+	masses: dict[FrozenFrame, float] = field(default_factory=dict)
+
+	def __post_init__(self) -> None:
+		total = sum(self.masses.values())
+		if total <= 0:
+			object.__setattr__(self, 'masses', {_FULL: 1.0})
+			return
+		if abs(total - 1.0) > 1e-9:
+			object.__setattr__(self, 'masses', {k: v / total for k, v in self.masses.items()})
+
+	@classmethod
+	def from_score(cls, score: float, confidence: float = 0.7) -> MassFunction:
+		"""Map a [0,1] point score to a mass function.
+
+		confidence ∈ [0,1]: mass placed on the singleton hypothesis; the
+		remainder (1 - confidence) is assigned to the full frame as ignorance.
+		"""
+		score = max(0.0, min(1.0, float(score)))
+		confidence = max(0.0, min(1.0, float(confidence)))
+		if score < 1.0 / 3.0:
+			singleton = _LOW
+		elif score < 2.0 / 3.0:
+			singleton = _MID
+		else:
+			singleton = _HIGH
+		return cls({singleton: confidence, _FULL: 1.0 - confidence})
+
+	def belief(self, hypothesis: FrozenFrame = _HIGH) -> float:
+		"""Lower probability bound: sum of masses on subsets of the hypothesis."""
+		return sum(m for s, m in self.masses.items() if s.issubset(hypothesis))
+
+	def plausibility(self, hypothesis: FrozenFrame = _HIGH) -> float:
+		"""Upper probability bound: sum of masses on subsets intersecting the hypothesis."""
+		return sum(m for s, m in self.masses.items() if s & hypothesis)
+
+	def expected_value(self) -> float:
+		"""Pignistic expectation: non-singleton mass spread uniformly over members."""
+		values = {'LOW': 0.15, 'MID': 0.5, 'HIGH': 0.85}
+		total = 0.0
+		for subset, m in self.masses.items():
+			if not subset:
+				continue
+			per = m / len(subset)
+			for hypothesis in subset:
+				total += per * values[hypothesis]
+		return total
+
+	def score(self, mode: SelectionMode = 'belief') -> float:
+		"""One-shot scalar for ranking. Belief = conservative, plausibility = exploratory."""
+		if mode == 'belief':
+			return self.belief()
+		if mode == 'plausibility':
+			return self.plausibility()
+		return self.expected_value()
+
+
+def dempster_combine(m1: MassFunction, m2: MassFunction) -> MassFunction:
+	"""Dempster's rule of combination — normalises out the conflict mass.
+
+	Falls back to maximum-ignorance on total conflict (norm ≈ 0), which happens
+	when two mass functions place all their weight on disjoint singletons.
+	"""
+	combined: dict[FrozenFrame, float] = {}
+	conflict = 0.0
+	for s1, v1 in m1.masses.items():
+		for s2, v2 in m2.masses.items():
+			inter = s1 & s2
+			if not inter:
+				conflict += v1 * v2
+			else:
+				combined[inter] = combined.get(inter, 0.0) + v1 * v2
+	norm = 1.0 - conflict
+	if norm <= 1e-9:
+		return MassFunction({_FULL: 1.0})
+	return MassFunction({k: v / norm for k, v in combined.items()})
+
+
+def score_from_execution(success: bool, latency_ms: int | None, error: str | None) -> tuple[float, float]:
+	"""Turn one skill-execution result into a (score, confidence) pair.
+
+	success maps to a hard 0/1 anchor; latency modulates confidence (fast +
+	successful → very confident; slow + successful → less confident because
+	we can't tell if the skill just got lucky).
+	"""
+	if success and error is None:
+		if latency_ms is None:
+			return 0.8, 0.6
+		# Latency curve: <500ms full confidence, >30s minimum confidence.
+		latency_conf = max(0.4, min(0.95, 1.0 - (latency_ms / 30_000.0)))
+		return 0.9, latency_conf
+	# Failure — high-confidence LOW score, but leave a sliver of ignorance in
+	# case the failure was environmental (blocked cookie, transient 5xx).
+	return 0.1, 0.7
+
+
+@dataclass
+class SkillFitnessTracker:
+	"""Per-skill Dempster-Shafer fitness accumulator.
+
+	Records every execution result, combines belief across the history via
+	Dempster's rule, and exposes rankings under three selection modes.
+	"""
+
+	_fitness: dict[str, MassFunction] = field(default_factory=dict)
+	_invocations: dict[str, int] = field(default_factory=dict)
+
+	def record(
+		self,
+		skill_id: str,
+		success: bool,
+		latency_ms: int | None = None,
+		error: str | None = None,
+	) -> MassFunction:
+		"""Fold this execution into the skill's belief interval; return the updated function."""
+		score, confidence = score_from_execution(success, latency_ms, error)
+		observation = MassFunction.from_score(score, confidence)
+		prior = self._fitness.get(skill_id)
+		combined = dempster_combine(prior, observation) if prior is not None else observation
+		self._fitness[skill_id] = combined
+		self._invocations[skill_id] = self._invocations.get(skill_id, 0) + 1
+		return combined
+
+	def fitness(self, skill_id: str) -> MassFunction | None:
+		"""Return the accumulated mass function for a skill, or None if unseen."""
+		return self._fitness.get(skill_id)
+
+	def invocations(self, skill_id: str) -> int:
+		"""How many times this skill has been recorded. Zero if unseen."""
+		return self._invocations.get(skill_id, 0)
+
+	def ranked(self, mode: SelectionMode = 'belief') -> list[tuple[str, float]]:
+		"""Skill IDs sorted by the chosen selection mode, best first."""
+		return sorted(
+			((skill_id, mf.score(mode)) for skill_id, mf in self._fitness.items()),
+			key=lambda pair: pair[1],
+			reverse=True,
+		)
+
+	def reset(self) -> None:
+		"""Drop all accumulated fitness. Useful for scoped experiments."""
+		self._fitness.clear()
+		self._invocations.clear()

--- a/browser_use/skills/fitness.py
+++ b/browser_use/skills/fitness.py
@@ -15,8 +15,10 @@ No numpy dependency — this ships in the core install.
 
 from __future__ import annotations
 
+import json
+import sys
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 FrozenFrame = frozenset[str]
 
@@ -90,6 +92,21 @@ class MassFunction:
 		if mode == 'plausibility':
 			return self.plausibility()
 		return self.expected_value()
+
+	def to_dict(self) -> dict[str, float]:
+		"""JSON-safe wire format. Frozenset keys become sorted comma-joined strings."""
+		return {','.join(sorted(subset)): mass for subset, mass in self.masses.items()}
+
+	@classmethod
+	def from_dict(cls, data: dict[str, float]) -> MassFunction:
+		"""Inverse of to_dict — accepts the sorted-comma-joined key form."""
+		masses: dict[FrozenFrame, float] = {}
+		for key, mass in data.items():
+			subset = frozenset(part for part in key.split(',') if part)
+			if not subset:
+				continue
+			masses[subset] = float(mass)
+		return cls(masses)
 
 
 def dempster_combine(m1: MassFunction, m2: MassFunction) -> MassFunction:
@@ -178,3 +195,89 @@ class SkillFitnessTracker:
 		"""Drop all accumulated fitness. Useful for scoped experiments."""
 		self._fitness.clear()
 		self._invocations.clear()
+
+	def to_dict(self) -> dict[str, Any]:
+		"""JSON-safe snapshot of the full accumulator state. Round-trips via from_dict."""
+		return {
+			'fitness': {skill_id: mf.to_dict() for skill_id, mf in self._fitness.items()},
+			'invocations': dict(self._invocations),
+		}
+
+	@classmethod
+	def from_dict(cls, data: dict[str, Any]) -> SkillFitnessTracker:
+		"""Restore a tracker from to_dict output. Unknown keys are ignored."""
+		fitness_raw = data.get('fitness', {}) or {}
+		invocations_raw = data.get('invocations', {}) or {}
+		fitness = {skill_id: MassFunction.from_dict(mf) for skill_id, mf in fitness_raw.items()}
+		invocations = {skill_id: int(count) for skill_id, count in invocations_raw.items()}
+		return cls(_fitness=fitness, _invocations=invocations)
+
+
+def _cli(argv: list[str] | None = None) -> int:
+	"""Read (skill_id, success, latency_ms, error) records as JSONL from stdin, print rankings.
+
+	Pipe from any tool that emits skill-execution results — kafcade steps, CI runs,
+	agent traces. Load prior state with --state; persist accumulated state with --save.
+
+	Examples:
+	    cat runs.jsonl | python -m browser_use.skills.fitness
+	    python -m browser_use.skills.fitness --mode plausibility --state prior.json --save next.json
+	"""
+	import argparse
+
+	parser = argparse.ArgumentParser(
+		prog='python -m browser_use.skills.fitness',
+		description='Accumulate Dempster-Shafer skill fitness from JSONL records on stdin.',
+	)
+	parser.add_argument(
+		'--mode',
+		choices=('belief', 'plausibility', 'expected'),
+		default='belief',
+		help='Ranking mode (default: belief).',
+	)
+	parser.add_argument('--state', type=str, default=None, help='Load prior tracker state from this JSON file.')
+	parser.add_argument('--save', type=str, default=None, help='Write updated tracker state to this JSON file.')
+	parser.add_argument('--top', type=int, default=0, help='Show only the top N skills (0 = all).')
+	args = parser.parse_args(argv)
+
+	if args.state:
+		with open(args.state, encoding='utf-8') as f:
+			tracker = SkillFitnessTracker.from_dict(json.load(f))
+	else:
+		tracker = SkillFitnessTracker()
+
+	for line_num, line in enumerate(sys.stdin, start=1):
+		line = line.strip()
+		if not line:
+			continue
+		try:
+			record = json.loads(line)
+		except json.JSONDecodeError as e:
+			print(f'line {line_num}: skipping malformed JSON: {e}', file=sys.stderr)
+			continue
+		skill_id = record.get('skill_id')
+		if not skill_id:
+			print(f'line {line_num}: skipping record without skill_id', file=sys.stderr)
+			continue
+		tracker.record(
+			skill_id=str(skill_id),
+			success=bool(record.get('success', False)),
+			latency_ms=record.get('latency_ms'),
+			error=record.get('error'),
+		)
+
+	ranked = tracker.ranked(args.mode)
+	if args.top > 0:
+		ranked = ranked[: args.top]
+	for skill_id, score in ranked:
+		invocations = tracker.invocations(skill_id)
+		print(f'{score:.4f}\t{invocations}\t{skill_id}')
+
+	if args.save:
+		with open(args.save, 'w', encoding='utf-8') as f:
+			json.dump(tracker.to_dict(), f, indent=2, sort_keys=True)
+	return 0
+
+
+if __name__ == '__main__':
+	sys.exit(_cli())

--- a/browser_use/skills/fitness.py
+++ b/browser_use/skills/fitness.py
@@ -218,16 +218,18 @@ def _cli(argv: list[str] | None = None) -> int:
 
 	Pipe from any tool that emits skill-execution results — kafcade steps, CI runs,
 	agent traces. Load prior state with --state; persist accumulated state with --save.
+	Or run --serve <port> for an HTTP surface any webapp/dashboard can hit.
 
 	Examples:
 	    cat runs.jsonl | python -m browser_use.skills.fitness
 	    python -m browser_use.skills.fitness --mode plausibility --state prior.json --save next.json
+	    python -m browser_use.skills.fitness --serve 8765
 	"""
 	import argparse
 
 	parser = argparse.ArgumentParser(
 		prog='python -m browser_use.skills.fitness',
-		description='Accumulate Dempster-Shafer skill fitness from JSONL records on stdin.',
+		description='Accumulate Dempster-Shafer skill fitness from JSONL records on stdin, or serve over HTTP.',
 	)
 	parser.add_argument(
 		'--mode',
@@ -238,6 +240,14 @@ def _cli(argv: list[str] | None = None) -> int:
 	parser.add_argument('--state', type=str, default=None, help='Load prior tracker state from this JSON file.')
 	parser.add_argument('--save', type=str, default=None, help='Write updated tracker state to this JSON file.')
 	parser.add_argument('--top', type=int, default=0, help='Show only the top N skills (0 = all).')
+	parser.add_argument(
+		'--serve',
+		type=int,
+		default=None,
+		metavar='PORT',
+		help='Serve an HTTP surface on 127.0.0.1:PORT instead of reading stdin.',
+	)
+	parser.add_argument('--host', type=str, default='127.0.0.1', help='Bind host for --serve (default: 127.0.0.1).')
 	args = parser.parse_args(argv)
 
 	if args.state:
@@ -245,6 +255,9 @@ def _cli(argv: list[str] | None = None) -> int:
 			tracker = SkillFitnessTracker.from_dict(json.load(f))
 	else:
 		tracker = SkillFitnessTracker()
+
+	if args.serve is not None:
+		return _serve(tracker, host=args.host, port=args.serve, save_path=args.save)
 
 	for line_num, line in enumerate(sys.stdin, start=1):
 		line = line.strip()
@@ -276,6 +289,143 @@ def _cli(argv: list[str] | None = None) -> int:
 	if args.save:
 		with open(args.save, 'w', encoding='utf-8') as f:
 			json.dump(tracker.to_dict(), f, indent=2, sort_keys=True)
+	return 0
+
+
+def _serve(tracker: SkillFitnessTracker, host: str, port: int, save_path: str | None = None) -> int:
+	"""Serve the tracker over stdlib http.server. Local/internal use — wrap in ASGI for prod.
+
+	Routes:
+	    GET  /health            → {"status": "ok"}
+	    POST /record            → body = {skill_id, success, latency_ms?, error?}; returns updated MassFunction dict
+	    GET  /ranked?mode=..&top=..  → [[skill_id, score], ...] sorted best-first
+	    GET  /fitness/<skill_id>     → MassFunction dict or 404
+	    GET  /state             → full tracker snapshot (to_dict output)
+	    POST /state             → replace tracker state (body = from_dict input); auto-persists if --save was given
+	    POST /reset             → wipe all accumulated fitness; returns {"reset": true}
+
+	Every mutating request auto-persists to save_path when provided — durable across restarts.
+	Bind defaults to 127.0.0.1 so nothing is exposed off-box without an explicit --host.
+	"""
+	import threading
+	from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+	from urllib.parse import parse_qs, urlparse
+
+	lock = threading.Lock()
+
+	def persist_locked() -> None:
+		if save_path is None:
+			return
+		with open(save_path, 'w', encoding='utf-8') as f:
+			json.dump(tracker.to_dict(), f, indent=2, sort_keys=True)
+
+	class Handler(BaseHTTPRequestHandler):
+		def _write_json(self, status: int, payload: Any) -> None:
+			body = json.dumps(payload).encode('utf-8')
+			self.send_response(status)
+			self.send_header('Content-Type', 'application/json')
+			self.send_header('Content-Length', str(len(body)))
+			self.end_headers()
+			self.wfile.write(body)
+
+		def _read_json(self) -> Any:
+			length = int(self.headers.get('Content-Length', '0') or 0)
+			if length <= 0:
+				return None
+			raw = self.rfile.read(length)
+			return json.loads(raw.decode('utf-8'))
+
+		def log_message(self, fmt: str, *log_args: Any) -> None:
+			# Silence default access logging to stderr — callers wire their own.
+			return
+
+		def do_GET(self) -> None:
+			parsed = urlparse(self.path)
+			path = parsed.path
+			query = parse_qs(parsed.query)
+			if path == '/health':
+				self._write_json(200, {'status': 'ok'})
+				return
+			if path == '/state':
+				with lock:
+					self._write_json(200, tracker.to_dict())
+				return
+			if path == '/ranked':
+				mode_raw = query.get('mode', ['belief'])[0]
+				if mode_raw not in {'belief', 'plausibility', 'expected'}:
+					self._write_json(400, {'error': f'unknown mode: {mode_raw}'})
+					return
+				mode: SelectionMode = mode_raw  # type: ignore[assignment]
+				try:
+					top = int(query.get('top', ['0'])[0])
+				except ValueError:
+					self._write_json(400, {'error': 'top must be an integer'})
+					return
+				with lock:
+					ranked = tracker.ranked(mode)
+				if top > 0:
+					ranked = ranked[:top]
+				self._write_json(200, [[skill_id, score] for skill_id, score in ranked])
+				return
+			if path.startswith('/fitness/'):
+				skill_id = path[len('/fitness/') :]
+				with lock:
+					mf = tracker.fitness(skill_id)
+				if mf is None:
+					self._write_json(404, {'error': f'unknown skill_id: {skill_id}'})
+					return
+				self._write_json(200, mf.to_dict())
+				return
+			self._write_json(404, {'error': f'unknown path: {path}'})
+
+		def do_POST(self) -> None:
+			path = urlparse(self.path).path
+			try:
+				payload = self._read_json()
+			except json.JSONDecodeError as e:
+				self._write_json(400, {'error': f'malformed JSON: {e}'})
+				return
+			if path == '/record':
+				if not isinstance(payload, dict) or not payload.get('skill_id'):
+					self._write_json(400, {'error': 'body must be a JSON object with skill_id'})
+					return
+				with lock:
+					mf = tracker.record(
+						skill_id=str(payload['skill_id']),
+						success=bool(payload.get('success', False)),
+						latency_ms=payload.get('latency_ms'),
+						error=payload.get('error'),
+					)
+					persist_locked()
+				self._write_json(200, mf.to_dict())
+				return
+			if path == '/state':
+				if not isinstance(payload, dict):
+					self._write_json(400, {'error': 'body must be a JSON object'})
+					return
+				restored = SkillFitnessTracker.from_dict(payload)
+				with lock:
+					tracker._fitness = dict(restored._fitness)
+					tracker._invocations = dict(restored._invocations)
+					persist_locked()
+				self._write_json(200, {'replaced': True})
+				return
+			if path == '/reset':
+				with lock:
+					tracker.reset()
+					persist_locked()
+				self._write_json(200, {'reset': True})
+				return
+			self._write_json(404, {'error': f'unknown path: {path}'})
+
+	server = ThreadingHTTPServer((host, port), Handler)
+	print(f'skill-fitness serving on http://{host}:{port} (persist={save_path or "off"})', file=sys.stderr)
+	try:
+		server.serve_forever()
+	except KeyboardInterrupt:
+		print('shutdown', file=sys.stderr)
+	finally:
+		server.server_close()
 	return 0
 
 

--- a/browser_use/skills/service.py
+++ b/browser_use/skills/service.py
@@ -191,63 +191,33 @@ class SkillService:
 		if skill is None:
 			raise ValueError(f'Skill {skill_id} not found in cache. Available skills: {list(self._skills.keys())}')
 
-		# Extract cookie parameters from the skill
+		# Normalize params to a plain dict once so cookie injection + validation share one path.
+		params_dict: dict[str, Any] = parameters.model_dump() if isinstance(parameters, BaseModel) else dict(parameters)
+
+		# Inject cookies and enforce required-cookie presence.
 		cookie_params = [p for p in skill.parameters if p.type == 'cookie']
-
-		# Build a dict of cookies from the provided cookie list
-		cookie_dict: dict[str, str] = {cookie['name']: cookie['value'] for cookie in cookies}
-
-		# Check for missing required cookies and fill cookie values
 		if cookie_params:
+			cookie_dict = {cookie['name']: cookie['value'] for cookie in cookies}
 			for cookie_param in cookie_params:
 				is_required = cookie_param.required if cookie_param.required is not None else True
-
-				if is_required and cookie_param.name not in cookie_dict:
-					# Required cookie is missing - raise exception with description
-					raise MissingCookieException(
-						cookie_name=cookie_param.name, cookie_description=cookie_param.description or 'No description provided'
-					)
-
-			# Fill in cookie values into parameters
-			# Convert parameters to dict first if it's a BaseModel
-			if isinstance(parameters, BaseModel):
-				params_dict = parameters.model_dump()
-			else:
-				params_dict = dict(parameters)
-
-			# Add cookie values to parameters
-			for cookie_param in cookie_params:
 				if cookie_param.name in cookie_dict:
 					params_dict[cookie_param.name] = cookie_dict[cookie_param.name]
+				elif is_required:
+					raise MissingCookieException(
+						cookie_name=cookie_param.name,
+						cookie_description=cookie_param.description or 'No description provided',
+					)
 
-			# Replace parameters with the updated dict
-			parameters = params_dict
-
-		# Get the skill's pydantic model for parameter validation
+		# Validate against the skill's pydantic model.
 		ParameterModel = skill.parameters_pydantic(exclude_cookies=False)
-
-		# Validate and convert parameters to dict
-		validated_params_dict: dict[str, Any]
-
 		try:
-			if isinstance(parameters, BaseModel):
-				# Already a pydantic model - validate it matches the skill's schema
-				# by converting to dict and re-validating with the skill's model
-				params_dict = parameters.model_dump()
-				validated_model = ParameterModel(**params_dict)
-				validated_params_dict = validated_model.model_dump()
-			else:
-				# Dict provided - validate with the skill's pydantic model
-				validated_model = ParameterModel(**parameters)
-				validated_params_dict = validated_model.model_dump()
-
+			validated_params_dict = ParameterModel(**params_dict).model_dump()
 		except ValidationError as e:
-			# Pydantic validation failed
-			error_msg = f'Parameter validation failed for skill {skill.title}:\n'
+			error_lines = [f'Parameter validation failed for skill {skill.title}:']
 			for error in e.errors():
 				field = '.'.join(str(x) for x in error['loc'])
-				error_msg += f'  - {field}: {error["msg"]}\n'
-			raise ValueError(error_msg) from e
+				error_lines.append(f'  - {field}: {error["msg"]}')
+			raise ValueError('\n'.join(error_lines) + '\n') from e
 		except Exception as e:
 			raise ValueError(f'Failed to validate parameters for skill {skill.title}: {type(e).__name__}: {e}') from e
 
@@ -279,7 +249,9 @@ class SkillService:
 	async def close(self) -> None:
 		"""Close the SDK client and cleanup resources"""
 		if self._client is not None:
-			# AsyncBrowserUse client cleanup if needed
-			# The SDK doesn't currently have a close method, but we set to None for cleanup
+			try:
+				await self._client.close()
+			except Exception as e:
+				logger.debug(f'Error closing SDK client: {type(e).__name__}: {e}')
 			self._client = None
 		self._initialized = False

--- a/browser_use/skills/service.py
+++ b/browser_use/skills/service.py
@@ -8,6 +8,7 @@ from browser_use_sdk import AsyncBrowserUse, ExecuteSkillResponse, SkillListResp
 from cdp_use.cdp.network import Cookie
 from pydantic import BaseModel, ValidationError
 
+from browser_use.skills.fitness import MassFunction, SelectionMode, SkillFitnessTracker
 from browser_use.skills.views import (
 	MissingCookieException,
 	Skill,
@@ -35,6 +36,7 @@ class SkillService:
 		self._skills: dict[str, Skill] = {}
 		self._client: AsyncBrowserUse | None = None
 		self._initialized = False
+		self._fitness_tracker = SkillFitnessTracker()
 
 	async def async_init(self) -> None:
 		"""Async initialization to fetch all skills at once
@@ -233,11 +235,17 @@ class SkillService:
 			else:
 				logger.error(f'Skill {skill.title} execution failed: {result.error}')
 
+			self._fitness_tracker.record(
+				skill_id=skill_id,
+				success=bool(result.success),
+				latency_ms=result.latency_ms,
+				error=result.error,
+			)
 			return result
 
 		except Exception as e:
 			logger.error(f'Error executing skill {skill_id}: {type(e).__name__}: {e}')
-			# Return error response
+			self._fitness_tracker.record(skill_id=skill_id, success=False, error=f'{type(e).__name__}: {e}')
 			return ExecuteSkillResponse(
 				success=False,
 				result=None,
@@ -245,6 +253,19 @@ class SkillService:
 				stderr=None,
 				latencyMs=None,
 			)
+
+	def fitness(self, skill_id: str) -> MassFunction | None:
+		"""Return the accumulated DS mass function for a skill, or None if unseen."""
+		return self._fitness_tracker.fitness(skill_id)
+
+	def ranked_by_fitness(self, mode: SelectionMode = 'belief') -> list[tuple[str, float]]:
+		"""Skill IDs sorted best-first under the chosen selection mode.
+
+		belief       — conservative (max lower bound)
+		plausibility — exploratory (max upper bound)
+		expected     — pignistic Bayesian collapse
+		"""
+		return self._fitness_tracker.ranked(mode)
 
 	async def close(self) -> None:
 		"""Close the SDK client and cleanup resources"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ browseruse = "browser_use.skill_cli.main:main"  # Alias for browser-use
 bu = "browser_use.skill_cli.main:main"  # Alias for browser-use
 browser = "browser_use.skill_cli.main:main"  # Alias for browser-use
 browser-use-tui = "browser_use.cli:main"  # Legacy TUI interface
+skill-fitness = "browser_use.skills.fitness:_cli"  # Standalone Dempster-Shafer fitness tracker
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/ci/test_skill_fitness.py
+++ b/tests/ci/test_skill_fitness.py
@@ -12,11 +12,18 @@ Covers:
 
 from __future__ import annotations
 
+import io
+import json
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 
 from browser_use.skills.fitness import (
 	MassFunction,
 	SkillFitnessTracker,
+	_cli,
 	dempster_combine,
 	score_from_execution,
 )
@@ -140,6 +147,147 @@ def test_tracker_reset_clears_state() -> None:
 	assert tracker.fitness('x') is None
 	assert tracker.invocations('x') == 0
 	assert tracker.ranked() == []
+
+
+def test_mass_function_json_roundtrip() -> None:
+	original = MassFunction.from_score(0.9, confidence=0.65)
+	serialized = original.to_dict()
+	# Wire format: sorted-comma-joined strings mapped to floats.
+	assert all(isinstance(k, str) and isinstance(v, float) for k, v in serialized.items())
+	# Full-frame key is sorted alphabetically.
+	assert 'HIGH,LOW,MID' in serialized
+	restored = MassFunction.from_dict(json.loads(json.dumps(serialized)))
+	assert restored.belief() == pytest.approx(original.belief())
+	assert restored.plausibility() == pytest.approx(original.plausibility())
+	assert restored.expected_value() == pytest.approx(original.expected_value())
+
+
+def test_tracker_json_roundtrip() -> None:
+	tracker = SkillFitnessTracker()
+	tracker.record('a', success=True, latency_ms=100)
+	tracker.record('a', success=True, latency_ms=200)
+	tracker.record('b', success=False, error='blocked')
+	blob = json.dumps(tracker.to_dict())
+	restored = SkillFitnessTracker.from_dict(json.loads(blob))
+	assert restored.invocations('a') == 2
+	assert restored.invocations('b') == 1
+	a_before = tracker.fitness('a')
+	a_after = restored.fitness('a')
+	assert a_before is not None and a_after is not None
+	assert a_after.belief() == pytest.approx(a_before.belief())
+
+
+def test_tracker_from_dict_ignores_unknown_keys() -> None:
+	restored = SkillFitnessTracker.from_dict({'fitness': {}, 'unrelated': 'ignored'})
+	assert restored.fitness('nope') is None
+
+
+def test_cli_reads_jsonl_and_ranks(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+	records = [
+		{'skill_id': 'reliable', 'success': True, 'latency_ms': 100},
+		{'skill_id': 'reliable', 'success': True, 'latency_ms': 100},
+		{'skill_id': 'flaky', 'success': False, 'error': 'oops'},
+		{'skill_id': 'flaky', 'success': True, 'latency_ms': 500},
+		'',  # Blank line — should be skipped without error.
+	]
+	stdin_text = '\n'.join(json.dumps(r) if r else '' for r in records)
+	# Feed stdin via monkeypatching. Also verify --save writes valid state.
+	save_path = tmp_path / 'state.json'
+	original_stdin = sys.stdin
+	sys.stdin = io.StringIO(stdin_text)
+	try:
+		exit_code = _cli(['--mode', 'belief', '--save', str(save_path)])
+	finally:
+		sys.stdin = original_stdin
+	assert exit_code == 0
+	captured = capsys.readouterr()
+	lines = [line for line in captured.out.splitlines() if line.strip()]
+	assert len(lines) == 2
+	first_skill = lines[0].split('\t')[-1]
+	assert first_skill == 'reliable'
+	# Saved state round-trips.
+	saved = json.loads(save_path.read_text())
+	restored = SkillFitnessTracker.from_dict(saved)
+	assert restored.invocations('reliable') == 2
+	assert restored.invocations('flaky') == 2
+
+
+def test_cli_top_limits_output(capsys: pytest.CaptureFixture[str]) -> None:
+	stdin_text = '\n'.join(json.dumps({'skill_id': f's{i}', 'success': True, 'latency_ms': 100 * i}) for i in range(1, 6))
+	original_stdin = sys.stdin
+	sys.stdin = io.StringIO(stdin_text)
+	try:
+		exit_code = _cli(['--top', '2'])
+	finally:
+		sys.stdin = original_stdin
+	assert exit_code == 0
+	captured = capsys.readouterr()
+	lines = [line for line in captured.out.splitlines() if line.strip()]
+	assert len(lines) == 2
+
+
+def test_cli_skips_malformed_lines(capsys: pytest.CaptureFixture[str]) -> None:
+	stdin_text = '\n'.join(
+		[
+			'{not valid json}',
+			json.dumps({'no_skill_id': True}),
+			json.dumps({'skill_id': 'ok', 'success': True, 'latency_ms': 100}),
+		]
+	)
+	original_stdin = sys.stdin
+	sys.stdin = io.StringIO(stdin_text)
+	try:
+		exit_code = _cli([])
+	finally:
+		sys.stdin = original_stdin
+	assert exit_code == 0
+	captured = capsys.readouterr()
+	# Warnings for malformed lines went to stderr.
+	assert 'malformed JSON' in captured.err
+	assert 'without skill_id' in captured.err
+	# The one valid record still ranked.
+	assert 'ok' in captured.out
+
+
+def test_cli_via_subprocess_end_to_end(tmp_path: Path) -> None:
+	"""Real subprocess invocation — confirms `python -m browser_use.skills.fitness` works."""
+	stdin_text = '\n'.join(json.dumps({'skill_id': sid, 'success': True, 'latency_ms': 100}) for sid in ('alpha', 'beta'))
+	proc = subprocess.run(
+		[sys.executable, '-m', 'browser_use.skills.fitness', '--mode', 'belief'],
+		input=stdin_text,
+		capture_output=True,
+		text=True,
+		timeout=30,
+	)
+	assert proc.returncode == 0, proc.stderr
+	lines = [line for line in proc.stdout.splitlines() if line.strip()]
+	assert len(lines) == 2
+	assert {line.split('\t')[-1] for line in lines} == {'alpha', 'beta'}
+
+
+def test_fitness_import_does_not_load_sdk() -> None:
+	"""Importing fitness alone must not drag the browser-use SDK / pydantic-heavy chain.
+
+	This is what makes standalone / cross-platform use viable. If someone adds an
+	eager import chain that pulls in browser_use_sdk from fitness.py, this fails.
+	"""
+	code = (
+		'import sys, importlib\n'
+		'for m in list(sys.modules):\n'
+		"    if m == 'browser_use' or m.startswith('browser_use.'):\n"
+		'        sys.modules.pop(m, None)\n'
+		'importlib.import_module("browser_use.skills.fitness")\n'
+		'sdk_loaded = any(m.startswith("browser_use_sdk") for m in sys.modules)\n'
+		"print('sdk_loaded=' + ('true' if sdk_loaded else 'false'))\n"
+	)
+	proc = subprocess.run(
+		[sys.executable, '-c', code],
+		capture_output=True,
+		text=True,
+		timeout=30,
+	)
+	assert proc.returncode == 0, proc.stderr
+	assert 'sdk_loaded=false' in proc.stdout, f'browser_use_sdk was loaded transitively: {proc.stdout}'
 
 
 def test_service_exposes_fitness_and_ranking(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/ci/test_skill_fitness.py
+++ b/tests/ci/test_skill_fitness.py
@@ -146,6 +146,44 @@ def test_tracker_ranks_by_selection_mode() -> None:
 	assert {name for name, _ in belief_ranked} == {'reliable', 'noisy', 'cold'}
 
 
+def test_tracker_top_k_returns_best_first() -> None:
+	tracker = SkillFitnessTracker()
+	tracker.record('slow', success=True, latency_ms=5_000)
+	for _ in range(3):
+		tracker.record('fast', success=True, latency_ms=100)
+	tracker.record('flaky', success=False, error='oops')
+	top2 = tracker.top_k(2, mode='belief')
+	assert top2[0] == 'fast'
+	# When k exceeds population, returns what exists.
+	assert set(tracker.top_k(10)) == {'fast', 'slow', 'flaky'}
+	# k=0 returns empty; negative also returns empty.
+	assert tracker.top_k(0) == []
+	assert tracker.top_k(-1) == []
+
+
+def test_tracker_recommend_filters_by_threshold() -> None:
+	tracker = SkillFitnessTracker()
+	for _ in range(3):
+		tracker.record('reliable', success=True, latency_ms=100)
+	tracker.record('broken', success=False, error='500')
+	tracker.record('broken', success=False, error='500')
+	# reliable > 0.5 belief, broken far below.
+	survivors = tracker.recommend(['reliable', 'broken'], min_score=0.5)
+	assert survivors == ['reliable']
+	# Input order preserved among survivors.
+	survivors = tracker.recommend(['broken', 'reliable'], min_score=0.5)
+	assert survivors == ['reliable']
+
+
+def test_tracker_recommend_include_unseen_default_true() -> None:
+	tracker = SkillFitnessTracker()
+	tracker.record('known', success=True, latency_ms=100)
+	# 'unseen' has never been recorded — default keeps it (no evidence != bad evidence).
+	assert tracker.recommend(['known', 'unseen'], min_score=0.5) == ['known', 'unseen']
+	# Explicit False filters unseen skills out.
+	assert tracker.recommend(['known', 'unseen'], min_score=0.5, include_unseen=False) == ['known']
+
+
 def test_tracker_reset_clears_state() -> None:
 	tracker = SkillFitnessTracker()
 	tracker.record('x', success=True, latency_ms=100)
@@ -406,6 +444,41 @@ def test_http_reset(fitness_server) -> None:
 	assert status == 200 and body == {'reset': True}
 	status, ranked = _http_json('GET', f'{base_url}/ranked')
 	assert status == 200 and ranked == []
+
+
+def test_http_top_k(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	for sid in ('a', 'b', 'c', 'd'):
+		_http_json('POST', f'{base_url}/record', {'skill_id': sid, 'success': True, 'latency_ms': 100})
+	status, top = _http_json('GET', f'{base_url}/top_k?mode=belief&k=2')
+	assert status == 200
+	assert isinstance(top, list) and len(top) == 2
+
+
+def test_http_recommend(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	for _ in range(3):
+		_http_json('POST', f'{base_url}/record', {'skill_id': 'good', 'success': True, 'latency_ms': 100})
+	_http_json('POST', f'{base_url}/record', {'skill_id': 'bad', 'success': False, 'error': 'e'})
+	# Default include_unseen=True keeps 'unseen' in the output.
+	status, out = _http_json(
+		'POST',
+		f'{base_url}/recommend',
+		{'candidates': ['good', 'bad', 'unseen'], 'min_score': 0.5},
+	)
+	assert status == 200
+	assert out == ['good', 'unseen']
+	# include_unseen=False drops it.
+	status, out = _http_json(
+		'POST',
+		f'{base_url}/recommend',
+		{'candidates': ['good', 'bad', 'unseen'], 'min_score': 0.5, 'include_unseen': False},
+	)
+	assert status == 200
+	assert out == ['good']
+	# Bad body → 400.
+	status, _ = _http_json('POST', f'{base_url}/recommend', {'candidates': 'not-a-list'})
+	assert status == 400
 
 
 def test_http_bad_input_returns_400(fitness_server) -> None:

--- a/tests/ci/test_skill_fitness.py
+++ b/tests/ci/test_skill_fitness.py
@@ -294,6 +294,28 @@ def test_cli_skips_malformed_lines(capsys: pytest.CaptureFixture[str]) -> None:
 	assert 'ok' in captured.out
 
 
+def test_standalone_entry_point_available() -> None:
+	"""Verify the `skill-fitness` console script is registered and dispatches to _cli.
+
+	Adds the value of this being installable via pipx/uvx as a standalone tool —
+	if this test fails, someone removed the entry point from pyproject.toml.
+	"""
+	import shutil
+
+	entry_path = shutil.which('skill-fitness')
+	if entry_path is None:
+		pytest.skip('skill-fitness entry point not on PATH (package not installed with -e)')
+	proc = subprocess.run(
+		[entry_path, '--help'],
+		capture_output=True,
+		text=True,
+		timeout=15,
+	)
+	assert proc.returncode == 0, proc.stderr
+	assert '--serve' in proc.stdout
+	assert '--mode' in proc.stdout
+
+
 def test_cli_via_subprocess_end_to_end(tmp_path: Path) -> None:
 	"""Real subprocess invocation — confirms `python -m browser_use.skills.fitness` works."""
 	stdin_text = '\n'.join(json.dumps({'skill_id': sid, 'success': True, 'latency_ms': 100}) for sid in ('alpha', 'beta'))
@@ -479,6 +501,100 @@ def test_http_recommend(fitness_server) -> None:
 	# Bad body → 400.
 	status, _ = _http_json('POST', f'{base_url}/recommend', {'candidates': 'not-a-list'})
 	assert status == 400
+
+
+def _http_raw(method: str, url: str, body: object | None = None) -> tuple[int, dict[str, str], bytes]:
+	data = None if body is None else json.dumps(body).encode('utf-8')
+	req = urllib.request.Request(url, data=data, method=method)
+	if data is not None:
+		req.add_header('Content-Type', 'application/json')
+	try:
+		with urllib.request.urlopen(req, timeout=5) as resp:
+			return resp.status, dict(resp.headers), resp.read()
+	except urllib.error.HTTPError as e:
+		return e.code, dict(e.headers), e.read()
+
+
+def test_http_ready_endpoint(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	status, body = _http_json('GET', f'{base_url}/ready')
+	assert status == 200
+	assert body == {'status': 'ready'}
+
+
+def test_http_metrics_prometheus_format(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	_http_json('POST', f'{base_url}/record', {'skill_id': 'a', 'success': True, 'latency_ms': 100})
+	_http_json('POST', f'{base_url}/record', {'skill_id': 'a', 'success': True, 'latency_ms': 100})
+	_http_json('POST', f'{base_url}/record', {'skill_id': 'b', 'success': False, 'error': 'boom'})
+	status, headers, body = _http_raw('GET', f'{base_url}/metrics')
+	assert status == 200
+	assert 'text/plain' in headers.get('Content-Type', '')
+	text = body.decode('utf-8')
+	# HELP + TYPE lines present per convention.
+	assert '# HELP skill_fitness_records_total' in text
+	assert '# TYPE skill_fitness_records_total counter' in text
+	assert 'skill_fitness_records_total 3' in text
+	assert 'skill_fitness_tracked_skills 2' in text
+	assert 'skill_fitness_invocations{skill="a"} 2' in text
+	assert 'skill_fitness_belief_high{skill="a"}' in text
+
+
+def test_http_metrics_escapes_label_values(fitness_server) -> None:
+	"""Prometheus label values need backslash/quote/newline escaping. Verify no injection."""
+	base_url, _, _ = fitness_server
+	tricky = 'name"with\\special\nchars'
+	_http_json('POST', f'{base_url}/record', {'skill_id': tricky, 'success': True, 'latency_ms': 100})
+	status, _, body = _http_raw('GET', f'{base_url}/metrics')
+	assert status == 200
+	text = body.decode('utf-8')
+	# Quote is escaped; newline is \n; backslash is \\.
+	assert 'skill_fitness_invocations{skill="name\\"with\\\\special\\nchars"}' in text
+
+
+def test_http_openapi_schema(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	status, spec = _http_json('GET', f'{base_url}/openapi.json')
+	assert status == 200
+	assert isinstance(spec, dict)
+	assert spec['openapi'].startswith('3.')  # type: ignore[index]
+	assert '/record' in spec['paths']  # type: ignore[index]
+	assert '/metrics' in spec['paths']  # type: ignore[index]
+	assert '/recommend' in spec['paths']  # type: ignore[index]
+
+
+def test_http_v1_alias_routes_to_same_handler(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	# /v1/health should behave identically to /health.
+	status, body = _http_json('GET', f'{base_url}/v1/health')
+	assert status == 200 and body == {'status': 'ok'}
+	# Also for a POST route.
+	status, _ = _http_json('POST', f'{base_url}/v1/record', {'skill_id': 'v1test', 'success': True, 'latency_ms': 50})
+	assert status == 200
+	# /v1/ranked returns the same shape.
+	status, ranked_v1 = _http_json('GET', f'{base_url}/v1/ranked?mode=belief')
+	assert status == 200 and isinstance(ranked_v1, list)
+	# 404 preserves original path with the /v1 prefix.
+	status, body = _http_json('GET', f'{base_url}/v1/does-not-exist')
+	assert status == 404
+
+
+def test_http_cors_on_get_endpoints(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	status, headers, _ = _http_raw('GET', f'{base_url}/health')
+	assert status == 200
+	assert headers.get('Access-Control-Allow-Origin') == '*'
+	assert 'GET' in headers.get('Access-Control-Allow-Methods', '')
+
+
+def test_http_options_preflight(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	status, headers, _ = _http_raw('OPTIONS', f'{base_url}/record')
+	assert status == 204
+	allow_methods = headers.get('Access-Control-Allow-Methods', '')
+	assert 'POST' in allow_methods
+	assert 'GET' in allow_methods
+	assert headers.get('Access-Control-Allow-Origin') == '*'
 
 
 def test_http_bad_input_returns_400(fitness_server) -> None:

--- a/tests/ci/test_skill_fitness.py
+++ b/tests/ci/test_skill_fitness.py
@@ -14,8 +14,13 @@ from __future__ import annotations
 
 import io
 import json
+import socket
 import subprocess
 import sys
+import threading
+import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -24,6 +29,7 @@ from browser_use.skills.fitness import (
 	MassFunction,
 	SkillFitnessTracker,
 	_cli,
+	_serve,
 	dempster_combine,
 	score_from_execution,
 )
@@ -288,6 +294,131 @@ def test_fitness_import_does_not_load_sdk() -> None:
 	)
 	assert proc.returncode == 0, proc.stderr
 	assert 'sdk_loaded=false' in proc.stdout, f'browser_use_sdk was loaded transitively: {proc.stdout}'
+
+
+def _find_free_port() -> int:
+	with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+		sock.bind(('127.0.0.1', 0))
+		return sock.getsockname()[1]
+
+
+def _http_json(method: str, url: str, body: object | None = None) -> tuple[int, object]:
+	data = None if body is None else json.dumps(body).encode('utf-8')
+	req = urllib.request.Request(url, data=data, method=method)
+	if data is not None:
+		req.add_header('Content-Type', 'application/json')
+	try:
+		with urllib.request.urlopen(req, timeout=5) as resp:
+			return resp.status, json.loads(resp.read().decode('utf-8'))
+	except urllib.error.HTTPError as e:
+		return e.code, json.loads(e.read().decode('utf-8'))
+
+
+@pytest.fixture
+def fitness_server(tmp_path: Path):
+	"""Start _serve on a free port in a background thread; yield (base_url, tracker, save_path)."""
+	tracker = SkillFitnessTracker()
+	port = _find_free_port()
+	save_path = tmp_path / 'state.json'
+	thread = threading.Thread(
+		target=_serve,
+		args=(tracker,),
+		kwargs={'host': '127.0.0.1', 'port': port, 'save_path': str(save_path)},
+		daemon=True,
+	)
+	thread.start()
+	# Poll /health until the server is up (500ms cap).
+	base_url = f'http://127.0.0.1:{port}'
+	deadline = time.monotonic() + 0.5
+	while time.monotonic() < deadline:
+		try:
+			status, _ = _http_json('GET', f'{base_url}/health')
+			if status == 200:
+				break
+		except (urllib.error.URLError, ConnectionRefusedError):
+			time.sleep(0.02)
+	else:
+		pytest.fail('fitness server did not become ready within 500ms')
+	yield base_url, tracker, save_path
+	# Best-effort shutdown — the thread is a daemon so it dies with the test process anyway.
+
+
+def test_http_health(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	status, body = _http_json('GET', f'{base_url}/health')
+	assert status == 200
+	assert body == {'status': 'ok'}
+
+
+def test_http_record_then_ranked_and_persist(fitness_server) -> None:
+	base_url, tracker, save_path = fitness_server
+	# Record three fast successes for 'reliable' and one failure for 'flaky'.
+	for _ in range(3):
+		status, mf = _http_json('POST', f'{base_url}/record', {'skill_id': 'reliable', 'success': True, 'latency_ms': 100})
+		assert status == 200
+		assert isinstance(mf, dict)
+	status, _ = _http_json('POST', f'{base_url}/record', {'skill_id': 'flaky', 'success': False, 'error': 'boom'})
+	assert status == 200
+	# Ranked endpoint puts reliable first under belief mode.
+	status, ranked = _http_json('GET', f'{base_url}/ranked?mode=belief')
+	assert status == 200
+	assert isinstance(ranked, list)
+	assert ranked[0][0] == 'reliable'
+	# Auto-persistence: save_path was written on every mutation.
+	saved = json.loads(save_path.read_text())
+	restored = SkillFitnessTracker.from_dict(saved)
+	assert restored.invocations('reliable') == 3
+	assert restored.invocations('flaky') == 1
+
+
+def test_http_fitness_endpoint_and_404(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	_http_json('POST', f'{base_url}/record', {'skill_id': 'seen', 'success': True, 'latency_ms': 100})
+	status, mf = _http_json('GET', f'{base_url}/fitness/seen')
+	assert status == 200
+	assert isinstance(mf, dict)
+	status, body = _http_json('GET', f'{base_url}/fitness/never-seen')
+	assert status == 404
+	assert 'unknown skill_id' in body['error']  # type: ignore[index]
+
+
+def test_http_state_get_and_replace(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	_http_json('POST', f'{base_url}/record', {'skill_id': 'a', 'success': True, 'latency_ms': 100})
+	status, state = _http_json('GET', f'{base_url}/state')
+	assert status == 200
+	assert 'a' in state['invocations']  # type: ignore[index]
+	# Replace state with a fresh snapshot.
+	fresh = SkillFitnessTracker()
+	fresh.record('b', success=True, latency_ms=200)
+	status, body = _http_json('POST', f'{base_url}/state', fresh.to_dict())
+	assert status == 200 and body == {'replaced': True}
+	status, state_after = _http_json('GET', f'{base_url}/state')
+	assert 'a' not in state_after['invocations']  # type: ignore[index]
+	assert 'b' in state_after['invocations']  # type: ignore[index]
+
+
+def test_http_reset(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	_http_json('POST', f'{base_url}/record', {'skill_id': 'x', 'success': True, 'latency_ms': 100})
+	status, body = _http_json('POST', f'{base_url}/reset')
+	assert status == 200 and body == {'reset': True}
+	status, ranked = _http_json('GET', f'{base_url}/ranked')
+	assert status == 200 and ranked == []
+
+
+def test_http_bad_input_returns_400(fitness_server) -> None:
+	base_url, _, _ = fitness_server
+	# Missing skill_id.
+	status, body = _http_json('POST', f'{base_url}/record', {'success': True})
+	assert status == 400
+	assert 'skill_id' in body['error']  # type: ignore[index]
+	# Unknown mode.
+	status, body = _http_json('GET', f'{base_url}/ranked?mode=nonsense')
+	assert status == 400
+	# Unknown route.
+	status, _ = _http_json('GET', f'{base_url}/does-not-exist')
+	assert status == 404
 
 
 def test_service_exposes_fitness_and_ranking(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/ci/test_skill_fitness.py
+++ b/tests/ci/test_skill_fitness.py
@@ -1,0 +1,165 @@
+"""Tests for the Dempster-Shafer skill-fitness accumulator.
+
+Real objects, no mocks — the fitness math is pure Python and deterministic.
+Covers:
+  - MassFunction normalisation + belief/plausibility/expected axes
+  - from_score confidence gating (0 → pure ignorance, 1 → point mass on singleton)
+  - Dempster combination reinforces agreeing observations
+  - Dempster combination on total conflict falls back to maximum-ignorance
+  - SkillFitnessTracker accumulates + ranks under all three selection modes
+  - SkillService wiring records every execution result
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from browser_use.skills.fitness import (
+	MassFunction,
+	SkillFitnessTracker,
+	dempster_combine,
+	score_from_execution,
+)
+
+_HIGH = frozenset({'HIGH'})
+_LOW = frozenset({'LOW'})
+_FULL = frozenset({'LOW', 'MID', 'HIGH'})
+
+
+def test_mass_function_normalises_to_unit() -> None:
+	m = MassFunction({_HIGH: 2.0, _FULL: 2.0})
+	assert abs(sum(m.masses.values()) - 1.0) < 1e-9
+	assert m.masses[_HIGH] == pytest.approx(0.5)
+	assert m.masses[_FULL] == pytest.approx(0.5)
+
+
+def test_mass_function_empty_collapses_to_max_ignorance() -> None:
+	m = MassFunction({})
+	assert m.masses == {_FULL: 1.0}
+	assert m.belief() == 0.0
+	assert m.plausibility() == 1.0
+
+
+def test_from_score_confidence_gates_ignorance() -> None:
+	certain = MassFunction.from_score(0.9, confidence=1.0)
+	assert certain.masses.get(_HIGH) == pytest.approx(1.0)
+	assert certain.belief() == pytest.approx(1.0)
+	assert certain.plausibility() == pytest.approx(1.0)
+
+	ignorant = MassFunction.from_score(0.9, confidence=0.0)
+	assert ignorant.masses.get(_FULL) == pytest.approx(1.0)
+	assert ignorant.belief() == 0.0
+	assert ignorant.plausibility() == pytest.approx(1.0)
+
+	mid = MassFunction.from_score(0.5, confidence=0.6)
+	assert mid.belief(frozenset({'MID'})) == pytest.approx(0.6)
+
+
+def test_score_boundaries_partition_correctly() -> None:
+	low = MassFunction.from_score(0.0, confidence=1.0)
+	assert _LOW in low.masses
+	mid = MassFunction.from_score(0.5, confidence=1.0)
+	assert frozenset({'MID'}) in mid.masses
+	high = MassFunction.from_score(1.0, confidence=1.0)
+	assert _HIGH in high.masses
+
+
+def test_dempster_reinforces_agreement() -> None:
+	m1 = MassFunction.from_score(0.9, confidence=0.6)
+	m2 = MassFunction.from_score(0.9, confidence=0.6)
+	combined = dempster_combine(m1, m2)
+	# Two independent HIGH observations should push belief above either alone.
+	assert combined.belief() > m1.belief()
+	assert combined.belief() > 0.6
+
+
+def test_dempster_total_conflict_reverts_to_ignorance() -> None:
+	high_certain = MassFunction({_HIGH: 1.0})
+	low_certain = MassFunction({_LOW: 1.0})
+	combined = dempster_combine(high_certain, low_certain)
+	# No mass on a shared subset → norm = 0 → fall back to full-frame ignorance.
+	assert combined.masses == {_FULL: 1.0}
+
+
+def test_score_from_execution_success_high_confidence_when_fast() -> None:
+	score, confidence = score_from_execution(success=True, latency_ms=100, error=None)
+	assert score >= 0.8
+	assert confidence >= 0.9
+
+
+def test_score_from_execution_failure_low_score() -> None:
+	score, confidence = score_from_execution(success=False, latency_ms=None, error='boom')
+	assert score < 0.3
+	assert 0.5 < confidence < 1.0
+
+
+def test_tracker_accumulates_belief_across_calls() -> None:
+	tracker = SkillFitnessTracker()
+	assert tracker.fitness('skill-a') is None
+	assert tracker.invocations('skill-a') == 0
+
+	for _ in range(3):
+		tracker.record('skill-a', success=True, latency_ms=200)
+	fitness = tracker.fitness('skill-a')
+	assert fitness is not None
+	# Three fast successes should give near-certain HIGH belief.
+	assert fitness.belief() > 0.85
+	assert tracker.invocations('skill-a') == 3
+
+
+def test_tracker_ranks_by_selection_mode() -> None:
+	tracker = SkillFitnessTracker()
+	# Reliable skill: three fast successes.
+	for _ in range(3):
+		tracker.record('reliable', success=True, latency_ms=100)
+	# Noisy skill: one success then one failure — high conflict, low belief but wide plausibility.
+	tracker.record('noisy', success=True, latency_ms=100)
+	tracker.record('noisy', success=False, error='transient')
+	# Untried skill: never recorded.
+	# Cold skill: one moderate-latency success.
+	tracker.record('cold', success=True, latency_ms=5_000)
+
+	belief_ranked = tracker.ranked('belief')
+	plausibility_ranked = tracker.ranked('plausibility')
+	expected_ranked = tracker.ranked('expected')
+
+	# All three modes should list reliable first.
+	assert belief_ranked[0][0] == 'reliable'
+	assert plausibility_ranked[0][0] == 'reliable'
+	assert expected_ranked[0][0] == 'reliable'
+
+	# Rankings are proper permutations of what was recorded.
+	assert {name for name, _ in belief_ranked} == {'reliable', 'noisy', 'cold'}
+
+
+def test_tracker_reset_clears_state() -> None:
+	tracker = SkillFitnessTracker()
+	tracker.record('x', success=True, latency_ms=100)
+	assert tracker.fitness('x') is not None
+	tracker.reset()
+	assert tracker.fitness('x') is None
+	assert tracker.invocations('x') == 0
+	assert tracker.ranked() == []
+
+
+def test_service_exposes_fitness_and_ranking(monkeypatch: pytest.MonkeyPatch) -> None:
+	"""SkillService should expose fitness() and ranked_by_fitness() and populate on record."""
+	monkeypatch.setenv('BROWSER_USE_API_KEY', 'test-not-called')
+	from browser_use.skills import SkillService
+
+	svc = SkillService(skill_ids=['abc'])
+	# No calls yet.
+	assert svc.fitness('abc') is None
+	assert svc.ranked_by_fitness() == []
+
+	# Simulate what execute_skill's tail would do — feed the tracker directly.
+	svc._fitness_tracker.record('abc', success=True, latency_ms=250)
+	svc._fitness_tracker.record('abc', success=True, latency_ms=250)
+	mf = svc.fitness('abc')
+	assert mf is not None
+	assert mf.belief() > 0.6
+
+	svc._fitness_tracker.record('def', success=False, error='blocked')
+	ranking = svc.ranked_by_fitness('belief')
+	names = [name for name, _ in ranking]
+	assert names.index('abc') < names.index('def')

--- a/tests/ci/test_skill_fitness.py
+++ b/tests/ci/test_skill_fitness.py
@@ -22,6 +22,7 @@ import time
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -419,6 +420,83 @@ def test_http_bad_input_returns_400(fitness_server) -> None:
 	# Unknown route.
 	status, _ = _http_json('GET', f'{base_url}/does-not-exist')
 	assert status == 404
+
+
+def test_agent_record_action_fitness_success() -> None:
+	"""The Agent._record_action_fitness helper feeds the tracker on success."""
+	from browser_use.agent.service import Agent
+	from browser_use.agent.views import ActionResult
+
+	tracker = SkillFitnessTracker()
+
+	class _Shim:
+		action_fitness_tracker = tracker
+
+	# 250ms fake latency by lying about the start timestamp.
+	start_ns = time.perf_counter_ns() - 250 * 1_000_000
+	result = ActionResult(extracted_content='ok')
+	# Agent._record_action_fitness reads only self.action_fitness_tracker — safe to call unbound.
+	Agent._record_action_fitness(cast(Any, _Shim()), 'click_by_index', result, start_ns)
+
+	mf = tracker.fitness('click_by_index')
+	assert mf is not None
+	assert mf.belief() > 0.5
+	assert tracker.invocations('click_by_index') == 1
+
+
+def test_agent_record_action_fitness_soft_failure() -> None:
+	"""ActionResult.error set → tracker records a failure without an exception path."""
+	from browser_use.agent.service import Agent
+	from browser_use.agent.views import ActionResult
+
+	tracker = SkillFitnessTracker()
+
+	class _Shim:
+		action_fitness_tracker = tracker
+
+	Agent._record_action_fitness(
+		cast(Any, _Shim()),
+		'extract_content',
+		ActionResult(error='no matching element'),
+		time.perf_counter_ns(),
+	)
+	mf = tracker.fitness('extract_content')
+	assert mf is not None
+	# Failure → LOW singleton dominates → HIGH belief must be near zero.
+	assert mf.belief() < 0.1
+
+
+def test_agent_record_action_fitness_hard_exception() -> None:
+	"""The exception path records with the exception's type + message."""
+	from browser_use.agent.service import Agent
+
+	tracker = SkillFitnessTracker()
+
+	class _Shim:
+		action_fitness_tracker = tracker
+
+	Agent._record_action_fitness(
+		cast(Any, _Shim()),
+		'unstable_skill',
+		None,
+		time.perf_counter_ns(),
+		exc=RuntimeError('kaboom'),
+	)
+	mf = tracker.fitness('unstable_skill')
+	assert mf is not None
+	assert tracker.invocations('unstable_skill') == 1
+
+
+def test_agent_record_action_fitness_no_tracker_is_noop() -> None:
+	"""When action_fitness_tracker is None, the helper is a zero-cost no-op."""
+	from browser_use.agent.service import Agent
+	from browser_use.agent.views import ActionResult
+
+	class _Shim:
+		action_fitness_tracker = None
+
+	# Should not raise.
+	Agent._record_action_fitness(cast(Any, _Shim()), 'anything', ActionResult(), time.perf_counter_ns())
 
 
 def test_service_exposes_fitness_and_ranking(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Dempster–Shafer skill fitness tracker with a CLI/HTTP service and wires it into the Agent and `SkillService` to score and rank actions by reliability. Enables safer tool selection with Prometheus metrics and OpenAPI, with zero new dependencies.

- **New Features**
  - New `SkillFitnessTracker` in `browser_use.skills.fitness` with belief/plausibility/expected ranking, JSON round‑trip, and `top_k`/`recommend`.
  - New `skill-fitness` console tool: CLI and stdlib HTTP server with `/health`, `/ready`, `/record`, `/ranked`, `/top_k`, `/recommend`, `/fitness/<id>`, `/state`, `/reset`, `/metrics`, `/openapi.json`, and `/v1/*` aliases; CORS and optional on-disk persistence.
  - Agent opt‑in `action_fitness_tracker` to record per‑action outcomes (success, latency, errors) during `multi_act`.
  - `SkillService` now records outcomes and exposes `fitness(skill_id)` and `ranked_by_fitness(mode)`; README documents installs (pipx/uvx/pip/Docker/systemd/launchd/Windows) and use cases; added end‑to‑end tests for math, CLI, HTTP, and Agent wiring.

- **Refactors**
  - `SkillService.execute_skill`: normalize params once, inject/validate cookies, improve pydantic error messages, and raise `MissingCookieException` by class; `close()` now calls `AsyncBrowserUse.close()`.
  - Agent skill handler simplified and now catches `MissingCookieException`; action timing recorded once and fed to `_record_action_fitness` on success and exceptions.
  - `browser_use/skills/__init__.py` and `skill_cli/__init__.py`: lazy exports with `TYPE_CHECKING` to keep cold imports lean.

<sup>Written for commit 76e792fca2af2948dfba1032b8e147aadf7d873b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

