### PR TITLE
fix(tools): report action failures via ActionResult.error (#5361)

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -786,7 +786,8 @@ class Tools(Generic[Context]):
 			if node is None:
 				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				# Must set error= so multi_act aborts remaining actions and consecutive_failures increments
+				return ActionResult(error=msg)
 
 			# Highlight the element being typed into (truly non-blocking)
 			create_task_with_error_handling(
@@ -1411,7 +1412,8 @@ You will be given a query and the markdown of a webpage that has been filtered t
 					num_full_pages = int(params.pages)
 					remaining_fraction = params.pages - num_full_pages
 
-					completed_scrolls = 0
+					completed_scrolls = 0.0
+					last_scroll_error: Exception | None = None
 
 					# Scroll one page at a time
 					for i in range(num_full_pages):
@@ -1431,6 +1433,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 							await asyncio.sleep(0.15)
 
 						except Exception as e:
+							last_scroll_error = e
 							logger.warning(f'Scroll {i + 1}/{num_full_pages} failed: {e}')
 							# Continue with remaining scrolls even if one fails
 
@@ -1449,7 +1452,16 @@ You will be given a query and the markdown of a webpage that has been filtered t
 							completed_scrolls += remaining_fraction
 
 						except Exception as e:
+							last_scroll_error = e
 							logger.warning(f'Fractional scroll failed: {e}')
+
+					# Zero completed scrolls is a total failure — report error so multi_act / consecutive_failures react.
+					# Default pages=1.0 used to always claim success even when every attempt failed.
+					if completed_scrolls == 0:
+						detail = f': {last_scroll_error}' if last_scroll_error else ''
+						error_msg = f'Failed to scroll {direction}{(" " + target) if target else ""}{detail}'.strip()
+						logger.error(error_msg)
+						return ActionResult(error=error_msg)
 
 					if params.pages == 1.0:
 						long_term_memory = f'Scrolled {direction} {target} {viewport_height}px'.replace('  ', ' ')
@@ -1470,7 +1482,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 				return ActionResult(extracted_content=msg, long_term_memory=long_term_memory)
 			except Exception as e:
 				logger.error(f'Failed to dispatch ScrollEvent: {type(e).__name__}: {e}')
-				error_msg = 'Failed to execute scroll action.'
+				error_msg = f'Failed to execute scroll action: {e}'
 				return ActionResult(error=error_msg)
 
 		@self.registry.action(
@@ -1498,20 +1510,30 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			event = browser_session.event_bus.dispatch(ScrollToTextEvent(text=text))
 
 			try:
-				# The handler returns None on success or raises an exception if text not found
+				# The handler returns None on success or raises BrowserError if text not found
 				await event.event_result(raise_if_any=True, raise_if_none=False)
 				memory = f'Scrolled to text: {text}'
 				msg = f'🔍  {memory}'
 				logger.info(msg)
 				return ActionResult(extracted_content=memory, long_term_memory=memory)
+			except BrowserError as e:
+				# Legitimate negative result: text is simply not on the page (non-error for LLM planning)
+				if e.message.startswith('Text not found'):
+					msg = f"Text '{text}' not found or not visible on page"
+					logger.info(msg)
+					return ActionResult(
+						extracted_content=msg,
+						long_term_memory=f"Tried scrolling to text '{text}' but it was not found",
+					)
+				# Other BrowserErrors (stale node, CDP policy, etc.) are real failures
+				error_msg = f"Failed to scroll to text '{text}': {e.message}"
+				logger.error(error_msg)
+				return ActionResult(error=error_msg)
 			except Exception as e:
-				# Text not found
-				msg = f"Text '{text}' not found or not visible on page"
-				logger.info(msg)
-				return ActionResult(
-					extracted_content=msg,
-					long_term_memory=f"Tried scrolling to text '{text}' but it was not found",
-				)
+				# CDP/transport/unexpected failures must set error= so the agent loop reacts
+				error_msg = f"Failed to scroll to text '{text}': {type(e).__name__}: {e}"
+				logger.error(error_msg)
+				return ActionResult(error=error_msg)
 
 		@self.registry.action(
 			'Take a screenshot of the current viewport. If file_name is provided, saves to that file and returns the path. '

--- a/tests/ci/test_action_failure_error_reporting.py
+++ b/tests/ci/test_action_failure_error_reporting.py
@@ -1,0 +1,173 @@
+"""Regression tests for #5361: failed scroll/input/find_text must set ActionResult.error.
+
+The agent loop keys off ActionResult.error:
+- multi_act() aborts the remaining action queue when results[-1].error is set
+- _post_process() increments consecutive_failures only when error is set
+
+If tools report total failure as success (error=None), the LLM is fed a false
+premise and max_failures never trips.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from browser_use.browser.views import BrowserError
+from browser_use.tools.service import Tools
+from browser_use.tools.views import InputTextAction, ScrollAction
+
+
+class _BoomEvent:
+	"""Event whose event_result always raises — models a broken CDP dispatch."""
+
+	def __init__(self, message: str = 'CDP scroll dispatch failed'):
+		self._message = message
+
+	def __await__(self):
+		async def _complete():
+			return self
+
+		return _complete().__await__()
+
+	async def event_result(self, **_kwargs: Any) -> None:
+		raise RuntimeError(self._message)
+
+
+class _SuccessEvent:
+	"""Event that resolves cleanly (no error)."""
+
+	def __await__(self):
+		async def _complete():
+			return self
+
+		return _complete().__await__()
+
+	async def event_result(self, **_kwargs: Any) -> None:
+		return None
+
+
+class _BoomBus:
+	def dispatch(self, _ev: Any) -> _BoomEvent:
+		return _BoomEvent()
+
+
+class _ConfigurableBus:
+	"""Bus that can return boom or BrowserError / success results per call."""
+
+	def __init__(self, factory):
+		self._factory = factory
+
+	def dispatch(self, _ev: Any):
+		return self._factory()
+
+
+class _FakeSession:
+	"""Minimal browser_session stub for action-handler unit tests."""
+
+	def __init__(self, event_bus: Any | None = None, element: Any | None = object()):
+		self.event_bus = event_bus if event_bus is not None else _BoomBus()
+		self._element = element
+
+	async def get_element_by_index(self, _index: int) -> Any | None:
+		return self._element
+
+	async def get_or_create_cdp_session(self) -> Any:
+		raise RuntimeError('no cdp')
+
+
+def _action_fn(tools: Tools, name: str):
+	return tools.registry.registry.actions[name].function
+
+
+async def test_scroll_default_pages_reports_error_when_all_scrolls_fail():
+	"""pages=1.0 (default) used to claim success after every scroll attempt failed."""
+	tools = Tools()
+	scroll = _action_fn(tools, 'scroll')
+	session = _FakeSession(event_bus=_BoomBus())
+
+	# Avoid slow asyncio.sleep(0.15) between multi-page iterations: pages=1.0 loops once.
+	result = await scroll(params=ScrollAction(down=True, pages=1.0), browser_session=session)
+
+	assert result.error is not None, f'expected error, got memory={result.long_term_memory!r}'
+	assert 'scroll' in result.error.lower()
+	assert result.long_term_memory is None or 'Scrolled' not in (result.long_term_memory or '')
+
+
+async def test_scroll_multi_page_total_failure_reports_error():
+	"""pages=3.0 with zero completed scrolls must set error= (not 'Scrolled 0.0 pages')."""
+	tools = Tools()
+	scroll = _action_fn(tools, 'scroll')
+	result = await scroll(
+		params=ScrollAction(down=True, pages=3.0),
+		browser_session=_FakeSession(event_bus=_BoomBus()),
+	)
+
+	assert result.error is not None
+	assert '0.0 pages' not in (result.extracted_content or '')
+	assert '0.0 pages' not in (result.long_term_memory or '')
+
+
+async def test_scroll_fractional_page_failure_reports_error():
+	"""pages<1.0 already went through the outer except; keep that contract."""
+	tools = Tools()
+	scroll = _action_fn(tools, 'scroll')
+	result = await scroll(
+		params=ScrollAction(down=True, pages=0.5),
+		browser_session=_FakeSession(event_bus=_BoomBus()),
+	)
+
+	assert result.error is not None
+	assert 'scroll' in result.error.lower()
+
+
+async def test_input_missing_index_reports_error():
+	"""Stale element index must set error= so a queued submit click is aborted."""
+	tools = Tools()
+	input_fn = _action_fn(tools, 'input')
+	session = _FakeSession(element=None)
+
+	result = await input_fn(
+		params=InputTextAction(index=42, text='hello'),
+		browser_session=session,
+	)
+
+	assert result.error is not None
+	assert '42' in result.error
+	assert result.extracted_content is None or result.error
+
+
+async def test_find_text_cdp_failure_reports_error():
+	"""CDP/transport failures during scroll-to-text must set error=."""
+	tools = Tools()
+	find_text = _action_fn(tools, 'find_text')
+	session = _FakeSession(event_bus=_BoomBus())
+
+	result = await find_text(text='needle', browser_session=session)
+
+	assert result.error is not None
+	assert 'needle' in result.error
+	assert 'not found or not visible' not in (result.extracted_content or '')
+
+
+async def test_find_text_not_found_is_non_error_negative_result():
+	"""Genuine 'text not on page' stays a non-error result for LLM planning."""
+
+	class _NotFoundEvent:
+		def __await__(self):
+			async def _complete():
+				return self
+
+			return _complete().__await__()
+
+		async def event_result(self, **_kwargs: Any) -> None:
+			raise BrowserError('Text not found: "needle"', details={'text': 'needle'})
+
+	tools = Tools()
+	find_text = _action_fn(tools, 'find_text')
+	session = _FakeSession(event_bus=_ConfigurableBus(lambda: _NotFoundEvent()))
+
+	result = await find_text(text='needle', browser_session=session)
+
+	assert result.error is None
+	assert result.extracted_content is not None
+	assert 'not found' in result.extracted_content.lower()


### PR DESCRIPTION
## Summary
- `scroll` / `input` / `find_text` set `ActionResult.error` on real failures
- Regression tests in `tests/ci/test_action_failure_error_reporting.py`

Fixes #5361

## Test plan
- [x] `uv run pytest -vxs tests/ci/test_action_failure_error_reporting.py` (6 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `scroll`, `input`, and `find_text` set `ActionResult.error` on real failures so the agent aborts remaining actions and `consecutive_failures` increments as expected. Fixes #5361.

- **Bug Fixes**
  - `input`: return `error` when the target element index is missing/stale.
  - `scroll`: track completed pages and return `error` if all attempts fail; include last exception in the message and improve dispatch error text.
  - `find_text`: keep “Text not found” as a non-error result; return `error` for other `BrowserError`/CDP failures with details.

<sup>Written for commit 01a058565868be77decd088dc0ebf8c0d01113da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

