### PR TITLE
fix(browser): stop leaking temp directories on every BrowserProfile() construction

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -476,7 +476,10 @@ class BrowserLaunchArgs(BaseModel):
 				downloads_path = Path(tempfile.gettempdir()) / f'browser-use-downloads-{unique_id}'
 
 			self.downloads_path = downloads_path
-			self.downloads_path.mkdir(parents=True, exist_ok=True)
+			# NOTE: Do not mkdir here. The DownloadsWatchdog creates the
+			# directory when a browser actually launches, avoiding leaked
+			# temp dirs when BrowserProfile is constructed but never used
+			# (e.g. the module-level DEFAULT_BROWSER_PROFILE).
 		return self
 
 	@staticmethod

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -170,10 +170,21 @@ class LocalBrowserWatchdog(BaseWatchdog):
 						pass
 
 				# Keep only the in-use directory for cleanup during browser kill
-				if currently_used_dir and 'browseruse-tmp-' in currently_used_dir:
+				if currently_used_dir and any(
+					prefix in currently_used_dir
+					for prefix in self._TEMP_DIR_PREFIXES
+				):
 					self._temp_dirs_to_cleanup = [Path(currently_used_dir)]
 				else:
 					self._temp_dirs_to_cleanup = []
+
+				# Also track the downloads temp dir for cleanup
+				downloads_dir = str(profile.downloads_path) if profile.downloads_path else None
+				if downloads_dir and any(
+					prefix in downloads_dir
+					for prefix in self._TEMP_DIR_PREFIXES
+				):
+					self._temp_dirs_to_cleanup.append(Path(downloads_dir))
 
 				return process, cdp_url
 
@@ -460,6 +471,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			# Ignore any other errors during cleanup
 			pass
 
+	# Prefixes used by browser-use when creating temporary directories
+	_TEMP_DIR_PREFIXES = ('browseruse-tmp-', 'browser-use-user-data-dir-', 'browser-use-downloads-')
+
 	def _cleanup_temp_dir(self, temp_dir: Path | str) -> None:
 		"""Clean up temporary directory.
 
@@ -472,7 +486,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		try:
 			temp_path = Path(temp_dir)
 			# Only remove if it's actually a temp directory we created
-			if 'browseruse-tmp-' in str(temp_path):
+			if any(prefix in temp_path.name for prefix in self._TEMP_DIR_PREFIXES):
 				shutil.rmtree(temp_path, ignore_errors=True)
 		except Exception as e:
 			self.logger.debug(f'Failed to cleanup temp dir {temp_dir}: {e}')

--- a/tests/ci/test_temp_dir_leak.py
+++ b/tests/ci/test_temp_dir_leak.py
@@ -1,0 +1,97 @@
+"""Tests for browser-use temp directory leak fix (issue #5422).
+
+Validates that:
+1. BrowserProfile construction no longer eagerly creates downloads temp dirs.
+2. The watchdog cleanup recognises all browser-use temp dir prefixes.
+3. Downloads temp dirs are tracked for cleanup on browser kill.
+"""
+
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. BrowserProfile no longer calls mkdir during construction
+# ---------------------------------------------------------------------------
+
+class TestBrowserProfileNoEagerMkdir:
+    """set_default_downloads_path must assign a path without creating it."""
+
+    def test_default_downloads_path_not_created_on_disk(self):
+        """Constructing BrowserProfile() should NOT create the downloads dir."""
+        from browser_use.browser.profile import BrowserProfile
+
+        profile = BrowserProfile()
+        downloads = Path(profile.downloads_path)
+        # The path should be set but NOT exist on disk
+        assert str(downloads).startswith(str(Path(tempfile.gettempdir())))
+        assert 'browser-use-downloads-' in downloads.name
+        assert not downloads.exists(), (
+            f"Downloads dir {downloads} should not be created eagerly"
+        )
+
+    def test_explicit_downloads_path_untouched(self):
+        """When the user supplies a downloads_path, we must not touch it."""
+        from browser_use.browser.profile import BrowserProfile
+
+        custom = Path(tempfile.gettempdir()) / "my-custom-downloads"
+        profile = BrowserProfile(downloads_path=str(custom))
+        assert Path(profile.downloads_path) == custom
+
+
+# ---------------------------------------------------------------------------
+# 2. Watchdog _cleanup_temp_dir recognises all prefixes
+# ---------------------------------------------------------------------------
+
+class TestCleanupTempDirPrefixes:
+    """_cleanup_temp_dir must clean dirs with any browser-use prefix."""
+
+    def _make_watchdog(self):
+        from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+        wd = LocalBrowserWatchdog.__new__(LocalBrowserWatchdog)
+        wd.logger = MagicMock()
+        return wd
+
+    @pytest.mark.parametrize("prefix", [
+        "browseruse-tmp-",
+        "browser-use-user-data-dir-",
+        "browser-use-downloads-",
+    ])
+    def test_recognised_prefixes_are_cleaned(self, prefix, tmp_path):
+        wd = self._make_watchdog()
+        target = tmp_path / f"{prefix}abcd1234"
+        target.mkdir()
+        (target / "somefile.txt").write_text("data")
+
+        wd._cleanup_temp_dir(target)
+        assert not target.exists(), f"Dir with prefix '{prefix}' should be removed"
+
+    def test_non_matching_prefix_not_cleaned(self, tmp_path):
+        wd = self._make_watchdog()
+        target = tmp_path / "important-data-dir"
+        target.mkdir()
+        (target / "keep.txt").write_text("important")
+
+        wd._cleanup_temp_dir(target)
+        assert target.exists(), "Dir without browser-use prefix must NOT be removed"
+
+    def test_empty_path_is_noop(self):
+        wd = self._make_watchdog()
+        wd._cleanup_temp_dir("")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# 3. _TEMP_DIR_PREFIXES constant is defined
+# ---------------------------------------------------------------------------
+
+class TestTempDirPrefixesConstant:
+    def test_constant_exists_and_has_all_prefixes(self):
+        from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+        prefixes = LocalBrowserWatchdog._TEMP_DIR_PREFIXES
+        assert 'browseruse-tmp-' in prefixes
+        assert 'browser-use-user-data-dir-' in prefixes
+        assert 'browser-use-downloads-' in prefixes


### PR DESCRIPTION
## Problem

Every `BrowserProfile()` construction creates a downloads temp directory on disk via `mkdir()` in the `set_default_downloads_path` model validator. These directories are never cleaned up because:

1. **Eager `mkdir()` in the validator** — the `DownloadsWatchdog.on_BrowserLaunchEvent()` already creates the downloads directory when a browser is actually launched (line 190 of `downloads_watchdog.py`), so the `mkdir` in the validator is redundant. The module-level `DEFAULT_BROWSER_PROFILE = BrowserProfile()` in `session.py` triggers this at import time, creating a leaked directory on every process start.

2. **Watchdog cleanup only matches `browseruse-tmp-` prefix** — the `_cleanup_temp_dir()` method in `LocalBrowserWatchdog` only removes directories whose path contains `'browseruse-tmp-'`, but the actual temp directories use `'browser-use-downloads-'` and `'browser-use-user-data-dir-'` prefixes. This means they are never cleaned up even when the browser is properly killed.

3. **Downloads temp dir not tracked for cleanup** — even if the prefix matched, the downloads directory was never added to `_temp_dirs_to_cleanup`, so it would be skipped during browser kill cleanup.

Users have reported 7,741+ orphaned directories totalling 14GB in their `$TMPDIR`.

## Fix

- **Remove the eager `mkdir()`** from `set_default_downloads_path` — assign the path only. The `DownloadsWatchdog` handles directory creation when a browser session actually starts.
- **Add `_TEMP_DIR_PREFIXES` class constant** listing all three prefixes: `browseruse-tmp-`, `browser-use-user-data-dir-`, `browser-use-downloads-`.
- **Update `_cleanup_temp_dir()`** to match against all known prefixes instead of just `browseruse-tmp-`.
- **Track downloads temp dir** in `_temp_dirs_to_cleanup` during browser launch so it gets cleaned up on browser kill.

## Testing

6 tests in `tests/ci/test_temp_dir_leak.py`:
- `TestBrowserProfileNoEagerMkdir`: verifies construction does not create the directory on disk, and explicit paths are untouched
- `TestCleanupTempDirPrefixes`: verifies all three prefixes are recognised and cleaned, non-matching dirs are left alone, empty paths are a no-op
- `TestTempDirPrefixesConstant`: verifies the constant contains all expected prefixes

Closes #5422

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops leaking temp directories by removing eager creation in `BrowserProfile()` and ensuring the watchdog tracks and cleans all temp dirs. Prevents orphaned downloads and user-data dirs and reduces disk usage.

- **Bug Fixes**
  - Removed eager `mkdir()` in `set_default_downloads_path`; `DownloadsWatchdog` creates the dir on browser launch.
  - Added `_TEMP_DIR_PREFIXES` and updated `_cleanup_temp_dir()` to handle `browseruse-tmp-`, `browser-use-user-data-dir-`, and `browser-use-downloads-`.
  - Tracked the downloads temp dir in `_temp_dirs_to_cleanup` so it’s removed on browser kill.

<sup>Written for commit d5a8e6c3940e137df990c07d79e7857bee6b4d86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

