### PR TITLE
fix(session): re-schedule reconnect when WebSocket drops during reconnect window

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -587,6 +587,7 @@ class BrowserSession(BaseModel):
 	# Default: 3 * 15s + (1+2+4)s + 2s = 54s
 	RECONNECT_WAIT_TIMEOUT: float = 54.0
 	_reconnecting: bool = PrivateAttr(default=False)
+	_drop_during_reconnect: bool = PrivateAttr(default=False)
 	_reconnect_event: asyncio.Event = PrivateAttr(default_factory=asyncio.Event)
 	_reconnect_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
 	_reconnect_task: asyncio.Task | None = PrivateAttr(default=None)
@@ -2246,6 +2247,7 @@ class BrowserSession(BaseModel):
 			if self._reconnecting:
 				return  # already in progress from another caller
 			self._reconnecting = True
+			self._drop_during_reconnect = False
 			self._reconnect_event.clear()
 
 		start_time = time.time()
@@ -2294,6 +2296,18 @@ class BrowserSession(BaseModel):
 			self._reconnecting = False
 			self._reconnect_event.set()  # wake up all waiters regardless of outcome
 
+			# If a WS drop arrived while we were reconnecting, the one-shot
+			# done_callback could not schedule a new reconnect (it saw
+			# _reconnecting=True).  Re-schedule now so the drop is not lost.
+			if self._drop_during_reconnect:
+				self._drop_during_reconnect = False
+				self.logger.info('🔄 WebSocket drop occurred during reconnect window — scheduling another reconnect')
+				try:
+					loop = asyncio.get_running_loop()
+					self._reconnect_task = loop.create_task(self._auto_reconnect())
+				except RuntimeError:
+					self.logger.error('🔌 No event loop available for re-scheduled auto-reconnect')
+
 	def _attach_ws_drop_callback(self) -> None:
 		"""Attach a done callback to the CDPClient's message handler task to detect WS drops."""
 		if not self._cdp_client_root or not hasattr(self._cdp_client_root, '_message_handler_task'):
@@ -2304,8 +2318,15 @@ class BrowserSession(BaseModel):
 			return
 
 		def _on_message_handler_done(fut: asyncio.Future) -> None:
-			# Guard: skip if intentionally stopped, already reconnecting, or no cdp_url
-			if self._intentional_stop or self._reconnecting or not self.cdp_url:
+			# Guard: skip if intentionally stopped or no cdp_url
+			if self._intentional_stop or not self.cdp_url:
+				return
+
+			# If a reconnect is already in progress, record the drop so the
+			# finally block in _auto_reconnect can re-schedule.
+			if self._reconnecting:
+				self._drop_during_reconnect = True
+				self.logger.debug('🔌 WebSocket drop detected during reconnect window — flagged for re-schedule')
 				return
 
 			# The message handler task exiting means the WS connection dropped

--- a/tests/ci/test_ws_drop_during_reconnect.py
+++ b/tests/ci/test_ws_drop_during_reconnect.py
@@ -1,0 +1,151 @@
+"""Tests for WebSocket drop detection during the reconnect window.
+
+Verifies fix for issue #5366: when a CDP WebSocket drops while
+_auto_reconnect() is in progress (_reconnecting=True), the one-shot
+done_callback must not silently discard the event.  Instead it sets
+_drop_during_reconnect so the finally block can re-schedule.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from browser_use.browser.session import BrowserSession
+
+
+@pytest.fixture
+def session() -> BrowserSession:
+    """Create a minimal BrowserSession for unit testing."""
+    s = BrowserSession(cdp_url='ws://localhost:9222/devtools/browser/fake')
+    s._intentional_stop = False
+    return s
+
+
+class TestDropDuringReconnectFlag:
+    """The done_callback sets _drop_during_reconnect when _reconnecting is True."""
+
+    async def test_flag_set_when_drop_during_reconnect(self, session: BrowserSession) -> None:
+        """When the callback fires while _reconnecting=True, the flag must be set."""
+        session._reconnecting = True
+        session._drop_during_reconnect = False
+
+        # Build a mock CDPClient with a live Future as its _message_handler_task
+        mock_task = asyncio.get_running_loop().create_future()
+        mock_cdp = MagicMock()
+        mock_cdp._message_handler_task = mock_task
+        session._cdp_client_root = mock_cdp
+
+        session._attach_ws_drop_callback()
+
+        # Complete the task to simulate a WS drop — the callback should fire
+        mock_task.set_result(None)
+        await asyncio.sleep(0)
+
+        assert session._drop_during_reconnect is True, (
+            '_drop_during_reconnect should be True after a drop while _reconnecting=True'
+        )
+
+    async def test_flag_not_set_when_intentional_stop(self, session: BrowserSession) -> None:
+        """When _intentional_stop is True, the callback should not set the flag."""
+        session._reconnecting = True
+        session._intentional_stop = True
+        session._drop_during_reconnect = False
+
+        mock_task = asyncio.get_running_loop().create_future()
+        mock_cdp = MagicMock()
+        mock_cdp._message_handler_task = mock_task
+        session._cdp_client_root = mock_cdp
+
+        session._attach_ws_drop_callback()
+        mock_task.set_result(None)
+        await asyncio.sleep(0)
+
+        assert session._drop_during_reconnect is False, (
+            '_drop_during_reconnect should remain False when _intentional_stop is True'
+        )
+
+    async def test_flag_not_set_when_no_cdp_url(self, session: BrowserSession) -> None:
+        """When cdp_url is empty, the callback should not set the flag."""
+        session._reconnecting = True
+        session.browser_profile.cdp_url = None
+        session._drop_during_reconnect = False
+
+        mock_task = asyncio.get_running_loop().create_future()
+        mock_cdp = MagicMock()
+        mock_cdp._message_handler_task = mock_task
+        session._cdp_client_root = mock_cdp
+
+        session._attach_ws_drop_callback()
+        mock_task.set_result(None)
+        await asyncio.sleep(0)
+
+        assert session._drop_during_reconnect is False, (
+            '_drop_during_reconnect should remain False when cdp_url is None'
+        )
+
+
+class TestAutoReconnectReschedule:
+    """The finally block in _auto_reconnect detects the flag and re-schedules."""
+
+    async def test_reschedule_on_flag(self, session: BrowserSession) -> None:
+        """If _drop_during_reconnect is set during reconnect, a new reconnect is scheduled."""
+        reconnect_call_count = 0
+
+        async def mock_reconnect(self_inner):
+            nonlocal reconnect_call_count
+            reconnect_call_count += 1
+            # On the first call, simulate a WS drop arriving mid-reconnect
+            if reconnect_call_count == 1:
+                session._drop_during_reconnect = True
+
+        with patch.object(BrowserSession, 'reconnect', mock_reconnect):
+            with patch.object(BrowserSession, '_setup_proxy_auth', AsyncMock()):
+                with patch.object(BrowserSession, '_attach_ws_drop_callback', lambda self_inner: None):
+                    # Run _auto_reconnect — the first call should succeed, detect the
+                    # flag, and schedule a second call.
+                    await session._auto_reconnect(max_attempts=1)
+                    # Let the re-scheduled task run
+                    await asyncio.sleep(0.1)
+
+        assert reconnect_call_count >= 2, (
+            f'Expected reconnect to be called at least twice (re-scheduled), '
+            f'but was called {reconnect_call_count} time(s)'
+        )
+        assert session._drop_during_reconnect is False, (
+            '_drop_during_reconnect should be cleared after re-schedule'
+        )
+
+    async def test_no_reschedule_without_flag(self, session: BrowserSession) -> None:
+        """If _drop_during_reconnect is NOT set, no extra reconnect is scheduled."""
+        reconnect_call_count = 0
+
+        async def mock_reconnect(self_inner):
+            nonlocal reconnect_call_count
+            reconnect_call_count += 1
+
+        with patch.object(BrowserSession, 'reconnect', mock_reconnect):
+            with patch.object(BrowserSession, '_setup_proxy_auth', AsyncMock()):
+                with patch.object(BrowserSession, '_attach_ws_drop_callback', lambda self_inner: None):
+                    await session._auto_reconnect(max_attempts=1)
+                    await asyncio.sleep(0.1)
+
+        assert reconnect_call_count == 1, (
+            f'Expected reconnect to be called exactly once, '
+            f'but was called {reconnect_call_count} time(s)'
+        )
+
+    async def test_flag_reset_at_start(self, session: BrowserSession) -> None:
+        """_drop_during_reconnect is reset to False at the start of _auto_reconnect."""
+        session._drop_during_reconnect = True
+
+        async def mock_reconnect(self_inner):
+            # Verify the flag was cleared before reconnect() runs
+            assert session._drop_during_reconnect is False, (
+                '_drop_during_reconnect should be reset at the start of _auto_reconnect'
+            )
+
+        with patch.object(BrowserSession, 'reconnect', mock_reconnect):
+            with patch.object(BrowserSession, '_setup_proxy_auth', AsyncMock()):
+                with patch.object(BrowserSession, '_attach_ws_drop_callback', lambda self_inner: None):
+                    await session._auto_reconnect(max_attempts=1)


### PR DESCRIPTION
## Problem

When `_auto_reconnect()` is in progress (`_reconnecting=True`), a second WebSocket drop fires the `_on_message_handler_done` done-callback. The callback's guard condition checks `self._reconnecting` and returns early, silently discarding the event. The `finally` block in `_auto_reconnect` then clears `_reconnecting` and sets the event, but nothing re-schedules a reconnect for the second drop. The session is left with a dead WebSocket and no reconnect attempt.

This is a race condition that occurs when the newly established WebSocket connection drops immediately after reconnection — before the old reconnect task has finished its cleanup in the `finally` block.

## Fix

Add a `_drop_during_reconnect: bool` flag (PrivateAttr, default False):

1. **`_on_message_handler_done`**: Instead of silently returning when `_reconnecting=True`, set `self._drop_during_reconnect = True` and log a debug message. The guard for `_intentional_stop` and missing `cdp_url` remains unchanged.

2. **`_auto_reconnect`**: Clear the flag at the start (`self._drop_during_reconnect = False`). In the `finally` block, after clearing `_reconnecting` and setting the event, check the flag. If set, clear it and schedule a new `_auto_reconnect` task.

This ensures no WebSocket drop is silently lost, regardless of timing.

## Testing

6 tests in `tests/ci/test_ws_drop_during_reconnect.py`:

**TestDropDuringReconnectFlag** (3 tests):
- Flag is set when callback fires during reconnect
- Flag is not set when `_intentional_stop` is True
- Flag is not set when `cdp_url` is None

**TestAutoReconnectReschedule** (3 tests):
- Reconnect is re-scheduled when flag is set
- No extra reconnect when flag is not set
- Flag is reset to False at the start of `_auto_reconnect`

Closes #5366

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where a WebSocket drop during the reconnect window was ignored, leaving the session stuck with a dead connection. Reconnect is now re-scheduled if a drop happens while reconnecting.

- **Bug Fixes**
  - Added `_drop_during_reconnect` flag; `_on_message_handler_done` sets it when a drop occurs while `_reconnecting=True`.
  - `_auto_reconnect` clears the flag on start and, in `finally`, re-schedules `_auto_reconnect` if the flag was set.

<sup>Written for commit 9fa8b8e9cf03cc4eddf4559677f53cb2a2463307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

