### PR TITLE
fix(tools): report actual wait duration (#5362)

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -594,7 +594,9 @@ class Tools(Generic[Context]):
 				error_msg = f'Failed to go back: {str(e)}'
 				return ActionResult(error=error_msg)
 
-		@self.registry.action('Wait for x seconds. Maximum wait is 30 seconds; longer requests are capped and the response reports the actual wait.')
+		@self.registry.action(
+			'Wait for x seconds. Maximum wait is 30 seconds; longer requests are capped and the response reports the actual wait.'
+		)
 		async def wait(seconds: int = 3):
 			# Cap at 30s and report *what we actually slept*, not the requested value.
 			# Do not subtract a guessed LLM latency — wait can be mid-multi_act and the

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -594,16 +594,20 @@ class Tools(Generic[Context]):
 				error_msg = f'Failed to go back: {str(e)}'
 				return ActionResult(error=error_msg)
 
-		@self.registry.action('Wait for x seconds.')
+		@self.registry.action('Wait for x seconds. Maximum wait is 30 seconds; longer requests are capped and the response reports the actual wait.')
 		async def wait(seconds: int = 3):
-			# Cap wait time at maximum 30 seconds
-			# Reduce the wait time by 3 seconds to account for the llm call which takes at least 3 seconds
-			# So if the model decides to wait for 5 seconds, the llm call took at least 3 seconds, so we only need to wait for 2 seconds
-			# Note by Mert: the above doesnt make sense because we do the LLM call right after this or this could be followed by another action after which we would like to wait
-			# so I revert this.
-			actual_seconds = min(max(seconds - 1, 0), 30)
-			memory = f'Waited for {seconds} seconds'
-			logger.info(f'🕒 waited for {seconds} second{"" if seconds == 1 else "s"}')
+			# Cap at 30s and report *what we actually slept*, not the requested value.
+			# Do not subtract a guessed LLM latency — wait can be mid-multi_act and the
+			# next model call may be many steps later (Mert's note was correct).
+			max_wait = 30
+			requested = max(int(seconds), 0)
+			actual_seconds = min(requested, max_wait)
+			unit = 'second' if actual_seconds == 1 else 'seconds'
+			if requested > max_wait:
+				memory = f'Waited for {actual_seconds} {unit} (capped from requested {requested}s; max wait is {max_wait}s)'
+			else:
+				memory = f'Waited for {actual_seconds} {unit}'
+			logger.info(f'🕒 {memory}')
 			await asyncio.sleep(actual_seconds)
 			return ActionResult(extracted_content=memory, long_term_memory=memory)
 

--- a/tests/ci/test_action_wait_honest_duration.py
+++ b/tests/ci/test_action_wait_honest_duration.py
@@ -1,0 +1,84 @@
+"""Regression tests for #5362: wait action must report the duration it actually slept.
+
+Previously wait:
+- subtracted 1 second silently (comment claimed -3 and said it was reverted)
+- slept min(seconds-1, 30) but reported `seconds` unchanged into long_term_memory
+- so a request for 120s slept 30s and told the LLM it waited 120s
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from browser_use.tools.service import Tools
+
+
+def _wait_fn(tools: Tools):
+	return tools.registry.registry.actions['wait'].function
+
+
+async def test_wait_sleeps_and_reports_requested_duration(monkeypatch):
+	"""No silent -1: request 5s → sleep 5s and report 5s."""
+	slept: list[float] = []
+
+	async def _record_sleep(seconds: float):
+		slept.append(seconds)
+
+	monkeypatch.setattr(asyncio, 'sleep', _record_sleep)
+
+	result = await _wait_fn(Tools())(seconds=5)
+
+	assert slept == [5]
+	assert result.error is None
+	assert result.long_term_memory == 'Waited for 5 seconds'
+	assert result.extracted_content == 'Waited for 5 seconds'
+	assert '4' not in (result.long_term_memory or '')
+
+
+async def test_wait_cap_is_honest_in_memory(monkeypatch):
+	"""Request >30s: sleep 30 and tell the model about the cap, not the requested value alone."""
+	slept: list[float] = []
+
+	async def _record_sleep(seconds: float):
+		slept.append(seconds)
+
+	monkeypatch.setattr(asyncio, 'sleep', _record_sleep)
+
+	result = await _wait_fn(Tools())(seconds=120)
+
+	assert slept == [30]
+	assert result.long_term_memory is not None
+	assert '30' in result.long_term_memory
+	assert '120' in result.long_term_memory  # requested, disclosed
+	assert 'capped' in result.long_term_memory.lower()
+	# Must not claim we waited the full requested duration as if uncapped
+	assert result.long_term_memory != 'Waited for 120 seconds'
+
+
+async def test_wait_singular_second(monkeypatch):
+	slept: list[float] = []
+
+	async def _record_sleep(seconds: float):
+		slept.append(seconds)
+
+	monkeypatch.setattr(asyncio, 'sleep', _record_sleep)
+
+	result = await _wait_fn(Tools())(seconds=1)
+
+	assert slept == [1]
+	assert result.long_term_memory == 'Waited for 1 second'
+
+
+async def test_wait_clamps_negative_to_zero(monkeypatch):
+	slept: list[float] = []
+
+	async def _record_sleep(seconds: float):
+		slept.append(seconds)
+
+	monkeypatch.setattr(asyncio, 'sleep', _record_sleep)
+
+	result = await _wait_fn(Tools())(seconds=-3)
+
+	assert slept == [0]
+	assert result.long_term_memory is not None
+	assert '0' in result.long_term_memory

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -161,10 +161,11 @@ class TestToolsIntegration:
 		# Verify the result
 		assert isinstance(result, ActionResult)
 		assert result.extracted_content is not None
-		assert 'Waited for' in result.extracted_content or 'Waiting for' in result.extracted_content
+		assert 'Waited for 3 seconds' in result.extracted_content
+		assert result.long_term_memory == 'Waited for 3 seconds'
 
-		# Verify that approximately 1 second has passed (allowing some margin)
-		assert end_time - start_time <= 2.5  # We wait 3-1 seconds for LLM call
+		# Wait the full requested duration (no silent -1 LLM adjustment — see #5362)
+		assert 2.5 <= end_time - start_time <= 3.5
 
 		# longer wait
 		# Record start time
@@ -179,9 +180,10 @@ class TestToolsIntegration:
 		# Verify the result
 		assert isinstance(result, ActionResult)
 		assert result.extracted_content is not None
-		assert 'Waited for' in result.extracted_content or 'Waiting for' in result.extracted_content
+		assert 'Waited for 5 seconds' in result.extracted_content
+		assert result.long_term_memory == 'Waited for 5 seconds'
 
-		assert 3.5 <= end_time - start_time <= 4.5  # We wait 5-1 seconds for LLM call
+		assert 4.5 <= end_time - start_time <= 5.5
 
 	async def test_go_back_action(self, tools, browser_session, base_url):
 		"""Test that go_back action navigates to the previous page."""


### PR DESCRIPTION
## Summary
- Remove silent `-1` adjustment from `wait`
- Cap at 30s and report the actual duration (incl. when capped)
- CI regression tests

Fixes #5362

## Test plan
- [x] `uv run pytest -vxs tests/ci/test_action_wait_honest_duration.py` (4 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `wait` action honest: it now sleeps the requested time (capped at 30s) and reports the actual duration, not the requested value. Adds CI regression tests and fixes #5362.

- **Bug Fixes**
  - Removed the silent -1s adjustment; negative inputs clamp to 0 and waits cap at 30s (help text updated).
  - Memory/logs now report the actual sleep with correct singular/plural; if capped, they include the requested value and note the cap. Tests aligned and expanded for cap/negatives.

<sup>Written for commit b38c971a7c19e32e468f9f60aa92c69c1e285a5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

