### PR TITLE
fix(browser): close two CDP detection leaks + actively trigger Bright Data's CAPTCHA solver

### DIFF
--- a/browser_use/actor/page.py
+++ b/browser_use/actor/page.py
@@ -63,9 +63,18 @@ class Page:
 			await asyncio.gather(
 				self._client.send.Page.enable(session_id=self._session_id),
 				self._client.send.DOM.enable(session_id=self._session_id),
-				self._client.send.Runtime.enable(session_id=self._session_id),
 				self._client.send.Network.enable(session_id=self._session_id),
 			)
+
+			# Runtime.evaluate/callFunctionOn work without the Runtime domain staying
+			# "enabled" — enable is only needed to receive Runtime.* events, which we
+			# don't consume here. Leaving it enabled makes Chrome emit a
+			# Runtime.consoleAPICalled event that page-side JS can detect in a few
+			# lines, a signal anti-bot vendors (Cloudflare, DataDome) key off of.
+			# Immediately disabling after enable still lets executionContextCreated
+			# fire once, closing the leak window.
+			await self._client.send.Runtime.enable(session_id=self._session_id)
+			await self._client.send.Runtime.disable(session_id=self._session_id)
 
 		return self._session_id
 

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1037,6 +1037,14 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		try:
 			if self.browser_session:
 				try:
+					# Covers navigations that happened via an in-page click (e.g. a showtime
+					# link) rather than an explicit navigate action, which the CDP hook in
+					# on_NavigateToUrlEvent alone would miss. No-op on non-Bright Data connections.
+					await self.browser_session.solve_captcha_on_current_page_if_brightdata()
+				except Exception as e:
+					self.logger.warning(f'Phase 0 Bright Data captcha solve failed (non-fatal): {e}')
+
+				try:
 					captcha_wait = await self.browser_session.wait_if_captcha_solving()
 					if captcha_wait and captcha_wait.waited:
 						# Reset step timing to exclude the captcha wait from step duration metrics

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -524,6 +524,17 @@ class BrowserSession(BaseModel):
 			return await self._captcha_watchdog.wait_if_captcha_solving(timeout=timeout)
 		return None
 
+	async def solve_captcha_on_current_page_if_brightdata(self) -> None:
+		"""Actively trigger Bright Data's CDP CAPTCHA solver on whatever page currently has focus.
+
+		Covers navigations that happen via an in-page click (e.g. selecting a showtime
+		link) rather than an explicit agent navigate action, which `_solve_captcha_if_brightdata`
+		alone would miss since it only fires from `on_NavigateToUrlEvent`.
+		"""
+		if not self.agent_focus_target_id:
+			return
+		await self._solve_captcha_if_brightdata(self.agent_focus_target_id)
+
 	@property
 	def is_reconnecting(self) -> bool:
 		"""Whether a WebSocket reconnection attempt is currently in progress."""
@@ -972,6 +983,9 @@ class BrowserSession(BaseModel):
 			# Close any extension options pages that might have opened
 			await self._close_extension_options_pages()
 
+			# Actively trigger Bright Data's CAPTCHA solver (no-op on other proxies/local Chrome)
+			await self._solve_captcha_if_brightdata(target_id)
+
 			# Dispatch navigation complete
 			self.logger.debug(f'Dispatching NavigationCompleteEvent for {event.url} (tab #{target_id[-4:]})')
 			await self.event_bus.dispatch(
@@ -1275,6 +1289,45 @@ class BrowserSession(BaseModel):
 		host = urlparse(self.cdp_url).hostname or ''
 		match = re.match(r'^([0-9a-fA-F-]{36})\.cdp\d+\.browser-use\.com$', host)
 		return match.group(1) if match else None
+
+	def _is_brightdata_cdp_url(self) -> bool:
+		"""Whether the current connection is Bright Data's Browser API (superproxy.io)."""
+		if not self.cdp_url:
+			return False
+		return (urlparse(self.cdp_url).hostname or '').endswith('superproxy.io')
+
+	async def _solve_captcha_if_brightdata(self, target_id: str) -> None:
+		"""Actively trigger Bright Data's CDP CAPTCHA solver after navigation.
+
+		Bright Data's proxy-level auto-solver doesn't reliably clear interactive
+		challenges (e.g. Cloudflare Turnstile) on its own — passive waiting after
+		navigation often just times out. Bright Data exposes an explicit
+		``Captcha.solve`` CDP command that actively detects and solves a challenge
+		on the current page, returning a real status (`solve_finished`,
+		`solve_failed`, `not_detected`) instead of leaving the caller to guess.
+		No-op for any connection that isn't Bright Data's Browser API.
+		"""
+		if not self._is_brightdata_cdp_url():
+			return
+		try:
+			cdp_session = await self.get_or_create_cdp_session(target_id, focus=False)
+			# detectTimeout only bounds how long Bright Data looks for a challenge before
+			# giving up (returns 'not_detected') - it does NOT cap the solve itself once one
+			# is found, so a short value keeps the common no-challenge case cheap (~1-2s)
+			# without limiting how long an actual solve is allowed to take.
+			result = await cdp_session.cdp_client.send_raw(
+				'Captcha.solve', {'detectTimeout': 3_000}, session_id=cdp_session.session_id
+			)
+			status = result.get('status') if isinstance(result, dict) else None
+			if status == 'solve_finished':
+				self.logger.info('🔓 Bright Data solved a CAPTCHA/challenge on this page')
+			elif status == 'solve_failed':
+				self.logger.warning('🔒 Bright Data detected a CAPTCHA/challenge but failed to solve it')
+			# 'not_detected' is the common case (no challenge present) - nothing to log
+		except Exception as e:
+			# Non-Bright Data proxies, or older zones without this CDP domain, will
+			# raise "method not found" here - this must never block navigation.
+			self.logger.debug(f'Bright Data Captcha.solve check failed (non-fatal): {type(e).__name__}: {e}')
 
 	async def on_BrowserStopEvent(self, event: BrowserStopEvent) -> None:
 		"""Handle browser stop request."""

--- a/browser_use/browser/session_manager.py
+++ b/browser_use/browser/session_manager.py
@@ -15,6 +15,23 @@ from browser_use.utils import create_task_with_error_handling
 if TYPE_CHECKING:
 	from browser_use.browser.session import BrowserSession, CDPSession, Target
 
+# Chromium bug https://issues.chromium.org/issues/40280325: Input.dispatchMouseEvent
+# (what every CDP-driven click uses) constructs MouseEvent/PointerEvent objects whose
+# .screenX/.screenY are silently set equal to .clientX/.clientY. Real pointer hardware
+# essentially never produces that equality (screen coords include the OS window's
+# position, viewport coords don't), so Cloudflare Turnstile's interactive checkbox
+# checks for it and flags the click as non-human. Patching the prototype getters closes
+# the leak; values are randomized once per document so repeated clicks stay self-consistent.
+_SCREEN_XY_PATCH_SCRIPT = """(function(){
+	function r(min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
+	var screenX = r(800, 1200);
+	var screenY = r(400, 600);
+	try {
+		Object.defineProperty(MouseEvent.prototype, 'screenX', {get: function(){ return screenX; }, configurable: true});
+		Object.defineProperty(MouseEvent.prototype, 'screenY', {get: function(){ return screenY; }, configurable: true});
+	} catch (e) {}
+})();"""
+
 
 class SessionManager:
 	"""Event-driven CDP session manager.
@@ -489,6 +506,16 @@ class SessionManager:
 				self.logger.debug(f'[SessionManager] Fetch.enable(handleAuthRequests=True) on session {session_id[:8]}...')
 		except Exception as e:
 			self.logger.debug(f'[SessionManager] Fetch.enable on attached session failed: {type(e).__name__}: {e}')
+
+		# Applied to every target (main frame + OOPIFs) since Turnstile's checkbox
+		# renders in its own cross-origin iframe target with an independent session.
+		try:
+			await cdp_session.cdp_client.send.Page.addScriptToEvaluateOnNewDocument(
+				params={'source': _SCREEN_XY_PATCH_SCRIPT, 'runImmediately': True},
+				session_id=cdp_session.session_id,
+			)
+		except Exception as e:
+			self.logger.debug(f'[SessionManager] screenX/screenY patch injection failed for {target_id[:8]}...: {e}')
 
 		self.logger.debug(
 			f'[SessionManager] Created session {session_id[:8]}... for target {target_id[:8]}... '


### PR DESCRIPTION
## Summary
Three fixes addressing why `browser-use` reliably got blocked by Cloudflare Turnstile's interactive checkbox challenge on a real ticketing site (Cineworld), found via live iterative testing across multiple environments:

1. **`Runtime.enable` left on** (`actor/page.py`, `Page._ensure_session()`): leaving the CDP Runtime domain enabled makes Chrome emit a `Runtime.consoleAPICalled` event with a side effect page JS can detect in a few lines. `Runtime.evaluate`/`Runtime.callFunctionOn` work regardless of whether the domain stays "enabled" — enable/disable only gates event notifications, not command execution — so calling `Runtime.disable` immediately after `Runtime.enable` closes the leak with no behavior change.

2. **`MouseEvent.screenX`/`screenY` equal `clientX`/`clientY`** (`browser/session_manager.py`): a documented Chromium bug ([issue 40280325](https://issues.chromium.org/issues/40280325)) — `Input.dispatchMouseEvent`, used by every CDP-driven click in this codebase, silently sets `screenX`/`screenY` equal to the viewport-relative coordinates. Real pointer hardware essentially never produces that equality. Cloudflare Turnstile's interactive checkbox checks for it and flags the click as non-human. Fixed by injecting a `MouseEvent.prototype` override via `Page.addScriptToEvaluateOnNewDocument` on every attached CDP session (main frame *and* cross-origin iframes/OOPIFs, since Turnstile's widget renders in its own iframe target).

3. **Bright Data's proxy-level auto-solver doesn't reliably clear interactive challenges on its own** (`browser/session.py`, `agent/service.py`): Bright Data's Browser API markets automatic CAPTCHA solving, but passively waiting after navigation was observed to time out repeatedly even with fixes #1 and #2 applied. Bright Data exposes an explicit `Captcha.solve` CDP command that actively detects and solves a challenge, returning a real status (`solve_finished`/`solve_failed`/`not_detected`) instead of leaving the caller to guess. This is now called automatically — after every explicit navigate, and once per agent step (to also cover navigations triggered by an in-page click, e.g. selecting a showtime link) — and is a no-op on any non-Bright Data connection.

## Evidence and honesty about what's proven vs. not
This was tested extensively across environments (local Chrome, a cloud VM, a residential-IP Linux box, and Bright Data's Browser API) on Cineworld's real Cloudflare-protected ticketing flow:

- Fixes #1 and #2 alone: measurably helped (the passive/managed Cloudflare challenge started clearing automatically), but were **not sufficient on their own** to reliably clear the *interactive* Turnstile checkbox — one clean end-to-end run succeeded, a subsequent run with a more exploratory task failed at the same wall. This is consistent with Cloudflare's Turnstile scoring session-level/behavioral signals beyond a one-time fingerprint check, which fixes #1/#2 cannot address.
- Fix #3 (actively calling `Captcha.solve`) is a genuinely different mechanism — it's Bright Data's own paid unblocking infrastructure doing the solve, not a fingerprint patch — and was the only approach that reliably cleared the interactive checkbox across repeated trials. Verified via direct CDP calls (`Captcha.solve` → `{"status": "solve_finished"}`, page transitions from "Just a moment..." to the real ticket flow) and end-to-end through the real `Agent`/`BrowserSession` path (log line `🔓 Bright Data solved a CAPTCHA/challenge on this page`, followed by successful guest checkout and ticket/seat selection).
- This fix is inherently Bright-Data-specific (checks the CDP URL host for `superproxy.io`) since `Captcha.solve` is Bright Data's own CDP extension — it has no effect on local Chrome or other CDP providers.

## Testing
- `uv run pytest tests/ci/` — 1065 passed, 34 skipped, 2 deselected pre-existing flakes (`test_beta_agent.py` generic-type-identity/test-ordering issues, unrelated to this change — both pass in isolation, reproduce identically on `main`)
- Manual CDP verification: dispatched `Input.dispatchMouseEvent` and read back `MouseEvent.screenX/screenY` vs `clientX/clientY` — confirmed no longer equal after fix #2
- Manual CDP verification: `Captcha.solve` with a short `detectTimeout` (3s) still returns `solve_finished` for real challenges that took 6-16s to actually solve, confirming `detectTimeout` only bounds detection, not the solve itself — so the common no-challenge case stays cheap
- Live end-to-end booking flow on Cineworld's Cloudflare-protected ticketing site through Bright Data's Browser API: cleared automatically, reached real ticket/seat selection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the CDP Runtime domain immediately after enabling during session init, and patch `MouseEvent.screenX`/`screenY` on every attached CDP session to remove two detectable automation signals used by Cloudflare Turnstile and similar vendors. On Bright Data connections, actively trigger `Captcha.solve` to reliably clear interactive challenges after navigations and in-page clicks.

- **Bug Fixes**
  - Call `Runtime.enable` then `Runtime.disable` in `Page._ensure_session()` to allow `executionContextCreated` but suppress `Runtime.*` events.
  - Inject a `MouseEvent.prototype.screenX`/`screenY` override via `Page.addScriptToEvaluateOnNewDocument` on every attached target (main frame + OOPIFs) to address Chromium bug 40280325 (`screenX/screenY == clientX/clientY` for CDP clicks).

- **New Features**
  - Trigger Bright Data’s `Captcha.solve` after each navigate and once per agent step (covers in-page navigations); no-op on non-Bright Data connections.
  - Short detect timeout, non-blocking, and logs `solve_finished`/`solve_failed`/`not_detected`.

<sup>Written for commit 8b023d2af8d3c4b805f8a37fc77774e9e6dc0f4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

