### PR TITLE
fix(mcp): update deprecated Bedrock Claude model identifier

### DIFF
--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -660,7 +660,7 @@ class BrowserUseServer:
 
 		# Get Bedrock-specific config
 		if model_provider and model_provider.lower() == 'bedrock':
-			llm_model = llm_config.get('model') or os.getenv('MODEL') or 'us.anthropic.claude-sonnet-4-20250514-v1:0'
+			llm_model = llm_config.get('model') or os.getenv('MODEL') or 'us.anthropic.claude-sonnet-4-6'
 			aws_region = llm_config.get('region') or os.getenv('REGION')
 			if not aws_region:
 				aws_region = 'us-east-1'

--- a/examples/models/aws.py
+++ b/examples/models/aws.py
@@ -24,7 +24,7 @@ async def example_anthropic_bedrock():
 
 	# Initialize with Anthropic Claude via AWS Bedrock
 	llm = ChatAnthropicBedrock(
-		model='us.anthropic.claude-sonnet-4-20250514-v1:0',
+		model='us.anthropic.claude-sonnet-4-6',
 		aws_region='us-east-1',
 		temperature=0.7,
 	)


### PR DESCRIPTION
## What

Updates the default Bedrock model identifier used by the MCP server fallback and
the AWS example, replacing `us.anthropic.claude-sonnet-4-20250514-v1:0` with
`us.anthropic.claude-sonnet-4-6`.

## Why

`browser_use/mcp/server.py` falls back to this identifier when neither the config
nor `MODEL` is set. That default no longer works today.

Per the Bedrock control plane, `anthropic.claude-sonnet-4-20250514-v1:0` is
`LEGACY` (legacy since 2026-04-14, EOL 2026-10-14). Legacy status is already
enforced: accounts that have not invoked the model in the last 30 days get a 404
instead of a completion. So this is not just a future EOL — the default path
currently fails for any Bedrock user who has not explicitly set `MODEL`.

`anthropic.claude-sonnet-4-6` is `ACTIVE` with no EOL date, and its `us.` and
`global.` system-defined inference profiles are `ACTIVE`.

The replacement still accepts `temperature`, so nothing else needs to change.
(Sampling parameters were only removed on Opus 4.7 and later.) The example keeps
`temperature=0.7`, and `ChatAnthropicBedrock` / `ChatAWSBedrock` leave `top_p` at
`None` unless explicitly set, so the "temperature and top_p cannot both be
specified" rejection does not apply either.

## Verification

Clean clone at 32601887c, `uv sync --dev --all-extras`:

- `ruff check --no-fix --select PLE` — before: pass, after: pass
- `ruff check --no-fix` — before: pass, after: pass
- `ruff format --check` — before: 385 files already formatted, after: identical
- `pyright` — before: 0 errors, after: 0 errors
- pytest, Bedrock/MCP/LLM files — before: 28 passed, after: 28 passed
  (`tests/ci/models/test_chat_anthropic_bedrock_empty_content.py`,
  `tests/ci/test_mcp_tool_annotations.py`,
  `tests/ci/security/test_mcp_allowed_domains.py`,
  `tests/ci/test_fallback_llm.py`, `tests/ci/test_llm_retries.py`)

The full suite needs Chromium and CI secrets, so I ran the subset covering the
touched paths.

Live Bedrock calls, the last two through this repo's own `ChatAnthropicBedrock`
(`aws_region='us-east-1'`, `temperature=0.7`):

<details><summary>Execution logs</summary>

```
$ aws bedrock get-foundation-model --model-identifier anthropic.claude-sonnet-4-20250514-v1:0
"lifecycle": {
    "status": "LEGACY",
    "startOfLifeTime": "2025-05-22T00:00:00Z",
    "legacyTime": "2026-04-14T08:00:00Z",
    "publicExtendedAccessTime": "2026-07-14T08:00:00Z",
    "endOfLifeTime": "2026-10-14T08:00:00Z"
}

$ aws bedrock get-foundation-model --model-identifier anthropic.claude-sonnet-4-6
"lifecycle": {
    "status": "ACTIVE",
    "startOfLifeTime": "2026-02-17T18:00:00Z"
}

$ aws bedrock list-inference-profiles --region us-east-1
us.anthropic.claude-sonnet-4-6      ACTIVE  SYSTEM_DEFINED
global.anthropic.claude-sonnet-4-6  ACTIVE  SYSTEM_DEFINED

--- us.anthropic.claude-sonnet-4-20250514-v1:0 ---
FAIL ModelProviderError: Error code: 404 - {'message': 'Access denied. This Model
is marked by provider as Legacy and you have not been actively using the model in
the last 30 days. Please upgrade to an active model on Amazon Bedrock'}

--- us.anthropic.claude-sonnet-4-6 ---
OK  completion='ok'  prompt_tokens=14 completion_tokens=4 total_tokens=18
```

</details>

## Scope

Two files, identifier only. No refactoring, no other model updates, no test
modifications. Model catalogues (`CLOUD.md`,
`skills/cloud/references/api-v2.md`) are deliberately untouched, since they need
to keep listing historical identifiers.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the MCP Bedrock fallback and AWS example to use `us.anthropic.claude-sonnet-4-6` instead of the legacy `us.anthropic.claude-sonnet-4-20250514-v1:0`. This avoids 404s for users who haven’t invoked the legacy model recently.

- **Bug Fixes**
  - Fallback model in `browser_use/mcp/server.py` now defaults to `us.anthropic.claude-sonnet-4-6` when unset.
  - `examples/models/aws.py` updated to the same active identifier; `temperature` remains supported.

<sup>Written for commit d2411b419846604a530e01d568a027044c102aec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

