### PR TITLE
Parse curl web searches in terminal history

### DIFF
--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -11,6 +11,7 @@ import logging
 import mimetypes
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -21,7 +22,7 @@ from contextlib import nullcontext, suppress
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Generic, Literal
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlparse
 
 from bubus import EventBus
 from pydantic import BaseModel, ValidationError, create_model
@@ -529,7 +530,112 @@ def _sdk_preview(value: Any, limit: int = 180) -> str | None:
 	return text[:limit] + f'...[{len(text) - limit} more chars]'
 
 
+def _curl_tokens(command: str) -> list[str] | None:
+	try:
+		tokens = shlex.split(command)
+	except ValueError:
+		return None
+	for index, token in enumerate(tokens):
+		if Path(token).name == 'curl':
+			return tokens[index:]
+	return None
+
+
+def _curl_data_query_params(tokens: list[str]) -> dict[str, str]:
+	params: dict[str, str] = {}
+	for index, token in enumerate(tokens):
+		value: str | None = None
+		if token in {'--data-urlencode', '--data', '--data-raw', '--data-binary', '-d'}:
+			next_index = index + 1
+			if next_index < len(tokens):
+				value = tokens[next_index]
+		elif token.startswith('--data-urlencode='):
+			value = token.split('=', 1)[1]
+		elif token.startswith('--data=') or token.startswith('--data-raw=') or token.startswith('--data-binary='):
+			value = token.split('=', 1)[1]
+		elif token.startswith('-d') and len(token) > 2:
+			value = token[2:]
+		if not value:
+			continue
+		if value.startswith('?'):
+			value = value[1:]
+		for key, parsed_value in parse_qsl(value, keep_blank_values=True):
+			if key in {'q', 'query'} and parsed_value:
+				params[key] = parsed_value
+	return params
+
+
+def _curl_urls(tokens: list[str]) -> list[str]:
+	urls: list[str] = []
+	for index, token in enumerate(tokens):
+		value: str | None = None
+		if token == '--url':
+			next_index = index + 1
+			if next_index < len(tokens):
+				value = tokens[next_index]
+		elif token.startswith('--url='):
+			value = token.split('=', 1)[1]
+		elif token.startswith(('http://', 'https://')):
+			value = token
+		if value and value.startswith(('http://', 'https://')):
+			urls.append(value)
+	return urls
+
+
+def _search_engine_from_url(raw_url: str) -> str | None:
+	parsed = urlparse(raw_url)
+	host = (parsed.hostname or '').lower()
+	path = parsed.path.rstrip('/') or '/'
+	if host in {'duckduckgo.com', 'www.duckduckgo.com', 'html.duckduckgo.com'}:
+		return 'duckduckgo'
+	if host in {'google.com', 'www.google.com'} and path == '/search':
+		return 'google'
+	if host in {'bing.com', 'www.bing.com'} and path == '/search':
+		return 'bing'
+	return None
+
+
+def _search_action_from_curl_command(command: str) -> dict[str, str] | None:
+	tokens = _curl_tokens(command)
+	if not tokens:
+		return None
+	extra_params = _curl_data_query_params(tokens)
+	for raw_url in _curl_urls(tokens):
+		engine = _search_engine_from_url(raw_url)
+		if engine is None:
+			continue
+		query_params = dict(parse_qsl(urlparse(raw_url).query, keep_blank_values=True))
+		query = query_params.get('q') or query_params.get('query') or extra_params.get('q') or extra_params.get('query')
+		if not isinstance(query, str) or not query.strip():
+			continue
+		return {'query': ' '.join(query.split()), 'engine': engine}
+	return None
+
+
+def _search_action_from_exec_command_args(arguments: dict[str, Any]) -> dict[str, str] | None:
+	command = arguments.get('cmd') or arguments.get('command')
+	if not isinstance(command, str):
+		return None
+	return _search_action_from_curl_command(command)
+
+
+def _search_label_from_payload(payload: dict[str, Any]) -> str | None:
+	if payload.get('name') != 'exec_command':
+		return None
+	arguments = payload.get('arguments')
+	if not isinstance(arguments, dict):
+		return None
+	search_action = _search_action_from_exec_command_args(arguments)
+	if search_action is None:
+		return None
+	query = json.dumps(search_action['query'], ensure_ascii=False)
+	return f'web_search engine={search_action["engine"]} query={query}'
+
+
 def _sdk_payload_label(payload: dict[str, Any]) -> str | None:
+	search_label = _search_label_from_payload(payload)
+	if search_label:
+		return search_label
 	for key in ('name', 'tool_name', 'tool', 'task', 'command', 'url', 'title', 'result', 'error', 'message'):
 		value = _sdk_preview(payload.get(key))
 		if value:
@@ -2022,11 +2128,17 @@ def _tool_call_from_payload(payload: dict[str, Any], fallback_id: str) -> dict[s
 	arguments = payload.get('arguments')
 	if arguments is None:
 		arguments = function.get('arguments')
+	parsed_arguments = _tool_arguments(arguments)
+	if name == 'exec_command':
+		search_action = _search_action_from_exec_command_args(parsed_arguments)
+		if search_action is not None:
+			name = 'search'
+			parsed_arguments = search_action
 	return {
 		'name': name,
 		'tool_call_id': str(call_id),
 		'_has_explicit_tool_call_id': raw_call_id is not None,
-		'arguments': _tool_arguments(arguments),
+		'arguments': parsed_arguments,
 	}
 
 

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -785,6 +785,68 @@ def test_rust_history_reconstructs_terminal_response_input_item_tool_results():
 	assert history.final_result() == 'Example Domain'
 
 
+def test_rust_history_reconstructs_curl_google_search_as_search_action():
+	from browser_use.beta.service import _history_from_events
+
+	history = _history_from_events(
+		[
+			{
+				'type': 'tool.started',
+				'payload': {
+					'name': 'exec_command',
+					'tool_call_id': 'call-search',
+					'arguments': {'cmd': 'curl -sS "https://www.google.com/search?q=browser+use+pricing&udm=14"'},
+				},
+			},
+			{
+				'type': 'tool.output',
+				'payload': {
+					'name': 'exec_command',
+					'tool_call_id': 'call-search',
+					'text': 'Browser Use pricing result',
+				},
+			},
+			{'event_type': 'session.done', 'payload': {'result': 'final answer'}},
+		],
+		model='gpt-test',
+		started=1.0,
+		finished=2.0,
+		output_model_schema=None,
+		process_error=None,
+	)
+
+	first_action = history.model_actions()[0]
+	first_history_action = history.action_history()[0][0]
+
+	assert history.action_names() == ['search', 'done']
+	assert first_action['search'] == {'query': 'browser use pricing', 'engine': 'google'}
+	assert first_history_action['search'] == {'query': 'browser use pricing', 'engine': 'google'}
+	assert 'curl' not in json.dumps(first_history_action, sort_keys=True)
+	assert history.final_result() == 'final answer'
+
+
+def test_sdk_notification_summary_prettifies_curl_duckduckgo_search():
+	from browser_use.beta.service import _sdk_notification_summary
+
+	summary = _sdk_notification_summary(
+		{
+			'method': 'agent.event',
+			'params': {
+				'event': {
+					'type': 'tool.started',
+					'payload': {
+						'name': 'exec_command',
+						'tool_call_id': 'call-search',
+						'arguments': {'cmd': "curl -G -s 'https://duckduckgo.com/' --data-urlencode 'q=best browser automation'"},
+					},
+				}
+			},
+		}
+	)
+
+	assert summary == 'tool.started web_search engine=duckduckgo query="best browser automation"'
+
+
 def test_rust_history_reconstructs_terminal_tool_finished_results():
 	from browser_use.beta.service import _history_from_events
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Parse recognized curl-based Google, DuckDuckGo, and Bing search commands into semantic `search` actions in beta terminal history
- Prettify SDK event summaries for curl web searches so logs show the engine and query instead of raw curl commands
- Add focused beta-agent coverage for history reconstruction and SDK summary formatting

## Tests
- `$HOME/.local/bin/uv run pytest -q tests/ci/test_beta_agent.py -k 'curl_google_search or prettifies_curl'`
- `PATH="$HOME/.local/bin:$PATH" $HOME/.local/bin/uv run pre-commit run --all-files`
- `PATH="$HOME/.local/bin:$PATH" $HOME/.local/bin/uv run --python 3.11 pytest -q tests/ci/test_beta_agent.py`
- `PATH="$HOME/.local/bin:$PATH" $HOME/.local/bin/uv run --python 3.11 pytest -q tests/ci` *(fails before the new tests on order-dependent `test_beta_agent_constructor_type_hints_match_browser_use_core_params`; the exact test and the full `test_beta_agent.py` file pass in isolation)*
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://browser-use.slack.com/archives/C084NF0JMPT/p1786461002498349?thread_ts=1786461002.498349&cid=C084NF0JMPT)

<div><a href="https://cursor.com/agents/bc-9fa7beeb-3718-5c16-a13e-8a8eac00215d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fa7beeb-3718-5c16-a13e-8a8eac00215d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converts curl-based Google, DuckDuckGo, and Bing searches into semantic `search` actions in beta terminal history. Also prettifies SDK event summaries to show the engine and query, not raw curl.

- **New Features**
  - Detects curl searches and maps `exec_command` to `search` with normalized `query` and `engine`.
  - SDK summaries label searches as `web_search engine=<engine> query="<query>"`.
  - Adds focused tests for history reconstruction and summary formatting.

<sup>Written for commit 394c4fd6abd7842b0ad6dc84ce61258a015f66d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

