### PR TITLE
fix(agent): valid done action on empty LLM recovery (#5360)

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1684,15 +1684,16 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
-				action_instance = self.ActionModel()
-				setattr(
-					action_instance,
-					'done',
-					{
-						'success': False,
-						'text': 'No next action returned by LLM!',
-					},
-				)
+				# ActionModel is a RootModel union of single-action models (no all-optional
+				# flat shape). ActionModel() therefore raises ValidationError — construct a
+				# proper done action instead (prefer DoneActionModel, one-field schema).
+				fallback_done = {'success': False, 'text': 'No next action returned by LLM!'}
+				try:
+					# model_validate keeps dynamic create_model types pyright-safe
+					action_instance = self.DoneActionModel.model_validate({'done': fallback_done})
+				except Exception:
+					# Full ActionModel union still accepts done={...} via validation
+					action_instance = self.ActionModel.model_validate({'done': fallback_done})
 				model_output.action = [action_instance]
 
 		return model_output

--- a/tests/ci/test_empty_action_recovery.py
+++ b/tests/ci/test_empty_action_recovery.py
@@ -1,0 +1,127 @@
+"""Regression tests for #5360: empty-action recovery must insert a valid done action.
+
+After create_action_model() switched to a RootModel union of single-action models,
+`self.ActionModel()` is invalid (no all-optional flat shape). The empty-action
+safety net must construct a proper `done` action instead of raising ValidationError.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import ValidationError
+
+from browser_use.agent.service import Agent
+from browser_use.agent.views import AgentOutput
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.tools.service import Tools
+
+
+def _empty_agent_output(output_format: type[AgentOutput]) -> AgentOutput:
+	"""Build an AgentOutput with action=[] that still passes type construction."""
+	# model_construct skips validation so we can force empty actions without
+	# fighting the dynamic action schema constraints.
+	return output_format.model_construct(
+		thinking='',
+		evaluation_previous_goal='',
+		memory='',
+		next_goal='',
+		action=[],
+	)
+
+
+def _create_empty_action_llm() -> tuple[BaseChatModel, dict[str, int]]:
+	"""LLM that always returns an AgentOutput with zero actions.
+
+	Returns (llm, counters) where counters['ainvoke'] tracks LLM calls.
+	"""
+	tools = Tools()
+	ActionModel = tools.registry.create_action_model()
+	AgentOutputWithActions = AgentOutput.type_with_custom_actions(ActionModel)
+
+	llm = AsyncMock(spec=BaseChatModel)
+	llm.model = 'empty-action-model'
+	llm._verified_api_keys = True
+	llm.provider = 'test'
+	llm.name = 'empty-action-model'
+	llm.model_name = 'empty-action-model'
+
+	counters = {'ainvoke': 0}
+
+	async def mock_ainvoke(*args, **kwargs):
+		counters['ainvoke'] += 1
+		output_format = None
+		if len(args) >= 2:
+			output_format = args[1]
+		elif 'output_format' in kwargs:
+			output_format = kwargs['output_format']
+
+		if output_format is None:
+			return ChatInvokeCompletion(completion='{"action":[]}', usage=None)
+
+		# Prefer agent-provided format so nested ActionModel types match.
+		fmt = output_format if issubclass(output_format, AgentOutput) else AgentOutputWithActions
+		return ChatInvokeCompletion(completion=_empty_agent_output(fmt), usage=None)
+
+	llm.ainvoke.side_effect = mock_ainvoke
+	return llm, counters
+
+
+def test_action_model_empty_ctor_raises_validation_error():
+	"""Document the regression root cause: bare ActionModel() is invalid."""
+	AM = Tools().registry.create_action_model()
+	with pytest.raises(ValidationError):
+		AM()
+
+
+def test_done_action_model_constructs_fallback_done():
+	"""DoneActionModel validates a fallback done payload."""
+	DoneAM = Tools().registry.create_action_model(include_actions=['done'])
+	action = DoneAM.model_validate({'done': {'success': False, 'text': 'No next action returned by LLM!'}})
+	dumped = action.model_dump(exclude_unset=True)
+	assert 'done' in dumped
+	assert dumped['done']['success'] is False
+	assert dumped['done']['text'] == 'No next action returned by LLM!'
+
+
+def test_full_action_model_constructs_with_done_kwargs():
+	"""Union ActionModel also validates a done action payload."""
+	AM = Tools().registry.create_action_model()
+	action = AM.model_validate({'done': {'success': False, 'text': 'No next action returned by LLM!'}})
+	dumped = action.model_dump(exclude_unset=True)
+	assert 'done' in dumped
+	assert dumped['done']['success'] is False
+
+
+async def test_get_model_output_with_retry_inserts_done_without_validation_error():
+	"""Empty LLM twice → fallback done action, no ValidationError."""
+	llm, counters = _create_empty_action_llm()
+	agent = Agent(task='test empty action recovery', llm=llm)
+
+	# Two empty responses: first detection + retry, then fallback insertion.
+	result = await agent._get_model_output_with_retry([])
+
+	assert result.action is not None
+	assert len(result.action) == 1
+
+	action_dump = result.action[0].model_dump(exclude_unset=True)
+	assert 'done' in action_dump
+	assert action_dump['done']['success'] is False
+	assert action_dump['done']['text'] == 'No next action returned by LLM!'
+
+	# Primary + retry LLM calls (before insert; insert itself is pure)
+	assert counters['ainvoke'] == 2
+
+
+async def test_get_model_output_with_retry_done_action_is_executable():
+	"""Fallback done action must be consumable by tools.act / multi_act dump path."""
+	llm, _ = _create_empty_action_llm()
+	agent = Agent(task='test empty action recovery', llm=llm)
+	result = await agent._get_model_output_with_retry([])
+
+	# multi_act iterates model_dump(exclude_unset=True) keys as action names
+	action_data = result.action[0].model_dump(exclude_unset=True)
+	action_name = next(iter(action_data.keys()))
+	assert action_name == 'done'


### PR DESCRIPTION
## Summary
- Fix empty-action safety net that raised ValidationError on ActionModel()
- Insert a proper done(success=False) via DoneActionModel.model_validate
- CI regression tests for construction + _get_model_output_with_retry

Fixes #5360

## Test plan
- [x] uv run pytest -vxs tests/ci/test_empty_action_recovery.py
- [x] ruff check / format
- [x] pyright on touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5360 by inserting a valid fallback `done` action when the LLM returns no actions. Prevents `ValidationError` from `ActionModel()` and makes `_get_model_output_with_retry` degrade gracefully.

- **Bug Fixes**
  - Build the fallback via `DoneActionModel.model_validate({'done': ...})`, with a safe fallback to `ActionModel.model_validate`.
  - Set `success: False` and a clear message to mark the noop `done` action.
  - Add regression tests for empty `ActionModel()` construction, `done` validation, and the retry path inserting a single executable `done` action.

<sup>Written for commit 826aa9b6f73785a8778561e319d498146bef3ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

