### PR TITLE
fix(tools): report missing element actions as errors

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -715,7 +715,7 @@ class Tools(Generic[Context]):
 				if node is None:
 					msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 					logger.warning(f'⚠️ {msg}')
-					return ActionResult(extracted_content=msg)
+					return ActionResult(error=msg)
 
 				# Get description of clicked element
 				element_desc = get_click_description(node)
@@ -1687,7 +1687,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			if node is None:
 				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(error=msg)
 
 			# Dispatch GetDropdownOptionsEvent to the event handler
 
@@ -1715,7 +1715,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			if node is None:
 				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(error=msg)
 
 			# Dispatch SelectDropdownOptionEvent to the event handler
 			from browser_use.browser.events import SelectDropdownOptionEvent
@@ -1741,7 +1741,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 				if 'short_term_memory' in selection_data and 'long_term_memory' in selection_data:
 					return ActionResult(
 						extracted_content=selection_data['short_term_memory'],
-						long_term_memory=selection_data['long_term_memory'],
+						error=selection_data['long_term_memory'],
 						include_extracted_content_only_once=True,
 					)
 				else:

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -109,6 +109,39 @@ class TestToolsIntegration:
 			assert tools.registry.registry.actions[action].function is not None
 			assert tools.registry.registry.actions[action].description is not None
 
+	async def test_missing_element_actions_return_errors(self, tools, browser_session):
+		"""Actions should report stale element indices as errors."""
+		missing_index = 999_999
+		actions = [
+			('click', {'index': missing_index}),
+			('dropdown_options', {'index': missing_index}),
+			('select_dropdown', {'index': missing_index, 'text': 'missing'}),
+		]
+
+		for action_name, action_params in actions:
+			result = await getattr(tools, action_name)(**action_params, browser_session=browser_session)
+
+			assert result.error is not None, f'{action_name} should report a missing element as an error'
+			assert f'Element index {missing_index} not available' in result.error
+
+	async def test_invalid_dropdown_selection_returns_error(self, tools, browser_session, base_url, http_server):
+		"""Structured dropdown failures should still be reported as errors."""
+		http_server.expect_request('/dropdown-invalid').respond_with_data(
+			'<select id="test-dropdown"><option>First Option</option><option>Second Option</option></select>',
+			content_type='text/html',
+		)
+		await tools.navigate(url=f'{base_url}/dropdown-invalid', new_tab=False, browser_session=browser_session)
+		await browser_session.get_browser_state_summary()
+		dropdown_index = await browser_session.get_index_by_id('test-dropdown')
+
+		assert dropdown_index is not None
+		result = await tools.select_dropdown(index=dropdown_index, text='Missing Option', browser_session=browser_session)
+
+		assert result.error is not None
+		assert "Couldn't select the dropdown option" in result.error
+		assert result.extracted_content is not None
+		assert 'First Option' in result.extracted_content
+
 	async def test_custom_action_registration(self, tools, browser_session, base_url):
 		"""Test registering a custom action and executing it."""
 


### PR DESCRIPTION
## Summary

- report missing element indices as errors for click, dropdown_options, and select_dropdown
- preserve structured dropdown guidance while marking failed selections as errors
- add focused real-browser coverage for stale indices and invalid dropdown options

Fixes #5438

## Verification

- uv run pytest -q tests/ci/test_tools.py::TestToolsIntegration::test_missing_element_actions_return_errors tests/ci/test_tools.py::TestToolsIntegration::test_invalid_dropdown_selection_returns_error
- uv run pre-commit run --files browser_use/tools/service.py tests/ci/test_tools.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports missing-element actions as errors so stale indices no longer masquerade as successful guidance text. `click`, `dropdown_options`, and `select_dropdown` now return `ActionResult(error=...)` instead of a message in `extracted_content`; invalid dropdown selections put failure details in `error`, keep guidance in `extracted_content`, and no longer set `long_term_memory`. Fixes #5438.

Adds browser-backed tests for stale indices and invalid dropdown selections.

**Migration**
- Check `result.error` to detect missing-element and failed-selection cases; do not rely on `extracted_content` or `long_term_memory` for failure signaling.

<sup>Written for commit c07e3b5a274d048ae49c7e421214686b58c2f4b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

