### PR TITLE
fix(tools): report missing elements as errors

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -715,7 +715,7 @@ class Tools(Generic[Context]):
 				if node is None:
 					msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 					logger.warning(f'⚠️ {msg}')
-					return ActionResult(extracted_content=msg)
+					return ActionResult(error=msg)
 
 				# Get description of clicked element
 				element_desc = get_click_description(node)
@@ -1679,7 +1679,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			if node is None:
 				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(error=msg)
 
 			# Dispatch GetDropdownOptionsEvent to the event handler
 
@@ -1707,7 +1707,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			if node is None:
 				msg = f'Element index {params.index} not available - page may have changed. Try refreshing browser state.'
 				logger.warning(f'⚠️ {msg}')
-				return ActionResult(extracted_content=msg)
+				return ActionResult(error=msg)
 
 			# Dispatch SelectDropdownOptionEvent to the event handler
 			from browser_use.browser.events import SelectDropdownOptionEvent
@@ -1729,11 +1729,10 @@ You will be given a query and the markdown of a webpage that has been filtered t
 				)
 			else:
 				# Handle structured error response
-				# TODO: raise BrowserError instead of returning ActionResult
 				if 'short_term_memory' in selection_data and 'long_term_memory' in selection_data:
 					return ActionResult(
 						extracted_content=selection_data['short_term_memory'],
-						long_term_memory=selection_data['long_term_memory'],
+						error=selection_data['long_term_memory'],
 						include_extracted_content_only_once=True,
 					)
 				else:

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -89,6 +89,22 @@ def tools():
 class TestToolsIntegration:
 	"""Integration tests for Tools using actual browser instances."""
 
+	@pytest.mark.parametrize(
+		('action_name', 'action_kwargs'),
+		[
+			('click', {'index': 999_999}),
+			('dropdown_options', {'index': 999_999}),
+			('select_dropdown', {'index': 999_999, 'text': 'Missing option'}),
+		],
+	)
+	async def test_missing_element_is_reported_as_error(self, tools, browser_session, action_name, action_kwargs):
+		"""Stale selector indexes must stop an action sequence instead of looking successful."""
+		result = await getattr(tools, action_name)(browser_session=browser_session, **action_kwargs)
+
+		expected_error = 'Element index 999999 not available - page may have changed. Try refreshing browser state.'
+		assert result.error == expected_error
+		assert result.extracted_content is None
+
 	async def test_registry_actions(self, tools, browser_session):
 		"""Test that the registry contains the expected default actions."""
 		# Check that common actions are registered
@@ -494,6 +510,20 @@ class TestToolsIntegration:
 		)
 		selected_value = selected_value_result.get('result', {}).get('value')
 		assert selected_value == 'option2'  # Second Option has value "option2"
+
+		# A structured selection failure should preserve the helpful options while
+		# still being marked as an error so multi-action execution stops.
+		failed_result = await tools.select_dropdown(
+			index=dropdown_index,
+			text='Missing Option',
+			browser_session=browser_session,
+		)
+		assert (
+			failed_result.error == "Couldn't select the dropdown option as 'Missing Option' is not one of the available options."
+		)
+		assert failed_result.extracted_content is not None
+		assert 'Available dropdown options' in failed_result.extracted_content
+		assert '- Second Option' in failed_result.extracted_content
 
 
 class TestStructuredOutputDoneWithFiles:


### PR DESCRIPTION
## Why

Missing selector indexes currently return an `ActionResult` with only `extracted_content`. That makes `click`, `dropdown_options`, and `select_dropdown` look successful to multi-action execution even though no browser action occurred.

Fixes #5438.

## What changed

- Return missing-element messages through `ActionResult.error` for the three affected actions.
- Mark structured dropdown selection failures as errors while preserving the short-term list of available options for the model.
- Add focused real-browser regression coverage for stale indexes and unavailable dropdown options.

## Behavior demo

```text
Before: error=None, extracted_content="Element index 999999 not available ..."
After:  error="Element index 999999 not available ...", extracted_content=None
```

This is an action-result semantics fix, so there is no visual UI change to capture in a screenshot.

## Validation

- `pytest -q tests/ci/test_tools.py` — 19 passed
- `pre-commit run --files browser_use/tools/service.py tests/ci/test_tools.py` — all hooks passed
- Full `tests/ci` run reached 525 passed / 9 skipped before a pre-existing Windows-only beta-agent test stopped the run; the three concurrent browser-test failures from that run all passed when rerun serially.

## AI assistance

AI assistance was used to inspect the affected paths, draft the focused patch, and run the repository's validation commands. The behavior and test results above were verified locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report missing element indexes as errors in tool actions so multi-action runs stop instead of appearing successful. Affects `click`, `dropdown_options`, and `select_dropdown`; no UI changes.

- **Bug Fixes**
  - Return `ActionResult.error` when an element index is missing for `click`, `dropdown_options`, and `select_dropdown` (no `extracted_content` on error).
  - Mark structured dropdown selection failures as errors while still returning the short-term list of available options in `extracted_content`.
  - Added focused real-browser regression tests for stale indexes and unavailable dropdown options.

<sup>Written for commit 237fa0b7aec1b79a82fafd36a111e8b9b37f20e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

