### PR TITLE
Add complete MiniMax chat provider

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
 	from browser_use.llm.litellm.chat import ChatLiteLLM
+	from browser_use.llm.minimax.chat import ChatMiniMax
 	from browser_use.llm.mistral.chat import ChatMistral
 	from browser_use.llm.oci_raw.chat import ChatOCIRaw
 	from browser_use.llm.ollama.chat import ChatOllama
@@ -100,6 +101,7 @@ _LAZY_IMPORTS = {
 	'ChatDeepSeek': ('browser_use.llm.deepseek.chat', 'ChatDeepSeek'),
 	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
 	'ChatLiteLLM': ('browser_use.llm.litellm.chat', 'ChatLiteLLM'),
+	'ChatMiniMax': ('browser_use.llm.minimax.chat', 'ChatMiniMax'),
 	'ChatMistral': ('browser_use.llm.mistral.chat', 'ChatMistral'),
 	'ChatAzureOpenAI': ('browser_use.llm.azure.chat', 'ChatAzureOpenAI'),
 	'ChatOCIRaw': ('browser_use.llm.oci_raw.chat', 'ChatOCIRaw'),
@@ -158,6 +160,7 @@ __all__ = [
 	'ChatGroq',
 	'ChatLiteLLM',
 	'ChatMistral',
+	'ChatMiniMax',
 	'ChatAzureOpenAI',
 	'ChatOCIRaw',
 	'ChatOllama',

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.deepseek.chat import ChatDeepSeek
 	from browser_use.llm.google.chat import ChatGoogle
 	from browser_use.llm.groq.chat import ChatGroq
+	from browser_use.llm.minimax.chat import ChatMiniMax
 	from browser_use.llm.mistral.chat import ChatMistral
 	from browser_use.llm.oci_raw.chat import ChatOCIRaw
 	from browser_use.llm.ollama.chat import ChatOllama
@@ -74,6 +75,8 @@ if TYPE_CHECKING:
 	google_gemini_2_5_pro: ChatGoogle
 	google_gemini_2_5_flash: ChatGoogle
 	google_gemini_2_5_flash_lite: ChatGoogle
+	minimax_m3: ChatMiniMax
+	minimax_m2_7: ChatMiniMax
 
 # Models are imported on-demand via __getattr__
 
@@ -88,6 +91,7 @@ _LAZY_IMPORTS = {
 	'ChatDeepSeek': ('browser_use.llm.deepseek.chat', 'ChatDeepSeek'),
 	'ChatGoogle': ('browser_use.llm.google.chat', 'ChatGoogle'),
 	'ChatGroq': ('browser_use.llm.groq.chat', 'ChatGroq'),
+	'ChatMiniMax': ('browser_use.llm.minimax.chat', 'ChatMiniMax'),
 	'ChatMistral': ('browser_use.llm.mistral.chat', 'ChatMistral'),
 	'ChatOCIRaw': ('browser_use.llm.oci_raw.chat', 'ChatOCIRaw'),
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
@@ -158,4 +162,5 @@ __all__ = [
 	'ChatOpenRouter',
 	'ChatVercel',
 	'ChatCerebras',
+	'ChatMiniMax',
 ]

--- a/browser_use/llm/minimax/chat.py
+++ b/browser_use/llm/minimax/chat.py
@@ -1,0 +1,75 @@
+import os
+from dataclasses import dataclass, field
+from typing import Literal, cast
+
+from browser_use.llm.openai.chat import ChatOpenAI
+
+MiniMaxRegion = Literal['global', 'cn']
+MiniMaxThinkingMode = Literal['adaptive', 'disabled', 'always_on']
+MiniMaxModality = Literal['text', 'image', 'video']
+
+MINIMAX_BASE_URLS: dict[MiniMaxRegion, str] = {
+	'global': 'https://api.minimax.io/v1',
+	'cn': 'https://api.minimaxi.com/v1',
+}
+
+
+@dataclass(frozen=True)
+class MiniMaxModelMetadata:
+	context_window: int
+	input_cost_per_million_tokens: float
+	output_cost_per_million_tokens: float
+	cache_read_cost_per_million_tokens: float
+	cache_write_cost_per_million_tokens: float | None
+	input_modalities: tuple[MiniMaxModality, ...]
+	thinking_modes: tuple[MiniMaxThinkingMode, ...]
+
+
+MINIMAX_MODEL_METADATA = {
+	'MiniMax-M3': MiniMaxModelMetadata(
+		context_window=1_000_000,
+		input_cost_per_million_tokens=0.6,
+		output_cost_per_million_tokens=2.4,
+		cache_read_cost_per_million_tokens=0.12,
+		cache_write_cost_per_million_tokens=None,
+		input_modalities=('text', 'image', 'video'),
+		thinking_modes=('adaptive', 'disabled'),
+	),
+	'MiniMax-M2.7': MiniMaxModelMetadata(
+		context_window=204_800,
+		input_cost_per_million_tokens=0.3,
+		output_cost_per_million_tokens=1.2,
+		cache_read_cost_per_million_tokens=0.06,
+		cache_write_cost_per_million_tokens=0.375,
+		input_modalities=('text',),
+		thinking_modes=('always_on',),
+	),
+}
+
+
+def _region_from_env() -> MiniMaxRegion:
+	return cast(MiniMaxRegion, os.getenv('MINIMAX_REGION', 'global').lower())
+
+
+@dataclass
+class ChatMiniMax(ChatOpenAI):
+	"""Chat client for MiniMax models with global and China endpoints."""
+
+	model: str = 'MiniMax-M3'
+	region: MiniMaxRegion = field(default_factory=_region_from_env)
+
+	def __post_init__(self) -> None:
+		if self.region not in MINIMAX_BASE_URLS:
+			raise ValueError(f"Unknown MiniMax region: '{self.region}'. Expected 'global' or 'cn'.")
+		if self.api_key is None:
+			self.api_key = os.getenv('MINIMAX_API_KEY')
+		if self.base_url is None:
+			self.base_url = os.getenv('MINIMAX_BASE_URL') or MINIMAX_BASE_URLS[self.region]
+
+	@property
+	def provider(self) -> str:
+		return 'minimax'
+
+	@property
+	def model_metadata(self) -> MiniMaxModelMetadata | None:
+		return MINIMAX_MODEL_METADATA.get(self.model)

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -18,6 +18,7 @@ from browser_use.llm.azure.chat import ChatAzureOpenAI
 from browser_use.llm.browser_use.chat import ChatBrowserUse
 from browser_use.llm.cerebras.chat import ChatCerebras
 from browser_use.llm.google.chat import ChatGoogle
+from browser_use.llm.minimax.chat import ChatMiniMax
 from browser_use.llm.mistral.chat import ChatMistral
 from browser_use.llm.openai.chat import ChatOpenAI
 
@@ -79,6 +80,9 @@ anthropic_claude_3_5_haiku_latest: 'BaseChatModel'
 cerebras_gpt_oss_120b: 'BaseChatModel'
 cerebras_zai_glm_4_7: 'BaseChatModel'
 cerebras_gemma_4_31b: 'BaseChatModel'
+
+minimax_m3: 'BaseChatModel'
+minimax_m2_7: 'BaseChatModel'
 
 bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
@@ -211,6 +215,13 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('CEREBRAS_API_KEY')
 		return ChatCerebras(model=model, api_key=api_key)
 
+	# MiniMax Models
+	elif provider == 'minimax':
+		api_key = os.getenv('MINIMAX_API_KEY')
+		region = os.getenv('MINIMAX_REGION', 'global').lower()
+		minimax_map = {'m3': 'MiniMax-M3', 'm2-7': 'MiniMax-M2.7'}
+		return ChatMiniMax(model=minimax_map.get(model, model), api_key=api_key, region=region)  # type: ignore[arg-type]
+
 	# Browser Use Models
 	elif provider == 'bu':
 		# Handle bu_latest -> bu-latest conversion (need to prepend 'bu-' back)
@@ -219,7 +230,7 @@ def get_llm_by_name(model_name: str):
 		return ChatBrowserUse(model=model, api_key=api_key)
 
 	else:
-		available_providers = ['openai', 'azure', 'google', 'anthropic', 'mistral', 'oci', 'cerebras', 'bu']
+		available_providers = ['openai', 'azure', 'google', 'anthropic', 'mistral', 'oci', 'cerebras', 'minimax', 'bu']
 		raise ValueError(f"Unknown provider: '{provider}'. Available providers: {', '.join(available_providers)}")
 
 
@@ -243,6 +254,8 @@ def __getattr__(name: str) -> 'BaseChatModel':
 		return ChatOCIRaw  # type: ignore
 	elif name == 'ChatCerebras':
 		return ChatCerebras  # type: ignore
+	elif name == 'ChatMiniMax':
+		return ChatMiniMax  # type: ignore
 	elif name == 'ChatBrowserUse':
 		return ChatBrowserUse  # type: ignore
 
@@ -260,6 +273,7 @@ __all__ = [
 	'ChatGoogle',
 	'ChatMistral',
 	'ChatCerebras',
+	'ChatMiniMax',
 	'ChatBrowserUse',
 ]
 
@@ -315,6 +329,9 @@ __all__ += [
 	'cerebras_gpt_oss_120b',
 	'cerebras_zai_glm_4_7',
 	'cerebras_gemma_4_31b',
+	# MiniMax instances - created on demand
+	'minimax_m3',
+	'minimax_m2_7',
 	# Browser Use instances - created on demand
 	'bu_latest',
 	'bu_1_0',

--- a/browser_use/tokens/custom_pricing.py
+++ b/browser_use/tokens/custom_pricing.py
@@ -9,6 +9,24 @@ from typing import Any
 # Custom model pricing data
 # Format matches LiteLLM's model_prices_and_context_window.json structure
 CUSTOM_MODEL_PRICING: dict[str, dict[str, Any]] = {
+	'MiniMax-M3': {
+		'input_cost_per_token': 0.6 / 1_000_000,
+		'output_cost_per_token': 2.4 / 1_000_000,
+		'cache_read_input_token_cost': 0.12 / 1_000_000,
+		'cache_creation_input_token_cost': None,
+		'max_tokens': 1_000_000,
+		'max_input_tokens': 1_000_000,
+		'max_output_tokens': None,
+	},
+	'MiniMax-M2.7': {
+		'input_cost_per_token': 0.3 / 1_000_000,
+		'output_cost_per_token': 1.2 / 1_000_000,
+		'cache_read_input_token_cost': 0.06 / 1_000_000,
+		'cache_creation_input_token_cost': 0.375 / 1_000_000,
+		'max_tokens': 204_800,
+		'max_input_tokens': 204_800,
+		'max_output_tokens': None,
+	},
 	'bu-1-0': {
 		'input_cost_per_token': 0.2 / 1_000_000,  # $0.20 per 1M tokens
 		'output_cost_per_token': 2.00 / 1_000_000,  # $2.00 per 1M tokens

--- a/tests/ci/models/test_llm_model_factory.py
+++ b/tests/ci/models/test_llm_model_factory.py
@@ -1,6 +1,8 @@
 from browser_use.llm.anthropic.chat import ChatAnthropic
 from browser_use.llm.cerebras.chat import ChatCerebras
+from browser_use.llm.minimax.chat import ChatMiniMax
 from browser_use.llm.models import get_llm_by_name
+from browser_use.tokens.custom_pricing import CUSTOM_MODEL_PRICING
 
 
 def test_get_llm_by_name_resolves_anthropic_from_env(monkeypatch):
@@ -21,3 +23,46 @@ def test_get_llm_by_name_preserves_cerebras_zai_glm_version_separator(monkeypatc
 	assert isinstance(llm, ChatCerebras)
 	assert llm.model == 'zai-glm-4.7'
 	assert llm.api_key == 'cerebras-test-key'
+
+
+def test_get_llm_by_name_resolves_minimax_models_and_global_endpoint(monkeypatch):
+	monkeypatch.setenv('MINIMAX_API_KEY', 'minimax-test-key')
+	monkeypatch.delenv('MINIMAX_REGION', raising=False)
+	monkeypatch.delenv('MINIMAX_BASE_URL', raising=False)
+
+	m3 = get_llm_by_name('minimax_m3')
+	m2_7 = get_llm_by_name('minimax_m2_7')
+
+	assert isinstance(m3, ChatMiniMax)
+	assert m3.model == 'MiniMax-M3'
+	assert str(m3.base_url) == 'https://api.minimax.io/v1'
+	assert m3.api_key == 'minimax-test-key'
+	assert isinstance(m2_7, ChatMiniMax)
+	assert m2_7.model == 'MiniMax-M2.7'
+	assert m2_7.model_metadata is not None
+	assert m2_7.model_metadata.thinking_modes == ('always_on',)
+
+
+def test_minimax_china_endpoint_and_model_metadata(monkeypatch):
+	monkeypatch.delenv('MINIMAX_BASE_URL', raising=False)
+	llm = ChatMiniMax(region='cn')
+
+	assert str(llm.base_url) == 'https://api.minimaxi.com/v1'
+	assert llm.model_metadata is not None
+	assert llm.model_metadata.context_window == 1_000_000
+	assert llm.model_metadata.input_modalities == ('text', 'image', 'video')
+	assert llm.model_metadata.thinking_modes == ('adaptive', 'disabled')
+
+
+def test_minimax_pricing_metadata():
+	m3 = CUSTOM_MODEL_PRICING['MiniMax-M3']
+	m2_7 = CUSTOM_MODEL_PRICING['MiniMax-M2.7']
+
+	assert m3['input_cost_per_token'] == 0.6 / 1_000_000
+	assert m3['output_cost_per_token'] == 2.4 / 1_000_000
+	assert m3['cache_read_input_token_cost'] == 0.12 / 1_000_000
+	assert m3['cache_creation_input_token_cost'] is None
+	assert m2_7['input_cost_per_token'] == 0.3 / 1_000_000
+	assert m2_7['output_cost_per_token'] == 1.2 / 1_000_000
+	assert m2_7['cache_read_input_token_cost'] == 0.06 / 1_000_000
+	assert m2_7['cache_creation_input_token_cost'] == 0.375 / 1_000_000


### PR DESCRIPTION
Reason: Browser Use lacks complete MiniMax chat support for both current models and regional endpoints.

This adds a first-class `ChatMiniMax` integration with global and China endpoint selection, environment-based configuration, and lazy public exports. It includes MiniMax-M3 and MiniMax-M2.7 factory aliases with current context, pricing, cache, thinking, and input-modality metadata while preserving arbitrary model names.

Checks:

- `uv run pytest -q tests/ci/models/test_llm_model_factory.py`
- `uv run pre-commit run --files browser_use/llm/minimax/chat.py browser_use/llm/models.py browser_use/llm/__init__.py browser_use/__init__.py browser_use/tokens/custom_pricing.py tests/ci/models/test_llm_model_factory.py`
- `uv run python -c "from browser_use import ChatMiniMax; from browser_use.llm import ChatMiniMax as L; assert ChatMiniMax is L"`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-class MiniMax chat provider with regional endpoint selection and pricing/context metadata. Previously MiniMax was unsupported; now `ChatMiniMax` enables global and China APIs, and the model factory resolves MiniMax models.

- New `browser_use.llm.minimax.chat.ChatMiniMax` with `provider='minimax'`; auto-configures from `MINIMAX_API_KEY`, `MINIMAX_REGION` (default `global`), and optional `MINIMAX_BASE_URL`.
- Model factory supports `minimax` with aliases `minimax_m3` → `MiniMax-M3` and `minimax_m2_7` → `MiniMax-M2.7`; provider list updated.
- Public exports add `ChatMiniMax` in `browser_use.__init__` and `browser_use.llm.__init__`; on-demand attributes included.
- Pricing/context metadata added for both models in `CUSTOM_MODEL_PRICING`.
- Tests cover endpoint selection, metadata, and pricing.

**Usage**
- Set `MINIMAX_API_KEY`; optionally set `MINIMAX_REGION` to `global` or `cn` (or override with `MINIMAX_BASE_URL`).
- Use `ChatMiniMax(model='MiniMax-M3', region='cn')` or `get_llm_by_name('minimax_m3'|'minimax_m2_7')`.
- No changes required for existing providers.

<sup>Written for commit 7faa98bcc4a348f955120685c09add2a516c6276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

