### PR TITLE
fix(llm): include the cache read in Anthropic total_tokens

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -208,15 +208,15 @@ class ChatAnthropic(BaseChatModel):
 
 	def _get_usage(self, response: Any) -> ChatInvokeUsage | None:
 		cache_creation_5m_tokens, cache_creation_1h_tokens = self._get_cache_creation_tokens(response)
+		# Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
+		prompt_tokens = response.usage.input_tokens + (response.usage.cache_read_input_tokens or 0)
+		completion_tokens = response.usage.output_tokens
 		usage = ChatInvokeUsage(
-			prompt_tokens=response.usage.input_tokens
-			+ (
-				response.usage.cache_read_input_tokens or 0
-			),  # Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
-			completion_tokens=response.usage.output_tokens,
-			total_tokens=response.usage.input_tokens
-			+ (response.usage.cache_read_input_tokens or 0)
-			+ response.usage.output_tokens,  # the cache read is part of the input, as prompt_tokens above reflects
+			prompt_tokens=prompt_tokens,
+			completion_tokens=completion_tokens,
+			# Derived from the two above rather than recomputed, so the total cannot drift
+			# out of agreement with its own parts the way it previously did.
+			total_tokens=prompt_tokens + completion_tokens,
 			prompt_cached_tokens=response.usage.cache_read_input_tokens,
 			prompt_cache_creation_tokens=response.usage.cache_creation_input_tokens,
 			prompt_cache_creation_5m_tokens=cache_creation_5m_tokens,

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -214,7 +214,9 @@ class ChatAnthropic(BaseChatModel):
 				response.usage.cache_read_input_tokens or 0
 			),  # Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
 			completion_tokens=response.usage.output_tokens,
-			total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+			total_tokens=response.usage.input_tokens
+			+ (response.usage.cache_read_input_tokens or 0)
+			+ response.usage.output_tokens,  # the cache read is part of the input, as prompt_tokens above reflects
 			prompt_cached_tokens=response.usage.cache_read_input_tokens,
 			prompt_cache_creation_tokens=response.usage.cache_creation_input_tokens,
 			prompt_cache_creation_5m_tokens=cache_creation_5m_tokens,

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -149,7 +149,9 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 				response.usage.cache_read_input_tokens or 0
 			),  # Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
 			completion_tokens=response.usage.output_tokens,
-			total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+			total_tokens=response.usage.input_tokens
+			+ (response.usage.cache_read_input_tokens or 0)
+			+ response.usage.output_tokens,  # the cache read is part of the input, as prompt_tokens above reflects
 			prompt_cached_tokens=response.usage.cache_read_input_tokens,
 			prompt_cache_creation_tokens=response.usage.cache_creation_input_tokens,
 			prompt_cache_creation_5m_tokens=cache_creation_5m_tokens,

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -143,15 +143,15 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 	def _get_usage(self, response: Message) -> ChatInvokeUsage | None:
 		"""Extract usage information from the response."""
 		cache_creation_5m_tokens, cache_creation_1h_tokens = self._get_cache_creation_tokens(response)
+		# Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
+		prompt_tokens = response.usage.input_tokens + (response.usage.cache_read_input_tokens or 0)
+		completion_tokens = response.usage.output_tokens
 		usage = ChatInvokeUsage(
-			prompt_tokens=response.usage.input_tokens
-			+ (
-				response.usage.cache_read_input_tokens or 0
-			),  # Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
-			completion_tokens=response.usage.output_tokens,
-			total_tokens=response.usage.input_tokens
-			+ (response.usage.cache_read_input_tokens or 0)
-			+ response.usage.output_tokens,  # the cache read is part of the input, as prompt_tokens above reflects
+			prompt_tokens=prompt_tokens,
+			completion_tokens=completion_tokens,
+			# Derived from the two above rather than recomputed, so the total cannot drift
+			# out of agreement with its own parts the way it previously did.
+			total_tokens=prompt_tokens + completion_tokens,
 			prompt_cached_tokens=response.usage.cache_read_input_tokens,
 			prompt_cache_creation_tokens=response.usage.cache_creation_input_tokens,
 			prompt_cache_creation_5m_tokens=cache_creation_5m_tokens,

--- a/tests/ci/models/test_llm_anthropic_usage.py
+++ b/tests/ci/models/test_llm_anthropic_usage.py
@@ -1,0 +1,66 @@
+"""Anthropic usage accounting: the total has to agree with its own parts.
+
+Anthropic does not return a `total_tokens` field, so unlike every other
+provider in this package these two files compute it themselves. Both compute it
+from the raw `input_tokens`, which excludes cache reads, while `prompt_tokens`
+one line above adds the cache read in. The result is a `ChatInvokeUsage` whose
+total disagrees with `prompt_tokens + completion_tokens` on any cached call.
+
+In an agent loop the system prompt and the accumulated history are re-read from
+cache on every step, so within a few steps the cache read is most of the input
+and the reported total is a small fraction of what was actually sent.
+"""
+
+from types import SimpleNamespace
+
+from browser_use.llm.anthropic.chat import ChatAnthropic
+from browser_use.llm.aws.chat_anthropic import ChatAnthropicBedrock
+
+
+def _response(input_tokens: int, output_tokens: int, cache_read: int = 0, cache_creation: int = 0):
+	"""A minimal stand-in for an Anthropic Message, carrying only usage."""
+	return SimpleNamespace(
+		usage=SimpleNamespace(
+			input_tokens=input_tokens,
+			output_tokens=output_tokens,
+			cache_read_input_tokens=cache_read,
+			cache_creation_input_tokens=cache_creation,
+			cache_creation=None,
+		)
+	)
+
+
+def test_total_agrees_with_its_parts_on_a_cached_call():
+	"""total_tokens must equal prompt_tokens + completion_tokens.
+
+	`prompt_tokens` is documented as including the cached tokens, so a total
+	that omits them contradicts the same object it is returned in.
+	"""
+	chat = ChatAnthropic(model='claude-sonnet-4-6', api_key='test')
+	usage = chat._get_usage(_response(input_tokens=10, output_tokens=5, cache_read=1000))
+
+	assert usage is not None
+	assert usage.prompt_tokens == 1010
+	assert usage.completion_tokens == 5
+	assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+	assert usage.total_tokens == 1015
+
+
+def test_bedrock_total_agrees_with_its_parts_on_a_cached_call():
+	"""The Bedrock client serves the same models and carries the same defect."""
+	chat = ChatAnthropicBedrock(model='anthropic.claude-sonnet-4-6-v1:0')
+	usage = chat._get_usage(_response(input_tokens=10, output_tokens=5, cache_read=1000))
+
+	assert usage is not None
+	assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+	assert usage.total_tokens == 1015
+
+
+def test_uncached_call_is_unchanged():
+	"""With no cache read the total is what it always was, so this is not a behaviour change."""
+	chat = ChatAnthropic(model='claude-sonnet-4-6', api_key='test')
+	usage = chat._get_usage(_response(input_tokens=10, output_tokens=5))
+
+	assert usage is not None
+	assert usage.prompt_tokens == 10
+	assert usage.total_tokens == 15

--- a/tests/ci/models/test_llm_anthropic_usage.py
+++ b/tests/ci/models/test_llm_anthropic_usage.py
@@ -49,7 +49,9 @@ def test_total_agrees_with_its_parts_on_a_cached_call():
 def test_bedrock_total_agrees_with_its_parts_on_a_cached_call():
 	"""The Bedrock client serves the same models and carries the same defect."""
 	chat = ChatAnthropicBedrock(model='anthropic.claude-sonnet-4-6-v1:0')
-	usage = chat._get_usage(_response(input_tokens=10, output_tokens=5, cache_read=1000))
+	# This overload annotates `response` as `Message` rather than `Any`, and the stand-in
+	# carries only the `usage` attribute the method actually reads.
+	usage = chat._get_usage(_response(input_tokens=10, output_tokens=5, cache_read=1000))  # type: ignore[arg-type]
 
 	assert usage is not None
 	assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens


### PR DESCRIPTION
### The defect

`_get_usage` adds the cache read back onto `prompt_tokens`, with a comment explaining exactly why:

```python
prompt_tokens=response.usage.input_tokens
+ (
    response.usage.cache_read_input_tokens or 0
),  # Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
completion_tokens=response.usage.output_tokens,
total_tokens=response.usage.input_tokens + response.usage.output_tokens,
```

The line below it builds `total_tokens` from the raw `input_tokens`, so the correction is dropped and the returned `ChatInvokeUsage` disagrees with itself. `total_tokens` is not `prompt_tokens + completion_tokens`.

On a call with 10 uncached input, 1000 cache-read and 5 output tokens, against `main`:

```
prompt=1010  completion=5  total=15
consistent? False
reports 15 of 1015 tokens actually sent (1.5%)
```

`prompt_tokens` is documented in `ChatInvokeUsage` as *"the number of tokens in the prompt (this includes the cached tokens as well)"*, so the total contradicts the docstring of the field it sits next to.

### Why it only affects these two files

Anthropic is the only provider here that returns no `total_tokens` of its own, so these are the only two places that compute one by hand. Every other client takes the provider's number:

| client | total |
|---|---|
| openai, azure, groq, cerebras, openrouter, vercel | `response.usage.total_tokens` |
| google | `usage_metadata.total_token_count` |
| aws bedrock | `usage_data.get('totalTokens', 0)` |
| litellm | `prompt_tokens + completion_tokens` |
| **anthropic, aws/chat_anthropic** | **`input_tokens + output_tokens`** |

### Why it matters here in particular

In an agent loop the system prompt and the accumulated history are re-read from cache on every step, so within a few steps the cache read is most of the input. The breakdown fields are all correct, which is what makes this easy to miss: `prompt_cached_tokens` and `prompt_cache_creation_tokens` are populated and right, and only the aggregate is wrong.

Nothing raises, so anything consuming `total_tokens` for cost or budgeting is quietly low.

### The change

One line in each of the two files, adding the cache read to the total so it agrees with `prompt_tokens`. **Uncached calls are unchanged**, so there is no behaviour change where no cache is in play.

### Tests

`tests/ci/models/test_llm_anthropic_usage.py`, three cases:

- the cached call on `ChatAnthropic`, asserting `total_tokens == prompt_tokens + completion_tokens` and the explicit 1015
- the same on `ChatAnthropicBedrock`, which carries the identical defect
- an uncached call pinned at 15, so the no-cache path is demonstrably untouched

The first two fail on `main`.

### Note on scope

`cache_creation_input_tokens` is also excluded from `input_tokens` by Anthropic and is not currently added to `prompt_tokens` either. I have deliberately left that alone, since changing it would shift `prompt_tokens` itself and your cost calculation subtracts `prompt_cached_tokens` from it. Happy to follow up separately if you want that too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include Anthropic cache-read tokens in `total_tokens` and derive it from `prompt_tokens + completion_tokens` so the aggregate matches its parts and reflects actual tokens sent. Previously `total_tokens` used raw `input_tokens` (excluding cache reads), undercounting cached calls; uncached calls are unchanged.

- Update `browser_use/llm/anthropic/chat.py` and `browser_use/llm/aws/chat_anthropic.py` to compute `prompt_tokens` with cache reads and set `total_tokens = prompt_tokens + completion_tokens` to prevent drift.
- Add `tests/ci/models/test_llm_anthropic_usage.py` covering cached and uncached cases for `ChatAnthropic` and `ChatAnthropicBedrock`; include `# type: ignore[arg-type]` for the Bedrock stand-in.
- Only affects Anthropic and Bedrock Anthropic clients; expect higher `total_tokens` in metrics for cached workloads. No migration.

<sup>Written for commit 42c238a50af7e72067c5e4f1b9d2a6d88249ecff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

