### PR TITLE
fix(profile): preserve CHROME_DEFAULT_ARGS order in get_args

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -896,7 +896,8 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		"""Get the list of all Chrome CLI launch args for this profile (compiled from defaults, user-provided, and system-specific)."""
 
 		if isinstance(self.ignore_default_args, list):
-			default_args = set(CHROME_DEFAULT_ARGS) - set(self.ignore_default_args)
+			# Preserve CHROME_DEFAULT_ARGS order — a set would reorder them (hash-seed dependent)
+			default_args = [arg for arg in CHROME_DEFAULT_ARGS if arg not in set(self.ignore_default_args)]
 		elif self.ignore_default_args is True:
 			default_args = []
 		elif not self.ignore_default_args:

--- a/tests/ci/browser/test_profile_args.py
+++ b/tests/ci/browser/test_profile_args.py
@@ -1,0 +1,54 @@
+"""Test that BrowserProfile.get_args() preserves the CHROME_DEFAULT_ARGS ordering.
+
+Regression test for: get_args() converted CHROME_DEFAULT_ARGS to a set when
+ignore_default_args was a list, so the remaining default args came back in an
+arbitrary order that varied between Python processes (hash-seed dependent).
+"""
+
+from browser_use.browser.profile import CHROME_DEFAULT_ARGS, BrowserProfile
+
+
+def _default_args_in_args_order(profile: BrowserProfile) -> list[str]:
+	"""The CHROME_DEFAULT_ARGS entries in the exact order get_args() returned them.
+
+	Iterating ``profile.get_args()`` (not ``CHROME_DEFAULT_ARGS``) keeps the
+	actual returned order, so a reordering by get_args() fails the assertions.
+	"""
+	default_args = set(CHROME_DEFAULT_ARGS)
+	return [arg for arg in profile.get_args() if arg in default_args]
+
+
+def test_get_args_preserves_default_order_with_ignore_list() -> None:
+	profile = BrowserProfile(
+		ignore_default_args=['--disable-popup-blocking'],
+		user_data_dir='/tmp/browser-use-test-profile',
+		enable_default_extensions=False,
+	)
+
+	args = profile.get_args()
+
+	assert '--disable-popup-blocking' not in args
+	expected = [arg for arg in CHROME_DEFAULT_ARGS if arg not in set(profile.ignore_default_args)]
+	assert _default_args_in_args_order(profile) == expected
+
+
+def test_get_args_returns_all_defaults_in_order_without_ignore() -> None:
+	profile = BrowserProfile(
+		ignore_default_args=[],
+		user_data_dir='/tmp/browser-use-test-profile',
+		enable_default_extensions=False,
+	)
+
+	assert _default_args_in_args_order(profile) == CHROME_DEFAULT_ARGS
+
+
+def test_get_args_ignores_all_defaults_when_true() -> None:
+	profile = BrowserProfile(
+		ignore_default_args=True,
+		user_data_dir='/tmp/browser-use-test-profile',
+		enable_default_extensions=False,
+	)
+
+	args = profile.get_args()
+
+	assert not any(arg in args for arg in CHROME_DEFAULT_ARGS)


### PR DESCRIPTION
## Why

`BrowserProfile.get_args()` computed the default args as
`set(CHROME_DEFAULT_ARGS) - set(ignore_default_args)` when
`ignore_default_args` was a list. Set iteration order is hash-seed
dependent, so the remaining default Chrome args came back in a different
order on every Python process — the launch-arg list was nondeterministic
across runs.

## What

Replace the set difference with a list comprehension that filters
`CHROME_DEFAULT_ARGS` while preserving its original order. The set of
args is unchanged — only the order becomes deterministic.

## Verification

- New regression tests in `tests/ci/browser/test_profile_args.py`: the
  remaining default args must appear in `CHROME_DEFAULT_ARGS` order when
  `ignore_default_args` is a list; the `[]` and `True` branches are
  covered too.
- Reproduced the bug across 5 `PYTHONHASHSEED` values (5 different
  orders before the fix); after the fix all 5 produce the canonical
  order.
- `uv run pytest tests/ci/browser/test_profile_args.py tests/ci/browser/test_profile_copy.py tests/ci/browser/test_cdp_headers.py` — 10 passed.
- `ruff check` and `ruff format --check` are clean.

Fixes #5397

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `CHROME_DEFAULT_ARGS` order in `BrowserProfile.get_args()` when `ignore_default_args` is a list. Previously a set difference produced hash-seed-dependent ordering; now it filters `CHROME_DEFAULT_ARGS` to keep its original order. Included args are unchanged; only ordering is deterministic. Behavior with `ignore_default_args=[]` (all defaults) and `True` (none) is otherwise unchanged.

**Review notes**
- Replace set difference with an ordered list comprehension; order now matches `CHROME_DEFAULT_ARGS`.
- Add `tests/ci/browser/test_profile_args.py` covering list, empty list, and `True` branches.
- No migration required.

<sup>Written for commit e031954c5b06db6086e5d26c06c49cfa4246b19e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

