### PR TITLE
fix(demo_mode): avoid innerHTML on Trusted Types pages

### DIFF
--- a/browser_use/browser/demo_mode.py
+++ b/browser_use/browser/demo_mode.py
@@ -18,7 +18,6 @@ _DEMO_PANEL_SCRIPT = r"""(function () {
   const PANEL_ID = 'browser-use-demo-panel';
   const STYLE_ID = 'browser-use-demo-panel-style';
   const STORAGE_KEY = '__browserUseDemoLogs__';
-  const STORAGE_HTML_KEY = '__browserUseDemoLogsHTML__';
   const PANEL_STATE_KEY = '__browserUseDemoPanelState__';
   const TOGGLE_BUTTON_ID = 'browser-use-demo-toggle';
   const MAX_MESSAGES = 100;
@@ -72,9 +71,7 @@ _DEMO_PANEL_SCRIPT = r"""(function () {
       document.documentElement.style.setProperty('--browser-use-demo-panel-width', `${savedWidth}px`);
     }
 
-    if (!hydrateFromStoredMarkup()) {
-      state.messages.forEach((entry) => appendEntry(entry, false));
-    }
+    state.messages.forEach((entry) => appendEntry(entry, false));
     attachCloseHandler();
     if (state.isOpen) {
       openPanel(false);
@@ -457,7 +454,7 @@ _DEMO_PANEL_SCRIPT = r"""(function () {
     closeBtn.setAttribute(EXCLUDE_ATTR, 'true');
     closeBtn.setAttribute('aria-label', 'Hide demo panel');
     closeBtn.dataset.role = 'close-toggle';
-    closeBtn.innerHTML = '&times;';
+    closeBtn.textContent = '×';
     actions.appendChild(closeBtn);
     header.appendChild(title);
     header.appendChild(actions);
@@ -594,36 +591,9 @@ _DEMO_PANEL_SCRIPT = r"""(function () {
   function persistMessages() {
     try {
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state.messages.slice(-MAX_MESSAGES)));
-      if (state.list) {
-        sessionStorage.setItem(STORAGE_HTML_KEY, state.list.innerHTML);
-      }
     } catch (err) {
       // Ignore sessionStorage errors (private mode, etc.)
     }
-  }
-
-  function hydrateFromStoredMarkup() {
-    if (!state.list) return false;
-    try {
-      const html = sessionStorage.getItem(STORAGE_HTML_KEY);
-      if (html) {
-        state.list.innerHTML = html;
-        for (const entryNode of state.list.querySelectorAll('.browser-use-demo-entry')) {
-          const toggle = entryNode.querySelector('.browser-use-entry-toggle');
-          if (toggle) {
-            toggle.addEventListener('click', () =>
-              toggleEntryExpansion(entryNode, toggle, entryNode.getAttribute('data-id'))
-            );
-          }
-          applyPersistedExpansion(entryNode);
-        }
-        state.list.scrollTop = state.list.scrollHeight;
-        return true;
-      }
-    } catch (err) {
-      // ignore hydration failures
-    }
-    return false;
   }
 
   function normalizeEntry(detail) {
@@ -679,7 +649,13 @@ _DEMO_PANEL_SCRIPT = r"""(function () {
     meta.className = 'browser-use-entry-meta';
     const time = formatTime(entry.timestamp);
     const label = LEVEL_LABELS[entry.level] || entry.level;
-    meta.innerHTML = `<span>${time}</span><span>${label}</span>`;
+    const timeSpan = document.createElement('span');
+    timeSpan.textContent = time;
+
+    const labelSpan = document.createElement('span');
+    labelSpan.textContent = label;
+
+    meta.replaceChildren(timeSpan, labelSpan);
 
     const messageWrapper = document.createElement('div');
     messageWrapper.className = 'browser-use-entry-message';


### PR DESCRIPTION
## Problem

The demo mode sidebar can fail to appear on pages that enforce CSP Trusted Types. **YouTube** is one example.

Before this change, the injected panel script assigned plain strings to `innerHTML`, like `closeBtn.innerHTML = '&times;'`. On Trusted Types-enforced pages, those assignments can throw:

`Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment.`

When that exception happens during panel initialization, the sidebar does not render, even though `demo_mode=True` is enabled.

The stored HTML hydration path also had a persistence issue: `persistMessages()` wrote `state.list.innerHTML` before the newest log node was appended, so the cached HTML could lag behind `state.messages`.

## Summary

- Fix demo mode sidebar on Trusted Types-enforced pages such as YouTube
- Remove remaining `innerHTML` usage from the injected demo panel
- Restore demo logs from JSON instead of cached rendered HTML

## Repro

1. Run an agent with `demo_mode=True` and `headless=False`.
2. Navigate to YouTube, for example `https://www.youtube.com`.
3. Open DevTools console.
4. Observe the TrustedHTML / `innerHTML` error from the injected demo panel script.
5. The Browser Use demo sidebar does not appear.

## Changes

- Replace `innerHTML` assignments with `textContent` and DOM node construction
- Remove `STORAGE_HTML_KEY` and `hydrateFromStoredMarkup()`
- Keep `STORAGE_KEY` as the source of truth for persisted log messages
- Rebuild restored log rows from JSON using `appendEntry(entry, false)`

## Validation

- `uv run python -m py_compile browser_use/browser/demo_mode.py`
- `uv run ruff check browser_use/browser/demo_mode.py`
- `uv run ruff format --check browser_use/browser/demo_mode.py`
- Manually verified the demo mode sidebar renders on YouTube with `demo_mode=True`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the demo mode sidebar on CSP Trusted Types pages by removing all `innerHTML` usage and rebuilding the UI with safe DOM APIs. Previously, the panel could fail to render when `innerHTML` assignments threw; now it renders consistently and restores logs from JSON.

- Replaces `innerHTML` with `textContent` and explicit element construction (e.g., the close button now sets `×` via `textContent`).
- Removes the HTML hydration path and `STORAGE_HTML_KEY`; session-stored markup is ignored. `STORAGE_KEY` remains the source of truth, and restored rows are rebuilt via `appendEntry(entry, false)`.
- Avoids stale cache issues by persisting only `state.messages` (no more writing list markup).
- Validate by loading a Trusted Types site (e.g., YouTube) with `demo_mode=True` and confirming the sidebar renders and logs persist across navigations.

<sup>Written for commit 77b447a4733e8ad9467509e2faa2410e39238333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

