### PR TITLE
docs: restore social video preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Browser Use lets an AI agent use a web browser the same way humans do — it ope
 ### 🍎 Extract data
 #### Task: "Extract structured data about my followers and export it as a CSV."
 
-![Social Data Extraction Demo](https://github.com/user-attachments/assets/485fd3ec-61b9-4afc-9e86-ee9b85acb592)
+https://github.com/user-attachments/assets/485fd3ec-61b9-4afc-9e86-ee9b85acb592
 
 [Browser Use Cloud Docs ↗](https://docs.browser-use.com/cloud/quickstart)
 


### PR DESCRIPTION
Restore the README social-data demo to GitHub’s bare video URL embed style.

The MP4 remains the trimmed 3.5s asset, but removing the image title syntax lets GitHub render the video preview/thumbnail like the previous README link.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the README social-data demo to GitHub’s bare video URL embed so the preview thumbnail renders again. Previously the Markdown image syntax showed a static image; now the trimmed 3.5s MP4 appears as an inline GitHub video preview.

- Verify on GitHub that the video shows an inline preview; other renderers may display a plain link.
- Docs-only change; no code or build impact.

<sup>Written for commit 55bc98dfcb14cca97c6e5811c1018ea321cbe0cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

