### PR TITLE
feat(llm): default ChatBrowserUse to bu-2-0-mini-preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ async def main():
     agent = Agent(
         task="Find the number of stars of the browser-use repo",
         llm=ChatBrowserUse(model='openai/gpt-5.5'),
-        # llm=ChatBrowserUse(model='bu-2-0'),  # Browser Use's optimized model
+        # llm=ChatBrowserUse(model='bu-2-0-mini-preview'),  # Browser Use's optimized model
         # llm=ChatOpenAI(model='gpt-5.5'),
         # llm=ChatAnthropic(model='claude-opus-4-8'),  # Sonnet also works well
     )

--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -60,7 +60,7 @@ class ChatBrowserUse(BaseChatModel):
 			model: Model name to use. Options:
 				- 'bu-2-0-mini-preview': Default model (fast + cheap, preview)
 				- 'bu-2-0' or 'bu-latest': Premium model
-				- 'bu-1-0': Previous generation model
+				- 'bu-1-0': Previous generation model, redirected to bu-2-0 at the gateway
 				- 'bu-qa-1': Website QA model (tests a site and scores functionality/aesthetics)
 				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
 				- Provider-prefixed ids resolved by the gateway, e.g. 'anthropic/claude-sonnet-4-6',

--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -44,7 +44,7 @@ class ChatBrowserUse(BaseChatModel):
 
 	def __init__(
 		self,
-		model: str = 'bu-2-0',
+		model: str = 'bu-2-0-mini-preview',
 		api_key: str | None = None,
 		base_url: str | None = None,
 		timeout: float = 120.0,
@@ -58,7 +58,8 @@ class ChatBrowserUse(BaseChatModel):
 
 		Args:
 			model: Model name to use. Options:
-				- 'bu-2-0' or 'bu-latest': Default model (latest premium)
+				- 'bu-2-0-mini-preview': Default model (fast + cheap, preview)
+				- 'bu-2-0' or 'bu-latest': Premium model
 				- 'bu-1-0': Previous generation model
 				- 'bu-qa-1': Website QA model (tests a site and scores functionality/aesthetics)
 				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
@@ -73,7 +74,7 @@ class ChatBrowserUse(BaseChatModel):
 		"""
 		# Accept 'bu-*' aliases and any provider-prefixed id; the gateway resolves the
 		# latter (anthropic/*, openai/*, google/*, browser-use/*), so we don't enumerate them.
-		bu_aliases = ['bu-latest', 'bu-1-0', 'bu-2-0', 'bu-qa-1']
+		bu_aliases = ['bu-latest', 'bu-1-0', 'bu-2-0', 'bu-2-0-mini-preview', 'bu-qa-1']
 		is_valid = model in bu_aliases or '/' in model
 		if not is_valid:
 			raise ValueError(
@@ -82,7 +83,8 @@ class ChatBrowserUse(BaseChatModel):
 				"'openai/gpt-5.5', or 'google/gemini-3-pro'."
 			)
 
-		# Normalize bu-latest to the current latest model
+		# Normalize bu-latest to the current latest model. Deliberately not the constructor
+		# default: 'latest' tracks the stable premium line, not the preview.
 		if model == 'bu-latest':
 			self.model = 'bu-2-0'
 		else:

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -8,7 +8,7 @@ Usage:
     model = llm.azure_gpt_4_1_mini
     model = llm.openai_gpt_4o
     model = llm.google_gemini_2_5_pro
-    model = llm.bu_latest  # or bu_1_0, bu_2_0
+    model = llm.bu_latest  # or bu_2_0_mini_preview, bu_2_0, bu_1_0
 """
 
 import os
@@ -83,6 +83,7 @@ cerebras_gemma_4_31b: 'BaseChatModel'
 bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
 bu_2_0: 'BaseChatModel'
+bu_2_0_mini_preview: 'BaseChatModel'
 
 
 def get_llm_by_name(model_name: str):
@@ -319,6 +320,7 @@ __all__ += [
 	'bu_latest',
 	'bu_1_0',
 	'bu_2_0',
+	'bu_2_0_mini_preview',
 ]
 
 # NOTE: OCI backend is optional. The try/except ImportError and conditional __all__ are required

--- a/browser_use/tokens/custom_pricing.py
+++ b/browser_use/tokens/custom_pricing.py
@@ -27,6 +27,16 @@ CUSTOM_MODEL_PRICING: dict[str, dict[str, Any]] = {
 		'max_input_tokens': None,  # Not specified
 		'max_output_tokens': None,  # Not specified
 	},
+	'bu-2-0-mini-preview': {
+		'input_cost_per_token': 0.15 / 1_000_000,  # $0.15 per 1M tokens
+		'output_cost_per_token': 1.50 / 1_000_000,  # $1.50 per 1M tokens
+		# No cache discount on this model: cached reads bill at the input rate.
+		'cache_read_input_token_cost': 0.15 / 1_000_000,  # $0.15 per 1M tokens
+		'cache_creation_input_token_cost': None,  # Not specified
+		'max_tokens': None,  # Not specified
+		'max_input_tokens': None,  # Not specified
+		'max_output_tokens': None,  # Not specified
+	},
 	'claude-sonnet-4-6': {
 		'input_cost_per_token': 3.00 / 1_000_000,
 		'output_cost_per_token': 15.00 / 1_000_000,

--- a/browser_use/tokens/custom_pricing.py
+++ b/browser_use/tokens/custom_pricing.py
@@ -9,15 +9,6 @@ from typing import Any
 # Custom model pricing data
 # Format matches LiteLLM's model_prices_and_context_window.json structure
 CUSTOM_MODEL_PRICING: dict[str, dict[str, Any]] = {
-	'bu-1-0': {
-		'input_cost_per_token': 0.2 / 1_000_000,  # $0.20 per 1M tokens
-		'output_cost_per_token': 2.00 / 1_000_000,  # $2.00 per 1M tokens
-		'cache_read_input_token_cost': 0.02 / 1_000_000,  # $0.02 per 1M tokens
-		'cache_creation_input_token_cost': None,  # Not specified
-		'max_tokens': None,  # Not specified
-		'max_input_tokens': None,  # Not specified
-		'max_output_tokens': None,  # Not specified
-	},
 	'bu-2-0': {
 		'input_cost_per_token': 0.60 / 1_000_000,  # $0.60 per 1M tokens
 		'output_cost_per_token': 3.50 / 1_000_000,  # $3.50 per 1M tokens
@@ -99,5 +90,8 @@ CUSTOM_MODEL_PRICING: dict[str, dict[str, Any]] = {
 	},
 }
 CUSTOM_MODEL_PRICING['bu-latest'] = CUSTOM_MODEL_PRICING['bu-2-0']
+
+# bu-1-0 is redirected to bu-2-0 at the gateway, so it bills at bu-2-0 rates.
+CUSTOM_MODEL_PRICING['bu-1-0'] = CUSTOM_MODEL_PRICING['bu-2-0']
 
 CUSTOM_MODEL_PRICING['smart'] = CUSTOM_MODEL_PRICING['bu-2-0']

--- a/examples/beta_agent/basic.py
+++ b/examples/beta_agent/basic.py
@@ -23,7 +23,7 @@ async def main() -> None:
 	agent = Agent(
 		task=task,
 		llm=ChatBrowserUse(model='openai/gpt-5.5'),
-		# llm=ChatBrowserUse(),  # Browser Use's own optimized model (bu-2-0)
+		# llm=ChatBrowserUse(),  # Browser Use's own optimized model (bu-2-0-mini-preview)
 		# llm=ChatOpenAI(model='gpt-5.5'),
 		# llm=ChatGoogle(model='gemini-3.1-pro-preview'),
 		# llm=ChatAnthropic(model='claude-opus-4-8'),  # Sonnet also works well.

--- a/examples/browser/cloud_browser.py
+++ b/examples/browser/cloud_browser.py
@@ -21,7 +21,7 @@ async def basic():
 
 	agent = Agent(
 		task='Go to github.com/browser-use/browser-use and tell me the star count',
-		llm=ChatBrowserUse(model='bu-2-0'),
+		llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 		browser=browser,
 	)
 
@@ -39,7 +39,7 @@ async def full_config():
 
 	agent = Agent(
 		task='go and check my ip address and the location',
-		llm=ChatBrowserUse(model='bu-2-0'),
+		llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 		browser=browser,
 	)
 

--- a/examples/browser/custom_headers.py
+++ b/examples/browser/custom_headers.py
@@ -90,7 +90,7 @@ async def main():
 			'Open https://httpbin.org/headers in two different tabs and extract the full JSON response. '
 			'Look for the custom headers X-Custom-Auth, X-Request-Source, and X-Trace-Id in the output and compare the results.'
 		),
-		llm=ChatBrowserUse(model='bu-2-0'),
+		llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 		browser=browser,
 	)
 

--- a/examples/demo_mode_example.py
+++ b/examples/demo_mode_example.py
@@ -6,7 +6,7 @@ from browser_use import Agent, ChatBrowserUse
 async def main() -> None:
 	agent = Agent(
 		task='Please find the latest commit on browser-use/browser-use repo and tell me the commit message. Please summarize what it is about.',
-		llm=ChatBrowserUse(model='bu-2-0'),
+		llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 		demo_mode=True,
 	)
 	await agent.run(max_steps=5)

--- a/examples/features/csv_file_generation.py
+++ b/examples/features/csv_file_generation.py
@@ -33,7 +33,7 @@ async def main():
 			'Create a CSV file called "top_cities.csv" with columns: rank, city name, country, population. '
 			'Make sure to include all cities even if some data is missing — leave those cells empty.'
 		),
-		llm=ChatBrowserUse(model='bu-2-0'),
+		llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 	)
 
 	history = await agent.run()

--- a/examples/features/judge_trace.py
+++ b/examples/features/judge_trace.py
@@ -27,7 +27,7 @@ Round your result to the nearest 1000 hours and do not use any comma separators 
 
 
 async def main():
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 	agent = Agent(
 		task=task,
 		llm=llm,

--- a/examples/features/rerun_history.py
+++ b/examples/features/rerun_history.py
@@ -59,7 +59,7 @@ async def main():
 	# Example task to demonstrate history saving and rerunning
 	history_file = Path('agent_history.json')
 	task = 'Go to https://browser-use.github.io/stress-tests/challenges/reference-number-form.html and fill the form with example data and submit and extract the refernence number.'
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 
 	# Optional: Use custom LLMs for AI features during rerun
 	# Uncomment to use a custom LLM:

--- a/examples/features/save_as_pdf.py
+++ b/examples/features/save_as_pdf.py
@@ -34,7 +34,7 @@ async def main():
 			'Go to https://news.ycombinator.com and save the front page as a PDF named "hackernews". '
 			'Then go to https://en.wikipedia.org/wiki/Web_browser and save just that article as a PDF in A4 format.'
 		),
-		llm=ChatBrowserUse(model='bu-2-0'),
+		llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 	)
 
 	history = await agent.run()

--- a/examples/getting_started/01_basic_search.py
+++ b/examples/getting_started/01_basic_search.py
@@ -19,7 +19,7 @@ from browser_use import Agent, ChatBrowserUse
 
 
 async def main():
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 	task = "Search Google for 'what is browser automation' and tell me the top 3 results"
 	agent = Agent(task=task, llm=llm)
 	await agent.run()

--- a/examples/getting_started/02_form_filling.py
+++ b/examples/getting_started/02_form_filling.py
@@ -30,7 +30,7 @@ from browser_use import Agent, ChatBrowserUse
 
 async def main():
 	# Initialize the model
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 
 	# Define a form filling task
 	task = """

--- a/examples/getting_started/03_data_extraction.py
+++ b/examples/getting_started/03_data_extraction.py
@@ -30,7 +30,7 @@ from browser_use import Agent, ChatBrowserUse
 
 async def main():
 	# Initialize the model
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 
 	# Define a data extraction task
 	task = """

--- a/examples/getting_started/04_multi_step_task.py
+++ b/examples/getting_started/04_multi_step_task.py
@@ -30,7 +30,7 @@ from browser_use import Agent, ChatBrowserUse
 
 async def main():
 	# Initialize the model
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 
 	# Define a multi-step task
 	task = """

--- a/examples/integrations/agentmail/2fa.py
+++ b/examples/integrations/agentmail/2fa.py
@@ -28,7 +28,7 @@ async def main():
 	tools = EmailTools(email_client=email_client, inbox=inbox)
 
 	# Initialize the LLM for browser-use agent
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 
 	# Set your local browser path
 	browser = Browser(executable_path='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome')

--- a/examples/models/browser_use_llm.py
+++ b/examples/models/browser_use_llm.py
@@ -20,12 +20,14 @@ if not os.getenv('BROWSER_USE_API_KEY'):
 
 
 async def main():
-	# `bu-2-0` is the optimized default. ChatBrowserUse can also route to
-	# provider-prefixed models (e.g. 'anthropic/claude-sonnet-4-6', 'openai/gpt-5.5',
-	# 'google/gemini-3-pro') through the same gateway - see browser_use_provider_models.py.
+	# `bu-2-0-mini-preview` is the optimized default - what a bare `ChatBrowserUse()` gives you.
+	# For the larger premium model pass `model='bu-2-0'` (or 'bu-latest', which tracks it).
+	# ChatBrowserUse can also route to provider-prefixed models (e.g. 'anthropic/claude-sonnet-4-6',
+	# 'openai/gpt-5.5', 'google/gemini-3-pro') through the same gateway - see
+	# browser_use_provider_models.py.
 	agent = Agent(
 		task='Find the number of stars of the browser-use repo',
-		llm=ChatBrowserUse(model='bu-2-0'),
+		llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 	)
 
 	# Run the agent

--- a/examples/sandbox/example.py
+++ b/examples/sandbox/example.py
@@ -37,7 +37,7 @@ async def pydantic_example(browser: Browser):
 	agent = Agent(
 		"""go and check my ip address and the location. return the result in json format""",
 		browser=browser,
-		llm=ChatBrowserUse(model='bu-2-0'),
+		llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 	)
 	res = await agent.run()
 

--- a/examples/sandbox/structured_output.py
+++ b/examples/sandbox/structured_output.py
@@ -29,7 +29,7 @@ async def get_ip_location(browser: Browser) -> AgentHistoryList:
 	agent = Agent(
 		task='Go to ipinfo.io and extract my IP address and location details (country, city, region)',
 		browser=browser,
-		llm=ChatBrowserUse(model='bu-2-0'),
+		llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 		output_model_schema=IPLocation,
 	)
 	return await agent.run(max_steps=10)

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -12,6 +12,6 @@ load_dotenv()
 
 agent = Agent(
 	task='Find the number of stars of the following repos: browser-use, playwright, stagehand, react, nextjs',
-	llm=ChatBrowserUse(model='bu-2-0'),
+	llm=ChatBrowserUse(model='bu-2-0-mini-preview'),
 )
 agent.run_sync()

--- a/examples/use-cases/buy_groceries.py
+++ b/examples/use-cases/buy_groceries.py
@@ -24,7 +24,7 @@ class GroceryCart(BaseModel):
 async def add_to_cart(items: list[str] = ['milk', 'eggs', 'bread']):
 	browser = Browser(cdp_url='http://localhost:9222')
 
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 
 	# Task prompt
 	task = f"""

--- a/examples/use-cases/pcpartpicker.py
+++ b/examples/use-cases/pcpartpicker.py
@@ -6,7 +6,7 @@ from browser_use import Agent, Browser, ChatBrowserUse, Tools
 async def main():
 	browser = Browser(cdp_url='http://localhost:9222')
 
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 
 	tools = Tools()
 

--- a/examples/use-cases/phone_comparison.py
+++ b/examples/use-cases/phone_comparison.py
@@ -34,7 +34,7 @@ async def find(item: str = 'Used iPhone 12'):
 	"""
 	browser = Browser(cdp_url='http://localhost:9222')
 
-	llm = ChatBrowserUse(model='bu-2-0')
+	llm = ChatBrowserUse(model='bu-2-0-mini-preview')
 
 	# Task prompt
 	task = f"""

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -59,8 +59,9 @@ Optimized for browser automation — highest accuracy, fastest speed, lowest tok
 ```python
 from browser_use import Agent, ChatBrowserUse
 
-llm = ChatBrowserUse()                    # bu-latest (default)
-llm = ChatBrowserUse(model='bu-2-0')      # Premium model
+llm = ChatBrowserUse()                              # bu-2-0-mini-preview (default)
+llm = ChatBrowserUse(model='bu-2-0-mini-preview')   # Default, named explicitly
+llm = ChatBrowserUse(model='bu-2-0')                # Premium model ('bu-latest' tracks this)
 ```
 
 **Env:** `BROWSER_USE_API_KEY` — get at https://cloud.browser-use.com/new-api-key
@@ -68,7 +69,8 @@ llm = ChatBrowserUse(model='bu-2-0')      # Premium model
 **Models & Pricing (per 1M tokens):**
 | Model | Input | Cached | Output |
 |-------|-------|--------|--------|
-| bu-1-0 / bu-latest (default) | $0.20 | $0.02 | $2.00 |
+| bu-2-0-mini-preview (default) | $0.15 | $0.15 | $1.50 |
+| bu-1-0 | $0.20 | $0.02 | $2.00 |
 | bu-2-0 (premium) | $0.60 | $0.06 | $3.50 |
 | browser-use/bu-30b-a3b-preview (OSS) | — | — | — |
 

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -70,8 +70,8 @@ llm = ChatBrowserUse(model='bu-2-0')                # Premium model ('bu-latest'
 | Model | Input | Cached | Output |
 |-------|-------|--------|--------|
 | bu-2-0-mini-preview (default) | $0.15 | $0.15 | $1.50 |
-| bu-1-0 | $0.20 | $0.02 | $2.00 |
 | bu-2-0 (premium) | $0.60 | $0.06 | $3.50 |
+| bu-1-0 (redirects to bu-2-0) | $0.60 | $0.06 | $3.50 |
 | browser-use/bu-30b-a3b-preview (OSS) | — | — | — |
 
 ## OpenAI

--- a/tests/ci/models/test_llm_browseruse.py
+++ b/tests/ci/models/test_llm_browseruse.py
@@ -56,6 +56,9 @@ def test_bu_2_0_mini_preview_is_priced():
 	assert pricing['output_cost_per_token'] > 0
 	# bu-latest resolves to bu-2-0, not to the preview, so it keeps the premium pricing.
 	assert CUSTOM_MODEL_PRICING['bu-latest'] == CUSTOM_MODEL_PRICING['bu-2-0']
+	# bu-1-0 is redirected to bu-2-0 at the gateway, so it must be billed at bu-2-0 rates
+	# rather than the retired bu-1-0 rates.
+	assert CUSTOM_MODEL_PRICING['bu-1-0'] == CUSTOM_MODEL_PRICING['bu-2-0']
 
 
 def test_llm_models_shortcut_resolves_mini_preview(monkeypatch):

--- a/tests/ci/models/test_llm_browseruse.py
+++ b/tests/ci/models/test_llm_browseruse.py
@@ -64,9 +64,14 @@ def test_bu_2_0_mini_preview_is_priced():
 def test_llm_models_shortcut_resolves_mini_preview(monkeypatch):
 	"""`llm.bu_2_0_mini_preview` must map the underscored name back to the dashed model id."""
 	monkeypatch.setenv('BROWSER_USE_API_KEY', TEST_API_KEY)
-	from browser_use.llm.models import get_llm_by_name
+	from browser_use import llm
+	from browser_use.llm import models
 
-	assert get_llm_by_name('bu_2_0_mini_preview').name == 'bu-2-0-mini-preview'
+	# Go through the advertised attribute rather than the factory beneath it, so dropping the
+	# name from __all__ or breaking module __getattr__ fails here instead of passing silently.
+	assert llm.bu_2_0_mini_preview.name == 'bu-2-0-mini-preview'
+	assert models.bu_2_0_mini_preview.name == 'bu-2-0-mini-preview'
+	assert 'bu_2_0_mini_preview' in models.__all__
 
 
 @pytest.mark.parametrize(

--- a/tests/ci/models/test_llm_browseruse.py
+++ b/tests/ci/models/test_llm_browseruse.py
@@ -25,13 +25,13 @@ async def test_browseruse_bu_latest(httpserver):
 # --- Model validation -------------------------------------------------------
 
 
-def test_default_model_is_bu_2_0():
+def test_default_model_is_bu_2_0_mini_preview():
 	chat = ChatBrowserUse(api_key=TEST_API_KEY)
-	assert chat.model == 'bu-2-0'
+	assert chat.model == 'bu-2-0-mini-preview'
 	assert chat.provider == 'browser-use'
 
 
-@pytest.mark.parametrize('alias', ['bu-1-0', 'bu-2-0', 'bu-qa-1'])
+@pytest.mark.parametrize('alias', ['bu-1-0', 'bu-2-0', 'bu-2-0-mini-preview', 'bu-qa-1'])
 def test_bu_aliases_are_accepted(alias):
 	chat = ChatBrowserUse(model=alias, api_key=TEST_API_KEY)
 	assert chat.model == alias
@@ -39,10 +39,31 @@ def test_bu_aliases_are_accepted(alias):
 	assert chat.provider == 'browser-use'
 
 
-def test_bu_latest_normalizes_to_bu_2_0():
+def test_bu_latest_still_normalizes_to_bu_2_0():
+	"""'latest' tracks the stable premium line, so it does NOT follow the preview default."""
 	chat = ChatBrowserUse(model='bu-latest', api_key=TEST_API_KEY)
 	assert chat.model == 'bu-2-0'
 	assert chat.name == 'bu-2-0'
+	assert ChatBrowserUse(api_key=TEST_API_KEY).model != chat.model
+
+
+def test_bu_2_0_mini_preview_is_priced():
+	"""The default model must have a pricing entry, or cost tracking silently reports $0."""
+	from browser_use.tokens.custom_pricing import CUSTOM_MODEL_PRICING
+
+	pricing = CUSTOM_MODEL_PRICING['bu-2-0-mini-preview']
+	assert pricing['input_cost_per_token'] > 0
+	assert pricing['output_cost_per_token'] > 0
+	# bu-latest resolves to bu-2-0, not to the preview, so it keeps the premium pricing.
+	assert CUSTOM_MODEL_PRICING['bu-latest'] == CUSTOM_MODEL_PRICING['bu-2-0']
+
+
+def test_llm_models_shortcut_resolves_mini_preview(monkeypatch):
+	"""`llm.bu_2_0_mini_preview` must map the underscored name back to the dashed model id."""
+	monkeypatch.setenv('BROWSER_USE_API_KEY', TEST_API_KEY)
+	from browser_use.llm.models import get_llm_by_name
+
+	assert get_llm_by_name('bu_2_0_mini_preview').name == 'bu-2-0-mini-preview'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds `bu-2-0-mini-preview` as an accepted model id and makes it the default for `ChatBrowserUse`, so a bare `ChatBrowserUse()` now routes there.

## Model resolution

```
ChatBrowserUse()                            -> bu-2-0-mini-preview   # default moved
ChatBrowserUse(model="bu-latest")           -> bu-2-0                # unchanged
ChatBrowserUse(model="bu-2-0-mini-preview") -> bu-2-0-mini-preview   # new
ChatBrowserUse(model="bu-2-0")              -> bu-2-0                # unchanged
ChatBrowserUse(model="bu-1-0")              -> bu-1-0                # unchanged (gateway redirects to bu-2-0)
```

`bu-2-0` is untouched: still accepted, still documented as the premium option, and `bu-latest` still resolves to it. Deliberately keeping `latest` on the stable line means callers pinned to that alias are not silently moved onto a preview model — only the bare-constructor default moves. There is a test asserting the two are *not* the same id, so the divergence does not get "helpfully" re-synced later.

## Back-compat

No id is removed or repointed. The only behavior change is which model a caller gets when they pass no `model=` at all.

## Pricing

Registered in `custom_pricing.py` alongside the model, so cost tracking does not silently report `$0` for what is now the default:

| Model | Input | Cached | Output |
|-------|-------|--------|--------|
| bu-2-0-mini-preview (default) | $0.15 | $0.15 | $1.50 |
| bu-2-0 (premium) | $0.60 | $0.06 | $3.50 |
| bu-1-0 (redirects to bu-2-0) | $0.60 | $0.06 | $3.50 |

Two things here:

- **`bu-2-0-mini-preview` has no cache discount**, so cached reads bill at the input rate. Called out in a comment so it does not read as a copy-paste slip.
- **`bu-1-0` was mispriced.** It is redirected to `bu-2-0` at the gateway, so requests naming it are served and billed as `bu-2-0`, but the table still carried the retired `bu-1-0` rates — under-reporting cost by 3x on input and 3x on output, and by 3x on cached reads. It is now aliased to the `bu-2-0` entry rather than duplicating the numbers, same as `bu-latest`, so the three cannot drift apart. This is a pre-existing cost-reporting bug, fixed here because the same table is being touched.

## Also in here

`skills/open-source/references/models.md` claimed `bu-latest` resolved to `bu-1-0`, which has not been true since `bu-2-0` shipped. Corrected.

## Test plan

- `uv run pytest tests/ci/models/test_llm_browseruse.py` — 23 passed, 1 skipped (needs `BROWSER_USE_API_KEY`). New coverage: default id, alias acceptance, `bu-latest` divergence from the default, pricing entries present and correctly aliased for both `bu-latest` and `bu-1-0`, and `llm.bu_2_0_mini_preview` mapping back to the dashed id.
- Full `tests/ci`: 481 passed, 33 skipped, plus one failure in `test_beta_agent.py::test_beta_agent_constructor_type_hints_match_browser_use_core_params` that reproduces identically on unmodified `main` (478/1/33) and is unrelated to this change — it passes in isolation and only fails in a full run.
- `pyright` and `ruff` clean; pre-commit hooks pass.