### PR TITLE
fix(llm): extract thinking tags and sanitize json code blocks

### DIFF
--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -20,6 +20,7 @@ from browser_use.llm.deepseek.serializer import DeepSeekMessageSerializer
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.utils import clean_and_extract_json
 from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
@@ -123,8 +124,10 @@ class ChatDeepSeek(BaseChatModel):
 					messages=ds_messages,  # type: ignore
 					**common,
 				)
+				content, thinking = clean_and_extract_json(resp.choices[0].message.content or '')
 				return ChatInvokeCompletion(
-					completion=resp.choices[0].message.content or '',
+					completion=content,
+					thinking=thinking,
 					usage=None,
 				)
 			except RateLimitError as e:
@@ -165,20 +168,24 @@ class ChatDeepSeek(BaseChatModel):
 				if not msg.tool_calls:
 					raise ValueError('Expected tool_calls in response but got none')
 				raw_args = msg.tool_calls[0].function.arguments
+				thinking = None
 				if isinstance(raw_args, str):
-					parsed = json.loads(raw_args)
+					cleaned_args, thinking = clean_and_extract_json(raw_args)
+					parsed = json.loads(cleaned_args)
 				else:
 					parsed = raw_args
 				# --------- Fix: only use model_validate when output_format is not None ----------
 				if output_format is not None:
 					return ChatInvokeCompletion(
 						completion=output_format.model_validate(parsed),
+						thinking=thinking,
 						usage=None,
 					)
 				else:
 					# If no output_format, return dict directly
 					return ChatInvokeCompletion(
 						completion=parsed,
+						thinking=thinking,
 						usage=None,
 					)
 			except RateLimitError as e:
@@ -197,12 +204,14 @@ class ChatDeepSeek(BaseChatModel):
 					response_format={'type': 'json_object'},
 					**common,
 				)
-				content = resp.choices[0].message.content
-				if not content:
+				raw_content = resp.choices[0].message.content
+				if not raw_content:
 					raise ModelProviderError('Empty JSON content in DeepSeek response', model=self.name)
-				parsed = output_format.model_validate_json(content)
+				content, thinking = clean_and_extract_json(raw_content)
+				parsed = output_format.model_validate_json(content)  # type: ignore[attr-defined]
 				return ChatInvokeCompletion(
 					completion=parsed,
+					thinking=thinking,
 					usage=None,
 				)
 			except RateLimitError as e:

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -124,7 +124,7 @@ class ChatDeepSeek(BaseChatModel):
 					messages=ds_messages,  # type: ignore
 					**common,
 				)
-				content, thinking = clean_and_extract_json(resp.choices[0].message.content or '')
+				content, thinking = clean_and_extract_json(resp.choices[0].message.content or '', strip_fences=False)
 				return ChatInvokeCompletion(
 					completion=content,
 					thinking=thinking,

--- a/browser_use/llm/utils.py
+++ b/browser_use/llm/utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+
+THINK_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
+OPEN_THINK_PATTERN = re.compile(r'<think>(.*)', re.DOTALL)
+JSON_FENCE_PATTERN = re.compile(r'```json\s*(.*?)\s*```', re.DOTALL)
+GENERIC_FENCE_PATTERN = re.compile(r'```\s*(.*?)\s*```', re.DOTALL)
+
+
+def clean_and_extract_json(content: str) -> tuple[str, str | None]:
+	"""
+	Extract <think> tags (including unclosed tags) and sanitize markdown JSON code blocks.
+	Returns a tuple of (cleaned_json_content, thinking_content_or_none).
+	"""
+	if not content or not isinstance(content, str):
+		return content or '', None
+
+	thinking: str | None = None
+
+	# 1. Extract <think> tags
+	match = THINK_PATTERN.search(content)
+	if match:
+		thinking = match.group(1).strip()
+		content = THINK_PATTERN.sub('', content).strip()
+	else:
+		# Fallback for unclosed <think> tags (e.g. truncated by max_tokens)
+		open_match = OPEN_THINK_PATTERN.search(content)
+		if open_match:
+			thinking = open_match.group(1).strip()
+			content = content[: open_match.start()].strip()
+
+	# Strip isolated stray closing tags
+	content = re.sub(r'</think>', '', content).strip()
+
+	# 2. Extract JSON code block (preferring ```json over generic ```)
+	json_match = JSON_FENCE_PATTERN.search(content)
+	if json_match:
+		content = json_match.group(1).strip()
+	else:
+		generic_match = GENERIC_FENCE_PATTERN.search(content)
+		if generic_match:
+			content = generic_match.group(1).strip()
+
+	return content, thinking

--- a/browser_use/llm/utils.py
+++ b/browser_use/llm/utils.py
@@ -1,45 +1,58 @@
 from __future__ import annotations
 
+import json
 import re
 
 THINK_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 OPEN_THINK_PATTERN = re.compile(r'<think>(.*)', re.DOTALL)
-JSON_FENCE_PATTERN = re.compile(r'```json\s*(.*?)\s*```', re.DOTALL)
-GENERIC_FENCE_PATTERN = re.compile(r'```\s*(.*?)\s*```', re.DOTALL)
+JSON_FENCE_PATTERN = re.compile(r'^\s*```(?:json)?\s*(.*?)\s*```\s*$', re.DOTALL)
 
 
-def clean_and_extract_json(content: str) -> tuple[str, str | None]:
-	"""
-	Extract <think> tags (including unclosed tags) and sanitize markdown JSON code blocks.
-	Returns a tuple of (cleaned_json_content, thinking_content_or_none).
+def clean_and_extract_json(content: str, strip_fences: bool = True) -> tuple[str, str | None]:
+	"""Extract <think> tags (including multiple or unclosed tags) and sanitize markdown JSON code blocks.
+
+	Args:
+		content: The raw text completion or tool call argument from the LLM.
+		strip_fences: If True, strips markdown code fences when parsing structured JSON.
+					If False, preserves markdown fences (used for plain text completions).
+
+	Returns:
+		A tuple of (cleaned_content, thinking_content_or_none).
 	"""
 	if not content or not isinstance(content, str):
 		return content or '', None
 
-	thinking: str | None = None
+	thinking_parts: list[str] = []
 
-	# 1. Extract <think> tags
-	match = THINK_PATTERN.search(content)
-	if match:
-		thinking = match.group(1).strip()
-		content = THINK_PATTERN.sub('', content).strip()
-	else:
-		# Fallback for unclosed <think> tags (e.g. truncated by max_tokens)
-		open_match = OPEN_THINK_PATTERN.search(content)
-		if open_match:
-			thinking = open_match.group(1).strip()
-			content = content[: open_match.start()].strip()
+	# 1. Extract all closed <think>...</think> blocks first
+	for match in THINK_PATTERN.finditer(content):
+		thinking_parts.append(match.group(1).strip())
+	content = THINK_PATTERN.sub('', content).strip()
+
+	# 2. Extract any remaining unclosed <think>... block (e.g. truncated by max_tokens)
+	open_match = OPEN_THINK_PATTERN.search(content)
+	if open_match:
+		thinking_parts.append(open_match.group(1).strip())
+		content = content[: open_match.start()].strip()
 
 	# Strip isolated stray closing tags
 	content = re.sub(r'</think>', '', content).strip()
 
-	# 2. Extract JSON code block (preferring ```json over generic ```)
-	json_match = JSON_FENCE_PATTERN.search(content)
-	if json_match:
-		content = json_match.group(1).strip()
-	else:
-		generic_match = GENERIC_FENCE_PATTERN.search(content)
-		if generic_match:
-			content = generic_match.group(1).strip()
+	thinking = '\n\n'.join(p for p in thinking_parts if p) if thinking_parts else None
+
+	# 3. Handle markdown code fences ONLY when strip_fences=True
+	if strip_fences:
+		# If content is already valid JSON, do not modify inner fenced strings
+		try:
+			json.loads(content)
+		except Exception:
+			# Only strip fences if they wrap the WHOLE response
+			fence_match = JSON_FENCE_PATTERN.match(content)
+			if fence_match:
+				content = fence_match.group(1).strip()
+			elif content.startswith('```') and content.endswith('```'):
+				lines = content.splitlines()
+				if len(lines) >= 2:
+					content = '\n'.join(lines[1:-1]).strip()
 
 	return content, thinking

--- a/browser_use/llm/utils.py
+++ b/browser_use/llm/utils.py
@@ -5,7 +5,7 @@ import re
 
 THINK_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 OPEN_THINK_PATTERN = re.compile(r'<think>(.*)', re.DOTALL)
-JSON_FENCE_PATTERN = re.compile(r'^\s*```(?:json)?\s*(.*?)\s*```\s*$', re.DOTALL)
+JSON_FENCE_PATTERN = re.compile(r'^\s*```[ \t]*(?:json)?[ \t]*(.*?)\s*```\s*$', re.DOTALL | re.IGNORECASE)
 
 
 def clean_and_extract_json(content: str, strip_fences: bool = True) -> tuple[str, str | None]:

--- a/tests/ci/models/test_llm_thinking.py
+++ b/tests/ci/models/test_llm_thinking.py
@@ -1,0 +1,36 @@
+from browser_use.llm.utils import clean_and_extract_json
+
+
+def test_clean_and_extract_json_plain():
+	raw = '{"action": "search"}'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == '{"action": "search"}'
+	assert thinking is None
+
+
+def test_clean_and_extract_json_only_thinking():
+	raw = '<think>I should search for the product.</think>{"action": "search"}'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == '{"action": "search"}'
+	assert thinking == 'I should search for the product.'
+
+
+def test_clean_and_extract_json_markdown():
+	raw = '```json\n{"action": "search"}\n```'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == '{"action": "search"}'
+	assert thinking is None
+
+
+def test_clean_and_extract_json_both():
+	raw = '<think>Thinking deep thoughts...</think>\n```json\n{"action": "search"}\n```'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == '{"action": "search"}'
+	assert thinking == 'Thinking deep thoughts...'
+
+
+def test_clean_and_extract_json_unclosed_tags():
+	raw = '<think>Truncated thought process without closing tag...'
+	content, thinking = clean_and_extract_json(raw)
+	assert thinking == 'Truncated thought process without closing tag...'
+	assert content == ''

--- a/tests/ci/models/test_llm_thinking.py
+++ b/tests/ci/models/test_llm_thinking.py
@@ -47,7 +47,7 @@ def test_clean_and_extract_json_multiple_and_unclosed_think():
 	raw = '<think>First thought</think>Mid prose<think>Second truncated thought'
 	content, thinking = clean_and_extract_json(raw)
 	assert content == 'Mid prose'
-	assert thinking is not None
+	assert isinstance(thinking, str)
 	assert 'First thought' in thinking
 	assert 'Second truncated thought' in thinking
 

--- a/tests/ci/models/test_llm_thinking.py
+++ b/tests/ci/models/test_llm_thinking.py
@@ -34,3 +34,26 @@ def test_clean_and_extract_json_unclosed_tags():
 	content, thinking = clean_and_extract_json(raw)
 	assert thinking == 'Truncated thought process without closing tag...'
 	assert content == ''
+
+
+def test_clean_and_extract_json_inner_fenced_code():
+	raw = '{"code": "```python\\nprint(\'hello\')\\n```"}'
+	content, thinking = clean_and_extract_json(raw, strip_fences=True)
+	assert content == '{"code": "```python\\nprint(\'hello\')\\n```"}'
+	assert thinking is None
+
+
+def test_clean_and_extract_json_multiple_and_unclosed_think():
+	raw = '<think>First thought</think>Mid prose<think>Second truncated thought'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == 'Mid prose'
+	assert thinking is not None
+	assert 'First thought' in thinking
+	assert 'Second truncated thought' in thinking
+
+
+def test_clean_and_extract_json_plain_text_preserves_fences():
+	raw = '<think>Thought</think>Here is the code:\n```python\nprint(1)\n```'
+	content, thinking = clean_and_extract_json(raw, strip_fences=False)
+	assert content == 'Here is the code:\n```python\nprint(1)\n```'
+	assert thinking == 'Thought'


### PR DESCRIPTION
## Summary

Resolves #4970. Prevents `ValidationError` and `JSONDecodeError` crashes when reasoning models (such as DeepSeek-R1, Ollama reasoning models, or OpenAI o-series) output thinking blocks (`<think>...</think>`) or markdown formatting code blocks (```json ... ```) before or around their structured JSON response.

## Changes

- Created utility helper `clean_and_extract_json` in `browser_use/llm/utils.py`:
  - Strips `<think>` tags (including unclosed tags when output is truncated by `max_tokens`) and populates the `thinking` field of `ChatInvokeCompletion`.
  - Sanitizes markdown code fences, preferring ```` ```json ```` blocks over generic ```` ``` ```` blocks.
- Integrated `clean_and_extract_json` into `browser_use/llm/deepseek/chat.py` across all invocation paths.
- Added comprehensive unit test coverage in `tests/ci/models/test_llm_thinking.py`.

## Testing

Created and executed unit tests in `tests/ci/models/test_llm_thinking.py` covering:
- `test_clean_and_extract_json_plain`: normal JSON string without thinking tags or code blocks.
- `test_clean_and_extract_json_only_thinking`: extracting thinking block and leaving raw JSON.
- `test_clean_and_extract_json_markdown`: stripping markdown formatting code blocks.
- `test_clean_and_extract_json_both`: both thinking tag and markdown code blocks together.
- `test_clean_and_extract_json_unclosed_tags`: recovery from unclosed/truncated thinking tags without throwing exceptions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts <think> content and strips only outer JSON code fences in reasoning-model outputs to prevent JSON parse errors and preserve reasoning. Previously, thinking blocks and fenced JSON could trigger ValidationError/JSONDecodeError and drop reasoning; now cleaned outputs parse reliably and `ChatInvokeCompletion.thinking` stores the thought.

- Adds `browser_use/llm/utils.clean_and_extract_json`: extracts multiple/unclosed <think> blocks, removes stray closing tags, strips only outer markdown JSON fences (case-insensitive), and preserves inner fenced code inside valid JSON strings.
- Integrates cleaning across `browser_use/llm/deepseek/chat.ainvoke` paths: for plain text, removes <think>, preserves code fences, sets `thinking`; for tool-call args and `json_object` responses, strips only outer fences, parses JSON, sets `thinking`, and validates via `output_format` when provided.
- Adds tests in `tests/ci/models/test_llm_thinking.py` for plain/fenced JSON, multiple and unclosed <think>, inner fenced code, and fence preservation in plain text.

<sup>Written for commit 8c38f1d751bf2ebdd67aaa2c6b543668661d7233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

