### PR TITLE
fix(llm): token usage tracking for Ollama and DeepSeek

### DIFF
--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -21,9 +21,46 @@ from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.utils import clean_and_extract_json
-from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
+
+
+def _extract_deepseek_usage(resp: Any) -> ChatInvokeUsage | None:
+	if not resp:
+		return None
+	if isinstance(resp, dict):
+		usage = resp.get('usage')
+	else:
+		usage = getattr(resp, 'usage', None)
+	if not usage:
+		return None
+
+	if isinstance(usage, dict):
+		prompt_tokens = usage.get('prompt_tokens', 0) or 0
+		completion_tokens = usage.get('completion_tokens', 0) or 0
+		total_tokens = usage.get('total_tokens', 0) or (prompt_tokens + completion_tokens)
+		cached_tokens = usage.get('prompt_cache_hit_tokens')
+	else:
+		prompt_tokens = getattr(usage, 'prompt_tokens', 0) or 0
+		completion_tokens = getattr(usage, 'completion_tokens', 0) or 0
+		total_tokens = getattr(usage, 'total_tokens', 0) or (prompt_tokens + completion_tokens)
+		cached_tokens = getattr(usage, 'prompt_cache_hit_tokens', None)
+		if cached_tokens is None and hasattr(usage, 'prompt_tokens_details'):
+			details = getattr(usage, 'prompt_tokens_details', None)
+			if details:
+				cached_tokens = (
+					details.get('cached_tokens') if isinstance(details, dict) else getattr(details, 'cached_tokens', None)
+				)
+
+	return ChatInvokeUsage(
+		prompt_tokens=prompt_tokens,
+		prompt_cached_tokens=cached_tokens,
+		prompt_cache_creation_tokens=None,
+		prompt_image_tokens=None,
+		completion_tokens=completion_tokens,
+		total_tokens=total_tokens,
+	)
 
 
 @dataclass
@@ -128,7 +165,7 @@ class ChatDeepSeek(BaseChatModel):
 				return ChatInvokeCompletion(
 					completion=content,
 					thinking=thinking,
-					usage=None,
+					usage=_extract_deepseek_usage(resp),
 				)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e
@@ -179,14 +216,14 @@ class ChatDeepSeek(BaseChatModel):
 					return ChatInvokeCompletion(
 						completion=output_format.model_validate(parsed),
 						thinking=thinking,
-						usage=None,
+						usage=_extract_deepseek_usage(resp),
 					)
 				else:
 					# If no output_format, return dict directly
 					return ChatInvokeCompletion(
 						completion=parsed,
 						thinking=thinking,
-						usage=None,
+						usage=_extract_deepseek_usage(resp),
 					)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e
@@ -212,7 +249,7 @@ class ChatDeepSeek(BaseChatModel):
 				return ChatInvokeCompletion(
 					completion=parsed,
 					thinking=thinking,
-					usage=None,
+					usage=_extract_deepseek_usage(resp),
 				)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -20,6 +20,7 @@ from browser_use.llm.deepseek.serializer import DeepSeekMessageSerializer
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.utils import clean_and_extract_json
 from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
@@ -123,8 +124,10 @@ class ChatDeepSeek(BaseChatModel):
 					messages=ds_messages,  # type: ignore
 					**common,
 				)
+				content, thinking = clean_and_extract_json(resp.choices[0].message.content or '')
 				return ChatInvokeCompletion(
-					completion=resp.choices[0].message.content or '',
+					completion=content,
+					thinking=thinking,
 					usage=None,
 				)
 			except RateLimitError as e:
@@ -165,20 +168,24 @@ class ChatDeepSeek(BaseChatModel):
 				if not msg.tool_calls:
 					raise ValueError('Expected tool_calls in response but got none')
 				raw_args = msg.tool_calls[0].function.arguments
+				thinking = None
 				if isinstance(raw_args, str):
-					parsed = json.loads(raw_args)
+					cleaned_args, thinking = clean_and_extract_json(raw_args)
+					parsed = json.loads(cleaned_args)
 				else:
 					parsed = raw_args
 				# --------- Fix: only use model_validate when output_format is not None ----------
 				if output_format is not None:
 					return ChatInvokeCompletion(
 						completion=output_format.model_validate(parsed),
+						thinking=thinking,
 						usage=None,
 					)
 				else:
 					# If no output_format, return dict directly
 					return ChatInvokeCompletion(
 						completion=parsed,
+						thinking=thinking,
 						usage=None,
 					)
 			except RateLimitError as e:
@@ -197,12 +204,14 @@ class ChatDeepSeek(BaseChatModel):
 					response_format={'type': 'json_object'},
 					**common,
 				)
-				content = resp.choices[0].message.content
-				if not content:
+				raw_content = resp.choices[0].message.content
+				if not raw_content:
 					raise ModelProviderError('Empty JSON content in DeepSeek response', model=self.name)
-				parsed = output_format.model_validate_json(content)
+				content, thinking = clean_and_extract_json(raw_content)
+				parsed = output_format.model_validate_json(content)  # type: ignore[attr-defined]
 				return ChatInvokeCompletion(
 					completion=parsed,
+					thinking=thinking,
 					usage=None,
 				)
 			except RateLimitError as e:

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -124,7 +124,7 @@ class ChatDeepSeek(BaseChatModel):
 					messages=ds_messages,  # type: ignore
 					**common,
 				)
-				content, thinking = clean_and_extract_json(resp.choices[0].message.content or '')
+				content, thinking = clean_and_extract_json(resp.choices[0].message.content or '', strip_fences=False)
 				return ChatInvokeCompletion(
 					completion=content,
 					thinking=thinking,

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -11,9 +11,34 @@ from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
-from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
+
+
+def _extract_ollama_usage(response: Any) -> ChatInvokeUsage | None:
+	if not response:
+		return None
+	if isinstance(response, dict):
+		prompt_tokens = response.get('prompt_eval_count')
+		completion_tokens = response.get('eval_count')
+	else:
+		prompt_tokens = getattr(response, 'prompt_eval_count', None)
+		completion_tokens = getattr(response, 'eval_count', None)
+
+	if prompt_tokens is None and completion_tokens is None:
+		return None
+
+	p_tokens = prompt_tokens or 0
+	c_tokens = completion_tokens or 0
+	return ChatInvokeUsage(
+		prompt_tokens=p_tokens,
+		prompt_cached_tokens=None,
+		prompt_cache_creation_tokens=None,
+		prompt_image_tokens=None,
+		completion_tokens=c_tokens,
+		total_tokens=p_tokens + c_tokens,
+	)
 
 
 @dataclass
@@ -78,7 +103,7 @@ class ChatOllama(BaseChatModel):
 					options=self.ollama_options,
 				)
 
-				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
+				return ChatInvokeCompletion(completion=response.message.content or '', usage=_extract_ollama_usage(response))
 			else:
 				schema = output_format.model_json_schema()
 
@@ -91,9 +116,9 @@ class ChatOllama(BaseChatModel):
 
 				completion = response.message.content or ''
 				if output_format is not None:
-					completion = output_format.model_validate_json(completion)
+					completion = output_format.model_validate_json(completion)  # type: ignore[attr-defined]
 
-				return ChatInvokeCompletion(completion=completion, usage=None)
+				return ChatInvokeCompletion(completion=completion, usage=_extract_ollama_usage(response))
 
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/utils.py
+++ b/browser_use/llm/utils.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+
+THINK_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
+OPEN_THINK_PATTERN = re.compile(r'<think>(.*)', re.DOTALL)
+JSON_FENCE_PATTERN = re.compile(r'```json\s*(.*?)\s*```', re.DOTALL)
+GENERIC_FENCE_PATTERN = re.compile(r'```\s*(.*?)\s*```', re.DOTALL)
+
+
+def clean_and_extract_json(content: str) -> tuple[str, str | None]:
+	"""
+	Extract <think> tags (including unclosed tags) and sanitize markdown JSON code blocks.
+	Returns a tuple of (cleaned_json_content, thinking_content_or_none).
+	"""
+	if not content or not isinstance(content, str):
+		return content or '', None
+
+	thinking: str | None = None
+
+	# 1. Extract <think> tags
+	match = THINK_PATTERN.search(content)
+	if match:
+		thinking = match.group(1).strip()
+		content = THINK_PATTERN.sub('', content).strip()
+	else:
+		# Fallback for unclosed <think> tags (e.g. truncated by max_tokens)
+		open_match = OPEN_THINK_PATTERN.search(content)
+		if open_match:
+			thinking = open_match.group(1).strip()
+			content = content[: open_match.start()].strip()
+
+	# Strip isolated stray closing tags
+	content = re.sub(r'</think>', '', content).strip()
+
+	# 2. Extract JSON code block (preferring ```json over generic ```)
+	json_match = JSON_FENCE_PATTERN.search(content)
+	if json_match:
+		content = json_match.group(1).strip()
+	else:
+		generic_match = GENERIC_FENCE_PATTERN.search(content)
+		if generic_match:
+			content = generic_match.group(1).strip()
+
+	return content, thinking

--- a/browser_use/llm/utils.py
+++ b/browser_use/llm/utils.py
@@ -1,45 +1,58 @@
 from __future__ import annotations
 
+import json
 import re
 
 THINK_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 OPEN_THINK_PATTERN = re.compile(r'<think>(.*)', re.DOTALL)
-JSON_FENCE_PATTERN = re.compile(r'```json\s*(.*?)\s*```', re.DOTALL)
-GENERIC_FENCE_PATTERN = re.compile(r'```\s*(.*?)\s*```', re.DOTALL)
+JSON_FENCE_PATTERN = re.compile(r'^\s*```(?:json)?\s*(.*?)\s*```\s*$', re.DOTALL)
 
 
-def clean_and_extract_json(content: str) -> tuple[str, str | None]:
-	"""
-	Extract <think> tags (including unclosed tags) and sanitize markdown JSON code blocks.
-	Returns a tuple of (cleaned_json_content, thinking_content_or_none).
+def clean_and_extract_json(content: str, strip_fences: bool = True) -> tuple[str, str | None]:
+	"""Extract <think> tags (including multiple or unclosed tags) and sanitize markdown JSON code blocks.
+
+	Args:
+		content: The raw text completion or tool call argument from the LLM.
+		strip_fences: If True, strips markdown code fences when parsing structured JSON.
+					If False, preserves markdown fences (used for plain text completions).
+
+	Returns:
+		A tuple of (cleaned_content, thinking_content_or_none).
 	"""
 	if not content or not isinstance(content, str):
 		return content or '', None
 
-	thinking: str | None = None
+	thinking_parts: list[str] = []
 
-	# 1. Extract <think> tags
-	match = THINK_PATTERN.search(content)
-	if match:
-		thinking = match.group(1).strip()
-		content = THINK_PATTERN.sub('', content).strip()
-	else:
-		# Fallback for unclosed <think> tags (e.g. truncated by max_tokens)
-		open_match = OPEN_THINK_PATTERN.search(content)
-		if open_match:
-			thinking = open_match.group(1).strip()
-			content = content[: open_match.start()].strip()
+	# 1. Extract all closed <think>...</think> blocks first
+	for match in THINK_PATTERN.finditer(content):
+		thinking_parts.append(match.group(1).strip())
+	content = THINK_PATTERN.sub('', content).strip()
+
+	# 2. Extract any remaining unclosed <think>... block (e.g. truncated by max_tokens)
+	open_match = OPEN_THINK_PATTERN.search(content)
+	if open_match:
+		thinking_parts.append(open_match.group(1).strip())
+		content = content[: open_match.start()].strip()
 
 	# Strip isolated stray closing tags
 	content = re.sub(r'</think>', '', content).strip()
 
-	# 2. Extract JSON code block (preferring ```json over generic ```)
-	json_match = JSON_FENCE_PATTERN.search(content)
-	if json_match:
-		content = json_match.group(1).strip()
-	else:
-		generic_match = GENERIC_FENCE_PATTERN.search(content)
-		if generic_match:
-			content = generic_match.group(1).strip()
+	thinking = '\n\n'.join(p for p in thinking_parts if p) if thinking_parts else None
+
+	# 3. Handle markdown code fences ONLY when strip_fences=True
+	if strip_fences:
+		# If content is already valid JSON, do not modify inner fenced strings
+		try:
+			json.loads(content)
+		except Exception:
+			# Only strip fences if they wrap the WHOLE response
+			fence_match = JSON_FENCE_PATTERN.match(content)
+			if fence_match:
+				content = fence_match.group(1).strip()
+			elif content.startswith('```') and content.endswith('```'):
+				lines = content.splitlines()
+				if len(lines) >= 2:
+					content = '\n'.join(lines[1:-1]).strip()
 
 	return content, thinking

--- a/browser_use/llm/utils.py
+++ b/browser_use/llm/utils.py
@@ -5,7 +5,7 @@ import re
 
 THINK_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 OPEN_THINK_PATTERN = re.compile(r'<think>(.*)', re.DOTALL)
-JSON_FENCE_PATTERN = re.compile(r'^\s*```(?:json)?\s*(.*?)\s*```\s*$', re.DOTALL)
+JSON_FENCE_PATTERN = re.compile(r'^\s*```[ \t]*(?:json)?[ \t]*(.*?)\s*```\s*$', re.DOTALL | re.IGNORECASE)
 
 
 def clean_and_extract_json(content: str, strip_fences: bool = True) -> tuple[str, str | None]:

--- a/tests/ci/models/test_llm_thinking.py
+++ b/tests/ci/models/test_llm_thinking.py
@@ -1,0 +1,36 @@
+from browser_use.llm.utils import clean_and_extract_json
+
+
+def test_clean_and_extract_json_plain():
+	raw = '{"action": "search"}'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == '{"action": "search"}'
+	assert thinking is None
+
+
+def test_clean_and_extract_json_only_thinking():
+	raw = '<think>I should search for the product.</think>{"action": "search"}'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == '{"action": "search"}'
+	assert thinking == 'I should search for the product.'
+
+
+def test_clean_and_extract_json_markdown():
+	raw = '```json\n{"action": "search"}\n```'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == '{"action": "search"}'
+	assert thinking is None
+
+
+def test_clean_and_extract_json_both():
+	raw = '<think>Thinking deep thoughts...</think>\n```json\n{"action": "search"}\n```'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == '{"action": "search"}'
+	assert thinking == 'Thinking deep thoughts...'
+
+
+def test_clean_and_extract_json_unclosed_tags():
+	raw = '<think>Truncated thought process without closing tag...'
+	content, thinking = clean_and_extract_json(raw)
+	assert thinking == 'Truncated thought process without closing tag...'
+	assert content == ''

--- a/tests/ci/models/test_llm_thinking.py
+++ b/tests/ci/models/test_llm_thinking.py
@@ -47,7 +47,7 @@ def test_clean_and_extract_json_multiple_and_unclosed_think():
 	raw = '<think>First thought</think>Mid prose<think>Second truncated thought'
 	content, thinking = clean_and_extract_json(raw)
 	assert content == 'Mid prose'
-	assert thinking is not None
+	assert isinstance(thinking, str)
 	assert 'First thought' in thinking
 	assert 'Second truncated thought' in thinking
 

--- a/tests/ci/models/test_llm_thinking.py
+++ b/tests/ci/models/test_llm_thinking.py
@@ -34,3 +34,26 @@ def test_clean_and_extract_json_unclosed_tags():
 	content, thinking = clean_and_extract_json(raw)
 	assert thinking == 'Truncated thought process without closing tag...'
 	assert content == ''
+
+
+def test_clean_and_extract_json_inner_fenced_code():
+	raw = '{"code": "```python\\nprint(\'hello\')\\n```"}'
+	content, thinking = clean_and_extract_json(raw, strip_fences=True)
+	assert content == '{"code": "```python\\nprint(\'hello\')\\n```"}'
+	assert thinking is None
+
+
+def test_clean_and_extract_json_multiple_and_unclosed_think():
+	raw = '<think>First thought</think>Mid prose<think>Second truncated thought'
+	content, thinking = clean_and_extract_json(raw)
+	assert content == 'Mid prose'
+	assert thinking is not None
+	assert 'First thought' in thinking
+	assert 'Second truncated thought' in thinking
+
+
+def test_clean_and_extract_json_plain_text_preserves_fences():
+	raw = '<think>Thought</think>Here is the code:\n```python\nprint(1)\n```'
+	content, thinking = clean_and_extract_json(raw, strip_fences=False)
+	assert content == 'Here is the code:\n```python\nprint(1)\n```'
+	assert thinking == 'Thought'

--- a/tests/ci/models/test_llm_usage.py
+++ b/tests/ci/models/test_llm_usage.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+from browser_use.llm.deepseek.chat import _extract_deepseek_usage
+from browser_use.llm.ollama.chat import _extract_ollama_usage
+
+
+def test_extract_ollama_usage_object():
+	response = SimpleNamespace(prompt_eval_count=100, eval_count=50)
+	usage = _extract_ollama_usage(response)
+	assert usage is not None
+	assert usage.prompt_tokens == 100
+	assert usage.completion_tokens == 50
+	assert usage.total_tokens == 150
+
+
+def test_extract_ollama_usage_dict():
+	response = {'prompt_eval_count': 80, 'eval_count': 40}
+	usage = _extract_ollama_usage(response)
+	assert usage is not None
+	assert usage.prompt_tokens == 80
+	assert usage.completion_tokens == 40
+	assert usage.total_tokens == 120
+
+
+def test_extract_ollama_usage_none():
+	assert _extract_ollama_usage(None) is None
+	assert _extract_ollama_usage(SimpleNamespace()) is None
+
+
+def test_extract_deepseek_usage_object():
+	usage_obj = SimpleNamespace(prompt_tokens=200, completion_tokens=75, total_tokens=275, prompt_cache_hit_tokens=50)
+	resp = SimpleNamespace(usage=usage_obj)
+	usage = _extract_deepseek_usage(resp)
+	assert usage is not None
+	assert usage.prompt_tokens == 200
+	assert usage.completion_tokens == 75
+	assert usage.total_tokens == 275
+	assert usage.prompt_cached_tokens == 50
+
+
+def test_extract_deepseek_usage_dict():
+	resp = {'usage': {'prompt_tokens': 150, 'completion_tokens': 30, 'total_tokens': 180, 'prompt_cache_hit_tokens': 20}}
+	usage = _extract_deepseek_usage(resp)
+	assert usage is not None
+	assert usage.prompt_tokens == 150
+	assert usage.completion_tokens == 30
+	assert usage.total_tokens == 180
+	assert usage.prompt_cached_tokens == 20
+
+
+def test_extract_deepseek_usage_none():
+	assert _extract_deepseek_usage(None) is None
+	assert _extract_deepseek_usage(SimpleNamespace(usage=None)) is None


### PR DESCRIPTION
## Summary

Resolves #4971. Adds token usage tracking (`prompt_tokens`, `completion_tokens`, `total_tokens`, `prompt_cached_tokens`) for `ChatOllama` and `ChatDeepSeek` model invocations. Previously, `usage` was hardcoded to `None`, preventing cost calculation and dashboard metric tracking for local and custom deployment models.

## Changes

- Implemented `_extract_ollama_usage` in `browser_use/llm/ollama/chat.py` extracting `prompt_eval_count` and `eval_count` with dual-mode parsing (`dict` and dataclass attributes).
- Implemented `_extract_deepseek_usage` in `browser_use/llm/deepseek/chat.py` extracting `prompt_tokens`, `completion_tokens`, `total_tokens`, and DeepSeek prompt cache hit tokens (`prompt_cache_hit_tokens`).
- Added unit tests in `tests/ci/models/test_llm_usage.py` testing usage extraction from objects, dictionaries, and fallback behavior.

## Testing

Created and executed unit tests in `tests/ci/models/test_llm_usage.py` covering:
- `test_extract_ollama_usage_object`: extracting token counts from Ollama response dataclass.
- `test_extract_ollama_usage_dict`: extracting token counts from Ollama raw dictionary response.
- `test_extract_ollama_usage_none`: fallback behavior when usage is omitted or None.
- `test_extract_deepseek_usage_object`: extracting DeepSeek token and cache hit metrics from response object.
- `test_extract_deepseek_usage_dict`: extracting DeepSeek metrics from dictionary responses.
- `test_extract_deepseek_usage_none`: fallback when usage is None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks token usage for Ollama and DeepSeek and sanitizes DeepSeek outputs for reliable JSON parsing. Previously `usage` was `None` and responses could include `<think>` tags or fenced JSON; now we return token counts (including DeepSeek prompt cache hits) and provide cleaned JSON plus an optional `thinking` field.

- DeepSeek: `_extract_deepseek_usage` reads `prompt_tokens`, `completion_tokens`, `total_tokens`, and `prompt_cache_hit_tokens` from dicts/objects; `clean_and_extract_json` removes `<think>` blocks (including unclosed) and strips top-level JSON code fences while preserving fences for plain‑text completions; `ChatInvokeCompletion` populates `thinking` and validates JSON when `output_format` is set.
- Ollama: `_extract_ollama_usage` maps `prompt_eval_count` and `eval_count` to `prompt_tokens`, `completion_tokens`, and `total_tokens` for dict/object responses.
- Migration: If you parsed fenced JSON or inline `<think>` from `completion`, read the cleaned `completion` and optional `thinking` fields instead.

<sup>Written for commit fe1788fb878e963ad097f4d402438732a608e94d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

