### PR TITLE
Add Taskmarket requester integration

### DIFF
--- a/browser_use/integrations/taskmarket/__init__.py
+++ b/browser_use/integrations/taskmarket/__init__.py
@@ -1,0 +1,19 @@
+"""
+Taskmarket integration for browser-use.
+
+Usage:
+    from browser_use import Tools
+    from browser_use.integrations.taskmarket import register_taskmarket_actions
+
+    tools = Tools()
+    register_taskmarket_actions(tools)
+
+The create action uses the first-party ``taskmarket`` CLI and requires a previously
+prepared preview plus fresh user authorization. Status and submission actions are
+read-only and no accept/reject/payment review actions are registered.
+"""
+
+from .actions import register_taskmarket_actions
+from .service import TaskMarketService, TaskMarketTaskDraft
+
+__all__ = ['TaskMarketService', 'TaskMarketTaskDraft', 'register_taskmarket_actions']

--- a/browser_use/integrations/taskmarket/__init__.py
+++ b/browser_use/integrations/taskmarket/__init__.py
@@ -9,11 +9,12 @@ Usage:
     register_taskmarket_actions(tools)
 
 The create action uses the first-party ``taskmarket`` CLI and requires a previously
-prepared preview plus fresh user authorization. Status and submission actions are
-read-only and no accept/reject/payment review actions are registered.
+prepared preview plus host-side user authorization via ``TaskMarketService.authorize_preview``
+or an authorization callback. Status and submission actions are read-only and no
+accept/reject/payment review actions are registered.
 """
 
 from .actions import register_taskmarket_actions
-from .service import TaskMarketService, TaskMarketTaskDraft
+from .service import TaskMarketPreview, TaskMarketService, TaskMarketTaskDraft
 
-__all__ = ['TaskMarketService', 'TaskMarketTaskDraft', 'register_taskmarket_actions']
+__all__ = ['TaskMarketPreview', 'TaskMarketService', 'TaskMarketTaskDraft', 'register_taskmarket_actions']

--- a/browser_use/integrations/taskmarket/actions.py
+++ b/browser_use/integrations/taskmarket/actions.py
@@ -20,14 +20,9 @@ class CreateTaskMarketTaskParams(BaseModel):
 	"""Parameters for creating a previously previewed Taskmarket task."""
 
 	preview_id: str = Field(description='Preview id returned by taskmarket_prepare_task.')
-	confirmation_token: str = Field(description='Confirmation token returned in the preview after the user authorizes it.')
-	confirm_authorized: bool = Field(
-		default=False,
-		description='Set true only after the user explicitly authorizes creating and funding this exact Taskmarket task.',
-	)
 	max_spend_usdc: Decimal | None = Field(
 		default=None,
-		description='Optional fresh user-authorized spend cap. Must be at least the previewed reward.',
+		description='Optional host-authorized spend cap. Must be between the previewed reward and prepared max spend.',
 	)
 
 	@field_validator('max_spend_usdc', mode='before')
@@ -60,7 +55,7 @@ def register_taskmarket_actions(
 	@tools.registry.action(
 		description=(
 			'Prepare a Taskmarket requester task preview. This does not create or fund anything. '
-			'Show the exact description, deliverables, reward, deadline, Base network, maximum spend, and confirmation token to the user.'
+			'Show the exact description, deliverables, reward, deadline, Base network, and maximum spend to the user.'
 		),
 		param_model=PrepareTaskMarketTaskParams,
 	)
@@ -80,7 +75,7 @@ def register_taskmarket_actions(
 	@tools.registry.action(
 		description=(
 			'Create and fund a previously previewed Taskmarket task using the first-party taskmarket CLI. '
-			'Only call after fresh explicit user authorization for this exact preview; never retry automatically after failure.'
+			'This succeeds only after the host application has authorized the preview out of band; never retry automatically after failure.'
 		),
 		param_model=CreateTaskMarketTaskParams,
 	)
@@ -90,8 +85,6 @@ def register_taskmarket_actions(
 		try:
 			created = await service.create_task(
 				preview_id=params.preview_id,
-				confirmation_token=params.confirmation_token,
-				confirm_authorized=params.confirm_authorized,
 				max_spend_usdc=params.max_spend_usdc,
 			)
 			content = json.dumps(created.model_dump(), indent=2)

--- a/browser_use/integrations/taskmarket/actions.py
+++ b/browser_use/integrations/taskmarket/actions.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal, InvalidOperation
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from .service import TaskMarketService, TaskMarketTaskDraft
+
+if TYPE_CHECKING:
+	from browser_use.tools.service import Tools
+
+
+class PrepareTaskMarketTaskParams(TaskMarketTaskDraft):
+	"""Parameters for preparing a Taskmarket requester task preview."""
+
+
+class CreateTaskMarketTaskParams(BaseModel):
+	"""Parameters for creating a previously previewed Taskmarket task."""
+
+	preview_id: str = Field(description='Preview id returned by taskmarket_prepare_task.')
+	confirmation_token: str = Field(description='Confirmation token returned in the preview after the user authorizes it.')
+	confirm_authorized: bool = Field(
+		default=False,
+		description='Set true only after the user explicitly authorizes creating and funding this exact Taskmarket task.',
+	)
+	max_spend_usdc: Decimal | None = Field(
+		default=None,
+		description='Optional fresh user-authorized spend cap. Must be at least the previewed reward.',
+	)
+
+	@field_validator('max_spend_usdc', mode='before')
+	@classmethod
+	def _parse_decimal(cls, value: Any) -> Decimal | None:
+		if value is None:
+			return None
+		try:
+			return Decimal(str(value))
+		except (InvalidOperation, ValueError) as exc:
+			raise ValueError('max_spend_usdc must be a decimal USDC amount') from exc
+
+
+class TaskMarketTaskIdParams(BaseModel):
+	"""Parameters for Taskmarket read-only task lookups."""
+
+	task_id: str = Field(description='0x-prefixed 32-byte Taskmarket task id.')
+
+
+def register_taskmarket_actions(
+	tools: Tools,
+	taskmarket_service: TaskMarketService | None = None,
+	api_url: str | None = None,
+	cli_path: str = 'taskmarket',
+) -> Tools:
+	"""Register opt-in Taskmarket requester workflow actions."""
+
+	service = taskmarket_service or TaskMarketService(api_url=api_url, cli_path=cli_path)
+
+	@tools.registry.action(
+		description=(
+			'Prepare a Taskmarket requester task preview. This does not create or fund anything. '
+			'Show the exact description, deliverables, reward, deadline, Base network, maximum spend, and confirmation token to the user.'
+		),
+		param_model=PrepareTaskMarketTaskParams,
+	)
+	async def taskmarket_prepare_task(params: PrepareTaskMarketTaskParams) -> Any:
+		from browser_use.agent.views import ActionResult
+
+		try:
+			preview = await service.prepare_task(params)
+			content = json.dumps(preview.model_dump(), indent=2)
+			return ActionResult(
+				extracted_content=content,
+				long_term_memory=f'Prepared Taskmarket preview {preview.preview_id}; user authorization is still required.',
+			)
+		except Exception as exc:
+			return ActionResult(error=f'Failed to prepare Taskmarket task: {exc}')
+
+	@tools.registry.action(
+		description=(
+			'Create and fund a previously previewed Taskmarket task using the first-party taskmarket CLI. '
+			'Only call after fresh explicit user authorization for this exact preview; never retry automatically after failure.'
+		),
+		param_model=CreateTaskMarketTaskParams,
+	)
+	async def taskmarket_create_task(params: CreateTaskMarketTaskParams) -> Any:
+		from browser_use.agent.views import ActionResult
+
+		try:
+			created = await service.create_task(
+				preview_id=params.preview_id,
+				confirmation_token=params.confirmation_token,
+				confirm_authorized=params.confirm_authorized,
+				max_spend_usdc=params.max_spend_usdc,
+			)
+			content = json.dumps(created.model_dump(), indent=2)
+			return ActionResult(
+				extracted_content=content,
+				long_term_memory=f'Created Taskmarket task {created.task_id}.',
+			)
+		except Exception as exc:
+			return ActionResult(error=f'Failed to create Taskmarket task: {exc}')
+
+	@tools.registry.action(
+		description='Retrieve live Taskmarket task status by id. This is read-only and does not use wallet authority.',
+		param_model=TaskMarketTaskIdParams,
+	)
+	async def taskmarket_get_task_status(params: TaskMarketTaskIdParams) -> Any:
+		from browser_use.agent.views import ActionResult
+
+		try:
+			status = await service.get_task_status(params.task_id)
+			return ActionResult(extracted_content=json.dumps(status, indent=2))
+		except Exception as exc:
+			return ActionResult(error=f'Failed to retrieve Taskmarket task status: {exc}')
+
+	@tools.registry.action(
+		description=(
+			'Retrieve Taskmarket submissions for human review. This is read-only and never accepts, rejects, rates, or pays workers.'
+		),
+		param_model=TaskMarketTaskIdParams,
+	)
+	async def taskmarket_list_submissions(params: TaskMarketTaskIdParams) -> Any:
+		from browser_use.agent.views import ActionResult
+
+		try:
+			submissions = await service.get_submissions(params.task_id)
+			return ActionResult(extracted_content=json.dumps(submissions, indent=2))
+		except Exception as exc:
+			return ActionResult(error=f'Failed to retrieve Taskmarket submissions: {exc}')
+
+	return tools

--- a/browser_use/integrations/taskmarket/service.py
+++ b/browser_use/integrations/taskmarket/service.py
@@ -1,0 +1,284 @@
+import asyncio
+import json
+import math
+import os
+import re
+import secrets
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Literal
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+BASE_CHAIN_ID = 8453
+DEFAULT_TASKMARKET_API_URL = 'https://api.taskmarket.dev'
+TASKMARKET_TASK_URL = 'https://taskmarket.dev/tasks/{task_id}'
+TASK_ID_RE = re.compile(r'^0x[a-fA-F0-9]{64}$')
+
+CommandRunner = Callable[[list[str]], Awaitable[tuple[int, str, str]]]
+
+
+class TaskMarketTaskDraft(BaseModel):
+	"""Validated Taskmarket requester task draft."""
+
+	model_config = ConfigDict(arbitrary_types_allowed=True)
+
+	description: str = Field(
+		min_length=20,
+		description='Exact requester-facing task description to publish.',
+	)
+	deliverables: str = Field(
+		min_length=3,
+		description='Exact deliverables and acceptance evidence the worker must submit.',
+	)
+	reward_usdc: Decimal = Field(gt=Decimal('0'), description='Task reward in USDC.')
+	max_spend_usdc: Decimal = Field(gt=Decimal('0'), description='Maximum user-authorized spend in USDC.')
+	deadline_iso: str = Field(description='Task deadline as an ISO-8601 timestamp.')
+	network: Literal['base'] = Field(default='base', description='Taskmarket production tasks are funded on Base.')
+	mode: Literal['bounty', 'claim', 'pitch', 'benchmark'] = Field(default='bounty')
+	task_visibility: Literal['public', 'unlisted', 'private'] = Field(default='public')
+	submission_visibility: Literal['public', 'reveal_all', 'winner_only', 'never'] = Field(default='public')
+	tags: list[str] = Field(default_factory=list, max_length=8)
+
+	@field_validator('reward_usdc', 'max_spend_usdc', mode='before')
+	@classmethod
+	def _parse_decimal(cls, value: Any) -> Decimal:
+		try:
+			return Decimal(str(value))
+		except (InvalidOperation, ValueError) as exc:
+			raise ValueError('Must be a decimal USDC amount') from exc
+
+	@field_validator('tags')
+	@classmethod
+	def _clean_tags(cls, value: list[str]) -> list[str]:
+		return [tag.strip() for tag in value if tag.strip()]
+
+	@model_validator(mode='after')
+	def _validate_spend_cap(self) -> 'TaskMarketTaskDraft':
+		if self.max_spend_usdc < self.reward_usdc:
+			raise ValueError('max_spend_usdc must be greater than or equal to reward_usdc')
+		return self
+
+	def deadline(self) -> datetime:
+		value = self.deadline_iso
+		if value.endswith('Z'):
+			value = f'{value[:-1]}+00:00'
+		try:
+			parsed = datetime.fromisoformat(value)
+		except ValueError as exc:
+			raise ValueError('deadline_iso must be a valid ISO-8601 timestamp') from exc
+		if parsed.tzinfo is None:
+			raise ValueError('deadline_iso must include a timezone')
+		return parsed.astimezone(UTC)
+
+	def duration_hours(self, now: datetime | None = None) -> int:
+		now = now or datetime.now(UTC)
+		deadline = self.deadline()
+		if deadline <= now:
+			raise ValueError('deadline_iso must be in the future')
+		return max(1, math.ceil((deadline - now).total_seconds() / 3600))
+
+	def task_description(self) -> str:
+		return f'{self.description.strip()}\n\nDeliverables:\n{self.deliverables.strip()}'
+
+
+class TaskMarketPreview(BaseModel):
+	"""Stored preview that must be confirmed before creating a task."""
+
+	preview_id: str
+	confirmation_token: str
+	network: Literal['base']
+	chain_id: int
+	description: str
+	deliverables: str
+	reward_usdc: str
+	max_spend_usdc: str
+	deadline_iso: str
+	duration_hours: int
+	mode: str
+	task_visibility: str
+	submission_visibility: str
+	tags: list[str]
+	command_preview: list[str]
+	approval_instruction: str
+
+
+class TaskMarketCreatedTask(BaseModel):
+	"""Result returned after the Taskmarket CLI creates and funds the task."""
+
+	task_id: str
+	task_url: str
+	raw: dict[str, Any]
+
+
+class TaskMarketService:
+	"""Taskmarket requester client for browser-use integrations."""
+
+	def __init__(
+		self,
+		api_url: str | None = None,
+		cli_path: str = 'taskmarket',
+		command_runner: CommandRunner | None = None,
+		http_client: httpx.AsyncClient | None = None,
+	):
+		self.api_url = (api_url or os.environ.get('TASKMARKET_API_URL') or DEFAULT_TASKMARKET_API_URL).rstrip('/')
+		self.cli_path = cli_path
+		self._command_runner = command_runner or self._run_command
+		self._http_client = http_client
+		self._previews: dict[str, tuple[TaskMarketTaskDraft, TaskMarketPreview]] = {}
+
+	async def prepare_task(self, draft: TaskMarketTaskDraft) -> TaskMarketPreview:
+		duration_hours = draft.duration_hours()
+		preview_id = secrets.token_urlsafe(8)
+		confirmation_token = secrets.token_urlsafe(10)
+		command_preview = self._build_create_command(draft, duration_hours)
+		preview = TaskMarketPreview(
+			preview_id=preview_id,
+			confirmation_token=confirmation_token,
+			network=draft.network,
+			chain_id=BASE_CHAIN_ID,
+			description=draft.description.strip(),
+			deliverables=draft.deliverables.strip(),
+			reward_usdc=self._format_decimal(draft.reward_usdc),
+			max_spend_usdc=self._format_decimal(draft.max_spend_usdc),
+			deadline_iso=draft.deadline().isoformat(),
+			duration_hours=duration_hours,
+			mode=draft.mode,
+			task_visibility=draft.task_visibility,
+			submission_visibility=draft.submission_visibility,
+			tags=draft.tags,
+			command_preview=command_preview,
+			approval_instruction=(
+				'Show this exact preview to the user. Create the task only after the user explicitly authorizes '
+				f'Base spend up to {self._format_decimal(draft.max_spend_usdc)} USDC and provides the confirmation token.'
+			),
+		)
+		self._previews[preview_id] = (draft, preview)
+		return preview
+
+	async def create_task(
+		self,
+		preview_id: str,
+		confirmation_token: str,
+		confirm_authorized: bool,
+		max_spend_usdc: Decimal | str | None = None,
+	) -> TaskMarketCreatedTask:
+		if not confirm_authorized:
+			raise ValueError('Fresh user authorization is required before creating or funding a Taskmarket task')
+		if preview_id not in self._previews:
+			raise ValueError('Unknown or expired Taskmarket preview_id')
+
+		draft, preview = self._previews[preview_id]
+		if not secrets.compare_digest(confirmation_token, preview.confirmation_token):
+			raise ValueError('Taskmarket confirmation token does not match the preview')
+
+		if max_spend_usdc is not None and Decimal(str(max_spend_usdc)) < draft.reward_usdc:
+			raise ValueError('Authorized max_spend_usdc is lower than the task reward')
+
+		duration_hours = draft.duration_hours()
+		command = self._build_create_command(draft, duration_hours)
+		returncode, stdout, stderr = await self._command_runner(command)
+		if returncode != 0:
+			raise RuntimeError(
+				'Taskmarket task creation failed. The command was not retried because settlement status may be unknown. '
+				f'stderr: {stderr.strip()}'
+			)
+
+		envelope = self._parse_cli_json(stdout)
+		if not envelope.get('ok', False):
+			raise RuntimeError(f'Taskmarket CLI returned an error: {envelope.get("error", "unknown error")}')
+
+		data = envelope.get('data') or {}
+		task_id = self._extract_task_id(data)
+		if not task_id:
+			raise RuntimeError('Taskmarket CLI succeeded but did not return a task id')
+		return TaskMarketCreatedTask(task_id=task_id, task_url=TASKMARKET_TASK_URL.format(task_id=task_id), raw=data)
+
+	async def get_task_status(self, task_id: str) -> dict[str, Any]:
+		self._validate_task_id(task_id)
+		return await self._get_json(f'/api/tasks/{task_id}')
+
+	async def get_submissions(self, task_id: str) -> dict[str, Any]:
+		self._validate_task_id(task_id)
+		data = await self._get_json(f'/api/tasks/{task_id}/submissions')
+		return {
+			'task_id': task_id,
+			'submissions': data if isinstance(data, list) else data.get('data', data),
+			'review_note': 'Present these submissions for human review. This integration does not accept or reject work automatically.',
+		}
+
+	def _build_create_command(self, draft: TaskMarketTaskDraft, duration_hours: int) -> list[str]:
+		command = [
+			self.cli_path,
+			'task',
+			'create',
+			'--description',
+			draft.task_description(),
+			'--reward',
+			self._format_decimal(draft.reward_usdc),
+			'--duration',
+			str(duration_hours),
+			'--mode',
+			draft.mode,
+			'--task-visibility',
+			draft.task_visibility,
+			'--submission-visibility',
+			draft.submission_visibility,
+		]
+		if draft.tags:
+			command.extend(['--tags', ','.join(draft.tags)])
+		return command
+
+	async def _run_command(self, command: list[str]) -> tuple[int, str, str]:
+		process = await asyncio.create_subprocess_exec(
+			*command,
+			stdout=asyncio.subprocess.PIPE,
+			stderr=asyncio.subprocess.PIPE,
+		)
+		stdout, stderr = await process.communicate()
+		return process.returncode or 1, stdout.decode(), stderr.decode()
+
+	async def _get_json(self, path: str) -> dict[str, Any]:
+		client = self._http_client
+		close_client = client is None
+		if client is None:
+			client = httpx.AsyncClient(timeout=30)
+		try:
+			response = await client.get(f'{self.api_url}{path}')
+			response.raise_for_status()
+			payload = response.json()
+			if isinstance(payload, dict) and payload.get('ok') is True and 'data' in payload:
+				return payload['data']
+			return payload
+		finally:
+			if close_client:
+				await client.aclose()
+
+	def _parse_cli_json(self, stdout: str) -> dict[str, Any]:
+		try:
+			payload = json.loads(stdout)
+		except json.JSONDecodeError as exc:
+			raise RuntimeError('Taskmarket CLI returned non-JSON output') from exc
+		if not isinstance(payload, dict):
+			raise RuntimeError('Taskmarket CLI returned an unexpected JSON shape')
+		return payload
+
+	def _extract_task_id(self, data: dict[str, Any]) -> str | None:
+		candidates = [
+			data.get('taskId'),
+			data.get('id'),
+			(data.get('task') or {}).get('id') if isinstance(data.get('task'), dict) else None,
+		]
+		for candidate in candidates:
+			if isinstance(candidate, str) and TASK_ID_RE.match(candidate):
+				return candidate
+		return None
+
+	def _validate_task_id(self, task_id: str) -> None:
+		if not TASK_ID_RE.match(task_id):
+			raise ValueError('Taskmarket task_id must be a 0x-prefixed 32-byte hex string')
+
+	def _format_decimal(self, value: Decimal) -> str:
+		return format(value.normalize(), 'f')

--- a/browser_use/integrations/taskmarket/service.py
+++ b/browser_use/integrations/taskmarket/service.py
@@ -66,7 +66,7 @@ class TaskMarketTaskDraft(BaseModel):
 		return [tag.strip() for tag in value if tag.strip()]
 
 	@model_validator(mode='after')
-	def _validate_spend_cap(self) -> 'TaskMarketTaskDraft':
+	def _validate_spend_cap(self) -> TaskMarketTaskDraft:
 		if self.max_spend_usdc < self.reward_usdc:
 			raise ValueError('max_spend_usdc must be greater than or equal to reward_usdc')
 		return self

--- a/browser_use/integrations/taskmarket/service.py
+++ b/browser_use/integrations/taskmarket/service.py
@@ -280,6 +280,10 @@ class TaskMarketService:
 		)
 		try:
 			stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self.command_timeout_seconds)
+		except asyncio.CancelledError:
+			process.kill()
+			await process.communicate()
+			raise
 		except TimeoutError as exc:
 			process.kill()
 			stdout, stderr = await process.communicate()

--- a/browser_use/integrations/taskmarket/service.py
+++ b/browser_use/integrations/taskmarket/service.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import asyncio
+import inspect
 import json
 import math
 import os
@@ -42,6 +45,13 @@ class TaskMarketTaskDraft(BaseModel):
 	submission_visibility: Literal['public', 'reveal_all', 'winner_only', 'never'] = Field(default='public')
 	tags: list[str] = Field(default_factory=list, max_length=8)
 
+	@field_validator('description', 'deliverables', mode='before')
+	@classmethod
+	def _strip_text(cls, value: Any) -> str:
+		if not isinstance(value, str):
+			raise ValueError('Must be a string')
+		return value.strip()
+
 	@field_validator('reward_usdc', 'max_spend_usdc', mode='before')
 	@classmethod
 	def _parse_decimal(cls, value: Any) -> Decimal:
@@ -81,14 +91,13 @@ class TaskMarketTaskDraft(BaseModel):
 		return max(1, math.ceil((deadline - now).total_seconds() / 3600))
 
 	def task_description(self) -> str:
-		return f'{self.description.strip()}\n\nDeliverables:\n{self.deliverables.strip()}'
+		return f'{self.description}\n\nDeliverables:\n{self.deliverables}'
 
 
 class TaskMarketPreview(BaseModel):
 	"""Stored preview that must be confirmed before creating a task."""
 
 	preview_id: str
-	confirmation_token: str
 	network: Literal['base']
 	chain_id: int
 	description: str
@@ -103,6 +112,9 @@ class TaskMarketPreview(BaseModel):
 	tags: list[str]
 	command_preview: list[str]
 	approval_instruction: str
+
+
+AuthorizationCallback = Callable[[TaskMarketPreview, Decimal | None], Awaitable[bool] | bool]
 
 
 class TaskMarketCreatedTask(BaseModel):
@@ -122,25 +134,28 @@ class TaskMarketService:
 		cli_path: str = 'taskmarket',
 		command_runner: CommandRunner | None = None,
 		http_client: httpx.AsyncClient | None = None,
+		authorization_callback: AuthorizationCallback | None = None,
+		command_timeout_seconds: float = 120,
 	):
 		self.api_url = (api_url or os.environ.get('TASKMARKET_API_URL') or DEFAULT_TASKMARKET_API_URL).rstrip('/')
 		self.cli_path = cli_path
 		self._command_runner = command_runner or self._run_command
 		self._http_client = http_client
+		self._authorization_callback = authorization_callback
+		self.command_timeout_seconds = command_timeout_seconds
 		self._previews: dict[str, tuple[TaskMarketTaskDraft, TaskMarketPreview]] = {}
+		self._authorized_previews: set[str] = set()
 
 	async def prepare_task(self, draft: TaskMarketTaskDraft) -> TaskMarketPreview:
 		duration_hours = draft.duration_hours()
 		preview_id = secrets.token_urlsafe(8)
-		confirmation_token = secrets.token_urlsafe(10)
 		command_preview = self._build_create_command(draft, duration_hours)
 		preview = TaskMarketPreview(
 			preview_id=preview_id,
-			confirmation_token=confirmation_token,
 			network=draft.network,
 			chain_id=BASE_CHAIN_ID,
-			description=draft.description.strip(),
-			deliverables=draft.deliverables.strip(),
+			description=draft.description,
+			deliverables=draft.deliverables,
 			reward_usdc=self._format_decimal(draft.reward_usdc),
 			max_spend_usdc=self._format_decimal(draft.max_spend_usdc),
 			deadline_iso=draft.deadline().isoformat(),
@@ -151,31 +166,34 @@ class TaskMarketService:
 			tags=draft.tags,
 			command_preview=command_preview,
 			approval_instruction=(
-				'Show this exact preview to the user. Create the task only after the user explicitly authorizes '
-				f'Base spend up to {self._format_decimal(draft.max_spend_usdc)} USDC and provides the confirmation token.'
+				'Show this exact preview to the user. The host application must authorize this preview out of band before '
+				f'task creation can spend up to {self._format_decimal(draft.max_spend_usdc)} USDC on Base.'
 			),
 		)
 		self._previews[preview_id] = (draft, preview)
 		return preview
 
+	def authorize_preview(self, preview_id: str, max_spend_usdc: Decimal | str | None = None) -> TaskMarketPreview:
+		if preview_id not in self._previews:
+			raise ValueError('Unknown, expired, or already used Taskmarket preview_id')
+		draft, preview = self._previews[preview_id]
+		self._validate_authorized_spend(draft, max_spend_usdc)
+		self._authorized_previews.add(preview_id)
+		return preview
+
 	async def create_task(
 		self,
 		preview_id: str,
-		confirmation_token: str,
-		confirm_authorized: bool,
 		max_spend_usdc: Decimal | str | None = None,
 	) -> TaskMarketCreatedTask:
-		if not confirm_authorized:
-			raise ValueError('Fresh user authorization is required before creating or funding a Taskmarket task')
 		if preview_id not in self._previews:
-			raise ValueError('Unknown or expired Taskmarket preview_id')
+			raise ValueError('Unknown, expired, or already used Taskmarket preview_id')
 
 		draft, preview = self._previews[preview_id]
-		if not secrets.compare_digest(confirmation_token, preview.confirmation_token):
-			raise ValueError('Taskmarket confirmation token does not match the preview')
-
-		if max_spend_usdc is not None and Decimal(str(max_spend_usdc)) < draft.reward_usdc:
-			raise ValueError('Authorized max_spend_usdc is lower than the task reward')
+		self._validate_authorized_spend(draft, max_spend_usdc)
+		await self._ensure_host_authorized(preview, max_spend_usdc)
+		self._previews.pop(preview_id)
+		self._authorized_previews.discard(preview_id)
 
 		duration_hours = draft.duration_hours()
 		command = self._build_create_command(draft, duration_hours)
@@ -195,6 +213,29 @@ class TaskMarketService:
 		if not task_id:
 			raise RuntimeError('Taskmarket CLI succeeded but did not return a task id')
 		return TaskMarketCreatedTask(task_id=task_id, task_url=TASKMARKET_TASK_URL.format(task_id=task_id), raw=data)
+
+	async def _ensure_host_authorized(self, preview: TaskMarketPreview, max_spend_usdc: Decimal | str | None) -> None:
+		if preview.preview_id in self._authorized_previews:
+			return
+		if self._authorization_callback is None:
+			raise ValueError('Taskmarket preview must be authorized by the host application before task creation')
+		result = self._authorization_callback(preview, Decimal(str(max_spend_usdc)) if max_spend_usdc is not None else None)
+		if inspect.isawaitable(result):
+			result = await result
+		if result is not True:
+			raise ValueError('Taskmarket preview was not authorized by the host application')
+
+	def _validate_authorized_spend(self, draft: TaskMarketTaskDraft, max_spend_usdc: Decimal | str | None) -> None:
+		if max_spend_usdc is None:
+			return
+		try:
+			authorized = Decimal(str(max_spend_usdc))
+		except (InvalidOperation, ValueError) as exc:
+			raise ValueError('max_spend_usdc must be a decimal USDC amount') from exc
+		if authorized < draft.reward_usdc:
+			raise ValueError('Authorized max_spend_usdc is lower than the task reward')
+		if authorized > draft.max_spend_usdc:
+			raise ValueError('Authorized max_spend_usdc is higher than the prepared spend cap')
 
 	async def get_task_status(self, task_id: str) -> dict[str, Any]:
 		self._validate_task_id(task_id)
@@ -237,7 +278,15 @@ class TaskMarketService:
 			stdout=asyncio.subprocess.PIPE,
 			stderr=asyncio.subprocess.PIPE,
 		)
-		stdout, stderr = await process.communicate()
+		try:
+			stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self.command_timeout_seconds)
+		except TimeoutError as exc:
+			process.kill()
+			stdout, stderr = await process.communicate()
+			message = stderr.decode().strip()
+			if message:
+				message = f': {message}'
+			raise TimeoutError(f'Taskmarket CLI timed out after {self.command_timeout_seconds} seconds{message}') from exc
 		return process.returncode or 1, stdout.decode(), stderr.decode()
 
 	async def _get_json(self, path: str) -> dict[str, Any]:

--- a/tests/integrations/test_taskmarket.py
+++ b/tests/integrations/test_taskmarket.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
@@ -32,19 +33,32 @@ async def test_prepare_task_preview_includes_required_authorization_details():
 	assert preview.chain_id == 8453
 	assert preview.reward_usdc == '2.5'
 	assert preview.max_spend_usdc == '2.5'
-	assert preview.confirmation_token
 	assert '--description' in preview.command_preview
 	assert '--reward' in preview.command_preview
 	assert 'Show this exact preview to the user' in preview.approval_instruction
+	assert 'confirmation_token' not in preview.model_dump()
 
 
 @pytest.mark.asyncio
-async def test_create_task_requires_fresh_authorization():
+async def test_create_task_requires_host_authorization():
 	service = TaskMarketService()
 	preview = await service.prepare_task(make_draft())
 
-	with pytest.raises(ValueError, match='Fresh user authorization'):
-		await service.create_task(preview.preview_id, preview.confirmation_token, confirm_authorized=False)
+	with pytest.raises(ValueError, match='host application'):
+		await service.create_task(preview.preview_id)
+
+
+def test_draft_validation_strips_text_before_length_checks():
+	draft = make_draft(
+		description='  Hire external workers to verify a browser automation benchmark.  ',
+		deliverables='  Report and logs.  ',
+	)
+
+	assert draft.description == 'Hire external workers to verify a browser automation benchmark.'
+	assert draft.deliverables == 'Report and logs.'
+
+	with pytest.raises(ValueError):
+		make_draft(description='     ', deliverables='Report and logs.')
 
 
 @pytest.mark.asyncio
@@ -57,12 +71,8 @@ async def test_create_task_uses_taskmarket_cli_once_without_shell():
 
 	service = TaskMarketService(cli_path='taskmarket-test', command_runner=runner)
 	preview = await service.prepare_task(make_draft())
-	created = await service.create_task(
-		preview.preview_id,
-		preview.confirmation_token,
-		confirm_authorized=True,
-		max_spend_usdc='2.5',
-	)
+	service.authorize_preview(preview.preview_id, max_spend_usdc='2.5')
+	created = await service.create_task(preview.preview_id, max_spend_usdc='2.5')
 
 	assert created.task_id == TASK_ID
 	assert created.task_url.endswith(TASK_ID)
@@ -70,6 +80,9 @@ async def test_create_task_uses_taskmarket_cli_once_without_shell():
 	assert calls[0][0:3] == ['taskmarket-test', 'task', 'create']
 	assert '--duration' in calls[0]
 	assert all('\n' not in arg or arg.startswith('Hire external workers') for arg in calls[0])
+
+	with pytest.raises(ValueError, match='already used'):
+		await service.create_task(preview.preview_id, max_spend_usdc='2.5')
 
 
 @pytest.mark.asyncio
@@ -83,21 +96,33 @@ async def test_create_task_does_not_retry_when_cli_status_is_unknown():
 
 	service = TaskMarketService(command_runner=runner)
 	preview = await service.prepare_task(make_draft())
+	service.authorize_preview(preview.preview_id)
 
 	with pytest.raises(RuntimeError, match='was not retried'):
-		await service.create_task(preview.preview_id, preview.confirmation_token, confirm_authorized=True)
+		await service.create_task(preview.preview_id)
 	assert calls == 1
+
+	with pytest.raises(ValueError, match='already used'):
+		await service.create_task(preview.preview_id)
 
 
 @pytest.mark.asyncio
-async def test_live_reads_use_public_api_and_present_submissions_for_review():
-	def handler(request: httpx.Request) -> httpx.Response:
-		if request.url.path.endswith('/submissions'):
-			return httpx.Response(200, json={'ok': True, 'data': [{'workerAddress': '0xabc', 'id': 'sub_1'}]})
-		return httpx.Response(200, json={'ok': True, 'data': {'id': TASK_ID, 'status': 'open'}})
+async def test_command_runner_times_out_and_kills_subprocess():
+	service = TaskMarketService(command_timeout_seconds=0.01)
 
-	async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-		service = TaskMarketService(api_url='https://taskmarket.test', http_client=client)
+	with pytest.raises(TimeoutError, match='timed out'):
+		await service._run_command([sys.executable, '-c', 'import time; time.sleep(10)'])
+
+
+@pytest.mark.asyncio
+async def test_live_reads_use_public_api_and_present_submissions_for_review(httpserver):
+	httpserver.expect_request(f'/api/tasks/{TASK_ID}').respond_with_json({'ok': True, 'data': {'id': TASK_ID, 'status': 'open'}})
+	httpserver.expect_request(f'/api/tasks/{TASK_ID}/submissions').respond_with_json(
+		{'ok': True, 'data': [{'workerAddress': '0xabc', 'id': 'sub_1'}]}
+	)
+
+	async with httpx.AsyncClient() as client:
+		service = TaskMarketService(api_url=httpserver.url_for('').rstrip('/'), http_client=client)
 		status = await service.get_task_status(TASK_ID)
 		submissions = await service.get_submissions(TASK_ID)
 

--- a/tests/integrations/test_taskmarket.py
+++ b/tests/integrations/test_taskmarket.py
@@ -1,0 +1,137 @@
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+import httpx
+import pytest
+
+from browser_use.integrations.taskmarket import TaskMarketService, TaskMarketTaskDraft, register_taskmarket_actions
+
+TASK_ID = '0x' + '1' * 64
+
+
+def make_draft(**overrides):
+	values: dict[str, Any] = {
+		'description': 'Hire external workers to verify a browser automation benchmark.',
+		'deliverables': 'Submit a Markdown report with reproduction steps, logs, and pass/fail evidence.',
+		'reward_usdc': '2.5',
+		'max_spend_usdc': '2.5',
+		'deadline_iso': (datetime.now(UTC) + timedelta(hours=6)).isoformat(),
+		'tags': ['browser-use', 'taskmarket'],
+	}
+	values.update(overrides)
+	return TaskMarketTaskDraft(**values)
+
+
+@pytest.mark.asyncio
+async def test_prepare_task_preview_includes_required_authorization_details():
+	service = TaskMarketService()
+	preview = await service.prepare_task(make_draft())
+
+	assert preview.network == 'base'
+	assert preview.chain_id == 8453
+	assert preview.reward_usdc == '2.5'
+	assert preview.max_spend_usdc == '2.5'
+	assert preview.confirmation_token
+	assert '--description' in preview.command_preview
+	assert '--reward' in preview.command_preview
+	assert 'Show this exact preview to the user' in preview.approval_instruction
+
+
+@pytest.mark.asyncio
+async def test_create_task_requires_fresh_authorization():
+	service = TaskMarketService()
+	preview = await service.prepare_task(make_draft())
+
+	with pytest.raises(ValueError, match='Fresh user authorization'):
+		await service.create_task(preview.preview_id, preview.confirmation_token, confirm_authorized=False)
+
+
+@pytest.mark.asyncio
+async def test_create_task_uses_taskmarket_cli_once_without_shell():
+	calls: list[list[str]] = []
+
+	async def runner(command: list[str]):
+		calls.append(command)
+		return 0, json.dumps({'ok': True, 'data': {'taskId': TASK_ID}}), ''
+
+	service = TaskMarketService(cli_path='taskmarket-test', command_runner=runner)
+	preview = await service.prepare_task(make_draft())
+	created = await service.create_task(
+		preview.preview_id,
+		preview.confirmation_token,
+		confirm_authorized=True,
+		max_spend_usdc='2.5',
+	)
+
+	assert created.task_id == TASK_ID
+	assert created.task_url.endswith(TASK_ID)
+	assert len(calls) == 1
+	assert calls[0][0:3] == ['taskmarket-test', 'task', 'create']
+	assert '--duration' in calls[0]
+	assert all('\n' not in arg or arg.startswith('Hire external workers') for arg in calls[0])
+
+
+@pytest.mark.asyncio
+async def test_create_task_does_not_retry_when_cli_status_is_unknown():
+	calls = 0
+
+	async def runner(command: list[str]):
+		nonlocal calls
+		calls += 1
+		return 1, '', '{"ok":false,"error":"network dropped"}'
+
+	service = TaskMarketService(command_runner=runner)
+	preview = await service.prepare_task(make_draft())
+
+	with pytest.raises(RuntimeError, match='was not retried'):
+		await service.create_task(preview.preview_id, preview.confirmation_token, confirm_authorized=True)
+	assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_live_reads_use_public_api_and_present_submissions_for_review():
+	def handler(request: httpx.Request) -> httpx.Response:
+		if request.url.path.endswith('/submissions'):
+			return httpx.Response(200, json={'ok': True, 'data': [{'workerAddress': '0xabc', 'id': 'sub_1'}]})
+		return httpx.Response(200, json={'ok': True, 'data': {'id': TASK_ID, 'status': 'open'}})
+
+	async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+		service = TaskMarketService(api_url='https://taskmarket.test', http_client=client)
+		status = await service.get_task_status(TASK_ID)
+		submissions = await service.get_submissions(TASK_ID)
+
+	assert status == {'id': TASK_ID, 'status': 'open'}
+	assert submissions['submissions'] == [{'workerAddress': '0xabc', 'id': 'sub_1'}]
+	assert 'does not accept or reject work automatically' in submissions['review_note']
+
+
+@pytest.mark.asyncio
+async def test_registered_actions_are_opt_in_and_do_not_register_review_writes():
+	class FakeRegistry:
+		def __init__(self):
+			self.actions = {}
+
+		def action(self, description, param_model=None):
+			def decorator(func):
+				self.actions[func.__name__] = {'description': description, 'param_model': param_model}
+				return func
+
+			return decorator
+
+	class FakeTools:
+		def __init__(self):
+			self.registry = FakeRegistry()
+
+	tools = FakeTools()
+	register_taskmarket_actions(cast(Any, tools))
+
+	actions = set(tools.registry.actions)
+	assert {
+		'taskmarket_prepare_task',
+		'taskmarket_create_task',
+		'taskmarket_get_task_status',
+		'taskmarket_list_submissions',
+	}.issubset(actions)
+	assert 'taskmarket_accept_submission' not in actions
+	assert 'taskmarket_reject_submission' not in actions


### PR DESCRIPTION
## Summary

Adds an opt-in Taskmarket integration for browser-use agents:

- `register_taskmarket_actions(tools)` registers actions to prepare/create a requester task, fetch live task status, and list submissions for human review.
- Task creation uses the first-party `taskmarket` CLI with argument lists, not shell interpolation.
- The create path requires a previously prepared preview, Base network, reward/max-spend validation, a confirmation token, and fresh explicit user authorization.
- Submission reads are review-only; this PR intentionally does not add accept, reject, rate, or payment review actions.

## Safety

- No private keys, seed phrases, cookies, or tokens are requested, stored, logged, or committed.
- No automatic retry after a failed create command because payment settlement status may be unknown.
- Read-only status/submission calls use the public Taskmarket API.

## Tests

- `UV_CACHE_DIR=/tmp/browser-use-uv-cache uv run ruff format browser_use/integrations/taskmarket tests/integrations/test_taskmarket.py`
- `UV_CACHE_DIR=/tmp/browser-use-uv-cache uv run ruff check browser_use/integrations/taskmarket tests/integrations/test_taskmarket.py`
- `UV_CACHE_DIR=/tmp/browser-use-uv-cache uv run python -m compileall -q browser_use/integrations/taskmarket tests/integrations/test_taskmarket.py`
- `UV_CACHE_DIR=/tmp/browser-use-uv-cache uv run pytest -q tests/integrations/test_taskmarket.py` (6 passed)

AI assistance was used to draft the boilerplate and tests; I reviewed the flow and verified the focused checks above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in Taskmarket requester integration to `browser_use` and hardens task creation authorization. Previously there was no Taskmarket flow; now agents prepare a preview, require host approval, create once via the `taskmarket` CLI, and read live status/submissions via the public API. Cancels and cleans up CLI subprocesses on timeout or cancellation.

- Registers `register_taskmarket_actions(tools)` with four actions: prepare preview, create task, get status, and list submissions; no accept/reject/rate/pay.
- Creation requires a host-authorized preview via `TaskMarketService.authorize_preview(...)` or an authorization callback; previews are single-use; optional `max_spend_usdc` must fall between the reward and the prepared cap; confirmation tokens are removed.
- Invokes the CLI with an argument list (no shell), never retries on failure, and kills stray processes on cancellation/timeout; tasks fund on Base (chain id 8453); status/submissions are read-only via the public API.
- Enablement: call `register_taskmarket_actions(tools)`, install the `taskmarket` CLI, and configure a wallet in the runtime.

<sup>Written for commit 3594b7e6c45396dc503414411712c33dc407ee5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

