### PR TITLE
fix(browser): keep CHROME_DEFAULT_ARGS order in get_args()

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -896,7 +896,8 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		"""Get the list of all Chrome CLI launch args for this profile (compiled from defaults, user-provided, and system-specific)."""
 
 		if isinstance(self.ignore_default_args, list):
-			default_args = set(CHROME_DEFAULT_ARGS) - set(self.ignore_default_args)
+			ignored_default_args = set(self.ignore_default_args)
+			default_args = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_default_args]
 		elif self.ignore_default_args is True:
 			default_args = []
 		elif not self.ignore_default_args:

--- a/tests/ci/test_profile_args.py
+++ b/tests/ci/test_profile_args.py
@@ -1,0 +1,32 @@
+from browser_use.browser.profile import CHROME_DEFAULT_ARGS, BrowserProfile
+
+
+def test_get_args_keeps_default_order_when_ignoring_default_args(tmp_path):
+	profile = BrowserProfile(
+		user_data_dir=tmp_path,
+		ignore_default_args=['--disable-popup-blocking', '--no-default-browser-check'],
+		enable_default_extensions=False,
+	)
+
+	args = profile.get_args()
+
+	expected_defaults = [
+		arg for arg in CHROME_DEFAULT_ARGS if arg not in {'--disable-popup-blocking', '--no-default-browser-check'}
+	]
+	actual_defaults = [arg for arg in args if arg in CHROME_DEFAULT_ARGS]
+
+	assert actual_defaults == expected_defaults
+	assert '--disable-popup-blocking' not in args
+	assert '--no-default-browser-check' not in args
+
+
+def test_get_args_keeps_default_order_with_default_ignored_args(tmp_path):
+	profile = BrowserProfile(user_data_dir=tmp_path, enable_default_extensions=False)
+
+	args = profile.get_args()
+
+	ignored_default_args = profile.ignore_default_args if isinstance(profile.ignore_default_args, list) else []
+	expected_defaults = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_default_args]
+	actual_defaults = [arg for arg in args if arg in CHROME_DEFAULT_ARGS]
+
+	assert actual_defaults == expected_defaults


### PR DESCRIPTION
## Why

`BrowserProfile.get_args()` collapses the default Chromium launch args into a set whenever `ignore_default_args` is a list:

```python
default_args = set(CHROME_DEFAULT_ARGS) - set(self.ignore_default_args)
```

Set iteration order depends on the hash seed, so the same profile can produce differently-ordered `--flag`s between runs or machines. Since `ignore_default_args` defaults to a list, this hits every default profile, not just ones that pass the option explicitly. The later dedupe step (`args_as_dict` -> `args_as_list`) preserves insertion order, so the set was the only place the ordering got scrambled.

## What changed

Filter the ignored args out of `CHROME_DEFAULT_ARGS` while keeping the original order:

```python
ignored_default_args = set(self.ignore_default_args)
default_args = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_default_args]
```

Added `tests/ci/test_profile_args.py` covering both an explicit ignore list and the default ignore list.

## Verification

- `uv run pytest tests/ci/test_profile_args.py` — 2 passed (fails on the old code)
- `uv run ruff check` / `ruff format --check` — clean
- `uv run pyright` — 0 errors
- pre-commit hooks pass

Fixes #5397

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps CHROME_DEFAULT_ARGS order in BrowserProfile.get_args() so Chrome launch flags are deterministic. Previously, list-based ignore_default_args converted defaults to a set and returned hash-dependent flag order; now we filter CHROME_DEFAULT_ARGS in order.

- Change is limited to BrowserProfile.get_args(); the flag set is unchanged, only order is now stable.
- Adds tests in tests/ci/test_profile_args.py for explicit and default ignore lists.

<sup>Written for commit 1837ccd57ab8949ca7c543ceca987df9e3bec606. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

