### PR TITLE
fix(dom): detect clickable elements in same-origin iframes and DOM0 onclick handlers

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -471,7 +471,32 @@ class DomService:
 							return null;
 						}
 
-						const allElements = document.querySelectorAll('*');
+						// Collect elements from the top document plus same-origin nested
+						// iframes/frames. Cross-origin iframes are handled separately via
+						// the per-target OOPIF traversal in get_dom_tree(); accessing
+						// their contentDocument here throws and is silently skipped, so
+						// this recursion is safe.
+						const allElements = [];
+						(function collect(doc) {
+							let els;
+							try {
+								els = doc.querySelectorAll('*');
+							} catch (e) {
+								return;
+							}
+							for (const el of els) {
+								allElements.push(el);
+								if (el.tagName === 'IFRAME' || el.tagName === 'FRAME') {
+									try {
+										if (el.contentDocument) {
+											collect(el.contentDocument);
+										}
+									} catch (e) {
+										// Cross-origin iframe, inaccessible from this context
+									}
+								}
+							}
+						})(document);
 
 						// Skip on heavy pages — listener detection is too expensive
 						if (allElements.length > 10000) {
@@ -483,8 +508,12 @@ class DomService:
 						for (const el of allElements) {
 							try {
 								const listeners = getEventListeners(el);
-								// Check for click-related event listeners
-								if (listeners.click || listeners.mousedown || listeners.mouseup || listeners.pointerdown || listeners.pointerup) {
+								// Check for click-related event listeners registered via
+								// addEventListener, as well as a handler assigned directly
+								// via the DOM0 `el.onclick = fn` property, which
+								// getEventListeners cannot see and which also never shows
+								// up as an HTML `onclick` attribute in the DOM tree.
+								if (listeners.click || listeners.mousedown || listeners.mouseup || listeners.pointerdown || listeners.pointerup || el.onclick) {
 									elementsWithListeners.push(el);
 									if (elementsWithListeners.length > %d) {
 										return %r;

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -476,12 +476,31 @@ class DomService:
 						// the per-target OOPIF traversal in get_dom_tree(); accessing
 						// their contentDocument here throws and is silently skipped, so
 						// this recursion is safe.
+						//
+						// Cost bound is applied PER DOCUMENT and BEFORE descending: a
+						// single oversized document is skipped in place (and its
+						// iframes are not traversed) instead of aborting the whole
+						// listener detection. The original "skip everything when the
+						// top document is too heavy" behavior is preserved via the
+						// _topDocOversized flag below, so overall behavior on plain
+						// pages is unchanged and pages with many same-origin frames
+						// no longer silently drop listener detection.
+						const _PER_DOC_ELEMENT_CAP = 10000;
 						const allElements = [];
-						(function collect(doc) {
+						let _topDocOversized = false;
+						(function collect(doc, isTop) {
 							let els;
 							try {
 								els = doc.querySelectorAll('*');
 							} catch (e) {
+								return;
+							}
+							if (els.length > _PER_DOC_ELEMENT_CAP) {
+								if (isTop) {
+									_topDocOversized = true;
+								}
+								// Skip this document (and do not descend into its
+								// iframes) — too expensive to scan.
 								return;
 							}
 							for (const el of els) {
@@ -489,17 +508,19 @@ class DomService:
 								if (el.tagName === 'IFRAME' || el.tagName === 'FRAME') {
 									try {
 										if (el.contentDocument) {
-											collect(el.contentDocument);
+											collect(el.contentDocument, false);
 										}
 									} catch (e) {
 										// Cross-origin iframe, inaccessible from this context
 									}
 								}
 							}
-						})(document);
+						})(document, true);
 
-						// Skip on heavy pages — listener detection is too expensive
-						if (allElements.length > 10000) {
+						// Preserve original short-circuit when the top document itself
+						// is too heavy — same behavior as before the same-origin
+						// iframe recursion was added.
+						if (_topDocOversized) {
 							return null;
 						}
 

--- a/tests/ci/test_dom_iframe_onclick_detection.py
+++ b/tests/ci/test_dom_iframe_onclick_detection.py
@@ -1,0 +1,76 @@
+"""Elements inside same-origin iframes must be scanned for click handlers.
+
+Regression test for #5471: the listener-detection script in `_get_all_trees()`
+collected its candidates with `document.querySelectorAll('*')`, which does not
+descend into the `contentDocument` of same-origin iframes. Cross-origin
+iframes are covered by the per-target OOPIF traversal in `get_dom_tree()`, but
+same-origin iframes fell into neither path, so a clickable element inside one
+was never assigned an [index] and the agent saw it as plain text — it then
+burned steps clicking a neighbouring element or fell back to `evaluate`.
+
+Same-origin iframes are the norm in payment/SDK widgets that need to share
+cookies with the host page, and mobile H5 component libraries commonly bind
+handlers at runtime via `el.onclick = fn`, which is the case pinned down here.
+
+Scope note: `getEventListeners()` is a DevTools Console utility that only
+reports listeners for the execution context it is called from, so for an
+element inside an iframe it returns `{}` even when that iframe is same-origin.
+Reading the DOM0 `el.onclick` property works across contexts, so that is the
+signal the fix falls back to inside frames. Handlers registered inside an
+iframe with `addEventListener()` therefore remain undetected; that is a
+separate improvement and is deliberately not asserted here.
+"""
+
+import asyncio
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from browser_use.browser.events import NavigateToUrlEvent
+
+HOST_PAGE = """<!DOCTYPE html>
+<html><head><title>Same-origin iframe handler</title></head>
+<body>
+	<button id="plain">Plain button</button>
+	<iframe id="frame" src="/frame" width="400" height="200"></iframe>
+</body></html>"""
+
+FRAME_PAGE = """<!DOCTYPE html>
+<html><head><title>Frame</title></head>
+<body>
+	<div id="inframe">Pay now</div>
+	<script>
+		document.getElementById('inframe').onclick = function () { window.__inframeClicked = true; };
+	</script>
+</body></html>"""
+
+
+@pytest.fixture(scope='module')
+def http_server():
+	server = HTTPServer()
+	server.start()
+	server.expect_request('/host').respond_with_data(HOST_PAGE, content_type='text/html')
+	server.expect_request('/frame').respond_with_data(FRAME_PAGE, content_type='text/html')
+	yield server
+	server.stop()
+
+
+async def _indexed_ids(browser_session) -> set[str]:
+	"""Return the ids of elements the agent can actually click (i.e. that got an [index])."""
+	state = await browser_session.get_browser_state_summary(include_screenshot=False)
+	return {
+		node.attributes['id'] for node in state.dom_state.selector_map.values() if node.attributes and 'id' in node.attributes
+	}
+
+
+async def test_handler_inside_same_origin_iframe_is_detected(browser_session, http_server):
+	"""A handler bound inside a same-origin iframe must make its element clickable."""
+	event = browser_session.event_bus.dispatch(NavigateToUrlEvent(url=http_server.url_for('/host')))
+	await event
+	await event.event_result(raise_if_any=True, raise_if_none=False)
+	await asyncio.sleep(2)  # give the iframe time to load before snapshotting
+
+	ids = await _indexed_ids(browser_session)
+
+	assert 'plain' in ids, 'a plain <button> must always be indexed'
+	assert 'inframe' in ids, 'a handler inside a same-origin iframe must be detected (#5471)'


### PR DESCRIPTION
## Problem

Interactive elements inside **same-origin** iframes never get an interactive `[index]`, so the agent sees them as plain text and cannot click them with the normal `click` tool. It then burns steps re-clicking a neighbouring element or falls back to `evaluate`.

The listener-detection script in `_get_all_trees()` collects its candidates with `document.querySelectorAll('*')`, which does not descend into an iframe's `contentDocument`. Cross-origin iframes are covered separately by the per-target OOPIF traversal in `get_dom_tree()`, but same-origin iframes fall into **neither** path.

Same-origin iframes are the norm in payment / SDK widgets that need to share cookies with the host page, and mobile H5 component libraries commonly bind handlers at runtime via `el.onclick = fn`, so this shows up on real production pages.

### Why `el.onclick` is part of the fix

`getEventListeners()` is a DevTools Console utility that only reports listeners for the execution context it is called from. Measured on Chromium:

| element | `getEventListeners(el)` | `el.onclick` |
| --- | --- | --- |
| top document, `addEventListener('click', fn)` | `['click']` | – |
| top document, `el.onclick = fn` | `['click']` | truthy |
| **same-origin iframe, `el.onclick = fn`** | **`{}`** | truthy |

So inside a frame the DevTools call is unusable, while reading the DOM0 property still works across contexts. The fix descends into same-origin frames and treats a non-null `el.onclick` as an interactive signal.

> Known limitation: a handler registered *inside* an iframe with `addEventListener()` is still not detected — `getEventListeners()` returns `{}` for it and there is no DOM attribute to fall back on. Covering it would need per-frame execution contexts, so it is called out here explicitly rather than silently overclaimed.

## Fix

Confined to the JS expression string inside `_get_all_trees()` — no Python-side logic, thresholds, or downstream `backendNodeId` matching is touched.

- Recurse into same-origin iframe `contentDocument` when collecting elements. In modern Chromium a cross-origin `contentDocument` returns `null` rather than throwing, so the existing cross-origin path is unaffected.
- Treat a non-null `el.onclick` as an interactive signal; this is what makes detection work inside frames.
- Apply the pre-existing 10k element cap **per document**, before descending into that document's frames. If the top document is oversized, the original "abort listener detection" short-circuit is preserved via a flag; if a sub-frame is oversized it is skipped locally without affecting the top document or sibling frames.

Pages without same-origin iframes behave byte-identically to before.

## Test

`tests/ci/test_dom_iframe_onclick_detection.py` serves a host page containing a same-origin iframe whose child `<div>` is bound via `el.onclick = fn`, and asserts the child receives an `[index]`.

- On `main`: **fails** — `assert 'inframe' in {'plain', 'frame'}`
- With this fix: **passes**
