### PR TITLE
fix(browser): enable validate_default on BrowserLaunchPersistentContextArgs for user_data_dir resolution

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -540,7 +540,7 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch-persistent-context
 	"""
 
-	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
+	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always', validate_default=True)
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
 	user_data_dir: str | Path | None = None

--- a/tests/ci/browser/test_profile_copy.py
+++ b/tests/ci/browser/test_profile_copy.py
@@ -69,16 +69,15 @@ def test_user_data_dir_default_validation_when_omitted() -> None:
 	profile_omitted = BrowserProfile(headless=True)
 	profile_empty = BrowserProfile()
 
-	assert profile_explicit_none.user_data_dir is not None
-	assert profile_omitted.user_data_dir is not None
-	assert profile_empty.user_data_dir is not None
+	try:
+		assert profile_explicit_none.user_data_dir is not None
+		assert profile_omitted.user_data_dir is not None
+		assert profile_empty.user_data_dir is not None
 
-	assert 'browser-use-user-data-dir-' in str(profile_explicit_none.user_data_dir)
-	assert 'browser-use-user-data-dir-' in str(profile_omitted.user_data_dir)
-	assert 'browser-use-user-data-dir-' in str(profile_empty.user_data_dir)
-
-	# Clean up temp dirs
-	shutil.rmtree(profile_explicit_none.user_data_dir, ignore_errors=True)
-	shutil.rmtree(profile_omitted.user_data_dir, ignore_errors=True)
-	shutil.rmtree(profile_empty.user_data_dir, ignore_errors=True)
-
+		assert 'browser-use-user-data-dir-' in str(profile_explicit_none.user_data_dir)
+		assert 'browser-use-user-data-dir-' in str(profile_omitted.user_data_dir)
+		assert 'browser-use-user-data-dir-' in str(profile_empty.user_data_dir)
+	finally:
+		shutil.rmtree(profile_explicit_none.user_data_dir, ignore_errors=True)
+		shutil.rmtree(profile_omitted.user_data_dir, ignore_errors=True)
+		shutil.rmtree(profile_empty.user_data_dir, ignore_errors=True)

--- a/tests/ci/browser/test_profile_copy.py
+++ b/tests/ci/browser/test_profile_copy.py
@@ -69,15 +69,22 @@ def test_user_data_dir_default_validation_when_omitted() -> None:
 	profile_omitted = BrowserProfile(headless=True)
 	profile_empty = BrowserProfile()
 
-	try:
-		assert profile_explicit_none.user_data_dir is not None
-		assert profile_omitted.user_data_dir is not None
-		assert profile_empty.user_data_dir is not None
+	dir_explicit_none = profile_explicit_none.user_data_dir
+	dir_omitted = profile_omitted.user_data_dir
+	dir_empty = profile_empty.user_data_dir
 
-		assert 'browser-use-user-data-dir-' in str(profile_explicit_none.user_data_dir)
-		assert 'browser-use-user-data-dir-' in str(profile_omitted.user_data_dir)
-		assert 'browser-use-user-data-dir-' in str(profile_empty.user_data_dir)
+	try:
+		assert dir_explicit_none is not None
+		assert dir_omitted is not None
+		assert dir_empty is not None
+
+		assert 'browser-use-user-data-dir-' in str(dir_explicit_none)
+		assert 'browser-use-user-data-dir-' in str(dir_omitted)
+		assert 'browser-use-user-data-dir-' in str(dir_empty)
 	finally:
-		shutil.rmtree(profile_explicit_none.user_data_dir, ignore_errors=True)
-		shutil.rmtree(profile_omitted.user_data_dir, ignore_errors=True)
-		shutil.rmtree(profile_empty.user_data_dir, ignore_errors=True)
+		if dir_explicit_none is not None:
+			shutil.rmtree(dir_explicit_none, ignore_errors=True)
+		if dir_omitted is not None:
+			shutil.rmtree(dir_omitted, ignore_errors=True)
+		if dir_empty is not None:
+			shutil.rmtree(dir_empty, ignore_errors=True)

--- a/tests/ci/browser/test_profile_copy.py
+++ b/tests/ci/browser/test_profile_copy.py
@@ -61,3 +61,24 @@ def test_chrome_profile_copy_lock_error_is_actionable(tmp_path: Path, monkeypatc
 		)
 
 	assert not temp_user_data_dir.exists()
+
+
+def test_user_data_dir_default_validation_when_omitted() -> None:
+	"""user_data_dir field_validator should execute when field is omitted or explicitly None."""
+	profile_explicit_none = BrowserProfile(user_data_dir=None)
+	profile_omitted = BrowserProfile(headless=True)
+	profile_empty = BrowserProfile()
+
+	assert profile_explicit_none.user_data_dir is not None
+	assert profile_omitted.user_data_dir is not None
+	assert profile_empty.user_data_dir is not None
+
+	assert 'browser-use-user-data-dir-' in str(profile_explicit_none.user_data_dir)
+	assert 'browser-use-user-data-dir-' in str(profile_omitted.user_data_dir)
+	assert 'browser-use-user-data-dir-' in str(profile_empty.user_data_dir)
+
+	# Clean up temp dirs
+	shutil.rmtree(profile_explicit_none.user_data_dir, ignore_errors=True)
+	shutil.rmtree(profile_omitted.user_data_dir, ignore_errors=True)
+	shutil.rmtree(profile_empty.user_data_dir, ignore_errors=True)
+


### PR DESCRIPTION
### Summary

Fixes #5414

In Pydantic v2, `field_validator('user_data_dir', mode='after')` is by default skipped when a field is left at its declared default value (`None`) rather than explicitly passed as a keyword argument.

Because `BrowserProfile` and `BrowserLaunchPersistentContextArgs` did not set `validate_default=True`, constructing `BrowserProfile(headless=True)` or `BrowserProfile()` left `user_data_dir` as raw `None` during `model_post_init`, while `BrowserProfile(user_data_dir=None)` properly ran the validator and generated a temporary directory.

### Changes
1. Added `validate_default=True` to `BrowserLaunchPersistentContextArgs.model_config`.
2. Added regression unit test in `tests/ci/browser/test_profile_copy.py` confirming that omitted kwargs, explicit `None`, and default construction all resolve `user_data_dir` consistently to a valid temp path.

### Verification
```bash
uv run pytest tests/ci/browser/test_profile_copy.py tests/ci/test_chrome_profile_helpers.py -q
# 6 passed in 0.10s
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Pydantic default validation for `BrowserLaunchPersistentContextArgs` so `user_data_dir` resolves to a temp directory when omitted or `None`. Previously, omitting `user_data_dir` left it as `None`; now omitted, explicit `None`, and default construction all resolve to a temp dir, while explicit paths stay unchanged.

- Set `validate_default=True` in `BrowserLaunchPersistentContextArgs.model_config`.
- Added a regression test covering omitted, `None`, and default cases; used try/finally with local variable capture to safely clean up temp dirs and satisfy static typing in the finally block.
- No migration required.

<sup>Written for commit 5dfae0a0b3c8fc9ae3435338d3b8aa9f8bdf97e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

