### PR TITLE
feat: add a3m-router as optional dependency

### DIFF
--- a/browser_use/llm/a3m/chat.py
+++ b/browser_use/llm/a3m/chat.py
@@ -1,0 +1,228 @@
+"""
+ChatA3M - A3M Router chat model wrapper for browser-use.
+
+Provides intelligent LLM routing for browser automation with:
+- Automatic routing to cheapest capable model
+- Stealth mode for anti-detection
+- Parallel ensemble for reliability
+- Parallel ensemble for reliable extraction
+
+Requires the `adaptive-memory-multi-model-router` package:
+    pip install adaptive-memory-multi-model-router
+
+Usage:
+    from browser_use import Agent
+    from browser_use.llm.a3m import ChatA3M
+
+    agent = Agent(
+        task="Fill out this job application form",
+        llm=ChatA3M(model="auto", stealth=True),
+    )
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, TypeVar, overload
+
+from pydantic import BaseModel
+
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
+
+from .serializer import A3MMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar('T', bound=BaseModel)
+
+
+@dataclass
+class ChatA3M(BaseChatModel):
+    """
+    A3M Router - Intelligent routing for browser automation.
+
+    Attributes:
+        model: Model to use. Use "auto" for automatic routing.
+        api_key: A3M API key (optional, uses env A3M_API_KEY if not provided).
+        stealth: Enable stealth mode for anti-detection.
+        parallel_ensemble: Number of providers to run in parallel.
+
+        temperature: Sampling temperature.
+        max_tokens: Maximum tokens to generate.
+    """
+
+    model: str = "auto"
+    api_key: str | None = None
+    stealth: bool = True
+    parallel_ensemble: int = 1
+    temperature: float | None = 0.0
+    max_tokens: int | None = 4096
+
+    _a3m_router: Any = field(default=None, init=False, repr=False)
+    _provider_name: str = field(default='a3m', init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Initialize A3M router."""
+        try:
+            from a3m.router import A3MRouter
+
+            self._a3m_router = A3MRouter(
+                model=self.model,
+                stealth=self.stealth,
+                parallel_ensemble=self.parallel_ensemble,
+            )
+            logger.debug(
+                'ChatA3M initialized: model=%s, stealth=%s, ensemble=%s',
+                self.model,
+                self.stealth,
+                self.parallel_ensemble,
+            )
+        except ImportError as e:
+            raise ModelProviderError(
+                message=f"A3M Router not installed. Run: pip install adaptive-memory-multi-model-router. Error: {e}",
+                model=self.model,
+            ) from e
+
+    @property
+    def provider(self) -> str:
+        return self._provider_name
+
+    @property
+    def name(self) -> str:
+        return f"a3m-{self.model}"
+
+    @staticmethod
+    def _parse_usage(response: Any) -> ChatInvokeUsage | None:
+        """Extract token usage from an A3M response."""
+        usage = getattr(response, 'usage', None)
+        if usage is None:
+            return None
+
+        prompt_tokens = getattr(usage, 'prompt_tokens', 0) or 0
+        completion_tokens = getattr(usage, 'completion_tokens', 0) or 0
+
+        return ChatInvokeUsage(
+            prompt_tokens=prompt_tokens,
+            prompt_cached_tokens=None,
+            prompt_cache_creation_tokens=None,
+            prompt_image_tokens=None,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        )
+
+    @overload
+    async def ainvoke(
+        self,
+        messages: list[BaseMessage],
+        output_format: None = None,
+        **kwargs: Any,
+    ) -> ChatInvokeCompletion[str]: ...
+
+    @overload
+    async def ainvoke(
+        self,
+        messages: list[BaseMessage],
+        output_format: type[T],
+        **kwargs: Any,
+    ) -> ChatInvokeCompletion[T]: ...
+
+    async def ainvoke(
+        self,
+        messages: list[BaseMessage],
+        output_format: type[T] | None = None,
+        **kwargs: Any,
+    ) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+        """Invoke A3M Router with automatic provider selection."""
+        from a3m.router import RouteResponse
+
+        # Serialize messages for A3M
+        a3m_messages = A3MMessageSerializer.serialize(messages)
+
+        # Build request params
+        params: dict[str, Any] = {
+            'model': self.model,
+            'messages': a3m_messages,
+            'temperature': self.temperature or 0.0,
+            'max_tokens': self.max_tokens or 4096,
+        }
+
+        if self.api_key:
+            params['api_key'] = self.api_key
+
+        # Add output format if specified
+        if output_format is not None:
+            schema = SchemaOptimizer.create_optimized_json_schema(output_format)
+            params['response_format'] = {
+                'type': 'json_schema',
+                'json_schema': {
+                    'name': 'agent_output',
+                    'strict': True,
+                    'schema': schema,
+                },
+            }
+
+        # Route the request through A3M (run sync call in executor to avoid blocking event loop)
+        try:
+            import asyncio
+            loop = asyncio.get_event_loop()
+            result: RouteResponse = await loop.run_in_executor(
+                None, lambda: self._a3m_router.route(**params)
+            )
+        except Exception as e:
+            error_msg = str(e)
+            if 'rate limit' in error_msg.lower() or '429' in error_msg:
+                raise ModelRateLimitError(
+                    message=error_msg,
+                    model=self.name,
+                ) from e
+            raise ModelProviderError(
+                message=error_msg,
+                model=self.name,
+            ) from e
+
+        # Extract response content
+        content = result.content if hasattr(result, 'content') else str(result)
+        usage = self._parse_usage(result) if hasattr(result, 'usage') else None
+        stop_reason = getattr(result, 'finish_reason', None)
+
+        # Get thinking content if available
+        thinking: str | None = None
+        if hasattr(result, 'thinking'):
+            thinking = result.thinking
+
+        if output_format is not None:
+            if not content:
+                raise ModelProviderError(
+                    message='Model returned empty content for structured output request',
+                    status_code=500,
+                    model=self.name,
+                )
+            parsed = output_format.model_validate_json(content)
+            return ChatInvokeCompletion(
+                completion=parsed,
+                thinking=thinking,
+                usage=usage,
+                stop_reason=stop_reason,
+            )
+
+        return ChatInvokeCompletion(
+            completion=content,
+            thinking=thinking,
+            usage=usage,
+            stop_reason=stop_reason,
+        )
+
+    def get_cost(self) -> dict[str, Any]:
+        """Get cost statistics from A3M router."""
+        if self._a3m_router and hasattr(self._a3m_router, 'get_cost'):
+            return self._a3m_router.get_cost()
+        return {}
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get routing statistics from A3M router."""
+        if self._a3m_router and hasattr(self._a3m_router, 'get_stats'):
+            return self._a3m_router.get_stats()
+        return {}

--- a/browser_use/llm/a3m/serializer.py
+++ b/browser_use/llm/a3m/serializer.py
@@ -1,0 +1,31 @@
+"""
+A3M Router message serializer.
+
+Converts browser-use BaseMessage objects to A3M Router format.
+A3M uses OpenAI-compatible API, so we delegate to the existing OpenAI serializer.
+"""
+
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.openai.serializer import OpenAIMessageSerializer
+
+
+class A3MMessageSerializer:
+    """
+    Serializer for converting browser-use messages to A3M Router format.
+
+    A3M Router uses the OpenAI-compatible API, so we reuse the OpenAI serializer.
+    """
+
+    @staticmethod
+    def serialize(messages: list[BaseMessage]) -> list[dict]:
+        """
+        Convert a list of browser-use BaseMessage objects to A3M Router format.
+
+        Args:
+            messages: List of BaseMessage objects from browser-use
+
+        Returns:
+            List of message dicts in A3M Router format (OpenAI-compatible)
+        """
+        # A3M uses OpenAI-compatible format, delegate to existing serializer
+        return OpenAIMessageSerializer.serialize_messages(messages)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ core = [
     "browser-use-core==0.13.2; sys_platform == 'linux' and platform_machine == 'aarch64'",
     "browser-use-core==0.13.2; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
 ]
+a3m = ["a3m-router>=2.2.2"]
 aws = ["boto3==1.42.37"]
 oci = ["oci==2.166.0"]
 video = ["imageio[ffmpeg]==2.37.2", "numpy==2.4.1"]


### PR DESCRIPTION
## Summary

Add `a3m-router` as an optional dependency so users can `pip install browser-use[a3m]` to get A3M Router support.

## Why optional?

- `pip install browser-use` works without A3M (no surprise dependencies)
- `pip install browser-use[a3m]` installs with A3M support
- A3M Router (`a3m-router` on PyPI) is a Python package separate from the npm package

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional A3M Router support via an `a3m` extra (`a3m-router>=2.2.2`). Previously there was no A3M extra; now installing `browser-use[a3m]` pulls in A3M without changing the default install.

- Existing users need no changes; the base install adds no new dependencies.
- ChatA3M runs router calls in an executor so async requests no longer block the event loop.
- ChatA3M now uses the actual `finish_reason` for `stop_reason`, preserves refusal type, and warns on unknown message types.

<sup>Written for commit 893806aa452777d78b5c89d3a99164dd6ea0ee93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

