### PR TITLE
feat: add first-party OpenClaw skill support

### DIFF
--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -6,7 +6,6 @@ metadata:
   {
     "openclaw":
       {
-        "emoji": "🌐",
         "requires": { "bins": ["browser-use"] },
         "install":
           [

--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -1,6 +1,25 @@
 ---
 name: browser-use
 description: "Direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/app work."
+homepage: https://browser-use.com
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🌐",
+        "requires": { "bins": ["browser-use"] },
+        "install":
+          [
+            {
+              "id": "uv",
+              "kind": "uv",
+              "package": "browser-use==0.13.7",
+              "bins": ["browser-use"],
+              "label": "Install Browser Use CLI (uv)",
+            },
+          ],
+      },
+  }
 ---
 
 # Browser Use

--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -13,7 +13,7 @@ metadata:
             {
               "id": "uv",
               "kind": "uv",
-              "package": "browser-use==0.13.7",
+              "package": "browser-use",
               "bins": ["browser-use"],
               "label": "Install Browser Use CLI (uv)",
             },

--- a/browser_use/skills/browser_use.py
+++ b/browser_use/skills/browser_use.py
@@ -6,34 +6,27 @@ import re
 from importlib import resources
 from pathlib import Path
 
-
-def _canonical_skill_path() -> Path:
-	return Path(__file__).resolve().parent / 'browser-use' / 'SKILL.md'
-
-
-def _canonical_metadata_lines() -> list[str]:
-	"""Read the metadata block from the canonical Browser Use skill."""
-	skill_path = _canonical_skill_path()
-	if not skill_path.exists():
-		return []
-
-	try:
-		_, frontmatter, _ = skill_path.read_text(encoding='utf-8').split('---\n', 2)
-	except ValueError:
-		return []
-
-	lines = frontmatter.splitlines()
-	try:
-		start = lines.index('metadata:')
-	except ValueError:
-		return []
-
-	end = len(lines)
-	for index in range(start + 1, len(lines)):
-		if lines[index] and not lines[index][0].isspace():
-			end = index
-			break
-	return lines[start:end]
+# Browser Use-only frontmatter added while generating both checked-in SKILL.md copies.
+# Keep this as the source of truth; scripts/sync_browser_harness_skill.py verifies the outputs.
+OPENCLAW_METADATA_LINES = (
+	'metadata:',
+	'  {',
+	'    "openclaw":',
+	'      {',
+	'        "requires": { "bins": ["browser-use"] },',
+	'        "install":',
+	'          [',
+	'            {',
+	'              "id": "uv",',
+	'              "kind": "uv",',
+	'              "package": "browser-use",',
+	'              "bins": ["browser-use"],',
+	'              "label": "Install Browser Use CLI (uv)",',
+	'            },',
+	'          ],',
+	'      },',
+	'  }',
+)
 
 
 def as_browser_use_skill(text: str) -> str:
@@ -71,7 +64,7 @@ def as_browser_use_skill(text: str) -> str:
 	if not any(line.startswith('homepage:') for line in lines):
 		lines.append('homepage: https://browser-use.com')
 	if not any(line.startswith('metadata:') for line in lines):
-		lines.extend(_canonical_metadata_lines())
+		lines.extend(OPENCLAW_METADATA_LINES)
 
 	body = body.replace('# browser-harness', '# Browser Use', 1).replace('# Browser Harness', '# Browser Use', 1)
 	# Rebrand every mention except repo URLs (github.com/browser-use/browser-harness/...)
@@ -83,7 +76,7 @@ def as_browser_use_skill(text: str) -> str:
 
 def skill_text() -> str:
 	"""Return the canonical Browser Use skill."""
-	skill_path = _canonical_skill_path()
+	skill_path = Path(__file__).resolve().parent / 'browser-use' / 'SKILL.md'
 	if skill_path.exists():
 		return skill_path.read_text(encoding='utf-8')
 

--- a/browser_use/skills/browser_use.py
+++ b/browser_use/skills/browser_use.py
@@ -6,26 +6,34 @@ import re
 from importlib import resources
 from pathlib import Path
 
-OPENCLAW_METADATA = (
-	'metadata:\n'
-	'  {\n'
-	'    "openclaw":\n'
-	'      {\n'
-	'        "emoji": "🌐",\n'
-	'        "requires": { "bins": ["browser-use"] },\n'
-	'        "install":\n'
-	'          [\n'
-	'            {\n'
-	'              "id": "uv",\n'
-	'              "kind": "uv",\n'
-	'              "package": "browser-use",\n'
-	'              "bins": ["browser-use"],\n'
-	'              "label": "Install Browser Use CLI (uv)",\n'
-	'            },\n'
-	'          ],\n'
-	'      },\n'
-	'  }'
-)
+
+def _canonical_skill_path() -> Path:
+	return Path(__file__).resolve().parent / 'browser-use' / 'SKILL.md'
+
+
+def _canonical_metadata_lines() -> list[str]:
+	"""Read the metadata block from the canonical Browser Use skill."""
+	skill_path = _canonical_skill_path()
+	if not skill_path.exists():
+		return []
+
+	try:
+		_, frontmatter, _ = skill_path.read_text(encoding='utf-8').split('---\n', 2)
+	except ValueError:
+		return []
+
+	lines = frontmatter.splitlines()
+	try:
+		start = lines.index('metadata:')
+	except ValueError:
+		return []
+
+	end = len(lines)
+	for index in range(start + 1, len(lines)):
+		if lines[index] and not lines[index][0].isspace():
+			end = index
+			break
+	return lines[start:end]
 
 
 def as_browser_use_skill(text: str) -> str:
@@ -63,7 +71,7 @@ def as_browser_use_skill(text: str) -> str:
 	if not any(line.startswith('homepage:') for line in lines):
 		lines.append('homepage: https://browser-use.com')
 	if not any(line.startswith('metadata:') for line in lines):
-		lines.extend(OPENCLAW_METADATA.splitlines())
+		lines.extend(_canonical_metadata_lines())
 
 	body = body.replace('# browser-harness', '# Browser Use', 1).replace('# Browser Harness', '# Browser Use', 1)
 	# Rebrand every mention except repo URLs (github.com/browser-use/browser-harness/...)
@@ -75,7 +83,7 @@ def as_browser_use_skill(text: str) -> str:
 
 def skill_text() -> str:
 	"""Return the canonical Browser Use skill."""
-	skill_path = Path(__file__).resolve().parent / 'browser-use' / 'SKILL.md'
+	skill_path = _canonical_skill_path()
 	if skill_path.exists():
 		return skill_path.read_text(encoding='utf-8')
 

--- a/browser_use/skills/browser_use.py
+++ b/browser_use/skills/browser_use.py
@@ -6,6 +6,27 @@ import re
 from importlib import resources
 from pathlib import Path
 
+OPENCLAW_METADATA = (
+	'metadata:\n'
+	'  {\n'
+	'    "openclaw":\n'
+	'      {\n'
+	'        "emoji": "🌐",\n'
+	'        "requires": { "bins": ["browser-use"] },\n'
+	'        "install":\n'
+	'          [\n'
+	'            {\n'
+	'              "id": "uv",\n'
+	'              "kind": "uv",\n'
+	'              "package": "browser-use",\n'
+	'              "bins": ["browser-use"],\n'
+	'              "label": "Install Browser Use CLI (uv)",\n'
+	'            },\n'
+	'          ],\n'
+	'      },\n'
+	'  }'
+)
+
 
 def as_browser_use_skill(text: str) -> str:
 	"""Expose the Browser Harness skill under the Browser Use skill identity."""
@@ -39,6 +60,10 @@ def as_browser_use_skill(text: str) -> str:
 			1,
 			'description: "Direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/app work."',
 		)
+	if not any(line.startswith('homepage:') for line in lines):
+		lines.append('homepage: https://browser-use.com')
+	if not any(line.startswith('metadata:') for line in lines):
+		lines.extend(OPENCLAW_METADATA.splitlines())
 
 	body = body.replace('# browser-harness', '# Browser Use', 1).replace('# Browser Harness', '# Browser Use', 1)
 	# Rebrand every mention except repo URLs (github.com/browser-use/browser-harness/...)

--- a/browser_use/skills/install.py
+++ b/browser_use/skills/install.py
@@ -29,6 +29,7 @@ TARGET_DIR_BUILDERS = {
 	'copilot': lambda: _home_skill_dir('copilot'),
 	'cursor': lambda: _home_skill_dir('cursor'),
 	'gemini': lambda: _home_skill_dir('gemini'),
+	'openclaw': lambda: _home_skill_dir('openclaw'),
 	'opencode': lambda: _xdg_config_home() / 'opencode' / 'skills' / SKILL_NAME,
 }
 

--- a/browser_use/skills/install.py
+++ b/browser_use/skills/install.py
@@ -152,11 +152,16 @@ def _print_skill_text(text: str) -> None:
 	# Windows consoles commonly default to cp1252, which cannot encode the emoji
 	# in OpenClaw skill metadata. Prefer UTF-8 when stdout supports reconfiguration.
 	reconfigure = getattr(sys.stdout, 'reconfigure', None)
+	reconfigured = False
 	if callable(reconfigure):
 		try:
-			reconfigure(encoding='utf-8')
-		except OSError:
+			reconfigure(encoding='utf-8', errors='replace')
+			reconfigured = True
+		except (OSError, TypeError, ValueError):
 			pass
+	if not reconfigured:
+		encoding = getattr(sys.stdout, 'encoding', None) or 'utf-8'
+		text = text.encode(encoding, errors='replace').decode(encoding)
 	print(text, end='')
 
 

--- a/browser_use/skills/install.py
+++ b/browser_use/skills/install.py
@@ -148,6 +148,18 @@ def _validate_output_paths(output_paths: list[Path]) -> None:
 			raise RuntimeError(f'{ancestor} is not a directory.')
 
 
+def _print_skill_text(text: str) -> None:
+	# Windows consoles commonly default to cp1252, which cannot encode the emoji
+	# in OpenClaw skill metadata. Prefer UTF-8 when stdout supports reconfiguration.
+	reconfigure = getattr(sys.stdout, 'reconfigure', None)
+	if callable(reconfigure):
+		try:
+			reconfigure(encoding='utf-8')
+		except OSError:
+			pass
+	print(text, end='')
+
+
 def handle(argv: list[str]) -> int:
 	parser = _build_parser()
 	args = parser.parse_args(argv)
@@ -160,7 +172,7 @@ def handle(argv: list[str]) -> int:
 		except RuntimeError as exc:
 			print(f'Error: {exc}', file=sys.stderr)
 			return 1
-		print(text, end='')
+		_print_skill_text(text)
 		return 0
 
 	if command == 'install':

--- a/browser_use/skills/install.py
+++ b/browser_use/skills/install.py
@@ -148,23 +148,6 @@ def _validate_output_paths(output_paths: list[Path]) -> None:
 			raise RuntimeError(f'{ancestor} is not a directory.')
 
 
-def _print_skill_text(text: str) -> None:
-	# Windows consoles commonly default to cp1252, which cannot encode the emoji
-	# in OpenClaw skill metadata. Prefer UTF-8 when stdout supports reconfiguration.
-	reconfigure = getattr(sys.stdout, 'reconfigure', None)
-	reconfigured = False
-	if callable(reconfigure):
-		try:
-			reconfigure(encoding='utf-8', errors='replace')
-			reconfigured = True
-		except (OSError, TypeError, ValueError):
-			pass
-	if not reconfigured:
-		encoding = getattr(sys.stdout, 'encoding', None) or 'utf-8'
-		text = text.encode(encoding, errors='replace').decode(encoding)
-	print(text, end='')
-
-
 def handle(argv: list[str]) -> int:
 	parser = _build_parser()
 	args = parser.parse_args(argv)
@@ -177,7 +160,7 @@ def handle(argv: list[str]) -> int:
 		except RuntimeError as exc:
 			print(f'Error: {exc}', file=sys.stderr)
 			return 1
-		_print_skill_text(text)
+		print(text, end='')
 		return 0
 
 	if command == 'install':

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -6,7 +6,6 @@ metadata:
   {
     "openclaw":
       {
-        "emoji": "🌐",
         "requires": { "bins": ["browser-use"] },
         "install":
           [

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -1,6 +1,25 @@
 ---
 name: browser-use
 description: "Direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/app work."
+homepage: https://browser-use.com
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🌐",
+        "requires": { "bins": ["browser-use"] },
+        "install":
+          [
+            {
+              "id": "uv",
+              "kind": "uv",
+              "package": "browser-use==0.13.7",
+              "bins": ["browser-use"],
+              "label": "Install Browser Use CLI (uv)",
+            },
+          ],
+      },
+  }
 ---
 
 # Browser Use

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -13,7 +13,7 @@ metadata:
             {
               "id": "uv",
               "kind": "uv",
-              "package": "browser-use==0.13.7",
+              "package": "browser-use",
               "bins": ["browser-use"],
               "label": "Install Browser Use CLI (uv)",
             },

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -12,6 +12,7 @@ EXPECTED_SKILL_INSTALL_PATHS = (
 	Path('.copilot') / 'skills' / 'browser-use' / 'SKILL.md',
 	Path('.cursor') / 'skills' / 'browser-use' / 'SKILL.md',
 	Path('.gemini') / 'skills' / 'browser-use' / 'SKILL.md',
+	Path('.openclaw') / 'skills' / 'browser-use' / 'SKILL.md',
 	Path('.config') / 'opencode' / 'skills' / 'browser-use' / 'SKILL.md',
 )
 

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -150,3 +150,41 @@ def test_skill_show_reconfigures_windows_stdout_to_utf8(monkeypatch):
 	windows_stdout.flush()
 
 	assert buffer.getvalue().decode('utf-8') == 'Browser Use 🌐\n'
+
+
+def test_skill_show_replaces_unsupported_characters_without_reconfigure(monkeypatch):
+	from browser_use.skills import install
+
+	class LegacyStdout:
+		encoding = 'cp1252'
+
+		def __init__(self):
+			self.buffer = BytesIO()
+
+		def write(self, text: str) -> int:
+			data = text.encode(self.encoding)
+			self.buffer.write(data)
+			return len(text)
+
+	class FailingReconfigureStdout(LegacyStdout):
+		def reconfigure(self, **kwargs):
+			raise OSError('legacy stream cannot be reconfigured')
+
+	for legacy_stdout in (LegacyStdout(), FailingReconfigureStdout()):
+		monkeypatch.setattr(sys, 'stdout', legacy_stdout)
+		install._print_skill_text('Browser Use 🌐\n')
+
+		assert legacy_stdout.buffer.getvalue().decode('cp1252') == 'Browser Use ?\n'
+
+
+def test_browser_use_alias_sources_metadata_from_canonical_skill():
+	from browser_use.skills import browser_use
+
+	canonical = browser_use.skill_text()
+	_, canonical_frontmatter, _ = canonical.split('---\n', 2)
+	metadata = canonical_frontmatter[canonical_frontmatter.index('metadata:') :]
+
+	converted = browser_use.as_browser_use_skill('---\nname: browser-harness\n---\n\n# Browser Harness\n')
+	_, converted_frontmatter, _ = converted.split('---\n', 2)
+
+	assert metadata in converted_frontmatter

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+from io import BytesIO, TextIOWrapper
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -87,6 +88,25 @@ def test_browser_use_cli_installs_browser_harness_package_skill(tmp_path):
 		'---\n'
 		'name: browser-use\n'
 		'description: "Direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/app work."\n'
+		'homepage: https://browser-use.com\n'
+		'metadata:\n'
+		'  {\n'
+		'    "openclaw":\n'
+		'      {\n'
+		'        "emoji": "🌐",\n'
+		'        "requires": { "bins": ["browser-use"] },\n'
+		'        "install":\n'
+		'          [\n'
+		'            {\n'
+		'              "id": "uv",\n'
+		'              "kind": "uv",\n'
+		'              "package": "browser-use",\n'
+		'              "bins": ["browser-use"],\n'
+		'              "label": "Install Browser Use CLI (uv)",\n'
+		'            },\n'
+		'          ],\n'
+		'      },\n'
+		'  }\n'
 		'---\n\n'
 		'# Browser Use\n'
 	)
@@ -118,3 +138,15 @@ def test_browser_use_cli_validates_destination_before_installing_harness(tmp_pat
 	assert result.returncode == 1
 	assert 'is not a directory' in result.stderr
 	assert not uv_args.exists()
+
+
+def test_skill_show_reconfigures_windows_stdout_to_utf8(monkeypatch):
+	from browser_use.skills import install
+
+	buffer = BytesIO()
+	windows_stdout = TextIOWrapper(buffer, encoding='cp1252')
+	monkeypatch.setattr(sys, 'stdout', windows_stdout)
+	install._print_skill_text('Browser Use 🌐\n')
+	windows_stdout.flush()
+
+	assert buffer.getvalue().decode('utf-8') == 'Browser Use 🌐\n'

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 import sys
-from io import BytesIO, TextIOWrapper
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -93,7 +92,6 @@ def test_browser_use_cli_installs_browser_harness_package_skill(tmp_path):
 		'  {\n'
 		'    "openclaw":\n'
 		'      {\n'
-		'        "emoji": "🌐",\n'
 		'        "requires": { "bins": ["browser-use"] },\n'
 		'        "install":\n'
 		'          [\n'
@@ -138,53 +136,3 @@ def test_browser_use_cli_validates_destination_before_installing_harness(tmp_pat
 	assert result.returncode == 1
 	assert 'is not a directory' in result.stderr
 	assert not uv_args.exists()
-
-
-def test_skill_show_reconfigures_windows_stdout_to_utf8(monkeypatch):
-	from browser_use.skills import install
-
-	buffer = BytesIO()
-	windows_stdout = TextIOWrapper(buffer, encoding='cp1252')
-	monkeypatch.setattr(sys, 'stdout', windows_stdout)
-	install._print_skill_text('Browser Use 🌐\n')
-	windows_stdout.flush()
-
-	assert buffer.getvalue().decode('utf-8') == 'Browser Use 🌐\n'
-
-
-def test_skill_show_replaces_unsupported_characters_without_reconfigure(monkeypatch):
-	from browser_use.skills import install
-
-	class LegacyStdout:
-		encoding = 'cp1252'
-
-		def __init__(self):
-			self.buffer = BytesIO()
-
-		def write(self, text: str) -> int:
-			data = text.encode(self.encoding)
-			self.buffer.write(data)
-			return len(text)
-
-	class FailingReconfigureStdout(LegacyStdout):
-		def reconfigure(self, **kwargs):
-			raise OSError('legacy stream cannot be reconfigured')
-
-	for legacy_stdout in (LegacyStdout(), FailingReconfigureStdout()):
-		monkeypatch.setattr(sys, 'stdout', legacy_stdout)
-		install._print_skill_text('Browser Use 🌐\n')
-
-		assert legacy_stdout.buffer.getvalue().decode('cp1252') == 'Browser Use ?\n'
-
-
-def test_browser_use_alias_sources_metadata_from_canonical_skill():
-	from browser_use.skills import browser_use
-
-	canonical = browser_use.skill_text()
-	_, canonical_frontmatter, _ = canonical.split('---\n', 2)
-	metadata = canonical_frontmatter[canonical_frontmatter.index('metadata:') :]
-
-	converted = browser_use.as_browser_use_skill('---\nname: browser-harness\n---\n\n# Browser Harness\n')
-	_, converted_frontmatter, _ = converted.split('---\n', 2)
-
-	assert metadata in converted_frontmatter


### PR DESCRIPTION
## Summary

- add OpenClaw to `browser-use skill install` targets
- generate OpenClaw dependency and uv-installer metadata in both Browser Use skill artifacts
- keep Browser Harness as the body source while applying Browser Use-specific frontmatter in one transformer

## Why

OpenClaw discovers managed skills from `~/.openclaw/skills`, but the Browser Use installer did not target that directory. The skill also lacked the metadata OpenClaw uses to detect and install the CLI dependency.

After this change, `browser-use skill install --target openclaw` works directly, the default `all` target includes OpenClaw, and OpenClaw can install the CLI with `uv tool install browser-use`.

## Validation

- rebased onto current `main`
- Browser Harness skill sync check passes
- focused CLI/skill tests: 3 passed
- all affected-file pre-commit hooks pass
- full pyright: 0 errors
- local wheel `uvx` show/install smoke passes
- current OpenClaw parser accepts the generated metadata as `requires.bins = ["browser-use"]` and a `uv` installer for package `browser-use`