### PR TITLE
fix(deps): unblock OpenHands with rich 14.3.3

### DIFF
--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -36,7 +36,7 @@ If the daemon cannot connect, run diagnostics:
 browser-use --doctor
 ```
 
-If Chrome is not running at all, the harness launches it automatically and retries — no user action needed beyond clicking Allow if a permission popup appears.
+If Chrome is not running at all, the harness launches it automatically and retries.
 
 If Chrome is running but remote debugging is not enabled, the harness opens:
 
@@ -44,7 +44,14 @@ If Chrome is running but remote debugging is not enabled, the harness opens:
 chrome://inspect/#remote-debugging
 ```
 
-Ask the user to tick "Allow remote debugging for this browser instance" and click Allow if Chrome shows a permission popup. Then retry the same `browser-use` command.
+On macOS, when Chrome asks for remote-debugging permission, run:
+
+```text
+browser-use mac-approve
+```
+
+Continue browser work when it returns `ready`; otherwise follow its printed
+instruction.
 
 ## Remote Browsers
 
@@ -160,7 +167,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 ## Gotchas
 
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
-- Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow. Do not retry in a loop — Chrome pops a fresh dialog for every new connection, and the daemon's single held connection is what makes this a one-time click.
+- On macOS, if Chrome shows an "Allow remote debugging?" popup, run `browser-use mac-approve`. Do not poll in a loop — the daemon holds one connection.
 - Omnibox popups are not real work tabs.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "bubus==1.5.6",
     "click==8.3.1",
     "InquirerPy==0.3.4",
-    "rich==14.3.1",
+    "rich==14.3.3",
     "google-api-core==2.29.0",
     "httpx==0.28.1",
     "posthog==7.7.0",

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -36,7 +36,7 @@ If the daemon cannot connect, run diagnostics:
 browser-use --doctor
 ```
 
-If Chrome is not running at all, the harness launches it automatically and retries — no user action needed beyond clicking Allow if a permission popup appears.
+If Chrome is not running at all, the harness launches it automatically and retries.
 
 If Chrome is running but remote debugging is not enabled, the harness opens:
 
@@ -44,7 +44,14 @@ If Chrome is running but remote debugging is not enabled, the harness opens:
 chrome://inspect/#remote-debugging
 ```
 
-Ask the user to tick "Allow remote debugging for this browser instance" and click Allow if Chrome shows a permission popup. Then retry the same `browser-use` command.
+On macOS, when Chrome asks for remote-debugging permission, run:
+
+```text
+browser-use mac-approve
+```
+
+Continue browser work when it returns `ready`; otherwise follow its printed
+instruction.
 
 ## Remote Browsers
 
@@ -160,7 +167,7 @@ If you get stuck on a browser mechanic, check https://github.com/browser-use/bro
 ## Gotchas
 
 - `chrome://inspect/#remote-debugging` must be enabled for local Chrome control.
-- Chrome may show an "Allow remote debugging?" popup; wait for the user to click Allow. Do not retry in a loop — Chrome pops a fresh dialog for every new connection, and the daemon's single held connection is what makes this a one-time click.
+- On macOS, if Chrome shows an "Allow remote debugging?" popup, run `browser-use mac-approve`. Do not poll in a loop — the daemon holds one connection.
 - Omnibox popups are not real work tabs.
 - CDP target order is not Chrome's visible tab-strip order.
 - `BU_CDP_URL` is an HTTP DevTools endpoint; the daemon resolves it to WebSocket.


### PR DESCRIPTION
## Why

Browser Use 0.13.7 publishes `rich==14.3.1`. OpenHands enforces `rich>=14.3.3` because of the denial-of-service issue documented in Textualize/rich#3958, so its resolver rejects Browser Use 0.13.x.

## What

- Bump the exact Rich pin to 14.3.3. The lockfile already resolves 14.3.3.
- Refresh the two generated Browser Use skill copies required by the repository's sync check. This is a mechanical sync of current macOS Chrome guidance, not the separate OpenClaw skill feature in #5476.

## Verification

- `python3 scripts/sync_browser_harness_skill.py --check`
- `uv run pre-commit run --files pyproject.toml skills/browser-use/SKILL.md browser_use/skills/browser-use/SKILL.md`
- Compiled `rich>=14.3.3` with the local Browser Use package on Python 3.13; resolution selected `rich==14.3.3`.

## Follow-up

Ship this in the next Browser Use patch, then upgrade `OpenHands/software-agent-sdk` from its 0.11.x lock to 0.13.x.