### PR TITLE
docs: replace broken profile.sh link with profile-use releases link

### DIFF
--- a/skills/cloud/references/quickstart.md
+++ b/skills/cloud/references/quickstart.md
@@ -153,7 +153,7 @@ Typical task: 10 steps = ~$0.03 (with Browser Use LLM)
 - Set `start_url`
 
 **Login issues?**
-- Profile sync (easiest): `curl -fsSL https://browser-use.com/profile.sh | sh`
+- Profile sync (easiest): [Install profile-use](https://github.com/browser-use/profile-use-releases/releases/latest) for your platform, then follow the [profile sync guide](https://github.com/browser-use/browser-harness/blob/main/interaction-skills/profile-sync.md)
 - Secrets (per-domain credentials)
 - 1Password (most secure, auto 2FA)
 

--- a/skills/cloud/references/sessions.md
+++ b/skills/cloud/references/sessions.md
@@ -89,8 +89,9 @@ Upload local browser cookies to cloud profiles:
 
 ```bash
 export BROWSER_USE_API_KEY=your_key
-curl -fsSL https://browser-use.com/profile.sh | sh
 ```
+
+Then [install profile-use](https://github.com/browser-use/profile-use-releases/releases/latest) for your platform and follow the [profile sync guide](https://github.com/browser-use/browser-harness/blob/main/interaction-skills/profile-sync.md).
 
 Opens a browser where you log into sites. Returns a `profile_id` to use in tasks.
 
@@ -99,9 +100,7 @@ Opens a browser where you log into sites. Returns a `profile_id` to use in tasks
 ### 1. Profile Sync (Easiest)
 
 Log in locally, sync cookies to cloud:
-```bash
-curl -fsSL https://browser-use.com/profile.sh | sh
-```
+[Install profile-use](https://github.com/browser-use/profile-use-releases/releases/latest) for your platform, then follow the [profile sync guide](https://github.com/browser-use/browser-harness/blob/main/interaction-skills/profile-sync.md).
 
 ### 2. Secrets (Domain-Scoped)
 

--- a/skills/open-source/references/quickstart.md
+++ b/skills/open-source/references/quickstart.md
@@ -144,8 +144,10 @@ async def stealth_task(browser: Browser):
 
 1. Sync local cookies:
 ```bash
-export BROWSER_USE_API_KEY=your_key && curl -fsSL https://browser-use.com/profile.sh | sh
+export BROWSER_USE_API_KEY=your_key
 ```
+
+Then [install profile-use](https://github.com/browser-use/profile-use-releases/releases/latest) for your platform and follow the [profile sync guide](https://github.com/browser-use/browser-harness/blob/main/interaction-skills/profile-sync.md).
 
 2. Use the returned profile_id:
 ```python


### PR DESCRIPTION
## Summary

Replaces the broken `curl https://browser-use.com/profile.sh` command (returns 404) with a link to the official [profile-use releases](https://github.com/browser-use/profile-use-releases/releases/latest) page and [profile sync guide](https://github.com/browser-use/browser-harness/blob/main/interaction-skills/profile-sync.md).

## Changes

- `skills/open-source/references/quickstart.md` — fixed in code block and FAQ section
- `skills/cloud/references/sessions.md` — fixed in 2 code blocks (Profile Sync + Authentication Strategies)
- `skills/cloud/references/quickstart.md` — fixed in FAQ section

## Context

Fixes #5331. The README FAQ was already updated to point to the official releases, but these 3 skill documentation files still contained the old broken `profile.sh` URL.

## Verification

- [x] All 4 occurrences of `browser-use.com/profile.sh` replaced
- [x] Replacement links point to valid, working URLs
- [x] Markdown formatting preserved (links outside code blocks)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the broken profile sync one‑liner (`curl https://browser-use.com/profile.sh | sh`) with links to the official `profile-use` releases and profile sync guide. This removes a 404 and aligns docs with the current install and sync flow.

- Updates `skills/cloud/references/sessions.md` and both quickstarts to replace the one‑liner with “Install `profile-use` for your platform, then follow the profile sync guide,” keeping `BROWSER_USE_API_KEY` export steps where relevant.

**Migration**
- If you copied the old one‑liner, install `profile-use` from the releases page and follow the profile sync guide to sync profiles.
- Update any scripts that used `curl ...profile.sh | sh` to invoke `profile-use` directly; keep exporting `BROWSER_USE_API_KEY` before syncing.

<sup>Written for commit 9d6e4a1eaac1d50a266d6e8367cf3a1f2c12d593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

