### PR TITLE
Remove inactive pytest xdist option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ markers = [
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py", "*_test.py"]
-addopts = "-svx --strict-markers --tb=short --dist=loadscope"
+addopts = "-svx --strict-markers --tb=short"
 log_cli = true
 log_cli_format = "%(levelname)-8s [%(name)s] %(message)s"
 filterwarnings = [


### PR DESCRIPTION
Fixes #5427

## Summary
- remove the inactive --dist=loadscope option from global pytest addopts
- preserve the current serial test execution unless callers explicitly enable xdist with -n

## Testing
Not run locally; configuration-only change and draft PR for CI validation.

<!-- pr-relay-job relay-85-ced01ebc1b033e8dd2c9 -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the inactive --dist=loadscope flag from global `pytest` addopts because `pytest-xdist` is not enabled by default. Default runs stay serial; when using -n, `pytest-xdist` uses its default distribution.

**Rollout/Migration**
- No change for runs without -n; CI remains serial.
- If you require loadscope when running in parallel, pass --dist=loadscope with -n or set it in a local pytest config.
- Only `pyproject.toml` changed.

<sup>Written for commit 5fb5651c2b94093469f3eb454802aef36c2eaf74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

