### PR TITLE
Release 0.13.8 with Browser Harness 0.1.9

### DIFF
--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -44,6 +44,10 @@ PY
 - Invoke as `browser-use`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
 - First navigation is `new_tab(url)`, not `goto_url(url)`.
+- `new_tab()` and `switch_tab()` attach and move the horse marker without
+  changing Chrome's visible tab. Screenshots and normal CDP input work in the
+  background; call `activate_tab(target)` only when the user explicitly asks
+  or a page demonstrably pauses rendering while hidden.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "browser-use"
 description = "Make websites accessible for AI agents"
 authors = [{ name = "Gregor Zunic" }]
-version = "0.13.7"
+version = "0.13.8"
 readme = "README.md"
 requires-python = ">=3.11,<4.0"
 classifiers = [
@@ -41,12 +41,12 @@ dependencies = [
     "reportlab==4.4.9",
     "cdp-use==1.4.5",
     "pyotp==2.9.0",
-    "pillow==12.2.0",
+    "pillow==12.3.0",
     "cloudpickle==3.1.2",
     "markdownify==1.2.2",
     "python-docx==1.2.0",
     "browser-use-sdk==3.4.2",
-    "browser-harness==0.1.8",
+    "browser-harness==0.1.9",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste
@@ -60,11 +60,11 @@ dependencies = [
 [project.optional-dependencies]
 cli = []
 core = [
-    "browser-use-core==0.13.2; sys_platform == 'darwin' and platform_machine == 'arm64'",
-    "browser-use-core==0.13.2; sys_platform == 'darwin' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.2; sys_platform == 'linux' and platform_machine == 'x86_64'",
-    "browser-use-core==0.13.2; sys_platform == 'linux' and platform_machine == 'aarch64'",
-    "browser-use-core==0.13.2; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
+    "browser-use-core==0.13.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
+    "browser-use-core==0.13.3; sys_platform == 'darwin' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.3; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "browser-use-core==0.13.3; sys_platform == 'linux' and platform_machine == 'aarch64'",
+    "browser-use-core==0.13.3; sys_platform == 'win32' and (platform_machine == 'AMD64' or platform_machine == 'x86_64')",
 ]
 aws = ["boto3==1.42.37"]
 oci = ["oci==2.166.0"]

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -44,6 +44,10 @@ PY
 - Invoke as `browser-use`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
 - First navigation is `new_tab(url)`, not `goto_url(url)`.
+- `new_tab()` and `switch_tab()` attach and move the horse marker without
+  changing Chrome's visible tab. Screenshots and normal CDP input work in the
+  background; call `activate_tab(target)` only when the user explicitly asks
+  or a page demonstrably pauses rendering while hidden.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome


### PR DESCRIPTION
## Summary

- bump Browser Use from 0.13.7 to 0.13.8
- upgrade `browser-harness` from 0.1.8 to 0.1.9
- align Pillow at 12.3.0 and `browser-use-core` at 0.13.3 so the dependency set is resolvable
- sync both packaged Browser Use skill copies from the immutable Browser Harness `v0.1.9` tag

Prerequisites are published and verified on PyPI:

- `browser-harness==0.1.9`
- `browser-use-core==0.13.3` (all five platform wheels)

## Validation

- `uv sync --dev --all-extras --python 3.11 --refresh-package browser-use-core`
- `uv run --no-sync pre-commit run --all-files --show-diff-on-failure`
- 6 focused CLI/skill-install tests passed
- tagged and current-main Browser Harness skill sync checks passed
- `uv build --wheel`
- strict clean-venv install of the built `browser-use[core]` wheel
- verified resolved versions: Browser Use 0.13.8, Harness 0.1.9, Core 0.13.3, Pillow 12.3.0
- verified `browser-use --help`, `browser-use auth --help`, `browser-use skill show`, all CLI aliases, and `browser-use-terminal --version`

Publishing the Browser Use GitHub release is intentionally left for manual execution after this PR merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases `browser-use` 0.13.8 to align with `browser-harness` 0.1.9 and a resolvable dependency set (`browser-use-core` 0.13.3, `pillow` 12.3.0). Updates packaged skill docs to clarify that `new_tab()` and `switch_tab()` work in background and to use `activate_tab()` only when needed.

- Syncs both packaged `browser-use` skills with `browser-harness` v0.1.9 docs.
- After merge: publish the `browser-use` 0.13.8 GitHub release. No migration actions.

<sup>Written for commit fa57d340e2bf771286db67c6754fbda50a4f0cf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

