### PR TITLE
fix(security): stop data:/blob: URLs bypassing domain policy (#4763)

### DIFF
--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -196,9 +196,16 @@ class SecurityWatchdog(BaseWatchdog):
 			# Invalid URL
 			return False
 
-		# Allow data: and blob: URLs (they don't have hostnames)
+		# Allow data: and blob: URLs only while no domain policy is configured.
+		# They carry no hostname, so once allowed_domains/prohibited_domains are set they would
+		# otherwise sail past every domain check below and become an allowlist bypass (#4763).
+		# With a policy active they fall through to the `not host` check and are blocked.
 		if parsed.scheme in ['data', 'blob']:
-			return True
+			if (
+				not self.browser_session.browser_profile.allowed_domains
+				and not self.browser_session.browser_profile.prohibited_domains
+			):
+				return True
 
 		# Get the actual host (domain)
 		host = parsed.hostname

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -567,3 +567,73 @@ class TestDomainListOptimization:
 		# Should work correctly
 		assert watchdog._is_url_allowed('https://blocked0.com') is False
 		assert watchdog._is_url_allowed('https://example.com') is True
+
+
+class TestHostlessSchemeBypass:
+	"""Regression tests for #4763: hostname-less schemes must not bypass domain policy."""
+
+	@staticmethod
+	def _watchdog(**profile_kwargs):
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(headless=True, user_data_dir=None, **profile_kwargs)
+		browser_session = BrowserSession(browser_profile=browser_profile)
+		return SecurityWatchdog(browser_session=browser_session, event_bus=EventBus())
+
+	def test_data_and_blob_blocked_under_allowlist(self):
+		"""data:/blob: carry no hostname, so an allowlist must not let them through."""
+		watchdog = self._watchdog(allowed_domains=['example.com'])
+
+		assert watchdog._is_url_allowed('data:text/html,<script>alert(1)</script>') is False
+		assert watchdog._is_url_allowed('data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==') is False
+		assert watchdog._is_url_allowed('blob:https://malicious.com/550e8400-e29b-41d4-a716-446655440000') is False
+
+		# A blob URL naming an allowed origin is still blocked: the origin lives in the path,
+		# not the host, so there is nothing the domain policy can validate against.
+		assert watchdog._is_url_allowed('blob:https://example.com/550e8400-e29b-41d4-a716-446655440000') is False
+
+		# The allowlist itself still works.
+		assert watchdog._is_url_allowed('https://example.com') is True
+
+	def test_data_and_blob_blocked_under_prohibited_list(self):
+		"""A prohibited list is also an active policy, so the same gate applies."""
+		watchdog = self._watchdog(prohibited_domains=['malicious.com'])
+
+		assert watchdog._is_url_allowed('data:text/html,<h1>hi</h1>') is False
+		assert watchdog._is_url_allowed('blob:https://malicious.com/abc') is False
+
+		# Unrelated domains are unaffected by the change.
+		assert watchdog._is_url_allowed('https://example.com') is True
+		assert watchdog._is_url_allowed('https://malicious.com') is False
+
+	def test_data_and_blob_allowed_when_no_policy_configured(self):
+		"""Default, policy-free sessions keep the previous permissive behaviour."""
+		watchdog = self._watchdog()
+
+		assert watchdog._is_url_allowed('data:text/html,<h1>hi</h1>') is True
+		assert watchdog._is_url_allowed('blob:https://example.com/abc') is True
+
+	def test_other_hostless_schemes_stay_blocked_under_policy(self):
+		"""javascript:/file:/about: were already blocked by the host check - keep it that way."""
+		watchdog = self._watchdog(allowed_domains=['example.com'])
+
+		assert watchdog._is_url_allowed('javascript:alert(1)') is False
+		assert watchdog._is_url_allowed('file:///etc/passwd') is False
+		assert watchdog._is_url_allowed('about:srcdoc') is False
+
+	def test_internal_targets_still_exempt(self):
+		"""The internal new-tab/blank allowance is checked before scheme handling."""
+		watchdog = self._watchdog(allowed_domains=['example.com'])
+
+		assert watchdog._is_url_allowed('about:blank') is True
+		assert watchdog._is_url_allowed('chrome://new-tab-page/') is True
+
+	def test_explicitly_allowlisted_scheme_with_host_still_works(self):
+		"""Non-HTTP URLs that do have a host are unaffected and still match patterns."""
+		watchdog = self._watchdog(allowed_domains=['chrome://version', 'brave://*'])
+
+		assert watchdog._is_url_allowed('chrome://version') is True
+		assert watchdog._is_url_allowed('brave://settings') is True
+		assert watchdog._is_url_allowed('chrome://settings') is False


### PR DESCRIPTION
Fixes #4763.

## The bug

`SecurityWatchdog._is_url_allowed()` returns `True` for any `data:` or `blob:` URL **before** it consults `allowed_domains` / `prohibited_domains`:

```python
# Allow data: and blob: URLs (they don't have hostnames)
if parsed.scheme in ['data', 'blob']:
    return True
```

So a session configured with `allowed_domains=['example.com']` will still permit `data:text/html,<script>...</script>`. The domain policy is bypassed entirely by either scheme. Still reproducible on `main` (verified at `eb41269`, v0.13.8).

This is the bypass reported in #4763. PR #4850 addressed the surrounding area but the early return is still present.

## The fix

Gate the early return on there being no policy configured:

```python
if parsed.scheme in ['data', 'blob']:
    if (
        not self.browser_session.browser_profile.allowed_domains
        and not self.browser_session.browser_profile.prohibited_domains
    ):
        return True
```

With a policy active, these URLs fall through to the existing `if not host: return False` check and are blocked — neither scheme carries a hostname. Sessions with no domain policy keep the previous behaviour exactly.

## Credit / relationship to #5101

**The code change here is behaviourally identical to @itxaiohanglover's #5101**, which has been open since 30 June with green CI. I found it while triaging and deliberately did not diverge from it — if that PR is easier to merge, please take it instead and I'll close this one.

What this PR adds on top is the part that's missing: **regression tests**. `tests/ci/security/` currently has no coverage of `data:` or `blob:` at all across any of its seven files, so nothing stops this from regressing a third time.

## Tests

Adds `TestHostlessSchemeBypass` to `tests/ci/security/test_domain_filtering.py`:

| Test | Asserts |
|---|---|
| `test_data_and_blob_blocked_under_allowlist` | both schemes blocked when `allowed_domains` is set |
| `test_data_and_blob_blocked_under_prohibited_list` | same when only `prohibited_domains` is set |
| `test_data_and_blob_allowed_when_no_policy_configured` | policy-free sessions unchanged |
| `test_other_hostless_schemes_stay_blocked_under_policy` | `javascript:` / `file:` / `about:` still blocked |
| `test_internal_targets_still_exempt` | `about:blank`, `chrome://new-tab-page/` still exempt |
| `test_explicitly_allowlisted_scheme_with_host_still_works` | `chrome://version`, `brave://*` still match patterns |

The last three are no-regression guards — they pass both before and after the fix. The first two fail on unpatched `main` and pass with it:

```
$ uv run pytest tests/ci/security/test_domain_filtering.py::TestHostlessSchemeBypass -o addopts=""
# without the fix:
2 failed, 4 passed
# with the fix:
6 passed
```

Full suite, lint and types:

```
$ uv run pytest tests/ci/security/     ->  105 passed
$ uv run ruff check                    ->  All checks passed!
$ uv run pyright browser_use/browser/watchdogs/security_watchdog.py
                                       ->  0 errors, 0 warnings
```

## Notes / scope

- `blob:https://example.com/<uuid>` is blocked even when `example.com` is allowlisted. A blob URL's origin lives in its path, not its host, so there's nothing for the domain policy to validate. Blocking is the conservative reading; happy to change it if you'd rather parse the inner origin.
- This does not touch the broader "should non-HTTP schemes be an allowlist rather than a blocklist" question raised in #5099 — that's a larger behavioural change and deserves its own discussion.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `data:` and `blob:` URLs from bypassing the domain policy in `SecurityWatchdog._is_url_allowed()`. Previously these schemes were always allowed before domain checks; now they are allowed only when no `allowed_domains`/`prohibited_domains` are configured.

**Behavior and tests**
- With any policy, hostless schemes (`data:`, `blob:`) fall through to the no-host check and are blocked; policy-free sessions are unchanged.
- `blob:` stays blocked even when it references an allowlisted origin; we do not parse the inner origin.
- Existing allowances/blocks are unchanged: `about:blank` and `chrome://new-tab-page/` allowed; `javascript:`, `file:`, `about:` blocked; explicit patterns like `chrome://version` and `brave://*` still match.
- Adds `TestHostlessSchemeBypass` in `tests/ci/security/test_domain_filtering.py` to cover the bypass fix and guard against regressions.

<sup>Written for commit d9cd4744be7e67b3286644ae7616e0fea640960d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

