### PR TITLE
test: use Windows-resolvable fake skill tools

### DIFF
--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -24,20 +24,20 @@ def _fake_browser_harness_tools(tmp_path: Path, skill_text: str) -> Path:
 
 	uv_script = bin_dir / 'fake_uv.py'
 	uv_script.write_text(
-		'import os, pathlib, sys\\n'
-		'pathlib.Path(os.environ["UV_TOOL_INSTALL_ARGS_FILE"]).write_text(" ".join(sys.argv[1:]), encoding="utf-8")\\n',
+		'import os, pathlib, sys\n'
+		'pathlib.Path(os.environ["UV_TOOL_INSTALL_ARGS_FILE"]).write_text(" ".join(sys.argv[1:]), encoding="utf-8")\n',
 		encoding='utf-8',
 	)
 
 	browser_harness_script = bin_dir / 'fake_browser_harness.py'
 	browser_harness_script.write_text(
-		'import sys\\n'
-		f'text = {skill_text!r}\\n'
-		'if sys.argv[1:] == ["skill"]:\\n'
-		'    print(text, end="")\\n'
-		'else:\\n'
-		'    print("usage: browser-harness skill", file=sys.stderr)\\n'
-		'    sys.exit(2)\\n',
+		'import sys\n'
+		f'text = {skill_text!r}\n'
+		'if sys.argv[1:] == ["skill"]:\n'
+		'    print(text, end="")\n'
+		'else:\n'
+		'    print("usage: browser-harness skill", file=sys.stderr)\n'
+		'    sys.exit(2)\n',
 		encoding='utf-8',
 	)
 
@@ -45,13 +45,13 @@ def _fake_browser_harness_tools(tmp_path: Path, skill_text: str) -> Path:
 		# Windows does not resolve extensionless files through shutil.which().
 		for name, script in (('uv', uv_script), ('browser-harness', browser_harness_script)):
 			(bin_dir / f'{name}.cmd').write_text(
-				f'@echo off\\n"{sys.executable}" "{script}" %*\\n',
+				f'@echo off\n"{sys.executable}" "{script}" %*\n',
 				encoding='utf-8',
 			)
 	else:
 		for name, script in (('uv', uv_script), ('browser-harness', browser_harness_script)):
 			tool = bin_dir / name
-			tool.write_text(f'#!/bin/sh\\nexec "{sys.executable}" "{script}" "$@"\\n', encoding='utf-8')
+			tool.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{script}" "$@"\n', encoding='utf-8')
 			tool.chmod(0o755)
 
 	return bin_dir

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -22,28 +22,38 @@ def _fake_browser_harness_tools(tmp_path: Path, skill_text: str) -> Path:
 	bin_dir = tmp_path / 'bin'
 	bin_dir.mkdir()
 
-	uv = bin_dir / 'uv'
-	uv.write_text(
-		'#!/usr/bin/env python3\n'
-		'import os, pathlib, sys\n'
-		'pathlib.Path(os.environ["UV_TOOL_INSTALL_ARGS_FILE"]).write_text(" ".join(sys.argv[1:]), encoding="utf-8")\n',
+	uv_script = bin_dir / 'fake_uv.py'
+	uv_script.write_text(
+		'import os, pathlib, sys\\n'
+		'pathlib.Path(os.environ["UV_TOOL_INSTALL_ARGS_FILE"]).write_text(" ".join(sys.argv[1:]), encoding="utf-8")\\n',
 		encoding='utf-8',
 	)
-	uv.chmod(0o755)
 
-	browser_harness = bin_dir / 'browser-harness'
-	browser_harness.write_text(
-		'#!/usr/bin/env python3\n'
-		'import sys\n'
-		f'text = {skill_text!r}\n'
-		'if sys.argv[1:] == ["skill"]:\n'
-		'    print(text, end="")\n'
-		'else:\n'
-		'    print("usage: browser-harness skill", file=sys.stderr)\n'
-		'    sys.exit(2)\n',
+	browser_harness_script = bin_dir / 'fake_browser_harness.py'
+	browser_harness_script.write_text(
+		'import sys\\n'
+		f'text = {skill_text!r}\\n'
+		'if sys.argv[1:] == ["skill"]:\\n'
+		'    print(text, end="")\\n'
+		'else:\\n'
+		'    print("usage: browser-harness skill", file=sys.stderr)\\n'
+		'    sys.exit(2)\\n',
 		encoding='utf-8',
 	)
-	browser_harness.chmod(0o755)
+
+	if os.name == 'nt':
+		# Windows does not resolve extensionless files through shutil.which().
+		for name, script in (('uv', uv_script), ('browser-harness', browser_harness_script)):
+			(bin_dir / f'{name}.cmd').write_text(
+				f'@echo off\\n"{sys.executable}" "{script}" %*\\n',
+				encoding='utf-8',
+			)
+	else:
+		for name, script in (('uv', uv_script), ('browser-harness', browser_harness_script)):
+			tool = bin_dir / name
+			tool.write_text(f'#!/bin/sh\\nexec "{sys.executable}" "{script}" "$@"\\n', encoding='utf-8')
+			tool.chmod(0o755)
+
 	return bin_dir
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Makes the skill install docs test reliable on Windows by generating resolvable fake `uv` and `browser-harness` tools and fixing real newline emission in fixtures. Previously the test wrote extensionless, shebang-based executables that `shutil.which()` could not find on Windows; now it writes Python scripts with `.cmd` launchers on Windows and POSIX shell wrappers elsewhere.

- `_fake_browser_harness_tools` now creates `fake_uv.py` and `fake_browser_harness.py` plus platform-specific wrappers; test semantics are unchanged.
- Windows uses `.cmd` wrappers that invoke `sys.executable`; POSIX uses `#!/bin/sh` wrappers with `exec`, both forwarding args.
- Fixture output now emits real newlines; `UV_TOOL_INSTALL_ARGS_FILE` capture and assertions remain unchanged.

<sup>Written for commit d2eeaef8a0aa966ea6531436d568182b6258b092. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

