### PR TITLE
fix(tools): report failed tab switches as errors instead of successes (#5486)

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1008,24 +1008,32 @@ class Tools(Generic[Context]):
 		)
 		async def switch(params: SwitchTabAction, browser_session: BrowserSession):
 			# Simple switch tab logic
+			failure_memory = (
+				f'Failed to switch to tab #{params.tab_id} - the tab may have been closed. '
+				f'Check the tabs list in browser state for currently open tab_ids.'
+			)
 			try:
 				target_id = await browser_session.get_target_id_from_tab_id(params.tab_id)
 
 				event = browser_session.event_bus.dispatch(SwitchTabEvent(target_id=target_id))
 				await event
 				new_target_id = await event.event_result(raise_if_any=False, raise_if_none=False)  # Don't raise on errors
-
-				if new_target_id:
-					memory = f'Switched to tab #{new_target_id[-4:]}'
-				else:
-					memory = f'Switched to tab #{params.tab_id}'
-
-				logger.info(f'🔄  {memory}')
-				return ActionResult(extracted_content=memory, long_term_memory=memory)
 			except Exception as e:
-				logger.warning(f'Tab switch may have failed: {e}')
-				memory = f'Attempted to switch to tab #{params.tab_id}'
-				return ActionResult(extracted_content=memory, long_term_memory=memory)
+				logger.warning(f'Tab switch failed: {e}')
+				raise BrowserError(f'Failed to switch to tab #{params.tab_id}: {e}', long_term_memory=failure_memory)
+
+			# on_SwitchTabEvent returns the newly focused TargetID on every success path, so a
+			# missing result means the handler failed - raise_if_any=False above swallowed the
+			# exception rather than the switch having quietly succeeded.
+			if not new_target_id:
+				raise BrowserError(
+					f'Failed to switch to tab #{params.tab_id}: tab switch produced no result',
+					long_term_memory=failure_memory,
+				)
+
+			memory = f'Switched to tab #{new_target_id[-4:]}'
+			logger.info(f'🔄  {memory}')
+			return ActionResult(extracted_content=memory, long_term_memory=memory)
 
 		@self.registry.action(
 			'Close a tab by tab_id. Tab IDs are shown in browser state tabs list (last 4 chars of target_id). Use to clean up tabs you no longer need.',

--- a/tests/ci/browser/test_tabs.py
+++ b/tests/ci/browser/test_tabs.py
@@ -26,6 +26,7 @@ from pytest_httpserver import HTTPServer
 from browser_use.agent.service import Agent
 from browser_use.browser import BrowserSession
 from browser_use.browser.profile import BrowserProfile
+from browser_use.tools.service import Tools
 from tests.ci.conftest import create_mock_llm
 
 
@@ -669,3 +670,60 @@ class TestMultiTabOperations:
 			assert 'Successfully' in final_result, 'Agent should report success'
 		except TimeoutError:
 			pytest.fail('Test timed out after 2 minutes - agent hung during multiple tab operations')
+
+
+class TestTabSwitchFailureReporting:
+	"""A failed `switch` must surface as ActionResult.error rather than a fake success.
+
+	The agent loop reads `ActionResult.error` in two places: multi_act() aborts the remaining
+	queued actions on it, and _post_process() increments consecutive_failures from it. A switch
+	that reports success after failing leaves the agent believing it is on a tab it never
+	reached, and the false claim is persisted via long_term_memory into the next step's prompt.
+	"""
+
+	async def test_switch_to_nonexistent_tab_reports_error(self, browser_session):
+		"""An unknown tab_id must produce an error, not 'Switched to tab #...'."""
+		tools = Tools()
+		ActionModel = tools.registry.create_action_model()
+
+		tabs_before = await browser_session.get_tabs()
+		live_ids = {tab.target_id[-4:] for tab in tabs_before}
+
+		# get_target_id_from_tab_id() raises ValueError for a tab_id matching no live target,
+		# which is the common real-world case: the model names a tab that has since closed.
+		bogus_tab_id = 'zzzz'
+		assert bogus_tab_id not in live_ids
+
+		result = await tools.act(ActionModel(switch={'tab_id': bogus_tab_id}), browser_session=browser_session)
+
+		# What the agent loop actually keys off of.
+		assert result.error is not None, 'a failed tab switch must set ActionResult.error'
+		assert bogus_tab_id in result.error
+
+		# Must not claim the switch happened anywhere the LLM reads.
+		assert 'Switched to tab' not in (result.extracted_content or '')
+		assert 'Switched to tab' not in (result.long_term_memory or '')
+
+		# And the tab set is genuinely unchanged.
+		tabs_after = await browser_session.get_tabs()
+		assert {tab.target_id[-4:] for tab in tabs_after} == live_ids
+
+	async def test_switch_to_open_tab_still_succeeds(self, browser_session, base_url):
+		"""The happy path is unchanged: a valid tab_id switches and reports no error."""
+		tools = Tools()
+		ActionModel = tools.registry.create_action_model()
+
+		original_tab_id = (await browser_session.get_tabs())[0].target_id[-4:]
+
+		# Open a second tab so there is somewhere to switch back from.
+		open_result = await tools.act(
+			ActionModel(navigate={'url': f'{base_url}/page1', 'new_tab': True}),
+			browser_session=browser_session,
+		)
+		assert open_result.error is None, f'opening a new tab should not error: {open_result.error}'
+
+		result = await tools.act(ActionModel(switch={'tab_id': original_tab_id}), browser_session=browser_session)
+
+		assert result.error is None, f'switching to a live tab must not error: {result.error}'
+		assert result.long_term_memory is not None
+		assert 'Switched to tab' in result.long_term_memory

--- a/tests/ci/browser/test_tabs.py
+++ b/tests/ci/browser/test_tabs.py
@@ -19,11 +19,13 @@ Usage:
 
 import asyncio
 import time
+from typing import Any
 
 import pytest
 from pytest_httpserver import HTTPServer
 
 from browser_use.agent.service import Agent
+from browser_use.agent.views import ActionModel
 from browser_use.browser import BrowserSession
 from browser_use.browser.profile import BrowserProfile
 from browser_use.tools.service import Tools
@@ -672,6 +674,18 @@ class TestMultiTabOperations:
 			pytest.fail('Test timed out after 2 minutes - agent hung during multiple tab operations')
 
 
+class _TabActionModel(ActionModel):
+	"""ActionModel with explicit slots for the tab actions driven directly via tools.act().
+
+	registry.create_action_model() builds its fields at runtime, so a statically declared
+	subclass is what keeps pyright able to check these call sites. act() dispatches on the
+	key returned by model_dump(exclude_unset=True), so the real registered actions still run.
+	"""
+
+	switch: dict[str, Any] | None = None
+	navigate: dict[str, Any] | None = None
+
+
 class TestTabSwitchFailureReporting:
 	"""A failed `switch` must surface as ActionResult.error rather than a fake success.
 
@@ -684,7 +698,6 @@ class TestTabSwitchFailureReporting:
 	async def test_switch_to_nonexistent_tab_reports_error(self, browser_session):
 		"""An unknown tab_id must produce an error, not 'Switched to tab #...'."""
 		tools = Tools()
-		ActionModel = tools.registry.create_action_model()
 
 		tabs_before = await browser_session.get_tabs()
 		live_ids = {tab.target_id[-4:] for tab in tabs_before}
@@ -694,7 +707,7 @@ class TestTabSwitchFailureReporting:
 		bogus_tab_id = 'zzzz'
 		assert bogus_tab_id not in live_ids
 
-		result = await tools.act(ActionModel(switch={'tab_id': bogus_tab_id}), browser_session=browser_session)
+		result = await tools.act(_TabActionModel(switch={'tab_id': bogus_tab_id}), browser_session=browser_session)
 
 		# What the agent loop actually keys off of.
 		assert result.error is not None, 'a failed tab switch must set ActionResult.error'
@@ -711,18 +724,17 @@ class TestTabSwitchFailureReporting:
 	async def test_switch_to_open_tab_still_succeeds(self, browser_session, base_url):
 		"""The happy path is unchanged: a valid tab_id switches and reports no error."""
 		tools = Tools()
-		ActionModel = tools.registry.create_action_model()
 
 		original_tab_id = (await browser_session.get_tabs())[0].target_id[-4:]
 
 		# Open a second tab so there is somewhere to switch back from.
 		open_result = await tools.act(
-			ActionModel(navigate={'url': f'{base_url}/page1', 'new_tab': True}),
+			_TabActionModel(navigate={'url': f'{base_url}/page1', 'new_tab': True}),
 			browser_session=browser_session,
 		)
 		assert open_result.error is None, f'opening a new tab should not error: {open_result.error}'
 
-		result = await tools.act(ActionModel(switch={'tab_id': original_tab_id}), browser_session=browser_session)
+		result = await tools.act(_TabActionModel(switch={'tab_id': original_tab_id}), browser_session=browser_session)
 
 		assert result.error is None, f'switching to a live tab must not error: {result.error}'
 		assert result.long_term_memory is not None


### PR DESCRIPTION
Fixes #5486.

## The bug

The `switch` action returns a **non-error** `ActionResult` on both of its failure paths, so a tab switch that never happened is reported to the agent as one that did.

```python
        if new_target_id:
            memory = f'Switched to tab #{new_target_id[-4:]}'
        else:
            memory = f'Switched to tab #{params.tab_id}'      # claims success on no result
        ...
    except Exception as e:
        logger.warning(f'Tab switch may have failed: {e}')
        memory = f'Attempted to switch to tab #{params.tab_id}'
        return ActionResult(extracted_content=memory, long_term_memory=memory)   # no error=
```

**Path 1.** `get_target_id_from_tab_id()` raises `ValueError('No TargetID found ending in tab_id=...')` (`browser/session.py:2607`) for any `tab_id` with no live target — the common case when the model names a tab that has since closed. The bare `except Exception` catches it, logs at *warning*, and returns success-shaped output.

**Path 2.** `event_result(raise_if_any=False, raise_if_none=False)` returns `None` when the handler raised, and the `else` branch reports `'Switched to tab #N'` anyway. `on_SwitchTabEvent` returns a truthy `TargetID` on every success path, so `None` unambiguously means failure — never a quiet success.

Because the agent loop keys off `ActionResult.error`, neither path aborts the queue in `multi_act()` nor increments `consecutive_failures` in `_post_process()`. `terminates_sequence=True` limits the damage inside one step, but the false claim goes into **`long_term_memory`**, so it persists into history and the next step plans against a tab the agent never reached.

Same status-inversion class as #5361 / #5438, in an action neither covers.

## The fix

Both failure paths now `raise BrowserError(..., long_term_memory=...)`, which `handle_browser_error()` converts to `ActionResult(error=...)`. This matches how `upload_file` in this same file already reports failure (`tools/service.py:1000`) — `switch` was the outlier.

The `else` branch is gone: a missing event result is now an error rather than a success message, and the success path reads the real target id.

## Verification

Reproduction from the issue, before and after:

```
# before
error            : None
extracted_content: 'Attempted to switch to tab #zzzz'
long_term_memory : 'Attempted to switch to tab #zzzz'

# after
error            : 'Failed to switch to tab #zzzz - the tab may have been closed.
                    Check the tabs list in browser state for currently open tab_ids.'
extracted_content: None
```

## Tests

Adds `TestTabSwitchFailureReporting` to `tests/ci/browser/test_tabs.py`:

| Test | Asserts |
|---|---|
| `test_switch_to_nonexistent_tab_reports_error` | `error` is set, no "Switched to tab" text in either memory field, tab set unchanged |
| `test_switch_to_open_tab_still_succeeds` | happy path unchanged — live `tab_id` switches with `error is None` |

The first fails on unpatched `main`, the second passes either way (no-regression guard):

```
$ uv run pytest tests/ci/browser/test_tabs.py::TestTabSwitchFailureReporting -o addopts=""
# without the fix:
1 failed, 1 passed
# with the fix:
2 passed
```

Existing suites, lint and types:

```
$ uv run pytest tests/ci/browser/test_tabs.py                     ->  7 passed
$ uv run pytest tests/ci/test_tools.py tests/ci/test_multi_act_guards.py \
                tests/ci/test_action_timeout.py                   -> 34 passed
$ uv run ruff check                                               -> All checks passed!
$ uv run pyright browser_use/tools/service.py                     -> 0 errors, 0 warnings
```

## Scope note

`close` has the same shape (`tools/service.py:1050`), returning `'Tab #N closed (was already closed or invalid)'` on exception. For a *close* that's arguably correct idempotency, so I deliberately left it out rather than bundle a debatable behaviour change into a clear-cut fix. Happy to add it here or separately if you'd rather it changed too.

One behavioural note for review: agents that previously sailed past a failed switch will now see an error and have it counted toward `max_failures`. That's the point of the change, but it does mean a task relying on the silent no-op will now surface the failure instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report failed tab switches as errors so the agent stops planning against tabs it never reached. Previously `switch` returned a success-shaped `ActionResult` on failures; now it raises `BrowserError` and sets `ActionResult.error`.

- Raise `BrowserError` when `get_target_id_from_tab_id(...)` fails or when `event_result(raise_if_any=False, raise_if_none=False)` returns `None`; include failure `long_term_memory` directing the agent to check the tabs list.
- Remove the fallback “Switched to tab #N”; success uses the actual returned `TargetID`.
- Workflows relying on silent no-ops must handle the error; the loop now aborts queued actions and increments failure counts.
- Tests: add failure/success coverage in `tests/ci/browser/test_tabs.py`; declare `_TabActionModel(ActionModel)` with explicit `switch`/`navigate` slots so pyright checks `Tools.act(...)` call sites.

<sup>Written for commit f495b264c7bfcdf1f12b54a69b3245133b449e92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

