### PR TITLE
fix(llm): make bu-2-0 the ChatBrowserUse default again, keep mini opt-in

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -44,7 +44,7 @@ class ChatBrowserUse(BaseChatModel):
 
 	def __init__(
 		self,
-		model: str = 'bu-2-0-mini-preview',
+		model: str = 'bu-2-0',
 		api_key: str | None = None,
 		base_url: str | None = None,
 		timeout: float = 120.0,
@@ -58,8 +58,8 @@ class ChatBrowserUse(BaseChatModel):
 
 		Args:
 			model: Model name to use. Options:
-				- 'bu-2-0-mini-preview': Default model (fast + cheap, preview)
-				- 'bu-2-0' or 'bu-latest': Premium model
+				- 'bu-2-0' or 'bu-latest': Default model (premium)
+				- 'bu-2-0-mini-preview': Cheaper and faster per token, opt-in while in preview
 				- 'bu-1-0': Previous generation model, redirected to bu-2-0 at the gateway
 				- 'bu-qa-1': Website QA model (tests a site and scores functionality/aesthetics)
 				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
@@ -83,8 +83,8 @@ class ChatBrowserUse(BaseChatModel):
 				"'openai/gpt-5.5', or 'google/gemini-3-pro'."
 			)
 
-		# Normalize bu-latest to the current latest model. Deliberately not the constructor
-		# default: 'latest' tracks the stable premium line, not the preview.
+		# Normalize bu-latest to the current latest model, which is also the default: a
+		# preview model is opt-in, never something a caller lands on by omission.
 		if model == 'bu-latest':
 			self.model = 'bu-2-0'
 		else:

--- a/examples/beta_agent/basic.py
+++ b/examples/beta_agent/basic.py
@@ -23,7 +23,7 @@ async def main() -> None:
 	agent = Agent(
 		task=task,
 		llm=ChatBrowserUse(model='openai/gpt-5.5'),
-		# llm=ChatBrowserUse(),  # Browser Use's own optimized model (bu-2-0-mini-preview)
+		# llm=ChatBrowserUse(),  # Browser Use's own optimized model (bu-2-0)
 		# llm=ChatOpenAI(model='gpt-5.5'),
 		# llm=ChatGoogle(model='gemini-3.1-pro-preview'),
 		# llm=ChatAnthropic(model='claude-opus-4-8'),  # Sonnet also works well.

--- a/examples/models/browser_use_llm.py
+++ b/examples/models/browser_use_llm.py
@@ -20,8 +20,9 @@ if not os.getenv('BROWSER_USE_API_KEY'):
 
 
 async def main():
-	# `bu-2-0-mini-preview` is the optimized default - what a bare `ChatBrowserUse()` gives you.
-	# For the larger premium model pass `model='bu-2-0'` (or 'bu-latest', which tracks it).
+	# A bare `ChatBrowserUse()` gives you `bu-2-0`, the premium default (as does 'bu-latest').
+	# `bu-2-0-mini-preview`, used below, is cheaper and faster per token but is in preview, so
+	# you opt into it by name rather than getting it by default.
 	# ChatBrowserUse can also route to provider-prefixed models (e.g. 'anthropic/claude-sonnet-4-6',
 	# 'openai/gpt-5.5', 'google/gemini-3-pro') through the same gateway - see
 	# browser_use_provider_models.py.

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -59,9 +59,8 @@ Optimized for browser automation — highest accuracy, fastest speed, lowest tok
 ```python
 from browser_use import Agent, ChatBrowserUse
 
-llm = ChatBrowserUse()                              # bu-2-0-mini-preview (default)
-llm = ChatBrowserUse(model='bu-2-0-mini-preview')   # Default, named explicitly
-llm = ChatBrowserUse(model='bu-2-0')                # Premium model ('bu-latest' tracks this)
+llm = ChatBrowserUse()                              # bu-2-0 (default, 'bu-latest' tracks it)
+llm = ChatBrowserUse(model='bu-2-0-mini-preview')   # Cheaper per token, opt-in while in preview
 ```
 
 **Env:** `BROWSER_USE_API_KEY` — get at https://cloud.browser-use.com/new-api-key
@@ -69,8 +68,8 @@ llm = ChatBrowserUse(model='bu-2-0')                # Premium model ('bu-latest'
 **Models & Pricing (per 1M tokens):**
 | Model | Input | Cached | Output |
 |-------|-------|--------|--------|
-| bu-2-0-mini-preview (default) | $0.15 | $0.15 | $1.50 |
-| bu-2-0 (premium) | $0.60 | $0.06 | $3.50 |
+| bu-2-0 (default, premium) | $0.60 | $0.06 | $3.50 |
+| bu-2-0-mini-preview (opt-in) | $0.15 | $0.15 | $1.50 |
 | bu-1-0 (redirects to bu-2-0) | $0.60 | $0.06 | $3.50 |
 | browser-use/bu-30b-a3b-preview (OSS) | — | — | — |
 

--- a/tests/ci/models/test_llm_browseruse.py
+++ b/tests/ci/models/test_llm_browseruse.py
@@ -25,10 +25,12 @@ async def test_browseruse_bu_latest(httpserver):
 # --- Model validation -------------------------------------------------------
 
 
-def test_default_model_is_bu_2_0_mini_preview():
+def test_default_model_is_bu_2_0():
+	"""The default must be a stable model - a preview is opt-in, never reached by omission."""
 	chat = ChatBrowserUse(api_key=TEST_API_KEY)
-	assert chat.model == 'bu-2-0-mini-preview'
+	assert chat.model == 'bu-2-0'
 	assert chat.provider == 'browser-use'
+	assert 'preview' not in chat.model
 
 
 @pytest.mark.parametrize('alias', ['bu-1-0', 'bu-2-0', 'bu-2-0-mini-preview', 'bu-qa-1'])
@@ -39,12 +41,12 @@ def test_bu_aliases_are_accepted(alias):
 	assert chat.provider == 'browser-use'
 
 
-def test_bu_latest_still_normalizes_to_bu_2_0():
-	"""'latest' tracks the stable premium line, so it does NOT follow the preview default."""
+def test_bu_latest_normalizes_to_bu_2_0():
+	"""'latest' tracks the stable premium line, which is also what omitting the model gives."""
 	chat = ChatBrowserUse(model='bu-latest', api_key=TEST_API_KEY)
 	assert chat.model == 'bu-2-0'
 	assert chat.name == 'bu-2-0'
-	assert ChatBrowserUse(api_key=TEST_API_KEY).model != chat.model
+	assert ChatBrowserUse(api_key=TEST_API_KEY).model == chat.model
 
 
 def test_bu_2_0_mini_preview_is_priced():


### PR DESCRIPTION
Reverts the *default* to `bu-2-0`. `bu-2-0-mini-preview` stays a first-class option — still accepted, still priced, still what the examples demonstrate — it is just opted into by name rather than landed on by omission.

Follow-up to #5465, which shipped in 0.13.8.

## What changes

```
ChatBrowserUse()                            -> bu-2-0                # was bu-2-0-mini-preview
ChatBrowserUse(model="bu-latest")           -> bu-2-0                # unchanged
Agent(task=..., llm=None)                   -> bu-2-0                # was bu-2-0-mini-preview
ChatBrowserUse(model="bu-2-0-mini-preview") -> bu-2-0-mini-preview   # unchanged
```

Only the paths that reach a model *by omission* move. Every explicit id behaves exactly as before, and no id is removed.

## Why

**A preview id is the wrong thing to reach by omission.** As shipped, anyone with `Agent(task=...)` and no `llm=` moved onto a preview model on `pip install -U`, with no change on their side. Preview means the behaviour can shift or the id can be renamed; that is fine for callers who asked for it by name and surprising for callers who did not.

**Per-token price is the wrong yardstick for an agent.** Total cost is roughly:

```
tokens per step  ×  number of steps
```

and the step count is a function of model quality. A model that is 4x cheaper per output token but needs more steps to complete a task can end up costing more and taking longer, and its extra failures are the expensive outcome — a run that gives up still bills for every step it took. The headline `$0.15 / $1.50` does not by itself establish that mini is cheaper *per task*.

We do not currently have a per-task benchmark number for `bu-2-0-mini-preview` against `bu-2-0`. That number, not the per-token price, is what should decide the default. This PR restores the conservative choice until it exists; flipping back afterwards is a one-line change.

## Tests

`test_default_model_is_bu_2_0` gains `assert "preview" not in chat.model`, so the invariant being protected is the general one rather than this specific id.

`test_bu_latest_still_normalizes_to_bu_2_0` previously asserted that `bu-latest` and the constructor default were *different* ids — that divergence was the point when the default was the preview. It no longer exists, so the assertion inverts to `==` and the test is renamed to match; leaving the old name would have been misleading.

23 passed, 1 skipped (the one needing `BROWSER_USE_API_KEY`). `pyright` and `ruff` clean.

## Open question for review

The `examples/getting_started/` files still pin `bu-2-0-mini-preview`. That is deliberate here — mini is a reasonable cheap way to try the library, and a copied example is an explicit choice rather than an accident. But if the concern is what a first-time user ends up running, the examples are the on-ramp, so it is worth deciding explicitly whether those four should be `bu-2-0`, stay on mini, or use a bare `ChatBrowserUse()` so they always track the default. Happy to fold any of those in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `bu-2-0` as the `ChatBrowserUse` default; `bu-2-0-mini-preview` remains a first-class option but is opt-in by name. This reverses the 0.13.8 behavior where callers who omitted a model (including `Agent(task=..., llm=None)`) were moved to a preview model.

- Old: default -> `bu-2-0-mini-preview`. New: default -> `bu-2-0`. Explicit IDs (including `bu-2-0-mini-preview` and `bu-latest`) are unchanged; `bu-latest` normalizes to `bu-2-0`. Tests and docs updated to match.

**Migration**
- If you want mini, pass `model='bu-2-0-mini-preview'` explicitly.
- No change required for callers already specifying a model.

<sup>Written for commit 5953df7d2f9d4432964534af570758aa6e56e3a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

