### PR TITLE
docs(skills): make browser-use description state when to invoke

### DIFF
--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-use
-description: "Direct browser control over CDP. Use when the user wants a website automated, a page scraped, a web app tested, or screenshots captured from a live site."
+description: "Direct browser control over CDP. Use when a task needs interaction such as clicking, typing or navigating, the user's logged-in session, JavaScript rendering, or a bot-protected page, or when a direct HTTP fetch has already failed. A plain public page, API or docs needs no browser."
 homepage: https://browser-use.com
 metadata:
   {

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-use
-description: "Direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/app work."
+description: "Direct browser control over CDP. Use when the user wants a website automated, a page scraped, a web app tested, or screenshots captured from a live site."
 homepage: https://browser-use.com
 metadata:
   {


### PR DESCRIPTION
The `browser-use` skill description currently states what the skill *is*, but not when an agent should reach for it.

Per the [Agent Skills specification](https://agentskills.io/specification), the description is what an agent sees at all times and is the sole basis for deciding whether to load a skill. A description without trigger conditions makes invocation less reliable — the agent has to infer applicability from a capability list.

**Before**
```yaml
description: "Direct browser control via CDP for web interaction: automation, scraping, testing, screenshots, and site/app work."
```

**After**
```yaml
description: "Direct browser control over CDP. Use when the user wants a website automated, a page scraped, a web app tested, or screenshots captured from a live site."
```

Same four capabilities, expressed as the user-intent branches that should fire the skill. Identity stays in the skill body, where it does not cost context on every turn.

One line changed; no behavioural change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies when to invoke the `browser-use` skill by replacing a capability list with explicit triggers and adding “when not to use” guidance, improving agent load decisions. No runtime behavior change.

- Invoke when: interaction is needed (clicking, typing, navigating), the user’s logged-in session is required, JavaScript must run, a page is bot-protected, or a direct HTTP fetch has already failed.
- Do not use for: plain public pages, APIs, or docs retrievable via HTTP.
- One-line description update in `skills/browser-use/SKILL.md`.

<sup>Written for commit 2766e6fbc2dbf43f0b6b22293026ab683244a0c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

