### PR TITLE
docs: use canonical contribution guide URLs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 We love contributions! Please read through these links to get started:
 
- - 🔢 [Contribution Guidelines](https://docs.browser-use.com/development/contribution-guide)
- - 👾 [Local Development Setup Guide](https://docs.browser-use.com/development/local-setup)
+ - 🔢 [Contribution Guidelines](https://docs.browser-use.com/open-source/development/setup/contribution-guide)
+ - 👾 [Local Development Setup Guide](https://docs.browser-use.com/open-source/development/setup/local-setup)
  - 🏷️ [Issues Tagged: `#help-wanted`](https://github.com/browser-use/browser-use/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)
  - 🔌 [Integration Example Guidelines](../examples/integrations/README.md)


### PR DESCRIPTION
## Summary

Update the contribution and local development setup links to use their canonical Open Source documentation paths.

## Why

The previous URLs redirect to the current documentation structure. Linking to the canonical paths avoids an unnecessary redirect and keeps contributor onboarding aligned with the docs navigation.

## Validation

- `npx --yes markdown-link-check .github/CONTRIBUTING.md -q`
- `git diff --check`

No issue is linked because this is a small documentation fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches links in `.github/CONTRIBUTING.md` to canonical Open Source docs so contributors land on final pages without redirects. Previously used `/development/...`; now use `/open-source/development/setup/...`.

- Validated with `npx --yes markdown-link-check .github/CONTRIBUTING.md -q`.
- Only link targets changed; no migration or content edits.

<sup>Written for commit 666c2036aac3f7576338f8fc9b3d8bfaa6ca1165. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

