### PR TITLE
fix(browser): track and drain HAR response body fetches before writing HAR

### DIFF
--- a/browser_use/browser/watchdogs/har_recording_watchdog.py
+++ b/browser_use/browser/watchdogs/har_recording_watchdog.py
@@ -7,6 +7,7 @@ and `record_har_mode` (full/minimal).
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import json
@@ -151,6 +152,7 @@ class HarRecordingWatchdog(BaseWatchdog):
 		super().__init__(*args, **kwargs)
 		self._enabled: bool = False
 		self._entries: dict[str, _HarEntryBuilder] = {}
+		self._pending_body_fetches: set[asyncio.Task[None]] = set()  # in-flight response body fetches
 		self._top_level_pages: dict[
 			str, dict
 		] = {}  # frameId -> {url, title, startedDateTime, monotonic_start, onContentLoad, onLoad}
@@ -201,10 +203,28 @@ class HarRecordingWatchdog(BaseWatchdog):
 		if not self._enabled:
 			return
 		try:
+			await self._drain_body_fetches()
 			await self._write_har()
 			self.logger.info(f'📊 HAR file saved: {self._har_path}')
 		except Exception as e:
 			self.logger.warning(f'Failed to write HAR: {e}')
+
+	async def _drain_body_fetches(self, timeout_s: float = 5.0) -> None:
+		"""Wait briefly for in-flight response body fetches so their content lands in the HAR.
+
+		Body fetches are fire-and-forget during recording; on stop, pending ones get a
+		bounded window to complete, otherwise their entries fall back to the (possibly
+		incomplete) dataReceived buffer.
+		"""
+		pending = [task for task in self._pending_body_fetches if not task.done()]
+		if not pending:
+			return
+		try:
+			await asyncio.wait_for(asyncio.gather(*pending, return_exceptions=True), timeout=timeout_s)
+		except TimeoutError:
+			self.logger.debug(
+				f'[HarRecordingWatchdog] {len(pending)} response body fetch(es) did not finish within {timeout_s}s; writing HAR without them'
+			)
 
 	# =============== CDP Event Handlers (sync) ==================
 	def _on_request_will_be_sent(self, params: RequestWillBeSentEvent, session_id: str | None) -> None:
@@ -385,9 +405,8 @@ class HarRecordingWatchdog(BaseWatchdog):
 				return
 			entry = self._entries[request_id]
 			entry.ts_finished = params.get('timestamp')
-			# Fetch response body via CDP as dataReceived may be incomplete
-			import asyncio as _asyncio
 
+			# Fetch response body via CDP as dataReceived may be incomplete
 			async def _fetch_body(self_ref, req_id, sess_id):
 				try:
 					resp = await self_ref.browser_session.cdp_client.send.Network.getResponseBody(
@@ -407,10 +426,16 @@ class HarRecordingWatchdog(BaseWatchdog):
 						data = bytes(data) if data else b''
 					entry.response_body = data
 				except Exception:
-					pass
+					self_ref.logger.debug(
+						f'[HarRecordingWatchdog] Failed to fetch response body for request {req_id}', exc_info=True
+					)
 
-			# Always schedule the response body fetch task
-			_asyncio.create_task(_fetch_body(self, request_id, session_id))
+			# Always schedule the response body fetch task. Keep a strong reference so the
+			# task cannot be garbage-collected mid-flight, and so pending fetches can be
+			# drained before the HAR is written on stop.
+			task = asyncio.create_task(_fetch_body(self, request_id, session_id))
+			self._pending_body_fetches.add(task)
+			task.add_done_callback(self._pending_body_fetches.discard)
 
 			encoded_length = (
 				params.get('encodedDataLength') if hasattr(params, 'get') else getattr(params, 'encodedDataLength', None)

--- a/browser_use/browser/watchdogs/har_recording_watchdog.py
+++ b/browser_use/browser/watchdogs/har_recording_watchdog.py
@@ -214,17 +214,19 @@ class HarRecordingWatchdog(BaseWatchdog):
 
 		Body fetches are fire-and-forget during recording; on stop, pending ones get a
 		bounded window to complete, otherwise their entries fall back to the (possibly
-		incomplete) dataReceived buffer.
+		incomplete) dataReceived buffer. Uses asyncio.wait rather than wait_for so a
+		fetch that ignores cancellation cannot delay the HAR write past the timeout.
 		"""
 		pending = [task for task in self._pending_body_fetches if not task.done()]
 		if not pending:
 			return
-		try:
-			await asyncio.wait_for(asyncio.gather(*pending, return_exceptions=True), timeout=timeout_s)
-		except TimeoutError:
+		_done, stuck = await asyncio.wait(pending, timeout=timeout_s)
+		if stuck:
 			self.logger.debug(
-				f'[HarRecordingWatchdog] {len(pending)} response body fetch(es) did not finish within {timeout_s}s; writing HAR without them'
+				f'[HarRecordingWatchdog] {len(stuck)} response body fetch(es) did not finish within {timeout_s}s; writing HAR without them'
 			)
+			for task in stuck:
+				task.cancel()  # best effort; intentionally not awaited
 
 	# =============== CDP Event Handlers (sync) ==================
 	def _on_request_will_be_sent(self, params: RequestWillBeSentEvent, session_id: str | None) -> None:

--- a/tests/ci/test_har_recording_watchdog.py
+++ b/tests/ci/test_har_recording_watchdog.py
@@ -107,5 +107,7 @@ async def test_stop_writes_har_when_body_fetch_is_stuck(tmp_path):
 	_finish_loading(watchdog, stuck_get_body)
 
 	await asyncio.wait_for(watchdog._drain_body_fetches(timeout_s=0.05), timeout=2)
+	await asyncio.sleep(0.05)
 	for task in watchdog._pending_body_fetches:
+		assert task.cancelled() or task.done(), 'stuck fetch was not cancelled after the drain window'
 		task.cancel()

--- a/tests/ci/test_har_recording_watchdog.py
+++ b/tests/ci/test_har_recording_watchdog.py
@@ -1,0 +1,111 @@
+"""Regression tests for HAR recording response-body capture.
+
+The watchdog fetches each finished response's body via CDP in a fire-and-forget
+task. Those tasks must be tracked (so they can't be garbage-collected
+mid-flight) and drained before the HAR is written on stop — otherwise entries
+fall back to the (possibly incomplete) dataReceived buffer and response bodies
+go missing from the HAR.
+"""
+
+import asyncio
+import base64
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+from bubus import EventBus
+
+from browser_use.browser.session import BrowserSession
+from browser_use.browser.watchdogs.har_recording_watchdog import HarRecordingWatchdog
+
+
+def _make_watchdog(tmp_path) -> HarRecordingWatchdog:
+	watchdog = HarRecordingWatchdog(
+		event_bus=MagicMock(spec=EventBus),
+		browser_session=MagicMock(spec=BrowserSession),
+	)
+	watchdog._enabled = True
+	watchdog._content_mode = 'embed'
+	watchdog._mode = 'full'
+	watchdog._har_path = tmp_path / 'out.har'
+	watchdog._har_dir = tmp_path
+	watchdog._browser_name = 'Chromium'
+	watchdog._browser_version = ''
+	return watchdog
+
+
+def _prime_entry(watchdog: HarRecordingWatchdog, request_id: str = 'r1') -> None:
+	params: Any = {'requestId': request_id, 'request': {'url': 'https://example.com/', 'method': 'GET'}}
+	watchdog._on_request_will_be_sent(params, session_id='s1')
+
+
+def _finish_loading(watchdog: HarRecordingWatchdog, get_body, request_id: str = 'r1') -> None:
+	network: Any = watchdog.browser_session.cdp_client.send.Network
+	network.getResponseBody = get_body
+	params: Any = {'requestId': request_id, 'timestamp': 123.0}
+	watchdog._on_loading_finished(params, session_id='s1')
+
+
+async def test_body_fetch_tasks_are_tracked(tmp_path):
+	"""loadingFinished must keep a strong reference to the body-fetch task."""
+	watchdog = _make_watchdog(tmp_path)
+	_prime_entry(watchdog)
+
+	gate = asyncio.Event()
+	body_b64 = base64.b64encode(b'<html>hi</html>').decode()
+
+	async def slow_get_body(params, session_id=None):
+		await gate.wait()
+		return {'body': body_b64, 'base64Encoded': True}
+
+	try:
+		_finish_loading(watchdog, slow_get_body)
+		pending = [t for t in watchdog._pending_body_fetches if not t.done()]
+		assert len(pending) == 1, f'expected 1 tracked body-fetch task, got {len(pending)}'
+	finally:
+		gate.set()
+		await asyncio.gather(*watchdog._pending_body_fetches, return_exceptions=True)
+
+
+async def test_stop_waits_for_in_flight_body_fetch(tmp_path):
+	"""on_BrowserStopEvent must drain pending body fetches so their content lands in the HAR."""
+	watchdog = _make_watchdog(tmp_path)
+	_prime_entry(watchdog)
+
+	gate = asyncio.Event()
+	body_b64 = base64.b64encode(b'<html>secret body</html>').decode()
+
+	async def slow_get_body(params, session_id=None):
+		await gate.wait()
+		return {'body': body_b64, 'base64Encoded': True}
+
+	_finish_loading(watchdog, slow_get_body)
+
+	stop_task = asyncio.create_task(watchdog.on_BrowserStopEvent(MagicMock()))
+	await asyncio.sleep(0.05)
+	assert not stop_task.done(), 'stop completed while a body fetch was still in flight'
+
+	gate.set()
+	await asyncio.wait_for(stop_task, timeout=2)
+
+	har = json.loads(watchdog._har_path.read_text())
+	texts = [e['response']['content'].get('text') for e in har['log']['entries']]
+	assert '<html>secret body</html>' in texts, f'fetched body missing from HAR: {texts}'
+
+
+async def test_stop_writes_har_when_body_fetch_is_stuck(tmp_path):
+	"""A stuck body fetch must not block HAR writing forever (bounded drain)."""
+	watchdog = _make_watchdog(tmp_path)
+	_prime_entry(watchdog)
+
+	never = asyncio.Event()
+
+	async def stuck_get_body(params, session_id=None):
+		await never.wait()
+		return {'body': '', 'base64Encoded': False}
+
+	_finish_loading(watchdog, stuck_get_body)
+
+	await asyncio.wait_for(watchdog._drain_body_fetches(timeout_s=0.05), timeout=2)
+	for task in watchdog._pending_body_fetches:
+		task.cancel()

--- a/tests/ci/test_har_recording_watchdog.py
+++ b/tests/ci/test_har_recording_watchdog.py
@@ -105,9 +105,12 @@ async def test_stop_writes_har_when_body_fetch_is_stuck(tmp_path):
 		return {'body': '', 'base64Encoded': False}
 
 	_finish_loading(watchdog, stuck_get_body)
+	# Capture the task before the drain: cancelled tasks are discarded from
+	# _pending_body_fetches via their done_callback, so the set is empty afterwards.
+	stuck_tasks = list(watchdog._pending_body_fetches)
+	assert len(stuck_tasks) == 1
 
 	await asyncio.wait_for(watchdog._drain_body_fetches(timeout_s=0.05), timeout=2)
 	await asyncio.sleep(0.05)
-	for task in watchdog._pending_body_fetches:
-		assert task.cancelled() or task.done(), 'stuck fetch was not cancelled after the drain window'
-		task.cancel()
+	assert stuck_tasks[0].cancelled() or stuck_tasks[0].done(), 'stuck fetch was not cancelled after the drain window'
+	stuck_tasks[0].cancel()


### PR DESCRIPTION
## Why

Found while auditing the watchdogs: `HarRecordingWatchdog._on_loading_finished` fetches each response body via CDP (`Network.getResponseBody`) in a **bare `asyncio.create_task(...)`** — no reference stored, never awaited:

1. **Unreferenced task** — per asyncio docs, the event loop only holds weak refs to tasks, so an unreferenced task may be garbage-collected before completion.
2. **Never drained** — `on_BrowserStopEvent` calls `_write_har()` immediately, so any body fetch still in flight at stop time is silently lost: the entry falls back to the `dataReceived` buffer, which the code itself notes *"may be incomplete"*. Result: response bodies missing from the recorded HAR.
3. Fetch failures were swallowed by a bare `except Exception: pass`.

## What

- Track in-flight fetches in `self._pending_body_fetches` (strong refs; self-cleaning via `add_done_callback`).
- New `_drain_body_fetches(timeout_s=5.0)`, awaited in `on_BrowserStopEvent` **before** `_write_har()` — pending fetches get a bounded window to complete so their content lands in the HAR; a stuck fetch can't block shutdown forever.
- Body-fetch failures now log at debug instead of being silently swallowed.

30 insertions / 5 deletions in one file, plus regression tests.

## Testing

New `tests/ci/test_har_recording_watchdog.py` (3 tests, all verified to fail on the old code):

- `test_body_fetch_tasks_are_tracked` — the fetch task is strongly referenced.
- `test_stop_waits_for_in_flight_body_fetch` — stop blocks until the in-flight fetch completes, and the fetched body is present in the written HAR.
- `test_stop_writes_har_when_body_fetch_is_stuck` — a wedged fetch can't hang HAR writing (bounded drain).

```
tests/ci/test_har_recording_watchdog.py::test_body_fetch_tasks_are_tracked PASSED
tests/ci/test_har_recording_watchdog.py::test_stop_waits_for_in_flight_body_fetch PASSED
tests/ci/test_har_recording_watchdog.py::test_stop_writes_har_when_body_fetch_is_stuck PASSED
```

Also green: related watchdog suites (`test_downloads_watchdog`, `test_remote_download_complete_callback`), ruff, pyright, pre-commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures recorded HARs include response bodies by draining in‑flight CDP body fetches before writing the file. Previously we spawned unreferenced, never‑awaited tasks on loadingFinished and wrote the HAR on stop, dropping bodies still in flight.

- Track response‑body fetch tasks in a strong‑ref set; auto‑remove via done_callback.
- On stop, drain pending fetches with a 5s timeout using asyncio.wait; cancel stuck tasks best‑effort and log timeouts at debug so non‑cancellable CDP calls can’t extend shutdown.
- Log body‑fetch failures at debug instead of swallowing exceptions.
- Tests cover task tracking, draining so the body appears in the HAR, and bounded drain for a stuck fetch; the stuck‑fetch test now asserts on a captured task reference because the drain’s done_callback discards tasks from the set.

<sup>Written for commit 09442df1a8bf4c72bef6ec3068f9b8f067392baa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

