### PR TITLE
fix(filesystem): report missing target text in replace_file

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -792,6 +792,8 @@ class FileSystem:
 
 		try:
 			content = file_obj.read()
+			if old_str not in content:
+				return f'Error: Could not find the specified text in file {full_filename}.'
 			content = content.replace(old_str, new_str)
 			await file_obj.write(content, self.data_dir)
 			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -478,6 +478,18 @@ class TestFileSystem:
 		assert 'not found' in result
 		assert 'auto-corrected' in result
 
+	async def test_replace_file_reports_missing_text(self, temp_filesystem):
+		"""Test that replacing absent text reports an error without changing the file."""
+		fs = temp_filesystem
+		original_content = '- [ ] First task\n- [ ] Second task'
+		await fs.write_file('todo.md', original_content)
+
+		result = await fs.replace_file_str('todo.md', '- [ ] Missing task', '- [x] Missing task')
+
+		assert result == 'Error: Could not find the specified text in file todo.md.'
+		assert fs.get_file('todo.md').content == original_content
+		assert (fs.data_dir / 'todo.md').read_text(encoding='utf-8') == original_content
+
 	async def test_append_json_file(self, temp_filesystem):
 		"""Test appending content to JSON files."""
 		fs = temp_filesystem


### PR DESCRIPTION
## Summary

- Return an explicit error when `replace_file_str` cannot find `old_str`.
- Avoid writing unchanged content while incorrectly reporting a successful edit.
- Add a regression test that verifies both in-memory and on-disk content remain unchanged.

## Why

Python's `str.replace()` is a no-op when the target text is absent. The current
implementation then writes the unchanged content and reports success. Because
the `replace_file` action forwards that result to the agent, the agent can
incorrectly treat a failed targeted edit as completed and continue with stale
file content.

## Reproduction

Before the production change, replacing a missing checklist entry returned:

```text
Successfully replaced all occurrences ...
```

while the in-memory and on-disk file content remained unchanged. The new test
failed on that false-success response and passes after the explicit membership
check is added.

## Demo

Not applicable: this is a non-visual filesystem error-path fix. The regression
test captures the observable before/after behavior.

## Tests

- `uv run pytest tests/ci/infrastructure/test_filesystem.py::TestFileSystem::test_replace_file_reports_missing_text -q`
  — 1 passed
- `uv run pytest tests/ci/infrastructure/test_filesystem.py -q`
  — 80 passed
- `uv run pytest tests/ci/infrastructure/test_filesystem.py tests/ci/test_file_system_images.py tests/ci/test_file_system_docx.py -q`
  — 105 passed
- `uv run pre-commit run --files browser_use/filesystem/file_system.py tests/ci/infrastructure/test_filesystem.py`
  — all hooks passed, including ruff, ruff-format, pyright, codespell, and
  repository integrity checks

## AI Assistance

OpenAI Codex assisted with investigation, implementation, duplicate checking,
and test execution. I reviewed and understood the complete change, verified
the failing behavior before the fix, and confirmed the test results above.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report an explicit error when `replace_file_str` cannot find the target text and avoid writing unchanged files. Previously a missing target produced a no-op write and a false-success message; now it returns an error and leaves both in-memory and on-disk content untouched.

- Impact: Callers must handle the error string "Error: Could not find the specified text in file {path}." and should not treat it as a successful edit.
- Test coverage: Added `test_replace_file_reports_missing_text` to assert both buffers and disk remain unchanged.

<sup>Written for commit 3648bbad7f2aa9e8447ff796a54ffbde840a789d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

