### PR TITLE
fix(filesystem): escape plain text in generated PDFs

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import csv
+import html
 import io
 import os
 import re
@@ -264,15 +265,16 @@ class PdfFile(BaseFile):
 
 			for line in content_lines:
 				if line.strip():
+					escaped_line = html.escape(line)
 					# Handle basic markdown headers
 					if line.startswith('# '):
-						para = Paragraph(line[2:], styles['Title'])
+						para = Paragraph(escaped_line[2:], styles['Title'])
 					elif line.startswith('## '):
-						para = Paragraph(line[3:], styles['Heading1'])
+						para = Paragraph(escaped_line[3:], styles['Heading1'])
 					elif line.startswith('### '):
-						para = Paragraph(line[4:], styles['Heading2'])
+						para = Paragraph(escaped_line[4:], styles['Heading2'])
 					else:
-						para = Paragraph(line, styles['Normal'])
+						para = Paragraph(escaped_line, styles['Normal'])
 					story.append(para)
 				else:
 					story.append(Spacer(1, 6))

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -265,17 +265,17 @@ class PdfFile(BaseFile):
 
 			for line in content_lines:
 				if line.strip():
-					escaped_line = html.escape(line)
 					# Handle basic markdown headers
 					if line.startswith('# '):
-						para = Paragraph(escaped_line[2:], styles['Title'])
+						text, style = line[2:], styles['Title']
 					elif line.startswith('## '):
-						para = Paragraph(escaped_line[3:], styles['Heading1'])
+						text, style = line[3:], styles['Heading1']
 					elif line.startswith('### '):
-						para = Paragraph(escaped_line[4:], styles['Heading2'])
+						text, style = line[4:], styles['Heading2']
 					else:
-						para = Paragraph(escaped_line, styles['Normal'])
-					story.append(para)
+						text, style = line, styles['Normal']
+					# Paragraph parses its input as ReportLab markup, but our content is plain text
+					story.append(Paragraph(html.escape(text), style))
 				else:
 					story.append(Spacer(1, 6))
 

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -258,9 +258,7 @@ class PdfFile(BaseFile):
 			styles = getSampleStyleSheet()
 			story = []
 
-			# Convert markdown content to simple text and add to PDF
-			# For basic implementation, we'll treat content as plain text
-			# This avoids the AGPL license issue while maintaining functionality
+			# Plain text plus markdown headers only, to avoid an AGPL markdown-to-PDF dependency
 			content_lines = self.content.split('\n')
 
 			for line in content_lines:

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from pypdf import PdfReader
 
 from browser_use.filesystem.file_system import (
 	DEFAULT_FILE_SYSTEM_PATH,
@@ -221,6 +222,17 @@ class TestFileSystem:
 				fs.nuke()
 			except Exception:
 				pass
+
+	async def test_write_pdf_preserves_plain_text_angle_brackets(self, empty_filesystem):
+		"""PDF content should be rendered as plain text, not ReportLab markup."""
+		content = 'Comparison: 2 <b y & 5 > 4'
+
+		result = await empty_filesystem.write_file('comparison.pdf', content)
+
+		assert result == 'Data written to file comparison.pdf successfully.'
+		pdf_path = empty_filesystem.data_dir / 'comparison.pdf'
+		extracted_text = '\n'.join(page.extract_text() or '' for page in PdfReader(pdf_path).pages)
+		assert content in extracted_text
 
 	def test_filesystem_initialization(self, temp_filesystem):
 		"""Test FileSystem initialization with default files."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -223,7 +223,7 @@ class TestFileSystem:
 			except Exception:
 				pass
 
-	async def test_write_pdf_preserves_plain_text_angle_brackets(self, empty_filesystem):
+	async def test_write_pdf_renders_content_as_plain_text(self, empty_filesystem):
 		"""PDF content should be rendered as plain text, not ReportLab markup."""
 		# (markdown source, text expected in the PDF)
 		headers = [
@@ -231,18 +231,19 @@ class TestFileSystem:
 			('## Section 2 & 3', 'Section 2 & 3'),
 			('### Notes <i> #1', 'Notes <i> #1'),
 		]
-		body = 'Comparison: 2 <b y & 5 > 4'
+		body = ['Comparison: 2 <b y & 5 > 4', '#hashtag is not a header', 'O\'Brien said "hi" & left']
 
-		result = await empty_filesystem.write_file('comparison.pdf', '\n\n'.join([source for source, _ in headers] + [body]))
+		result = await empty_filesystem.write_file('comparison.pdf', '\n\n'.join([source for source, _ in headers] + body))
 
 		assert result == 'Data written to file comparison.pdf successfully.'
 		pdf_path = empty_filesystem.data_dir / 'comparison.pdf'
 		extracted_text = '\n'.join(page.extract_text() or '' for page in PdfReader(pdf_path).pages)
-		assert body in extracted_text
-		for source, rendered in headers:
-			# Only the leading header marker is stripped, everything else survives verbatim
-			assert rendered in extracted_text
-			assert source not in extracted_text
+		# Match whole lines: a substring check still passes with a leftover '# ' marker
+		extracted_lines = [line.strip() for line in extracted_text.splitlines()]
+		for _, rendered in headers:
+			assert rendered in extracted_lines
+		for line in body:
+			assert line in extracted_lines
 
 	def test_filesystem_initialization(self, temp_filesystem):
 		"""Test FileSystem initialization with default files."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -225,14 +225,19 @@ class TestFileSystem:
 
 	async def test_write_pdf_preserves_plain_text_angle_brackets(self, empty_filesystem):
 		"""PDF content should be rendered as plain text, not ReportLab markup."""
-		content = 'Comparison: 2 <b y & 5 > 4'
+		lines = ['# Q&A: <b y vs 5', '## Section 2 & 3', '### Notes <i>', 'Comparison: 2 <b y & 5 > 4']
 
-		result = await empty_filesystem.write_file('comparison.pdf', content)
+		result = await empty_filesystem.write_file('comparison.pdf', '\n\n'.join(lines))
 
 		assert result == 'Data written to file comparison.pdf successfully.'
 		pdf_path = empty_filesystem.data_dir / 'comparison.pdf'
 		extracted_text = '\n'.join(page.extract_text() or '' for page in PdfReader(pdf_path).pages)
-		assert content in extracted_text
+		# Header markers are stripped, everything else survives verbatim
+		assert 'Q&A: <b y vs 5' in extracted_text
+		assert 'Section 2 & 3' in extracted_text
+		assert 'Notes <i>' in extracted_text
+		assert 'Comparison: 2 <b y & 5 > 4' in extracted_text
+		assert '#' not in extracted_text
 
 	def test_filesystem_initialization(self, temp_filesystem):
 		"""Test FileSystem initialization with default files."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -20,6 +20,15 @@ from browser_use.filesystem.file_system import (
 )
 
 
+def _extract_pdf_text(path: Path) -> tuple[str, list[str]]:
+	"""Extract a PDF as (whitespace-collapsed blob, non-empty stripped lines).
+
+	The blob tolerates line wrapping; the lines are what header markers would survive on.
+	"""
+	text = '\n'.join(page.extract_text() or '' for page in PdfReader(path).pages)
+	return ' '.join(text.split()), [line.strip() for line in text.splitlines() if line.strip()]
+
+
 class TestBaseFile:
 	"""Test the BaseFile abstract base class and its implementations."""
 
@@ -236,14 +245,25 @@ class TestFileSystem:
 		result = await empty_filesystem.write_file('comparison.pdf', '\n\n'.join([source for source, _ in headers] + body))
 
 		assert result == 'Data written to file comparison.pdf successfully.'
-		pdf_path = empty_filesystem.data_dir / 'comparison.pdf'
-		extracted_text = '\n'.join(page.extract_text() or '' for page in PdfReader(pdf_path).pages)
-		# Match whole lines: a substring check still passes with a leftover '# ' marker
-		extracted_lines = [line.strip() for line in extracted_text.splitlines()]
+		blob, lines = _extract_pdf_text(empty_filesystem.data_dir / 'comparison.pdf')
 		for _, rendered in headers:
-			assert rendered in extracted_lines
+			assert rendered in blob
 		for line in body:
-			assert line in extracted_lines
+			assert line in blob
+		# Content checks alone pass with a leftover marker, e.g. '# Notes <i> #1' contains 'Notes <i> #1'
+		assert [line for line in lines if line.startswith(('# ', '## ', '### '))] == []
+
+	async def test_append_pdf_escapes_both_halves(self, empty_filesystem):
+		"""Appending re-renders the whole PDF, so old and new content must both stay plain text."""
+		# The markup that breaks ReportLab goes in the appended half, so this fails on the append path alone
+		await empty_filesystem.write_file('report.pdf', 'First & half')
+
+		result = await empty_filesystem.append_file('report.pdf', '\nSecond <b half > 2')
+
+		assert result == 'Data appended to file report.pdf successfully.'
+		blob, _ = _extract_pdf_text(empty_filesystem.data_dir / 'report.pdf')
+		assert 'First & half' in blob
+		assert 'Second <b half > 2' in blob
 
 	def test_filesystem_initialization(self, temp_filesystem):
 		"""Test FileSystem initialization with default files."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -225,19 +225,24 @@ class TestFileSystem:
 
 	async def test_write_pdf_preserves_plain_text_angle_brackets(self, empty_filesystem):
 		"""PDF content should be rendered as plain text, not ReportLab markup."""
-		lines = ['# Q&A: <b y vs 5', '## Section 2 & 3', '### Notes <i>', 'Comparison: 2 <b y & 5 > 4']
+		# (markdown source, text expected in the PDF)
+		headers = [
+			('# Q&A: <b y vs 5', 'Q&A: <b y vs 5'),
+			('## Section 2 & 3', 'Section 2 & 3'),
+			('### Notes <i> #1', 'Notes <i> #1'),
+		]
+		body = 'Comparison: 2 <b y & 5 > 4'
 
-		result = await empty_filesystem.write_file('comparison.pdf', '\n\n'.join(lines))
+		result = await empty_filesystem.write_file('comparison.pdf', '\n\n'.join([source for source, _ in headers] + [body]))
 
 		assert result == 'Data written to file comparison.pdf successfully.'
 		pdf_path = empty_filesystem.data_dir / 'comparison.pdf'
 		extracted_text = '\n'.join(page.extract_text() or '' for page in PdfReader(pdf_path).pages)
-		# Header markers are stripped, everything else survives verbatim
-		assert 'Q&A: <b y vs 5' in extracted_text
-		assert 'Section 2 & 3' in extracted_text
-		assert 'Notes <i>' in extracted_text
-		assert 'Comparison: 2 <b y & 5 > 4' in extracted_text
-		assert '#' not in extracted_text
+		assert body in extracted_text
+		for source, rendered in headers:
+			# Only the leading header marker is stripped, everything else survives verbatim
+			assert rendered in extracted_text
+			assert source not in extracted_text
 
 	def test_filesystem_initialization(self, temp_filesystem):
 		"""Test FileSystem initialization with default files."""


### PR DESCRIPTION
## Why

`PdfFile` documents its input as plain text, but each line was passed directly to ReportLab's `Paragraph` parser. Text such as `Comparison: 2 <b y & 5 > 4` was interpreted as malformed markup, so `write_file` returned an error instead of creating the PDF.

## What changed

- Escape plain-text content before passing it to ReportLab
- Keep the existing Markdown heading style selection
- Add a regression test through the real `FileSystem.write_file` path and verify the generated PDF text with `PdfReader`

## Before / after

- Before: the regression failed with a ReportLab parse error expecting a closing `</b>` tag
- After: the PDF is created successfully and extracts back to the exact original text

A screenshot is not applicable to this generated-file failure; the regression validates the resulting PDF content directly.

## Testing

- Focused regression: RED on the base commit, then 1 passed after the fix
- `python -m pytest -o addopts='' -p no:cacheprovider --confcutdir=tests/ci/infrastructure -q tests/ci/infrastructure/test_filesystem.py` (81 passed)
- `./bin/lint.sh --staged` (Ruff, Pyright, and other pre-commit hooks passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escape plain text and strip only leading Markdown header markers when generating PDFs so markup-like characters no longer break creation and extracted text matches input. Previously lines were passed to `reportlab` `Paragraph` as markup and could error; now we slice header markers to select styles and escape the remaining text.

- Render: detect `# `, `## `, `### ` to choose the style, then pass `html.escape(text)` to `Paragraph`; applies to both `FileSystem.write_file` and `append_file`.
- Tests: end-to-end via `FileSystem.write_file`/`append_file`, validate with `pypdf` `PdfReader` using a whitespace-collapsed blob to tolerate wrapping; assert only leading header markers are stripped; cover literal `#` in content, a non-header starting with `#`, and quotes/angle brackets. No migration; heading styles unchanged.

<sup>Written for commit e6b92bec5648c485e778568edb28ca28447c1f81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

