### PR TITLE
fix(dom): keep the "... N more options..." indicator for <select> elements

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -1010,7 +1010,10 @@ class DOMTreeSerializer:
 						if 'options_count' in child_info and child_info['options_count'] is not None:
 							parts.append(f'count={child_info["options_count"]}')
 						if 'first_options' in child_info and child_info['first_options']:
-							options_str = '|'.join(child_info['first_options'][:4])  # Limit to 4 options
+							# Already capped by _extract_select_options: up to 4 labels plus a
+							# trailing "... N more options..." indicator. Re-slicing here would
+							# drop exactly that indicator.
+							options_str = '|'.join(child_info['first_options'])
 							parts.append(f'options={options_str}')
 						if 'format_hint' in child_info and child_info['format_hint']:
 							parts.append(f'format={child_info["format_hint"]}')

--- a/tests/ci/test_dom_select_options_serialization.py
+++ b/tests/ci/test_dom_select_options_serialization.py
@@ -1,0 +1,103 @@
+"""Regression test for the "... N more options..." indicator on <select> elements.
+
+`DOMTreeSerializer._extract_select_options()` renders at most 4 option labels and,
+when the select has more than 4 options, appends a trailing
+`"... N more options..."` entry so the LLM knows the list is truncated.
+
+`serialize_tree()` used to re-slice that list with `[:4]`, which cut off exactly
+the indicator it was meant to preserve — the model saw `count=6` alongside four
+labels and no signal that the remaining options existed.
+"""
+
+from browser_use.dom.serializer.serializer import DOMTreeSerializer
+from browser_use.dom.views import EnhancedAXNode, EnhancedDOMTreeNode, NodeType, SimplifiedNode
+
+
+def _make_node(
+	node_id: int,
+	node_name: str,
+	node_type: NodeType = NodeType.ELEMENT_NODE,
+	node_value: str = '',
+	attributes: dict[str, str] | None = None,
+	ax_node: EnhancedAXNode | None = None,
+) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=node_id,
+		backend_node_id=node_id,
+		node_type=node_type,
+		node_name=node_name,
+		node_value=node_value,
+		attributes=attributes or {},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='test-target',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=ax_node,
+		snapshot_node=None,
+	)
+
+
+def _make_select(option_labels: list[str]) -> EnhancedDOMTreeNode:
+	"""Build a <select> whose AX node advertises children, as a real select would."""
+	select = _make_node(
+		node_id=1,
+		node_name='SELECT',
+		attributes={'id': 'fruit'},
+		ax_node=EnhancedAXNode(
+			ax_node_id='ax-1',
+			ignored=False,
+			role='combobox',
+			name='fruit',
+			description=None,
+			properties=None,
+			child_ids=['ax-2'],
+		),
+	)
+
+	children = []
+	for offset, label in enumerate(option_labels):
+		option = _make_node(node_id=10 + offset * 2, node_name='OPTION', attributes={'value': label.lower()})
+		text = _make_node(node_id=11 + offset * 2, node_name='#text', node_type=NodeType.TEXT_NODE, node_value=label)
+		text.parent_node = option
+		option.children_nodes = [text]
+		option.parent_node = select
+		children.append(option)
+
+	select.children_nodes = children
+	return select
+
+
+def _serialize_select(option_labels: list[str]) -> str:
+	select = _make_select(option_labels)
+	# A <select> always lands in the selector map, so it is serialized as an
+	# interactive element with a selector index.
+	simplified = SimplifiedNode(original_node=select, children=[], is_interactive=True, selector_index=5)
+
+	serializer = DOMTreeSerializer(root_node=select)
+	serializer._add_compound_components(simplified, select)
+
+	return DOMTreeSerializer.serialize_tree(simplified, [])
+
+
+class TestSelectOptionsSerialization:
+	def test_more_options_indicator_survives_serialization(self):
+		"""A select with 6 options must tell the LLM that 2 options are not shown."""
+		output = _serialize_select(['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry', 'Fig'])
+
+		assert 'count=6' in output
+		assert 'options=Apple|Banana|Cherry|Date|... 2 more options...' in output
+
+	def test_all_options_shown_when_not_truncated(self):
+		"""Four or fewer options are listed in full, with no truncation indicator."""
+		output = _serialize_select(['Apple', 'Banana', 'Cherry', 'Date'])
+
+		assert 'count=4' in output
+		assert 'options=Apple|Banana|Cherry|Date' in output
+		assert 'more options' not in output


### PR DESCRIPTION
Fixes #5195

## Why?

A dropdown the agent cannot see the bottom of is a dropdown the agent will pick the wrong item from.

The serializer deliberately truncates long `<select>` option lists to keep the prompt small — that part is correct. But it also deliberately appends a `"... N more options..."` marker so the model knows the list was cut. That marker is the entire mechanism by which the LLM learns to scroll or re-query instead of choosing from what it can see. It was being dropped before it ever reached the model.

The result is the worst version of truncation: silent truncation. The model is handed `count=6` and four labels with no indication they are only four of six, so a correct answer sitting in position five is invisible and unrequestable. On country pickers, date selectors, or any long dropdown, the agent confidently picks the best of the first four.

The information was already computed, already formatted, and already in the list. It was thrown away one line before use.

## The bug

`DOMTreeSerializer._extract_select_options()` builds `first_options` as **up to 4 option labels plus** a trailing indicator:

```python
# Add ellipsis indicator if there are more options than shown
if len(options) > 4:
	first_options.append(f'... {len(options) - 4} more options...')
```

The consumer in `serialize_tree()` then re-sliced that list back down to 4 entries:

```python
options_str = '|'.join(child_info['first_options'][:4])  # Limit to 4 options
```

For a select with more than 4 options `first_options` has 5 elements, so `[:4]` cut off exactly the indicator it was meant to preserve. The two functions disagreed about the list length — the producer's cap is "4 labels + marker", the consumer's cap was "4 elements total".

A 6-option `<select>` serialized as:

```
[5]<select compound_components=(name=Dropdown Toggle,role=button),(name=Options,role=listbox,count=6,options=Apple|Banana|Cherry|Date) />
```

## What changed

The producer already caps the list, so the second slice is redundant as well as harmful — removed it. Same select now serializes as:

```
[5]<select compound_components=(name=Dropdown Toggle,role=button),(name=Options,role=listbox,count=6,options=Apple|Banana|Cherry|Date|... 2 more options...) />
```

Four labels is still the cap. Only the truncation hint is restored, so the prompt grows by one short string and only for selects that were already being truncated.

## Tests

Added `tests/ci/test_dom_select_options_serialization.py`, which builds a real `<select>` node tree and runs it through `_add_compound_components()` + `serialize_tree()` — no mocks, no browser needed:

- a 6-option select must surface `... 2 more options...`
- a 4-option select must list all four with **no** truncation hint, guarding against the fix over-reaching in the other direction

Both fail on `main` before the change and pass after.

## Verification

- `pytest tests/ci -k "dom or serial or select or dropdown"` → 108 passed, 10 skipped
- `tests/ci/browser/test_dom_serializer.py` and `tests/ci/test_dom_paint_order_serialization.py` (real-browser serializer coverage) pass
- `ruff format --check` and `ruff check` clean
- `pyright` on the touched file: 32 errors before and after — unchanged, all pre-existing