### PR TITLE
fix(browser): clean up the temp .zip in _extract_extension on every path

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1180,7 +1180,6 @@ async function initialize(checkInitialized, magic) {{
 
 	def _extract_extension(self, crx_path: Path, extract_dir: Path) -> None:
 		"""Extract .crx file to directory."""
-		import os
 		import zipfile
 
 		# Remove existing directory
@@ -1221,16 +1220,30 @@ async function initialize(checkInitialized, magic) {{
 				# Extract ZIP data
 				zip_data = f.read()
 
-			# Write ZIP data to temp file and extract
+			# Write ZIP data to temp file and extract.
+			# The temp file is created with delete=False, so cleanup is ours on every
+			# path — a corrupt or truncated payload makes extractall() raise, and the
+			# .zip would otherwise survive in the system temp dir indefinitely.
+			# The handle is also closed before the file is reopened and removed, since
+			# Windows refuses to unlink a file that still has an open handle.
+			temp_zip_path = None
+			try:
+				with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
+					temp_zip_path = Path(temp_zip.name)
+					temp_zip.write(zip_data)
 
-			with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
-				temp_zip.write(zip_data)
-				temp_zip.flush()
-
-				with zipfile.ZipFile(temp_zip.name, 'r') as zip_ref:
+				with zipfile.ZipFile(temp_zip_path, 'r') as zip_ref:
 					zip_ref.extractall(extract_dir)
-
-				os.unlink(temp_zip.name)
+			finally:
+				if temp_zip_path is not None:
+					try:
+						temp_zip_path.unlink(missing_ok=True)
+					except OSError as cleanup_error:
+						# Never let a cleanup failure replace the extraction error that
+						# is already propagating — the original exception is the useful
+						# one. Windows can still refuse the unlink if another process
+						# holds the file, so this is not merely theoretical.
+						logger.warning(f'Failed to remove temp file {_log_pretty_path(temp_zip_path)}: {cleanup_error}')
 
 	def detect_display_configuration(self) -> None:
 		"""

--- a/tests/ci/test_extension_extraction.py
+++ b/tests/ci/test_extension_extraction.py
@@ -1,0 +1,124 @@
+"""Tests for BrowserProfile._extract_extension() temp-file handling.
+
+`_extract_extension()` has two branches:
+
+1. Open the .crx directly with `ZipFile(crx_path)`. Python's zipfile scans
+   backwards for the end-of-central-directory record and corrects the
+   central-directory offsets for any prepended bytes (the same support that
+   makes self-extracting archives work), so an **intact** .crx opens here
+   despite its `Cr24` header. No temp file is involved.
+2. On BadZipFile, skip the CRX header, write the remaining payload to a
+   `delete=False` temp .zip, and extract that. This branch owns the temp
+   file's lifetime completely.
+
+Because the only difference between the two inputs is the leading header, and
+zipfile self-corrects for it, branch 2 is reached exactly when the zip payload
+is damaged enough that branch 1 could not read it — in which case branch 2
+cannot read it either. So the realistic behaviour of branch 2 is: enter, fail,
+and (before this fix) strand a .zip in the system temp dir.
+
+The tests below therefore pin *which* branch they exercise rather than assuming.
+"""
+
+import struct
+import tempfile
+import traceback
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+
+CRX_HEADER = b'crx3-header-placeholder'
+
+
+def _make_crx(payload: bytes, crx_header: bytes = CRX_HEADER) -> bytes:
+	"""Build a CRX v3 container: magic + version + header length + header + payload."""
+	return b'Cr24' + struct.pack('<I', 3) + struct.pack('<I', len(crx_header)) + crx_header + payload
+
+
+def _make_zip_payload() -> bytes:
+	"""A minimal but genuine zip archive holding an extension manifest."""
+	buffer = BytesIO()
+	with zipfile.ZipFile(buffer, 'w') as archive:
+		archive.writestr('manifest.json', '{"name": "test", "version": "1.0", "manifest_version": 3}')
+	return buffer.getvalue()
+
+
+@pytest.fixture
+def temp_dir(tmp_path, monkeypatch) -> Path:
+	"""Point tempfile at a private directory so leaked temp files are attributable."""
+	temp_root = tmp_path / 'tmp'
+	temp_root.mkdir()
+	monkeypatch.setattr(tempfile, 'tempdir', str(temp_root))
+	return temp_root
+
+
+def _leaked_zips(temp_dir: Path) -> list[Path]:
+	return list(temp_dir.glob('*.zip'))
+
+
+class TestExtractExtensionTempFileCleanup:
+	def test_no_temp_zip_left_behind_when_header_skip_extraction_fails(self, tmp_path, temp_dir):
+		"""Branch 2: a CRX whose payload is not a valid zip must not leak its temp .zip."""
+		crx_path = tmp_path / 'corrupt.crx'
+		crx_path.write_bytes(_make_crx(b'this is not a zip archive'))
+
+		profile = BrowserProfile()
+
+		with pytest.raises(zipfile.BadZipFile) as exc_info:
+			profile._extract_extension(crx_path, tmp_path / 'extracted')
+
+		# Pin the branch: the failure must come from the temp-file extraction in the
+		# header-skipping fallback, not from the initial in-place ZipFile attempt.
+		# Without this the leak assertion below could pass vacuously.
+		frames = traceback.extract_tb(exc_info.tb)
+		assert any(frame.line and 'ZipFile(temp_zip' in frame.line for frame in frames), (
+			f'expected the header-skipping branch to raise, got frames: {[f.line for f in frames]}'
+		)
+
+		assert _leaked_zips(temp_dir) == [], 'temp .zip survived a failed extraction'
+
+	def test_intact_crx_extracts_in_place_without_creating_a_temp_zip(self, tmp_path, temp_dir):
+		"""Branch 1: an intact CRX opens directly, so no temp file is ever created.
+
+		This does not exercise the fallback cleanup — it documents that the common
+		case never reaches it, and guards the method's overall no-leak invariant.
+		"""
+		crx_path = tmp_path / 'valid.crx'
+		crx_path.write_bytes(_make_crx(_make_zip_payload()))
+		extract_dir = tmp_path / 'extracted'
+
+		# Precondition for the branch this test claims to cover.
+		with zipfile.ZipFile(crx_path, 'r') as archive:
+			assert archive.namelist() == ['manifest.json']
+
+		profile = BrowserProfile()
+		profile._extract_extension(crx_path, extract_dir)
+
+		assert (extract_dir / 'manifest.json').exists()
+		assert _leaked_zips(temp_dir) == []
+
+
+class TestExtractExtensionCleanupErrors:
+	def test_cleanup_failure_does_not_mask_the_extraction_error(self, tmp_path, temp_dir, monkeypatch):
+		"""A failing unlink in the `finally` must not replace the real exception."""
+		crx_path = tmp_path / 'corrupt.crx'
+		crx_path.write_bytes(_make_crx(b'this is not a zip archive'))
+
+		original_unlink = Path.unlink
+
+		def failing_unlink(self, *args, **kwargs):
+			if self.suffix == '.zip':
+				raise PermissionError(32, 'The process cannot access the file')
+			return original_unlink(self, *args, **kwargs)
+
+		monkeypatch.setattr(Path, 'unlink', failing_unlink)
+
+		profile = BrowserProfile()
+
+		# The caller must still see BadZipFile, not the PermissionError from cleanup.
+		with pytest.raises(zipfile.BadZipFile):
+			profile._extract_extension(crx_path, tmp_path / 'extracted')


### PR DESCRIPTION
Fixes #5364

> **Correction (updated after review):** an earlier version of this description claimed the header-skipping branch is the normal path for every `.crx`. **That was wrong** — I repeated it from the issue report without verifying. Python's `zipfile` corrects central-directory offsets for prepended bytes, so an intact `.crx` opens on the first attempt. The corrected analysis is below; the leak itself is real either way.

## Why?

Loading a browser extension should not silently strand files on disk, and cleanup should never swallow the error that explains why extraction failed.

`_extract_extension()` writes the CRX payload to a `delete=False` temp file, which means Python will never clean it up — the function owns that file's lifetime entirely. It only deleted it on the happy path, and deleted it in a way Windows rejects.

**When is that branch actually reached?** `zipfile` scans backwards for the end-of-central-directory record and adjusts for prepended bytes — the same support that makes self-extracting archives work. So an intact `.crx` opens directly despite its `Cr24` header:

```
prepend      0 bytes -> OPENS OK ['manifest.json']
prepend     12 bytes -> OPENS OK ['manifest.json']
prepend  65536 bytes -> OPENS OK ['manifest.json']
```

The fallback is reached only when the payload is damaged enough that the first attempt fails. And since the *only* difference between the two inputs is the leading header, a payload that defeats the first attempt defeats the second too. I probed this directly:

| CRX | branch 1 (in place) | branch 2 (header-skipped) |
|---|---|---|
| intact | OK | *never reached* |
| truncated payload | BadZipFile | BadZipFile |
| garbage payload | BadZipFile | BadZipFile |

No input produces "branch 1 fails, branch 2 succeeds". **So the realistic behaviour of this branch is: enter, fail, leak a `.zip` that nothing will ever remove.** Every corrupt or truncated extension download leaves one behind, permanently and silently — the same accumulation shape as #5422 (7741 leaked temp dirs / 14GB observed).

The Windows half is narrower than I first claimed but still real: the unlink ran while `NamedTemporaryFile` held the file open, which POSIX allows and Windows rejects with `PermissionError: [WinError 32]`.

## What changed

```python
temp_zip_path = None
try:
	with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
		temp_zip_path = Path(temp_zip.name)
		temp_zip.write(zip_data)

	with zipfile.ZipFile(temp_zip_path, 'r') as zip_ref:
		zip_ref.extractall(extract_dir)
finally:
	if temp_zip_path is not None:
		try:
			temp_zip_path.unlink(missing_ok=True)
		except OSError as cleanup_error:
			logger.warning(f'Failed to remove temp file {_log_pretty_path(temp_zip_path)}: {cleanup_error}')
```

Three things: cleanup moved into `finally`; the write handle is closed before the file is reopened and removed; and the unlink is itself guarded, so a cleanup failure cannot replace the `BadZipFile` that is already propagating — which matters most precisely on the Windows lock this change is hardening against. Also dropped the `import os` that became unused.

Extraction failures still propagate unchanged — this only fixes cleanup, it does not swallow errors.

## Tests

`tests/ci/test_extension_extraction.py` — real CRX containers, real method calls, no browser. `tempfile.tempdir` is pointed at a per-test directory so a leaked file is unambiguously attributable.

Each test **pins which branch it exercises** rather than assuming, because that assumption is exactly what went wrong in my first draft of this PR:

- **`test_no_temp_zip_left_behind_when_header_skip_extraction_fails`** — corrupt payload. Asserts via the traceback that the failure really came from the header-skipping branch before asserting no leak, so the leak assertion cannot pass vacuously.
- **`test_intact_crx_extracts_in_place_without_creating_a_temp_zip`** — asserts up front that plain `ZipFile` opens the file, then documents that this common case never creates a temp file at all.
- **`test_cleanup_failure_does_not_mask_the_extraction_error`** — forces the unlink to raise `PermissionError` and requires the caller to still see `BadZipFile`.

Behaviour across revisions, verified by checking out each version:

| test | upstream `main` | first push of this PR | now |
|---|---|---|---|
| header-skip leak | **FAIL** | PASS | PASS |
| intact CRX | PASS | PASS | PASS |
| cleanup masks error | PASS¹ | **FAIL** | PASS |

¹ passes on `main` because `main` never reaches the unlink on the failure path — masking was a defect the first version of *this PR* introduced, caught in review.

## Verification

- `pytest tests/ci -k "extension or profile or download"` → 93 passed
- `ruff format --check` and `ruff check` clean
- `pyright` on `profile.py`: 55 errors before and after — unchanged, all pre-existing

## Noted but not fixed (out of scope)

A CRX with a corrupt end-of-central-directory offset raises `OSError: [Errno 22] Invalid argument` from the first attempt, which `except zipfile.BadZipFile` does not catch, so it escapes uncaught and the fallback never runs. Filed separately as #5506.

(An earlier revision of this section named `ValueError: negative seek value` — that is what an in-memory `BytesIO` raises; a real file on disk raises `OSError`. Corrected after checking against the actual method rather than my probe.)
