### PR TITLE
fix: preserve CHROME_DEFAULT_ARGS order when ignore_default_args is a list

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -896,7 +896,8 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		"""Get the list of all Chrome CLI launch args for this profile (compiled from defaults, user-provided, and system-specific)."""
 
 		if isinstance(self.ignore_default_args, list):
-			default_args = set(CHROME_DEFAULT_ARGS) - set(self.ignore_default_args)
+			ignored_args = set(self.ignore_default_args)
+			default_args = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_args]
 		elif self.ignore_default_args is True:
 			default_args = []
 		elif not self.ignore_default_args:

--- a/tests/ci/security/test_security_flags.py
+++ b/tests/ci/security/test_security_flags.py
@@ -81,3 +81,27 @@ class TestBrowserProfileDisableSecurity:
 		# Should have all test features without duplicates
 		expected_test_features = {'TestFeature1', 'TestFeature2', 'TestFeature3'}
 		assert expected_test_features.issubset(features), f'Missing test features: {expected_test_features - features}'
+
+	def test_ignore_default_args_list_preserves_order(self):
+		"""get_args() must keep CHROME_DEFAULT_ARGS' relative order when ignore_default_args is a list.
+
+		A prior implementation computed the surviving default args via a set
+		difference, which discards list order and made the launch args
+		non-deterministic across process/hash-seed variation.
+		"""
+		from browser_use.browser.profile import CHROME_DEFAULT_ARGS
+
+		ignored = {CHROME_DEFAULT_ARGS[2], CHROME_DEFAULT_ARGS[5]}
+		profile = BrowserProfile(
+			ignore_default_args=list(ignored),
+			user_data_dir=tempfile.mkdtemp(prefix='test-arg-order-'),
+		)
+		profile.detect_display_configuration()
+		args = profile.get_args()
+
+		expected_order = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored]
+		surviving_default_args = [arg for arg in args if arg in expected_order]
+
+		assert surviving_default_args == expected_order, (
+			f'Default args out of order: got {surviving_default_args}, expected {expected_order}'
+		)


### PR DESCRIPTION
Fixes #5397.

## Problem
`BrowserProfile.get_args()` computed the surviving default Chrome args via a set difference:

```python
default_args = set(CHROME_DEFAULT_ARGS) - set(self.ignore_default_args)
```

Set difference discards the original list order of `CHROME_DEFAULT_ARGS`, so whenever a caller passed `ignore_default_args` as a list, the resulting Chrome launch args came out in a non-deterministic order (varies across process/hash-seed).

## Fix
Replaced the set difference with an order-preserving filter:

```python
ignored_args = set(self.ignore_default_args)
default_args = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_args]
```

Traced the rest of `get_args()` (the `pre_conversion_args` build, the `--disable-features` merge, and the final dedup pass) to confirm nothing downstream re-derives order — everything else already uses plain lists/insertion-order dicts, so the fix is isolated to this one line.

## Test plan
- Added `test_ignore_default_args_list_preserves_order` to `tests/ci/security/test_security_flags.py`, following the repo's TDD convention: confirmed it fails against the pre-fix code (order scrambled), then passes after the fix.
- `uv run pytest -vxs tests/ci/security/test_security_flags.py` — 3/3 passed
- `uv run pytest -vxs tests/ci` — 482 passed, 34 skipped, 1 unrelated failure (`test_beta_agent_constructor_type_hints_match_browser_use_core_params`, a `Tools[~Context]` generic-identity assertion). Verified this failure is pre-existing test-order flakiness, not caused by this change: it passes in isolation both with and without this diff, and only fails when run deep inside the full suite — no code path connects it to `browser/profile.py`.
- `uv run ruff check` / `uv run ruff format --check` — clean
- `uv run pyright` — 0 errors
- `uv run pre-commit run --files browser_use/browser/profile.py tests/ci/security/test_security_flags.py` — all hooks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `CHROME_DEFAULT_ARGS` order when `ignore_default_args` is a list. Previously, `BrowserProfile.get_args()` used a set difference that scrambled order and made launch args nondeterministic; now it filters with an order-preserving list comprehension. Behavior with `ignore_default_args=True` or falsy is unchanged.

- Change is isolated to one line in `browser_use/browser/profile.py`; downstream logic already preserves order.
- Adds regression test `test_ignore_default_args_list_preserves_order` in `tests/ci/security/test_security_flags.py` to lock in ordering.

<sup>Written for commit 9ee78a0e191fe5eba67bba7f62d3dcbef3d41db1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

