### PR TITLE
build: require Browser Harness 0.1.10

### DIFF
--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -43,11 +43,22 @@ PY
 
 - Invoke as `browser-use`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
-- First navigation is `new_tab(url)`, not `goto_url(url)`.
+- First navigation for a task is `new_tab(url)`, not `goto_url(url)`. The daemon
+  preserves the attached tab across separate CLI invocations, so do not call
+  `new_tab()` again in every script.
+- Keep one working tab per task/site. Before opening another, inspect
+  `current_tab()` and `list_tabs()` and use `switch_tab()` to reuse a matching
+  tab. Do not leave duplicate tabs on the same URL or close tabs you did not
+  create.
 - `new_tab()` and `switch_tab()` attach and move the horse marker without
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
   background; call `activate_tab(target)` only when the user explicitly asks
   or a page demonstrably pauses rendering while hidden.
+- A timed-out `scroll(...)` on an attached background tab is evidence that the
+  page needs to be visible. Call `activate_tab(current_tab())`, retry the same
+  scroll once, then re-read the scroll position. This visibly switches tabs,
+  so do not use it when the user has forbidden foreground changes. Do not
+  invent a `Runtime.evaluate` scroll replacement or a cross-frame JS walker.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "markdownify==1.2.2",
     "python-docx==1.2.0",
     "browser-use-sdk==3.4.2",
-    "browser-harness==0.1.9",
+    "browser-harness==0.1.10",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -43,11 +43,22 @@ PY
 
 - Invoke as `browser-use`. Use heredocs for multi-line commands.
 - Helpers are pre-imported. `run.py` calls `ensure_daemon()` before `exec`.
-- First navigation is `new_tab(url)`, not `goto_url(url)`.
+- First navigation for a task is `new_tab(url)`, not `goto_url(url)`. The daemon
+  preserves the attached tab across separate CLI invocations, so do not call
+  `new_tab()` again in every script.
+- Keep one working tab per task/site. Before opening another, inspect
+  `current_tab()` and `list_tabs()` and use `switch_tab()` to reuse a matching
+  tab. Do not leave duplicate tabs on the same URL or close tabs you did not
+  create.
 - `new_tab()` and `switch_tab()` attach and move the horse marker without
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
   background; call `activate_tab(target)` only when the user explicitly asks
   or a page demonstrably pauses rendering while hidden.
+- A timed-out `scroll(...)` on an attached background tab is evidence that the
+  page needs to be visible. Call `activate_tab(current_tab())`, retry the same
+  scroll once, then re-read the scroll position. This visibly switches tabs,
+  so do not use it when the user has forbidden foreground changes. Do not
+  invent a `Runtime.evaluate` scroll replacement or a cross-frame JS walker.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome


### PR DESCRIPTION
## What Problem This Solves

Browser Use CLI 3.0 currently installs Browser Harness 0.1.9, so downstream agents cannot receive the hardened lifecycle, screenshot, privacy, and Cloud crash-recovery changes prepared for 0.1.10.

## Why This Change Was Made

- Pin the Browser Use package to Browser Harness 0.1.10.
- Keep the production dependency on a released PyPI artifact rather than a Git commit.
- Preserve the existing Browser Use CLI 3.0 and Python API behavior; this is only a dependency release pickup.

## Dependencies and rollout

This PR intentionally remains draft until all of the following are complete:

1. [Browser Use Cloud #5609](https://github.com/browser-use/cloud/pull/5609) is deployed with keyed-create recovery enabled.
2. Browser Harness [#626](https://github.com/browser-use/browser-harness/pull/626), [#634](https://github.com/browser-use/browser-harness/pull/634), and [#636](https://github.com/browser-use/browser-harness/pull/636) are merged.
3. Browser Harness 0.1.10 is published to PyPI.

## User Impact

New Browser Use installs will pick up the hardened Browser Harness release automatically. Existing Browser Use CLI 3.0 behavior and the model-facing contract are unchanged.

## Evidence

- `uv build --wheel --out-dir /tmp/browser-use-wheel-check` passed.
- Built wheel metadata contains `Requires-Dist: browser-harness==0.1.10`.
- The exact source stack was evaluated with Browser Use `85ddbfedf609166b2d2c76c3d80506649fee82a9` and combined Browser Harness candidate `d98ccca17a17c362fe315cc220ddb1cb069b7b4b`: 92/106 semantic passes, 106/106 explicit Cloud-browser stops, zero Harness IPC timeouts, and zero screenshot capture errors.

Blocked until Browser Harness 0.1.10 is published to PyPI.
