### PR TITLE
fix(deps): bump anthropic to 1.0.0 and route sampling params via `extra_body`

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -4,7 +4,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
-import httpx
+# Imported eagerly because httpx2 defers it to the first client construction, which performs
+# blocking I/O when that construction happens inside the event loop.
+import httpcore2  # noqa: F401
+import httpx2
 from anthropic import (
 	APIConnectionError,
 	APIStatusError,
@@ -34,6 +37,17 @@ T = TypeVar('T', bound=BaseModel)
 _TEXT_TOOL_CALL_PARAMETER = re.compile(r'<parameter name="([^"]+)">(.*?)(?:</parameter>|</\1>)', re.DOTALL)
 
 
+def _to_httpx2_timeout(timeout: float | Timeout | httpx2.Timeout | None | NotGiven) -> float | httpx2.Timeout | None | NotGiven:
+	"""Rebuild a legacy `httpx.Timeout` as the `httpx2.Timeout` the Anthropic SDK now takes.
+
+	`AsyncAnthropic` accepts a legacy `httpx.Timeout` at construction and then fails at request time,
+	surfacing as an `APIConnectionError`. Everything else passes through unchanged.
+	"""
+	if isinstance(timeout, Timeout):
+		return httpx2.Timeout(connect=timeout.connect, read=timeout.read, write=timeout.write, pool=timeout.pool)
+	return timeout
+
+
 @dataclass
 class ChatAnthropic(BaseChatModel):
 	"""
@@ -45,7 +59,7 @@ class ChatAnthropic(BaseChatModel):
 	max_tokens: int = 8192
 	temperature: float | None = None
 	top_p: float | None = None
-	seed: int | None = None
+	seed: int | None = None  # not sent: the Anthropic Messages API has no seed parameter
 	output_config: dict[str, Any] | None = None
 	thinking: dict[str, Any] | None = None
 	betas: list[str] | None = None
@@ -55,12 +69,12 @@ class ChatAnthropic(BaseChatModel):
 	# Client initialization parameters
 	api_key: str | None = None
 	auth_token: str | None = None
-	base_url: str | httpx.URL | None = None
-	timeout: float | Timeout | None | NotGiven = NotGiven()
+	base_url: str | httpx2.URL | None = None
+	timeout: float | Timeout | httpx2.Timeout | None | NotGiven = NotGiven()
 	max_retries: int = 10
 	default_headers: Mapping[str, str] | None = None
 	default_query: Mapping[str, object] | None = None
-	http_client: httpx.AsyncClient | None = None
+	http_client: httpx2.AsyncClient | None = None
 
 	# Static
 	@property
@@ -74,7 +88,7 @@ class ChatAnthropic(BaseChatModel):
 			'api_key': self.api_key,
 			'auth_token': self.auth_token,
 			'base_url': self.base_url,
-			'timeout': self.timeout,
+			'timeout': _to_httpx2_timeout(self.timeout),
 			'max_retries': self.max_retries,
 			'default_headers': self.default_headers,
 			'default_query': self.default_query,
@@ -124,6 +138,21 @@ class ChatAnthropic(BaseChatModel):
 		return betas
 
 	def _get_extra_body_for_invoke(self) -> dict[str, Any] | None:
+		"""Build the `extra_body` the SDK merges into the top-level request JSON.
+
+		`anthropic>=1` dropped `temperature` and `top_p` from `messages.create()`, where passing either
+		is now a `TypeError`. The API still accepts them, so they travel through `extra_body` -- the
+		route the SDK migration guide names -- instead of being dropped. Entries set explicitly on this
+		model win over the sampling values on a name collision.
+		"""
+		sampling: dict[str, Any] = {}
+
+		if self.temperature is not None:
+			sampling['temperature'] = self.temperature
+
+		if self.top_p is not None:
+			sampling['top_p'] = self.top_p
+
 		extra_body: dict[str, Any] = {}
 
 		if self.output_config is not None:
@@ -135,7 +164,7 @@ class ChatAnthropic(BaseChatModel):
 		if self.inference_geo is not None:
 			extra_body['inference_geo'] = self.inference_geo
 
-		return extra_body or None
+		return {**sampling, **extra_body} or None
 
 	def _get_client_params_for_invoke(self) -> dict[str, Any]:
 		"""Prepare client parameters dictionary for invoke."""
@@ -143,17 +172,8 @@ class ChatAnthropic(BaseChatModel):
 
 		client_params = {}
 
-		if self.temperature is not None:
-			client_params['temperature'] = self.temperature
-
 		if self.max_tokens is not None:
 			client_params['max_tokens'] = self.max_tokens
-
-		if self.top_p is not None:
-			client_params['top_p'] = self.top_p
-
-		if self.seed is not None:
-			client_params['seed'] = self.seed
 
 		if self.thinking is not None:
 			client_params['thinking'] = self.thinking

--- a/browser_use/llm/aws/chat_anthropic.py
+++ b/browser_use/llm/aws/chat_anthropic.py
@@ -45,7 +45,7 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 	top_p: float | None = None
 	top_k: int | None = None
 	stop_sequences: list[str] | None = None
-	seed: int | None = None
+	seed: int | None = None  # not sent: the Anthropic Messages API has no seed parameter
 
 	# AWS credentials and configuration
 	aws_access_key: str | None = None
@@ -99,21 +99,29 @@ class ChatAnthropicBedrock(ChatAWSBedrock):
 		return client_params
 
 	def _get_client_params_for_invoke(self) -> dict[str, Any]:
-		"""Prepare client parameters dictionary for invoke."""
-		client_params = {}
+		"""Prepare client parameters dictionary for invoke.
 
-		if self.temperature is not None:
-			client_params['temperature'] = self.temperature
+		`anthropic>=1` dropped `temperature`/`top_p`/`top_k` from `messages.create()`, where passing
+		one is now a `TypeError`. Bedrock still accepts them in the request body, so they travel
+		through `extra_body` -- the route the SDK migration guide names -- which merges them into the
+		top-level request JSON.
+		"""
+		client_params: dict[str, Any] = {}
+
 		if self.max_tokens is not None:
 			client_params['max_tokens'] = self.max_tokens
-		if self.top_p is not None:
-			client_params['top_p'] = self.top_p
-		if self.top_k is not None:
-			client_params['top_k'] = self.top_k
-		if self.seed is not None:
-			client_params['seed'] = self.seed
 		if self.stop_sequences is not None:
 			client_params['stop_sequences'] = self.stop_sequences
+
+		extra_body: dict[str, Any] = {}
+		if self.temperature is not None:
+			extra_body['temperature'] = self.temperature
+		if self.top_p is not None:
+			extra_body['top_p'] = self.top_p
+		if self.top_k is not None:
+			extra_body['top_k'] = self.top_k
+		if extra_body:
+			client_params['extra_body'] = extra_body
 
 		return client_params
 

--- a/browser_use/logging_config.py
+++ b/browser_use/logging_config.py
@@ -209,6 +209,7 @@ def setup_logging(stream=None, log_level=None, force_setup=False, debug_log_file
 	third_party_loggers = [
 		'WDM',
 		'httpx',
+		'httpx2',
 		'selenium',
 		'playwright',
 		'urllib3',
@@ -217,6 +218,7 @@ def setup_logging(stream=None, log_level=None, force_setup=False, debug_log_file
 		'langsmith.client',
 		'openai',
 		'httpcore',
+		'httpcore2',
 		'charset_normalizer',
 		'anthropic._base_client',
 		'PIL.PngImagePlugin',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "uuid7==0.1.0",
     "google-genai==1.65.0",
     "openai==2.16.0",
-    "anthropic==0.76.0",
+    "anthropic==1.0.0",
     "groq==1.0.0",
     "ollama==0.6.1",
     "google-api-python-client==2.188.0",

--- a/tests/ci/test_anthropic_serialized_tool_input.py
+++ b/tests/ci/test_anthropic_serialized_tool_input.py
@@ -1,9 +1,14 @@
 """Regression test: when Claude calls the tool but writes the whole call out as text inside a
 single string argument, the arguments must be recovered instead of failing validation with a
-misleading 'Field required' error for the fields that were never populated."""
+misleading 'Field required' error for the fields that were never populated.
+
+Also covers the request shaping the `anthropic>=1` migration moved: sampling settings now reach the
+API through `extra_body`, and a caller's legacy `httpx.Timeout` is converted before the SDK sees it.
+"""
 
 import json
 
+import httpx
 import pytest
 from pydantic import BaseModel
 
@@ -112,6 +117,57 @@ async def test_serialized_tool_call_outside_thinking_is_not_recovered(httpserver
 		await _chat(httpserver).ainvoke([UserMessage(content='next step')], output_format=StepOutput)
 
 	assert 'action' in str(exc_info.value)
+
+
+async def test_sampling_settings_reach_the_wire(httpserver):
+	"""`anthropic>=1` dropped `temperature`/`top_p` from `messages.create()`, so they ride in `extra_body`.
+
+	Asserted on the wire rather than on the SDK call: `extra_body` arriving at the client says nothing
+	about the request body it then builds. The settings routed through `extra_body` before this change
+	(here `inference_geo`) must still land alongside them.
+	"""
+	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(
+		_tool_use_response({'thinking': 'Clicking submit.', 'action': []})
+	)
+	chat = ChatAnthropic(
+		model='claude-sonnet-5',
+		api_key='test-key',
+		base_url=httpserver.url_for('/'),
+		temperature=0.2,
+		top_p=0.9,
+		inference_geo='us',
+	)
+
+	await chat.ainvoke([UserMessage(content='next step')], output_format=StepOutput)
+
+	request, _ = httpserver.log[0]
+	body = request.get_json()
+	assert body['temperature'] == 0.2
+	assert body['top_p'] == 0.9
+	assert body['inference_geo'] == 'us'
+	assert 'extra_body' not in body
+
+
+async def test_legacy_httpx_timeout_still_works(httpserver):
+	"""A caller's `httpx.Timeout` must be rebuilt as the `httpx2.Timeout` the SDK now takes.
+
+	`AsyncAnthropic` accepts the legacy object at construction and only trips over it once it issues
+	the request, where the `TypeError` surfaces as an unrelated-looking `APIConnectionError`.
+	"""
+	actions = [{'click_element_by_index': {'index': 5}}]
+	httpserver.expect_request('/v1/messages', method='POST').respond_with_json(
+		_tool_use_response({'thinking': 'Clicking submit.', 'action': actions})
+	)
+	chat = ChatAnthropic(
+		model='claude-sonnet-5',
+		api_key='test-key',
+		base_url=httpserver.url_for('/'),
+		timeout=httpx.Timeout(30.0, connect=5.0),
+	)
+
+	result = await chat.ainvoke([UserMessage(content='next step')], output_format=StepOutput)
+
+	assert result.completion.action == actions
 
 
 async def test_unrecoverable_tool_input_still_raises(httpserver):


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

Bumps the exact pin `anthropic==0.76.0` -> `anthropic==1.0.0` and migrates the two Anthropic wrappers to the 1.x SDK surface. This is a bump, not a loosening: the pin stays exact, per this repo's dependency policy.

Motivation: pydantic-ai (2.33.0 at the time of writing) floors `anthropic>=1.0.0` (pydantic/pydantic-ai#7657), so the `==0.76.0` pin deadlocks any environment that installs browser-use alongside it. Same situation as the openai pin, addressed in a separate PR.

anthropic 1.0.0 removed `temperature`/`top_p`/`top_k`/`seed` from `messages.create()` (passing one is now a `TypeError`) and moved its HTTP layer from httpx to httpx2. Migration guide: <https://github.com/anthropics/anthropic-sdk-python/blob/main/MIGRATION.md>

## Changes

- `browser_use/llm/anthropic/chat.py`
  - `temperature`/`top_p` now travel via `extra_body`, which the SDK merges into the top-level request JSON -- the route the migration guide names for removed request params. `seed` is dropped instead of rerouted: the Messages API has no `seed` parameter, so forwarding it was already a `TypeError` on 0.76 and no request ever carried it. The dataclass field stays so existing constructor calls keep working.
  - `base_url`/`timeout`/`http_client` follow `AsyncAnthropic` onto httpx2 types. A caller's legacy `httpx.Timeout` is converted before the SDK sees it: `AsyncAnthropic` accepts the legacy object at construction and only fails at request time, where the `TypeError` surfaces as an unrelated-looking `APIConnectionError`.
  - `httpcore2` is imported eagerly at module level: httpx2 otherwise defers that import to the first client construction, which performs blocking I/O inside the event loop.
- `browser_use/llm/aws/chat_anthropic.py`: same `extra_body` routing for `temperature`/`top_p`/`top_k`, same `seed` drop, for `ChatAnthropicBedrock`.
- `browser_use/logging_config.py`: `httpx2` and `httpcore2` join the silenced third-party loggers next to their `httpx`/`httpcore` counterparts (logger names verified from the installed packages).
- `tests/ci/test_anthropic_serialized_tool_input.py`: two new fake-wire tests. One asserts `temperature`/`top_p` (and the pre-existing `inference_geo` extra-body entry) land top-level in the request JSON with no literal `extra_body` key; asserting what reaches the SDK call would prove nothing once routing goes through `extra_body`. The other asserts a request built with a legacy `httpx.Timeout` still completes.

Notes for review:

- httpx and httpx2 are separate distributions and coexist. The repo's own `httpx==0.28.1` pin and every non-Anthropic HTTP path are untouched; groq/ollama still require legacy httpx and are untouched.
- `httpx2`/`httpcore2` are now imported directly by `browser_use/llm/anthropic/chat.py` but arrive transitively via the `anthropic` pin. Happy to add explicit pins if you want direct imports declared.
- TLS behavior change inherited from the SDK: httpx2 verifies against the OS trust store (via truststore) rather than certifi.
- `requires-python = ">=3.11"` is unaffected (the SDK's new floor is 3.10).

## Verification

Fork CI skips live tests, so a local live run is the only real-provider proof; ran with a real `ANTHROPIC_API_KEY`:

- One real `messages.create` through `ChatAnthropic` with `temperature` set and a legacy `httpx.Timeout`: completion returned normally. A run with both `temperature` and `top_p` set returned the API's "cannot both be specified for this model" 400, i.e. both params reached the API top-level through `extra_body`.
- `uv run pytest tests/ci`: passes. The two `test_beta_agent.py` failures reproduce identically on the base commit (`85ddbfedf`) and never occur in CI, which runs each test file as its own matrix job.
- `browser_use/llm/tests/test_anthropic_cache.py` is in no CI path, so it was run manually: 18/18 pass.
- `uv run pyright` (all three `include` roots): 0 errors. `ruff check`, `ruff format --check`, `pre-commit run --all-files`: all pass.
- Swept the wrappers for every other MIGRATION.md removal (`messages.stream`/`parse`/`count_tokens`/`batches`, `with_raw_response`, `HUMAN_PROMPT`, `completions.create`, `Transport`, `tool_runner`): no hits.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `anthropic` to `1.0.0` and migrates our Anthropic chat wrappers to the 1.x SDK. Old behavior passed `temperature`/`top_p`/`top_k` to `messages.create()` and used `httpx`; new behavior routes those via `extra_body`, ignores `seed`, and uses `httpx2`.

- Routes `temperature`/`top_p` (and Bedrock `top_k`) via `extra_body`; the API still receives them at the top level. `seed` remains a field for compatibility but is not sent.
- Migrates client types to `httpx2`; legacy `httpx.Timeout` is converted internally. Required: update any custom `httpx.AsyncClient` to `httpx2.AsyncClient`.
- Eagerly imports `httpcore2` to avoid blocking I/O on first client creation and silences `httpx2`/`httpcore2` loggers.
- Other HTTP paths stay on `httpx`; their pins and behavior are unchanged.

<sup>Written for commit 4bb152e9d2a10b9717c5167345dd18ea2544177e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


