### PR TITLE
 fix(eventbus): prevent cross-loop contamination in bubus EventBus

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -43,6 +43,22 @@ def _patched_del(self):
 base_subprocess.BaseSubprocessTransport.__del__ = _patched_del
 
 
+# Patch bubus 1.x's cross-loop EventBus contamination bug
+# (https://github.com/browser-use/browser-use/issues/5509) until a fixed bubus is released.
+# Without this, parallel agent sessions on separate event loops can run one bus's handlers
+# on another bus's loop, where they hang and pile up until the bus hits its 100-event
+# capacity. See browser_use/bubus_compat.py.
+try:
+	from browser_use.bubus_compat import apply_bubus_compat_patches
+
+	apply_bubus_compat_patches()
+except ImportError:
+	# bubus is a hard dependency of browser-use (pinned in pyproject.toml), but guard the
+	# compat patch anyway so a bare `import browser_use` can never hard-fail on a missing or
+	# partially-installed bubus.
+	pass
+
+
 # Type stubs for lazy imports - fixes linter warnings
 if TYPE_CHECKING:
 	from browser_use.agent.prompts import SystemPrompt

--- a/browser_use/bubus_compat.py
+++ b/browser_use/bubus_compat.py
@@ -1,0 +1,160 @@
+"""Compatibility patches for the pinned ``bubus`` library (browser-use/browser-use#5509).
+
+bubus 1.5.6's ``BaseEvent.__await__`` has a cross-loop contamination bug. When an event is
+awaited from inside a handler that holds the global processing lock, ``__await__`` enters a
+drain/polling loop that iterates ``EventBus.all_instances`` — the process-global WeakSet of
+*every* bus, regardless of which event loop each bus was started on — and calls
+``await bus.process_event(...)`` for any bus with a queued event. Handlers therefore run on
+the awaiting task's event loop, which in a multi-loop application (e.g. several parallel
+agent sessions, each on its own loop) is the *wrong* loop for that bus. They hang forever,
+events pile up in the ``started`` state, and the bus eventually hits its 100-event capacity
+and ``dispatch()`` raises ``RuntimeError: EventBus at capacity: 100 pending events (100 max)``.
+
+The fix (tracked upstream in browser-use/bubus#30, not yet released into the ``bubus==1.5.6``
+pin) is to make the drain loop only touch buses that were started on the current running
+loop — every other bus is already drained by its own ``_run_loop`` task on its own loop.
+
+This module carries that fix into browser-use as an idempotent compatibility patch:
+- ``EventBus._loop`` records the event loop a bus's ``_start()`` ran on.
+- ``BaseEvent.__await__`` skips buses whose ``_loop`` differs from the current running loop
+  and buses that are no longer running.
+
+The patch is a no-op when bubus already tracks ``EventBus._loop``, i.e. once upstream ships
+the fix.
+"""
+
+import asyncio
+import logging
+
+_logger = logging.getLogger('bubus')
+
+# Marker attribute set on ``EventBus`` once these patches have been applied.
+_PATCH_MARKER = '_browser_use_cross_loop_patched'
+
+
+def is_bubus_cross_loop_fixed() -> bool:
+	"""Return True when the cross-loop drain protection is active.
+
+	Either the local compat patch was applied, or the installed bubus already carries
+	the upstream fix (it tracks ``EventBus._loop``).
+	"""
+	from bubus.service import EventBus
+
+	return getattr(EventBus, _PATCH_MARKER, False) or hasattr(EventBus, '_loop')
+
+
+def apply_bubus_compat_patches() -> bool:
+	"""Apply the local bubus compat patches; idempotent and safe to call repeatedly.
+
+	Returns True when a patch was applied by this call. Returns False (and does nothing)
+	when the patches were already applied or when an installed bubus already ships the
+	upstream fix (i.e. it tracks ``EventBus._loop``).
+	"""
+	from bubus.models import BaseEvent
+	from bubus.service import EventBus
+
+	if getattr(EventBus, _PATCH_MARKER, False) or hasattr(EventBus, '_loop'):
+		return False
+
+	_original_start = EventBus._start  # type: ignore[attr-defined]
+
+	def _patched_start(self: EventBus) -> None:
+		"""Record the owning event loop so BaseEvent.__await__ can stay on-loop."""
+		_original_start(self)
+		try:
+			loop = asyncio.get_running_loop()
+		except RuntimeError:
+			# No loop running: _start() no-ops, nothing to record.
+			return
+		if self._is_running:
+			setattr(self, '_loop', loop)
+
+	setattr(EventBus, '_start', _patched_start)
+
+	def _patched_base_event_await(self: BaseEvent):
+		"""bubus.models.BaseEvent.__await__ that never drains another loop's buses."""
+
+		async def wait_for_handlers_to_complete_then_return_event():
+			assert self.event_completed_signal is not None
+
+			# If we're inside a handler and this event isn't complete yet,
+			# we need to process it immediately to avoid deadlock
+			from bubus.service import EventBus, holds_global_lock, inside_handler_context
+
+			if not self.event_completed_signal.is_set() and inside_handler_context.get() and holds_global_lock.get():
+				# We're inside a handler and hold the global lock
+				# Process events until this one completes
+
+				# Keep processing events from this loop's buses until this event is complete
+				max_iterations = 1000  # Prevent infinite loops
+				iterations = 0
+
+				current_loop = asyncio.get_running_loop()
+
+				try:
+					while not self.event_completed_signal.is_set() and iterations < max_iterations:
+						iterations += 1
+						processed_any = False
+
+						# Process any queued events on buses owned by THIS event loop only.
+						# Create a list copy to avoid "Set changed size during iteration" error
+						for bus in list(EventBus.all_instances):
+							if not bus or not bus.event_queue:
+								continue
+
+							# Only drain running buses that belong to the current event loop.
+							# Draining a bus owned by another loop runs its handlers on the wrong
+							# loop, where they hang forever and pile up until the bus hits its
+							# capacity limit (cross-loop contamination, browser-use/browser-use#5509).
+							# Each bus's own _run_loop drains it on its own loop. Skip buses that
+							# haven't started (_loop is None) or have been stopped (_is_running is
+							# False) — a stopped bus can keep _loop set with events still queued, and
+							# nothing should run its handlers after stop().
+							if not bus._is_running or getattr(bus, '_loop', None) is not current_loop:
+								continue
+
+							# Process one event from this bus if available
+							try:
+								if bus.event_queue.qsize() > 0:
+									event = bus.event_queue.get_nowait()
+									await bus.process_event(event)
+									bus.event_queue.task_done()
+									processed_any = True
+									# Check if the event we're waiting for is now complete
+									if self.event_completed_signal.is_set():
+										break
+							except asyncio.QueueEmpty:
+								pass
+
+						# Break out of the loop if event completed after processing
+						if self.event_completed_signal.is_set():
+							break
+
+						if not processed_any:
+							# No events to process, yield control and check for cancellation
+							try:
+								await asyncio.sleep(0)
+							except asyncio.CancelledError:
+								raise
+				except asyncio.CancelledError:
+					# Handler was cancelled due to timeout, exit cleanly
+					_logger.debug(f'Polling loop cancelled for {self}')
+					raise
+
+				if iterations >= max_iterations:
+					# logger.error(f'Max iterations reached while waiting for {self}')
+					pass
+			else:
+				# Not in handler context - wait for the event to complete normally
+				await self.event_completed_signal.wait()
+
+			# Return the completed event without raising errors.
+			# Errors should only be raised when explicitly requested via event_result() methods.
+			return self
+
+		return wait_for_handlers_to_complete_then_return_event().__await__()
+
+	setattr(BaseEvent, '__await__', _patched_base_event_await)
+
+	setattr(EventBus, _PATCH_MARKER, True)
+	return True

--- a/tests/ci/test_bubus_cross_loop_isolation.py
+++ b/tests/ci/test_bubus_cross_loop_isolation.py
@@ -1,0 +1,133 @@
+"""Regression tests for bubus cross-loop contamination (browser-use/browser-use#5509).
+
+bubus 1.5.6's ``BaseEvent.__await__`` has a drain loop that processes events from
+*every* ``EventBus`` in the process, regardless of which event loop each bus was
+started on. In a multi-loop application (e.g. parallel agent sessions, each on its
+own loop) that runs one bus's handlers on another bus's loop, where they hang and
+pile up until the bus hits its capacity limit:
+
+    RuntimeError: EventBus at capacity: 100 pending events (100 max)
+
+browser-use carries the upstream fix (browser-use/bubus#30 -- not yet released)
+locally in ``browser_use.bubus_compat``. These tests lock the fix in: they fail
+when run against an unpatched bubus 1.5.6.
+"""
+
+import asyncio
+import threading
+
+from bubus import BaseEvent, EventBus
+
+from browser_use.bubus_compat import apply_bubus_compat_patches, is_bubus_cross_loop_fixed
+
+
+class BlockerEvent(BaseEvent):
+	pass
+
+
+class ProbeEvent(BaseEvent):
+	pass
+
+
+class ParentEvent(BaseEvent):
+	pass
+
+
+def _spin_loop(loop: asyncio.AbstractEventLoop) -> None:
+	asyncio.set_event_loop(loop)
+	loop.run_forever()
+
+
+async def _dispatch_probe(bus: EventBus) -> ProbeEvent:
+	return bus.dispatch(ProbeEvent())
+
+
+async def _await_probe(probe: ProbeEvent) -> None:
+	await probe
+
+
+def test_cross_loop_fix_is_active_or_upstream():
+	"""The cross-loop guard must be effective (local patch or upstream bubus fix)."""
+	assert is_bubus_cross_loop_fixed()
+
+
+async def test_await_drain_does_not_process_other_loops_buses():
+	"""A bus on another loop must never be drained by BaseEvent.__await__ on this loop."""
+	apply_bubus_compat_patches()
+
+	loop_a = asyncio.get_running_loop()
+
+	# --- Bus B lives on its own event loop, running in a background thread ---
+	loop_b = asyncio.new_event_loop()
+	thread = threading.Thread(target=_spin_loop, args=(loop_b,), daemon=True)
+	thread.start()
+
+	ran_on: dict[str, int] = {}
+	release_blocker = threading.Event()
+	bus_a: EventBus | None = None
+
+	async def blocker_handler(event: BlockerEvent) -> None:
+		# Occupy bus B's serial processing so its own run loop cannot advance the
+		# ProbeEvent. That way the *only* thing that could move the ProbeEvent while
+		# the blocker is held is a (buggy) cross-loop drain from loop A.
+		while not release_blocker.is_set():  # noqa: ASYNC110
+			await asyncio.sleep(0.01)
+
+	async def probe_handler(event: ProbeEvent) -> None:
+		ran_on['probe'] = id(asyncio.get_running_loop())
+
+	async def build_bus_b() -> EventBus:
+		b = EventBus(name='BusB')
+		b.on(BlockerEvent, blocker_handler)
+		b.on(ProbeEvent, probe_handler)
+		b.dispatch(BlockerEvent())  # starts B's run loop and keeps it busy
+		return b
+
+	bus_b = asyncio.run_coroutine_threadsafe(build_bus_b(), loop_b).result(timeout=5)
+
+	try:
+		# Create the probe on loop B; it sits queued behind the blocker.
+		probe = await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(_dispatch_probe(bus_b), loop_b))
+		await asyncio.sleep(0.1)
+		assert bus_b.event_queue is not None and bus_b.event_queue.qsize() >= 1
+
+		# --- Bus A: a handler on loop A awaits bus B's probe event -> enters the drain ---
+		bus_a = EventBus(name='BusA')
+
+		async def parent_handler(event: ParentEvent) -> None:
+			# Awaiting from inside a handler (holding the global lock) triggers the
+			# cross-bus drain loop. Give it a bounded window to (wrongly) pick up the
+			# probe from bus B, then stop waiting so the test can assert.
+			try:
+				await asyncio.wait_for(_await_probe(probe), timeout=0.4)
+			except asyncio.TimeoutError:
+				pass
+
+		bus_a.on(ParentEvent, parent_handler)
+		await bus_a.dispatch(ParentEvent())
+
+		# Give loop A's drain loop a chance to (wrongly) steal the probe from bus B.
+		await asyncio.sleep(0.6)
+
+		# The probe belongs to bus B's loop. Loop A must NOT have run it.
+		assert ran_on.get('probe') != id(loop_a), "ProbeEvent from bus B ran on bus A's loop — cross-loop contamination"
+
+		# Once bus B is free, its own loop processes the probe — on loop B.
+		release_blocker.set()
+		for _ in range(200):
+			if 'probe' in ran_on:
+				break
+			await asyncio.sleep(0.05)
+		assert ran_on.get('probe') == id(loop_b), f"ProbeEvent did not run on bus B's own loop: {ran_on}"
+	finally:
+		# Always tear down, even if an assertion above fails, so a failing run
+		# never leaks bus B's still-spinning run loop or its background thread
+		# into later tests.
+		release_blocker.set()
+		try:
+			asyncio.run_coroutine_threadsafe(bus_b.stop(), loop_b).result(timeout=5)
+		finally:
+			if bus_a is not None:
+				await bus_a.stop()
+			loop_b.call_soon_threadsafe(loop_b.stop)
+			thread.join(timeout=5)


### PR DESCRIPTION
Fixes #5509 


This PR fixes a cross-loop bug in bubus==1.5.6 that causes parallel agent sessions to fail with:
RuntimeError: EventBus at capacity: 100 pending events (100 max).
Queue: 50, Processing: 50. Cannot accept new events until some complete.


Root cause
BaseEvent.__await__ drains every EventBus in the process (EventBus.all_instances) regardless of which event loop each bus belongs to. When handlers await child events while holding the global lock, the drain loop runs other buses' handlers on the wrong event loop — where they hang, pile up, and overflow the bus capacity.


The fix
- Track each bus's owning event loop and make the __await__ drain only process buses on the current loop (every other bus is drained by its own run loop).
- Applied as an idempotent patch in browser_use/bubus_compat.py, wired up at import time in browser_use/__init__.py.
- The patch auto-no-ops once a fixed bubus is released.
- Added a regression test (tests/ci/test_bubus_cross_loop_isolation.py) that fails on unpatched bubus and passes with the fix.


Tests
- New isolation test: 2 passed
- Existing test_event_bus_resilience.py: 5 passed
- ruff, pyright, codespell: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross-loop event processing in `bubus` so parallel agent sessions no longer hang and hit the 100-event capacity. Old: `BaseEvent.__await__` drained every process-wide `EventBus`, running handlers on the wrong loop; New: it only drains buses on the current loop, leaving others to their own run loops.

- Adds `browser_use/bubus_compat.py`: records an `EventBus`’s owning loop in `_start` and patches `BaseEvent.__await__` to skip buses not on the current loop or that are stopped; idempotent and auto no-op once upstream `bubus` exposes `_loop`.
- Wires the patch at import time in `browser_use/__init__.py`, guarded with `try/except ImportError` so `import browser_use` never hard-fails.
- Adds `tests/ci/test_bubus_cross_loop_isolation.py` to lock the behavior; existing resilience tests remain green.

<sup>Written for commit 3c657dd362b1453b3a59bb18bd8e7678d6d075a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

