### PR TITLE
fix(dom): detect native disabled attribute in pagination buttons

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -1196,8 +1196,13 @@ class DomService:
 			# as EMPTY STRINGS, not 'true'. So the presence of the attribute means disabled,
 			# regardless of value. aria-disabled="" is ambiguous per the ARIA spec, so only
 			# an explicit 'true' counts there.
+			# The native `disabled` attribute is only meaningful on form controls; on other
+			# elements (e.g. <a>, <div>) it is inert per the HTML spec, so scope the presence
+			# check to form controls and keep the aria-disabled/class checks element-agnostic.
+			tag = node.tag_name
+			is_form_control = tag in ('button', 'input', 'select', 'textarea', 'option', 'optgroup', 'fieldset')
 			is_disabled = (
-				node.attributes.get('disabled') is not None
+				(is_form_control and node.attributes.get('disabled') is not None)
 				or node.attributes.get('aria-disabled') == 'true'
 				or 'disabled' in class_name
 			)

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -1192,8 +1192,12 @@ class DomService:
 			all_text = f'{text} {aria_label} {title} {class_name}'.strip()
 
 			# Check if it's disabled
+			# NOTE: CDP's DOM.getDocument parses HTML boolean attributes (e.g. <button disabled>)
+			# as EMPTY STRINGS, not 'true'. So the presence of the attribute means disabled,
+			# regardless of value. aria-disabled="" is ambiguous per the ARIA spec, so only
+			# an explicit 'true' counts there.
 			is_disabled = (
-				node.attributes.get('disabled') == 'true'
+				node.attributes.get('disabled') is not None
 				or node.attributes.get('aria-disabled') == 'true'
 				or 'disabled' in class_name
 			)

--- a/tests/ci/test_pagination_disabled_detection.py
+++ b/tests/ci/test_pagination_disabled_detection.py
@@ -16,12 +16,13 @@ def _pagination_node(
 	backend_node_id: int,
 	text: str = 'Next',
 	attributes: dict[str, str] | None = None,
+	tag: str = 'BUTTON',
 ) -> EnhancedDOMTreeNode:
 	return EnhancedDOMTreeNode(
 		node_id=backend_node_id,
 		backend_node_id=backend_node_id,
 		node_type=NodeType.ELEMENT_NODE,
-		node_name='BUTTON',
+		node_name=tag,
 		node_value='',
 		attributes=attributes or {},
 		is_scrollable=False,
@@ -138,3 +139,45 @@ def test_enabled_button_is_not_disabled():
 	node = _with_text(_pagination_node(backend_node_id=1), 'Next')
 	buttons = _detect([node])
 	assert buttons[0]['is_disabled'] is False
+
+
+def test_disabled_attribute_on_anchor_is_inert():
+	"""The native `disabled` attribute is inert on non-form elements per HTML:
+	<a disabled> still navigates, so it must NOT be reported as disabled."""
+	node = _with_text(
+		_pagination_node(backend_node_id=1, attributes={'disabled': ''}, tag='A'),
+		'Next',
+	)
+	buttons = _detect([node])
+	assert buttons[0]['is_disabled'] is False
+
+
+def test_disabled_attribute_on_div_is_inert():
+	"""<div disabled> is a common (invalid) authoring pattern; the attribute has
+	no HTML semantics there, so only aria-disabled / class-based signals count."""
+	node = _with_text(
+		_pagination_node(backend_node_id=1, attributes={'disabled': ''}, tag='DIV'),
+		'Next',
+	)
+	buttons = _detect([node])
+	assert buttons[0]['is_disabled'] is False
+
+
+def test_aria_disabled_on_anchor_still_counts():
+	"""aria-disabled is element-agnostic — it applies to links too."""
+	node = _with_text(
+		_pagination_node(backend_node_id=1, attributes={'aria-disabled': 'true'}, tag='A'),
+		'Next',
+	)
+	buttons = _detect([node])
+	assert buttons[0]['is_disabled'] is True
+
+
+def test_disabled_attribute_on_input_is_disabled():
+	"""<input disabled> is a form control — presence still means disabled."""
+	node = _with_text(
+		_pagination_node(backend_node_id=1, attributes={'disabled': ''}, tag='INPUT'),
+		'Next',
+	)
+	buttons = _detect([node])
+	assert buttons[0]['is_disabled'] is True

--- a/tests/ci/test_pagination_disabled_detection.py
+++ b/tests/ci/test_pagination_disabled_detection.py
@@ -1,0 +1,140 @@
+"""Regression coverage for pagination button disabled-state detection.
+
+CDP's DOM.getDocument parses HTML boolean attributes (e.g. ``<button disabled>``)
+as empty strings rather than ``'true'``, so disabled detection must treat the
+*presence* of the ``disabled`` attribute as disabled.
+"""
+
+from typing import Any
+
+from browser_use.dom.service import DomService
+from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, EnhancedSnapshotNode, NodeType
+
+
+def _pagination_node(
+	*,
+	backend_node_id: int,
+	text: str = 'Next',
+	attributes: dict[str, str] | None = None,
+) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=backend_node_id,
+		backend_node_id=backend_node_id,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='BUTTON',
+		node_value='',
+		attributes=attributes or {},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=DOMRect(x=0, y=0, width=100, height=30),
+		target_id='target-1',
+		frame_id=None,
+		session_id='main',
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=[],
+		ax_node=None,
+		snapshot_node=EnhancedSnapshotNode(
+			is_clickable=True,
+			cursor_style='pointer',
+			bounds=DOMRect(x=0, y=0, width=100, height=30),
+			clientRects=DOMRect(x=0, y=0, width=100, height=30),
+			scrollRects=None,
+			computed_styles={
+				'display': 'block',
+				'visibility': 'visible',
+				'opacity': '1',
+				'background-color': 'rgba(0, 0, 0, 0)',
+			},
+			paint_order=None,
+			stacking_contexts=None,
+		),
+	)
+
+
+def _children_text(node: EnhancedDOMTreeNode) -> str:
+	return ' '.join(
+		child.node_value for child in node.children_nodes if child.node_type == NodeType.TEXT_NODE and child.node_value
+	)
+
+
+# EnhancedDOMTreeNode.get_all_children_text() walks children; wire our text in via
+# a text-node child so the real production method is exercised.
+def _with_text(node: EnhancedDOMTreeNode, text: str) -> EnhancedDOMTreeNode:
+	text_node = EnhancedDOMTreeNode(
+		node_id=node.node_id + 1000,
+		backend_node_id=node.backend_node_id + 1000,
+		node_type=NodeType.TEXT_NODE,
+		node_name='#text',
+		node_value=text,
+		attributes={},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=None,
+		target_id=node.target_id,
+		frame_id=None,
+		session_id=node.session_id,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=node,
+		children_nodes=[],
+		ax_node=None,
+		snapshot_node=None,
+	)
+	node.children_nodes = [text_node]
+	return node
+
+
+def _detect(nodes: list[EnhancedDOMTreeNode]) -> list[dict[str, Any]]:
+	selector_map = {i: node for i, node in enumerate(nodes, start=1)}
+	return DomService.detect_pagination_buttons(selector_map)
+
+
+def test_native_disabled_attribute_empty_string_is_disabled():
+	"""<button disabled>Next</button> — CDP yields attributes={'disabled': ''}."""
+	node = _with_text(
+		_pagination_node(backend_node_id=1, attributes={'disabled': ''}),
+		'Next',
+	)
+	buttons = _detect([node])
+	assert len(buttons) == 1
+	assert buttons[0]['button_type'] == 'next'
+	assert buttons[0]['is_disabled'] is True
+
+
+def test_disabled_attribute_with_true_value_is_disabled():
+	"""<button disabled="true"> keeps an explicit string value."""
+	node = _with_text(
+		_pagination_node(backend_node_id=1, attributes={'disabled': 'true'}),
+		'Next',
+	)
+	buttons = _detect([node])
+	assert buttons[0]['is_disabled'] is True
+
+
+def test_aria_disabled_true_is_disabled():
+	node = _with_text(
+		_pagination_node(backend_node_id=1, attributes={'aria-disabled': 'true'}),
+		'Next',
+	)
+	buttons = _detect([node])
+	assert buttons[0]['is_disabled'] is True
+
+
+def test_aria_disabled_empty_string_is_not_disabled():
+	"""aria-disabled='' is ambiguous per the ARIA spec — do not treat as disabled."""
+	node = _with_text(
+		_pagination_node(backend_node_id=1, attributes={'aria-disabled': ''}),
+		'Next',
+	)
+	buttons = _detect([node])
+	assert buttons[0]['is_disabled'] is False
+
+
+def test_enabled_button_is_not_disabled():
+	node = _with_text(_pagination_node(backend_node_id=1), 'Next')
+	buttons = _detect([node])
+	assert buttons[0]['is_disabled'] is False


### PR DESCRIPTION
## Description

- Fixes pagination button disabled-state detection in `DomService.detect_pagination_buttons`.
- CDP's `DOM.getDocument` parses HTML boolean attributes (`<button disabled>`) as **empty strings**, not `'true'`. The old check `attributes.get('disabled') == 'true'` therefore never matched natively disabled controls, so `BrowserStateSummary.pagination_buttons` reported `is_disabled: false` for them — e.g. on page 1 of a paginated list where "Previous" is `<button disabled>`, the agent wasted a step clicking a disabled button.
- Fix: treat the **presence** of the `disabled` attribute as disabled regardless of value; keep requiring an explicit `'true'` for `aria-disabled` since `aria-disabled=""` is ambiguous per the ARIA spec.

## Checklist

- [x] With `aria-disabled="true"` → `is_disabled: True` (unchanged behavior)
- [x] With `class="...disabled..."` → `is_disabled: True` (unchanged behavior)
- [x] New: `<button disabled>` / `disabled=""` (CDP: `{'disabled': ''}`) → `is_disabled: True`
- [x] New: `disabled="true"` → `is_disabled: True`
- [x] `aria-disabled=""` alone → not disabled (deliberate, spec-ambiguous)
- [x] No attribute → not disabled

Regression tests added in `tests/ci/test_pagination_disabled_detection.py` (5 cases, all pass; the empty-string case fails on the previous implementation).

## Related

Companion analysis issues for other pagination-detection problems (substring false positives / numeric page buttons): #5514

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects native disabled attributes in pagination buttons correctly and avoids clicking disabled controls. Previously only `disabled == 'true'` counted; CDP emits empty strings, so `<button disabled>` appeared enabled. Now presence of `disabled` marks form controls as disabled; `aria-disabled` still requires `'true'`, and `disabled` on non-form elements is ignored.

- Updates `DomService.detect_pagination_buttons`: scope native `disabled` detection to form controls (`button`, `input`, `select`, `textarea`, `option`, `optgroup`, `fieldset`); keep `aria-disabled == 'true'` and `class`-based signals element-agnostic.
- Adds regression tests in `tests/ci/test_pagination_disabled_detection.py` covering empty-string/native cases, `aria-disabled`, inert `disabled` on `<a>`/`<div>`, and enabled controls.

<sup>Written for commit 4f46006289f06dfe181362f0183a9b4b2a1c2afc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

