### PR TITLE
fix(tokens): prune pricing cache files after each refresh + drop deprecated utcnow

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cache
 from pathlib import Path
 from typing import Any
@@ -248,7 +248,7 @@ class DBStyleEntry(BaseModel):
 
 	id: str = Field(default_factory=lambda: str(uuid4()))
 	default: bool = Field(default=False)
-	created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+	created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
 
 class BrowserProfileEntry(DBStyleEntry):

--- a/browser_use/tokens/service.py
+++ b/browser_use/tokens/service.py
@@ -171,7 +171,10 @@ class TokenCost:
 
 			# Prune superseded cache files so the directory doesn't grow unboundedly
 			# across long-running sessions (one new timestamped file per refresh).
-			await self.clean_old_caches()
+			# The cleanup reads and parses every cached JSON file, so run it in a
+			# worker thread to keep the event loop responsive when the cache
+			# directory has a large backlog.
+			await anyio.to_thread.run_sync(self._clean_old_caches_sync)
 		except Exception as e:
 			logger.debug(f'Error fetching pricing data: {e}')
 			# Fall back to empty pricing data
@@ -612,6 +615,11 @@ class TokenCost:
 
 	async def clean_old_caches(self, keep_count: int = 3) -> None:
 		"""Clean up old cache files, keeping only the most recent ones from this source URL"""
+		await anyio.to_thread.run_sync(lambda: self._clean_old_caches_sync(keep_count))
+
+	def _clean_old_caches_sync(self, keep_count: int = 3) -> None:
+		"""Synchronous cache pruning; runs on a worker thread so reading and
+		parsing every cached JSON file never blocks the event loop."""
 		try:
 			# List all JSON files in the cache directory
 			cache_files = list(self._cache_dir.glob('*.json'))

--- a/browser_use/tokens/service.py
+++ b/browser_use/tokens/service.py
@@ -168,6 +168,10 @@ class TokenCost:
 			cache_file = self._cache_dir / f'pricing_{timestamp_str}.json'
 
 			await anyio.Path(cache_file).write_text(cached.model_dump_json(indent=2))
+
+			# Prune superseded cache files so the directory doesn't grow unboundedly
+			# across long-running sessions (one new timestamped file per refresh).
+			await self.clean_old_caches()
 		except Exception as e:
 			logger.debug(f'Error fetching pricing data: {e}')
 			# Fall back to empty pricing data

--- a/tests/ci/test_pricing_cache_cleanup.py
+++ b/tests/ci/test_pricing_cache_cleanup.py
@@ -10,33 +10,45 @@ import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
+from pytest_httpserver import HTTPServer
+
 from browser_use.tokens.service import TokenCost
 
 
-def _write_cache_file(cache_dir: Path, name: str, age_hours: float) -> None:
+def _write_cache_file(cache_dir: Path, name: str, age_hours: float, source_url: str) -> None:
 	content = (
 		'{"timestamp": "'
 		+ (datetime.now() - timedelta(hours=age_hours)).isoformat()
-		+ '", "source_url": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json", "data": {}}'
+		+ '", "source_url": "' + source_url + '", "data": {}}'
 	)
 	target = cache_dir / name
 	target.write_text(content, encoding='utf-8')
-	# mtime ordering must match the age so pruning keeps the newest
+	# Pin mtime to the intended age so pruning order is unambiguous.
 	stat = target.stat()
 	os.utime(target, (stat.st_atime, stat.st_mtime - age_hours * 3600))
 
 
-def _service(tmp_path: Path) -> TokenCost:
-	service = TokenCost(include_cost=True)
+def _service(tmp_path: Path, pricing_url: str | None = None) -> TokenCost:
+	service = TokenCost(include_cost=True, pricing_url=pricing_url)
 	service._cache_dir = tmp_path
 	return service
 
 
-def test_clean_old_caches_prunes_to_keep_count(tmp_path: Path):
+def test_clean_old_caches_prunes_by_mtime_not_filename(tmp_path: Path):
+	"""Pruning must order by mtime, not by filename: the oldest file here has
+	the lexicographically largest name, so a filename-based sort would keep the
+	wrong files."""
 	service = _service(tmp_path)
 
+	# Ages are deliberately opposite to filename order: pricing_000005 is the
+	# OLDEST file (48h) and pricing_000000 is the NEWEST (0h).
+	ages = {'pricing_20260101_000005.json': 48, 'pricing_20260101_000004.json': 24, 'pricing_20260101_000003.json': 5}
+	DEFAULT_SOURCE = 'https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json'
+
 	for i in range(6):
-		_write_cache_file(tmp_path, f'pricing_20260101_00000{i}.json', age_hours=6 - i)
+		name = f'pricing_20260101_00000{i}.json'
+		_write_cache_file(tmp_path, name, age_hours=ages.get(name, i), source_url=DEFAULT_SOURCE)
+	# Files 000000-000002 are recent (ages 0..2h), 000003-000005 are old (5..48h).
 
 	assert len(list(tmp_path.glob('*.json'))) == 6
 
@@ -44,47 +56,37 @@ def test_clean_old_caches_prunes_to_keep_count(tmp_path: Path):
 
 	remaining = sorted(f.name for f in tmp_path.glob('*.json'))
 	assert remaining == [
-		'pricing_20260101_000003.json',
-		'pricing_20260101_000004.json',
-		'pricing_20260101_000005.json',
-	]
+		'pricing_20260101_000000.json',
+		'pricing_20260101_000001.json',
+		'pricing_20260101_000002.json',
+	], 'must keep the newest-by-mtime files, not the lexicographically smallest names'
 
 
-def test_fetch_and_cache_invokes_cleanup(monkeypatch, tmp_path: Path):
-	"""_fetch_and_cache_pricing_data must call clean_old_caches after writing."""
-	service = _service(tmp_path)
+def test_fetch_and_cache_invokes_cleanup_end_to_end(httpserver: HTTPServer, tmp_path: Path):
+	"""_fetch_and_cache_pricing_data must call clean_old_caches after writing.
 
-	calls: list[int] = []
+	Serves the pricing payload from a local httpserver with the real httpx
+	client and the real clean_old_caches, then asserts the final file list:
+	also verifies pruning end to end instead of only that a stub was called.
+	"""
+	httpserver.expect_request('/pricing.json').respond_with_json(
+		{'gpt-4o': {'input_cost_per_token': 1e-05, 'output_cost_per_token': 2e-05}}
+	)
 
-	async def fake_clean(keep_count: int = 3) -> None:
-		calls.append(keep_count)
+	# Seed 3 stale cache files from the same source URL so pruning has work to do
+	# once the fresh fetch writes a 4th file.
+	seeded_url = httpserver.url_for('/pricing.json')
+	for i in range(3):
+		_write_cache_file(tmp_path, f'pricing_20260101_10000{i}.json', age_hours=10 - i, source_url=seeded_url)
 
-	monkeypatch.setattr(service, 'clean_old_caches', fake_clean)
-
-	class _FakeResponse:
-		def raise_for_status(self) -> None: ...
-
-		def json(self) -> dict:
-			return {'gpt-4o': {'input_cost_per_token': 1e-05, 'output_cost_per_token': 2e-05}}
-
-	class _FakeClient:
-		def __init__(self, *args, **kwargs): ...
-
-		async def __aenter__(self):
-			return self
-
-		async def __aexit__(self, *args):
-			return False
-
-		async def get(self, url, timeout):
-			return _FakeResponse()
-
-	import httpx
-
-	monkeypatch.setattr(httpx, 'AsyncClient', _FakeClient)
+	service = _service(tmp_path, pricing_url=httpserver.url_for('/pricing.json'))
 
 	asyncio.run(service._fetch_and_cache_pricing_data())
 
-	assert calls == [3], 'clean_old_caches must be invoked exactly once after a successful cache write'
 	assert service._pricing_data == {'gpt-4o': {'input_cost_per_token': 1e-05, 'output_cost_per_token': 2e-05}}
-	assert len(list(tmp_path.glob('pricing_*.json'))) == 1
+
+	files = sorted(f.name for f in tmp_path.glob('*.json'))
+	assert len(files) == 3, f'expected pruning to keep 3 files, got {files}'
+	# The fresh fetch is newest, so it survives; exactly two of the three seeded files remain.
+	fresh = [name for name in files if not name.startswith('pricing_20260101_10000')]
+	assert len(fresh) == 1, f'expected the newly written file to survive pruning, got {files}'

--- a/tests/ci/test_pricing_cache_cleanup.py
+++ b/tests/ci/test_pricing_cache_cleanup.py
@@ -1,0 +1,90 @@
+"""Regression coverage for pricing cache cleanup.
+
+Every pricing refresh writes a new timestamped file into the cache dir;
+`clean_old_caches` must be invoked after each write so the directory is
+pruned instead of growing unboundedly across long-running sessions.
+"""
+
+import asyncio
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from browser_use.tokens.service import TokenCost
+
+
+def _write_cache_file(cache_dir: Path, name: str, age_hours: float) -> None:
+	content = (
+		'{"timestamp": "'
+		+ (datetime.now() - timedelta(hours=age_hours)).isoformat()
+		+ '", "source_url": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json", "data": {}}'
+	)
+	target = cache_dir / name
+	target.write_text(content, encoding='utf-8')
+	# mtime ordering must match the age so pruning keeps the newest
+	stat = target.stat()
+	os.utime(target, (stat.st_atime, stat.st_mtime - age_hours * 3600))
+
+
+def _service(tmp_path: Path) -> TokenCost:
+	service = TokenCost(include_cost=True)
+	service._cache_dir = tmp_path
+	return service
+
+
+def test_clean_old_caches_prunes_to_keep_count(tmp_path: Path):
+	service = _service(tmp_path)
+
+	for i in range(6):
+		_write_cache_file(tmp_path, f'pricing_20260101_00000{i}.json', age_hours=6 - i)
+
+	assert len(list(tmp_path.glob('*.json'))) == 6
+
+	asyncio.run(service.clean_old_caches(keep_count=3))
+
+	remaining = sorted(f.name for f in tmp_path.glob('*.json'))
+	assert remaining == [
+		'pricing_20260101_000003.json',
+		'pricing_20260101_000004.json',
+		'pricing_20260101_000005.json',
+	]
+
+
+def test_fetch_and_cache_invokes_cleanup(monkeypatch, tmp_path: Path):
+	"""_fetch_and_cache_pricing_data must call clean_old_caches after writing."""
+	service = _service(tmp_path)
+
+	calls: list[int] = []
+
+	async def fake_clean(keep_count: int = 3) -> None:
+		calls.append(keep_count)
+
+	monkeypatch.setattr(service, 'clean_old_caches', fake_clean)
+
+	class _FakeResponse:
+		def raise_for_status(self) -> None: ...
+
+		def json(self) -> dict:
+			return {'gpt-4o': {'input_cost_per_token': 1e-05, 'output_cost_per_token': 2e-05}}
+
+	class _FakeClient:
+		def __init__(self, *args, **kwargs): ...
+
+		async def __aenter__(self):
+			return self
+
+		async def __aexit__(self, *args):
+			return False
+
+		async def get(self, url, timeout):
+			return _FakeResponse()
+
+	import httpx
+
+	monkeypatch.setattr(httpx, 'AsyncClient', _FakeClient)
+
+	asyncio.run(service._fetch_and_cache_pricing_data())
+
+	assert calls == [3], 'clean_old_caches must be invoked exactly once after a successful cache write'
+	assert service._pricing_data == {'gpt-4o': {'input_cost_per_token': 1e-05, 'output_cost_per_token': 2e-05}}
+	assert len(list(tmp_path.glob('pricing_*.json'))) == 1


### PR DESCRIPTION
## Description

- `TokenCost._fetch_and_cache_pricing_data` writes a new timestamped file `pricing_YYYYMMDD_HHMMSS.json` on every refresh, but `clean_old_caches()` had **no call sites anywhere** in the codebase — cache files accumulated indefinitely in `~/.cache/browser_use/token_cost` (one new file per refresh, ≥1/day for long-running services).
- This PR invokes `clean_old_caches()` after each successful cache write so only the most recent files (`keep_count=3`) survive.
- Also replaces the deprecated `datetime.utcnow()` in `DBStyleEntry.created_at` with `datetime.now(timezone.utc)` — `utcnow()` is deprecated since Python 3.12 and returns a naive datetime, inconsistent with the timezone-aware usage elsewhere in the codebase. Output now correctly carries `+00:00`.

## Testing

- `tests/ci/test_pricing_cache_cleanup.py`:
  - `test_clean_old_caches_prunes_to_keep_count` — 6 cache files → pruning keeps the 3 newest
  - `test_fetch_and_cache_invokes_cleanup` — network mocked; verifies `clean_old_caches` is invoked exactly once after a successful write and the pricing payload is cached
- Both pass on this branch; `test_fetch_and_cache_invokes_cleanup` fails without the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes pricing cache files after each refresh and runs cleanup off the event loop to prevent I/O stalls. Also replaces deprecated `utcnow` with a timezone-aware timestamp.

- After a successful write, `_fetch_and_cache_pricing_data()` calls `_clean_old_caches_sync` via `anyio.to_thread.run_sync`; `clean_old_caches()` delegates to the same helper. Keeps only the 3 newest files by mtime; older files are removed on the next refresh. No config changes.
- `DBStyleEntry.created_at` now uses `datetime.now(timezone.utc)` so timestamps include `+00:00`.
- Tests: verify pruning orders by mtime (not filename) and add an end-to-end test using `httpx` with `pytest-httpserver` that confirms post-write cleanup and correct caching.

<sup>Written for commit f08a0f9c121abd29b3b1f50970d6dd9bcce1e1c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

