### PR TITLE
fix(deps): bump openai to 3.3.1 and follow the SDK onto httpx2

### DIFF
--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -2,7 +2,10 @@ import os
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
-import httpx
+# Imported eagerly because httpx2 defers it to the first client construction, which performs
+# blocking I/O when that construction happens inside the event loop.
+import httpcore2  # noqa: F401
+import httpx2
 from openai import APIConnectionError, APIStatusError, RateLimitError
 from openai import AsyncAzureOpenAI as AsyncAzureOpenAIClient
 from openai.types.responses import Response
@@ -109,8 +112,8 @@ class ChatAzureOpenAI(ChatOpenAILike):
 			_client_params['http_client'] = self.http_client
 		else:
 			# Create a new async HTTP client with custom limits
-			_client_params['http_client'] = httpx.AsyncClient(
-				limits=httpx.Limits(max_connections=20, max_keepalive_connections=6)
+			_client_params['http_client'] = httpx2.AsyncClient(
+				limits=httpx2.Limits(max_connections=20, max_keepalive_connections=6)
 			)
 
 		self.client = AsyncAzureOpenAIClient(**_client_params)

--- a/browser_use/llm/cerebras/chat.py
+++ b/browser_use/llm/cerebras/chat.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
-import httpx
+import httpx2
 from openai import (
 	APIConnectionError,
 	APIError,
@@ -38,8 +38,8 @@ class ChatCerebras(BaseChatModel):
 
 	# Connection parameters
 	api_key: str | None = None
-	base_url: str | httpx.URL | None = 'https://api.cerebras.ai/v1'
-	timeout: float | httpx.Timeout | None = None
+	base_url: str | httpx2.URL | None = 'https://api.cerebras.ai/v1'
+	timeout: float | httpx2.Timeout | None = None
 	client_params: dict[str, Any] | None = None
 
 	@property

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
-import httpx
+import httpx2
 from openai import (
 	APIConnectionError,
 	APIError,
@@ -39,8 +39,8 @@ class ChatDeepSeek(BaseChatModel):
 
 	# Connection parameters
 	api_key: str | None = None
-	base_url: str | httpx.URL | None = 'https://api.deepseek.com/v1'
-	timeout: float | httpx.Timeout | None = None
+	base_url: str | httpx2.URL | None = 'https://api.deepseek.com/v1'
+	timeout: float | httpx2.Timeout | None = None
 	client_params: dict[str, Any] | None = None
 
 	@property

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar, overload
 
-import httpx
+import httpx2
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
 from openai.types.chat import ChatCompletionContentPartTextParam
 from openai.types.chat.chat_completion import ChatCompletion
@@ -53,13 +53,13 @@ class ChatOpenAI(BaseChatModel):
 	api_key: str | None = None
 	organization: str | None = None
 	project: str | None = None
-	base_url: str | httpx.URL | None = None
-	websocket_base_url: str | httpx.URL | None = None
-	timeout: float | httpx.Timeout | None = None
+	base_url: str | httpx2.URL | None = None
+	websocket_base_url: str | httpx2.URL | None = None
+	timeout: float | httpx2.Timeout | None = None
 	max_retries: int = 5  # Increase default retries for automation reliability
 	default_headers: Mapping[str, str] | None = None
 	default_query: Mapping[str, object] | None = None
-	http_client: httpx.AsyncClient | None = None
+	http_client: httpx2.AsyncClient | None = None
 	_strict_response_validation: bool = False
 	max_completion_tokens: int | None = 4096
 	reasoning_models: list[ChatModel | str] | None = field(

--- a/browser_use/llm/openrouter/chat.py
+++ b/browser_use/llm/openrouter/chat.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
-import httpx
+import httpx2
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.shared_params.response_format_json_schema import (
@@ -41,12 +41,12 @@ class ChatOpenRouter(BaseChatModel):
 	# Client initialization parameters
 	api_key: str | None = None
 	http_referer: str | None = None  # OpenRouter specific parameter for tracking
-	base_url: str | httpx.URL = 'https://openrouter.ai/api/v1'
-	timeout: float | httpx.Timeout | None = None
+	base_url: str | httpx2.URL = 'https://openrouter.ai/api/v1'
+	timeout: float | httpx2.Timeout | None = None
 	max_retries: int = 10
 	default_headers: Mapping[str, str] | None = None
 	default_query: Mapping[str, object] | None = None
-	http_client: httpx.AsyncClient | None = None
+	http_client: httpx2.AsyncClient | None = None
 	_strict_response_validation: bool = False
 	extra_body: dict[str, Any] | None = None
 

--- a/browser_use/llm/vercel/chat.py
+++ b/browser_use/llm/vercel/chat.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeAlias, TypeVar, overload
 
-import httpx
+import httpx2
 from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
 from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.shared_params.response_format_json_schema import (
@@ -328,12 +328,12 @@ class ChatVercel(BaseChatModel):
 
 	# Client initialization parameters
 	api_key: str | None = None
-	base_url: str | httpx.URL = 'https://ai-gateway.vercel.sh/v1'
-	timeout: float | httpx.Timeout | None = None
+	base_url: str | httpx2.URL = 'https://ai-gateway.vercel.sh/v1'
+	timeout: float | httpx2.Timeout | None = None
 	max_retries: int = 5
 	default_headers: Mapping[str, str] | None = None
 	default_query: Mapping[str, object] | None = None
-	http_client: httpx.AsyncClient | None = None
+	http_client: httpx2.AsyncClient | None = None
 	_strict_response_validation: bool = False
 	provider_options: dict[str, Any] | None = None
 	reasoning: dict[str, dict[str, Any]] | None = None

--- a/examples/custom-functions/cua.py
+++ b/examples/custom-functions/cua.py
@@ -261,6 +261,9 @@ async def openai_cua_fallback(params: OpenAICUAAction, browser_session: BrowserS
 			raise Exception('No computer calls found in CUA response')
 
 		action = computer_call.action
+		if not action:
+			raise Exception('Computer call in CUA response carried no action')
+
 		print(f'🎬 Executing CUA action: {action.type} - {action}')
 
 		action_result = await handle_model_action(browser_session, action)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "typing-extensions==4.15.0",
     "uuid7==0.1.0",
     "google-genai==1.65.0",
-    "openai==2.16.0",
+    "openai==3.3.1",
     "anthropic==0.76.0",
     "groq==1.0.0",
     "ollama==0.6.1",
@@ -76,7 +76,7 @@ examples = [
     "imgcat==0.6.0",
     # "stagehand-py>=0.3.6",
     # "browserbase>=0.4.0",
-    "langchain-openai==1.1.7",
+    "langchain-openai==1.6.0",
 ]
 eval = [
     "lmnr[all]==0.7.42",


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-fable-5 on behalf of David.

Bumps the exact pins `openai==2.16.0` -> `openai==3.3.1` and `langchain-openai==1.1.7` -> `langchain-openai==1.6.0` (examples extra; 1.1.7 caps `openai<3`, which would leave the extra unresolvable). Both pins stay exact: this is a bump, not a loosening, per the policy stated in [#5402](https://github.com/browser-use/browser-use/pull/5402#issuecomment-5207671490):

> Hey due to supply chain attacks, we prefer to pin the version, happy if you want to upgrade the openai pin to latest version and if all the tests look good!

Motivation: #4285 -- the `==2.16.0` pin deadlocks environments installing browser-use next to anything on the current SDK. pydantic-ai (2.33.0 at the time of writing) floors `openai>=3.0.0`, so a 2.x bump no longer clears it; #4894, #5405 and #5382 bump within 2.x and would leave that conflict in place. This PR crosses the major instead. The sibling PR #5511 does the same for the anthropic pin; the two are independent.

openai 3.x moved the SDK's HTTP layer from httpx to httpx2 -- a separate distribution that installs alongside the `httpx==0.28.1` browser-use pins for its own HTTP, which is untouched (as are groq/ollama, which stay on legacy httpx). Nothing browser-use calls was removed across the major, so there are no call-site changes; the migration is the client parameter types. SDK migration guide: <https://github.com/openai/openai-python/blob/main/httpx2.md>

## Changes

- `browser_use/llm/openai/chat.py`, `openrouter/chat.py`, `vercel/chat.py`, `cerebras/chat.py`, `deepseek/chat.py`: `base_url`/`websocket_base_url`/`timeout`/`http_client` fields retyped to the httpx2 types from the SDK's migration table. `ChatOpenAILike` and `ChatAzureOpenAI` inherit these fields. `base_url` is the one that bites at runtime -- a legacy `httpx.URL` now raises `TypeError` (plain `str` is unaffected). A legacy `httpx.Timeout`, `httpx.Limits` or `httpx.AsyncClient` is still normalized by the SDK's compatibility layer (`openai/_httpx2.py`), verified against a local slow server with per-field timeout fidelity intact -- so for those this is annotation-only, no behavior change and no converter needed.
- `browser_use/llm/azure/chat.py`: `ChatAzureOpenAI.get_client()` builds its own connection-limited client, so that construction becomes `httpx2.AsyncClient(limits=httpx2.Limits(...))`, with a module-level eager `import httpcore2` beside it (httpx2 otherwise defers that import to the first client construction, which performs blocking I/O inside the event loop).
- `examples/custom-functions/cua.py`: openai 3 retypes `ResponseComputerToolCall.action` as optional, so `openai_cua_fallback` guards it next to the existing `computer_call` guard.

Notes for review:

- The silenced-logger list in `logging_config.py` is deliberately not touched here: #5511 adds `httpx2`/`httpcore2` to it and both PRs would collide on the same hunk. If this PR merges first, OpenAI request logs from the `httpx2` logger show up at INFO until #5511 lands.
- TLS behavior change inherited from the SDK: httpx2 verifies against the OS trust store (via truststore) rather than certifi, and the SDK no longer pulls certifi in. Can matter in minimal containers and behind TLS-inspecting proxies; `SSL_CERT_FILE`/`SSL_CERT_DIR` are the documented escape hatches.
- `requires-python = ">=3.11"` is unaffected (the SDK's new floor is 3.10).

## Verification

Fork CI skips live tests, so a local live run is the only real-provider proof; ran with a real `OPENAI_API_KEY`:

- One real chat completion through `ChatOpenAI` on 3.3.1 with `temperature` set and a legacy `httpx.Timeout`: completion returned normally over httpx2.
- `uv run pytest tests/ci`: same result as the base commit, verified by running the full suite on base `85ddbfedf` too -- identical 2 failed / 1076 passed / 28 skipped, where the two `test_beta_agent.py` failures are duplicate-module import pollution unrelated to openai and never occur in CI (one file per matrix job).
- The existing `tests/ci/test_llm_output_truncation.py` already drives `ChatOpenAI` end to end against a fake wire server and passes on 3.3.1.
- `uv run pyright` (all three `include` roots): 0 errors. `ruff check`, `ruff format --check`, `pre-commit run --all-files`: all pass.
- Resolved environment: `openai 3.3.1`, `langchain-openai 1.6.0`, `httpx 0.28.1` and `httpx2 2.12.0` coexisting.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `openai` from 2.16.0 to 3.3.1 and follows the SDK to `httpx2`. The only behavior change that affects callers: `base_url` must be a `str` or `httpx2.URL`; passing a legacy `httpx.URL` now raises TypeError.

- Updates examples extra to `langchain-openai` 1.6.0 to satisfy `openai>=3`.
- Retypes client parameters to `httpx2` across `ChatOpenAI`, `ChatAzureOpenAI`, `ChatOpenRouter`, `ChatVercel`, `ChatCerebras`, and `ChatDeepSeek`:
  - `base_url`/`websocket_base_url`: now `str | httpx2.URL` (migrate any `httpx.URL` to `str` or `httpx2.URL`).
  - `timeout`: now `float | httpx2.Timeout` and `http_client`: now `httpx2.AsyncClient`. The SDK still accepts legacy `httpx.Timeout`/`httpx.Limits`/`httpx.AsyncClient` via a compat layer.
- `ChatAzureOpenAI.get_client()` builds an `httpx2.AsyncClient` with `httpx2.Limits`; adds an eager `httpcore2` import to avoid blocking I/O on first construction.
- `examples/custom-functions/cua.py`: guards an optional `action` field per `openai` 3.x typing.
- TLS change from the SDK: verification now uses the OS trust store (via `truststore`) instead of `certifi`. In minimal containers or TLS-inspected networks, set `SSL_CERT_FILE`/`SSL_CERT_DIR` if needed.
- Temporary logging note: `httpx2` requests may log at INFO until a follow-up silences the `httpx2`/`httpcore2` loggers.

<sup>Written for commit 42ee8f69f830a7bdb8c364818f916f8d5db9b80c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

