### PR TITLE
fix(tools): report failed tab switches

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1007,25 +1007,25 @@ class Tools(Generic[Context]):
 			terminates_sequence=True,
 		)
 		async def switch(params: SwitchTabAction, browser_session: BrowserSession):
-			# Simple switch tab logic
 			try:
 				target_id = await browser_session.get_target_id_from_tab_id(params.tab_id)
 
 				event = browser_session.event_bus.dispatch(SwitchTabEvent(target_id=target_id))
 				await event
-				new_target_id = await event.event_result(raise_if_any=False, raise_if_none=False)  # Don't raise on errors
+				new_target_id = await event.event_result(raise_if_any=False, raise_if_none=False)
 
 				if new_target_id:
 					memory = f'Switched to tab #{new_target_id[-4:]}'
-				else:
-					memory = f'Switched to tab #{params.tab_id}'
+					logger.info(f'🔄  {memory}')
+					return ActionResult(extracted_content=memory, long_term_memory=memory)
 
-				logger.info(f'🔄  {memory}')
-				return ActionResult(extracted_content=memory, long_term_memory=memory)
+				error = f'Failed to switch to tab #{params.tab_id}: no target was activated'
+				logger.warning(error)
+				return ActionResult(error=error)
 			except Exception as e:
-				logger.warning(f'Tab switch may have failed: {e}')
-				memory = f'Attempted to switch to tab #{params.tab_id}'
-				return ActionResult(extracted_content=memory, long_term_memory=memory)
+				error = f'Failed to switch to tab #{params.tab_id}: {e}'
+				logger.warning(error)
+				return ActionResult(error=error)
 
 		@self.registry.action(
 			'Close a tab by tab_id. Tab IDs are shown in browser state tabs list (last 4 chars of target_id). Use to clean up tabs you no longer need.',

--- a/tests/ci/test_switch_action.py
+++ b/tests/ci/test_switch_action.py
@@ -1,0 +1,59 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from browser_use.agent.views import ActionResult
+from browser_use.tools.service import Tools
+
+
+class AwaitableEvent:
+	def __init__(self, result: str | None) -> None:
+		self.event_result = AsyncMock(return_value=result)
+
+	def __await__(self):
+		async def wait() -> 'AwaitableEvent':
+			return self
+
+		return wait().__await__()
+
+
+@pytest.mark.asyncio
+async def test_switch_returns_error_when_tab_id_is_invalid() -> None:
+	tools = Tools()
+	browser_session = Mock()
+	browser_session.get_target_id_from_tab_id = AsyncMock(side_effect=ValueError('unknown tab'))
+
+	result = await tools.switch(tab_id='zzzz', browser_session=browser_session)
+
+	assert isinstance(result, ActionResult)
+	assert result.error == 'Failed to switch to tab #zzzz: unknown tab'
+	assert result.extracted_content is None
+
+
+@pytest.mark.asyncio
+async def test_switch_returns_error_when_event_does_not_activate_target() -> None:
+	tools = Tools()
+	browser_session = Mock()
+	browser_session.get_target_id_from_tab_id = AsyncMock(return_value='target-id')
+	event = AwaitableEvent(None)
+	browser_session.event_bus.dispatch.return_value = event
+
+	result = await tools.switch(tab_id='1234', browser_session=browser_session)
+
+	assert isinstance(result, ActionResult)
+	assert result.error == 'Failed to switch to tab #1234: no target was activated'
+	assert result.extracted_content is None
+
+
+@pytest.mark.asyncio
+async def test_switch_reports_activated_target() -> None:
+	tools = Tools()
+	browser_session = Mock()
+	browser_session.get_target_id_from_tab_id = AsyncMock(return_value='target-id1234')
+	event = AwaitableEvent('target-id5678')
+	browser_session.event_bus.dispatch.return_value = event
+
+	result = await tools.switch(tab_id='1234', browser_session=browser_session)
+
+	assert result.error is None
+	assert result.extracted_content == 'Switched to tab #5678'


### PR DESCRIPTION
## Summary

- Report failed `switch` actions through `ActionResult.error` when the tab ID is invalid.
- Report an error when the switch event completes without activating a target.
- Add deterministic regression tests for both failure paths and the successful path.

Fixes #5486

## Root cause

The `switch` action swallowed `get_target_id_from_tab_id()` exceptions and returned success-shaped content. It also treated a `None` event result as a successful switch, even though the switch event returns a target ID on success.

## Verification

- `ruff check browser_use/tools/service.py tests/ci/test_switch_action.py` — passed
- `ruff format browser_use/tools/service.py tests/ci/test_switch_action.py` — passed
- `python -m compileall -q browser_use/tools/service.py tests/ci/test_switch_action.py` — passed
- `git diff --check` — passed
- `uv run pytest tests/ci/test_switch_action.py -q` — blocked: this checkout has no `uv.lock`, and dependency resolution could not complete in the available environment (`pytest_httpserver` was unavailable).

The tests use a deterministic fake event and do not require an LLM or a live browser.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report failed tab switches via ActionResult.error instead of success-shaped responses. Previously, switch swallowed lookup errors and treated a missing event result as success; now it returns an explicit error and logs the failure. Fixes #5486.

- Return ActionResult(error=...) when get_target_id_from_tab_id fails or when the switch event completes without activating a target; success still returns “Switched to tab #XXXX”.
- Add deterministic tests covering invalid tab ID, no activated target, and successful switch.
- Migration: Callers that assumed switch always succeeds must check result.error and must not rely on the former “Attempted to switch…” memory message.

<sup>Written for commit 3ead28b58b6368ac7e94d2227323788caf1c18df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

