### PR TITLE
fix(agent): prevent double step-count increment on timed-out steps

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2463,6 +2463,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		self.logger.debug(f'🚶 Starting step {step + 1}/{max_steps}...')
 
+		n_steps_before = self.state.n_steps
 		try:
 			await asyncio.wait_for(
 				self.step(step_info),
@@ -2476,9 +2477,12 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			await self._demo_mode_log(error_msg, 'error', {'step': step + 1})
 			self.state.consecutive_failures += 1
 			self.state.last_result = [ActionResult(error=error_msg)]
-			# Ensure step counter advances on timeout — _finalize() may have
-			# been skipped or returned early due to the cancellation.
-			if self.state.n_steps == step + 1:
+			# Ensure step counter advances on timeout — cancellation can skip
+			# _finalize()'s increment. Compare against the pre-step baseline:
+			# a cancelled step() still runs its finally/_finalize path, which
+			# already incremented, so an unconditional bump would count the
+			# same step twice.
+			if self.state.n_steps == n_steps_before:
 				self.state.n_steps += 1
 
 		if on_step_end is not None:


### PR DESCRIPTION
Fixes #5513 - see discussion: https://github.com/browser-use/browser-use/issues/5513#issuecomment-5386436743

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double increment of the step counter when a step times out. Previously, the timeout path could increment even after cancellation had already advanced it, inflating step counts and causing premature max-step termination.

- Capture a pre-step snapshot of `state.n_steps` and, on timeout, increment only if it matches the snapshot.
- Change is limited to the timeout/cancellation path; successful and non-timeout failures are unchanged.

<sup>Written for commit e6ff9e87285ff6fe66b22a37225c141dc744c192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

