### PR TITLE
fix(filesystem): preserve state when disk writes fail

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -167,6 +167,7 @@ class BaseFile(BaseModel, ABC):
 
 	async def _update_and_sync(self, content: str, path: Path, *, append: bool) -> None:
 		async with self._write_lock:
+			path.mkdir(parents=True, exist_ok=True)
 			staging_path = Path(tempfile.mkdtemp(dir=path))
 			candidate = self.model_copy()
 			try:

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -6,12 +6,13 @@ import io
 import os
 import re
 import shutil
+import tempfile
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 UNSUPPORTED_BINARY_EXTENSIONS = {
 	'png',
@@ -133,6 +134,7 @@ class BaseFile(BaseModel, ABC):
 
 	name: str
 	content: str = ''
+	_write_lock: asyncio.Lock = PrivateAttr(default_factory=asyncio.Lock)
 
 	# --- Subclass must define this ---
 	@property
@@ -163,17 +165,31 @@ class BaseFile(BaseModel, ABC):
 		with ThreadPoolExecutor() as executor:
 			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content, encoding='utf-8'))
 
+	async def _update_and_sync(self, content: str, path: Path, *, append: bool) -> None:
+		async with self._write_lock:
+			staging_path = Path(tempfile.mkdtemp(dir=path))
+			candidate = self.model_copy()
+			try:
+				if append:
+					candidate.append_file_content(content)
+				else:
+					candidate.write_file_content(content)
+
+				staged_file = staging_path / self.full_name
+				destination = path / self.full_name
+				if destination.exists():
+					shutil.copy2(destination, staged_file)
+				await candidate.sync_to_disk(staging_path)
+				os.replace(staged_file, destination)
+			finally:
+				shutil.rmtree(staging_path, ignore_errors=True)
+			self.content = candidate.content
+
 	async def write(self, content: str, path: Path) -> None:
-		candidate = self.model_copy()
-		candidate.write_file_content(content)
-		await candidate.sync_to_disk(path)
-		self.content = candidate.content
+		await self._update_and_sync(content, path, append=False)
 
 	async def append(self, content: str, path: Path) -> None:
-		candidate = self.model_copy()
-		candidate.append_file_content(content)
-		await candidate.sync_to_disk(path)
-		self.content = candidate.content
+		await self._update_and_sync(content, path, append=True)
 
 	def read(self) -> str:
 		return self.content

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -164,12 +164,16 @@ class BaseFile(BaseModel, ABC):
 			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content, encoding='utf-8'))
 
 	async def write(self, content: str, path: Path) -> None:
-		self.write_file_content(content)
-		await self.sync_to_disk(path)
+		candidate = self.model_copy()
+		candidate.write_file_content(content)
+		await candidate.sync_to_disk(path)
+		self.content = candidate.content
 
 	async def append(self, content: str, path: Path) -> None:
-		self.append_file_content(content)
-		await self.sync_to_disk(path)
+		candidate = self.model_copy()
+		candidate.append_file_content(content)
+		await candidate.sync_to_disk(path)
+		self.content = candidate.content
 
 	def read(self) -> str:
 		return self.content
@@ -791,10 +795,10 @@ class FileSystem:
 				file_obj = self.files[full_filename]
 			else:
 				file_obj = file_class(name=name_without_ext)
-				self.files[full_filename] = file_obj  # Use full filename as key
 
 			# Use file-specific write method
 			await file_obj.write(content, self.data_dir)
+			self.files[full_filename] = file_obj  # Use full filename as key
 			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
 			return f'Data written to file {full_filename} successfully.{sanitize_note}'
 		except FileSystemError as e:

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -177,9 +177,9 @@ class BaseFile(BaseModel, ABC):
 
 				staged_file = staging_path / self.full_name
 				destination = path / self.full_name
-				if destination.exists():
-					shutil.copy2(destination, staged_file)
 				await candidate.sync_to_disk(staging_path)
+				if destination.exists():
+					shutil.copystat(destination, staged_file)
 				os.replace(staged_file, destination)
 			finally:
 				shutil.rmtree(staging_path, ignore_errors=True)

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -1101,7 +1101,6 @@ class TestFileSystemEdgeCases:
 
 			fs.nuke()
 
-
 	async def test_disk_write_failure_preserves_persisted_state(self, monkeypatch):
 		"""Failed writes must not leak unpersisted content into the file registry."""
 		with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1120,7 +1119,9 @@ class TestFileSystemEdgeCases:
 			assert 'disk unavailable' in write_result
 			assert 'disk unavailable' in append_result
 			assert 'disk unavailable' in new_file_result
-			assert fs.get_file('existing.txt').content == 'persisted'
+			existing_file = fs.get_file('existing.txt')
+			assert existing_file is not None
+			assert existing_file.content == 'persisted'
 			assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
 			assert fs.get_file('ghost.txt') is None
 			assert not (fs.data_dir / 'ghost.txt').exists()

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -184,6 +184,17 @@ class TestBaseFile:
 			assert file_path.read_text() == expected_content
 			assert file_obj.content == expected_content
 
+	async def test_write_creates_missing_directory(self):
+		"""Atomic writes retain BaseFile's existing parent-directory behavior."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			path = Path(tmp_dir) / 'new' / 'nested'
+			file_obj = TxtFile(name='notes')
+
+			await file_obj.write('hello', path)
+
+			assert (path / 'notes.txt').read_text(encoding='utf-8') == 'hello'
+			assert file_obj.content == 'hello'
+
 	async def test_json_file_disk_operations(self):
 		"""Test JSON file sync to disk operations."""
 		with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -1,6 +1,7 @@
 """Tests for the FileSystem class and related file operations."""
 
 import asyncio
+import stat
 import tempfile
 from pathlib import Path
 
@@ -1108,6 +1109,7 @@ class TestFileSystemEdgeCases:
 			await fs.write_file('existing.txt', 'persisted')
 
 			async def fail_sync(_file, _path):
+				(_path / _file.full_name).write_text('partial', encoding='utf-8')
 				raise OSError('disk unavailable')
 
 			monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
@@ -1126,6 +1128,139 @@ class TestFileSystemEdgeCases:
 			assert fs.get_file('ghost.txt') is None
 			assert not (fs.data_dir / 'ghost.txt').exists()
 			assert list(fs.get_state().files) == ['existing.txt']
+
+			fs.nuke()
+
+	async def test_concurrent_appends_preserve_both_updates(self, monkeypatch):
+		"""Concurrent appends must serialize before deriving their new content."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			fs = FileSystem(base_dir=tmp_dir, create_default_files=False)
+			await fs.write_file('existing.txt', 'base')
+
+			original_sync = TxtFile.sync_to_disk
+			first_started = asyncio.Event()
+			release_first = asyncio.Event()
+
+			async def controlled_sync(file, path):
+				if file.content.endswith('A'):
+					first_started.set()
+					await release_first.wait()
+				await original_sync(file, path)
+
+			monkeypatch.setattr(TxtFile, 'sync_to_disk', controlled_sync)
+
+			first = asyncio.create_task(fs.append_file('existing.txt', 'A'))
+			await first_started.wait()
+			second = asyncio.create_task(fs.append_file('existing.txt', 'B'))
+			await asyncio.sleep(0)
+			release_first.set()
+			await asyncio.gather(first, second)
+
+			existing_file = fs.get_file('existing.txt')
+			assert existing_file is not None
+			assert existing_file.content == 'baseAB'
+			assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'baseAB'
+
+			fs.nuke()
+
+	async def test_cancelled_write_preserves_persisted_state(self, monkeypatch):
+		"""Cancellation during persistence must not commit only one side of the state."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			fs = FileSystem(base_dir=tmp_dir, create_default_files=False)
+			await fs.write_file('existing.txt', 'persisted')
+
+			staged = asyncio.Event()
+			blocker = asyncio.Event()
+
+			async def stage_then_wait(file, path):
+				(path / file.full_name).write_text(file.content, encoding='utf-8')
+				staged.set()
+				await blocker.wait()
+
+			monkeypatch.setattr(TxtFile, 'sync_to_disk', stage_then_wait)
+
+			write_task = asyncio.create_task(fs.write_file('existing.txt', 'replacement'))
+			await staged.wait()
+			write_task.cancel()
+			with pytest.raises(asyncio.CancelledError):
+				await write_task
+
+			existing_file = fs.get_file('existing.txt')
+			assert existing_file is not None
+			assert existing_file.content == 'persisted'
+			assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
+
+			fs.nuke()
+
+	async def test_write_preserves_existing_file_permissions(self):
+		"""Replacing an existing file must retain its restrictive mode."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			fs = FileSystem(base_dir=tmp_dir, create_default_files=False)
+			await fs.write_file('existing.txt', 'persisted')
+
+			destination = fs.data_dir / 'existing.txt'
+			destination.chmod(0o600)
+			expected_mode = stat.S_IMODE(destination.stat().st_mode)
+
+			await fs.write_file('existing.txt', 'replacement')
+
+			assert stat.S_IMODE(destination.stat().st_mode) == expected_mode
+			assert destination.read_text(encoding='utf-8') == 'replacement'
+
+			fs.nuke()
+
+	async def test_staging_directory_failure_preserves_state(self, monkeypatch):
+		"""Failure before staging starts must leave memory and disk untouched."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			fs = FileSystem(base_dir=tmp_dir, create_default_files=False)
+			await fs.write_file('existing.txt', 'persisted')
+
+			def fail_staging(*_args, **_kwargs):
+				raise OSError('no space for staging')
+
+			monkeypatch.setattr(tempfile, 'mkdtemp', fail_staging)
+
+			result = await fs.write_file('existing.txt', 'replacement')
+
+			existing_file = fs.get_file('existing.txt')
+			assert 'no space for staging' in result
+			assert existing_file is not None
+			assert existing_file.content == 'persisted'
+			assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
+
+			fs.nuke()
+
+	async def test_pending_write_is_not_visible_to_readers(self, monkeypatch):
+		"""Reads and serialized state must expose only committed content."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			fs = FileSystem(base_dir=tmp_dir, create_default_files=False)
+			await fs.write_file('existing.txt', 'persisted')
+
+			staged = asyncio.Event()
+			release = asyncio.Event()
+			original_sync = TxtFile.sync_to_disk
+
+			async def controlled_sync(file, path):
+				await original_sync(file, path)
+				staged.set()
+				await release.wait()
+
+			monkeypatch.setattr(TxtFile, 'sync_to_disk', controlled_sync)
+
+			write_task = asyncio.create_task(fs.write_file('existing.txt', 'replacement'))
+			await staged.wait()
+
+			existing_file = fs.get_file('existing.txt')
+			assert existing_file is not None
+			assert existing_file.content == 'persisted'
+			assert fs.get_state().files['existing.txt']['data']['content'] == 'persisted'
+			assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
+
+			release.set()
+			await write_task
+
+			assert existing_file.content == 'replacement'
+			assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'replacement'
 
 			fs.nuke()
 

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -1199,12 +1199,14 @@ class TestFileSystemEdgeCases:
 			await fs.write_file('existing.txt', 'persisted')
 
 			destination = fs.data_dir / 'existing.txt'
-			destination.chmod(0o600)
+			destination.chmod(0o200)
 			expected_mode = stat.S_IMODE(destination.stat().st_mode)
 
-			await fs.write_file('existing.txt', 'replacement')
+			result = await fs.write_file('existing.txt', 'replacement')
 
+			assert result == 'Data written to file existing.txt successfully.'
 			assert stat.S_IMODE(destination.stat().st_mode) == expected_mode
+			destination.chmod(0o600)
 			assert destination.read_text(encoding='utf-8') == 'replacement'
 
 			fs.nuke()

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -1101,6 +1101,33 @@ class TestFileSystemEdgeCases:
 
 			fs.nuke()
 
+
+	async def test_disk_write_failure_preserves_persisted_state(self, monkeypatch):
+		"""Failed writes must not leak unpersisted content into the file registry."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			fs = FileSystem(base_dir=tmp_dir, create_default_files=False)
+			await fs.write_file('existing.txt', 'persisted')
+
+			async def fail_sync(_file, _path):
+				raise OSError('disk unavailable')
+
+			monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
+
+			write_result = await fs.write_file('existing.txt', 'phantom update')
+			append_result = await fs.append_file('existing.txt', ' phantom append')
+			new_file_result = await fs.write_file('ghost.txt', 'phantom file')
+
+			assert 'disk unavailable' in write_result
+			assert 'disk unavailable' in append_result
+			assert 'disk unavailable' in new_file_result
+			assert fs.get_file('existing.txt').content == 'persisted'
+			assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
+			assert fs.get_file('ghost.txt') is None
+			assert not (fs.data_dir / 'ghost.txt').exists()
+			assert list(fs.get_state().files) == ['existing.txt']
+
+			fs.nuke()
+
 	def test_from_state_with_unknown_file_type(self):
 		"""Test restoring state with unknown file types (should skip them)."""
 		with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Failed writes and appends can leave `BaseFile.content` and disk out of sync. On current main (`843819cb`), a partial-write failure returns an error while memory contains the replacement and disk contains partial data.

This change serializes mutations per file, prepares content on a detached model, and writes into a temporary directory beside the destination. It replaces the destination and publishes the new in-memory content only after persistence succeeds. Failed or cancelled staging leaves the previous content intact.

Symbolic links are preserved by staging beside and replacing their resolved target. Existing hard-linked destinations return a `FileSystemError` without changing the links or content: replacing one directory entry would silently detach it from the shared inode. This is an explicit compatibility limit of atomic replacement.

The branch includes current main and its delayed registration of new files. The remaining PR diff is limited to `browser_use/filesystem/file_system.py` and its filesystem tests.

Closes #5527

Validation on `02e65542`:

- Current-main partial-write reproduction: memory and disk diverged as described above.
- Three new link cases fail against the previous PR implementation and pass after the fix (existing symlink, dangling symlink, hard-linked destination).
- `BROWSER_USE_SETUP_LOGGING=false ANONYMIZED_TELEMETRY=false .venv/bin/python -m pytest --noconftest -o addopts='' --asyncio-mode=auto tests/ci/infrastructure/test_filesystem.py tests/ci/test_file_system_images.py -q`: 121 passed. These file and image tests were run in isolation from the browser/cloud fixtures.
- `pre-commit run --files browser_use/filesystem/file_system.py tests/ci/infrastructure/test_filesystem.py`: passed, including Ruff, Pyright, and the remaining applicable hooks.
- `git diff --check`: passed.

AI assistance: Codex was used to implement the change and run the validation above.
