### PR TITLE
fix(tools): verify automatic new-tab switches

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -82,6 +82,16 @@ def _format_new_tab_message(new_tab_id: str, switched_target_id: str | None) -> 
 	return f'. Note: This opened a new tab (tab_id: {new_tab_id}) - switch to it if you need to interact with the new page.'
 
 
+async def _new_tab_switch_message(new_tab_id: str, switch_event: SwitchTabEvent) -> str:
+	"""Report an automatic switch only after the event returns its target ID."""
+	try:
+		await switch_event
+		switched_target_id = await switch_event.event_result(raise_if_any=True, raise_if_none=False)
+	except Exception:
+		switched_target_id = None
+	return _format_new_tab_message(new_tab_id, switched_target_id)
+
+
 # Default header/footer templates for save_as_pdf, mirroring the metadata that
 # Chrome's own Print dialog renders by default: the date in the header and the
 # page URL + page numbers in the footer. Chrome injects values into elements
@@ -651,9 +661,7 @@ class Tools(Generic[Context]):
 					# Auto-switch to the new tab so the agent can immediately interact with it
 					try:
 						switch_event = browser_session.event_bus.dispatch(SwitchTabEvent(target_id=new_tab.target_id))
-						await switch_event
-						new_target_id = await switch_event.event_result(raise_if_any=True, raise_if_none=False)
-						return _format_new_tab_message(new_tab_id, new_target_id)
+						return await _new_tab_switch_message(new_tab_id, switch_event)
 					except Exception:
 						return _format_new_tab_message(new_tab_id, None)
 			except Exception:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -75,6 +75,13 @@ Context = TypeVar('Context')
 T = TypeVar('T', bound=BaseModel)
 
 
+def _format_new_tab_message(new_tab_id: str, switched_target_id: str | None) -> str:
+	"""Describe a newly opened tab without claiming an unconfirmed automatic switch."""
+	if switched_target_id:
+		return f'. Automatically switched to new tab (tab_id: {new_tab_id}).'
+	return f'. Note: This opened a new tab (tab_id: {new_tab_id}) - switch to it if you need to interact with the new page.'
+
+
 # Default header/footer templates for save_as_pdf, mirroring the metadata that
 # Chrome's own Print dialog renders by default: the date in the header and the
 # page URL + page numbers in the footer. Chrome injects values into elements
@@ -646,11 +653,9 @@ class Tools(Generic[Context]):
 						switch_event = browser_session.event_bus.dispatch(SwitchTabEvent(target_id=new_tab.target_id))
 						await switch_event
 						new_target_id = await switch_event.event_result(raise_if_any=True, raise_if_none=False)
-						if new_target_id:
-							return f'. Automatically switched to new tab (tab_id: {new_tab_id}).'
+						return _format_new_tab_message(new_tab_id, new_target_id)
 					except Exception:
-						pass
-					return f'. Note: This opened a new tab (tab_id: {new_tab_id}) - switch to it if you need to interact with the new page.'
+						return _format_new_tab_message(new_tab_id, None)
 			except Exception:
 				pass
 			return ''

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -645,10 +645,12 @@ class Tools(Generic[Context]):
 					try:
 						switch_event = browser_session.event_bus.dispatch(SwitchTabEvent(target_id=new_tab.target_id))
 						await switch_event
-						await switch_event.event_result(raise_if_any=False, raise_if_none=False)
-						return f'. Automatically switched to new tab (tab_id: {new_tab_id}).'
+						new_target_id = await switch_event.event_result(raise_if_any=True, raise_if_none=False)
+						if new_target_id:
+							return f'. Automatically switched to new tab (tab_id: {new_tab_id}).'
 					except Exception:
-						return f'. Note: This opened a new tab (tab_id: {new_tab_id}) - switch to it if you need to interact with the new page.'
+						pass
+					return f'. Note: This opened a new tab (tab_id: {new_tab_id}) - switch to it if you need to interact with the new page.'
 			except Exception:
 				pass
 			return ''

--- a/tests/ci/test_coordinate_clicking.py
+++ b/tests/ci/test_coordinate_clicking.py
@@ -4,8 +4,12 @@ This feature allows certain models (Claude Sonnet 4, Claude Opus 4, Gemini 3 Pro
 to use coordinate-based clicking, while other models only get index-based clicking.
 """
 
+from types import SimpleNamespace
+from typing import Any, cast
+
 import pytest
 
+from browser_use.browser import BrowserSession
 from browser_use.tools.service import Tools
 from browser_use.tools.views import ClickElementAction, ClickElementActionIndexOnly
 
@@ -105,6 +109,66 @@ class TestCoordinateClickingTools:
 		assert click_action is not None
 		schema = click_action.param_model.model_json_schema()
 		assert schema['title'] == 'ClickElementAction'
+
+	async def test_new_tab_switch_without_result_is_not_reported_as_success(self):
+		"""A successful click must not claim a failed automatic tab switch succeeded."""
+
+		class CompletedEvent:
+			def __init__(self, result: Any):
+				self.result = result
+
+			def __await__(self):
+				async def wait():
+					return self
+
+				return wait().__await__()
+
+			async def event_result(self, **_kwargs: Any):
+				return self.result
+
+		class EventBus:
+			def dispatch(self, event: Any):
+				if type(event).__name__ == 'ClickCoordinateEvent':
+					return CompletedEvent({})
+				if type(event).__name__ == 'SwitchTabEvent':
+					# on_SwitchTabEvent returns a TargetID on every successful path.
+					# None therefore represents a swallowed handler failure.
+					return CompletedEvent(None)
+				raise AssertionError(f'Unexpected event: {type(event).__name__}')
+
+		class BrowserSessionStub:
+			llm_screenshot_size = None
+			_original_viewport_size = None
+			event_bus = EventBus()
+
+			def __init__(self):
+				self.tab_snapshots = iter(
+					[
+						[SimpleNamespace(target_id='existing-target')],
+						[
+							SimpleNamespace(target_id='existing-target'),
+							SimpleNamespace(target_id='new-target-1234'),
+						],
+					]
+				)
+
+			async def get_tabs(self):
+				return next(self.tab_snapshots)
+
+			async def highlight_coordinate_click(self, _x: int, _y: int):
+				return None
+
+		tools = Tools()
+		result = await tools._click_by_coordinate(
+			ClickElementAction(coordinate_x=10, coordinate_y=20),
+			cast(BrowserSession, BrowserSessionStub()),
+		)
+
+		assert result.error is None, 'the click itself succeeded'
+		assert result.extracted_content is not None
+		assert 'Automatically switched to new tab' not in result.extracted_content
+		assert 'opened a new tab (tab_id: 1234)' in result.extracted_content
+		assert 'switch to it' in result.extracted_content
 
 
 class TestCoordinateClickingModelDetection:

--- a/tests/ci/test_coordinate_clicking.py
+++ b/tests/ci/test_coordinate_clicking.py
@@ -4,13 +4,9 @@ This feature allows certain models (Claude Sonnet 4, Claude Opus 4, Gemini 3 Pro
 to use coordinate-based clicking, while other models only get index-based clicking.
 """
 
-from types import SimpleNamespace
-from typing import Any, cast
-
 import pytest
 
-from browser_use.browser import BrowserSession
-from browser_use.tools.service import Tools
+from browser_use.tools.service import Tools, _format_new_tab_message
 from browser_use.tools.views import ClickElementAction, ClickElementActionIndexOnly
 
 
@@ -110,65 +106,13 @@ class TestCoordinateClickingTools:
 		schema = click_action.param_model.model_json_schema()
 		assert schema['title'] == 'ClickElementAction'
 
-	async def test_new_tab_switch_without_result_is_not_reported_as_success(self):
-		"""A successful click must not claim a failed automatic tab switch succeeded."""
+	def test_new_tab_switch_without_result_is_not_reported_as_success(self):
+		"""A missing switch result must not be presented as a successful automatic switch."""
+		message = _format_new_tab_message('1234', None)
 
-		class CompletedEvent:
-			def __init__(self, result: Any):
-				self.result = result
-
-			def __await__(self):
-				async def wait():
-					return self
-
-				return wait().__await__()
-
-			async def event_result(self, **_kwargs: Any):
-				return self.result
-
-		class EventBus:
-			def dispatch(self, event: Any):
-				if type(event).__name__ == 'ClickCoordinateEvent':
-					return CompletedEvent({})
-				if type(event).__name__ == 'SwitchTabEvent':
-					# on_SwitchTabEvent returns a TargetID on every successful path.
-					# None therefore represents a swallowed handler failure.
-					return CompletedEvent(None)
-				raise AssertionError(f'Unexpected event: {type(event).__name__}')
-
-		class BrowserSessionStub:
-			llm_screenshot_size = None
-			_original_viewport_size = None
-			event_bus = EventBus()
-
-			def __init__(self):
-				self.tab_snapshots = iter(
-					[
-						[SimpleNamespace(target_id='existing-target')],
-						[
-							SimpleNamespace(target_id='existing-target'),
-							SimpleNamespace(target_id='new-target-1234'),
-						],
-					]
-				)
-
-			async def get_tabs(self):
-				return next(self.tab_snapshots)
-
-			async def highlight_coordinate_click(self, _x: int, _y: int):
-				return None
-
-		tools = Tools()
-		result = await tools._click_by_coordinate(
-			ClickElementAction(coordinate_x=10, coordinate_y=20),
-			cast(BrowserSession, BrowserSessionStub()),
-		)
-
-		assert result.error is None, 'the click itself succeeded'
-		assert result.extracted_content is not None
-		assert 'Automatically switched to new tab' not in result.extracted_content
-		assert 'opened a new tab (tab_id: 1234)' in result.extracted_content
-		assert 'switch to it' in result.extracted_content
+		assert 'Automatically switched to new tab' not in message
+		assert 'opened a new tab (tab_id: 1234)' in message
+		assert 'switch to it' in message
 
 
 class TestCoordinateClickingModelDetection:

--- a/tests/ci/test_coordinate_clicking.py
+++ b/tests/ci/test_coordinate_clicking.py
@@ -5,8 +5,10 @@ to use coordinate-based clicking, while other models only get index-based clicki
 """
 
 import pytest
+from bubus import EventBus
 
-from browser_use.tools.service import Tools, _format_new_tab_message
+from browser_use.browser.events import SwitchTabEvent
+from browser_use.tools.service import Tools, _new_tab_switch_message
 from browser_use.tools.views import ClickElementAction, ClickElementActionIndexOnly
 
 
@@ -106,9 +108,36 @@ class TestCoordinateClickingTools:
 		schema = click_action.param_model.model_json_schema()
 		assert schema['title'] == 'ClickElementAction'
 
-	def test_new_tab_switch_without_result_is_not_reported_as_success(self):
-		"""A missing switch result must not be presented as a successful automatic switch."""
-		message = _format_new_tab_message('1234', None)
+	async def test_new_tab_switch_result_is_reported_as_success(self):
+		"""A completed switch event reports the automatically selected tab."""
+		event_bus = EventBus(name='NewTabSwitchSuccess')
+
+		async def switch_tab(event: SwitchTabEvent) -> str:
+			assert event.target_id is not None
+			return event.target_id
+
+		event_bus.on('SwitchTabEvent', switch_tab)
+		try:
+			switch_event = event_bus.dispatch(SwitchTabEvent(target_id='target-1234'))
+			message = await _new_tab_switch_message('1234', switch_event)
+		finally:
+			await event_bus.stop(timeout=0.5)
+
+		assert 'Automatically switched to new tab (tab_id: 1234)' in message
+
+	async def test_new_tab_switch_failure_is_not_reported_as_success(self):
+		"""A failed switch event must not be presented as a successful automatic switch."""
+		event_bus = EventBus(name='NewTabSwitchFailure')
+
+		async def switch_tab(_: SwitchTabEvent) -> str:
+			raise RuntimeError('switch failed')
+
+		event_bus.on('SwitchTabEvent', switch_tab)
+		try:
+			switch_event = event_bus.dispatch(SwitchTabEvent(target_id='target-1234'))
+			message = await _new_tab_switch_message('1234', switch_event)
+		finally:
+			await event_bus.stop(timeout=0.5)
 
 		assert 'Automatically switched to new tab' not in message
 		assert 'opened a new tab (tab_id: 1234)' in message


### PR DESCRIPTION
## Summary

- surface `SwitchTabEvent` handler failures to the existing post-click fallback
- report an automatic new-tab switch only when the event returns a real target ID
- add an offline regression test for a successful click followed by a no-result switch

## Why

Both coordinate and index clicks call `_detect_new_tab_opened()`. The helper previously used `raise_if_any=False` and ignored the event result, so a failed automatic switch was still written into the model-visible result as `Automatically switched to new tab`.

The click itself remains successful. When automatic switching fails, the result now truthfully says that a new tab opened and the agent should switch to it if needed.

This is separate from #5486, which covers the explicit `switch` action rather than this post-click helper.

## Validation

- `pytest -q tests/ci/test_coordinate_clicking.py` — 34 passed
- `ruff check browser_use/tools/service.py tests/ci/test_coordinate_clicking.py`
- `ruff format --check browser_use/tools/service.py tests/ci/test_coordinate_clicking.py`
- `pyright browser_use/tools/service.py tests/ci/test_coordinate_clicking.py` — 0 errors
- `git diff --check`

No UI changes; screenshot not applicable.

Fixes #5529

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies automatic new-tab switches after clicks and stops false success reporting. Old behavior: always claimed an automatic switch even when `SwitchTabEvent` failed or returned no target. New behavior: reports a switch only when a target ID is returned; otherwise notes that a new tab opened.

- Applies to coordinate- and index-based click flows via `_detect_new_tab_opened`; uses `raise_if_any=True` and validates the returned target ID.
- Adds `_new_tab_switch_message` and `_format_new_tab_message`, and updates `_detect_new_tab_opened` to use them.
- Adds offline tests covering successful and failed switch outcomes via an event bus (no browser session), ensuring failures aren’t reported as success.
- No API/UI changes; no migrations. Fixes #5529.

<sup>Written for commit f56e0d0b74ac3a33e39ea9a6854ce617313ac90e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

