### PR TITLE
test(config): make cache path assertion cross-platform

### DIFF
--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -84,7 +84,7 @@ class TestLazyConfig:
 
 			# Test default path expansion
 			os.environ.pop('XDG_CACHE_HOME', None)
-			assert '/.cache' in str(CONFIG.XDG_CACHE_HOME)
+			assert CONFIG.XDG_CACHE_HOME == (Path.home() / '.cache').resolve()
 		finally:
 			if original_value:
 				os.environ['XDG_CACHE_HOME'] = original_value


### PR DESCRIPTION
## Summary

- make the default cache path assertion platform-independent
- compare resolved `Path` values instead of matching a POSIX-only path fragment

## Root cause

`test_path_configuration` checked that the rendered cache path contained `/.cache`. On Windows, `Path.resolve()` produces a path such as `C:\Users\username\.cache`, so the assertion failed even though the configured path was correct.

## Validation

- `uv run pytest tests/ci/infrastructure/test_config.py -q` (5 passed)
- `uv run pre-commit run --files tests/ci/infrastructure/test_config.py` (passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the cache path assertion in config tests cross‑platform so Windows paths no longer fail. Previously the test matched the POSIX substring '/.cache'; now it asserts CONFIG.XDG_CACHE_HOME equals (Path.home() / '.cache').resolve(), removing the POSIX-only assumption and preventing false negatives on Windows without changing runtime behavior.

<sup>Written for commit b8d95d6988c5ff3984bc238bb016fdd042b745d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

