### PR TITLE
Fix automatic new-tab switch detection (Fixes #5529)

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -645,8 +645,11 @@ class Tools(Generic[Context]):
 					try:
 						switch_event = browser_session.event_bus.dispatch(SwitchTabEvent(target_id=new_tab.target_id))
 						await switch_event
-						await switch_event.event_result(raise_if_any=False, raise_if_none=False)
-						return f'. Automatically switched to new tab (tab_id: {new_tab_id}).'
+						result = await switch_event.event_result(raise_if_any=False, raise_if_none=False)
+						if result is not None:
+							return f'. Automatically switched to new tab (tab_id: {new_tab_id}).'
+						else:
+							return f'. Note: This opened a new tab (tab_id: {new_tab_id}) - switch to it if you need to interact with the new page.'
 					except Exception:
 						return f'. Note: This opened a new tab (tab_id: {new_tab_id}) - switch to it if you need to interact with the new page.'
 			except Exception:


### PR DESCRIPTION
## Summary

This PR fixes issue #5529 where failed automatic new-tab switches were reported as successful.

## Problem

When a click opens a new tab, the `_detect_new_tab_opened` function would dispatch a `SwitchTabEvent` and then immediately return a success message, regardless of whether the switch actually succeeded. The code was ignoring the result of `event_result()` and always returning a success message.

## Root Cause

The code was calling `switch_event.event_result(raise_if_any=False, raise_if_none=False)` but ignoring the return value. If the `SwitchTabEvent` handler failed or returned no result, the code would still report success.

## Fix

Modified `_detect_new_tab_opened` in `browser_use/tools/service.py` to:
1. Check the result of `event_result()` before returning success
2. Only return success message when `event_result()` returns a valid result (not None)
3. Return a fallback message when the switch fails or returns no result

## Changes

- Modified `_detect_new_tab_opened` in `browser_use/tools/service.py`
- Added proper result checking after `event_result()` call
- Returns appropriate fallback message when switch fails

Fixes #5529

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes automatic new-tab switch detection so we don’t report a successful switch when the `SwitchTabEvent` handler fails or returns no result. Previously we always returned “Automatically switched…” after dispatch; now we check `event_result()` and return a fallback note if the switch didn’t succeed.

- Old: Always returned success after dispatching `SwitchTabEvent`.
- New: Return success only when `event_result()` is not None; otherwise return a note telling the user to switch tabs manually.
- Scope: Changes are limited to `_detect_new_tab_opened` in browser_use/tools/service.py.

<sup>Written for commit 0c58f1653a71e863575705f00f709814c6302a9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

