### PR TITLE
fix(dom): keep unparseable deeply nested lines during markdown extraction

### DIFF
--- a/browser_use/dom/markdown_extractor.py
+++ b/browser_use/dom/markdown_extractor.py
@@ -180,7 +180,9 @@ def _preprocess_markdown_content(content: str, max_newlines: int = 3) -> tuple[s
 				try:
 					json.loads(stripped)
 					continue
-				except ValueError:
+				except (ValueError, RecursionError):
+					# RecursionError: nesting past json.loads' limit means it is not a
+					# blob we can parse, so keep the line rather than aborting extraction.
 					pass
 			filtered_lines.append(line)
 

--- a/tests/ci/test_markdown_extractor.py
+++ b/tests/ci/test_markdown_extractor.py
@@ -144,3 +144,19 @@ class TestPreservesLinksAndEncoding:
 		assert '%20' in content
 		assert '%2F' in content
 		assert '%26' in content
+
+	def test_preserves_deeply_nested_bracket_lines(self):
+		"""A deeply nested bracket line must not abort the JSON heuristic.
+
+		`json.loads` raises RecursionError (not ValueError) past its nesting
+		limit, so hostile page text like `[[[[...` used to propagate out of
+		markdown extraction and fail the whole extract action.
+		"""
+		line = '[' * 20_000
+		assert len(line) > 100
+		content = f'Header\n{line}\nFooter'
+		filtered, _ = _preprocess_markdown_content(content)
+
+		assert line in filtered
+		assert 'Header' in filtered
+		assert 'Footer' in filtered


### PR DESCRIPTION
The SPA-JSON-blob filter in `_preprocess_markdown_content` drops long lines that parse as JSON, keeping the rest. It guards `json.loads` with `except ValueError`, but `json.loads` raises `RecursionError` — not a `ValueError` subclass — once a line nests past the scanner's limit.

So a page whose text contains a long deeply nested run (e.g. `[[[[…`) makes the exception escape `_preprocess_markdown_content`, propagate through `convert_html_to_markdown` and `extract_clean_markdown`, and fail the entire `extract` action for that page. Page content is untrusted input, so this is trivially triggerable.

Treating `RecursionError` like a decode error matches the intent: if we can't parse it, it isn't a blob we should drop.

Test: `tests/ci/test_markdown_extractor.py::TestPreservesLinksAndEncoding::test_preserves_deeply_nested_bracket_lines` — fails with `RecursionError` before the change, passes after. Pure unit test, no browser: `uv run pytest` goes from `1 failed, 14 passed` to `15 passed`. `ruff format --check` and `ruff check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents markdown extraction from failing on deeply nested bracket runs by treating `json.loads` `RecursionError` as a decode failure in the SPA-JSON-blob filter. Previously such lines raised `RecursionError`, escaped `_preprocess_markdown_content`, and aborted `extract_clean_markdown`; now they are kept and extraction continues.

- Catch `(ValueError, RecursionError)` around `json.loads` and keep unparseable lines.
- Add unit test `tests/ci/test_markdown_extractor.py::TestPreservesLinksAndEncoding::test_preserves_deeply_nested_bracket_lines`.

<sup>Written for commit c93da2b946e26b9138ea019b492fd17cd5294b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

