### PR TITLE
fix(filesystem): render markdown emphasis in PDF export

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -99,15 +99,27 @@ def _markdown_inline_to_rml(text: str) -> str:
 	injected ``<b>`` / ``<i>`` / ``<font>`` tags are unambiguous.
 
 	Underscore emphasis is intentionally unsupported so ``snake_case`` identifiers
-	survive unchanged.
+	survive unchanged. Inline code is stashed before emphasis so markers inside
+	backticks stay Courier-only. Bold content cannot start with ``/``, so globs
+	like ``**/foo/**`` stay literal.
 	"""
 	text = html.escape(text)
+	# Stash code spans first — Markdown renders their contents literally.
+	code_spans: list[str] = []
+
+	def _stash_code(match: re.Match[str]) -> str:
+		code_spans.append(match.group(1))
+		return f'\x00C{len(code_spans) - 1}\x00'
+
+	text = re.sub(r'`([^`]+)`', _stash_code, text)
 	# Bold before italic so ``**`` is not treated as two italic markers.
 	# Content cannot contain ``*`` — otherwise globs like ``*.txt and **/*.py`` pair across tokens.
-	text = re.sub(r'\*\*([^\s*](?:[^*]*[^\s*])?)\*\*', r'<b>\1</b>', text)
+	# Content cannot start with ``/`` — otherwise ``**/foo/**`` is treated as bold.
+	text = re.sub(r'\*\*([^\s*/](?:[^*]*[^\s*])?)\*\*', r'<b>\1</b>', text)
 	# Non-space boundaries keep ``2 * 3 * 4`` literal; leading ``* `` is a bullet, not italic
 	text = re.sub(r'(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)', r'<i>\1</i>', text)
-	text = re.sub(r'`([^`]+)`', r'<font face="Courier">\1</font>', text)
+	for i, span in enumerate(code_spans):
+		text = text.replace(f'\x00C{i}\x00', f'<font face="Courier">{span}</font>')
 	return text
 
 

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -104,23 +104,19 @@ def _markdown_inline_to_rml(text: str) -> str:
 	like ``**/foo/**`` stay literal.
 	"""
 	text = html.escape(text)
-	# Stash code spans first — Markdown renders their contents literally.
-	code_spans: list[str] = []
-
-	def _stash_code(match: re.Match[str]) -> str:
-		code_spans.append(match.group(1))
-		return f'\x00C{len(code_spans) - 1}\x00'
-
-	text = re.sub(r'`([^`]+)`', _stash_code, text)
-	# Bold before italic so ``**`` is not treated as two italic markers.
-	# Content cannot contain ``*`` — otherwise globs like ``*.txt and **/*.py`` pair across tokens.
-	# Content cannot start with ``/`` — otherwise ``**/foo/**`` is treated as bold.
-	text = re.sub(r'\*\*([^\s*/](?:[^*]*[^\s*])?)\*\*', r'<b>\1</b>', text)
-	# Non-space boundaries keep ``2 * 3 * 4`` literal; leading ``* `` is a bullet, not italic
-	text = re.sub(r'(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)', r'<i>\1</i>', text)
-	for i, span in enumerate(code_spans):
-		text = text.replace(f'\x00C{i}\x00', f'<font face="Courier">{span}</font>')
-	return text
+	rendered: list[str] = []
+	for part in re.split(r'(`[^`]+`)', text):
+		if part.startswith('`') and part.endswith('`'):
+			rendered.append(f'<font face="Courier">{part[1:-1]}</font>')
+			continue
+		# Bold before italic so ``**`` is not treated as two italic markers.
+		# Content cannot contain ``*`` — otherwise globs like ``*.txt and **/*.py`` pair across tokens.
+		# Content cannot start with ``/`` — otherwise ``**/foo/**`` is treated as bold.
+		part = re.sub(r'\*\*([^\s*/](?:[^*]*[^\s*])?)\*\*', r'<b>\1</b>', part)
+		# Non-space boundaries keep ``2 * 3 * 4`` literal; leading ``* `` is a bullet, not italic
+		part = re.sub(r'(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)', r'<i>\1</i>', part)
+		rendered.append(part)
+	return ''.join(rendered)
 
 
 DEFAULT_FILE_SYSTEM_PATH = 'browseruse_agent_data'

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -74,6 +74,43 @@ def _build_filename_error_message(file_name: str, supported_extensions: list[str
 	)
 
 
+def _split_heading(line: str) -> tuple[str, int | None]:
+	"""Split a markdown ATX heading into (text, level).
+
+	Only ``# `` / ``## `` / ``### `` (note the required space) are headings.
+	Anything else, including ``#hashtag``, is returned unchanged with level None.
+	"""
+	if line.startswith('### '):
+		return line[4:], 3
+	if line.startswith('## '):
+		return line[3:], 2
+	if line.startswith('# '):
+		return line[2:], 1
+	return line, None
+
+
+_BULLET_RE = re.compile(r'^(\s*)[-*]\s+(.*)$')
+
+
+def _markdown_inline_to_rml(text: str) -> str:
+	"""Escape plain text, then convert a markdown subset to ReportLab markup.
+
+	Order matters: after html.escape there are no user-supplied ``<`` left, so
+	injected ``<b>`` / ``<i>`` / ``<font>`` tags are unambiguous.
+
+	Underscore emphasis is intentionally unsupported so ``snake_case`` identifiers
+	survive unchanged.
+	"""
+	text = html.escape(text)
+	# Bold before italic so ``**`` is not treated as two italic markers.
+	# Content cannot contain ``*`` — otherwise globs like ``*.txt and **/*.py`` pair across tokens.
+	text = re.sub(r'\*\*([^\s*](?:[^*]*[^\s*])?)\*\*', r'<b>\1</b>', text)
+	# Non-space boundaries keep ``2 * 3 * 4`` literal; leading ``* `` is a bullet, not italic
+	text = re.sub(r'(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)', r'<i>\1</i>', text)
+	text = re.sub(r'`([^`]+)`', r'<font face="Courier">\1</font>', text)
+	return text
+
+
 DEFAULT_FILE_SYSTEM_PATH = 'browseruse_agent_data'
 
 
@@ -257,25 +294,36 @@ class PdfFile(BaseFile):
 			doc = SimpleDocTemplate(str(file_path), pagesize=letter)
 			styles = getSampleStyleSheet()
 			story = []
+			heading_styles = {1: styles['Title'], 2: styles['Heading1'], 3: styles['Heading2']}
 
-			# Plain text plus markdown headers only, to avoid an AGPL markdown-to-PDF dependency
-			content_lines = self.content.split('\n')
+			# Escape first, then markdown → RML. Avoids an AGPL markdown-to-PDF dependency.
+			in_fence = False
+			for line in self.content.split('\n'):
+				stripped = line.strip()
+				if stripped.startswith('```'):
+					in_fence = not in_fence
+					continue
 
-			for line in content_lines:
-				if line.strip():
-					# Handle basic markdown headers
-					if line.startswith('# '):
-						text, style = line[2:], styles['Title']
-					elif line.startswith('## '):
-						text, style = line[3:], styles['Heading1']
-					elif line.startswith('### '):
-						text, style = line[4:], styles['Heading2']
-					else:
-						text, style = line, styles['Normal']
-					# Paragraph parses its input as ReportLab markup, but our content is plain text
-					story.append(Paragraph(html.escape(text), style))
-				else:
+				if not stripped:
 					story.append(Spacer(1, 6))
+					continue
+
+				if in_fence:
+					# Fenced blocks are literal: no emphasis / inline-code conversion
+					story.append(Paragraph(html.escape(line), styles['Code']))
+					continue
+
+				text, heading_level = _split_heading(line)
+				if heading_level is not None:
+					story.append(Paragraph(_markdown_inline_to_rml(text), heading_styles[heading_level]))
+					continue
+
+				bullet = _BULLET_RE.match(line)
+				if bullet:
+					story.append(Paragraph(f'&bull; {_markdown_inline_to_rml(bullet.group(2))}', styles['Normal']))
+					continue
+
+				story.append(Paragraph(_markdown_inline_to_rml(line), styles['Normal']))
 
 			doc.build(story)
 		except Exception as e:
@@ -305,13 +353,9 @@ class DocxFile(BaseFile):
 
 			for line in content_lines:
 				if line.strip():
-					# Handle basic markdown headers
-					if line.startswith('# '):
-						doc.add_heading(line[2:], level=1)
-					elif line.startswith('## '):
-						doc.add_heading(line[3:], level=2)
-					elif line.startswith('### '):
-						doc.add_heading(line[4:], level=3)
+					text, heading_level = _split_heading(line)
+					if heading_level is not None:
+						doc.add_heading(text, level=heading_level)
 					else:
 						doc.add_paragraph(line)
 				else:

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -17,6 +17,7 @@ from browser_use.filesystem.file_system import (
 	JsonlFile,
 	MarkdownFile,
 	TxtFile,
+	_markdown_inline_to_rml,
 	_split_heading,
 )
 
@@ -52,6 +53,16 @@ class TestBaseFile:
 		assert _split_heading('#hashtag is not a header') == ('#hashtag is not a header', None)
 		assert _split_heading('plain') == ('plain', None)
 		assert _split_heading('#### too deep') == ('#### too deep', None)
+
+	def test_markdown_inline_glob_is_not_bold(self):
+		"""Recursive globs must not be treated as bold delimiters."""
+		assert _markdown_inline_to_rml('**/foo/**') == '**/foo/**'
+		assert _markdown_inline_to_rml('**bold** and **/foo/**') == '<b>bold</b> and **/foo/**'
+
+	def test_markdown_inline_code_protects_emphasis(self):
+		"""Emphasis markers inside backticks stay Courier, not italic/bold."""
+		assert _markdown_inline_to_rml('`*literal*`') == '<font face="Courier">*literal*</font>'
+		assert _markdown_inline_to_rml('`**bold**`') == '<font face="Courier">**bold**</font>'
 
 	def test_txt_file_creation(self):
 		"""Test TxtFile creation and basic properties."""
@@ -308,6 +319,7 @@ class TestFileSystem:
 			[
 				'Arithmetic 2 * 3 * 4 stays literal',
 				'Glob pattern *.txt and **/*.py stay literal',
+				'Recursive glob **/foo/** stays literal',
 			]
 		)
 		result = await empty_filesystem.write_file('stars.pdf', source)
@@ -316,6 +328,7 @@ class TestFileSystem:
 		assert '2 * 3 * 4' in blob
 		assert '*.txt' in blob
 		assert '**/*.py' in blob
+		assert '**/foo/**' in blob
 
 	async def test_write_pdf_underscore_is_not_italic(self, empty_filesystem):
 		"""Underscores are identifiers, not emphasis."""
@@ -341,6 +354,17 @@ class TestFileSystem:
 		blob, _ = _extract_pdf_text(empty_filesystem.data_dir / 'backticks.pdf')
 		assert 'Run $(cmd) inline.' in blob
 		assert 'echo `$(cmd)`' in blob
+
+	async def test_write_pdf_inline_code_protects_emphasis_markers(self, empty_filesystem):
+		"""Stars inside inline code stay literal instead of becoming italic/bold."""
+		source = 'Keep `*literal*` and `**bold**` as code.'
+		result = await empty_filesystem.write_file('code_stars.pdf', source)
+		assert result == 'Data written to file code_stars.pdf successfully.'
+		blob, _ = _extract_pdf_text(empty_filesystem.data_dir / 'code_stars.pdf')
+		assert '*literal*' in blob
+		assert '**bold**' in blob
+		assert '`*literal*`' not in blob
+		assert '`**bold**`' not in blob
 
 	def test_filesystem_initialization(self, temp_filesystem):
 		"""Test FileSystem initialization with default files."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -31,6 +31,21 @@ def _extract_pdf_text(path: Path) -> tuple[str, list[str]]:
 	return ' '.join(text.split()), [line.strip() for line in text.splitlines() if line.strip()]
 
 
+def _extract_pdf_fonts(path: Path) -> set[str]:
+	"""Return the PDF base fonts used to render non-empty text."""
+	fonts: set[str] = set()
+
+	def _record_font(text: str, _cm, _tm, font_dictionary, _font_size) -> None:
+		if text.strip() and font_dictionary is not None:
+			base_font = font_dictionary.get('/BaseFont')
+			if base_font is not None:
+				fonts.add(str(base_font))
+
+	for page in PdfReader(path).pages:
+		page.extract_text(visitor_text=_record_font)
+	return fonts
+
+
 class TestBaseFile:
 	"""Test the BaseFile abstract base class and its implementations."""
 
@@ -63,6 +78,15 @@ class TestBaseFile:
 		"""Emphasis markers inside backticks stay Courier, not italic/bold."""
 		assert _markdown_inline_to_rml('`*literal*`') == '<font face="Courier">*literal*</font>'
 		assert _markdown_inline_to_rml('`**bold**`') == '<font face="Courier">**bold**</font>'
+
+	def test_markdown_inline_code_token_cannot_replace_user_text(self):
+		"""A user-provided placeholder-like sequence must survive code-span restoration."""
+		literal = '\x00C0\x00'
+		assert _markdown_inline_to_rml(f'Keep {literal} and `code`.') == (f'Keep {literal} and <font face="Courier">code</font>.')
+		prefix_literal = '\x00BROWSER_USE_INLINE_CODE_0\x00'
+		assert _markdown_inline_to_rml(f'Keep {prefix_literal} and `code`.') == (
+			f'Keep {prefix_literal} and <font face="Courier">code</font>.'
+		)
 
 	def test_txt_file_creation(self):
 		"""Test TxtFile creation and basic properties."""
@@ -300,7 +324,9 @@ class TestFileSystem:
 		)
 		result = await empty_filesystem.write_file('formatted.pdf', source)
 		assert result == 'Data written to file formatted.pdf successfully.'
-		blob, lines = _extract_pdf_text(empty_filesystem.data_dir / 'formatted.pdf')
+		pdf_path = empty_filesystem.data_dir / 'formatted.pdf'
+		blob, lines = _extract_pdf_text(pdf_path)
+		fonts = _extract_pdf_fonts(pdf_path)
 
 		assert 'bold text' in blob
 		assert '**bold text**' not in blob
@@ -312,6 +338,7 @@ class TestFileSystem:
 		assert 'second bullet item' in blob
 		assert 'star bullet item' in blob
 		assert not any(line.startswith(('- ', '* ')) for line in lines)
+		assert {'/Helvetica-Bold', '/Helvetica-Oblique', '/Courier'} <= fonts
 
 	async def test_write_pdf_star_overload_is_not_emphasis(self, empty_filesystem):
 		"""Arithmetic and glob stars must not be treated as italic or bullets."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -17,6 +17,7 @@ from browser_use.filesystem.file_system import (
 	JsonlFile,
 	MarkdownFile,
 	TxtFile,
+	_split_heading,
 )
 
 
@@ -42,6 +43,15 @@ class TestBaseFile:
 		assert md_file.full_name == 'test.md'
 		assert md_file.get_size == 13
 		assert md_file.get_line_count == 1
+
+	def test_split_heading_levels(self):
+		"""PdfFile and DocxFile share one heading parser."""
+		assert _split_heading('# Title') == ('Title', 1)
+		assert _split_heading('## Section') == ('Section', 2)
+		assert _split_heading('### Notes') == ('Notes', 3)
+		assert _split_heading('#hashtag is not a header') == ('#hashtag is not a header', None)
+		assert _split_heading('plain') == ('plain', None)
+		assert _split_heading('#### too deep') == ('#### too deep', None)
 
 	def test_txt_file_creation(self):
 		"""Test TxtFile creation and basic properties."""
@@ -264,6 +274,73 @@ class TestFileSystem:
 		blob, _ = _extract_pdf_text(empty_filesystem.data_dir / 'report.pdf')
 		assert 'First & half' in blob
 		assert 'Second <b half > 2' in blob
+
+	async def test_write_pdf_renders_markdown_formatting(self, empty_filesystem):
+		"""PDF export honors bold, italic, inline code, and bullets."""
+		source = '\n'.join(
+			[
+				'This is **bold text** in a sentence.',
+				'This is *italic text* in a sentence.',
+				'Use `inline_code` here.',
+				'- first bullet item',
+				'- second bullet item',
+				'* star bullet item',
+			]
+		)
+		result = await empty_filesystem.write_file('formatted.pdf', source)
+		assert result == 'Data written to file formatted.pdf successfully.'
+		blob, lines = _extract_pdf_text(empty_filesystem.data_dir / 'formatted.pdf')
+
+		assert 'bold text' in blob
+		assert '**bold text**' not in blob
+		assert 'italic text' in blob
+		assert '*italic text*' not in blob
+		assert 'inline_code' in blob
+		assert '`inline_code`' not in blob
+		assert 'first bullet item' in blob
+		assert 'second bullet item' in blob
+		assert 'star bullet item' in blob
+		assert not any(line.startswith(('- ', '* ')) for line in lines)
+
+	async def test_write_pdf_star_overload_is_not_emphasis(self, empty_filesystem):
+		"""Arithmetic and glob stars must not be treated as italic or bullets."""
+		source = '\n'.join(
+			[
+				'Arithmetic 2 * 3 * 4 stays literal',
+				'Glob pattern *.txt and **/*.py stay literal',
+			]
+		)
+		result = await empty_filesystem.write_file('stars.pdf', source)
+		assert result == 'Data written to file stars.pdf successfully.'
+		blob, _ = _extract_pdf_text(empty_filesystem.data_dir / 'stars.pdf')
+		assert '2 * 3 * 4' in blob
+		assert '*.txt' in blob
+		assert '**/*.py' in blob
+
+	async def test_write_pdf_underscore_is_not_italic(self, empty_filesystem):
+		"""Underscores are identifiers, not emphasis."""
+		source = 'Keep snake_case_names and file_name_here unchanged.'
+		result = await empty_filesystem.write_file('names.pdf', source)
+		assert result == 'Data written to file names.pdf successfully.'
+		blob, _ = _extract_pdf_text(empty_filesystem.data_dir / 'names.pdf')
+		assert 'snake_case_names' in blob
+		assert 'file_name_here' in blob
+
+	async def test_write_pdf_fenced_backticks_stay_literal(self, empty_filesystem):
+		"""Inline code strips backticks; fenced shell snippets keep them."""
+		source = '\n'.join(
+			[
+				'Run `$(cmd)` inline.',
+				'```',
+				'echo `$(cmd)`',
+				'```',
+			]
+		)
+		result = await empty_filesystem.write_file('backticks.pdf', source)
+		assert result == 'Data written to file backticks.pdf successfully.'
+		blob, _ = _extract_pdf_text(empty_filesystem.data_dir / 'backticks.pdf')
+		assert 'Run $(cmd) inline.' in blob
+		assert 'echo `$(cmd)`' in blob
 
 	def test_filesystem_initialization(self, temp_filesystem):
 		"""Test FileSystem initialization with default files."""


### PR DESCRIPTION
`write_file` tells the model that PDF content is markdown, but after #5502 only `#` / `##` / `###` headings were styled. Bold, italic, inline code, and bullets printed as literal `**syntax**`.

Keep the #5502 escape-first behavior (raw ReportLab markup cannot be restored — that is the parse bug). After `html.escape`, convert a small markdown subset to RML. Underscores stay literal so `snake_case` names are not italicized. `*` is only emphasis when it actually wraps a span — `2 * 3 * 4` and globs are left alone. Fenced blocks skip inline conversion so shell backticks survive.

Heading offsets are shared with `DocxFile` via `_split_heading`.

Fixes #5538

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render markdown emphasis in PDF exports from `write_file` so PDFs match the documented markdown contract. Previously only `#`/`##`/`###` headings rendered; now bold, italic, inline code, and bullets format correctly while we keep the escape-first fix to avoid `ReportLab` parse issues.

- Convert `**bold**`, `*italic*`, `` `inline` ``, and list bullets (`-`/`*`) to RML; code fences bypass inline conversion; underscores never italicize.
- Keep glob tokens and arithmetic stars literal (e.g., `*.txt`, `**/foo/**`, `2 * 3 * 4`); inline code protects emphasis markers.
- Restore inline code via collision-safe placeholders so user text cannot be mistaken for stash tokens.
- Share heading parsing with `DocxFile` to align `#`/`##`/`###` levels; add tests for emphasis, bullets, fences, globs, and edge cases.

<sup>Written for commit f168606cb97b59f86d87e6666d2cd551af0eeb1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

