### PR TITLE
fix(llm): ignore empty reasoning model patterns

### DIFF
--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -179,7 +179,7 @@ class ChatAzureOpenAI(ChatOpenAILike):
 				model_params['service_tier'] = self.service_tier
 
 			# Handle reasoning models
-			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+			if self.reasoning_models and any(str(m) and str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
 				# For reasoning models, use reasoning parameter instead of reasoning_effort
 				model_params['reasoning'] = {'effort': self.reasoning_effort}
 				model_params.pop('temperature', None)

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -186,7 +186,7 @@ class ChatOpenAI(BaseChatModel):
 			if self.service_tier is not None:
 				model_params['service_tier'] = self.service_tier
 
-			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+			if self.reasoning_models and any(str(m) and str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
 				model_params['reasoning_effort'] = self.reasoning_effort
 				model_params.pop('temperature', None)
 				model_params.pop('frequency_penalty', None)

--- a/browser_use/llm/vercel/chat.py
+++ b/browser_use/llm/vercel/chat.py
@@ -557,7 +557,7 @@ class ChatVercel(BaseChatModel):
 				is_google_model = self.model.startswith('google/')
 				is_anthropic_model = self.model.startswith('anthropic/')
 				is_reasoning_model = self.reasoning_models and any(
-					str(pattern).lower() in str(self.model).lower() for pattern in self.reasoning_models
+					pattern and pattern.lower() in str(self.model).lower() for pattern in self.reasoning_models
 				)
 
 				if is_google_model or is_anthropic_model or is_reasoning_model:

--- a/browser_use/llm/vercel/chat.py
+++ b/browser_use/llm/vercel/chat.py
@@ -557,7 +557,7 @@ class ChatVercel(BaseChatModel):
 				is_google_model = self.model.startswith('google/')
 				is_anthropic_model = self.model.startswith('anthropic/')
 				is_reasoning_model = self.reasoning_models and any(
-					pattern and pattern.lower() in str(self.model).lower() for pattern in self.reasoning_models
+					str(pattern) and str(pattern).lower() in str(self.model).lower() for pattern in self.reasoning_models
 				)
 
 				if is_google_model or is_anthropic_model or is_reasoning_model:

--- a/tests/ci/models/test_llm_azure.py
+++ b/tests/ci/models/test_llm_azure.py
@@ -1,6 +1,10 @@
-"""Test Azure OpenAI model button click."""
+"""Test Azure OpenAI model behavior."""
 
-from browser_use.llm.azure.chat import ChatAzureOpenAI
+from types import SimpleNamespace
+
+import pytest
+
+from browser_use.llm.azure.chat import ChatAzureOpenAI, ResponsesAPIMessageSerializer
 from tests.ci.models.model_test_helper import run_model_button_click_test
 
 
@@ -13,3 +17,35 @@ async def test_azure_gpt_4_1_mini(httpserver):
 		extra_kwargs={},  # Azure endpoint will be added by helper
 		httpserver=httpserver,
 	)
+
+
+@pytest.mark.parametrize(
+	('reasoning_models', 'expect_reasoning'),
+	[
+		([''], False),
+		(['gpt-5'], True),
+	],
+)
+async def test_reasoning_model_patterns_ignore_empty_entries(monkeypatch, reasoning_models, expect_reasoning):
+	"""Empty patterns must not classify every model as a reasoning model."""
+	model = 'gpt-5-mini' if expect_reasoning else 'gpt-4.1'
+	chat = ChatAzureOpenAI(
+		model=model,
+		temperature=0.7,
+		reasoning_models=reasoning_models,
+		use_responses_api=True,
+	)
+	captured = {}
+
+	async def create(**kwargs):
+		captured.update(kwargs)
+		return SimpleNamespace(output_text='ok', usage=None, status='completed')
+
+	client = SimpleNamespace(responses=SimpleNamespace(create=create))
+	monkeypatch.setattr(ResponsesAPIMessageSerializer, 'serialize_messages', lambda _messages: [])
+	monkeypatch.setattr(chat, 'get_client', lambda: client)
+
+	await chat.ainvoke(messages=[])
+
+	assert ('reasoning' in captured) is expect_reasoning
+	assert ('temperature' in captured) is not expect_reasoning

--- a/tests/ci/models/test_llm_openai.py
+++ b/tests/ci/models/test_llm_openai.py
@@ -1,6 +1,10 @@
-"""Test OpenAI model button click."""
+"""Test OpenAI model behavior."""
 
-from browser_use.llm.openai.chat import ChatOpenAI
+from types import SimpleNamespace
+
+import pytest
+
+from browser_use.llm.openai.chat import ChatOpenAI, OpenAIMessageSerializer
 from tests.ci.models.model_test_helper import run_model_button_click_test
 
 
@@ -13,3 +17,43 @@ async def test_openai_gpt_4_1_mini(httpserver):
 		extra_kwargs={},
 		httpserver=httpserver,
 	)
+
+
+@pytest.mark.parametrize(
+	('reasoning_models', 'expect_reasoning'),
+	[
+		([''], False),
+		(['gpt-5'], True),
+	],
+)
+async def test_reasoning_model_patterns_ignore_empty_entries(monkeypatch, reasoning_models, expect_reasoning):
+	"""Empty patterns must not classify every model as a reasoning model."""
+	model = 'gpt-5-mini' if expect_reasoning else 'gpt-4.1'
+	chat = ChatOpenAI(
+		model=model,
+		temperature=0.7,
+		frequency_penalty=0.5,
+		reasoning_models=reasoning_models,
+	)
+	captured = {}
+
+	async def create(**kwargs):
+		captured.update(kwargs)
+		return SimpleNamespace(
+			choices=[SimpleNamespace(message=SimpleNamespace(content='ok'), finish_reason='stop')],
+			usage=None,
+		)
+
+	client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+	monkeypatch.setattr(
+		OpenAIMessageSerializer,
+		'serialize_messages',
+		lambda _messages: [{'role': 'user', 'content': 'ping'}],
+	)
+	monkeypatch.setattr(chat, 'get_client', lambda: client)
+
+	await chat.ainvoke(messages=[])
+
+	assert ('reasoning_effort' in captured) is expect_reasoning
+	assert ('temperature' in captured) is not expect_reasoning
+	assert ('frequency_penalty' in captured) is not expect_reasoning

--- a/tests/ci/models/test_llm_vercel.py
+++ b/tests/ci/models/test_llm_vercel.py
@@ -1,0 +1,51 @@
+"""Test Vercel AI Gateway model behavior."""
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.vercel.chat import ChatVercel
+
+
+class StructuredOutput(BaseModel):
+	value: str
+
+
+class StringablePattern:
+	def __init__(self, value: str):
+		self.value = value
+
+	def __str__(self) -> str:
+		return self.value
+
+
+@pytest.mark.parametrize(
+	('reasoning_models', 'expect_reasoning'),
+	[
+		([''], False),
+		(['gpt-5'], True),
+		(cast(list[str], [StringablePattern('gpt-5')]), True),
+	],
+)
+async def test_reasoning_model_patterns_ignore_empty_entries(monkeypatch, reasoning_models, expect_reasoning):
+	"""Empty patterns are ignored while string-compatible values remain supported."""
+	model = 'openai/gpt-5-mini' if expect_reasoning else 'openai/gpt-4o'
+	chat = ChatVercel(model=model, api_key='test', reasoning_models=reasoning_models)
+	captured = {}
+
+	async def create(**kwargs):
+		captured.update(kwargs)
+		return SimpleNamespace(
+			choices=[SimpleNamespace(message=SimpleNamespace(content='{"value":"ok"}'), finish_reason='stop')],
+			usage=None,
+		)
+
+	client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+	monkeypatch.setattr(chat, 'get_client', lambda: client)
+
+	result = await chat.ainvoke(messages=[], output_format=StructuredOutput)
+
+	assert result.completion == StructuredOutput(value='ok')
+	assert ('response_format' not in captured) is expect_reasoning


### PR DESCRIPTION
## Summary

- ignore empty entries when matching configured reasoning-model patterns
- preserve sampling parameters for non-reasoning models
- apply the same guard to the OpenAI, Azure OpenAI, and Vercel providers
- add regression coverage for both an empty pattern and a valid reasoning-model pattern

## Root cause

Python treats the empty string as a substring of every string. With `reasoning_models=['']`, the existing `'' in model_name` check therefore classified every model as a reasoning model, removed `temperature` and `frequency_penalty`, and added `reasoning_effort`.

## Verification

- `.venv/bin/pytest -q tests/ci/models/test_llm_openai.py tests/ci/models/test_llm_azure.py tests/ci/models/test_llm_vercel.py` — 7 passed, 2 credentialed integration tests skipped
- `.venv/bin/pyright browser_use/llm/azure/chat.py browser_use/llm/openai/chat.py browser_use/llm/vercel/chat.py tests/ci/models/test_llm_openai.py tests/ci/models/test_llm_azure.py tests/ci/models/test_llm_vercel.py` — 0 errors
- `.venv/bin/ruff check ...` and `.venv/bin/ruff format --check ...` — passed

Fixes #5543

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignores empty reasoning-model patterns so only intended models get reasoning settings. Previously an empty string matched every model and forced reasoning mode; now only matched models switch and others keep their sampling params.

**Bug Fixes**
- Ignore empty entries in `reasoning_models` for `openai`, `azure`, and `vercel` providers.
- Preserve `temperature`, `frequency_penalty`, and `response_format` on non-reasoning models; apply reasoning params only to matches.
- Add regression tests across providers, including support for string-like pattern objects.

<sup>Written for commit d88ec1f8f8225d5e544bfd4c6d4d5b6c5dace841. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


