### PR TITLE
fix(llm): ignore empty patterns in reasoning_models matching

### DIFF
--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -179,7 +179,9 @@ class ChatAzureOpenAI(ChatOpenAILike):
 				model_params['service_tier'] = self.service_tier
 
 			# Handle reasoning models
-			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+			if self.reasoning_models and any(
+				str(m).strip() and str(m).lower() in str(self.model).lower() for m in self.reasoning_models
+			):
 				# For reasoning models, use reasoning parameter instead of reasoning_effort
 				model_params['reasoning'] = {'effort': self.reasoning_effort}
 				model_params.pop('temperature', None)

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -186,7 +186,9 @@ class ChatOpenAI(BaseChatModel):
 			if self.service_tier is not None:
 				model_params['service_tier'] = self.service_tier
 
-			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+			if self.reasoning_models and any(
+				str(m).strip() and str(m).lower() in str(self.model).lower() for m in self.reasoning_models
+			):
 				model_params['reasoning_effort'] = self.reasoning_effort
 				model_params.pop('temperature', None)
 				model_params.pop('frequency_penalty', None)

--- a/browser_use/llm/vercel/chat.py
+++ b/browser_use/llm/vercel/chat.py
@@ -557,7 +557,8 @@ class ChatVercel(BaseChatModel):
 				is_google_model = self.model.startswith('google/')
 				is_anthropic_model = self.model.startswith('anthropic/')
 				is_reasoning_model = self.reasoning_models and any(
-					str(pattern).lower() in str(self.model).lower() for pattern in self.reasoning_models
+					str(pattern).strip() and str(pattern).lower() in str(self.model).lower()
+					for pattern in self.reasoning_models
 				)
 
 				if is_google_model or is_anthropic_model or is_reasoning_model:

--- a/tests/ci/models/test_llm_azure.py
+++ b/tests/ci/models/test_llm_azure.py
@@ -1,6 +1,8 @@
 """Test Azure OpenAI model button click."""
 
-from browser_use.llm.azure.chat import ChatAzureOpenAI
+from types import SimpleNamespace
+
+from browser_use.llm.azure.chat import ChatAzureOpenAI, ResponsesAPIMessageSerializer
 from tests.ci.models.model_test_helper import run_model_button_click_test
 
 
@@ -13,3 +15,43 @@ async def test_azure_gpt_4_1_mini(httpserver):
 		extra_kwargs={},  # Azure endpoint will be added by helper
 		httpserver=httpserver,
 	)
+
+
+async def test_azure_empty_reasoning_model_pattern_does_not_match_every_model(
+	monkeypatch,
+):
+	chat = ChatAzureOpenAI(
+		model='gpt-4.1',
+		temperature=0.7,
+		reasoning_models=[''],
+		use_responses_api=True,
+		azure_endpoint='https://dummy.openai.azure.com',
+		api_key='dummy_key',
+	)
+	captured = {}
+
+	async def create(**kwargs):
+		captured.update(kwargs)
+		return SimpleNamespace(
+			output_text='ok',
+			status='completed',
+			usage=None,
+		)
+
+	client = SimpleNamespace(
+		responses=SimpleNamespace(create=create),
+	)
+
+	monkeypatch.setattr(
+		ResponsesAPIMessageSerializer,
+		'serialize_messages',
+		lambda _messages: [{'role': 'user', 'content': 'ping'}],
+	)
+	monkeypatch.setattr(chat, 'get_client', lambda: client)
+
+	await chat.ainvoke(messages=[])
+
+	assert 'reasoning' not in captured
+	assert captured.get('temperature') == 0.7
+
+

--- a/tests/ci/models/test_llm_openai.py
+++ b/tests/ci/models/test_llm_openai.py
@@ -1,6 +1,8 @@
 """Test OpenAI model button click."""
 
-from browser_use.llm.openai.chat import ChatOpenAI
+from types import SimpleNamespace
+
+from browser_use.llm.openai.chat import ChatOpenAI, OpenAIMessageSerializer
 from tests.ci.models.model_test_helper import run_model_button_click_test
 
 
@@ -13,3 +15,47 @@ async def test_openai_gpt_4_1_mini(httpserver):
 		extra_kwargs={},
 		httpserver=httpserver,
 	)
+
+
+async def test_empty_reasoning_model_pattern_does_not_match_every_model(
+	monkeypatch,
+):
+	chat = ChatOpenAI(
+		model='gpt-4.1',
+		temperature=0.7,
+		frequency_penalty=0.5,
+		reasoning_models=[''],
+	)
+	captured = {}
+
+	async def create(**kwargs):
+		captured.update(kwargs)
+		return SimpleNamespace(
+			choices=[
+				SimpleNamespace(
+					message=SimpleNamespace(content='ok'),
+					finish_reason='stop',
+				)
+			],
+			usage=None,
+		)
+
+	client = SimpleNamespace(
+		chat=SimpleNamespace(
+			completions=SimpleNamespace(create=create),
+		)
+	)
+
+	monkeypatch.setattr(
+		OpenAIMessageSerializer,
+		'serialize_messages',
+		lambda _messages: [{'role': 'user', 'content': 'ping'}],
+	)
+	monkeypatch.setattr(chat, 'get_client', lambda: client)
+
+	await chat.ainvoke(messages=[])
+
+	assert 'reasoning_effort' not in captured
+	assert captured.get('temperature') == 0.7
+	assert captured.get('frequency_penalty') == 0.5
+


### PR DESCRIPTION
## Summary
Fixes #5543.

In `browser_use/llm/openai/chat.py`, `browser_use/llm/azure/chat.py`, and `browser_use/llm/vercel/chat.py`, the reasoning model check used substring matching:
```python
if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
```
When `reasoning_models` contained empty strings (e.g. `reasoning_models=['']`), `"" in str(self.model).lower()` evaluated to `True` for every model, incorrectly classifying regular models as reasoning models and dropping sampling parameters such as `temperature` and `frequency_penalty`.

## Changes
1. Filter out empty/whitespace-only patterns (`str(m).strip()`) during the `reasoning_models` substring matching in:
   - `browser_use/llm/openai/chat.py`
   - `browser_use/llm/azure/chat.py`
   - `browser_use/llm/vercel/chat.py`
2. Added regression tests in:
   - `tests/ci/models/test_llm_openai.py`
   - `tests/ci/models/test_llm_azure.py`

## Verification
- Ran `uv run pytest tests/ci/models/` (54 passed, 7 skipped).
- Ran `uv run ruff check browser_use/ tests/ci/models/` (all checks passed).
- Ran `uv run pyright browser_use/llm/openai/chat.py browser_use/llm/azure/chat.py browser_use/llm/vercel/chat.py` (0 errors).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reasoning model detection so an empty entry in `reasoning_models` no longer marks every model as a reasoning model. Previously this stripped sampling params like `temperature` and `frequency_penalty`; now regular models keep these settings.

**Bug Fixes**
- Ignore empty and whitespace-only patterns when checking `reasoning_models` in `browser_use/llm/openai/chat.py`, `browser_use/llm/azure/chat.py`, and `browser_use/llm/vercel/chat.py`.
- Add regression tests for OpenAI and Azure paths to prevent false matches.

<sup>Written for commit c7231773c98eb5ca00c066541426740cd21d8f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

