### PR TITLE
docs: correct Odysseys leaderboard rank from #1 to #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Check out the [library docs](https://docs.browser-use.com/open-source/introducti
 
 We benchmark Browser Use across 100 real-world browser tasks. Full benchmark is open source: **[browser-use/benchmark](https://github.com/browser-use/benchmark)**.
 
-Browser Use is also **#1 on the [Odysseys leaderboard](https://odysseysbench.com/leaderboard)** with an 87.4% average, ahead of computer-use agents from OpenAI, Anthropic, Google, and Microsoft. Odysseys measures the agent's performance on 200 long-horizon web tasks.
+Browser Use is also **#2 on the [Odysseys leaderboard](https://odysseysbench.com/leaderboard)** with an 87.4% rubric average, ahead of computer-use agents from OpenAI, Anthropic, Google, and Microsoft. Odysseys measures the agent's performance on 200 long-horizon web tasks.
 
 **Use the Open-Source Agent**
 - Free, and runs on your own machine


### PR DESCRIPTION
The README currently states that Browser Use is **#1 on the [Odysseys leaderboard](https://odysseysbench.com/leaderboard)**. As of today, the leaderboard lists **BrowserCode (Opus 4.7)** at **#2**, behind **Skyvern (Claude Opus 5)**.

This holds under both available sort orders:

| Sort | #1 | #2 |
|---|---|---|
| Rubric average | Skyvern (Claude Opus 5) — 98.1 | BrowserCode (Opus 4.7) — 87.4 |
| Perfect rubric (default) | Skyvern (Claude Opus 5) — 90.5 | BrowserCode (Opus 4.7) — 65.0 |

Two parts of the sentence are unchanged because they're still accurate:

- **87.4% is correct** — it's the Rubric Avg column. I've labelled it "rubric average" to disambiguate it from the Perfect column (65.0), since the leaderboard defaults to sorting by the latter.
- **"ahead of computer-use agents from OpenAI, Anthropic, Google, and Microsoft" still holds.** Skyvern is an independent hybrid agent, not one of those four. GPT-5.6 Luna is #4, Gemini 3.5 Flash #5, Claude Opus 4.6 #6, and Microsoft Research's WebWright #3.

Happy to reword if you'd prefer to frame it differently — e.g. Browser Use is still the top-ranked *terminal* agent on the board, which the current sentence doesn't capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the README to state Browser Use is #2 (not #1) on the Odysseys leaderboard and clarifies that 87.4% is the rubric average. This fixes an inaccurate claim; no code or API changes.

<sup>Written for commit e444289b225ddb21b64d3b453c5ac0ec0a3f49c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

