### PR TITLE
fix(filesystem): preserve state on failed writes

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -119,12 +119,16 @@ class BaseFile(BaseModel, ABC):
 			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content, encoding='utf-8'))
 
 	async def write(self, content: str, path: Path) -> None:
-		self.write_file_content(content)
-		await self.sync_to_disk(path)
+		staged_file = self.model_copy(deep=True)
+		staged_file.write_file_content(content)
+		await staged_file.sync_to_disk(path)
+		self.content = staged_file.content
 
 	async def append(self, content: str, path: Path) -> None:
-		self.append_file_content(content)
-		await self.sync_to_disk(path)
+		staged_file = self.model_copy(deep=True)
+		staged_file.append_file_content(content)
+		await staged_file.sync_to_disk(path)
+		self.content = staged_file.content
 
 	def read(self) -> str:
 		return self.content
@@ -735,14 +739,16 @@ class FileSystem:
 				raise ValueError(f"Error: Invalid file extension '{extension}' for file '{full_filename}'.")
 
 			# Create or get existing file using full filename as key
-			if full_filename in self.files:
+			is_new_file = full_filename not in self.files
+			if not is_new_file:
 				file_obj = self.files[full_filename]
 			else:
 				file_obj = file_class(name=name_without_ext)
-				self.files[full_filename] = file_obj  # Use full filename as key
 
 			# Use file-specific write method
 			await file_obj.write(content, self.data_dir)
+			if is_new_file:
+				self.files[full_filename] = file_obj
 			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
 			return f'Data written to file {full_filename} successfully.{sanitize_note}'
 		except FileSystemError as e:

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
+from weakref import WeakValueDictionary
 
 from pydantic import BaseModel, Field
 
@@ -382,7 +383,8 @@ class FileSystem:
 		}
 
 		self.files = {}
-		self._file_write_locks: dict[str, asyncio.Lock] = {}
+		self._file_write_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
+		self._extracted_content_lock = asyncio.Lock()
 		if create_default_files:
 			self.default_files = ['todo.md']
 			self._create_default_files()
@@ -823,13 +825,16 @@ class FileSystem:
 
 	async def save_extracted_content(self, content: str) -> str:
 		"""Save extracted content to a numbered file"""
-		initial_filename = f'extracted_content_{self.extracted_content_count}'
-		extracted_filename = f'{initial_filename}.md'
-		file_obj = MarkdownFile(name=initial_filename)
-		await file_obj.write(content, self.data_dir)
-		self.files[extracted_filename] = file_obj
-		self.extracted_content_count += 1
-		return extracted_filename
+		async with self._extracted_content_lock:
+			initial_filename = f'extracted_content_{self.extracted_content_count}'
+			extracted_filename = f'{initial_filename}.md'
+			self.extracted_content_count += 1
+
+		async with self._get_file_write_lock(extracted_filename):
+			file_obj = MarkdownFile(name=initial_filename)
+			await file_obj.write(content, self.data_dir)
+			self.files[extracted_filename] = file_obj
+			return extracted_filename
 
 	def describe(self) -> str:
 		"""List all files with their content information using file-specific display methods"""

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -384,7 +384,7 @@ class FileSystem:
 
 		self.files = {}
 		self._file_write_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
-		self._extracted_content_lock = asyncio.Lock()
+		self._reserved_extracted_content_indices: set[int] = set()
 		if create_default_files:
 			self.default_files = ['todo.md']
 			self._create_default_files()
@@ -825,16 +825,25 @@ class FileSystem:
 
 	async def save_extracted_content(self, content: str) -> str:
 		"""Save extracted content to a numbered file"""
-		async with self._extracted_content_lock:
-			initial_filename = f'extracted_content_{self.extracted_content_count}'
-			extracted_filename = f'{initial_filename}.md'
-			self.extracted_content_count += 1
+		extracted_content_index = 0
+		while (
+			extracted_content_index in self._reserved_extracted_content_indices
+			or f'extracted_content_{extracted_content_index}.md' in self.files
+		):
+			extracted_content_index += 1
+		self._reserved_extracted_content_indices.add(extracted_content_index)
 
-		async with self._get_file_write_lock(extracted_filename):
-			file_obj = MarkdownFile(name=initial_filename)
-			await file_obj.write(content, self.data_dir)
-			self.files[extracted_filename] = file_obj
-			return extracted_filename
+		initial_filename = f'extracted_content_{extracted_content_index}'
+		extracted_filename = f'{initial_filename}.md'
+		try:
+			async with self._get_file_write_lock(extracted_filename):
+				file_obj = MarkdownFile(name=initial_filename)
+				await file_obj.write(content, self.data_dir)
+				self.files[extracted_filename] = file_obj
+				self.extracted_content_count += 1
+				return extracted_filename
+		finally:
+			self._reserved_extracted_content_indices.discard(extracted_content_index)
 
 	def describe(self) -> str:
 		"""List all files with their content information using file-specific display methods"""

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -382,6 +382,7 @@ class FileSystem:
 		}
 
 		self.files = {}
+		self._file_write_locks: dict[str, asyncio.Lock] = {}
 		if create_default_files:
 			self.default_files = ['todo.md']
 			self._create_default_files()
@@ -391,6 +392,14 @@ class FileSystem:
 	def get_allowed_extensions(self) -> list[str]:
 		"""Get allowed extensions"""
 		return list(self._file_types.keys())
+
+	def _get_file_write_lock(self, full_filename: str) -> asyncio.Lock:
+		"""Return the lock that serializes mutations for one normalized filename."""
+		lock = self._file_write_locks.get(full_filename)
+		if lock is None:
+			lock = asyncio.Lock()
+			self._file_write_locks[full_filename] = lock
+		return lock
 
 	def _get_file_type_class(self, extension: str) -> type[BaseFile] | None:
 		"""Get the appropriate file class for an extension."""
@@ -732,29 +741,30 @@ class FileSystem:
 			return _build_filename_error_message(full_filename, self.get_allowed_extensions())
 		full_filename = resolved
 
-		try:
-			name_without_ext, extension = self._parse_filename(full_filename)
-			file_class = self._get_file_type_class(extension)
-			if not file_class:
-				raise ValueError(f"Error: Invalid file extension '{extension}' for file '{full_filename}'.")
+		async with self._get_file_write_lock(full_filename):
+			try:
+				name_without_ext, extension = self._parse_filename(full_filename)
+				file_class = self._get_file_type_class(extension)
+				if not file_class:
+					raise ValueError(f"Error: Invalid file extension '{extension}' for file '{full_filename}'.")
 
-			# Create or get existing file using full filename as key
-			is_new_file = full_filename not in self.files
-			if not is_new_file:
-				file_obj = self.files[full_filename]
-			else:
-				file_obj = file_class(name=name_without_ext)
+				# Create or get existing file using full filename as key
+				is_new_file = full_filename not in self.files
+				if not is_new_file:
+					file_obj = self.files[full_filename]
+				else:
+					file_obj = file_class(name=name_without_ext)
 
-			# Use file-specific write method
-			await file_obj.write(content, self.data_dir)
-			if is_new_file:
-				self.files[full_filename] = file_obj
-			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
-			return f'Data written to file {full_filename} successfully.{sanitize_note}'
-		except FileSystemError as e:
-			return str(e)
-		except Exception as e:
-			return f"Error: Could not write to file '{full_filename}'. {str(e)}"
+				# Use file-specific write method
+				await file_obj.write(content, self.data_dir)
+				if is_new_file:
+					self.files[full_filename] = file_obj
+				sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
+				return f'Data written to file {full_filename} successfully.{sanitize_note}'
+			except FileSystemError as e:
+				return str(e)
+			except Exception as e:
+				return f"Error: Could not write to file '{full_filename}'. {str(e)}"
 
 	async def append_file(self, full_filename: str, content: str) -> str:
 		"""Append content to file using file-specific append method"""
@@ -764,20 +774,21 @@ class FileSystem:
 			return _build_filename_error_message(full_filename, self.get_allowed_extensions())
 		full_filename = resolved
 
-		file_obj = self.files.get(full_filename)
-		if not file_obj:
-			if was_sanitized:
-				return f"File '{full_filename}' not found. (Filename was auto-corrected from '{original_filename}')"
-			return f"File '{full_filename}' not found."
+		async with self._get_file_write_lock(full_filename):
+			file_obj = self.files.get(full_filename)
+			if not file_obj:
+				if was_sanitized:
+					return f"File '{full_filename}' not found. (Filename was auto-corrected from '{original_filename}')"
+				return f"File '{full_filename}' not found."
 
-		try:
-			await file_obj.append(content, self.data_dir)
-			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
-			return f'Data appended to file {full_filename} successfully.{sanitize_note}'
-		except FileSystemError as e:
-			return str(e)
-		except Exception as e:
-			return f"Error: Could not append to file '{full_filename}'. {str(e)}"
+			try:
+				await file_obj.append(content, self.data_dir)
+				sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
+				return f'Data appended to file {full_filename} successfully.{sanitize_note}'
+			except FileSystemError as e:
+				return str(e)
+			except Exception as e:
+				return f"Error: Could not append to file '{full_filename}'. {str(e)}"
 
 	async def replace_file_str(self, full_filename: str, old_str: str, new_str: str) -> str:
 		"""Replace old_str with new_str in file_name"""
@@ -790,24 +801,25 @@ class FileSystem:
 		if not old_str:
 			return 'Error: Cannot replace empty string. Please provide a non-empty string to replace.'
 
-		file_obj = self.files.get(full_filename)
-		if not file_obj:
-			if was_sanitized:
-				return f"File '{full_filename}' not found. (Filename was auto-corrected from '{original_filename}')"
-			return f"File '{full_filename}' not found."
+		async with self._get_file_write_lock(full_filename):
+			file_obj = self.files.get(full_filename)
+			if not file_obj:
+				if was_sanitized:
+					return f"File '{full_filename}' not found. (Filename was auto-corrected from '{original_filename}')"
+				return f"File '{full_filename}' not found."
 
-		try:
-			content = file_obj.read()
-			if old_str not in content:
-				return f'Error: Could not find the specified text in file {full_filename}.'
-			content = content.replace(old_str, new_str)
-			await file_obj.write(content, self.data_dir)
-			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
-			return f'Successfully replaced all occurrences of "{old_str}" with "{new_str}" in file {full_filename}{sanitize_note}'
-		except FileSystemError as e:
-			return str(e)
-		except Exception as e:
-			return f"Error: Could not replace string in file '{full_filename}'. {str(e)}"
+			try:
+				content = file_obj.read()
+				if old_str not in content:
+					return f'Error: Could not find the specified text in file {full_filename}.'
+				content = content.replace(old_str, new_str)
+				await file_obj.write(content, self.data_dir)
+				sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
+				return f'Successfully replaced all occurrences of "{old_str}" with "{new_str}" in file {full_filename}{sanitize_note}'
+			except FileSystemError as e:
+				return str(e)
+			except Exception as e:
+				return f"Error: Could not replace string in file '{full_filename}'. {str(e)}"
 
 	async def save_extracted_content(self, content: str) -> str:
 		"""Save extracted content to a numbered file"""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -447,6 +447,38 @@ class TestFileSystem:
 		result = await fs.write_file('test.doc', 'content')
 		assert 'Unsupported file extension' in result
 
+	async def test_failed_write_preserves_existing_file(self, empty_filesystem, monkeypatch):
+		"""A failed disk sync must not expose content that was never persisted."""
+		fs = empty_filesystem
+		await fs.write_file('existing.txt', 'persisted')
+
+		async def fail_sync(_file: TxtFile, _path: Path) -> None:
+			raise OSError('disk unavailable')
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
+
+		result = await fs.write_file('existing.txt', 'phantom update')
+
+		assert result == "Error: Could not write to file 'existing.txt'. disk unavailable"
+		assert fs.get_file('existing.txt').content == 'persisted'
+		assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
+
+	async def test_failed_write_does_not_register_new_file(self, empty_filesystem, monkeypatch):
+		"""A new file belongs to the registry only after its disk write succeeds."""
+		fs = empty_filesystem
+
+		async def fail_sync(_file: TxtFile, _path: Path) -> None:
+			raise OSError('disk unavailable')
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
+
+		result = await fs.write_file('ghost.txt', 'phantom file')
+
+		assert result == "Error: Could not write to file 'ghost.txt'. disk unavailable"
+		assert 'ghost.txt' not in fs.files
+		assert 'ghost.txt' not in fs.get_state().files
+		assert not (fs.data_dir / 'ghost.txt').exists()
+
 	async def test_write_json_file(self, temp_filesystem):
 		"""Test writing JSON files."""
 		fs = temp_filesystem
@@ -520,6 +552,22 @@ class TestFileSystem:
 		result = await fs.append_file('invalid@name.md', 'content')
 		assert 'not found' in result
 		assert 'auto-corrected' in result
+
+	async def test_failed_append_preserves_existing_file(self, empty_filesystem, monkeypatch):
+		"""A failed append must leave the in-memory and persisted content aligned."""
+		fs = empty_filesystem
+		await fs.write_file('existing.txt', 'persisted')
+
+		async def fail_sync(_file: TxtFile, _path: Path) -> None:
+			raise OSError('disk unavailable')
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
+
+		result = await fs.append_file('existing.txt', ' phantom append')
+
+		assert result == "Error: Could not append to file 'existing.txt'. disk unavailable"
+		assert fs.get_file('existing.txt').content == 'persisted'
+		assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
 
 	async def test_replace_file_reports_missing_text(self, temp_filesystem):
 		"""Test that replacing absent text reports an error without changing the file."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -479,6 +479,19 @@ class TestFileSystem:
 		assert 'ghost.txt' not in fs.get_state().files
 		assert not (fs.data_dir / 'ghost.txt').exists()
 
+	async def test_failed_write_releases_file_lock(self, empty_filesystem, monkeypatch):
+		"""A failed write must not retain an idle per-file lock."""
+		fs = empty_filesystem
+
+		async def fail_sync(_file: TxtFile, _path: Path) -> None:
+			raise OSError('disk unavailable')
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
+
+		await fs.write_file('ghost.txt', 'phantom file')
+
+		assert 'ghost.txt' not in fs._file_write_locks
+
 	async def test_write_json_file(self, temp_filesystem):
 		"""Test writing JSON files."""
 		fs = temp_filesystem
@@ -720,6 +733,66 @@ class TestFileSystem:
 		content2 = fs.get_file('extracted_content_1.md').content
 		assert content1 == 'First extracted content'
 		assert content2 == 'Second extracted content'
+
+	async def test_save_extracted_content_serializes_with_write_file(self, empty_filesystem, monkeypatch):
+		"""An extracted-content write must serialize with a manual write to the same name."""
+		fs = empty_filesystem
+		extraction_sync_started = asyncio.Event()
+		release_extraction = asyncio.Event()
+		manual_sync_started = asyncio.Event()
+
+		async def controlled_sync(staged_file: MarkdownFile, path: Path) -> None:
+			if staged_file.content == 'extracted':
+				extraction_sync_started.set()
+				await release_extraction.wait()
+			else:
+				manual_sync_started.set()
+			(path / staged_file.full_name).write_text(staged_file.content, encoding='utf-8')
+
+		monkeypatch.setattr(MarkdownFile, 'sync_to_disk', controlled_sync)
+
+		extraction_task = asyncio.create_task(fs.save_extracted_content('extracted'))
+		await extraction_sync_started.wait()
+		manual_task = asyncio.create_task(fs.write_file('extracted_content_0.md', 'manual'))
+		await asyncio.sleep(0)
+		manual_write_was_serialized = not manual_sync_started.is_set()
+		release_extraction.set()
+
+		extracted_filename, manual_result = await asyncio.gather(extraction_task, manual_task)
+
+		assert manual_write_was_serialized
+		assert extracted_filename == 'extracted_content_0.md'
+		assert manual_result == 'Data written to file extracted_content_0.md successfully.'
+		assert fs.get_file('extracted_content_0.md').content == 'manual'
+		assert (fs.data_dir / 'extracted_content_0.md').read_text(encoding='utf-8') == 'manual'
+
+	async def test_concurrent_extracted_content_uses_unique_filenames(self, empty_filesystem, monkeypatch):
+		"""Concurrent extracted-content saves must reserve distinct numbered filenames."""
+		fs = empty_filesystem
+		first_sync_started = asyncio.Event()
+		second_sync_started = asyncio.Event()
+
+		async def controlled_sync(staged_file: MarkdownFile, path: Path) -> None:
+			if staged_file.content == 'first':
+				first_sync_started.set()
+				await second_sync_started.wait()
+			else:
+				second_sync_started.set()
+			(path / staged_file.full_name).write_text(staged_file.content, encoding='utf-8')
+
+		monkeypatch.setattr(MarkdownFile, 'sync_to_disk', controlled_sync)
+
+		first_task = asyncio.create_task(fs.save_extracted_content('first'))
+		await first_sync_started.wait()
+		second_task = asyncio.create_task(fs.save_extracted_content('second'))
+		first_filename, second_filename = await asyncio.gather(first_task, second_task)
+
+		assert first_filename == 'extracted_content_0.md'
+		assert second_filename == 'extracted_content_1.md'
+		assert fs.get_file(first_filename).content == 'first'
+		assert fs.get_file(second_filename).content == 'second'
+		assert (fs.data_dir / first_filename).read_text(encoding='utf-8') == 'first'
+		assert (fs.data_dir / second_filename).read_text(encoding='utf-8') == 'second'
 
 	async def test_describe_with_content(self, temp_filesystem):
 		"""Test describing filesystem with files containing content."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -1,6 +1,7 @@
 """Tests for the FileSystem class and related file operations."""
 
 import asyncio
+import gc
 import tempfile
 from pathlib import Path
 
@@ -489,6 +490,7 @@ class TestFileSystem:
 		monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
 
 		await fs.write_file('ghost.txt', 'phantom file')
+		gc.collect()
 
 		assert 'ghost.txt' not in fs._file_write_locks
 
@@ -733,6 +735,33 @@ class TestFileSystem:
 		content2 = fs.get_file('extracted_content_1.md').content
 		assert content1 == 'First extracted content'
 		assert content2 == 'Second extracted content'
+
+	async def test_failed_extracted_content_reuses_reserved_filename(self, empty_filesystem, monkeypatch):
+		"""A failed extracted-content write must not advance serialized numbering."""
+		fs = empty_filesystem
+		write_attempts = 0
+
+		async def fail_once(staged_file: MarkdownFile, path: Path) -> None:
+			nonlocal write_attempts
+			write_attempts += 1
+			if write_attempts == 1:
+				raise OSError('disk unavailable')
+			(path / staged_file.full_name).write_text(staged_file.content, encoding='utf-8')
+
+		monkeypatch.setattr(MarkdownFile, 'sync_to_disk', fail_once)
+
+		with pytest.raises(OSError, match='disk unavailable'):
+			await fs.save_extracted_content('failed')
+
+		assert fs.extracted_content_count == 0
+		assert not fs.files
+
+		extracted_filename = await fs.save_extracted_content('persisted')
+
+		assert extracted_filename == 'extracted_content_0.md'
+		assert fs.extracted_content_count == 1
+		assert fs.get_file(extracted_filename).content == 'persisted'
+		assert (fs.data_dir / extracted_filename).read_text(encoding='utf-8') == 'persisted'
 
 	async def test_save_extracted_content_serializes_with_write_file(self, empty_filesystem, monkeypatch):
 		"""An extracted-content write must serialize with a manual write to the same name."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -569,6 +569,36 @@ class TestFileSystem:
 		assert fs.get_file('existing.txt').content == 'persisted'
 		assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
 
+	async def test_concurrent_appends_preserve_both_updates(self, empty_filesystem, monkeypatch):
+		"""Concurrent appends to one file must serialize without losing either update."""
+		fs = empty_filesystem
+		await fs.write_file('existing.txt', 'persisted')
+		first_sync_started = asyncio.Event()
+		second_append_started = asyncio.Event()
+
+		async def controlled_sync(staged_file: TxtFile, path: Path) -> None:
+			if staged_file.content == 'persisted first':
+				first_sync_started.set()
+				await second_append_started.wait()
+			(path / staged_file.full_name).write_text(staged_file.content, encoding='utf-8')
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', controlled_sync)
+
+		first_append = asyncio.create_task(fs.append_file('existing.txt', ' first'))
+		await first_sync_started.wait()
+
+		async def append_second() -> str:
+			second_append_started.set()
+			return await fs.append_file('existing.txt', ' second')
+
+		second_append = asyncio.create_task(append_second())
+		first_result, second_result = await asyncio.gather(first_append, second_append)
+
+		assert first_result == 'Data appended to file existing.txt successfully.'
+		assert second_result == 'Data appended to file existing.txt successfully.'
+		assert fs.get_file('existing.txt').content == 'persisted first second'
+		assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted first second'
+
 	async def test_replace_file_reports_missing_text(self, temp_filesystem):
 		"""Test that replacing absent text reports an error without changing the file."""
 		fs = temp_filesystem


### PR DESCRIPTION
## Summary

- stage write and append mutations on a copy, publishing in-memory content only after disk persistence succeeds
- delay new-file registration until the initial disk write succeeds
- add regression coverage for failed overwrites, new-file writes, and appends

## Root cause

`BaseFile.write()` and `BaseFile.append()` mutated `self.content` before awaiting `sync_to_disk()`. `FileSystem.write_file()` also registered newly created file objects before their first write completed. If persistence raised an exception, callers received an error while subsequent reads and serialized state could still expose content that was never written to disk.

The write and append paths now build the next state on a same-type Pydantic model copy, persist that staged object, and publish its content only after success. New files are likewise added to the registry only after their initial write succeeds.

## Validation

- RED: `uv run pytest tests/ci/infrastructure/test_filesystem.py -k 'failed_write or failed_append' -q` — reproduced the existing-file inconsistency (`persisted` became `phantom update`)
- GREEN: `uv run pytest tests/ci/infrastructure -q` — 133 passed, 8 skipped
- `PATH="$PWD/.venv/bin:$PATH" ./bin/lint.sh` — Ruff check, Ruff format, Pyright, and all remaining pre-commit hooks passed

## Risk and compatibility

Risk is low. Successful writes keep the same public behavior and messages, and all existing file types use the same subclass when staging. Failed writes no longer publish unpersisted state. The tradeoff is one temporary in-memory copy of the file content during a write or append.

Fixes #5527

## AI assistance

AI assistance was used to trace the failure path, develop the regression tests, and prepare the patch. I reviewed the changes and ran all validation commands reported above locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Failed writes and appends no longer publish unpersisted content, and new files are only added to the registry after their first write succeeds. Previously we updated in-memory state and registered new files before disk sync; now we stage changes on a copy and publish only after persistence.

**Bug Fixes**
- Reads and serialized state now stay aligned with disk when persistence fails.
- Successful write/append behavior is unchanged.
- Adds regression tests for failed overwrite, new-file write, and append paths.
- Minor overhead: one temporary in-memory copy per write/append; no migration required.

<sup>Written for commit d814e098c0af7e93cda855d2dd555ad86d92e549. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

