### PR TITLE
docs: highlight rerunnable Cloud scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Browser Use is also **#1 on the [Odysseys leaderboard](https://odysseysbench.com
 - Best stealth with proxy rotation and captcha solving
 - 1000+ integrations (Gmail, Slack, Notion, and more)
 - Persistent filesystem and memory
+- Rerunnable scripts fetch live data, even when sites change ([guide](https://docs.browser-use.com/cloud/agent/scripts))
 
 ```sh
 curl -X POST https://api.browser-use.com/api/v4/runs \


### PR DESCRIPTION
## What changed

The Cloud section now links to the rerunnable-scripts guide and says what the feature does: save repeated data work, fetch live data on later runs, and repair the script when a site changes.

The old pricing-page example is gone.

## Checks

- applicable pre-commit checks passed for `README.md`
- `git diff --check`
