### PR TITLE
fix(cli): support module invocation on Windows

### DIFF
--- a/browser_use/__main__.py
+++ b/browser_use/__main__.py
@@ -1,0 +1,10 @@
+"""Run the Browser Use CLI with ``python -m browser_use``."""
+
+import sys
+
+from browser_use.cli import main
+
+if __name__ == '__main__':
+	result = main()
+	if result is not None:
+		sys.exit(result)

--- a/tests/ci/test_browser_use_cli.py
+++ b/tests/ci/test_browser_use_cli.py
@@ -6,11 +6,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _run_browser_use_cli(*args: str) -> subprocess.CompletedProcess[str]:
+def _run_browser_use_cli(*args: str, module: str = 'browser_use.cli') -> subprocess.CompletedProcess[str]:
 	env = os.environ.copy()
 	env['PYTHONPATH'] = os.pathsep.join(part for part in (str(ROOT), env.get('PYTHONPATH', '')) if part)
 	return subprocess.run(
-		[sys.executable, '-m', 'browser_use.cli', *args],
+		[sys.executable, '-m', module, *args],
 		cwd=ROOT,
 		env=env,
 		capture_output=True,
@@ -21,6 +21,14 @@ def _run_browser_use_cli(*args: str) -> subprocess.CompletedProcess[str]:
 
 def test_browser_use_doctor_help_prints_browser_use_usage():
 	result = _run_browser_use_cli('doctor', '--help')
+
+	assert result.returncode == 0
+	assert result.stdout == 'usage: browser-use doctor [--fix-snap]\n'
+	assert result.stderr == ''
+
+
+def test_browser_use_module_entrypoint_matches_cli_entrypoint():
+	result = _run_browser_use_cli('doctor', '--help', module='browser_use')
 
 	assert result.returncode == 0
 	assert result.stdout == 'usage: browser-use doctor [--fix-snap]\n'

--- a/tests/ci/test_browser_use_cli.py
+++ b/tests/ci/test_browser_use_cli.py
@@ -28,11 +28,12 @@ def test_browser_use_doctor_help_prints_browser_use_usage():
 
 
 def test_browser_use_module_entrypoint_matches_cli_entrypoint():
-	result = _run_browser_use_cli('doctor', '--help', module='browser_use')
+	cli_result = _run_browser_use_cli('doctor', '--help')
+	module_result = _run_browser_use_cli('doctor', '--help', module='browser_use')
 
-	assert result.returncode == 0
-	assert result.stdout == 'usage: browser-use doctor [--fix-snap]\n'
-	assert result.stderr == ''
+	assert module_result.returncode == cli_result.returncode == 0
+	assert module_result.stdout == cli_result.stdout
+	assert module_result.stderr == cli_result.stderr == ''
 
 
 def test_normalize_captured_cli_output_handles_string_system_exit(capsys):


### PR DESCRIPTION
## Description

Closes #5539

The `uv`-generated `browser-use.exe` console-script launcher can be blocked by Windows Smart App Control before Python starts. The package already exposes `browser_use.cli:main`, but it had no package module entry point, so users could not use the interpreter-based fallback.

## Type of Change

- [x] Bug fix (non-breaking change that fixes a known issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)

## Changes Made

- Add `browser_use/__main__.py` delegating to the existing CLI `main()`.
- Add a subprocess regression test proving `python -m browser_use doctor --help` matches the existing CLI module entry point.

## Testing

- [x] Focused CLI tests pass (`uv run pytest -q tests/ci/test_browser_use_cli.py`)
- [x] Ruff check passes (`uv run ruff check browser_use/__main__.py tests/ci/test_browser_use_cli.py`)
- [x] Ruff format check passes (`uv run ruff format --check browser_use/__main__.py tests/ci/test_browser_use_cli.py`)
- [x] Pre-commit passes on changed files (`uv run pre-commit run --files browser_use/__main__.py tests/ci/test_browser_use_cli.py`)
- [x] New test added for the module entry point
- [ ] Full test suite
- [ ] Pyright on the full repository

### Test Output

```text
uv run pytest -q tests/ci/test_browser_use_cli.py
4 passed in 1.72s

uv run ruff check browser_use/__main__.py tests/ci/test_browser_use_cli.py
All checks passed!

uv run ruff format --check browser_use/__main__.py tests/ci/test_browser_use_cli.py
2 files already formatted

uv run pre-commit run --files browser_use/__main__.py tests/ci/test_browser_use_cli.py
all applicable hooks passed
```

## Real Behavior Proof

- Environment: Windows 10 host, CPython 3.12.14 managed by `uv`, source checkout from `main`.
- Exact command / steps: `uv run python -m browser_use doctor --help` and `uv run python -m browser_use.cli doctor --help`.
- Observed result: both commands exited successfully and printed `usage: browser-use doctor [--fix-snap]`.
- Not tested: Windows 11 Smart App Control enforcement itself, because this environment does not expose that policy state. The module path avoids the generated console-script executable; signed distribution remains an upstream packaging concern.

## Runtime Rollout Safety

- Rollout-managed feature(s): none.
- Minimum rollout channel: next package release.
- Stable/default behavior changed: no; this adds an alternate invocation path.
- Kill switch / disable path: not applicable.
- Unsafe override required: none.
- Qualification impact: focused CLI tests and pre-commit checks.
- Rollback path: remove `browser_use/__main__.py` and its focused test.

## Review Readiness

- [x] I have performed a self-review
- [x] This PR is ready for human review

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the fix is effective
- [x] New and existing focused tests pass locally
- [x] I did **not** edit `CHANGELOG.md`

## Screenshots (if applicable)

Not applicable.

## Additional Notes

This provides the interpreter-based workaround requested in #5539 without disabling Smart App Control or changing the existing console-script behavior.
