### PR TITLE
fix(llm): ignore empty reasoning_models entries to prevent matching all models (#5543)

### DIFF
--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -179,7 +179,9 @@ class ChatAzureOpenAI(ChatOpenAILike):
 				model_params['service_tier'] = self.service_tier
 
 			# Handle reasoning models
-			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+			if self.reasoning_models and any(
+				str(m).strip() and str(m).lower() in str(self.model).lower() for m in self.reasoning_models
+			):
 				# For reasoning models, use reasoning parameter instead of reasoning_effort
 				model_params['reasoning'] = {'effort': self.reasoning_effort}
 				model_params.pop('temperature', None)

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -186,7 +186,9 @@ class ChatOpenAI(BaseChatModel):
 			if self.service_tier is not None:
 				model_params['service_tier'] = self.service_tier
 
-			if self.reasoning_models and any(str(m).lower() in str(self.model).lower() for m in self.reasoning_models):
+			if self.reasoning_models and any(
+				str(m).strip() and str(m).lower() in str(self.model).lower() for m in self.reasoning_models
+			):
 				model_params['reasoning_effort'] = self.reasoning_effort
 				model_params.pop('temperature', None)
 				model_params.pop('frequency_penalty', None)

--- a/browser_use/llm/vercel/chat.py
+++ b/browser_use/llm/vercel/chat.py
@@ -557,7 +557,7 @@ class ChatVercel(BaseChatModel):
 				is_google_model = self.model.startswith('google/')
 				is_anthropic_model = self.model.startswith('anthropic/')
 				is_reasoning_model = self.reasoning_models and any(
-					str(pattern).lower() in str(self.model).lower() for pattern in self.reasoning_models
+					str(pattern).strip() and str(pattern).lower() in str(self.model).lower() for pattern in self.reasoning_models
 				)
 
 				if is_google_model or is_anthropic_model or is_reasoning_model:


### PR DESCRIPTION
## Summary

Fixes #5543.

In OpenAI, Azure, and Vercel chat wrappers, `reasoning_models` checked substring containment via `str(m).lower() in str(self.model).lower()`. If `reasoning_models` contained an empty string (e.g. `[""]`), `"" in model` evaluated to `True` for every model, incorrectly stripping `temperature` and adding `reasoning_effort`.

### Changes
- Filters out empty/whitespace-only patterns (`str(m).strip()`) before matching in OpenAI, Azure, and Vercel LLM handlers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where an empty entry in `reasoning_models` (e.g. `[""]`) matched every model, causing the OpenAI, Azure, and Vercel chat wrappers to incorrectly strip `temperature` and add `reasoning_effort`. Empty and whitespace-only entries are now ignored during matching.

<sup>Written for commit e62f927accbb14a9068b0093b3d3f54fe85a026e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

