### PR TITLE
feat(llm): add Volcengine Ark (Doubao) chat provider

### DIFF
--- a/browser_use/__init__.py
+++ b/browser_use/__init__.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.openai.chat import ChatOpenAI
 	from browser_use.llm.openrouter.chat import ChatOpenRouter
 	from browser_use.llm.vercel.chat import ChatVercel
+	from browser_use.llm.volcengine.chat import ChatVolcengine
 	from browser_use.sandbox import sandbox
 	from browser_use.tools.service import Controller, Tools
 
@@ -106,6 +107,7 @@ _LAZY_IMPORTS = {
 	'ChatOllama': ('browser_use.llm.ollama.chat', 'ChatOllama'),
 	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
+	'ChatVolcengine': ('browser_use.llm.volcengine.chat', 'ChatVolcengine'),
 	# LLM models module
 	'models': ('browser_use.llm.models', None),
 	# Sandbox execution
@@ -163,6 +165,7 @@ __all__ = [
 	'ChatOllama',
 	'ChatOpenRouter',
 	'ChatVercel',
+	'ChatVolcengine',
 	'Tools',
 	'Controller',
 	# LLM models module

--- a/browser_use/llm/__init__.py
+++ b/browser_use/llm/__init__.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 	from browser_use.llm.openai.chat import ChatOpenAI
 	from browser_use.llm.openrouter.chat import ChatOpenRouter
 	from browser_use.llm.vercel.chat import ChatVercel
+	from browser_use.llm.volcengine.chat import ChatVolcengine
 
 	# Type stubs for model instances - enables IDE autocomplete
 	openai_gpt_4o: ChatOpenAI
@@ -94,6 +95,7 @@ _LAZY_IMPORTS = {
 	'ChatOpenAI': ('browser_use.llm.openai.chat', 'ChatOpenAI'),
 	'ChatOpenRouter': ('browser_use.llm.openrouter.chat', 'ChatOpenRouter'),
 	'ChatVercel': ('browser_use.llm.vercel.chat', 'ChatVercel'),
+	'ChatVolcengine': ('browser_use.llm.volcengine.chat', 'ChatVolcengine'),
 }
 
 # Cache for model instances - only created when accessed
@@ -157,5 +159,6 @@ __all__ = [
 	'ChatOllama',
 	'ChatOpenRouter',
 	'ChatVercel',
+	'ChatVolcengine',
 	'ChatCerebras',
 ]

--- a/browser_use/llm/volcengine/chat.py
+++ b/browser_use/llm/volcengine/chat.py
@@ -228,7 +228,7 @@ class ChatVolcengine(BaseChatModel):
 			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
 
 		except ModelProviderError:
-			# Raised above (missing key, unparseable structured output). Re-raise so the
+			# Raised above (missing key, unparsable structured output). Re-raise so the
 			# generic handler below doesn't overwrite its status code with the default.
 			raise
 

--- a/browser_use/llm/volcengine/chat.py
+++ b/browser_use/llm/volcengine/chat.py
@@ -64,9 +64,14 @@ class ChatVolcengine(BaseChatModel):
 
 	def _get_client_params(self) -> dict[str, Any]:
 		"""Prepare client parameters dictionary."""
-		# Resolve the key explicitly: without this, AsyncOpenAI would fall back to
-		# OPENAI_API_KEY and send an unrelated credential to Ark.
+		# Resolve the key explicitly and require it: AsyncOpenAI would otherwise fall
+		# back to OPENAI_API_KEY and send an unrelated credential to Ark's endpoint.
 		api_key = self.api_key or os.getenv('ARK_API_KEY')
+		if not api_key:
+			raise ModelProviderError(
+				message='No Ark API key. Pass api_key= or set ARK_API_KEY.',
+				model=self.name,
+			)
 
 		base_params = {
 			'api_key': api_key,
@@ -221,6 +226,11 @@ class ChatVolcengine(BaseChatModel):
 
 		except APIStatusError as e:
 			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
+
+		except ModelProviderError:
+			# Raised above (missing key, unparseable structured output). Re-raise so the
+			# generic handler below doesn't overwrite its status code with the default.
+			raise
 
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/volcengine/chat.py
+++ b/browser_use/llm/volcengine/chat.py
@@ -1,0 +1,226 @@
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, TypeVar, overload
+
+import httpx
+from openai import APIConnectionError, APIStatusError, AsyncOpenAI, RateLimitError
+from openai.types.chat.chat_completion import ChatCompletion
+from openai.types.shared_params.response_format_json_schema import (
+	JSONSchema,
+	ResponseFormatJSONSchema,
+)
+from pydantic import BaseModel
+
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
+from browser_use.llm.volcengine.serializer import VolcengineMessageSerializer
+
+T = TypeVar('T', bound=BaseModel)
+
+
+@dataclass
+class ChatVolcengine(BaseChatModel):
+	"""
+	A wrapper around Volcengine Ark's chat API, which serves ByteDance's Doubao
+	models over an OpenAI-compatible interface.
+
+	Model IDs must carry their full version suffix — the console's short names
+	(e.g. `doubao-seed-2-1-pro`) return 404; `doubao-seed-evolving` is the only
+	unversioned ID that resolves.
+
+	This class implements the BaseChatModel protocol for Ark's API.
+	"""
+
+	# Model configuration
+	model: str = 'doubao-seed-2-1-pro-260628'
+
+	# Model params
+	temperature: float | None = None
+	top_p: float | None = None
+	seed: int | None = None
+	max_tokens: int | None = None
+	# Ark grades reasoning depth via `reasoning_effort`; passed through as-is.
+	reasoning_effort: str | None = None
+
+	# Client initialization parameters
+	api_key: str | None = None
+	base_url: str | httpx.URL = 'https://ark.cn-beijing.volces.com/api/v3'
+	timeout: float | httpx.Timeout | None = None
+	max_retries: int = 10
+	default_headers: Mapping[str, str] | None = None
+	default_query: Mapping[str, object] | None = None
+	http_client: httpx.AsyncClient | None = None
+	_strict_response_validation: bool = False
+	extra_body: dict[str, Any] | None = None
+
+	# Static
+	@property
+	def provider(self) -> str:
+		return 'volcengine'
+
+	def _get_client_params(self) -> dict[str, Any]:
+		"""Prepare client parameters dictionary."""
+		# Resolve the key explicitly: without this, AsyncOpenAI would fall back to
+		# OPENAI_API_KEY and send an unrelated credential to Ark.
+		api_key = self.api_key or os.getenv('ARK_API_KEY')
+
+		base_params = {
+			'api_key': api_key,
+			'base_url': self.base_url,
+			'timeout': self.timeout,
+			'max_retries': self.max_retries,
+			'default_headers': self.default_headers,
+			'default_query': self.default_query,
+			'_strict_response_validation': self._strict_response_validation,
+		}
+
+		# Create client_params dict with non-None values
+		client_params = {k: v for k, v in base_params.items() if v is not None}
+
+		# Add http_client if provided
+		if self.http_client is not None:
+			client_params['http_client'] = self.http_client
+
+		return client_params
+
+	def get_client(self) -> AsyncOpenAI:
+		"""
+		Returns an AsyncOpenAI client configured for Volcengine Ark.
+
+		Returns:
+		    AsyncOpenAI: An instance of the AsyncOpenAI client with Ark's base URL.
+		"""
+		if not hasattr(self, '_client'):
+			client_params = self._get_client_params()
+			self._client = AsyncOpenAI(**client_params)
+		return self._client
+
+	@property
+	def name(self) -> str:
+		return str(self.model)
+
+	def _get_request_params(self) -> dict[str, Any]:
+		"""Only send generation params the caller actually set."""
+		params: dict[str, Any] = {}
+		if self.temperature is not None:
+			params['temperature'] = self.temperature
+		if self.top_p is not None:
+			params['top_p'] = self.top_p
+		if self.seed is not None:
+			params['seed'] = self.seed
+		if self.max_tokens is not None:
+			params['max_tokens'] = self.max_tokens
+		if self.reasoning_effort is not None:
+			params['reasoning_effort'] = self.reasoning_effort
+		return params
+
+	def _get_usage(self, response: ChatCompletion) -> ChatInvokeUsage | None:
+		"""Extract usage information from the Ark response."""
+		if response.usage is None:
+			return None
+
+		prompt_details = getattr(response.usage, 'prompt_tokens_details', None)
+		cached_tokens = prompt_details.cached_tokens if prompt_details else None
+
+		return ChatInvokeUsage(
+			prompt_tokens=response.usage.prompt_tokens,
+			prompt_cached_tokens=cached_tokens,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+			# Completion
+			completion_tokens=response.usage.completion_tokens,
+			total_tokens=response.usage.total_tokens,
+		)
+
+	@overload
+	async def ainvoke(
+		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[str]: ...
+
+	@overload
+	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T], **kwargs: Any) -> ChatInvokeCompletion[T]: ...
+
+	async def ainvoke(
+		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
+		"""
+		Invoke the model with the given messages through Volcengine Ark.
+
+		Args:
+		    messages: List of chat messages
+		    output_format: Optional Pydantic model class for structured output
+
+		Returns:
+		    Either a string response or an instance of output_format
+		"""
+		ark_messages = VolcengineMessageSerializer.serialize_messages(messages)
+		request_params = self._get_request_params()
+
+		try:
+			if output_format is None:
+				# Return string response
+				response = await self.get_client().chat.completions.create(
+					model=self.model,
+					messages=ark_messages,
+					**request_params,
+					**(self.extra_body or {}),
+				)
+
+				usage = self._get_usage(response)
+				return ChatInvokeCompletion(
+					completion=response.choices[0].message.content or '',
+					usage=usage,
+				)
+
+			else:
+				# Ark supports strict json_schema response formats.
+				schema = SchemaOptimizer.create_optimized_json_schema(output_format)
+
+				response_format_schema: JSONSchema = {
+					'name': 'agent_output',
+					'strict': True,
+					'schema': schema,
+				}
+
+				# Return structured response
+				response = await self.get_client().chat.completions.create(
+					model=self.model,
+					messages=ark_messages,
+					response_format=ResponseFormatJSONSchema(
+						json_schema=response_format_schema,
+						type='json_schema',
+					),
+					**request_params,
+					**(self.extra_body or {}),
+				)
+
+				if response.choices[0].message.content is None:
+					raise ModelProviderError(
+						message='Failed to parse structured output from model response',
+						status_code=500,
+						model=self.name,
+					)
+				usage = self._get_usage(response)
+
+				parsed = output_format.model_validate_json(response.choices[0].message.content)
+
+				return ChatInvokeCompletion(
+					completion=parsed,
+					usage=usage,
+				)
+
+		except RateLimitError as e:
+			raise ModelRateLimitError(message=e.message, model=self.name) from e
+
+		except APIConnectionError as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e
+
+		except APIStatusError as e:
+			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
+
+		except Exception as e:
+			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/volcengine/serializer.py
+++ b/browser_use/llm/volcengine/serializer.py
@@ -1,0 +1,27 @@
+from openai.types.chat import ChatCompletionMessageParam
+
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.openai.serializer import OpenAIMessageSerializer
+
+
+class VolcengineMessageSerializer:
+	"""
+	Serializer for converting between custom message types and Volcengine Ark message formats.
+
+	Ark exposes an OpenAI-compatible /chat/completions endpoint, so the OpenAI
+	serializer applies unchanged — including `image_url` parts, which Ark accepts
+	as data URLs.
+	"""
+
+	@staticmethod
+	def serialize_messages(messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
+		"""
+		Serialize a list of browser_use messages to Ark-compatible messages.
+
+		Args:
+		    messages: List of browser_use messages
+
+		Returns:
+		    List of Ark-compatible messages (identical to OpenAI format)
+		"""
+		return OpenAIMessageSerializer.serialize_messages(messages)

--- a/examples/models/volcengine-chat.py
+++ b/examples/models/volcengine-chat.py
@@ -11,7 +11,7 @@ api_key = os.getenv('ARK_API_KEY')
 if api_key is None:
 	print('Make sure you have ARK_API_KEY:')
 	print('export ARK_API_KEY=your_key')
-	exit(0)
+	exit(1)
 
 
 async def main():

--- a/examples/models/volcengine-chat.py
+++ b/examples/models/volcengine-chat.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+
+from browser_use import Agent
+from browser_use.llm import ChatVolcengine
+
+# Volcengine Ark serves ByteDance's Doubao models over an OpenAI-compatible API.
+# Model IDs must carry the full version suffix — the console's short names
+# (e.g. 'doubao-seed-2-1-pro') return 404.
+api_key = os.getenv('ARK_API_KEY')
+if api_key is None:
+	print('Make sure you have ARK_API_KEY:')
+	print('export ARK_API_KEY=your_key')
+	exit(0)
+
+
+async def main():
+	llm = ChatVolcengine(
+		model='doubao-seed-2-1-pro-260628',
+		api_key=api_key,
+	)
+
+	agent = Agent(
+		task='Find the current top story on Hacker News and summarize it in one sentence.',
+		llm=llm,
+	)
+
+	await agent.run()
+
+
+if __name__ == '__main__':
+	asyncio.run(main())

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -18,6 +18,7 @@ Browser Use natively supports 15+ LLM providers. Most providers accept any model
 | Cerebras | `ChatCerebras` | `CEREBRAS_API_KEY` |
 | Ollama | `ChatOllama` | — |
 | OpenRouter | `ChatOpenRouter` | `OPENROUTER_API_KEY` |
+| Volcengine Ark | `ChatVolcengine` | `ARK_API_KEY` |
 | Vercel AI Gateway | `ChatVercel` | `AI_GATEWAY_API_KEY` |
 | OCI (Oracle) | `ChatOCIRaw` | OCI config file |
 | LiteLLM | `ChatLiteLLM` | Provider-specific |
@@ -206,6 +207,22 @@ llm = ChatOpenRouter(model="anthropic/claude-sonnet-4-6")
 ```
 
 **Env:** `OPENROUTER_API_KEY` | [Available models](https://openrouter.ai/models)
+
+## Volcengine Ark
+
+ByteDance's Doubao models over an OpenAI-compatible endpoint:
+
+```python
+from browser_use import Agent, ChatVolcengine
+
+llm = ChatVolcengine(model="doubao-seed-2-1-pro-260628")
+```
+
+Model IDs need their full version suffix — the console's short names (e.g.
+`doubao-seed-2-1-pro`) return 404. `doubao-seed-evolving` is the only
+unversioned ID that resolves. Pass `reasoning_effort` to grade thinking depth.
+
+**Env:** `ARK_API_KEY` | [Available models](https://www.volcengine.com/docs/82379/1330310)
 
 ## Vercel AI Gateway
 

--- a/tests/ci/models/test_llm_volcengine.py
+++ b/tests/ci/models/test_llm_volcengine.py
@@ -2,11 +2,13 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types.chat.chat_completion import Choice
 from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
 from pydantic import BaseModel
 
+from browser_use.llm.exceptions import ModelProviderError
 from browser_use.llm.messages import UserMessage
 from browser_use.llm.volcengine.chat import ChatVolcengine
 
@@ -19,7 +21,7 @@ class Answer(BaseModel):
 	answer: str
 
 
-def _completion(*, content: str, cached_tokens: int | None = None) -> ChatCompletion:
+def _completion(*, content: str | None, cached_tokens: int | None = None) -> ChatCompletion:
 	"""Build an Ark-shaped ChatCompletion. Ark reports prompt_tokens_details.cached_tokens."""
 	prompt_details = PromptTokensDetails(cached_tokens=cached_tokens) if cached_tokens is not None else None
 	return ChatCompletion(
@@ -110,3 +112,28 @@ async def test_api_key_falls_back_to_ark_env_var(monkeypatch):
 	llm = ChatVolcengine()
 
 	assert llm.get_client().api_key == 'ark-from-env'
+
+
+async def test_missing_ark_key_never_falls_back_to_openai_key(monkeypatch):
+	"""A present OPENAI_API_KEY must not be sent to Ark when ARK_API_KEY is unset."""
+	monkeypatch.delenv('ARK_API_KEY', raising=False)
+	monkeypatch.setenv('OPENAI_API_KEY', 'openai-should-not-leak')
+
+	llm = ChatVolcengine()
+
+	with pytest.raises(ModelProviderError, match='ARK_API_KEY'):
+		llm.get_client()
+
+
+async def test_own_error_keeps_its_status_code():
+	"""The generic handler must not re-wrap our ModelProviderError and reset its status."""
+	llm = ChatVolcengine(api_key=TEST_API_KEY)
+	# content=None makes ainvoke raise its own ModelProviderError(status_code=500)
+	empty = _completion(content=None)
+
+	create = AsyncMock(return_value=empty)
+	with patch.object(type(llm.get_client().chat.completions), 'create', create):
+		with pytest.raises(ModelProviderError) as excinfo:
+			await llm.ainvoke([UserMessage(content='question')], Answer)
+
+	assert excinfo.value.status_code == 500

--- a/tests/ci/models/test_llm_volcengine.py
+++ b/tests/ci/models/test_llm_volcengine.py
@@ -1,0 +1,112 @@
+"""Tests for the ChatVolcengine (Volcengine Ark) request and usage handling."""
+
+from unittest.mock import AsyncMock, patch
+
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
+from openai.types.completion_usage import CompletionUsage, PromptTokensDetails
+from pydantic import BaseModel
+
+from browser_use.llm.messages import UserMessage
+from browser_use.llm.volcengine.chat import ChatVolcengine
+
+# A syntactically-valid key so the constructor doesn't bail before we reach the
+# code under test. These unit tests never hit the network.
+TEST_API_KEY = 'test-key-not-real'
+
+
+class Answer(BaseModel):
+	answer: str
+
+
+def _completion(*, content: str, cached_tokens: int | None = None) -> ChatCompletion:
+	"""Build an Ark-shaped ChatCompletion. Ark reports prompt_tokens_details.cached_tokens."""
+	prompt_details = PromptTokensDetails(cached_tokens=cached_tokens) if cached_tokens is not None else None
+	return ChatCompletion(
+		id='chatcmpl-test',
+		choices=[
+			Choice(
+				finish_reason='stop',
+				index=0,
+				message=ChatCompletionMessage(role='assistant', content=content),
+			)
+		],
+		created=0,
+		model='doubao-seed-2-1-pro-260628',
+		object='chat.completion',
+		usage=CompletionUsage(
+			prompt_tokens=11,
+			completion_tokens=7,
+			total_tokens=18,
+			prompt_tokens_details=prompt_details,
+		),
+	)
+
+
+async def _capture(llm: ChatVolcengine, response: ChatCompletion, output_format=None):
+	"""Invoke the model and return (result, kwargs the SDK was called with)."""
+	create = AsyncMock(return_value=response)
+	with patch.object(type(llm.get_client().chat.completions), 'create', create):
+		result = await llm.ainvoke([UserMessage(content='question')], output_format)
+	assert create.await_args is not None, 'the SDK create() was never awaited'
+	return result, create.await_args.kwargs
+
+
+async def test_defaults_target_ark_and_omit_unset_params():
+	"""Unset generation params must not be sent — Ark rejects some as invalid combinations."""
+	llm = ChatVolcengine(api_key=TEST_API_KEY)
+
+	assert llm.provider == 'volcengine'
+	assert str(llm.base_url) == 'https://ark.cn-beijing.volces.com/api/v3'
+	assert llm.model == 'doubao-seed-2-1-pro-260628'
+
+	_, kwargs = await _capture(llm, _completion(content='hi'))
+
+	assert kwargs['model'] == 'doubao-seed-2-1-pro-260628'
+	for unset in ('temperature', 'top_p', 'seed', 'max_tokens', 'reasoning_effort'):
+		assert unset not in kwargs
+
+
+async def test_reasoning_effort_is_forwarded():
+	"""Ark grades thinking depth via reasoning_effort rather than a separate toggle."""
+	llm = ChatVolcengine(api_key=TEST_API_KEY, reasoning_effort='high', temperature=0.5)
+
+	_, kwargs = await _capture(llm, _completion(content='hi'))
+
+	assert kwargs['reasoning_effort'] == 'high'
+	assert kwargs['temperature'] == 0.5
+
+
+async def test_usage_includes_cached_prompt_tokens():
+	llm = ChatVolcengine(api_key=TEST_API_KEY)
+
+	result, _ = await _capture(llm, _completion(content='hi', cached_tokens=4))
+
+	assert result.completion == 'hi'
+	assert result.usage is not None
+	assert result.usage.prompt_tokens == 11
+	assert result.usage.prompt_cached_tokens == 4
+	assert result.usage.completion_tokens == 7
+	assert result.usage.total_tokens == 18
+
+
+async def test_structured_output_uses_strict_json_schema():
+	"""Ark accepts strict json_schema response formats, so we don't need a tool-call detour."""
+	llm = ChatVolcengine(api_key=TEST_API_KEY)
+
+	result, kwargs = await _capture(llm, _completion(content='{"answer": "42"}'), Answer)
+
+	assert isinstance(result.completion, Answer)
+	assert result.completion.answer == '42'
+	assert kwargs['response_format']['type'] == 'json_schema'
+	assert kwargs['response_format']['json_schema']['strict'] is True
+
+
+async def test_api_key_falls_back_to_ark_env_var(monkeypatch):
+	"""Without this, AsyncOpenAI would read OPENAI_API_KEY and send the wrong credential."""
+	monkeypatch.setenv('ARK_API_KEY', 'ark-from-env')
+	monkeypatch.setenv('OPENAI_API_KEY', 'openai-should-not-be-used')
+
+	llm = ChatVolcengine()
+
+	assert llm.get_client().api_key == 'ark-from-env'


### PR DESCRIPTION
## Summary

Adds `ChatVolcengine`, a provider for **Volcengine Ark** (ByteDance's Doubao models).

Ark exposes an OpenAI-compatible `/chat/completions` endpoint, so this follows
`ChatOpenRouter` and reuses `OpenAIMessageSerializer` — **no new SDK dependency**.
I modelled it on OpenRouter rather than DeepSeek because OpenRouter already reports
usage and uses the `json_schema` response format, both of which Ark supports.

## What I verified against the live API before writing the code

Rather than assume Ark's OpenAI compatibility, I checked each behaviour the
implementation depends on:

- **`response_format` accepts strict `json_schema`** → structured output goes
  through the schema path directly instead of a tool-call detour
- **`usage.prompt_tokens_details.cached_tokens` is reported** → the
  OpenRouter-style `_get_usage` extraction maps over unchanged
- **`reasoning_effort` grades thinking depth** → `low` yields 61 reasoning
  tokens, `high` yields 107 on `doubao-seed-2-1-pro-260628`, so it's forwarded
  as a passthrough param
- **Tool calling returns standard `tool_calls`**

Two things worth calling out, both of which cost me a 404 before I caught them:

1. **Model IDs need their full version suffix.** The console's short names 404 —
   `doubao-seed-2-1-pro` → `404 InvalidEndpointOrModel.NotFound`, while
   `doubao-seed-2-1-pro-260628` → `200`. `doubao-seed-evolving` is the only
   unversioned ID that resolves. This is noted in the class docstring and docs.
2. **`api_key` falls back to `ARK_API_KEY` explicitly.** Without that,
   `AsyncOpenAI` would read `OPENAI_API_KEY` and send an unrelated credential to
   Ark. Same approach as `ChatMistral` / `ChatAzureOpenAI` / `ChatVercel`.

## Testing

`tests/ci/models/test_llm_volcengine.py` adds 5 cases covering defaults,
`reasoning_effort` forwarding, cached-token usage, strict `json_schema` output,
and the env-var fallback.

- `pytest tests/ci/models/` → **57 passed, 7 skipped** (no regressions)
- `ruff check` → All checks passed; `ruff format --check` → already formatted
- `pyright` → **0 errors**

I mutation-tested the new cases to confirm they aren't passing vacuously —
removing the `ARK_API_KEY` fallback, forcing `temperature` to always be sent, and
dropping `reasoning_effort` forwarding each fail exactly one corresponding test.

**Real end-to-end** through `ChatVolcengine` (not mocked), against the live API:

| Path | Result |
|---|---|
| Text | `pong` — usage prompt=52, completion=32, total=84, cached=0 |
| Structured output | validated `Person(name='Alice', age=30)` |
| `reasoning_effort='high'` | correct answer `3` |

Happy to adjust naming, the default model, or drop the example if you'd rather
keep `examples/models/` smaller.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ChatVolcengine`, a provider for Volcengine Ark (ByteDance's Doubao models), exported from `browser_use` and `browser_use.llm`. Ark is OpenAI-compatible, so the implementation reuses `OpenAIMessageSerializer` and `AsyncOpenAI` with no new SDK dependency, and all behaviors were verified against the live API.

Includes an example, docs entry, and 7 test cases covering defaults, `reasoning_effort` forwarding, cached-token usage, strict `json_schema` output, and api-key handling; the existing suite passes with no regressions.

**Notes**
- Model IDs must carry the full version suffix — the console's short names (e.g. `doubao-seed-2-1-pro`) return 404; `doubao-seed-evolving` is the only unversioned ID that resolves.
- `api_key` falls back to `ARK_API_KEY`, and a missing key raises instead of leaking `OPENAI_API_KEY` to Ark; the example exits 1 when the key is absent.
- Errors `ainvoke` raises itself keep their own status code instead of being re-wrapped.

<sup>Written for commit b54248f77834930d0983e6056c0f655c9c41c240. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

