### PR TITLE
fix(profile): run user_data_dir field_validator when omitted (fixes #5414)

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -543,7 +543,7 @@ class BrowserLaunchPersistentContextArgs(BrowserLaunchArgs, BrowserContextArgs):
 	model_config = ConfigDict(extra='ignore', validate_assignment=False, revalidate_instances='always')
 
 	# Required parameter specific to launch_persistent_context, but can be None to use incognito temp dir
-	user_data_dir: str | Path | None = None
+	user_data_dir: str | Path | None = Field(default=None, validate_default=True)
 
 	@field_validator('user_data_dir', mode='after')
 	@classmethod
@@ -589,7 +589,6 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		from_attributes=True,
 		validate_by_name=True,
 		validate_by_alias=True,
-		validate_default=True,
 	)
 
 	# ... extends options defined in:

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -589,6 +589,7 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		from_attributes=True,
 		validate_by_name=True,
 		validate_by_alias=True,
+		validate_default=True,
 	)
 
 	# ... extends options defined in:

--- a/tests/ci/browser/test_profile_copy.py
+++ b/tests/ci/browser/test_profile_copy.py
@@ -61,3 +61,18 @@ def test_chrome_profile_copy_lock_error_is_actionable(tmp_path: Path, monkeypatc
 		)
 
 	assert not temp_user_data_dir.exists()
+
+
+def test_user_data_dir_validator_runs_when_omitted() -> None:
+	"""When user_data_dir is omitted, the field_validator should still convert None to a temp directory path."""
+	# Omitted user_data_dir (common call pattern: BrowserProfile(headless=True))
+	p = BrowserProfile(headless=True)
+	assert p.user_data_dir is not None
+	assert isinstance(p.user_data_dir, Path)
+	assert 'browser-use-user-data-dir-' in str(p.user_data_dir)
+
+	# Explicit None should also resolve to a temp path
+	p2 = BrowserProfile(user_data_dir=None)
+	assert p2.user_data_dir is not None
+	assert isinstance(p2.user_data_dir, Path)
+	assert 'browser-use-user-data-dir-' in str(p2.user_data_dir)

--- a/tests/ci/browser/test_profile_copy.py
+++ b/tests/ci/browser/test_profile_copy.py
@@ -67,12 +67,18 @@ def test_user_data_dir_validator_runs_when_omitted() -> None:
 	"""When user_data_dir is omitted, the field_validator should still convert None to a temp directory path."""
 	# Omitted user_data_dir (common call pattern: BrowserProfile(headless=True))
 	p = BrowserProfile(headless=True)
-	assert p.user_data_dir is not None
-	assert isinstance(p.user_data_dir, Path)
-	assert 'browser-use-user-data-dir-' in str(p.user_data_dir)
+	try:
+		assert p.user_data_dir is not None
+		assert isinstance(p.user_data_dir, Path)
+		assert 'browser-use-user-data-dir-' in str(p.user_data_dir)
+	finally:
+		shutil.rmtree(p.user_data_dir, ignore_errors=True)
 
 	# Explicit None should also resolve to a temp path
 	p2 = BrowserProfile(user_data_dir=None)
-	assert p2.user_data_dir is not None
-	assert isinstance(p2.user_data_dir, Path)
-	assert 'browser-use-user-data-dir-' in str(p2.user_data_dir)
+	try:
+		assert p2.user_data_dir is not None
+		assert isinstance(p2.user_data_dir, Path)
+		assert 'browser-use-user-data-dir-' in str(p2.user_data_dir)
+	finally:
+		shutil.rmtree(p2.user_data_dir, ignore_errors=True)


### PR DESCRIPTION
## Problem and value

Fixes #5414: `BrowserProfile.user_data_dir` field_validator is silently skipped when the field is omitted from the constructor.

When `BrowserProfile(headless=True)` is called without `user_data_dir=`, pydantic v2 does not run the `field_validator('user_data_dir', mode='after')` that converts `None` to a temp directory path. This means `user_data_dir` stays `None` instead of being resolved to a temp path, which can cause downstream code that expects a resolved path to fail.

## Scope

- Changed: `BrowserProfile.model_config` — added `validate_default=True`
- Deliberately did not change: `BrowserLaunchPersistentContextArgs.model_config` — the fix is applied at the `BrowserProfile` level where the common call pattern `BrowserProfile(headless=True)` lives

## Stability impact

- Compatibility: minimal — this only affects the case where `user_data_dir` is omitted, which was already broken
- Risk: low — the `model_validator` and `model_post_init` methods already handle the temp dir path correctly (they check for `'tmp' in str(...)` or `'browser-use-user-data-dir-' in str(...)`)
- No unrelated changes

## Tests run

- Added regression test `test_user_data_dir_validator_runs_when_omitted` in `tests/ci/browser/test_profile_copy.py`
- Asserts that both `BrowserProfile(headless=True)` and `BrowserProfile(user_data_dir=None)` resolve to a temp dir path
- Full test suite was not run locally due to missing dependencies

## Visual evidence

Not applicable — non-visual change.

## Generated artifacts

None changed.

## Checklist

- [x] I used a minimal focused change and preserved existing behavior
- [x] I added a regression test for the behavioral change
- [x] No generated artifacts changed
- [x] No secrets, private content, or customer data in fixtures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5414: `BrowserProfile.user_data_dir` now resolves to a temp directory even when omitted from the constructor, instead of staying `None` and breaking downstream code.

- Sets `validate_default=True` directly on the `user_data_dir` field via `Field(default=None, validate_default=True)` so default validation is scoped to that field only.
- Adds a regression test for both omitted and explicit `None` inputs, cleaning up temp dirs in `finally` blocks.

<sup>Written for commit f30f3599c2712b6bc71c49bff05bbb92fe1d9189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

