### PR TITLE
fix(filesystem): roll back in-memory state when a write/append fails to persist

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -159,12 +159,26 @@ class BaseFile(BaseModel, ABC):
 			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content, encoding='utf-8'))
 
 	async def write(self, content: str, path: Path) -> None:
+		previous_content = self.content
 		self.write_file_content(content)
-		await self.sync_to_disk(path)
+		try:
+			await self.sync_to_disk(path)
+		except Exception:
+			# A failed persist must not leave the in-memory content pointing at
+			# data that was never written to disk.
+			self.content = previous_content
+			raise
 
 	async def append(self, content: str, path: Path) -> None:
+		previous_content = self.content
 		self.append_file_content(content)
-		await self.sync_to_disk(path)
+		try:
+			await self.sync_to_disk(path)
+		except Exception:
+			# A failed persist must not leave the in-memory content pointing at
+			# data that was never written to disk.
+			self.content = previous_content
+			raise
 
 	def read(self) -> str:
 		return self.content
@@ -899,6 +913,7 @@ class FileSystem:
 			await file_obj.write(content, self.data_dir)
 			if is_new:
 				self.files[full_filename] = file_obj
+
 			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
 			return f'Data written to file {full_filename} successfully.{sanitize_note}'
 		except FileSystemError as e:

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -163,9 +163,9 @@ class BaseFile(BaseModel, ABC):
 		self.write_file_content(content)
 		try:
 			await self.sync_to_disk(path)
-		except Exception:
-			# A failed persist must not leave the in-memory content pointing at
-			# data that was never written to disk.
+		except (Exception, asyncio.CancelledError):
+			# Persistence cancellation is a BaseException on supported Python
+			# versions, so handle it explicitly before propagating the cancellation.
 			self.content = previous_content
 			raise
 
@@ -174,9 +174,9 @@ class BaseFile(BaseModel, ABC):
 		self.append_file_content(content)
 		try:
 			await self.sync_to_disk(path)
-		except Exception:
-			# A failed persist must not leave the in-memory content pointing at
-			# data that was never written to disk.
+		except (Exception, asyncio.CancelledError):
+			# Persistence cancellation is a BaseException on supported Python
+			# versions, so handle it explicitly before propagating the cancellation.
 			self.content = previous_content
 			raise
 

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -201,6 +201,22 @@ class TestBaseFile:
 				await file_obj.append(' phantom append', Path(tmp_dir))
 			assert file_obj.content == 'persisted'
 
+	@pytest.mark.parametrize(('operation', 'content'), [('write', 'phantom update'), ('append', ' phantom append')])
+	async def test_mutation_rolls_back_when_sync_is_cancelled(self, monkeypatch, operation, content):
+		"""A cancelled persist must restore content and still propagate cancellation."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			file_obj = TxtFile(name='notes', content='persisted')
+
+			async def cancel_sync(self, path):
+				# Simulate task cancellation while the disk write is still pending.
+				raise asyncio.CancelledError
+
+			monkeypatch.setattr(TxtFile, 'sync_to_disk', cancel_sync)
+
+			with pytest.raises(asyncio.CancelledError):
+				await getattr(file_obj, operation)(content, Path(tmp_dir))
+			assert file_obj.content == 'persisted'
+
 	async def test_json_file_disk_operations(self):
 		"""Test JSON file sync to disk operations."""
 		with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -183,6 +183,24 @@ class TestBaseFile:
 			assert file_path.read_text() == expected_content
 			assert file_obj.content == expected_content
 
+	async def test_write_rolls_back_on_sync_failure(self, monkeypatch):
+		"""A failed persist must not leave mutated in-memory content."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			file_obj = TxtFile(name='notes', content='persisted')
+
+			async def fail_sync(self, path):
+				raise OSError('disk unavailable')
+
+			monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
+
+			with pytest.raises(OSError, match='disk unavailable'):
+				await file_obj.write('phantom update', Path(tmp_dir))
+			assert file_obj.content == 'persisted'
+
+			with pytest.raises(OSError, match='disk unavailable'):
+				await file_obj.append(' phantom append', Path(tmp_dir))
+			assert file_obj.content == 'persisted'
+
 	async def test_json_file_disk_operations(self):
 		"""Test JSON file sync to disk operations."""
 		with tempfile.TemporaryDirectory() as tmp_dir:
@@ -554,6 +572,26 @@ class TestFileSystem:
 		assert 'not found' in result
 		assert 'invalidname.md' in result
 		assert 'auto-corrected' in result
+
+	async def test_write_file_does_not_register_on_failed_persist(self, empty_filesystem, monkeypatch):
+		"""A failed persist must not leave a phantom entry in the registry."""
+		fs = empty_filesystem
+		await fs.write_file('existing.txt', 'persisted')
+
+		async def fail_sync(self, path):
+			raise OSError('disk unavailable')
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
+
+		# A brand-new file must not be registered when its write fails.
+		result = await fs.write_file('ghost.txt', 'phantom file')
+		assert 'disk unavailable' in result
+		assert 'ghost.txt' not in fs.files
+
+		# An existing file must keep its last persisted content on failure.
+		result = await fs.write_file('existing.txt', 'phantom update')
+		assert 'disk unavailable' in result
+		assert fs.get_file('existing.txt').content == 'persisted'
 
 	async def test_write_file(self, temp_filesystem):
 		"""Test writing content to files."""


### PR DESCRIPTION
## Problem

`BaseFile.write()` / `BaseFile.append()` mutated `self.content` *before* syncing to disk, so when the persist failed (read-only filesystem, permission error, disk exhaustion, …) the in-memory content kept pointing at data that was never written.

`FileSystem.write_file()` also registered a brand-new file in `self.files` *before* its first persist, leaving a phantom entry in the in-memory registry and serialized state even though no file exists on disk.

Later reads and restored state can therefore report data that was never persisted.

## Fix

- `BaseFile.write()` / `BaseFile.append()` now snapshot `self.content`, and restore it (then re-raise) if `sync_to_disk()` raises.
- `FileSystem.write_file()` now registers a new file in the in-memory registry only after a successful persist. Existing files are unaffected (the re-assignment is a no-op).

## Tests

Added two regression tests in `tests/ci/infrastructure/test_filesystem.py`:
- `test_write_rolls_back_on_sync_failure` — a failed `write()`/`append()` leaves the last persisted content intact.
- `test_write_file_does_not_register_on_failed_persist` — a failed write of a new file leaves no phantom registry entry, and a failed overwrite keeps the existing file's last content.

Fixes #5527

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls back in-memory file state when a write or append fails to persist, including on task cancellation, so reads and restored state no longer report data that was never written to disk. New files are registered in the in-memory registry only after their first successful persist, eliminating phantom entries. Fixes #5527.

**Bug Fixes**
- `BaseFile.write()` and `BaseFile.append()` snapshot `self.content` and restore it (then re-raise) if `sync_to_disk()` raises or is cancelled.
- `FileSystem.write_file()` registers new files only after a successful persist; existing files are unaffected.

<sup>Written for commit c334a91224a82b7eb940f570fbe3f1473d4447b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

