### PR TITLE
fix(llm): stop putting format/stream inside Ollama options

### DIFF
--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
@@ -5,7 +6,7 @@ from typing import Any, TypeVar, overload
 import httpx
 from ollama import AsyncClient as OllamaAsyncClient
 from ollama import Options
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
@@ -14,6 +15,20 @@ from browser_use.llm.ollama.serializer import OllamaMessageSerializer
 from browser_use.llm.views import ChatInvokeCompletion
 
 T = TypeVar('T', bound=BaseModel)
+logger = logging.getLogger(__name__)
+
+# These belong on AsyncClient.chat(), not in the model `options` dict.
+_TOP_LEVEL_CHAT_KEYS = frozenset({'format', 'stream'})
+
+
+def _unwrap_json_content(content: str) -> str:
+	"""Strip markdown code fences that Ollama vision models often wrap around JSON."""
+	text = content.strip()
+	if text.startswith('```json') and text.endswith('```'):
+		return text[7:-3].strip()
+	if text.startswith('```') and text.endswith('```'):
+		return text[3:-3].strip()
+	return text
 
 
 @dataclass
@@ -57,6 +72,27 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def _chat_options(self) -> Mapping[str, Any] | Options | None:
+		"""Return ollama_options with top-level chat keys removed.
+
+		`format` and `stream` are parameters of `AsyncClient.chat()`, not model
+		runtime options. Putting them in `ollama_options` is ignored or fights
+		the structured-output schema we already pass as `format=`.
+		"""
+		options = self.ollama_options
+		if not options or not isinstance(options, Mapping):
+			return options
+
+		dropped = sorted(key for key in options if key in _TOP_LEVEL_CHAT_KEYS)
+		if not dropped:
+			return options
+
+		logger.warning(
+			'Ignoring %s in ollama_options; those are top-level chat() parameters, not model options',
+			', '.join(dropped),
+		)
+		return {key: value for key, value in options.items() if key not in _TOP_LEVEL_CHAT_KEYS}
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -71,29 +107,36 @@ class ChatOllama(BaseChatModel):
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
 
 		try:
+			options = self._chat_options()
 			if output_format is None:
 				response = await self.get_client().chat(
 					model=self.model,
 					messages=ollama_messages,
-					options=self.ollama_options,
+					options=options,
 				)
 
 				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
-			else:
-				schema = output_format.model_json_schema()
 
-				response = await self.get_client().chat(
-					model=self.model,
-					messages=ollama_messages,
-					format=schema,
-					options=self.ollama_options,
-				)
+			schema = output_format.model_json_schema()
+			response = await self.get_client().chat(
+				model=self.model,
+				messages=ollama_messages,
+				format=schema,
+				options=options,
+			)
 
-				completion = response.message.content or ''
-				if output_format is not None:
-					completion = output_format.model_validate_json(completion)
+			completion = _unwrap_json_content(response.message.content or '')
+			try:
+				parsed = output_format.model_validate_json(completion)
+			except ValidationError as e:
+				raise ModelProviderError(
+					message=f'Ollama returned invalid JSON for structured output: {e}',
+					model=self.name,
+				) from e
 
-				return ChatInvokeCompletion(completion=completion, usage=None)
+			return ChatInvokeCompletion(completion=parsed, usage=None)
 
+		except ModelProviderError:
+			raise
 		except Exception as e:
 			raise ModelProviderError(message=str(e), model=self.name) from e

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
@@ -18,16 +19,17 @@ T = TypeVar('T', bound=BaseModel)
 logger = logging.getLogger(__name__)
 
 # These belong on AsyncClient.chat(), not in the model `options` dict.
-_TOP_LEVEL_CHAT_KEYS = frozenset({'format', 'stream'})
+_PASSTHROUGH_CHAT_KEYS = frozenset({'think', 'logprobs', 'top_logprobs', 'keep_alive'})
+_IGNORED_CHAT_KEYS = frozenset({'format', 'stream'})
+_JSON_FENCE_RE = re.compile(r'\A```[ \t]*(?:json)?[ \t]*\r?\n(?P<body>.*?)\r?\n?```[ \t]*\Z', re.IGNORECASE | re.DOTALL)
 
 
 def _unwrap_json_content(content: str) -> str:
 	"""Strip markdown code fences that Ollama vision models often wrap around JSON."""
 	text = content.strip()
-	if text.startswith('```json') and text.endswith('```'):
-		return text[7:-3].strip()
-	if text.startswith('```') and text.endswith('```'):
-		return text[3:-3].strip()
+	match = _JSON_FENCE_RE.fullmatch(text)
+	if match:
+		return match.group('body').strip()
 	return text
 
 
@@ -72,26 +74,28 @@ class ChatOllama(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
-	def _chat_options(self) -> Mapping[str, Any] | Options | None:
-		"""Return ollama_options with top-level chat keys removed.
+	def _split_chat_options(self) -> tuple[Mapping[str, Any] | Options | None, dict[str, Any]]:
+		"""Split model options from supported top-level ``chat()`` parameters.
 
-		`format` and `stream` are parameters of `AsyncClient.chat()`, not model
-		runtime options. Putting them in `ollama_options` is ignored or fights
-		the structured-output schema we already pass as `format=`.
+		``format`` and ``stream`` cannot be honored here because this wrapper owns
+		the structured-output schema and requires a non-streaming response.
 		"""
 		options = self.ollama_options
 		if not options or not isinstance(options, Mapping):
-			return options
+			return options, {}
 
-		dropped = sorted(key for key in options if key in _TOP_LEVEL_CHAT_KEYS)
-		if not dropped:
-			return options
+		top_level = {key: options[key] for key in _PASSTHROUGH_CHAT_KEYS if key in options}
+		ignored = sorted(key for key in options if key in _IGNORED_CHAT_KEYS)
 
-		logger.warning(
-			'Ignoring %s in ollama_options; those are top-level chat() parameters, not model options',
-			', '.join(dropped),
-		)
-		return {key: value for key, value in options.items() if key not in _TOP_LEVEL_CHAT_KEYS}
+		if ignored:
+			logger.warning(
+				'Ignoring %s in ollama_options; ChatOllama controls structured output and streaming',
+				', '.join(ignored),
+			)
+
+		extracted = _PASSTHROUGH_CHAT_KEYS | _IGNORED_CHAT_KEYS
+		model_options = {key: value for key, value in options.items() if key not in extracted}
+		return model_options, top_level
 
 	@overload
 	async def ainvoke(
@@ -107,12 +111,13 @@ class ChatOllama(BaseChatModel):
 		ollama_messages = OllamaMessageSerializer.serialize_messages(messages)
 
 		try:
-			options = self._chat_options()
+			options, top_level = self._split_chat_options()
 			if output_format is None:
 				response = await self.get_client().chat(
 					model=self.model,
 					messages=ollama_messages,
 					options=options,
+					**top_level,
 				)
 
 				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
@@ -123,6 +128,7 @@ class ChatOllama(BaseChatModel):
 				messages=ollama_messages,
 				format=schema,
 				options=options,
+				**top_level,
 			)
 
 			completion = _unwrap_json_content(response.message.content or '')

--- a/tests/ci/models/test_llm_ollama.py
+++ b/tests/ci/models/test_llm_ollama.py
@@ -20,12 +20,20 @@ def _client_returning(content: str) -> MagicMock:
 	return client
 
 
-async def test_drops_format_and_stream_from_ollama_options():
-	"""format/stream belong on chat(), not inside options (#5017)."""
+async def test_splits_top_level_chat_parameters_from_ollama_options():
+	"""Top-level chat parameters must not be sent inside model options (#5017)."""
 	client = _client_returning('{"answer": "ok"}')
 	llm = ChatOllama(
 		model='test-model',
-		ollama_options={'think': False, 'format': 'json', 'stream': False, 'num_ctx': 2048},
+		ollama_options={
+			'think': False,
+			'logprobs': True,
+			'top_logprobs': 3,
+			'keep_alive': '10m',
+			'format': 'json',
+			'stream': False,
+			'num_ctx': 2048,
+		},
 	)
 
 	with patch.object(ChatOllama, 'get_client', return_value=client):
@@ -33,12 +41,18 @@ async def test_drops_format_and_stream_from_ollama_options():
 
 	assert result.completion.answer == 'ok'
 	kwargs = client.chat.await_args.kwargs
-	assert kwargs['options'] == {'think': False, 'num_ctx': 2048}
+	assert kwargs['options'] == {'num_ctx': 2048}
+	assert kwargs['think'] is False
+	assert kwargs['logprobs'] is True
+	assert kwargs['top_logprobs'] == 3
+	assert kwargs['keep_alive'] == '10m'
 	assert kwargs['format'] == Answer.model_json_schema()
+	assert kwargs.get('stream') is None
 
 
-async def test_parses_json_wrapped_in_markdown_fences():
-	client = _client_returning('```json\n{"answer": "ok"}\n```')
+@pytest.mark.parametrize('fence', ['```json', '```JSON', '``` json', '```'])
+async def test_parses_json_wrapped_in_markdown_fences(fence: str):
+	client = _client_returning(f'{fence}\n{{"answer": "ok"}}\n```')
 	llm = ChatOllama(model='test-model')
 
 	with patch.object(ChatOllama, 'get_client', return_value=client):

--- a/tests/ci/models/test_llm_ollama.py
+++ b/tests/ci/models/test_llm_ollama.py
@@ -1,0 +1,57 @@
+"""Tests for ChatOllama option handling and structured-output parsing."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.messages import UserMessage
+from browser_use.llm.ollama.chat import ChatOllama
+
+
+class Answer(BaseModel):
+	answer: str
+
+
+def _client_returning(content: str) -> MagicMock:
+	client = MagicMock()
+	client.chat = AsyncMock(return_value=MagicMock(message=MagicMock(content=content)))
+	return client
+
+
+async def test_drops_format_and_stream_from_ollama_options():
+	"""format/stream belong on chat(), not inside options (#5017)."""
+	client = _client_returning('{"answer": "ok"}')
+	llm = ChatOllama(
+		model='test-model',
+		ollama_options={'think': False, 'format': 'json', 'stream': False, 'num_ctx': 2048},
+	)
+
+	with patch.object(ChatOllama, 'get_client', return_value=client):
+		result = await llm.ainvoke([UserMessage(content='hi')], output_format=Answer)
+
+	assert result.completion.answer == 'ok'
+	kwargs = client.chat.await_args.kwargs
+	assert kwargs['options'] == {'think': False, 'num_ctx': 2048}
+	assert kwargs['format'] == Answer.model_json_schema()
+
+
+async def test_parses_json_wrapped_in_markdown_fences():
+	client = _client_returning('```json\n{"answer": "ok"}\n```')
+	llm = ChatOllama(model='test-model')
+
+	with patch.object(ChatOllama, 'get_client', return_value=client):
+		result = await llm.ainvoke([UserMessage(content='hi')], output_format=Answer)
+
+	assert result.completion.answer == 'ok'
+
+
+async def test_truncated_json_raises_model_provider_error():
+	client = _client_returning('{\n')
+	llm = ChatOllama(model='test-model')
+
+	with patch.object(ChatOllama, 'get_client', return_value=client), pytest.raises(ModelProviderError) as exc_info:
+		await llm.ainvoke([UserMessage(content='hi')], output_format=Answer)
+
+	assert 'Invalid JSON' in exc_info.value.message or 'invalid JSON' in exc_info.value.message.lower()


### PR DESCRIPTION
## Summary
- `format` and `stream` passed through `ChatOllama(ollama_options=...)` are not model options. They are top-level `chat()` parameters, and forwarding them is what produced the truncated structured JSON in #5017.
- Unwrap markdown `json` fences before `model_validate_json`, which Ollama vision models often add around the payload.

Fixes #5017.

## Test plan
- [x] `uv run pytest tests/ci/models/test_llm_ollama.py -q` failed on main, then passed after the change
- [ ] CI tests / lint on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5017 by stopping `format` and `stream` from being passed inside Ollama `ollama_options`; they are top-level `chat()` parameters and caused structured output to break.

- Moves `think`, `logprobs`, `top_logprobs`, and `keep_alive` to top-level `chat()` parameters as well.
- Strips markdown JSON fences that Ollama vision models often wrap around responses before parsing.
- Surfaces invalid JSON as a `ModelProviderError` instead of a raw validation error.
- Adds unit tests covering option splitting, fence handling, and truncated JSON.

<sup>Written for commit ed5f467957893427a5aa6944bd77e336146bf452. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

