### PR TITLE
fix: Update DeepSeek default model to deepseek-v4-flash

### DIFF
--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -36,13 +36,14 @@ class ChatDeepSeek(BaseChatModel):
 	temperature: float | None = None
 	top_p: float | None = None
 	seed: int | None = None
-	thinking: bool = False
 
 	# Connection parameters
 	api_key: str | None = None
 	base_url: str | httpx.URL | None = 'https://api.deepseek.com/v1'
 	timeout: float | httpx.Timeout | None = None
 	client_params: dict[str, Any] | None = None
+	
+	thinking: bool = False
 
 	@property
 	def provider(self) -> str:
@@ -60,6 +61,10 @@ class ChatDeepSeek(BaseChatModel):
 	def name(self) -> str:
 		return self.model
 
+	def _supports_thinking(self) -> bool:
+
+		return 'deepseek-v4' in self.model.lower()
+
 	def _request_kwargs(self) -> dict[str, Any]:
 		common: dict[str, Any] = {}
 
@@ -72,9 +77,10 @@ class ChatDeepSeek(BaseChatModel):
 		if self.seed is not None:
 			common['seed'] = self.seed
 
-		common['extra_body'] = {
-			'thinking': {'type': 'enabled' if self.thinking else 'disabled'},
-		}
+		if self._supports_thinking():
+			common['extra_body'] = {
+				'thinking': {'type': 'enabled' if self.thinking else 'disabled'},
+			}
 		return common
 
 	@overload

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -29,13 +29,14 @@ T = TypeVar('T', bound=BaseModel)
 class ChatDeepSeek(BaseChatModel):
 	"""DeepSeek /chat/completions wrapper (OpenAI-compatible)."""
 
-	model: str = 'deepseek-chat'
+	model: str = 'deepseek-v4-flash'
 
 	# Generation parameters
 	max_tokens: int | None = None
 	temperature: float | None = None
 	top_p: float | None = None
 	seed: int | None = None
+	thinking: bool = False
 
 	# Connection parameters
 	api_key: str | None = None
@@ -58,6 +59,23 @@ class ChatDeepSeek(BaseChatModel):
 	@property
 	def name(self) -> str:
 		return self.model
+
+	def _request_kwargs(self) -> dict[str, Any]:
+		common: dict[str, Any] = {}
+
+		if self.temperature is not None:
+			common['temperature'] = self.temperature
+		if self.max_tokens is not None:
+			common['max_tokens'] = self.max_tokens
+		if self.top_p is not None:
+			common['top_p'] = self.top_p
+		if self.seed is not None:
+			common['seed'] = self.seed
+
+		common['extra_body'] = {
+			'thinking': {'type': 'enabled' if self.thinking else 'disabled'},
+		}
+		return common
 
 	@overload
 	async def ainvoke(
@@ -96,16 +114,7 @@ class ChatDeepSeek(BaseChatModel):
 		"""
 		client = self._client()
 		ds_messages = DeepSeekMessageSerializer.serialize_messages(messages)
-		common: dict[str, Any] = {}
-
-		if self.temperature is not None:
-			common['temperature'] = self.temperature
-		if self.max_tokens is not None:
-			common['max_tokens'] = self.max_tokens
-		if self.top_p is not None:
-			common['top_p'] = self.top_p
-		if self.seed is not None:
-			common['seed'] = self.seed
+		common = self._request_kwargs()
 
 		# Beta conversation prefix continuation (see official documentation)
 		if self.base_url and str(self.base_url).endswith('/beta'):

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -42,7 +42,7 @@ class ChatDeepSeek(BaseChatModel):
 	base_url: str | httpx.URL | None = 'https://api.deepseek.com/v1'
 	timeout: float | httpx.Timeout | None = None
 	client_params: dict[str, Any] | None = None
-	
+
 	thinking: bool = False
 
 	@property
@@ -62,7 +62,6 @@ class ChatDeepSeek(BaseChatModel):
 		return self.model
 
 	def _supports_thinking(self) -> bool:
-
 		return 'deepseek-v4' in self.model.lower()
 
 	def _request_kwargs(self) -> dict[str, Any]:

--- a/examples/models/deepseek-chat.py
+++ b/examples/models/deepseek-chat.py
@@ -20,7 +20,7 @@ if deepseek_api_key is None:
 async def main():
 	llm = ChatDeepSeek(
 		base_url='https://api.deepseek.com/v1',
-		model='deepseek-chat',
+		model='deepseek-v4-flash',
 		api_key=deepseek_api_key,
 	)
 

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -150,7 +150,7 @@ Supports profiles, IAM roles, SSO via standard AWS credential chain. Install wit
 ```python
 from browser_use import Agent, ChatDeepSeek
 
-llm = ChatDeepSeek(model="deepseek-chat")
+llm = ChatDeepSeek(model="deepseek-v4-flash")
 ```
 
 **Env:** `DEEPSEEK_API_KEY` | [Available models](https://api-docs.deepseek.com/quick_start/pricing)


### PR DESCRIPTION
## Summary

- DeepSeek retired `deepseek-chat` / `deepseek-reasoner` on 2026-07-24. The default model is now `deepseek-v4-flash`. Details: https://api-docs.deepseek.com/news/news260424/
- Add a `thinking` flag for V4 (default `False`) and send `extra_body.thinking` to explicitly disable server-side thinking (on by default), matching the previous `deepseek-chat` behavior
- Update the example and skills docs to use the new model name

## Changes

- `browser_use/llm/deepseek/chat.py`: default `model=deepseek-v4-flash`; add `thinking: bool = False` and `_request_kwargs()`
- `examples/models/deepseek-chat.py`: switch the example to `deepseek-v4-flash`
- `skills/open-source/references/models.md`: sync the docs example

## Why

The old model IDs are no longer valid; without this update, the default `ChatDeepSeek()` call may fail. `deepseek-v4-flash` enables thinking by default, which changes latency and output shape, so we disable it by default for compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the DeepSeek default model to `deepseek-v4-flash` because DeepSeek retired `deepseek-chat` and `deepseek-reasoner` on 2026-07-24. Adds a `thinking` flag (default `False`) to keep the prior non-thinking behavior.

**Changes**
- Sends `extra_body.thinking` to explicitly disable server-side thinking, preserving prior latency and output shape; only applies to V4 model names.
- Extracts request-param construction into `_request_kwargs()` so the constructor keeps working positionally.
- Updates the example script and models doc to use `deepseek-v4-flash`.

<sup>Written for commit 2b66d1f1c0151d95392a3f046437a22db68f58dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

