### PR TITLE
fix(llm): cache client instances in ChatOpenAI, ChatAnthropic, and ChatGroq (#5565)

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -175,8 +175,10 @@ class ChatAnthropic(BaseChatModel):
 		Returns:
 			AsyncAnthropic: An instance of the AsyncAnthropic client.
 		"""
-		client_params = self._get_client_params()
-		return AsyncAnthropic(**client_params)
+		if not hasattr(self, '_client'):
+			client_params = self._get_client_params()
+			self._client = AsyncAnthropic(**client_params)
+		return self._client
 
 	@property
 	def name(self) -> str:

--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -175,8 +175,9 @@ class ChatAnthropic(BaseChatModel):
 		Returns:
 			AsyncAnthropic: An instance of the AsyncAnthropic client.
 		"""
-		if not hasattr(self, '_client'):
-			client_params = self._get_client_params()
+		client_params = self._get_client_params()
+		if not hasattr(self, '_client') or getattr(self, '_cached_client_params', None) != client_params:
+			self._cached_client_params = dict(client_params)
 			self._client = AsyncAnthropic(**client_params)
 		return self._client
 

--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -74,7 +74,9 @@ class ChatGroq(BaseChatModel):
 	max_retries: int = 10  # Increase default retries for automation reliability
 
 	def get_client(self) -> AsyncGroq:
-		return AsyncGroq(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout, max_retries=self.max_retries)
+		if not hasattr(self, '_client'):
+			self._client = AsyncGroq(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout, max_retries=self.max_retries)
+		return self._client
 
 	@property
 	def provider(self) -> str:

--- a/browser_use/llm/groq/chat.py
+++ b/browser_use/llm/groq/chat.py
@@ -74,8 +74,15 @@ class ChatGroq(BaseChatModel):
 	max_retries: int = 10  # Increase default retries for automation reliability
 
 	def get_client(self) -> AsyncGroq:
-		if not hasattr(self, '_client'):
-			self._client = AsyncGroq(api_key=self.api_key, base_url=self.base_url, timeout=self.timeout, max_retries=self.max_retries)
+		client_params = {
+			'api_key': self.api_key,
+			'base_url': self.base_url,
+			'timeout': self.timeout,
+			'max_retries': self.max_retries,
+		}
+		if not hasattr(self, '_client') or getattr(self, '_cached_client_params', None) != client_params:
+			self._cached_client_params = dict(client_params)
+			self._client = AsyncGroq(**client_params)
 		return self._client
 
 	@property

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -113,8 +113,9 @@ class ChatOpenAI(BaseChatModel):
 		Returns:
 			AsyncOpenAI: An instance of the AsyncOpenAI client.
 		"""
-		if not hasattr(self, '_client'):
-			client_params = self._get_client_params()
+		client_params = self._get_client_params()
+		if not hasattr(self, '_client') or getattr(self, '_cached_client_params', None) != client_params:
+			self._cached_client_params = dict(client_params)
 			self._client = AsyncOpenAI(**client_params)
 		return self._client
 

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -113,8 +113,10 @@ class ChatOpenAI(BaseChatModel):
 		Returns:
 			AsyncOpenAI: An instance of the AsyncOpenAI client.
 		"""
-		client_params = self._get_client_params()
-		return AsyncOpenAI(**client_params)
+		if not hasattr(self, '_client'):
+			client_params = self._get_client_params()
+			self._client = AsyncOpenAI(**client_params)
+		return self._client
 
 	@property
 	def name(self) -> str:

--- a/tests/ci/models/test_llm_client_caching.py
+++ b/tests/ci/models/test_llm_client_caching.py
@@ -1,7 +1,6 @@
-import pytest
-from browser_use.llm.openai.chat import ChatOpenAI
 from browser_use.llm.anthropic.chat import ChatAnthropic
 from browser_use.llm.groq.chat import ChatGroq
+from browser_use.llm.openai.chat import ChatOpenAI
 
 
 def test_openai_get_client_caching_and_invalidation():

--- a/tests/ci/models/test_llm_client_caching.py
+++ b/tests/ci/models/test_llm_client_caching.py
@@ -4,22 +4,40 @@ from browser_use.llm.anthropic.chat import ChatAnthropic
 from browser_use.llm.groq.chat import ChatGroq
 
 
-def test_openai_get_client_caching():
-	chat = ChatOpenAI(model='gpt-4o', api_key='sk-test')
+def test_openai_get_client_caching_and_invalidation():
+	chat = ChatOpenAI(model='gpt-4o', api_key='sk-test-1')
 	client1 = chat.get_client()
 	client2 = chat.get_client()
 	assert client1 is client2, 'ChatOpenAI.get_client() must return the cached client instance'
 
+	# Mutate config -> cache invalidated and rebuilt
+	chat.api_key = 'sk-test-2'
+	client3 = chat.get_client()
+	assert client3 is not client1, 'ChatOpenAI.get_client() must rebuild when api_key changes'
+	assert chat.get_client() is client3, 'ChatOpenAI.get_client() must cache the newly rebuilt client'
 
-def test_anthropic_get_client_caching():
-	chat = ChatAnthropic(model='claude-3-5-sonnet', api_key='sk-test')
+
+def test_anthropic_get_client_caching_and_invalidation():
+	chat = ChatAnthropic(model='claude-3-5-sonnet', api_key='sk-test-1')
 	client1 = chat.get_client()
 	client2 = chat.get_client()
 	assert client1 is client2, 'ChatAnthropic.get_client() must return the cached client instance'
 
+	# Mutate config -> cache invalidated and rebuilt
+	chat.api_key = 'sk-test-2'
+	client3 = chat.get_client()
+	assert client3 is not client1, 'ChatAnthropic.get_client() must rebuild when api_key changes'
+	assert chat.get_client() is client3, 'ChatAnthropic.get_client() must cache the newly rebuilt client'
 
-def test_groq_get_client_caching():
-	chat = ChatGroq(model='llama-3.3-70b-versatile', api_key='gsk-test')
+
+def test_groq_get_client_caching_and_invalidation():
+	chat = ChatGroq(model='llama-3.3-70b-versatile', api_key='gsk-test-1')
 	client1 = chat.get_client()
 	client2 = chat.get_client()
 	assert client1 is client2, 'ChatGroq.get_client() must return the cached client instance'
+
+	# Mutate config -> cache invalidated and rebuilt
+	chat.api_key = 'gsk-test-2'
+	client3 = chat.get_client()
+	assert client3 is not client1, 'ChatGroq.get_client() must rebuild when api_key changes'
+	assert chat.get_client() is client3, 'ChatGroq.get_client() must cache the newly rebuilt client'

--- a/tests/ci/models/test_llm_client_caching.py
+++ b/tests/ci/models/test_llm_client_caching.py
@@ -1,0 +1,25 @@
+import pytest
+from browser_use.llm.openai.chat import ChatOpenAI
+from browser_use.llm.anthropic.chat import ChatAnthropic
+from browser_use.llm.groq.chat import ChatGroq
+
+
+def test_openai_get_client_caching():
+	chat = ChatOpenAI(model='gpt-4o', api_key='sk-test')
+	client1 = chat.get_client()
+	client2 = chat.get_client()
+	assert client1 is client2, 'ChatOpenAI.get_client() must return the cached client instance'
+
+
+def test_anthropic_get_client_caching():
+	chat = ChatAnthropic(model='claude-3-5-sonnet', api_key='sk-test')
+	client1 = chat.get_client()
+	client2 = chat.get_client()
+	assert client1 is client2, 'ChatAnthropic.get_client() must return the cached client instance'
+
+
+def test_groq_get_client_caching():
+	chat = ChatGroq(model='llama-3.3-70b-versatile', api_key='gsk-test')
+	client1 = chat.get_client()
+	client2 = chat.get_client()
+	assert client1 is client2, 'ChatGroq.get_client() must return the cached client instance'


### PR DESCRIPTION
## Summary

Fixes #5565.

`ChatOpenAI.get_client()`, `ChatAnthropic.get_client()`, and `ChatGroq.get_client()` were creating a new client instance on every call to `get_client()` (invoked repeatedly per agent step during `ainvoke()`). This created leaked `httpx.AsyncClient` connection pools and socket handles over multi-step agent runs.

This PR matches the cached client pattern already used by `ChatOpenRouter` and `ChatGoogle`:
- Caches `_client` on `self` inside `get_client()` for `ChatOpenAI`, `ChatAnthropic`, and `ChatGroq`.
- Adds regression unit tests in `tests/ci/models/test_llm_client_caching.py` verifying that repeated `get_client()` calls return the same cached instance.

## Test Plan
- Run unit tests: `pytest tests/ci/models/test_llm_client_caching.py` (3/3 pass).
- Verify `ChatGroq` tests in CI pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `get_client()` in `ChatOpenAI`, `ChatAnthropic`, and `ChatGroq` from creating a fresh client on every call, leaking `httpx.AsyncClient` connection pools and socket handles over multi-step agent runs. The client is now cached on the instance and rebuilt only when configuration changes.

**Bug Fixes**
- Reuses the cached client pattern already in place for `ChatOpenRouter` and `ChatGoogle`, including cache invalidation on config mutation.
- Adds regression tests in `tests/ci/models/test_llm_client_caching.py` verifying repeated calls return the same instance and the cache rebuilds after `api_key` changes.

<sup>Written for commit 8504ce2c45b616fac89f01f824809eebcaf4ce84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

