### PR TITLE
fix(registry): replace sensitive placeholders inside tuple params

### DIFF
--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -464,7 +464,7 @@ class Registry(Generic[Context]):
 		# Filter out empty values
 		applicable_secrets = {k: v for k, v in applicable_secrets.items() if v}
 
-		def recursively_replace_secrets(value: str | dict | list) -> str | dict | list:
+		def recursively_replace_secrets(value: str | dict | list | tuple) -> str | dict | list | tuple:
 			if isinstance(value, str):
 				# 1. Handle tagged secrets: <secret>label</secret>
 				matches = secret_pattern.findall(value)
@@ -499,6 +499,8 @@ class Registry(Generic[Context]):
 				return {k: recursively_replace_secrets(v) for k, v in value.items()}
 			elif isinstance(value, list):
 				return [recursively_replace_secrets(v) for v in value]
+			elif isinstance(value, tuple):
+				return tuple(recursively_replace_secrets(v) for v in value)
 			return value
 
 		params_dump = params.model_dump()

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -18,6 +18,18 @@ class SensitiveParams(BaseModel):
 	text: str = Field(description='Text with sensitive data placeholders')
 
 
+class TupleSensitiveParams(BaseModel):
+	"""Test parameter model for tuple-based sensitive data placeholders."""
+
+	items: tuple[str, ...] = Field(description='Tuple with sensitive data placeholders')
+
+
+class NestedTupleSensitiveParams(BaseModel):
+	"""Test parameter model for nested tuple-based sensitive data placeholders."""
+
+	payload: tuple[dict[str, tuple[str, list[str]]], ...] = Field(description='Nested tuple with sensitive data placeholders')
+
+
 @pytest.fixture
 def registry():
 	return Registry()
@@ -70,6 +82,29 @@ def test_replace_sensitive_data_with_missing_keys(registry, caplog):
 	assert result.text == 'Please enter user123 and <secret>password</secret>'
 	assert 'user123' in result.text
 	assert '<secret>password</secret>' in result.text  # Empty value's tag remains
+
+
+def test_replace_sensitive_data_inside_tuple(registry):
+	"""Test that _replace_sensitive_data replaces placeholders inside tuple fields."""
+	params = TupleSensitiveParams(items=('<secret>api_key</secret>', 'username', 'unchanged'))
+	sensitive_data = {'api_key': 'sk-replaced', 'username': 'admin_user'}
+
+	result = registry._replace_sensitive_data(params, sensitive_data)
+
+	assert result.items == ('sk-replaced', 'admin_user', 'unchanged')
+	assert isinstance(result.items, tuple)
+
+
+def test_replace_sensitive_data_inside_nested_tuple(registry):
+	"""Test that _replace_sensitive_data replaces placeholders inside nested tuples."""
+	params = NestedTupleSensitiveParams(payload=({'credentials': ('<secret>token</secret>', ['<secret>username</secret>'])},))
+	sensitive_data = {'token': 'token-replaced', 'username': 'admin_user'}
+
+	result = registry._replace_sensitive_data(params, sensitive_data)
+
+	assert result.payload == ({'credentials': ('token-replaced', ['admin_user'])},)
+	assert isinstance(result.payload, tuple)
+	assert isinstance(result.payload[0]['credentials'], tuple)
 
 
 def test_simple_domain_specific_sensitive_data(registry, caplog):


### PR DESCRIPTION
### Summary

- add tuple traversal to `Registry._replace_sensitive_data`
- preserve tuple containers while replacing nested sensitive-data placeholders
- add regression coverage for tuple and nested tuple action params

### Tests

```powershell
.venv\Scripts\python.exe -m pytest tests\ci\security\test_sensitive_data.py::test_replace_sensitive_data_inside_tuple tests\ci\security\test_sensitive_data.py::test_replace_sensitive_data_inside_nested_tuple -q
.venv\Scripts\python.exe -m pytest tests\ci\security\test_sensitive_data.py -q
.venv\Scripts\python.exe -m ruff check browser_use\tools\registry\service.py tests\ci\security\test_sensitive_data.py
git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Registry._replace_sensitive_data` so sensitive-data placeholders inside tuple action params are replaced instead of left as-is, while preserving tuple types.

**Bug Fixes**
- Adds tuple traversal to the recursive secret replacement, keeping tuple containers intact for top-level and nested tuples.
- Adds regression tests covering tuple and nested tuple action params.

<sup>Written for commit 8a5a3000e04c6a67708f67dfe88f4a43478838db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

