### PR TITLE
fix: allow pydantic 2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "httpx==0.28.1",
     "posthog==7.7.0",
     "psutil==7.2.2",
-    "pydantic==2.12.5",
+    "pydantic>=2.12.5,<2.14",
     "pyobjc==12.1; platform_system == 'darwin'",
     "python-dotenv==1.2.2",
     "requests==2.33.0",


### PR DESCRIPTION
## What

Allow Pydantic 2.13 while keeping an upper bound for the next untested minor line. This is the narrow, tested Pydantic portion of #4877.

## Verification

- 75 focused registry, schema optimizer, sensitive-data, domain-filter, and config tests pass
- all current GitHub checks pass on the rebased head
- changed-file pre-commit, uv lock --check, and git diff --check pass
- a built wheel installs and imports with Pydantic 2.13.4

## Compatibility boundary

This does not fully resolve AgenticOS #801. Its current main also requires newer AnyIO, google-api-python-client, and google-auth versions than Browser Use currently permits. Those dependency ranges remain separate work.