### PR TITLE
fix(tools): handle tuple-valued parameters in _replace_sensitive_data (#5568)

### DIFF
--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -464,7 +464,7 @@ class Registry(Generic[Context]):
 		# Filter out empty values
 		applicable_secrets = {k: v for k, v in applicable_secrets.items() if v}
 
-		def recursively_replace_secrets(value: str | dict | list) -> str | dict | list:
+		def recursively_replace_secrets(value: Any) -> Any:
 			if isinstance(value, str):
 				# 1. Handle tagged secrets: <secret>label</secret>
 				matches = secret_pattern.findall(value)
@@ -499,6 +499,8 @@ class Registry(Generic[Context]):
 				return {k: recursively_replace_secrets(v) for k, v in value.items()}
 			elif isinstance(value, list):
 				return [recursively_replace_secrets(v) for v in value]
+			elif isinstance(value, tuple):
+				return tuple(recursively_replace_secrets(v) for v in value)
 			return value
 
 		params_dump = params.model_dump()

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -39,8 +39,25 @@ def message_manager():
 	)
 
 
+def test_replace_sensitive_data_inside_tuple(registry):
+	"""Test that _replace_sensitive_data handles tuple-valued fields (#5568)"""
+
+	class TupleSensitiveParams(BaseModel):
+		items: tuple[str, ...]
+
+	params = TupleSensitiveParams(
+		items=('<secret>KEY</secret>', 'normal_text'),
+	)
+
+	result = registry._replace_sensitive_data(
+		params,
+		{'KEY': 'REPLACED'},
+	)
+
+	assert result.items == ('REPLACED', 'normal_text')
+
+
 def test_replace_sensitive_data_with_missing_keys(registry, caplog):
-	"""Test that _replace_sensitive_data handles missing keys gracefully"""
 	# Create a simple Pydantic model with sensitive data placeholders
 	params = SensitiveParams(text='Please enter <secret>username</secret> and <secret>password</secret>')
 


### PR DESCRIPTION
## Summary

Fixes #5568.

In `browser_use/tools/registry/service.py`, `Registry._replace_sensitive_data` did not replace sensitive placeholders inside tuple-valued parameters. The recursive substitution helper handled `str`, `dict`, and `list`, but returned tuples unchanged, leaving unresolved `<secret>...</secret>` placeholders.

This PR:
- Adds `tuple` handling to `recursively_replace_secrets` while preserving the tuple container type.
- Adds regression unit test `test_replace_sensitive_data_inside_tuple` in `tests/ci/security/test_sensitive_data.py`.

## Test Plan
- Run unit tests: `uv run pytest tests/ci/security/test_sensitive_data.py` (15/15 passed).
- Linting: `uv run ruff check` and `uv run ruff format --check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `_replace_sensitive_data` so sensitive placeholders inside tuple-valued parameters now get replaced, instead of being left as unresolved `<secret>` tags. Adds a regression test for tuple-valued fields.

<sup>Written for commit c4c3820d01a6270563570958a2e60d123a3e5740. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

