### PR TITLE
fix(utils): preserve balanced closing brackets in sanitize_url_candidate (#5575)

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -46,7 +46,29 @@ def sanitize_url_candidate(url: str) -> str:
 	# "https://example.com/search.\\n2. Next step". Those are task text,
 	# not part of the URL.
 	candidate = re.split(r'\\[nrt]', candidate, maxsplit=1)[0]
-	return re.sub(r'[.,;:!?()\[\]]+$', '', candidate)
+
+	# Strip trailing punctuation, handling balanced parentheses/brackets
+	while candidate:
+		# If trailing char is simple punctuation
+		if candidate[-1] in '.,;:!?':
+			candidate = candidate[:-1]
+		# If trailing char is closing paren, only strip if unmatched
+		elif candidate[-1] == ')':
+			if candidate.count('(') < candidate.count(')'):
+				candidate = candidate[:-1]
+			else:
+				break
+		# If trailing char is closing bracket, only strip if unmatched
+		elif candidate[-1] == ']':
+			if candidate.count('[') < candidate.count(']'):
+				candidate = candidate[:-1]
+			else:
+				break
+		elif candidate[-1] in '([{':
+			candidate = candidate[:-1]
+		else:
+			break
+	return candidate
 
 
 # Lazy import for error types

--- a/tests/ci/test_sanitize_url_candidate.py
+++ b/tests/ci/test_sanitize_url_candidate.py
@@ -1,0 +1,24 @@
+from browser_use.utils import sanitize_url_candidate
+
+
+def test_sanitize_url_candidate_balanced_brackets():
+	# Issue #5575: URLs with balanced closing brackets should not be truncated
+	assert (
+		sanitize_url_candidate('https://en.wikipedia.org/wiki/Python_(programming_language)')
+		== 'https://en.wikipedia.org/wiki/Python_(programming_language)'
+	)
+	assert (
+		sanitize_url_candidate('https://en.wikipedia.org/wiki/Berlin_(disambiguation)')
+		== 'https://en.wikipedia.org/wiki/Berlin_(disambiguation)'
+	)
+	assert sanitize_url_candidate('https://example.com/a[1]') == 'https://example.com/a[1]'
+
+
+def test_sanitize_url_candidate_unmatched_trailing_brackets():
+	# Trailing prose closing brackets should be stripped
+	assert sanitize_url_candidate('https://example.com/docs)') == 'https://example.com/docs'
+	assert sanitize_url_candidate('https://example.com/docs]') == 'https://example.com/docs'
+	assert sanitize_url_candidate('https://example.com/docs.') == 'https://example.com/docs'
+	assert sanitize_url_candidate('https://example.com/docs...') == 'https://example.com/docs'
+	assert sanitize_url_candidate('https://example.com/docs,') == 'https://example.com/docs'
+	assert sanitize_url_candidate('https://example.com/docs!?:;') == 'https://example.com/docs'


### PR DESCRIPTION
## Summary

Fixes #5575.

When a task mentions a URL whose path ends in a closing bracket (such as Wikipedia disambiguation links: `https://en.wikipedia.org/wiki/Python_(programming_language)`), `sanitize_url_candidate()` in `browser_use/utils.py` was unconditionally stripping trailing `)` and `]` characters, truncating the URL before navigation.

This PR:
- Updates `sanitize_url_candidate()` to only strip trailing closing brackets/parentheses if they are unmatched in the candidate URL (i.e. opened by enclosing prose rather than part of the URL path itself).
- Adds regression unit tests in `tests/ci/test_sanitize_url_candidate.py`.

## Test Plan
- Run unit tests: `uv run pytest tests/ci/test_sanitize_url_candidate.py` (2/2 pass).
- Linting: `uv run ruff check` and `uv run ruff format --check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `sanitize_url_candidate()` truncating URLs whose path ends in a balanced closing bracket, such as Wikipedia disambiguation links like `https://en.wikipedia.org/wiki/Python_(programming_language)`.

- Previously stripped all trailing `)`, `]`, and other punctuation, cutting off valid URL paths.
- Now only strips trailing closing brackets or parentheses when they are unmatched in the candidate, preserving balanced ones.
- Adds regression tests covering both balanced and unmatched trailing brackets in `tests/ci/test_sanitize_url_candidate.py`.

<sup>Written for commit 82994a8f336263f1245237ab17f84c2532831288. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

