### PR TITLE
fix(browser): handle literal plus key and restrict enter delay to actual Enter actions (#5569, #5573)

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2506,25 +2506,51 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# Parse and normalize the key string
 			keys = event.keys
-			if '+' in keys:
-				# Handle key combinations like "ctrl+a"
-				parts = keys.split('+')
-				normalized_parts = []
-				for part in parts:
-					part_lower = part.strip().lower()
-					normalized = key_aliases.get(part_lower, part)
-					normalized_parts.append(normalized)
-				normalized_keys = '+'.join(normalized_parts)
+			modifier_aliases = {'ctrl', 'control', 'alt', 'option', 'meta', 'cmd', 'command', 'shift'}
+
+			# Check if this is a genuine key combination (e.g. "Control+A", "Control++")
+			# A combination has at least one modifier prefix before '+'
+			is_combo = False
+			if '+' in keys and keys != '+':
+				candidate_parts = keys.split('+')
+				# If all parts except the last one are known modifiers and last part is non-empty (or empty because keys ended with '+' like Ctrl++)
+				if len(candidate_parts) >= 2:
+					if keys.endswith('++'):
+						# e.g. "Control++"
+						mods = [p.strip().lower() for p in candidate_parts[:-2]]
+						if mods and all(m in modifier_aliases for m in mods):
+							is_combo = True
+					else:
+						mods = [p.strip().lower() for p in candidate_parts[:-1]]
+						if mods and all(m in modifier_aliases for m in mods):
+							is_combo = True
+
+			if is_combo:
+				# Handle key combinations like "ctrl+a" or "Control++"
+				if keys.endswith('++'):
+					raw_modifiers = keys[:-2].split('+')
+					main_key = '+'
+				else:
+					raw_parts = keys.split('+')
+					raw_modifiers = raw_parts[:-1]
+					main_key = raw_parts[-1]
+
+				normalized_modifiers = [key_aliases.get(m.strip().lower(), m) for m in raw_modifiers]
+				normalized_main_key = key_aliases.get(main_key.strip().lower(), main_key)
+				normalized_keys = '+'.join(normalized_modifiers + [normalized_main_key])
 			else:
-				# Single key
+				# Single key or plain text string
 				keys_lower = keys.strip().lower()
 				normalized_keys = key_aliases.get(keys_lower, keys)
 
+			is_enter_action = False
 			# Handle key combinations like "Control+A"
-			if '+' in normalized_keys:
+			if is_combo and '+' in normalized_keys:
 				parts = normalized_keys.split('+')
 				modifiers = parts[:-1]
 				main_key = parts[-1]
+				if main_key == 'Enter':
+					is_enter_action = True
 
 				# Calculate modifier bitmask
 				modifier_value = 0
@@ -2580,6 +2606,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 				# If it's a special key, use original logic
 				if normalized_keys in special_keys:
+					if normalized_keys == 'Enter':
+						is_enter_action = True
 					await self._dispatch_key_event(cdp_session, 'keyDown', normalized_keys)
 					# For Enter key, also dispatch a char event to trigger keypress listeners
 					if normalized_keys == 'Enter':
@@ -2598,6 +2626,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 					for char in normalized_keys:
 						# Special-case newline characters to dispatch as Enter
 						if char in ('\n', '\r'):
+							is_enter_action = True
 							await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
 								params={
 									'type': 'rawKeyDown',
@@ -2672,7 +2701,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# Note: We don't clear cached state on Enter; multi_act will detect DOM changes
 			# and rebuild explicitly. We still wait briefly for potential navigation.
-			if 'enter' in event.keys.lower() or 'return' in event.keys.lower():
+			if is_enter_action:
 				await asyncio.sleep(0.1)
 		except Exception as e:
 			raise

--- a/tests/ci/browser/test_send_keys_edge_cases.py
+++ b/tests/ci/browser/test_send_keys_edge_cases.py
@@ -1,0 +1,79 @@
+import asyncio
+from types import SimpleNamespace
+
+from browser_use.browser.events import SendKeysEvent
+from browser_use.browser.watchdogs.default_action_watchdog import DefaultActionWatchdog
+
+
+def test_send_keys_literal_plus_dispatches_char_event():
+	recorded_params = []
+	dispatched_keys = []
+
+	class Input:
+		async def dispatchKeyEvent(self, params=None, session_id=None):
+			recorded_params.append(params or {})
+
+	cdp_session = SimpleNamespace(
+		cdp_client=SimpleNamespace(send=SimpleNamespace(Input=Input())),
+		session_id='session-1',
+	)
+
+	class BrowserSession:
+		async def get_or_create_cdp_session(self, focus=False):
+			return cdp_session
+
+	async def dispatch_key_event(_session, event_type, key, modifiers=0):
+		dispatched_keys.append((event_type, key, modifiers))
+
+	watchdog = SimpleNamespace(
+		browser_session=BrowserSession(),
+		logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+		_dispatch_key_event=dispatch_key_event,
+		_get_char_modifiers_and_vk=lambda char: (0, 0, char),
+		_get_key_code_for_char=lambda key: f'Key{key.upper()}',
+	)
+
+	asyncio.run(DefaultActionWatchdog.on_SendKeysEvent(watchdog, SendKeysEvent(keys='+')))
+
+	assert any(params.get('type') == 'char' and params.get('text') == '+' for params in recorded_params), (
+		recorded_params,
+		dispatched_keys,
+	)
+
+
+def test_send_keys_text_containing_enter_has_no_enter_delay(monkeypatch):
+	delays = []
+
+	async def sleep(delay):
+		delays.append(delay)
+
+	monkeypatch.setattr(asyncio, 'sleep', sleep)
+
+	class Input:
+		async def dispatchKeyEvent(self, params=None, session_id=None):
+			return None
+
+	cdp_session = SimpleNamespace(
+		cdp_client=SimpleNamespace(send=SimpleNamespace(Input=Input())),
+		session_id='session-1',
+	)
+
+	class BrowserSession:
+		async def get_or_create_cdp_session(self, focus=False):
+			return cdp_session
+
+	async def dispatch_key_event(_session, event_type, key, modifiers=0):
+		return None
+
+	watchdog = SimpleNamespace(
+		browser_session=BrowserSession(),
+		logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+		_dispatch_key_event=dispatch_key_event,
+		_get_char_modifiers_and_vk=lambda char: (0, 0, char),
+		_get_key_code_for_char=lambda key: f'Key{key.upper()}',
+	)
+
+	asyncio.run(DefaultActionWatchdog.on_SendKeysEvent(watchdog, SendKeysEvent(keys='center')))
+
+	enter_delays = [delay for delay in delays if delay == 0.1]
+	assert enter_delays == []


### PR DESCRIPTION
## Summary

Fixes #5569 and fixes #5573.

In `browser_use/browser/watchdogs/default_action_watchdog.py`:
1. `DefaultActionWatchdog.on_SendKeysEvent` was treating any key string containing `+` as a combination, splitting literal `+` into empty parts and dropping the character event.
2. The post-send `0.1s` Enter delay was applied whenever `'enter'` or `'return'` appeared as a substring (e.g. typing words like `center`, `enterprise`, `returning`).

This PR:
- Only parses shortcut combinations when valid modifier prefixes precede the `+` delimiter, allowing literal `+` and `Control++` to be handled correctly.
- Flags and applies the `0.1s` delay only when the dispatched action actually triggers an Enter/Return key or combination.
- Adds regression unit tests in `tests/ci/browser/test_send_keys_edge_cases.py`.

## Test Plan
- Run unit tests: `uv run pytest tests/ci/browser/test_send_keys_edge_cases.py` (2/2 passed).
- Linting: `uv run ruff check` and `uv run ruff format --check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two `SendKeys` handling bugs: literal `+` keys are no longer dropped, and the 0.1s Enter delay only fires for real Enter/Return actions.

- Literal `+` and combinations like `Control++` are now parsed correctly by checking for valid modifier prefixes.
- Text such as `center` or `returning` no longer triggers the Enter delay.
- Adds regression tests for both cases.

<sup>Written for commit 0e6667466fb8d7006eb4f1fc0c4f2d4fdf0b8adf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

