### PR TITLE
feat: add A3M Router integration with type-safe imports

### DIFF
--- a/browser_use/llm/a3m/__init__.py
+++ b/browser_use/llm/a3m/__init__.py
@@ -13,4 +13,4 @@ Usage:
 
 from browser_use.llm.a3m.chat import ChatA3M
 
-__all__ = ["ChatA3M"]
+__all__ = ['ChatA3M']

--- a/browser_use/llm/a3m/__init__.py
+++ b/browser_use/llm/a3m/__init__.py
@@ -1,0 +1,16 @@
+"""
+A3M Router integration for browser-use.
+
+Usage:
+    from browser_use import Agent
+    from browser_use.llm.a3m import ChatA3M
+
+    agent = Agent(
+        task="Fill out this job application form",
+        llm=ChatA3M(model="auto", stealth=True),
+    )
+"""
+
+from browser_use.llm.a3m.chat import ChatA3M
+
+__all__ = ["ChatA3M"]

--- a/browser_use/llm/a3m/chat.py
+++ b/browser_use/llm/a3m/chat.py
@@ -145,10 +145,12 @@ class ChatA3M(BaseChatModel):
 			# When output_format is provided, inject schema as a system message
 			# since A3M Router uses OpenAI-compatible API
 			if output_format is not None:
+				import json
+
 				schema_json = output_format.model_json_schema()
 				schema_instruction = (
 					f'\n\nIMPORTANT: Your response MUST be valid JSON matching this schema:\n'
-					f'{schema_json}\n\nRespond ONLY with the JSON object, no additional text.'
+					f'{json.dumps(schema_json, indent=2)}\n\nRespond ONLY with the JSON object, no additional text.'
 				)
 				# Prepend schema instruction to last user message
 				for msg in reversed(a3m_messages):
@@ -156,6 +158,9 @@ class ChatA3M(BaseChatModel):
 						msg_content = msg.get('content', '')
 						if isinstance(msg_content, str):
 							msg['content'] = msg_content + schema_instruction
+						elif isinstance(msg_content, list) and msg_content:
+							# Multimodal content - append schema instruction as text part
+							msg_content.append({'type': 'text', 'text': schema_instruction})
 						break
 
 			response = await asyncio.wait_for(

--- a/browser_use/llm/a3m/chat.py
+++ b/browser_use/llm/a3m/chat.py
@@ -1,0 +1,158 @@
+"""
+ChatA3M - A3M Router chat model wrapper for browser-use.
+
+Provides intelligent LLM routing for browser automation with:
+- Automatic routing to cheapest capable model
+- Stealth mode for anti-detection
+- Parallel ensemble for reliability
+- Parallel ensemble for reliable extraction
+
+Requires the `a3m-router` package:
+    pip install a3m-router
+
+Usage:
+    from browser_use import Agent
+    from browser_use.llm.a3m import ChatA3M
+
+    agent = Agent(
+        task="Fill out this job application form",
+        llm=ChatA3M(model="auto", stealth=True),
+    )
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, overload
+
+from pydantic import BaseModel
+
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import BaseMessage
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+from browser_use.llm.a3m.serializer import A3MMessageSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class A3MRouterConfig(BaseModel):
+    """Configuration for A3M Router."""
+
+    model: str = "auto"
+    stealth: bool = False
+    parallel_ensemble: bool = False
+
+
+@dataclass
+class ChatA3M(BaseChatModel):
+    """A3M Router chat model for browser-use.
+
+    A3M Router provides intelligent LLM routing with:
+    - Automatic routing to cheapest capable model
+    - 80+ supported providers
+    - EXP3 game theory-based exploration/exploitation
+    - MVT rate-limit rotation
+    - ODT verification for adversarial patterns
+
+    Args:
+        model: Model name or "auto" for automatic routing
+        stealth: Enable stealth mode for anti-detection
+        parallel_ensemble: Use parallel ensemble for reliability
+    """
+
+    model: str = "auto"
+    stealth: bool = False
+    parallel_ensemble: bool = False
+    max_output_tokens: int = 8192
+    type: str = "chat_a3m"
+    _a3m_router: Any = None
+
+    def __post_init__(self) -> None:
+        """Initialize A3M router."""
+        try:
+            import a3m
+
+            self._a3m_router = a3m.A3MRouter(  # type: ignore[attr-defined]
+                model=self.model,
+                stealth=self.stealth,
+                parallel_ensemble=self.parallel_ensemble,
+            )
+            logger.info(f"Initialized A3M Router with model: {self.model}")
+        except ImportError as e:
+            raise ModelProviderError(
+                "A3M Router is not installed. Install with: pip install a3m-router"
+            ) from e
+
+    @property
+    def provider(self) -> str:
+        """Return provider name."""
+        return "a3m-router"
+
+    def messages_to_dict(self, messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
+        """Convert browser-use messages to A3M Router format."""
+        return A3MMessageSerializer.serialize(messages)
+
+    @overload
+    def generate(self, messages: list[BaseMessage]) -> str: ...
+
+    @overload
+    def generate(self, messages: list[BaseMessage], stream: bool) -> Any: ...
+
+    def generate(self, messages: list[BaseMessage], stream: bool = False) -> Any:
+        """Generate response from A3M Router."""
+        try:
+            import a3m
+
+            # Convert messages to A3M format
+            a3m_messages = self.messages_to_dict(messages)
+
+            # Use sync client for non-streaming
+            router_sync = a3m.A3MRouterSync(  # type: ignore[attr-defined]
+                client=self._a3m_router.client
+            )
+            response = router_sync.chat(
+                messages=a3m_messages,
+                model=self.model,
+                max_tokens=self.max_output_tokens,
+            )
+
+            if stream:
+                return self._stream_response(response)
+            return response.choices[0].message.content
+
+        except Exception as e:
+            logger.error(f"A3M Router error: {e}")
+            raise ModelProviderError(f"A3M Router generation failed: {e}") from e
+
+    def _stream_response(self, response: Any) -> Any:
+        """Stream response from A3M Router."""
+        for chunk in response:
+            if chunk.choices[0].delta.content:
+                yield chunk.choices[0].delta.content
+
+    async def generate_async(self, messages: list[BaseMessage]) -> str:
+        """Async generate response from A3M Router."""
+        import asyncio
+
+        try:
+            import a3m
+
+            a3m_messages = self.messages_to_dict(messages)
+            response = await asyncio.wait_for(
+                self._a3m_router.chat(messages=a3m_messages, model=self.model),
+                timeout=120,
+            )
+            return response.choices[0].message.content
+        except TimeoutError as e:
+            raise ModelRateLimitError(f"A3M Router timeout after 120s: {e}") from e
+        except Exception as e:
+            logger.error(f"A3M Router async error: {e}")
+            raise ModelProviderError(f"A3M Router async generation failed: {e}") from e
+
+    def get_cost(self) -> float | None:
+        """Get cost of last response if available."""
+        return None  # A3M Router tracks cost internally
+
+    def get_token_usage(self) -> dict[str, int] | None:
+        """Get token usage of last response if available."""
+        return None  # A3M Router tracks usage internally

--- a/browser_use/llm/a3m/chat.py
+++ b/browser_use/llm/a3m/chat.py
@@ -24,135 +24,131 @@ import logging
 from dataclasses import dataclass
 from typing import Any, overload
 
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
 from pydantic import BaseModel
 
+from browser_use.llm.a3m.serializer import A3MMessageSerializer
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
-from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
-from browser_use.llm.a3m.serializer import A3MMessageSerializer
 
 logger = logging.getLogger(__name__)
 
 
 class A3MRouterConfig(BaseModel):
-    """Configuration for A3M Router."""
+	"""Configuration for A3M Router."""
 
-    model: str = "auto"
-    stealth: bool = False
-    parallel_ensemble: bool = False
+	model: str = 'auto'
+	stealth: bool = False
+	parallel_ensemble: bool = False
 
 
 @dataclass
 class ChatA3M(BaseChatModel):
-    """A3M Router chat model for browser-use.
+	"""A3M Router chat model for browser-use.
 
-    A3M Router provides intelligent LLM routing with:
-    - Automatic routing to cheapest capable model
-    - 80+ supported providers
-    - EXP3 game theory-based exploration/exploitation
-    - MVT rate-limit rotation
-    - ODT verification for adversarial patterns
+	A3M Router provides intelligent LLM routing with:
+	- Automatic routing to cheapest capable model
+	- 80+ supported providers
+	- EXP3 game theory-based exploration/exploitation
+	- MVT rate-limit rotation
+	- ODT verification for adversarial patterns
 
-    Args:
-        model: Model name or "auto" for automatic routing
-        stealth: Enable stealth mode for anti-detection
-        parallel_ensemble: Use parallel ensemble for reliability
-    """
+	Args:
+	    model: Model name or "auto" for automatic routing
+	    stealth: Enable stealth mode for anti-detection
+	    parallel_ensemble: Use parallel ensemble for reliability
+	"""
 
-    model: str = "auto"
-    stealth: bool = False
-    parallel_ensemble: bool = False
-    max_output_tokens: int = 8192
-    type: str = "chat_a3m"
-    _a3m_router: Any = None
+	model: str = 'auto'
+	stealth: bool = False
+	parallel_ensemble: bool = False
+	max_output_tokens: int = 8192
+	type: str = 'chat_a3m'
+	_a3m_router: Any = None
 
-    def __post_init__(self) -> None:
-        """Initialize A3M router."""
-        try:
-            import a3m
+	def __post_init__(self) -> None:
+		"""Initialize A3M router."""
+		try:
+			import a3m
 
-            self._a3m_router = a3m.A3MRouter(  # type: ignore[attr-defined]
-                model=self.model,
-                stealth=self.stealth,
-                parallel_ensemble=self.parallel_ensemble,
-            )
-            logger.info(f"Initialized A3M Router with model: {self.model}")
-        except ImportError as e:
-            raise ModelProviderError(
-                "A3M Router is not installed. Install with: pip install a3m-router"
-            ) from e
+			self._a3m_router = a3m.A3MRouter(  # type: ignore[attr-defined]
+				model=self.model,
+				stealth=self.stealth,
+				parallel_ensemble=self.parallel_ensemble,
+			)
+			logger.info(f'Initialized A3M Router with model: {self.model}')
+		except ImportError as e:
+			raise ModelProviderError('A3M Router is not installed. Install with: pip install a3m-router') from e
 
-    @property
-    def provider(self) -> str:
-        """Return provider name."""
-        return "a3m-router"
+	@property
+	def provider(self) -> str:
+		"""Return provider name."""
+		return 'a3m-router'
 
-    def messages_to_dict(self, messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
-        """Convert browser-use messages to A3M Router format."""
-        return A3MMessageSerializer.serialize(messages)
+	def messages_to_dict(self, messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
+		"""Convert browser-use messages to A3M Router format."""
+		return A3MMessageSerializer.serialize(messages)
 
-    @overload
-    def generate(self, messages: list[BaseMessage]) -> str: ...
+	@overload
+	def generate(self, messages: list[BaseMessage]) -> str: ...
 
-    @overload
-    def generate(self, messages: list[BaseMessage], stream: bool) -> Any: ...
+	@overload
+	def generate(self, messages: list[BaseMessage], stream: bool) -> Any: ...
 
-    def generate(self, messages: list[BaseMessage], stream: bool = False) -> Any:
-        """Generate response from A3M Router."""
-        try:
-            import a3m
+	def generate(self, messages: list[BaseMessage], stream: bool = False) -> Any:
+		"""Generate response from A3M Router."""
+		try:
+			import a3m
 
-            # Convert messages to A3M format
-            a3m_messages = self.messages_to_dict(messages)
+			# Convert messages to A3M format
+			a3m_messages = self.messages_to_dict(messages)
 
-            # Use sync client for non-streaming
-            router_sync = a3m.A3MRouterSync(  # type: ignore[attr-defined]
-                client=self._a3m_router.client
-            )
-            response = router_sync.chat(
-                messages=a3m_messages,
-                model=self.model,
-                max_tokens=self.max_output_tokens,
-            )
+			# Use sync client for non-streaming
+			router_sync = a3m.A3MRouterSync(  # type: ignore[attr-defined]
+				client=self._a3m_router.client
+			)
+			response = router_sync.chat(
+				messages=a3m_messages,
+				model=self.model,
+				max_tokens=self.max_output_tokens,
+			)
 
-            if stream:
-                return self._stream_response(response)
-            return response.choices[0].message.content
+			if stream:
+				return self._stream_response(response)
+			return response.choices[0].message.content
 
-        except Exception as e:
-            logger.error(f"A3M Router error: {e}")
-            raise ModelProviderError(f"A3M Router generation failed: {e}") from e
+		except Exception as e:
+			logger.error(f'A3M Router error: {e}')
+			raise ModelProviderError(f'A3M Router generation failed: {e}') from e
 
-    def _stream_response(self, response: Any) -> Any:
-        """Stream response from A3M Router."""
-        for chunk in response:
-            if chunk.choices[0].delta.content:
-                yield chunk.choices[0].delta.content
+	def _stream_response(self, response: Any) -> Any:
+		"""Stream response from A3M Router."""
+		for chunk in response:
+			if chunk.choices[0].delta.content:
+				yield chunk.choices[0].delta.content
 
-    async def generate_async(self, messages: list[BaseMessage]) -> str:
-        """Async generate response from A3M Router."""
-        import asyncio
+	async def generate_async(self, messages: list[BaseMessage]) -> str:
+		"""Async generate response from A3M Router."""
+		import asyncio
 
-        try:
-            import a3m
+		try:
+			a3m_messages = self.messages_to_dict(messages)
+			response = await asyncio.wait_for(
+				self._a3m_router.chat(messages=a3m_messages, model=self.model),
+				timeout=120,
+			)
+			return response.choices[0].message.content
+		except TimeoutError as e:
+			raise ModelRateLimitError(f'A3M Router timeout after 120s: {e}') from e
+		except Exception as e:
+			logger.error(f'A3M Router async error: {e}')
+			raise ModelProviderError(f'A3M Router async generation failed: {e}') from e
 
-            a3m_messages = self.messages_to_dict(messages)
-            response = await asyncio.wait_for(
-                self._a3m_router.chat(messages=a3m_messages, model=self.model),
-                timeout=120,
-            )
-            return response.choices[0].message.content
-        except TimeoutError as e:
-            raise ModelRateLimitError(f"A3M Router timeout after 120s: {e}") from e
-        except Exception as e:
-            logger.error(f"A3M Router async error: {e}")
-            raise ModelProviderError(f"A3M Router async generation failed: {e}") from e
+	def get_cost(self) -> float | None:
+		"""Get cost of last response if available."""
+		return None  # A3M Router tracks cost internally
 
-    def get_cost(self) -> float | None:
-        """Get cost of last response if available."""
-        return None  # A3M Router tracks cost internally
-
-    def get_token_usage(self) -> dict[str, int] | None:
-        """Get token usage of last response if available."""
-        return None  # A3M Router tracks usage internally
+	def get_token_usage(self) -> dict[str, int] | None:
+		"""Get token usage of last response if available."""
+		return None  # A3M Router tracks usage internally

--- a/browser_use/llm/a3m/chat.py
+++ b/browser_use/llm/a3m/chat.py
@@ -1,4 +1,3 @@
-# pyright: reportInvalidTypeForm=false
 """
 ChatA3M - A3M Router chat model wrapper for browser-use.
 
@@ -19,6 +18,8 @@ Usage:
         llm=ChatA3M(model="auto", stealth=True),
     )
 """
+
+# pyright: reportInvalidTypeForm=false
 
 import logging
 from dataclasses import dataclass
@@ -123,16 +124,16 @@ class ChatA3M(BaseChatModel):
 				yield chunk.choices[0].delta.content
 
 	@overload
-	async def ainvoke(  # type: ignore[override]
+	async def ainvoke(  # type: ignore[reportInvalidTypeForm]
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
 	) -> ChatInvokeCompletion[str]: ...
 
 	@overload
-	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T], **kwargs: Any) -> ChatInvokeCompletion[T]: ...  # type: ignore[reportInvalidTypeForm]
+	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T], **kwargs: Any) -> ChatInvokeCompletion[T]: ...
 
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
-	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:  # type: ignore[reportInvalidTypeForm]
+	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:
 		"""Async invoke the A3M Router."""
 		import asyncio
 
@@ -140,6 +141,23 @@ class ChatA3M(BaseChatModel):
 			from browser_use.llm.openai.serializer import OpenAIMessageSerializer
 
 			a3m_messages = OpenAIMessageSerializer.serialize_messages(messages)
+
+			# When output_format is provided, inject schema as a system message
+			# since A3M Router uses OpenAI-compatible API
+			if output_format is not None:
+				schema_json = output_format.model_json_schema()
+				schema_instruction = (
+					f'\n\nIMPORTANT: Your response MUST be valid JSON matching this schema:\n'
+					f'{schema_json}\n\nRespond ONLY with the JSON object, no additional text.'
+				)
+				# Prepend schema instruction to last user message
+				for msg in reversed(a3m_messages):
+					if msg.get('role') == 'user':
+						msg_content = msg.get('content', '')
+						if isinstance(msg_content, str):
+							msg['content'] = msg_content + schema_instruction
+						break
+
 			response = await asyncio.wait_for(
 				self._a3m_router.chat(
 					messages=a3m_messages,
@@ -148,16 +166,25 @@ class ChatA3M(BaseChatModel):
 				),
 				timeout=120,
 			)
-			content = response.choices[0].message.content
+
+			content = response.choices[0].message.content or ''
 
 			if output_format is not None:
-				completion = output_format.model_validate_json(content)  # type: ignore[arg-type]
-				return ChatInvokeCompletion(completion=completion, usage=None)  # type: ignore[arg-type]
+				try:
+					completion = output_format.model_validate_json(content)
+					return ChatInvokeCompletion(completion=completion, usage=None)
+				except Exception as e:
+					raise ModelProviderError(
+						message=f'A3M Router returned invalid JSON for structured output: {e}',
+						model=self.name,
+					) from e
 
 			return ChatInvokeCompletion(completion=content, usage=None)
 
 		except TimeoutError as e:
 			raise ModelRateLimitError(f'A3M Router timeout after 120s: {e}') from e
+		except ModelProviderError:
+			raise
 		except Exception as e:
 			logger.error(f'A3M Router ainvoke error: {e}')
 			raise ModelProviderError(f'A3M Router ainvoke failed: {e}') from e

--- a/browser_use/llm/a3m/chat.py
+++ b/browser_use/llm/a3m/chat.py
@@ -1,3 +1,4 @@
+# pyright: reportInvalidTypeForm=false
 """
 ChatA3M - A3M Router chat model wrapper for browser-use.
 
@@ -5,7 +6,6 @@ Provides intelligent LLM routing for browser automation with:
 - Automatic routing to cheapest capable model
 - Stealth mode for anti-detection
 - Parallel ensemble for reliability
-- Parallel ensemble for reliable extraction
 
 Requires the `a3m-router` package:
     pip install a3m-router
@@ -22,25 +22,18 @@ Usage:
 
 import logging
 from dataclasses import dataclass
-from typing import Any, overload
+from typing import Any, TypeVar, overload
 
-from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
 from pydantic import BaseModel
 
-from browser_use.llm.a3m.serializer import A3MMessageSerializer
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
+from browser_use.llm.views import ChatInvokeCompletion
 
 logger = logging.getLogger(__name__)
 
-
-class A3MRouterConfig(BaseModel):
-	"""Configuration for A3M Router."""
-
-	model: str = 'auto'
-	stealth: bool = False
-	parallel_ensemble: bool = False
+T = TypeVar('T', bound=BaseModel)
 
 
 @dataclass
@@ -52,7 +45,6 @@ class ChatA3M(BaseChatModel):
 	- 80+ supported providers
 	- EXP3 game theory-based exploration/exploitation
 	- MVT rate-limit rotation
-	- ODT verification for adversarial patterns
 
 	Args:
 	    model: Model name or "auto" for automatic routing
@@ -70,7 +62,7 @@ class ChatA3M(BaseChatModel):
 	def __post_init__(self) -> None:
 		"""Initialize A3M router."""
 		try:
-			import a3m
+			import a3m  # type: ignore[attr-defined]
 
 			self._a3m_router = a3m.A3MRouter(  # type: ignore[attr-defined]
 				model=self.model,
@@ -86,9 +78,10 @@ class ChatA3M(BaseChatModel):
 		"""Return provider name."""
 		return 'a3m-router'
 
-	def messages_to_dict(self, messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
-		"""Convert browser-use messages to A3M Router format."""
-		return A3MMessageSerializer.serialize(messages)
+	@property
+	def name(self) -> str:
+		"""Return model name."""
+		return self.model
 
 	@overload
 	def generate(self, messages: list[BaseMessage]) -> str: ...
@@ -99,12 +92,12 @@ class ChatA3M(BaseChatModel):
 	def generate(self, messages: list[BaseMessage], stream: bool = False) -> Any:
 		"""Generate response from A3M Router."""
 		try:
-			import a3m
+			import a3m  # type: ignore[attr-defined]
 
-			# Convert messages to A3M format
-			a3m_messages = self.messages_to_dict(messages)
+			from browser_use.llm.openai.serializer import OpenAIMessageSerializer
 
-			# Use sync client for non-streaming
+			a3m_messages = OpenAIMessageSerializer.serialize_messages(messages)
+
 			router_sync = a3m.A3MRouterSync(  # type: ignore[attr-defined]
 				client=self._a3m_router.client
 			)
@@ -112,6 +105,7 @@ class ChatA3M(BaseChatModel):
 				messages=a3m_messages,
 				model=self.model,
 				max_tokens=self.max_output_tokens,
+				stream=stream,
 			)
 
 			if stream:
@@ -128,22 +122,45 @@ class ChatA3M(BaseChatModel):
 			if chunk.choices[0].delta.content:
 				yield chunk.choices[0].delta.content
 
-	async def generate_async(self, messages: list[BaseMessage]) -> str:
-		"""Async generate response from A3M Router."""
+	@overload
+	async def ainvoke(  # type: ignore[override]
+		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[str]: ...
+
+	@overload
+	async def ainvoke(self, messages: list[BaseMessage], output_format: type[T], **kwargs: Any) -> ChatInvokeCompletion[T]: ...  # type: ignore[reportInvalidTypeForm]
+
+	async def ainvoke(
+		self, messages: list[BaseMessage], output_format: type[T] | None = None, **kwargs: Any
+	) -> ChatInvokeCompletion[T] | ChatInvokeCompletion[str]:  # type: ignore[reportInvalidTypeForm]
+		"""Async invoke the A3M Router."""
 		import asyncio
 
 		try:
-			a3m_messages = self.messages_to_dict(messages)
+			from browser_use.llm.openai.serializer import OpenAIMessageSerializer
+
+			a3m_messages = OpenAIMessageSerializer.serialize_messages(messages)
 			response = await asyncio.wait_for(
-				self._a3m_router.chat(messages=a3m_messages, model=self.model),
+				self._a3m_router.chat(
+					messages=a3m_messages,
+					model=self.model,
+					max_tokens=self.max_output_tokens,
+				),
 				timeout=120,
 			)
-			return response.choices[0].message.content
+			content = response.choices[0].message.content
+
+			if output_format is not None:
+				completion = output_format.model_validate_json(content)  # type: ignore[arg-type]
+				return ChatInvokeCompletion(completion=completion, usage=None)  # type: ignore[arg-type]
+
+			return ChatInvokeCompletion(completion=content, usage=None)
+
 		except TimeoutError as e:
 			raise ModelRateLimitError(f'A3M Router timeout after 120s: {e}') from e
 		except Exception as e:
-			logger.error(f'A3M Router async error: {e}')
-			raise ModelProviderError(f'A3M Router async generation failed: {e}') from e
+			logger.error(f'A3M Router ainvoke error: {e}')
+			raise ModelProviderError(f'A3M Router ainvoke failed: {e}') from e
 
 	def get_cost(self) -> float | None:
 		"""Get cost of last response if available."""

--- a/browser_use/llm/a3m/serializer.py
+++ b/browser_use/llm/a3m/serializer.py
@@ -12,20 +12,20 @@ from browser_use.llm.openai.serializer import OpenAIMessageSerializer
 
 
 class A3MMessageSerializer:
-    """Serializer for converting browser-use messages to A3M Router format.
+	"""Serializer for converting browser-use messages to A3M Router format.
 
-    A3M Router uses the OpenAI-compatible API, so we reuse the OpenAI serializer.
-    """
+	A3M Router uses the OpenAI-compatible API, so we reuse the OpenAI serializer.
+	"""
 
-    @staticmethod
-    def serialize(messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
-        """Convert a list of browser-use BaseMessage objects to A3M Router format.
+	@staticmethod
+	def serialize(messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
+		"""Convert a list of browser-use BaseMessage objects to A3M Router format.
 
-        Args:
-            messages: List of BaseMessage objects from browser-use
+		Args:
+		    messages: List of BaseMessage objects from browser-use
 
-        Returns:
-            List of message dicts in A3M Router format (OpenAI-compatible)
-        """
-        # A3M uses OpenAI-compatible format, delegate to existing serializer
-        return OpenAIMessageSerializer.serialize_messages(messages)
+		Returns:
+		    List of message dicts in A3M Router format (OpenAI-compatible)
+		"""
+		# A3M uses OpenAI-compatible format, delegate to existing serializer
+		return OpenAIMessageSerializer.serialize_messages(messages)

--- a/browser_use/llm/a3m/serializer.py
+++ b/browser_use/llm/a3m/serializer.py
@@ -1,0 +1,31 @@
+"""
+A3M Router message serializer.
+
+Converts browser-use BaseMessage objects to A3M Router format.
+A3M uses OpenAI-compatible API, so we delegate to the existing OpenAI serializer.
+"""
+
+from openai.types.chat.chat_completion_message_param import ChatCompletionMessageParam
+
+from browser_use.llm.messages import BaseMessage
+from browser_use.llm.openai.serializer import OpenAIMessageSerializer
+
+
+class A3MMessageSerializer:
+    """Serializer for converting browser-use messages to A3M Router format.
+
+    A3M Router uses the OpenAI-compatible API, so we reuse the OpenAI serializer.
+    """
+
+    @staticmethod
+    def serialize(messages: list[BaseMessage]) -> list[ChatCompletionMessageParam]:
+        """Convert a list of browser-use BaseMessage objects to A3M Router format.
+
+        Args:
+            messages: List of BaseMessage objects from browser-use
+
+        Returns:
+            List of message dicts in A3M Router format (OpenAI-compatible)
+        """
+        # A3M uses OpenAI-compatible format, delegate to existing serializer
+        return OpenAIMessageSerializer.serialize_messages(messages)


### PR DESCRIPTION
Add A3M Router integration with proper type annotations and correct import paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `browser_use.llm.a3m` package with `ChatA3M`, a `BaseChatModel` wrapper that routes prompts through the `a3m-router` package, plus `A3MMessageSerializer` for OpenAI-compatible message conversion.

- Requires the optional `a3m-router` package; if missing, `ChatA3M` raises `ModelProviderError` with install instructions.
- `ainvoke` supports structured output by injecting the schema into the last user message—for both plain-text and multimodal content—and validating the JSON response; empty content returns an empty string.
- Reuses `OpenAIMessageSerializer` since A3M's API is OpenAI-compatible.

<sup>Written for commit cd761a6b093a4d89df935bcb4ec842ead6068faa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

