### PR TITLE
fix(utils): redact every value when domains share a placeholder name

### DIFF
--- a/browser_use/utils.py
+++ b/browser_use/utils.py
@@ -5,7 +5,7 @@ import platform
 import re
 import signal
 import time
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Mapping
 from fnmatch import fnmatch
 from functools import cache, wraps
 from pathlib import Path
@@ -82,36 +82,62 @@ _openai_bad_request_error: type | None = None
 _groq_bad_request_error: type | None = None
 
 
-def collect_sensitive_data_values(sensitive_data: dict[str, str | dict[str, str]] | None) -> dict[str, str]:
-	"""Flatten legacy and domain-scoped sensitive data into placeholder -> value mappings."""
+def collect_sensitive_data_values(sensitive_data: Mapping[str, str | Mapping[str, str]] | None) -> dict[str, str | list[str]]:
+	"""Flatten legacy and domain-scoped sensitive data into placeholder -> value mappings.
+
+	The same placeholder name can be scoped to several domains (e.g. two sites
+	that both use a ``password`` key). All distinct values are kept — colliding
+	ones are collected into a list — so redaction can mask every value. The
+	placeholder name itself stays unchanged, so domain-aware replacement still
+	resolves it against the current URL.
+	"""
 	if not sensitive_data:
 		return {}
 
-	sensitive_values: dict[str, str] = {}
+	def _add_value(values: dict[str, str | list[str]], key: str, value: str) -> None:
+		if not value:
+			return
+		existing = values.get(key)
+		if existing is None:
+			values[key] = value
+		elif isinstance(existing, list):
+			if value not in existing:
+				existing.append(value)
+		elif existing != value:
+			values[key] = [existing, value]
+
+	sensitive_values: dict[str, str | list[str]] = {}
 	for key_or_domain, content in sensitive_data.items():
-		if isinstance(content, dict):
+		if isinstance(content, Mapping):
 			for key, val in content.items():
-				if val:
-					sensitive_values[key] = val
-		elif content:
-			sensitive_values[key_or_domain] = content
+				_add_value(sensitive_values, key, val)
+		else:
+			_add_value(sensitive_values, key_or_domain, content)
 
 	return sensitive_values
 
 
-def redact_sensitive_string(value: str, sensitive_values: dict[str, str]) -> str:
+def redact_sensitive_string(value: str, sensitive_values: Mapping[str, str | list[str]]) -> str:
 	"""Replace sensitive values with placeholders, longest matches first to avoid partial leaks."""
 	if not sensitive_values:
 		return value
 
-	# Build a lookup from secret text → key name, longest secrets first so
-	# the regex alternation prefers the longest match.
-	sorted_items = sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True)
-	secret_to_key = {secret: key for key, secret in sorted_items}
+	# Build a lookup from secret text → key name. A key may carry several
+	# secrets when the same placeholder name is scoped to multiple domains;
+	# flatten those into one entry per distinct secret. Empty secrets are
+	# skipped so they cannot become empty regex alternatives.
+	secret_to_key: dict[str, str] = {}
+	for key, secrets in sensitive_values.items():
+		for secret in [secrets] if isinstance(secrets, str) else secrets:
+			if secret:
+				secret_to_key[secret] = key
+	if not secret_to_key:
+		return value
 
+	# Longest secrets first so the regex alternation prefers the longest match.
 	# Single-pass replacement: each position in the string is consumed at
 	# most once, so earlier replacements cannot be corrupted by later ones.
-	pattern = re.compile('|'.join(re.escape(secret) for secret in secret_to_key))
+	pattern = re.compile('|'.join(re.escape(secret) for secret in sorted(secret_to_key, key=len, reverse=True)))
 	return pattern.sub(lambda m: f'<secret>{secret_to_key[m.group(0)]}</secret>', value)
 
 

--- a/tests/ci/test_redact_cascade.py
+++ b/tests/ci/test_redact_cascade.py
@@ -1,6 +1,6 @@
 """Tests for redact_sensitive_string to ensure no cascading/corruption."""
 
-from browser_use.utils import redact_sensitive_string
+from browser_use.utils import collect_sensitive_data_values, redact_sensitive_string
 
 
 def test_normal_redaction():
@@ -46,3 +46,45 @@ def test_multiple_occurrences():
 	sensitive = {'tok': 'xyz'}
 	result = redact_sensitive_string('xyz-xyz-xyz', sensitive)
 	assert result == '<secret>tok</secret>-<secret>tok</secret>-<secret>tok</secret>'
+
+
+def test_cross_domain_same_key_collision():
+	"""Every value of a placeholder scoped to multiple domains gets redacted.
+
+	Regression test for issue #5592: collect_sensitive_data_values used to keep
+	only the last domain's value when several domains shared a placeholder
+	name, so the dropped values leaked verbatim into LLM-visible history.
+	"""
+	sensitive = {
+		'github.com': {'password': 'gh-login-aaa'},
+		'gitlab.com': {'password': 'gl-login-bbb'},
+	}
+	values = collect_sensitive_data_values(sensitive)
+	result = redact_sensitive_string('sign in with gh-login-aaa and gl-login-bbb', values)
+	assert result == 'sign in with <secret>password</secret> and <secret>password</secret>'
+
+
+def test_collect_same_key_same_value_deduplicated():
+	"""Identical values under a colliding key collapse to a single entry."""
+	sensitive = {
+		'a.com': {'token': 'shared-token'},
+		'b.com': {'token': 'shared-token'},
+	}
+	assert collect_sensitive_data_values(sensitive) == {'token': 'shared-token'}
+
+
+def test_legacy_and_domain_key_collision():
+	"""A legacy global value and a domain-scoped value sharing a key are both redacted."""
+	sensitive = {'password': 'first-login', 'example.com': {'password': 'second-login'}}
+	values = collect_sensitive_data_values(sensitive)
+	result = redact_sensitive_string('first-login second-login', values)
+	assert result == '<secret>password</secret> <secret>password</secret>'
+
+
+def test_empty_secret_value_is_ignored():
+	"""An empty secret value must not create an empty regex alternative.
+
+	An empty alternative in the alternation matches at every position and
+	corrupts the whole output with placeholder tags.
+	"""
+	assert redact_sensitive_string('abc', {'k': ''}) == 'abc'


### PR DESCRIPTION
Fixes #5592

## Summary

- `collect_sensitive_data_values()` keeps every distinct value when several domains share a placeholder name (colliding values are collected into a list) instead of silently keeping only the last one.
- `redact_sensitive_string()` accepts `dict[str, str | list[str]]` and flattens it into its internal value → key lookup, so every colliding value is masked. Plain `dict[str, str]` input keeps working unchanged.
- Empty secret values are skipped, which also stops an empty regex alternative from matching at every position and corrupting the whole output.
- 4 new regression tests alongside the existing cascade tests.

## Why

The replacement side (`Registry._replace_sensitive_data`) is domain-aware: it resolves `<secret>password</secret>` against the current URL, so a shared placeholder name is unambiguous there. The redaction side, however, flattened `sensitive_data` globally with a plain dict assignment, so when two domains used the same key the other values were dropped — and a dropped value has **no redaction coverage at all**. It reached message history, extracted content, and logs verbatim.

Domain scoping exists precisely so the same key (`username` / `password`) can carry different credentials per site, so this is the common configuration, not an edge case. A legacy global key colliding with a domain-scoped key has the same problem.

## Reproduction

Before this change, on current `main`:

```python
from browser_use.utils import collect_sensitive_data_values, redact_sensitive_string

sensitive_data = {
    'github.com': {'password': 'gh-secret-123'},
    'gitlab.com': {'password': 'gl-secret-456'},
}
values = collect_sensitive_data_values(sensitive_data)
print(values)
# {'password': 'gl-secret-456'}   <- github's password is gone

print(redact_sensitive_string('login with gh-secret-123 and gl-secret-456', values))
# login with gh-secret-123 and <secret>password</secret>
#                    ^^^^^^^^^^^^ leaked verbatim
```

After: both values are masked as `<secret>password</secret>`, matching what `Registry._replace_sensitive_data` resolves on each domain.

## Side effect analysis

- Placeholder names are unchanged, so domain-aware replacement in `Registry._replace_sensitive_data` and the `<secret>name</secret>` instructions the agent sees are untouched.
- `redact_sensitive_string`'s signature widens `dict[str, str]` → `dict[str, str | list[str]]`; both internal call sites (`message_manager/service.py`, `agent/views.py`) pass the output of `collect_sensitive_data_values()` straight through and don't iterate it, and existing callers with plain string values are unaffected (old tests pass unchanged).
- Identical values under a colliding key are deduplicated, so the alternation doesn't grow.
- No defaults, config, or agent-loop behavior changed.

## Tests

- `uv run pytest tests/ci/test_redact_cascade.py -q` — 10 passed
- `uv run pytest tests/ci/security/test_sensitive_data.py tests/ci/test_redact_cascade.py -q` — 26 passed
- `uv run pyright browser_use/utils.py` — 0 errors, 0 warnings
- `uv run ruff check` / `ruff format --check` on both files — clean

New cases: cross-domain same-key collision, identical-value dedup, legacy + domain collision, empty secret value ignored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5592 by keeping every distinct value when multiple domains share a placeholder name, so all sensitive values are redacted instead of only the last one.

**Behavior changes**
- `collect_sensitive_data_values()` now returns `dict[str, str | list[str]]` and collects colliding values into a list.
- `redact_sensitive_string()` flattens list values for lookup and skips empty secrets to avoid empty regex alternatives.
- Placeholder names stay unchanged, so domain-aware replacement in `Registry._replace_sensitive_data` still resolves correctly.
- Added regression tests for cross-domain key collisions, deduplication, legacy collisions, and empty secret values.

<sup>Written for commit 14a0f2d1ff8fa3b7970d1be2cc6fb3bf864989df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

