### PR TITLE
fix: dispatch literal plus key presses

### DIFF
--- a/browser_use/actor/page.py
+++ b/browser_use/actor/page.py
@@ -215,7 +215,7 @@ class Page:
 		session_id = await self._ensure_session()
 
 		# Handle key combinations like "Control+A"
-		if '+' in key:
+		if '+' in key and key != '+':
 			parts = key.split('+')
 			modifiers = parts[:-1]
 			main_key = parts[-1]

--- a/browser_use/actor/utils.py
+++ b/browser_use/actor/utils.py
@@ -27,6 +27,7 @@ class Utils:
 			'Escape': ('Escape', 27),
 			'Space': ('Space', 32),
 			' ': ('Space', 32),
+			'+': ('Equal', 187),
 			'PageUp': ('PageUp', 33),
 			'PageDown': ('PageDown', 34),
 			'End': ('End', 35),

--- a/tests/ci/test_actor_page_press.py
+++ b/tests/ci/test_actor_page_press.py
@@ -1,0 +1,40 @@
+"""Tests for Page.press keyboard event dispatch."""
+
+from typing import Any, cast
+
+import pytest
+
+from browser_use.actor.page import Page
+
+
+class _Input:
+	def __init__(self) -> None:
+		self.events: list[dict[str, object]] = []
+
+	async def dispatchKeyEvent(self, params: dict[str, object], *, session_id: str) -> None:
+		self.events.append(params)
+
+
+class _Client:
+	def __init__(self) -> None:
+		self.send = type('Send', (), {'Input': _Input()})()
+
+
+class _BrowserSession:
+	def __init__(self) -> None:
+		self.cdp_client = _Client()
+
+
+@pytest.mark.asyncio
+async def test_press_literal_plus_dispatches_plus_key() -> None:
+	input_client = _Input()
+	browser_session = _BrowserSession()
+	cast(Any, browser_session.cdp_client.send).Input = input_client
+	page = Page(cast(Any, browser_session), 'target', session_id='session')
+
+	await page.press('+')
+
+	events = input_client.events
+	assert [event['type'] for event in events] == ['keyDown', 'keyUp']
+	assert [event['key'] for event in events] == ['+', '+']
+	assert [event['code'] for event in events] == ['+', '+']

--- a/tests/ci/test_actor_page_press.py
+++ b/tests/ci/test_actor_page_press.py
@@ -37,4 +37,4 @@ async def test_press_literal_plus_dispatches_plus_key() -> None:
 	events = input_client.events
 	assert [event['type'] for event in events] == ['keyDown', 'keyUp']
 	assert [event['key'] for event in events] == ['+', '+']
-	assert [event['code'] for event in events] == ['+', '+']
+	assert [event['code'] for event in events] == ['Equal', 'Equal']


### PR DESCRIPTION
Fix literal plus key dispatch in `Page.press`.

When the key is exactly `+`, it should be dispatched as a regular key press. Previously, the combination-key parser split it into an empty main key, so callers could not send a literal plus character.

Added a deterministic regression test covering the emitted keyDown and keyUp events. Existing key-combination handling remains unchanged.

Tests: `uv run pytest tests/ci/test_actor_page_press.py`
Validation: ruff check, pyright, and `git diff --check` pass. Pre-commit could not run because Python 3.11 is unavailable in the local environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `Page.press` so a literal `+` key is dispatched as a regular key press instead of being parsed as a key combination with an empty main key. Existing key-combination handling (like `"Control+A"`) is unchanged.

- Maps `+` to the CDP code `Equal` (key code 187) in `get_key_info`.
- Adds a regression test covering the emitted `keyDown` and `keyUp` events for the `+` key.

<sup>Written for commit c6da4f092d3ddc9a6a01ef64a682e4eb1e19f1c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

