### PR TITLE
fix(send_keys): use explicit flag instead of substring match for Enter delay

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2476,6 +2476,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 		"""Handle send keys request with CDP."""
 		cdp_session = await self.browser_session.get_or_create_cdp_session(focus=True)
 		try:
+			sent_enter = False
+
 			# Normalize key names from common aliases
 			key_aliases = {
 				'ctrl': 'Control',
@@ -2541,6 +2543,9 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 				await self._dispatch_key_event(cdp_session, 'keyUp', main_key, modifier_value)
 
+				if main_key == 'Enter':
+					sent_enter = True
+
 				# Release modifier keys
 				for mod in reversed(modifiers):
 					await self._dispatch_key_event(cdp_session, 'keyUp', mod)
@@ -2580,6 +2585,8 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 				# If it's a special key, use original logic
 				if normalized_keys in special_keys:
+					if normalized_keys == 'Enter':
+						sent_enter = True
 					await self._dispatch_key_event(cdp_session, 'keyDown', normalized_keys)
 					# For Enter key, also dispatch a char event to trigger keypress listeners
 					if normalized_keys == 'Enter':
@@ -2598,6 +2605,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 					for char in normalized_keys:
 						# Special-case newline characters to dispatch as Enter
 						if char in ('\n', '\r'):
+							sent_enter = True
 							await cdp_session.cdp_client.send.Input.dispatchKeyEvent(
 								params={
 									'type': 'rawKeyDown',
@@ -2672,7 +2680,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# Note: We don't clear cached state on Enter; multi_act will detect DOM changes
 			# and rebuild explicitly. We still wait briefly for potential navigation.
-			if 'enter' in event.keys.lower() or 'return' in event.keys.lower():
+			if sent_enter:
 				await asyncio.sleep(0.1)
 		except Exception as e:
 			raise


### PR DESCRIPTION
## Summary

Fixes #5573

The Enter-specific post-keystroke delay (`asyncio.sleep(0.1)`) was triggered by checking `'enter' in event.keys.lower()`, which false-positives on any text containing the substring "enter" (e.g. "entertainment", "centered", "enter your password").

### Root cause

Line 2675 in `default_action_watchdog.py`:
```python
if 'enter' in event.keys.lower() or 'return' in event.keys.lower():
    await asyncio.sleep(0.1)
```

This is a substring match, not an exact key match. Any `send_keys` call with text containing "enter" or "return" would trigger the 100ms delay.

### Fix

Replace the substring check with a `sent_enter` boolean flag that is set only when an actual Enter key event is dispatched through any of the three code paths:
1. Combo keys (e.g. `Shift+Enter`)
2. Special keys (standalone `Enter`)
3. Newline characters (`\n`, `\r`)

The flag approach is more robust than regex or split-based matching since it tracks what actually happened during key dispatch rather than parsing the input string.

## Test plan

- [x] Typing text containing "enter" (e.g. "please enter your email") no longer triggers the delay
- [x] Pressing the actual Enter key still triggers the delay
- [x] Combo keys like `Shift+Enter` still trigger the delay
- [x] Newline characters in text still trigger the delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5573: typing text containing "enter" or "return" (e.g. "entertainment", "please enter your email") no longer triggers the accidental 100ms post-keystroke delay. The delay now fires only when an actual Enter key is dispatched via combo keys, special keys, or newline characters, preserving existing behavior for real Enter presses.

<sup>Written for commit 21e5bf2a5e3dda222172895e883bcfd5d405ddad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

