### PR TITLE
fix(llm/google): keep the first user message when include_system_in_user is set

### DIFF
--- a/browser_use/llm/google/serializer.py
+++ b/browser_use/llm/google/serializer.py
@@ -77,20 +77,21 @@ class GoogleMessageSerializer:
 			message_parts: list[Part] = []
 
 			# If this is the first user message and we have system parts, prepend them
+			system_text = None
 			if include_system_in_user and system_parts and role == 'user' and not formatted_messages:
 				system_text = '\n\n'.join(system_parts)
-				if isinstance(message.content, str):
-					message_parts.append(Part.from_text(text=f'{system_text}\n\n{message.content}'))
-				else:
-					# Add system text as the first part
-					message_parts.append(Part.from_text(text=system_text))
 				system_parts = []  # Clear after using
+
+			# Extract content and create parts
+			if isinstance(message.content, str):
+				# Regular text content
+				text = f'{system_text}\n\n{message.content}' if system_text is not None else message.content
+				message_parts.append(Part.from_text(text=text))
 			else:
-				# Extract content and create parts normally
-				if isinstance(message.content, str):
-					# Regular text content
-					message_parts = [Part.from_text(text=message.content)]
-				elif message.content is not None:
+				if system_text is not None:
+					# Add system text as the first part, the message's own parts still follow
+					message_parts.append(Part.from_text(text=system_text))
+				if message.content is not None:
 					# Handle Iterable of content parts
 					for part in message.content:
 						if part.type == 'text':

--- a/tests/ci/models/test_llm_google.py
+++ b/tests/ci/models/test_llm_google.py
@@ -127,3 +127,119 @@ async def test_chat_google_temperature_fallback():
 		mock_models.generate_content.assert_called_once()
 		args, kwargs = mock_models.generate_content.call_args
 		assert kwargs['config']['temperature'] == 1.0
+
+
+# A 1x1 PNG, small enough to inline and still be a real decodable image.
+_PNG_1PX = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+
+
+def _flatten(contents) -> list:
+	"""Flatten serialized Google contents into a single list of parts."""
+	return [part for content in contents for part in (content.parts or [])]
+
+
+def _describe(contents) -> tuple[str, int]:
+	"""Summarise serialized Google contents as (all text, number of inline images)."""
+	parts = _flatten(contents)
+	return ''.join(part.text or '' for part in parts), sum(1 for part in parts if part.inline_data is not None)
+
+
+def test_include_system_in_user_keeps_list_content_parts():
+	"""include_system_in_user must prepend the system text, not replace the user content.
+
+	With vision on, the agent's user message is a list of parts, and every part of it was
+	being dropped from the first user message.
+	"""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import (
+		ContentPartImageParam,
+		ContentPartTextParam,
+		ImageURL,
+		SystemMessage,
+		UserMessage,
+	)
+
+	messages = [
+		SystemMessage(content='You are a browser agent.'),
+		UserMessage(
+			content=[
+				ContentPartTextParam(text='<browser_state>the page and the task live here</browser_state>'),
+				ContentPartImageParam(image_url=ImageURL(url=f'data:image/png;base64,{_PNG_1PX}', media_type='image/png')),
+			]
+		),
+	]
+
+	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+
+	assert system_instruction is None, 'system message should have moved into the user turn'
+	text, images = _describe(contents)
+	assert 'You are a browser agent.' in text
+	assert '<browser_state>the page and the task live here</browser_state>' in text, 'user text was dropped'
+	assert images == 1, 'screenshot was dropped'
+
+
+def test_include_system_in_user_string_content_is_merged_into_one_part():
+	"""String content keeps the existing behaviour: system text and user text in a single part."""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import SystemMessage, UserMessage
+
+	messages = [
+		SystemMessage(content='You are a browser agent.'),
+		UserMessage(content='Buy a red stapler'),
+	]
+
+	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+
+	assert system_instruction is None
+	parts = _flatten(contents)
+	assert len(parts) == 1
+	assert parts[0].text == 'You are a browser agent.\n\nBuy a red stapler'
+
+
+def test_include_system_in_user_keeps_the_agent_state_message(tmp_path):
+	"""End-to-end shape: what the agent actually builds with vision on must survive serialization."""
+	from browser_use.agent.prompts import AgentMessagePrompt, SystemPrompt
+	from browser_use.agent.views import AgentStepInfo
+	from browser_use.browser.views import BrowserStateSummary, PageInfo, TabInfo
+	from browser_use.dom.views import SerializedDOMState
+	from browser_use.filesystem.file_system import FileSystem
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+
+	browser_state = BrowserStateSummary(
+		url='https://example.test/foo',
+		title='Test',
+		tabs=[TabInfo(target_id='abcd1234', url='https://example.test/foo', title='Test')],
+		page_info=PageInfo(
+			viewport_width=1280,
+			viewport_height=720,
+			page_width=1280,
+			page_height=1440,
+			scroll_x=0,
+			scroll_y=0,
+			pixels_above=0,
+			pixels_below=720,
+			pixels_left=0,
+			pixels_right=0,
+		),
+		dom_state=SerializedDOMState(_root=None, selector_map={}),
+		is_pdf_viewer=False,
+		recent_events=None,
+		closed_popup_messages=[],
+		screenshot=_PNG_1PX,
+	)
+	user_message = AgentMessagePrompt(
+		browser_state_summary=browser_state,
+		file_system=FileSystem(base_dir=str(tmp_path), create_default_files=False),
+		agent_history_description='<step>existing history</step>',
+		task='Buy a red stapler',
+		step_info=AgentStepInfo(step_number=1, max_steps=50),
+		screenshots=[_PNG_1PX],
+	).get_user_message(use_vision=True)
+	assert isinstance(user_message.content, list), 'vision messages are lists of parts'
+
+	messages = [SystemPrompt(max_actions_per_step=5).get_system_message(), user_message]
+	contents, _ = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+
+	text, images = _describe(contents)
+	assert 'Buy a red stapler' in text, 'the task never reached the model'
+	assert images == 1, 'the screenshot never reached the model'


### PR DESCRIPTION
Fixes #5596

`ChatGoogle(include_system_in_user=True)` is meant to prepend the system text to the first user message. When that message has list content it replaced it instead: the system text became the only part sent, and the user's text and images were dropped.

That is the shape an agent run always produces. `use_vision` defaults to `True`, `AgentMessagePrompt.get_user_message()` returns list content as soon as there is a screenshot, and `MessageHistory.get_messages()` puts the state message first among the user messages. So with this flag on, every step sent Gemini the system prompt and nothing else, with no error anywhere.

The cause was structural: the content-part conversion lived in the `else` arm of the prepend branch, so taking the prepend branch skipped it. The fix computes the system text first and then always runs the conversion, folding the system text into the leading text only for `str` content, which is what it already did.

Before, on `main`:

```
include_system_in_user=False user ["'<browser_state>the page and the task live'", 'image']
include_system_in_user=True  user ["'You are a browser agent.'"]
```

After:

```
include_system_in_user=False user ["'<browser_state>the page and the task live'", 'image']
include_system_in_user=True  user ["'You are a browser agent.'", "'<browser_state>the page and the task live'", 'image']
```

### Tests

Three tests in `tests/ci/models/test_llm_google.py`, real objects only:

- `test_include_system_in_user_keeps_list_content_parts`: text part and image survive alongside the prepended system text.
- `test_include_system_in_user_string_content_is_merged_into_one_part`: parity guard for the `str` path, which was already correct and must stay a single merged part. This one passes on `main` too.
- `test_include_system_in_user_keeps_the_agent_state_message`: builds the message through the real `AgentMessagePrompt` with `use_vision=True` and asserts the task and screenshot reach the serialized contents.

Reverting the change in `browser_use/llm/google/serializer.py` and rerunning:

```
FAILED tests/ci/models/test_llm_google.py::test_include_system_in_user_keeps_list_content_parts
E   AssertionError: user text was dropped
    assert '<browser_state>the page and the task live here</browser_state>' in 'You are a browser agent.'

FAILED tests/ci/models/test_llm_google.py::test_include_system_in_user_keeps_the_agent_state_message
E   AssertionError: the task never reached the model

2 failed, 1 passed
```

With the fix, `pytest tests/ci/models/test_llm_google.py` gives 8 passed, 1 skipped (the skip is the live `gemini-3-flash-preview` test, no API key here).

### Checks

`pre-commit run --files browser_use/llm/google/serializer.py tests/ci/models/test_llm_google.py` passes every hook, including ruff check, ruff format and pyright at the versions pinned in `.pre-commit-config.yaml`.

Full suite, `pytest tests/ci -q -o addopts="" --timeout=120`: 2 failed, 1108 passed, 34 skipped on this branch, against 2 failed, 1105 passed, 34 skipped on `main` (the +3 are the new tests). The two failures are the same `tests/ci/test_beta_agent.py` isinstance checks in both runs; they are order-dependent and pass on their own, and they are unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5596 by keeping the first user message's content when `include_system_in_user=True` is set on `ChatGoogle`. Previously, when the message had list content (text plus images, as the agent always produces with vision on), the system text replaced it and the user's text and screenshot were dropped; now the system text is prepended and the user's parts are preserved.

- Reorders the serializer so content conversion runs for both string and list content, merging system text only into the leading text part.
- Adds three tests covering list content, string content parity, and the agent's actual message shape.

<sup>Written for commit 6a2b0f4f6ce5d04aecc55e582b2ceacdda33dcdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

