### PR TITLE
docs: correct cloud browser session price

### DIFF
--- a/skills/cloud/references/quickstart.md
+++ b/skills/cloud/references/quickstart.md
@@ -133,7 +133,7 @@ Typical task: 10 steps = ~$0.03 (with Browser Use LLM)
 - PAYG: $10/GB, Business: $5/GB, Scaleup: $4/GB
 
 ### Tiers
-- **Business**: 25% off per-step, 50% off sessions/skills/proxy
+- **Business**: 25% off per-step, 50% off skills/proxy
 - **Scaleup**: 50% off per-step, 60% off proxy
 - **Enterprise**: Contact for ZDR, compliance, on-prem
 

--- a/skills/cloud/references/quickstart.md
+++ b/skills/cloud/references/quickstart.md
@@ -122,8 +122,7 @@ Typical task: 10 steps = ~$0.03 (with Browser Use LLM)
 | BU Max (Claude Sonnet 4.6) | ~$3.60 | ~$18.00 |
 
 ### Browser Sessions
-- PAYG: $0.06/hour
-- Business: $0.03/hour
+- All plans: $0.02/hour
 - Billed upfront, proportional refund on stop. Min 1 minute.
 
 ### Skills


### PR DESCRIPTION
The Cloud skill still says browser sessions cost $0.06/hour on PAYG and $0.03/hour on Business. The current rate is $0.02/hour on every plan.

This updates the two stale lines to one current rate.

Checks: `uv run pre-commit run --files skills/cloud/references/quickstart.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Cloud skill's browser session pricing so it no longer shows outdated rates or discounts.

- Replaces the old PAYG and Business rates with the current flat rate of $0.02/hour for all plans.
- Removes the stale 50% session discount from the Business tier, since sessions no longer vary by plan.

<sup>Written for commit a64224a790cf4c9263745bc5c4aa760231d58800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

