### PR TITLE
fix(llm/schema): flatten $ref behind a model field named description

### DIFF
--- a/browser_use/llm/schema.py
+++ b/browser_use/llm/schema.py
@@ -45,6 +45,14 @@ class SchemaOptimizer:
 				skip_fields = ['additionalProperties', '$defs']
 
 				for key, value in obj.items():
+					# Inside a `properties` map every key is a user-defined field name, not a JSON
+					# Schema keyword, so it must not be run through the keyword handling below.
+					# Otherwise a field called e.g. `description` is copied through verbatim and its
+					# `$ref` never gets flattened, leaving a dangling pointer once `$defs` is dropped.
+					if in_properties:
+						optimized[key] = optimize_schema(value, defs_lookup) if isinstance(value, (dict, list)) else value
+						continue
+
 					if key in skip_fields:
 						continue
 

--- a/tests/ci/models/test_llm_schema_optimizer.py
+++ b/tests/ci/models/test_llm_schema_optimizer.py
@@ -3,6 +3,8 @@ Tests for the SchemaOptimizer to ensure it correctly processes and
 optimizes the schemas for agent actions without losing information.
 """
 
+import json
+
 from pydantic import BaseModel
 
 from browser_use.agent.views import AgentOutput
@@ -74,3 +76,77 @@ def test_gemini_schema_retains_required_fields():
 
 	required_fields = set(schema['required'])
 	assert {'price', 'title'}.issubset(required_fields), 'Mandatory fields must stay required for Gemini.'
+
+
+class Details(BaseModel):
+	"""Nested model used behind a field whose name collides with a JSON Schema keyword."""
+
+	summary: str
+	bullets: list[str]
+
+
+class Article(BaseModel):
+	"""Structured output model with a field named after a JSON Schema keyword."""
+
+	headline: str
+	description: Details
+
+
+def _find_refs(obj, path='') -> list[str]:
+	"""Collect the location of every $ref left in a schema."""
+	refs = []
+	if isinstance(obj, dict):
+		for key, value in obj.items():
+			if key == '$ref':
+				refs.append(f'{path}/$ref -> {value}')
+			refs.extend(_find_refs(value, f'{path}/{key}'))
+	elif isinstance(obj, list):
+		for index, value in enumerate(obj):
+			refs.extend(_find_refs(value, f'{path}[{index}]'))
+	return refs
+
+
+def test_optimizer_flattens_ref_behind_field_named_description():
+	"""A model field named `description` must still get its $ref inlined.
+
+	`$defs` is stripped from the optimized schema, so any $ref left behind points at
+	nothing and the provider rejects the whole request.
+	"""
+	schema = SchemaOptimizer.create_optimized_json_schema(Article)
+
+	assert _find_refs(schema) == [], f'Unresolved $ref left in schema: {_find_refs(schema)}'
+	assert '$defs' not in json.dumps(schema)
+
+	description_schema = schema['properties']['description']
+	assert set(description_schema['properties']) == {'summary', 'bullets'}
+	assert description_schema['additionalProperties'] is False
+
+
+def test_structured_done_action_has_no_dangling_ref():
+	"""Same bug through the public path: Agent(output_model_schema=...) -> done action."""
+	tools = Tools(output_model=Article)
+	ActionModel = tools.registry.create_action_model()
+	agent_output_model = AgentOutput.type_with_custom_actions(ActionModel)
+
+	optimized_schema = SchemaOptimizer.create_optimized_json_schema(agent_output_model)
+
+	assert _find_refs(optimized_schema) == [], f'Unresolved $ref left in schema: {_find_refs(optimized_schema)}'
+
+
+def test_optimizer_keeps_fields_named_after_schema_keywords():
+	"""Field names that collide with JSON Schema keywords must survive optimization."""
+
+	class KeywordFields(BaseModel):
+		title: str
+		description: str
+		type: str
+		properties: str
+		items: str
+		required: str
+
+	schema = SchemaOptimizer.create_optimized_json_schema(KeywordFields)
+
+	assert set(schema['properties']) == set(KeywordFields.model_fields)
+	# metadata titles are still dropped from the property schemas themselves
+	assert schema['properties']['description'] == {'type': 'string'}
+	assert schema['properties']['properties'] == {'type': 'string'}


### PR DESCRIPTION
Closes #5603

## What

`SchemaOptimizer.create_optimized_json_schema` walks the schema dispatching on JSON Schema keyword names, and it walks into `properties` maps too, where the keys are the user's field names rather than keywords. A field named `description` therefore hits the `elif key == 'description':` branch, which copies the value straight through without recursing, so its `$ref` is never inlined. `$defs` has already been stripped by then, and the schema we send the provider points at nothing.

#2324 fixed exactly this for a field named `title` by threading an `in_properties` flag through the walker. This does the same for the rest of the keyword branches: once we know we are inside a `properties` map, every key is a field name, so recurse on the value and skip the keyword handling entirely.

Before, on d2fcda5:

```
>>> SchemaOptimizer.create_optimized_json_schema(Article)   # class Article: headline: str; description: Details
{'properties': {'headline': {'type': 'string'},
                'description': {'$ref': '#/$defs/Details'}},
 'required': ['headline', 'description'],
 'type': 'object',
 'additionalProperties': False}

>>> jsonschema.validate({'headline': 'x', 'description': {'summary': 'y'}}, schema)
_WrappedReferencingError: PointerToNowhere: '/$defs/Details' does not exist within {...}
```

After:

```
{'properties': {'headline': {'type': 'string'},
                'description': {'properties': {'summary': {'type': 'string'}},
                                'required': ['summary'],
                                'type': 'object',
                                'additionalProperties': False}},
 'required': ['headline', 'description'],
 'type': 'object',
 'additionalProperties': False}
```

Same through the agent path (`Tools(output_model=Article)` -> `AgentOutput.type_with_custom_actions`), which is where it actually bites: on main the done action carries

```
/properties/action/items/anyOf[0]/properties/done/properties/data/properties/description/$ref -> #/$defs/Details
```

and that dict is what `ChatOpenAI` puts in `response_format` with `strict: True`, what `ChatAnthropic` puts in `input_schema`, and so on.

The change also covers a field named `properties`, which used to keep its metadata `title` because `in_properties=True` leaked into the field's own schema. Every other keyword branch behaves identically before and after: for keys like `type`, `items`, `required`, `minimum` the old path already ended up calling `optimize_schema(value, defs_lookup)`, which is what the new branch does.

## Tests

Three tests added to `tests/ci/models/test_llm_schema_optimizer.py`, the file that came out of #2324:

- `test_optimizer_flattens_ref_behind_field_named_description` - no `$ref` survives, and the nested object is fully inlined with `additionalProperties: false`
- `test_structured_done_action_has_no_dangling_ref` - same assertion through the public `Tools(output_model=...)` path
- `test_optimizer_keeps_fields_named_after_schema_keywords` - fields named `title`, `description`, `type`, `properties`, `items`, `required` all survive, and their property schemas are still stripped of metadata titles

All three fail on main:

```
$ git stash push -- browser_use/llm/schema.py
$ .venv/bin/python -m pytest tests/ci/models/test_llm_schema_optimizer.py -q -o addopts=""
E    AssertionError: Unresolved $ref left in schema: ['/properties/description/$ref -> #/$defs/Details']
E    AssertionError: Unresolved $ref left in schema: ['/properties/action/items/anyOf[0]/properties/done/properties/data/properties/description/$ref -> #/$defs/Details']
E    AssertionError: assert {'title': 'De...pe': 'string'} == {'type': 'string'}
3 failed, 2 passed in 0.06s
```

and pass with it:

```
$ .venv/bin/python -m pytest tests/ci/models/test_llm_schema_optimizer.py -q -o addopts=""
5 passed in 0.03s
```

Full suite, macOS arm64:

- branch: `2 failed, 1106 passed, 34 skipped`
- clean main at d2fcda5: `2 failed, 1103 passed, 34 skipped`

Same two failures either way - the order-dependent `test_beta_agent.py` pair from #5425, which pass in isolation.

`browser_use/llm/tests`: `5 failed, 19 passed, 15 skipped` on both, the 5 being the live-API `test_single_step` cases with no keys set.

`pre-commit run --files browser_use/llm/schema.py tests/ci/models/test_llm_schema_optimizer.py`: every hook passed, including ruff v0.12.10 and pyright v1.1.404 as pinned in `.pre-commit-config.yaml`. `git status` afterwards shows only the two intended files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the schema optimizer so model fields named after JSON Schema keywords (like `description` or `properties`) no longer leave dangling `$ref`s in the optimized schema. Previously such a field was copied through verbatim, keeping a `$ref` that pointed at `$defs` after it was stripped, which made provider schemas invalid; now the walker recurses into every value inside a `properties` map and flattens the `$ref`, and fields named `properties` no longer keep their metadata `title`. Closes #5603.

<sup>Written for commit 8acb656948e94199427f8d506a3cd5600e252681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

