### PR TITLE
fix(llm): preserve schema-keyword field names

### DIFF
--- a/browser_use/llm/schema.py
+++ b/browser_use/llm/schema.py
@@ -45,11 +45,16 @@ class SchemaOptimizer:
 				skip_fields = ['additionalProperties', '$defs']
 
 				for key, value in obj.items():
+					# Keys inside `properties` are user field names, not schema keywords.
+					if in_properties:
+						optimized[key] = optimize_schema(value, defs_lookup)
+						continue
+
 					if key in skip_fields:
 						continue
 
-					# Skip metadata "title" unless we're iterating inside an actual `properties` map
-					if key == 'title' and not in_properties:
+					# Skip metadata "title"
+					if key == 'title':
 						continue
 
 					# Preserve FULL descriptions without truncation, skip empty ones

--- a/tests/ci/models/test_llm_schema_optimizer.py
+++ b/tests/ci/models/test_llm_schema_optimizer.py
@@ -3,7 +3,7 @@ Tests for the SchemaOptimizer to ensure it correctly processes and
 optimizes the schemas for agent actions without losing information.
 """
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from browser_use.agent.views import AgentOutput
 from browser_use.llm.schema import SchemaOptimizer
@@ -85,11 +85,13 @@ def test_optimizer_treats_property_names_as_data_not_schema_keywords():
 	class Article(BaseModel):
 		description: Details
 		properties: Details
+		additional_properties: Details = Field(alias='additionalProperties')
+		defs: Details = Field(alias='$defs')
 
 	schema = SchemaOptimizer.create_optimized_json_schema(Article)
 
 	assert '$defs' not in schema
-	for field_name in ('description', 'properties'):
+	for field_name in ('description', 'properties', 'additionalProperties', '$defs'):
 		field_schema = schema['properties'][field_name]
 		assert '$ref' not in field_schema
 		assert field_schema['properties']['summary']['type'] == 'string'

--- a/tests/ci/models/test_llm_schema_optimizer.py
+++ b/tests/ci/models/test_llm_schema_optimizer.py
@@ -74,3 +74,22 @@ def test_gemini_schema_retains_required_fields():
 
 	required_fields = set(schema['required'])
 	assert {'price', 'title'}.issubset(required_fields), 'Mandatory fields must stay required for Gemini.'
+
+
+def test_optimizer_treats_property_names_as_data_not_schema_keywords():
+	"""Nested fields named after schema keywords must still have their refs flattened."""
+
+	class Details(BaseModel):
+		summary: str
+
+	class Article(BaseModel):
+		description: Details
+		properties: Details
+
+	schema = SchemaOptimizer.create_optimized_json_schema(Article)
+
+	assert '$defs' not in schema
+	for field_name in ('description', 'properties'):
+		field_schema = schema['properties'][field_name]
+		assert '$ref' not in field_schema
+		assert field_schema['properties']['summary']['type'] == 'string'


### PR DESCRIPTION
## What

Treat keys inside a schema `properties` map as user field names before applying schema-keyword rules. This keeps fields named `description` or `properties` from retaining dangling `$ref` values.

Fixes #5603

## Test

- `uv run pytest -q tests/ci/models/test_llm_schema_optimizer.py`
- `uv run pre-commit run --files browser_use/llm/schema.py tests/ci/models/test_llm_schema_optimizer.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schema optimization so user fields named `description` or `properties` no longer keep dangling `$ref` values.

- Treats keys inside a `properties` map as field names before applying schema-keyword rules.
- Simplifies `title` skipping, which now only applies outside `properties`.
- Adds coverage for nested and aliased fields named after schema keywords.

<sup>Written for commit b2507091aa2234bdbfebc39300a7174b04505c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

