### PR TITLE
fix(cli): use core init templates when offline

### DIFF
--- a/browser_use/init_cmd.py
+++ b/browser_use/init_cmd.py
@@ -21,6 +21,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
+from browser_use.init_templates import CORE_INIT_TEMPLATE_CONTENTS, CORE_INIT_TEMPLATES
+
 # Rich console for styled output
 console = Console()
 
@@ -49,14 +51,16 @@ def _fetch_template_list() -> dict[str, Any] | None:
 
 def _get_template_list() -> dict[str, Any]:
 	"""
-	Get template list from GitHub.
+	Get template list from GitHub, falling back to the core templates.
 
-	Raises FileNotFoundError if GitHub fetch fails.
+	The default, advanced, and tools templates are bundled so the documented
+	init flow still works when the remote template library is unavailable.
 	"""
 	templates = _fetch_template_list()
 	if templates is not None:
 		return templates
-	raise FileNotFoundError('Could not fetch templates from GitHub. Check your internet connection.')
+	console.print('[yellow]⚠ Could not reach the template library; using built-in core templates.[/yellow]')
+	return dict(CORE_INIT_TEMPLATES)
 
 
 def _fetch_from_github(file_path: str) -> str | None:
@@ -97,6 +101,9 @@ def _get_template_content(file_path: str) -> str:
 
 	if content is not None:
 		return content
+
+	if file_path in CORE_INIT_TEMPLATE_CONTENTS:
+		return CORE_INIT_TEMPLATE_CONTENTS[file_path]
 
 	raise FileNotFoundError(f'Could not fetch template from GitHub: {file_path}')
 

--- a/browser_use/init_templates.py
+++ b/browser_use/init_templates.py
@@ -1,0 +1,168 @@
+"""Built-in templates used when the remote template library is unavailable."""
+
+CORE_INIT_TEMPLATES = {
+	'default': {
+		'file': 'default_template.py',
+		'description': 'Simplest setup - capable of any web task with minimal configuration',
+		'author': {
+			'name': 'Reagan Hsu',
+			'github_profile': 'https://github.com/Cheggin',
+			'last_modified_date': '2025-11-11',
+		},
+	},
+	'advanced': {
+		'file': 'advanced_template.py',
+		'description': 'All configuration options shown with defaults',
+		'author': {
+			'name': 'Reagan Hsu',
+			'github_profile': 'https://github.com/Cheggin',
+			'last_modified_date': '2025-11-11',
+		},
+	},
+	'tools': {
+		'file': 'tools_template.py',
+		'description': 'Custom tool example - extend agent capabilities with your own functions',
+		'author': {
+			'name': 'Reagan Hsu',
+			'github_profile': 'https://github.com/Cheggin',
+			'last_modified_date': '2025-11-11',
+		},
+	},
+}
+
+CORE_INIT_TEMPLATE_CONTENTS = {
+	'default_template.py': '''"""
+Default browser-use example using ChatBrowserUse
+
+The simplest way to use browser-use - capable of any web task
+with minimal configuration.
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from browser_use import Agent, Browser, ChatBrowserUse
+
+load_dotenv()
+
+
+async def main():
+    browser = Browser(use_cloud=False)
+    llm = ChatBrowserUse()
+    task = "Find the number of stars of the browser-use repository on GitHub"
+    agent = Agent(
+        browser=browser,
+        task=task,
+        llm=llm,
+    )
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+''',
+	'advanced_template.py': '''"""
+Advanced Example
+
+This example demonstrates how to configure the Agent and Browser
+with many configuration options, all set to default values.
+
+Check out all configuration settings at https://docs.browser-use.com/customize/agent/all-parameters.
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from browser_use import Agent, Browser, ChatBrowserUse
+
+load_dotenv()
+
+
+async def main():
+    browser = Browser(
+        use_cloud=False,
+        # headless=False,
+        # disable_security=False,
+        # extra_chromium_args=[],
+        # allowed_domains=None,
+        # prohibited_domains=None,
+        # cdp_url=None,
+    )
+
+    llm = ChatBrowserUse()
+
+    agent = Agent(
+        task="Find the number of stars of the browser-use repository on GitHub",
+        llm=llm,
+        browser=browser,
+        # use_vision='auto',
+        # save_conversation_path=None,
+        # max_failures=3,
+        # generate_gif=False,
+        # max_actions_per_step=4,
+        # use_thinking=True,
+        # flash_mode=False,
+        # calculate_cost=False,
+        # step_timeout=180,
+    )
+
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+''',
+	'tools_template.py': '''"""
+Custom Tools Example
+
+This example demonstrates how to create custom tools that the agent can use
+alongside the built-in browser actions.
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from browser_use import ActionResult, Agent, Browser, ChatBrowserUse, Tools
+
+load_dotenv()
+
+# Create a Tools instance to register custom actions
+tools = Tools()
+
+
+@tools.registry.action("Save text content to a file")
+async def save_to_file(filename: str, content: str):
+    from pathlib import Path
+
+    try:
+        Path(filename).write_text(content, encoding="utf-8")
+        return ActionResult(
+            extracted_content=f"Saved to {filename}", include_in_memory=True
+        )
+    except Exception as e:
+        return ActionResult(
+            extracted_content=f"Error saving file: {e}", include_in_memory=True
+        )
+
+
+async def main():
+    browser = Browser(use_cloud=False)
+    llm = ChatBrowserUse()
+    task = "Go to github.com and find the number of GitHub stars for browser-use and use the save_to_file tool to save the result to stars.txt"
+    agent = Agent(
+        task=task,
+        llm=llm,
+        browser=browser,
+        tools=tools,
+    )
+
+    await agent.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+''',
+}

--- a/tests/ci/test_browser_use_cli.py
+++ b/tests/ci/test_browser_use_cli.py
@@ -46,3 +46,30 @@ def test_browser_use_tui_is_deprecated_alias(monkeypatch, capsys):
 
 	assert browser_use_cli.browser_use_tui_main() == 0
 	assert capsys.readouterr().err == 'browser-use-tui is deprecated; use browser-use instead.\n'
+
+
+def test_init_core_templates_use_builtins_when_library_unavailable(monkeypatch, tmp_path):
+	"""The core templates remain available when GitHub cannot be reached."""
+	from urllib.error import URLError
+
+	from click.testing import CliRunner
+
+	from browser_use import init_cmd
+
+	monkeypatch.chdir(tmp_path)
+
+	def raise_url_error(*args, **kwargs):
+		raise URLError('template library unavailable')
+
+	monkeypatch.setattr(init_cmd.request, 'urlopen', raise_url_error)
+
+	for template in ('default', 'advanced', 'tools'):
+		result = CliRunner().invoke(
+			init_cmd.main,
+			['--template', template, '--output', 'main.py', '--force'],
+		)
+
+		assert result.exit_code == 0, result.output
+		output = tmp_path / template / 'main.py'
+		assert output.is_file()
+		assert 'ChatBrowserUse' in output.read_text()


### PR DESCRIPTION
Make `browser-use init --template default|advanced|tools` continue to work when the remote template library is unavailable.

- Bundle the three core template metadata and content in the package.
- Fall back to those templates after a remote `URLError`, while retaining remote templates for richer examples.
- Add a regression test covering all three core templates with a simulated network failure.
- Local template content hashes match the current template-library files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `browser-use init --template default|advanced|tools` fall back to bundled templates when the remote template library is unreachable, instead of failing with `FileNotFoundError`.

- Bundles the three core template metadata and contents in the package.
- Keeps using remote templates when available, and prints a warning when falling back.
- Adds a regression test that simulates a network failure across all three core templates.

<sup>Written for commit 8c4b0c195113d36064ff1c62f3e0d49651c16b5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

