### PR TITLE
fix(llm): preserve title fields for Vercel Gemini

### DIFF
--- a/browser_use/llm/vercel/chat.py
+++ b/browser_use/llm/vercel/chat.py
@@ -435,13 +435,15 @@ class ChatVercel(BaseChatModel):
 			schema = resolve_refs(schema)
 
 		# Remove unsupported properties
-		def clean_schema(obj: Any) -> Any:
+		def clean_schema(obj: Any, parent_key: str | None = None) -> Any:
 			if isinstance(obj, dict):
 				# Remove unsupported properties
 				cleaned = {}
 				for key, value in obj.items():
-					if key not in ['additionalProperties', 'title', 'default']:
-						cleaned_value = clean_schema(value)
+					# Keep a real field named "title" inside a JSON Schema properties map.
+					is_metadata_title = key == 'title' and parent_key != 'properties'
+					if key not in ['additionalProperties', 'default'] and not is_metadata_title:
+						cleaned_value = clean_schema(value, parent_key=key)
 						# Handle empty object properties - Gemini doesn't allow empty OBJECT types
 						if (
 							key == 'properties'
@@ -465,13 +467,9 @@ class ChatVercel(BaseChatModel):
 				):
 					cleaned['properties'] = {'_placeholder': {'type': 'string'}}
 
-				# Also remove 'title' from the required list if it exists
-				if 'required' in cleaned and isinstance(cleaned.get('required'), list):
-					cleaned['required'] = [p for p in cleaned['required'] if p != 'title']
-
 				return cleaned
 			elif isinstance(obj, list):
-				return [clean_schema(item) for item in obj]
+				return [clean_schema(item, parent_key=parent_key) for item in obj]
 			return obj
 
 		return clean_schema(schema)

--- a/tests/ci/models/test_llm_schema_optimizer.py
+++ b/tests/ci/models/test_llm_schema_optimizer.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from browser_use.agent.views import AgentOutput
 from browser_use.llm.schema import SchemaOptimizer
+from browser_use.llm.vercel import ChatVercel
 from browser_use.tools.service import Tools
 
 
@@ -74,3 +75,23 @@ def test_gemini_schema_retains_required_fields():
 
 	required_fields = set(schema['required'])
 	assert {'price', 'title'}.issubset(required_fields), 'Mandatory fields must stay required for Gemini.'
+
+
+def test_vercel_gemini_schema_preserves_title_property():
+	"""Vercel Gemini cleanup must preserve a user field named ``title``."""
+	chat = ChatVercel(model='openai/gpt-4o', api_key='test')
+	schema = {
+		'type': 'object',
+		'title': 'ProductInfo',
+		'properties': {
+			'title': {'type': 'string', 'title': 'Title'},
+			'price': {'type': 'number', 'title': 'Price'},
+		},
+		'required': ['title', 'price'],
+	}
+
+	cleaned = chat._fix_gemini_schema(schema)
+
+	assert set(cleaned['properties']) == {'title', 'price'}
+	assert 'title' not in cleaned['properties']['title']
+	assert cleaned['required'] == ['title', 'price']


### PR DESCRIPTION
## Summary

- preserve a real user field named `title` inside Vercel Gemini JSON Schema `properties`
- continue stripping schema metadata such as the top-level and nested property-schema `title`
- keep `title` in `required` when it is an actual field
- add focused regression coverage for `ChatVercel._fix_gemini_schema`

## Validation

- `uv run pytest -q tests/ci/models/test_llm_schema_optimizer.py`
- `uv run pre-commit run --files browser_use/llm/vercel/chat.py tests/ci/models/test_llm_schema_optimizer.py`
- `git diff --check`

Related: #5605 addresses the generic schema optimizer; this PR is scoped to the separate Vercel provider cleanup path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vercel Gemini schema cleanup so a user-defined field named `title` is preserved instead of being stripped along with schema metadata like the top-level and nested `title` hints. Also keeps `title` in `required` when it is an actual field.

- Removes the separate logic that always dropped `title` from `required`.
- Adds regression coverage for `ChatVercel._fix_gemini_schema` confirming fields, metadata, and `required` are handled correctly.

<sup>Written for commit 86f4cc266e24caa692bc676f6fc73d0aa59daebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

