### PR TITLE
fix(agent): measure step interval gap

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -1361,7 +1361,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				if last_history_item.metadata:
 					previous_end_time = last_history_item.metadata.step_end_time
 					previous_start_time = last_history_item.metadata.step_start_time
-					step_interval = max(0, previous_end_time - previous_start_time)
+					step_interval = max(0, self.step_start_time - previous_end_time)
 			metadata = StepMetadata(
 				step_number=self.state.n_steps,
 				step_start_time=self.step_start_time,

--- a/tests/ci/test_history_wait_time.py
+++ b/tests/ci/test_history_wait_time.py
@@ -21,19 +21,17 @@ def test_step_metadata_step_interval_optional():
 
 
 def test_step_interval_calculation():
-	"""Test step_interval calculation logic (uses previous step's duration)"""
-	# Previous step (Step 1): runs from 100.0 to 102.5 (duration: 2.5s)
-	previous_start = 100.0
+	"""Test that step_interval measures the gap between consecutive steps."""
+	# Previous step (Step 1): runs from 100.0 to 102.5.
 	previous_end = 102.5
-	previous_duration = previous_end - previous_start
 
-	# Current step (Step 2): should have step_interval = previous step's duration
-	# This tells the rerun system "wait 2.5s before executing Step 2"
-	expected_step_interval = previous_duration
-	calculated_step_interval = max(0, previous_end - previous_start)
+	# Current step (Step 2) starts after a 1.5s idle gap.
+	current_start = 104.0
+	expected_step_interval = current_start - previous_end
+	calculated_step_interval = max(0, current_start - previous_end)
 
 	assert abs(calculated_step_interval - expected_step_interval) < 0.001  # Float comparison
-	assert calculated_step_interval == 2.5
+	assert calculated_step_interval == 1.5
 
 
 def test_step_metadata_serialization_with_step_interval():


### PR DESCRIPTION
## Summary

- calculate `StepMetadata.step_interval` as the idle gap between the previous step ending and the current step starting
- retain the existing non-negative clamp and public field/serialization shape
- update the focused regression test to cover a 1.5-second gap rather than the previous step duration

This revisits the same bug reported in #4484 after earlier PRs were automatically closed as stale without maintainer rejection.

## Validation

- `uv run pytest -q tests/ci/test_history_wait_time.py` (8 passed)
- `uv run pre-commit run --files browser_use/agent/service.py tests/ci/test_history_wait_time.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the step interval calculation so `step_interval` reports the idle gap between the previous step's end and the current step's start, instead of the previous step's duration. The existing non-negative clamp and serialization shape are unchanged, and the regression test now covers a 1.5-second gap.

<sup>Written for commit ceec39cec12721c13bd4ac634542e95c728fbc73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

