### PR TITLE
fix(ci): report skipped agent tasks separately

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -254,20 +254,25 @@ jobs:
             cat result.txt
             echo "PASSED=$(grep '^PASSED=' result.txt | cut -d= -f2)" >> $GITHUB_ENV
             echo "TOTAL=$(grep '^TOTAL=' result.txt | cut -d= -f2)" >> $GITHUB_ENV
+            echo "SKIPPED=$(grep '^SKIPPED=' result.txt | cut -d= -f2)" >> $GITHUB_ENV
             echo "DETAILED_RESULTS=$(grep '^DETAILED_RESULTS=' result.txt | cut -d= -f2-)" >> $GITHUB_ENV
 
       - name: Print agent evaluation summary
         run: |
-          echo "Agent tasks passed: $PASSED / $TOTAL"
+          EXECUTED=$((TOTAL - SKIPPED))
+          echo "Agent tasks passed: $PASSED / $EXECUTED (skipped: $SKIPPED)"
 
       - name: Write agent evaluation summary to workflow overview
         run: |
-          if [ "$PASSED" = "$TOTAL" ]; then
+          EXECUTED=$((TOTAL - SKIPPED))
+          if [ "$EXECUTED" -eq 0 ]; then
+            COLOR="gray"
+          elif [ "$PASSED" = "$EXECUTED" ]; then
             COLOR="green"
           else
             COLOR="yellow"
           fi
-          echo "<h2>Agent Tasks Score: <span style='color:$COLOR;'>$PASSED/$TOTAL</span></h2>" >> $GITHUB_STEP_SUMMARY
+          echo "<h2>Agent Tasks Score: <span style='color:$COLOR;'>$PASSED/$EXECUTED passed</span> ($SKIPPED skipped)</h2>" >> $GITHUB_STEP_SUMMARY
 
       - name: Comment PR with agent evaluation results
         if: github.event_name == 'pull_request'
@@ -277,24 +282,28 @@ jobs:
           script: |
             const passed = parseInt(process.env.PASSED);
             const total = parseInt(process.env.TOTAL);
+            const skipped = parseInt(process.env.SKIPPED || '0');
+            const executed = total - skipped;
             const detailedResults = JSON.parse(process.env.DETAILED_RESULTS);
-            const score = `${passed}/${total}`;
-            const percentage = Math.round((passed / total) * 100);
+            const score = `${passed}/${executed}`;
+            const percentage = executed > 0 ? Math.round((passed / executed) * 100) : null;
 
-            // Fail the workflow if 0% pass rate
-            if (percentage === 0) {
-              core.setFailed(`Evaluation failed: 0% pass rate (${passed}/${total})`);
+            // Fail only when an executed task set has a 0% pass rate.
+            // A fork PR with no secrets has only skipped tasks and remains neutral.
+            if (executed > 0 && passed === 0) {
+              core.setFailed(`Evaluation failed: 0% pass rate (${passed}/${executed})`);
             }
 
             // Create detailed table
             let tableRows = '';
             detailedResults.forEach(result => {
-              const emoji = result.success ? '✅' : '❌';
-              const status = result.success ? 'Pass' : 'Fail';
+              const emoji = result.status === 'skipped' ? '⏭️' : result.success ? '✅' : '❌';
+              const status = result.status === 'skipped' ? 'Skipped' : result.success ? 'Pass' : 'Fail';
               tableRows += `| ${result.task} | ${emoji} ${status} | ${result.reason} |\n`;
             });
 
-            const comment = `## Agent Task Evaluation Results: ${score} (${percentage}%)
+            const percentageText = percentage === null ? 'no tasks executed' : `${percentage}%`;
+            const comment = `## Agent Task Evaluation Results: ${score} passed (${percentageText}; ${skipped} skipped)
 
             <details>
             <summary>View detailed results</summary>

--- a/tests/ci/evaluate_tasks.py
+++ b/tests/ci/evaluate_tasks.py
@@ -63,7 +63,8 @@ async def run_single_task(task_file):
 			print('[SKIP] BROWSER_USE_API_KEY is not set - skipping task evaluation', file=sys.stderr)
 			return {
 				'file': os.path.basename(task_file),
-				'success': True,  # Mark as success so it doesn't fail CI
+				'success': False,
+				'status': 'skipped',
 				'explanation': 'Skipped - API key not available (fork PR or missing secret)',
 			}
 
@@ -75,7 +76,8 @@ async def run_single_task(task_file):
 			print('[SKIP] GOOGLE_API_KEY is not set - skipping task evaluation', file=sys.stderr)
 			return {
 				'file': os.path.basename(task_file),
-				'success': True,  # Mark as success so it doesn't fail CI
+				'success': False,
+				'status': 'skipped',
 				'explanation': 'Skipped - Google API key not available (fork PR or missing secret)',
 			}
 
@@ -176,6 +178,7 @@ If the agent provided no output, explain what might have gone wrong.
 		result = {
 			'file': os.path.basename(task_file),
 			'success': judge_response.success,
+			'status': 'passed' if judge_response.success else 'failed',
 			'explanation': judge_response.explanation,
 		}
 
@@ -194,6 +197,7 @@ If the agent provided no output, explain what might have gone wrong.
 		return {
 			'file': os.path.basename(task_file),
 			'success': False,
+			'status': 'failed',
 			'explanation': f'Task failed with error: {str(e)}',
 		}
 
@@ -249,6 +253,7 @@ async def run_task_subprocess(task_file, semaphore):
 					result = {
 						'file': os.path.basename(task_file),
 						'success': False,
+						'status': 'failed',
 						'explanation': f'Failed to parse subprocess result: {str(e)[:100]}',
 					}
 					print(f'[PARENT] Task {os.path.basename(task_file)} failed to parse: {str(e)}')
@@ -258,6 +263,7 @@ async def run_task_subprocess(task_file, semaphore):
 				result = {
 					'file': os.path.basename(task_file),
 					'success': False,
+					'status': 'failed',
 					'explanation': f'Subprocess failed (code {proc.returncode}): {stderr_text[:200]}',
 				}
 				print(f'[PARENT] Task {os.path.basename(task_file)} subprocess failed with code {proc.returncode}')
@@ -270,6 +276,7 @@ async def run_task_subprocess(task_file, semaphore):
 			result = {
 				'file': os.path.basename(task_file),
 				'success': False,
+				'status': 'failed',
 				'explanation': f'Failed to start subprocess: {str(e)}',
 			}
 			print(f'[PARENT] Failed to start subprocess for {os.path.basename(task_file)}: {str(e)}')
@@ -285,23 +292,28 @@ async def main():
 
 	if not TASK_FILES:
 		print('No task files found!')
-		return 0, 0
+		return 0, 0, 0
 
 	# Run all tasks in parallel subprocesses
 	tasks = [run_task_subprocess(task_file, semaphore) for task_file in TASK_FILES]
 	results = await asyncio.gather(*tasks)
 
-	passed = sum(1 for r in results if r['success'])
+	for result in results:
+		if result.get('status') not in {'passed', 'failed', 'skipped'}:
+			result['status'] = 'passed' if result.get('success') else 'failed'
+	passed = sum(1 for r in results if r['status'] == 'passed')
+	skipped = sum(1 for r in results if r['status'] == 'skipped')
 	total = len(results)
 
 	print('\n' + '=' * 60)
 	print(f'{"RESULTS":^60}\n')
 
 	# Prepare table data
-	headers = ['Task', 'Success', 'Reason']
+	headers = ['Task', 'Status', 'Reason']
 	rows = []
 	for r in results:
-		status = '✅' if r['success'] else '❌'
+		status_icons = {'passed': '✅', 'failed': '❌', 'skipped': '⏭️'}
+		status = f'{status_icons[r["status"]]} {r["status"].title()}'
 		rows.append([r['file'], status, r['explanation']])
 
 	# Calculate column widths
@@ -319,12 +331,13 @@ async def main():
 	print('\n' + '=' * 60)
 	print(f'\n{"SCORE":^60}')
 	print(f'\n{"=" * 60}\n')
-	print(f'\n{"*" * 10}  {passed}/{total} PASSED  {"*" * 10}\n')
+	print(f'\n{"*" * 10}  {passed}/{total} PASSED  ({skipped} SKIPPED)  {"*" * 10}\n')
 	print('=' * 60 + '\n')
 
 	# Output results for GitHub Actions
 	print(f'PASSED={passed}')
 	print(f'TOTAL={total}')
+	print(f'SKIPPED={skipped}')
 
 	# Output detailed results as JSON for GitHub Actions
 	detailed_results = []
@@ -333,13 +346,14 @@ async def main():
 			{
 				'task': r['file'].replace('.yaml', ''),
 				'success': r['success'],
+				'status': r['status'],
 				'reason': r['explanation'],
 			}
 		)
 
 	print('DETAILED_RESULTS=' + json.dumps(detailed_results))
 
-	return passed, total
+	return passed, total, skipped
 
 
 if __name__ == '__main__':
@@ -358,15 +372,16 @@ if __name__ == '__main__':
 			error_result = {
 				'file': os.path.basename(args.task),
 				'success': False,
+				'status': 'failed',
 				'explanation': f'Critical subprocess error: {str(e)}',
 			}
 			print(json.dumps(error_result))
 	else:
 		# Parent process mode: run all tasks in parallel subprocesses
-		passed, total = asyncio.run(main())
+		passed, total, skipped = asyncio.run(main())
 		# Results already printed by main() function
 
 		# Fail if 0% pass rate (all tasks failed)
-		if total > 0 and passed == 0:
+		if total > 0 and passed == 0 and passed + skipped < total:
 			print('\n❌ CRITICAL: 0% pass rate - all tasks failed!')
 			sys.exit(1)


### PR DESCRIPTION
## Summary

- report missing-secret agent evaluations as `skipped` instead of a successful pass
- keep the existing `success` and `reason` fields while adding an explicit status
- exclude skipped tasks from pass-rate calculations and render them neutrally in the workflow summary and PR comment
- keep fork PRs with no available secrets neutral instead of showing a misleading 100% pass rate or failing as 0% executed passes

## Validation

- `env -u BROWSER_USE_API_KEY -u GOOGLE_API_KEY uv run python tests/ci/evaluate_tasks.py` (2 skipped, exit 0)
- `uv run pre-commit run --files tests/ci/evaluate_tasks.py .github/workflows/test.yaml`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports agent evaluation tasks skipped due to missing secrets as `skipped` instead of successful passes, so fork PRs without secrets no longer show a misleading 100% pass rate or fail at 0%.

- `tests/ci/evaluate_tasks.py` now emits a skipped count and a `status` field per task; skipped tasks get `success: False`.
- The workflow excludes skipped tasks from pass-rate totals and renders them with a neutral gray color.
- The PR comment shows "X/Y passed (Z skipped)" and only fails the workflow when executed tasks have a 0% pass rate.

<sup>Written for commit 242e30e28c90e710da5c3de895ffa4e03643d9e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

