### PR TITLE
ci: pin retry action to immutable SHA

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Run test with retry
         if: steps.check-file.outputs.exists == 'true'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 4
           max_attempts: 1
@@ -244,7 +244,7 @@ jobs:
 
       - name: Run agent tasks evaluation and capture score
         id: eval
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 4
           max_attempts: 1


### PR DESCRIPTION
## Summary

- pin both `nick-fields/retry` uses in `test.yaml` to the immutable commit for tag `v3`
- preserve the human-readable `# v3` version comments
- keep this focused on the two retry-action references rather than reopening the unrelated broad hardening scope from stale PR #4535

## Validation

- `uv run pre-commit run --files .github/workflows/test.yaml`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins both uses of `nick-fields/retry` in `.github/workflows/test.yaml` to the immutable commit `ce71cc2ab81d554ebbe88c79ab5975992d79ba08` for the `v3` tag, replacing the moving `@v3` reference. This enhances supply chain security without affecting behavior, and retains the `# v3` comment for clarity.

<sup>Written for commit bca82e633ba4bf9967ca810d4f331edc69cd0f24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

