### PR TITLE
fix(browser): lazy initialize cloud client

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Run test with retry
         if: steps.check-file.outputs.exists == 'true'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 4
           max_attempts: 1
@@ -244,7 +244,7 @@ jobs:
 
       - name: Run agent tasks evaluation and capture score
         id: eval
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
         with:
           timeout_minutes: 4
           max_attempts: 1

--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -579,7 +579,7 @@ class BrowserSession(BaseModel):
 	_captcha_watchdog: Any | None = PrivateAttr(default=None)
 	_watchdogs_attached: bool = PrivateAttr(default=False)
 
-	_cloud_browser_client: CloudBrowserClient = PrivateAttr(default_factory=lambda: CloudBrowserClient())
+	_cloud_browser_client_instance: CloudBrowserClient | None = PrivateAttr(default=None)
 	_demo_mode: 'DemoMode | None' = PrivateAttr(default=None)
 
 	# WebSocket reconnection state
@@ -592,6 +592,13 @@ class BrowserSession(BaseModel):
 	_reconnect_task: asyncio.Task | None = PrivateAttr(default=None)
 	_reconnect_pending: bool = PrivateAttr(default=False)
 	_intentional_stop: bool = PrivateAttr(default=False)
+
+	@property
+	def _cloud_browser_client(self) -> CloudBrowserClient:
+		"""Create the cloud client only when a cloud operation needs it."""
+		if self._cloud_browser_client_instance is None:
+			self._cloud_browser_client_instance = CloudBrowserClient()
+		return self._cloud_browser_client_instance
 
 	_logger: Any = PrivateAttr(default=None)
 

--- a/tests/ci/test_browser_session.py
+++ b/tests/ci/test_browser_session.py
@@ -4,6 +4,17 @@ from browser_use.browser.profile import BrowserProfile
 from browser_use.browser.session import BrowserSession
 
 
+def test_constructor_does_not_create_cloud_client_for_socks_proxy(monkeypatch) -> None:
+	"""A non-cloud session must not require optional SOCKS support at construction time."""
+	for variable in ('ALL_PROXY', 'all_proxy', 'HTTP_PROXY', 'http_proxy', 'HTTPS_PROXY', 'https_proxy'):
+		monkeypatch.delenv(variable, raising=False)
+	monkeypatch.setenv('ALL_PROXY', 'socks5://127.0.0.1:9999')
+
+	session = BrowserSession()
+
+	assert session._cloud_browser_client_instance is None
+
+
 class MessageHandlerClient:
 	def __init__(self, task: asyncio.Task) -> None:
 		self._message_handler_task = task


### PR DESCRIPTION
## Summary

- lazily create `CloudBrowserClient` instead of constructing it for every `BrowserSession`
- allow non-cloud `BrowserSession()` construction when `ALL_PROXY` uses SOCKS and optional `socksio` is not installed
- preserve the existing cloud client behavior when a cloud operation actually needs it
- add a regression test for construction under a SOCKS proxy environment

## Validation

- `uv run pytest -q tests/ci/test_browser_session.py` (2 passed)
- `uv run pre-commit run --files browser_use/browser/session.py tests/ci/test_browser_session.py`
- `git diff --check`

Reproduction addressed: `ALL_PROXY=socks5://127.0.0.1:9999 BrowserSession()` previously raised an `socksio` ImportError before any browser was started.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazily initializes the cloud browser client so constructing a `BrowserSession` no longer breaks under SOCKS proxy environments without `socksio`.

- `BrowserSession()` previously created a `CloudBrowserClient` eagerly, which raised an `ImportError` when `ALL_PROXY` used SOCKS and `socksio` was not installed.
- The cloud client is now created only when a cloud operation needs it.
- Adds a regression test covering session construction under a SOCKS proxy.
- Pins the `nick-fields/retry` GitHub Action version used in the test workflow.

<sup>Written for commit a4c8c96f370671a3f7d05527f5d77def62f0d8e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

