### PR TITLE
test(mcp): cover clean stdio shutdown

### DIFF
--- a/tests/ci/test_mcp_stdio_brokenpipe.py
+++ b/tests/ci/test_mcp_stdio_brokenpipe.py
@@ -1,0 +1,42 @@
+"""Regression tests for clean MCP stdio shutdown after a client disconnect."""
+
+from unittest.mock import AsyncMock
+
+import mcp.server.stdio
+import pytest
+
+from browser_use.mcp.cli_mcp import CLIMCPServer
+from browser_use.mcp.server import BrowserUseServer
+
+
+class BrokenPipeStdioContext:
+	async def __aenter__(self):
+		return object(), object()
+
+	async def __aexit__(self, exc_type, exc_value, traceback):
+		return False
+
+
+@pytest.mark.asyncio
+async def test_browser_use_server_handles_broken_pipe(monkeypatch):
+	"""The full MCP server should exit cleanly when its stdio client disconnects."""
+	server = BrowserUseServer()
+	server._start_cleanup_task = AsyncMock()
+	server.server.run = AsyncMock(side_effect=BrokenPipeError())
+	monkeypatch.setattr(mcp.server.stdio, 'stdio_server', BrokenPipeStdioContext)
+
+	await server.run()
+
+	server.server.run.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cli_mcp_server_handles_broken_pipe(monkeypatch):
+	"""The CLI MCP server should exit cleanly when its stdio client disconnects."""
+	server = CLIMCPServer()
+	server.server.run = AsyncMock(side_effect=BrokenPipeError())
+	monkeypatch.setattr(mcp.server.stdio, 'stdio_server', BrokenPipeStdioContext)
+
+	await server.run()
+
+	server.server.run.assert_awaited_once()


### PR DESCRIPTION
## Summary

- add mocked regression coverage for `BrowserUseServer.run()` handling a broken stdio pipe
- add the same coverage for the CLI MCP server entry point
- verify both servers return cleanly when the MCP client disconnects

## Validation

- `uv run pytest -q tests/ci/test_mcp_stdio_brokenpipe.py` (2 passed)
- `uv run pre-commit run --files tests/ci/test_mcp_stdio_brokenpipe.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests ensuring `BrowserUseServer` and `CLIMCPServer` exit cleanly when their stdio client disconnects with a broken pipe, so the servers no longer crash or hang.

<sup>Written for commit d56adcb602b4fd39e886a256d2e0321077eed382. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

