### PR TITLE
test: cover registry actions without regular arguments

### DIFF
--- a/tests/ci/infrastructure/test_registry_action_parameter_injection.py
+++ b/tests/ci/infrastructure/test_registry_action_parameter_injection.py
@@ -334,48 +334,29 @@ class TestBrowserContext:
 	# 	assert not attribute_exists, 'browser-user-highlight-id attribute should be removed'
 
 	@pytest.mark.asyncio
-	@pytest.mark.skip(reason='TODO: fix')
-	async def test_custom_action_with_no_arguments(self, browser_session, base_url):
-		"""Test that custom actions with no arguments are handled correctly"""
+	async def test_custom_actions_with_no_arguments(self):
+		"""Test registry execution and schemas for actions without regular arguments."""
 		from browser_use.agent.views import ActionResult
 		from browser_use.tools.registry.service import Registry
 
-		# Create a registry
 		registry = Registry()
 
-		# Register a custom action with no arguments
 		@registry.action('Some custom action with no args')
 		def simple_action():
 			return ActionResult(extracted_content='return some result')
 
-		# Navigate to a test page
-		from browser_use.browser.events import NavigateToUrlEvent
-
-		event = browser_session.event_bus.dispatch(NavigateToUrlEvent(url=f'{base_url}/'))
-		await event
-
-		# Execute the action
 		result = await registry.execute_action('simple_action', {})
-
-		# Verify the result
 		assert isinstance(result, ActionResult)
 		assert result.extracted_content == 'return some result'
 
-		# Test that the action model is created correctly
 		action_model = registry.create_action_model()
-
-		# The action should be in the model fields
 		assert 'simple_action' in action_model.model_fields
 
-		# Create an instance with the simple_action
 		action_instance = action_model(simple_action={})  # type: ignore[call-arg]
-
-		# Test that model_dump works correctly
 		dumped = action_instance.model_dump(exclude_unset=True)
 		assert 'simple_action' in dumped
 		assert dumped['simple_action'] == {}
 
-		# Test async version as well
 		@registry.action('Async custom action with no args')
 		async def async_simple_action():
 			return ActionResult(extracted_content='async result')
@@ -383,12 +364,17 @@ class TestBrowserContext:
 		result = await registry.execute_action('async_simple_action', {})
 		assert result.extracted_content == 'async result'
 
-		# Test with special parameters but no regular arguments
+		class MockBrowserSession:
+			agent_focus_target_id = None
+			cdp_client = None
+
+			async def get_current_page_url(self):
+				return 'about:blank'
+
 		@registry.action('Action with only special params')
 		async def special_params_only(browser_session):
-			current_url = await browser_session.get_current_page_url()
-			return ActionResult(extracted_content=f'Page URL: {current_url}')
+			return ActionResult(extracted_content=f'injected: {browser_session!r}')
 
-		result = await registry.execute_action('special_params_only', {}, browser_session=browser_session)
-		assert 'Page URL:' in result.extracted_content
-		assert base_url in result.extracted_content
+		injected_session = MockBrowserSession()
+		result = await registry.execute_action('special_params_only', {}, browser_session=injected_session)  # type: ignore[arg-type]
+		assert result.extracted_content == f'injected: {injected_session!r}'


### PR DESCRIPTION
## Summary

- restore the skipped registry action test as a focused unit-style regression
- cover sync and async actions with no regular arguments
- verify generated action schema/model dump and special-parameter injection without launching a browser

## Validation

- `uv run pytest -q tests/ci/infrastructure/test_registry_action_parameter_injection.py -k custom_actions_with_no_arguments`
- `uv run pre-commit run --files tests/ci/infrastructure/test_registry_action_parameter_injection.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the previously skipped registry action test as a focused unit test covering sync and async actions with no regular arguments, verifying action schemas and special-parameter injection without a browser.

<sup>Written for commit c116ca58e137d589984b28252e51079e3430ce42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

