### PR TITLE
docs: align proxy environment example with config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,7 +60,7 @@ BROWSER_USE_API_KEY=your_bu_api_key_here
 # BROWSER_USE_USER_DATA_DIR=./browser_data
 
 # Proxy Configuration (optional)
-# BROWSER_USE_PROXY_SERVER=http://proxy.example.com:8080
+# BROWSER_USE_PROXY_URL=http://proxy.example.com:8080
 # BROWSER_USE_NO_PROXY=localhost,127.0.0.1,*.internal
 # BROWSER_USE_PROXY_USERNAME=username
 # BROWSER_USE_PROXY_PASSWORD=password

--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -8,6 +8,22 @@ from browser_use.config import CONFIG
 class TestLazyConfig:
 	"""Test lazy loading of environment variables through CONFIG object."""
 
+	def test_proxy_env_vars_are_loaded_into_browser_profile(self, monkeypatch):
+		"""Test proxy environment variables map to the BrowserProfile proxy config."""
+		monkeypatch.setenv('BROWSER_USE_PROXY_URL', 'http://proxy.example.com:8080')
+		monkeypatch.setenv('BROWSER_USE_NO_PROXY', 'localhost, 127.0.0.1, *.internal')
+		monkeypatch.setenv('BROWSER_USE_PROXY_USERNAME', 'username')
+		monkeypatch.setenv('BROWSER_USE_PROXY_PASSWORD', 'password')
+
+		config = CONFIG.load_config()
+
+		assert config['browser_profile']['proxy'] == {
+			'server': 'http://proxy.example.com:8080',
+			'bypass': 'localhost,127.0.0.1,*.internal',
+			'username': 'username',
+			'password': 'password',
+		}
+
 	def test_config_reads_env_vars_lazily(self):
 		"""Test that CONFIG reads environment variables each time they're accessed."""
 		# Set an env var


### PR DESCRIPTION
## Summary

- align `.env.example` with the current `BROWSER_USE_PROXY_URL` setting
- add a focused regression test for proxy URL, bypass, username, and password environment variables

## Validation

- `uv run pytest -q tests/ci/infrastructure/test_config.py -k proxy_env_vars`
- `uv run pre-commit run --files .env.example tests/ci/infrastructure/test_config.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the proxy environment variable example with the actual config key and adds a regression test for proxy settings.

- Changes `BROWSER_USE_PROXY_SERVER` to `BROWSER_USE_PROXY_URL` in `.env.example`.
- Adds a test that verifies proxy URL, bypass, username, and password environment variables populate `config['browser_profile']['proxy']`.

<sup>Written for commit b4072aa26543e61a532f9ed7d00d73e0e37e3b9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

