### PR TITLE
docs: use current default init template

### DIFF
--- a/browser_use/skill_cli/README.md
+++ b/browser_use/skill_cli/README.md
@@ -34,7 +34,7 @@ browser-use setup    # Run setup wizard (optional)
 ```bash
 browser-use init                          # Interactive template selection
 browser-use init --list                   # List available templates
-browser-use init --template basic         # Generate specific template
+browser-use init --template default       # Generate the default template
 browser-use init --output my_script.py    # Specify output file
 browser-use init --force                  # Overwrite existing files
 ```


### PR DESCRIPTION
## Summary

- update the skill CLI README to use the currently supported `default` init template

## Validation

- `uv run pre-commit run --files browser_use/skill_cli/README.md`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the skill CLI README to use the current default init template (`default` instead of `basic`). The `--template` example now matches the actual default.

<sup>Written for commit 76d1dd5ca6842f748f7f201098354a59e88ea914. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

