### PR TITLE
fix(cli): accept doctor json flag after subcommand

### DIFF
--- a/browser_use/skill_cli/main.py
+++ b/browser_use/skill_cli/main.py
@@ -679,7 +679,8 @@ Setup:
 	p.add_argument('--yes', '-y', action='store_true', help='Skip interactive prompts')
 
 	# doctor
-	subparsers.add_parser('doctor', help='Check browser-use installation and dependencies')
+	p = subparsers.add_parser('doctor', help='Check browser-use installation and dependencies')
+	p.add_argument('--json', action='store_true', default=argparse.SUPPRESS, help='Output as JSON')
 
 	# connect (to local Chrome)
 	subparsers.add_parser('connect', help='Connect to running Chrome via CDP')

--- a/tests/ci/test_doctor_command.py
+++ b/tests/ci/test_doctor_command.py
@@ -1,6 +1,15 @@
 """Tests for doctor command."""
 
 from browser_use.skill_cli.commands import doctor
+from browser_use.skill_cli.main import build_parser
+
+
+def test_doctor_accepts_json_after_subcommand_without_breaking_global_flag():
+	"""Test both supported positions for the doctor JSON output flag."""
+	parser = build_parser()
+
+	assert parser.parse_args(['doctor', '--json']).json is True
+	assert parser.parse_args(['--json', 'doctor']).json is True
 
 
 async def test_doctor_handle_returns_valid_structure():


### PR DESCRIPTION
## Summary

- accept `browser-use doctor --json` in addition to the existing global `--json doctor` form
- preserve the global flag behavior with an argparse regression test

## Validation

- `uv run pytest -q tests/ci/test_doctor_command.py -k json_after_subcommand`
- `uv run pre-commit run --files browser_use/skill_cli/main.py tests/ci/test_doctor_command.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI doctor command so `browser-use doctor --json` now works in addition to the existing global `--json doctor` form. Adds a regression test covering both flag positions.

<sup>Written for commit e561eb5dd5d0dccbe82995a53a0b73e377d80cb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

