### PR TITLE
fix: create parent directories for history gifs

### DIFF
--- a/browser_use/agent/gif.py
+++ b/browser_use/agent/gif.py
@@ -5,6 +5,7 @@ import io
 import logging
 import os
 import platform
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from browser_use.agent.views import AgentHistoryList
@@ -196,6 +197,7 @@ def create_history_gif(
 	try:
 		if images:
 			# Save the GIF
+			Path(output_path).parent.mkdir(parents=True, exist_ok=True)
 			images[0].save(
 				output_path,
 				save_all=True,

--- a/tests/ci/test_agent_gif.py
+++ b/tests/ci/test_agent_gif.py
@@ -1,0 +1,30 @@
+"""Tests for agent history GIF output handling."""
+
+import base64
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from PIL import Image
+
+from browser_use.agent.gif import create_history_gif
+
+
+def test_create_history_gif_creates_nested_output_directory(tmp_path: Path):
+	"""Test custom GIF paths work when their parent directory does not exist."""
+	image_buffer = BytesIO()
+	Image.new('RGB', (2, 2), color='white').save(image_buffer, format='PNG')
+	screenshot = base64.b64encode(image_buffer.getvalue()).decode()
+	item = SimpleNamespace(
+		state=SimpleNamespace(url='https://example.com', get_screenshot=lambda: screenshot),
+		model_output=None,
+	)
+	history = SimpleNamespace(history=[item], screenshots=lambda return_none_if_not_screenshot: [screenshot])
+	output_path = tmp_path / 'nested' / 'history.gif'
+
+	with patch.object(Image.Image, 'save') as save:
+		create_history_gif(task='', history=history, output_path=str(output_path), show_task=False)  # type: ignore[arg-type]
+
+	assert output_path.parent.is_dir()
+	save.assert_called_once()


### PR DESCRIPTION
## Summary

- create missing parent directories before saving history GIFs
- add a focused regression test for nested custom output paths

## Validation

- `uv run pytest -q tests/ci/test_agent_gif.py`
- `uv run pre-commit run --files browser_use/agent/gif.py tests/ci/test_agent_gif.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes history GIF creation failing when the output path's parent directory does not exist. `create_history_gif` now creates missing parent directories before saving the GIF, so nested custom output paths work.

- Adds a regression test covering a nested output path that doesn't exist yet.

<sup>Written for commit 6b3f4942e556c5212d56bdb97c1ca794e74925ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

