### PR TITLE
test: cover bundled Chromium path priority

### DIFF
--- a/tests/ci/test_local_browser_watchdog.py
+++ b/tests/ci/test_local_browser_watchdog.py
@@ -1,0 +1,17 @@
+"""Tests for local browser executable discovery."""
+
+from pathlib import Path
+
+from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+
+def test_default_channel_prefers_playwright_chromium(monkeypatch, tmp_path: Path):
+	"""Test default discovery returns bundled Chromium before other fallbacks."""
+	monkeypatch.setattr('platform.system', lambda: 'Darwin')
+	monkeypatch.setenv('PLAYWRIGHT_BROWSERS_PATH', str(tmp_path))
+
+	bundled_chromium = tmp_path / 'chromium-123' / 'chrome-mac' / 'Chromium.app' / 'Contents' / 'MacOS' / 'Chromium'
+	bundled_chromium.parent.mkdir(parents=True)
+	bundled_chromium.touch()
+
+	assert LocalBrowserWatchdog._find_installed_browser_path() == str(bundled_chromium)


### PR DESCRIPTION
## Summary

- add an isolated regression test for default browser discovery
- verify bundled Playwright Chromium is selected when available

## Validation

- `uv run pytest -q tests/ci/test_local_browser_watchdog.py`
- `uv run pre-commit run --files tests/ci/test_local_browser_watchdog.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test for local browser discovery, verifying the bundled Playwright Chromium is selected before other fallbacks when available.

<sup>Written for commit 22110332107ef4be435052817e6e88ccab8dab5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

