### PR TITLE
fix(browser): report unsupported subprocess event loop

### DIFF
--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -19,6 +19,7 @@ from browser_use.browser.events import (
 	BrowserLaunchResult,
 	BrowserStopEvent,
 )
+from browser_use.browser.views import BrowserError
 from browser_use.browser.watchdog_base import BaseWatchdog
 from browser_use.observability import observe_debug
 
@@ -143,11 +144,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				self.logger.debug(
 					f'[LocalBrowserWatchdog] 📂 user_data_dir={profile.user_data_dir}, profile_directory={profile.profile_directory}'
 				)
-				subprocess = await asyncio.create_subprocess_exec(
+				subprocess = await self._create_subprocess_exec(
 					browser_path,
 					*launch_args,
-					stdout=asyncio.subprocess.PIPE,
-					stderr=asyncio.subprocess.PIPE,
 				)
 				self.logger.debug(
 					f'[LocalBrowserWatchdog] 🎭 Browser running with browser_pid= {subprocess.pid} 🔗 listening on CDP port :{debug_port}'
@@ -367,10 +366,8 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			cmd.append('--with-deps')
 
 		# Run in subprocess with timeout
-		process = await asyncio.create_subprocess_exec(
+		process = await self._create_subprocess_exec(
 			*cmd,
-			stdout=asyncio.subprocess.PIPE,
-			stderr=asyncio.subprocess.PIPE,
 		)
 
 		try:
@@ -392,6 +389,22 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				process.kill()
 				await process.wait()
 			raise RuntimeError(f'Error getting browser path: {e}')
+
+	@staticmethod
+	async def _create_subprocess_exec(*cmd: str | os.PathLike[str]) -> asyncio.subprocess.Process:
+		try:
+			return await asyncio.create_subprocess_exec(
+				*cmd,
+				stdout=asyncio.subprocess.PIPE,
+				stderr=asyncio.subprocess.PIPE,
+			)
+		except NotImplementedError as e:
+			raise BrowserError(
+				'The current asyncio event loop does not support subprocesses, so browser-use cannot launch a local browser. '
+				'On Windows this usually means a SelectorEventLoop is active, which can happen in Uvicorn/FastAPI apps. '
+				'Use asyncio.WindowsProactorEventLoopPolicy before starting the app, or run browser-use from a process that '
+				'supports asyncio subprocess transports.'
+			) from e
 
 	@staticmethod
 	def _find_free_port() -> int:

--- a/tests/ci/browser/test_local_browser_watchdog.py
+++ b/tests/ci/browser/test_local_browser_watchdog.py
@@ -1,0 +1,23 @@
+import asyncio
+
+import pytest
+
+from browser_use.browser.views import BrowserError
+from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+
+@pytest.mark.asyncio
+async def test_create_subprocess_exec_reports_unsupported_event_loop(monkeypatch):
+	async def unsupported_subprocess_exec(*_cmd, **_kwargs):
+		raise NotImplementedError
+
+	monkeypatch.setattr(asyncio, 'create_subprocess_exec', unsupported_subprocess_exec)
+
+	with pytest.raises(BrowserError) as exc_info:
+		await LocalBrowserWatchdog._create_subprocess_exec('chrome', '--remote-debugging-port=9222')
+
+	assert isinstance(exc_info.value.__cause__, NotImplementedError)
+	message = str(exc_info.value)
+	assert 'does not support subprocesses' in message
+	assert 'WindowsProactorEventLoopPolicy' in message
+	assert 'Uvicorn/FastAPI' in message


### PR DESCRIPTION
## Summary

Fixes #4709.

This wraps local browser subprocess creation so a Windows/SelectorEventLoop-style `NotImplementedError` becomes an actionable `BrowserError` instead of surfacing as an opaque launch failure.

The same helper is used for both local browser launch and the Playwright install subprocess path.

## Test plan

- `py -3.12 -m compileall browser_use\browser\watchdogs\local_browser_watchdog.py tests\ci\browser\test_local_browser_watchdog.py`
- `git diff --check`

I could not run the new pytest locally because this machine does not have the project dependencies installed (`bubus` is missing) and `uv` is not available globally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4709 by converting a `NotImplementedError` from subprocess creation (common on Windows when a `SelectorEventLoop` is active, e.g., in Uvicorn/FastAPI) into a clear `BrowserError` with actionable guidance. Previously, local browser launches and Playwright installs would fail with an opaque error; now the error explains the event-loop limitation and how to fix it. Applies the same wrapper to both the local browser launch and the Playwright install subprocess paths. Adds a test covering the new error message.

<sup>Written for commit 3af1d1458cb8706933f98ab1b1b5f0be3c0b0175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

