### PR TITLE
fix(browser): preserve default Chrome arg order

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -907,7 +907,8 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 		"""Get the list of all Chrome CLI launch args for this profile (compiled from defaults, user-provided, and system-specific)."""
 
 		if isinstance(self.ignore_default_args, list):
-			default_args = set(CHROME_DEFAULT_ARGS) - set(self.ignore_default_args)
+			ignored_default_args = set(self.ignore_default_args)
+			default_args = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_default_args]
 		elif self.ignore_default_args is True:
 			default_args = []
 		elif not self.ignore_default_args:

--- a/tests/ci/test_profile_args.py
+++ b/tests/ci/test_profile_args.py
@@ -1,0 +1,32 @@
+from browser_use.browser.profile import CHROME_DEFAULT_ARGS, BrowserProfile
+
+
+def test_get_args_keeps_default_order_when_ignoring_default_args(tmp_path):
+	profile = BrowserProfile(
+		user_data_dir=tmp_path,
+		ignore_default_args=['--disable-popup-blocking', '--no-default-browser-check'],
+		enable_default_extensions=False,
+	)
+
+	args = profile.get_args()
+
+	expected_defaults = [
+		arg for arg in CHROME_DEFAULT_ARGS if arg not in {'--disable-popup-blocking', '--no-default-browser-check'}
+	]
+	actual_defaults = [arg for arg in args if arg in CHROME_DEFAULT_ARGS]
+
+	assert actual_defaults == expected_defaults
+	assert '--disable-popup-blocking' not in args
+	assert '--no-default-browser-check' not in args
+
+
+def test_get_args_keeps_default_order_with_default_ignored_args(tmp_path):
+	profile = BrowserProfile(user_data_dir=tmp_path, enable_default_extensions=False)
+
+	args = profile.get_args()
+
+	ignored_default_args = profile.ignore_default_args if isinstance(profile.ignore_default_args, list) else []
+	expected_defaults = [arg for arg in CHROME_DEFAULT_ARGS if arg not in ignored_default_args]
+	actual_defaults = [arg for arg in args if arg in CHROME_DEFAULT_ARGS]
+
+	assert actual_defaults == expected_defaults


### PR DESCRIPTION
## Why

`set(CHROME_DEFAULT_ARGS) - set(ignore_default_args)` makes Chrome's default launch flags process-dependent. With `PYTHONHASHSEED=0`, the first flag changes from `--disable-field-trial-config` to `--disable-background-networking`.

## Fix

Filter the canonical list in place. Ignored flags are still removed, but every remaining flag keeps its existing order.

## Proof

- Red: both order regressions fail on current `main` with `PYTHONHASHSEED=0`.
- Green: both pass with seeds `0`, `1`, `2`, and `12345`.
- Existing security side-effect tests pass.
- All changed-file pre-commit hooks pass, including Ruff, format, Pyright, and private-key detection.
- `git diff --check` passes.

## Customer impact

No API or flag membership changes. The patch only removes nondeterministic reordering. Existing `disable_security` feature merging remains covered.

This is the maintainer-owned replacement for the stalled contributor implementations in #5470 and #5505; their branches were not edited.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nondeterministic ordering of Chrome default launch args. Previously the set difference in `get_args` could reorder flags depending on `PYTHONHASHSEED`; now ignored flags are filtered from the canonical list in place, with no flag membership or API behavior changes. Adds regression tests covering default-order preservation and ignored-flag removal.

<sup>Written for commit df2701e524819dbde580b0010e9f18be9a8b6922. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

