### PR TITLE
fix(history): redact sensitive mapping keys during persistence

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -632,7 +632,7 @@ class AgentHistory(BaseModel):
 						while generated_key in reserved_keys:
 							suffix += 1
 							generated_key = f'{filtered_key}#{suffix}'
-						unique_key = filter_generated_string(generated_key, reserved_keys)
+						unique_key = filter_generated_string(generated_key, reserved_keys | reserved_value_fallbacks)
 						reserved_keys.add(unique_key)
 					children.append((item, unique_key))
 				stack.append(('exit', (container_id, False), parent, key))

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -527,9 +527,60 @@ class AgentHistory(BaseModel):
 		sensitive_data: dict[str, str | dict[str, str]] | None,
 	) -> Any:
 		"""Filter nested sensitive data without relying on the Python recursion stack."""
+		sensitive_values = collect_sensitive_data_values(sensitive_data)
+		if not sensitive_values:
+			return value
+		sorted_sensitive_items = sorted(sensitive_values.items(), key=lambda item: len(item[1]), reverse=True)
+		secret_to_key = {secret: key for key, secret in sorted_sensitive_items}
+		redaction_pattern = re.compile('|'.join(re.escape(secret) for secret in secret_to_key))
+		single_character_secrets = {secret for secret in sensitive_values.values() if len(secret) == 1}
+
+		def filter_string(unfiltered: str) -> str:
+			return redaction_pattern.sub(lambda match: f'<secret>{secret_to_key[match.group(0)]}</secret>', unfiltered)
+
+		def fallback_candidates():
+			for start, end in ((0xE000, 0xF900), (0xF0000, 0xFFFFE), (0x100000, 0x10FFFE)):
+				for codepoint in range(start, end):
+					yield chr(codepoint)
+			for codepoint in range(1, 0x110000):
+				if 0xD800 <= codepoint <= 0xDFFF:
+					continue
+				yield chr(codepoint)
+			yield ''
+
+		fallback_values = fallback_candidates()
+		reserved_value_fallbacks: set[str] = set()
+		reservation_stack = [value]
+		reservation_seen: set[int] = set()
+		while reservation_stack:
+			reservation_value = reservation_stack.pop()
+			if isinstance(reservation_value, str):
+				filtered_reservation = filter_string(reservation_value)
+				if redaction_pattern.search(filtered_reservation) is None:
+					reserved_value_fallbacks.add(filtered_reservation)
+				continue
+			if not isinstance(reservation_value, (dict, list, tuple)):
+				continue
+			reservation_id = id(reservation_value)
+			if reservation_id in reservation_seen:
+				continue
+			reservation_seen.add(reservation_id)
+			reservation_stack.extend(reservation_value.values() if isinstance(reservation_value, dict) else reservation_value)
+
+		def filter_generated_string(generated: str, reserved_values: set[str] | None = None) -> str:
+			reserved_values = reserved_values or set()
+			if generated not in reserved_values and redaction_pattern.search(generated) is None:
+				return generated
+			for fallback in fallback_values:
+				if fallback not in reserved_values and fallback not in single_character_secrets:
+					return fallback
+			raise ValueError('Unable to preserve a unique sensitive-data-safe mapping key')
+
 		root: list[Any] = [None]
 		active_containers: set[int] = set()
 		stack: list[tuple[str, Any, Any, Any]] = [('visit', value, root, 0)]
+		circular_fallback: str | None = None
+		unsafe_value_fallbacks: dict[str, str] = {}
 
 		while stack:
 			operation, current, parent, key = stack.pop()
@@ -541,7 +592,15 @@ class AgentHistory(BaseModel):
 				continue
 
 			if isinstance(current, str):
-				parent[key] = self._filter_sensitive_data_from_string(current, sensitive_data)
+				filtered_string = filter_string(current)
+				if redaction_pattern.search(filtered_string) is not None:
+					safe_fallback = unsafe_value_fallbacks.get(filtered_string)
+					if safe_fallback is None:
+						safe_fallback = filter_generated_string(filtered_string, reserved_value_fallbacks)
+						unsafe_value_fallbacks[filtered_string] = safe_fallback
+						reserved_value_fallbacks.add(safe_fallback)
+					filtered_string = safe_fallback
+				parent[key] = filtered_string
 				continue
 			if not isinstance(current, (dict, list, tuple)):
 				parent[key] = current
@@ -549,7 +608,10 @@ class AgentHistory(BaseModel):
 
 			container_id = id(current)
 			if container_id in active_containers:
-				parent[key] = '<circular container reference>'
+				if circular_fallback is None:
+					circular_fallback = filter_generated_string('<circular container reference>', reserved_value_fallbacks)
+					reserved_value_fallbacks.add(circular_fallback)
+				parent[key] = circular_fallback
 				continue
 			active_containers.add(container_id)
 
@@ -558,18 +620,19 @@ class AgentHistory(BaseModel):
 				parent[key] = filtered_dict
 				children: list[tuple[Any, str]] = []
 				filtered_keys = [
-					(original_key, self._filter_sensitive_data_from_string(original_key, sensitive_data), item)
+					(original_key, filter_string(original_key), redaction_pattern.search(original_key) is not None, item)
 					for original_key, item in current.items()
 				]
-				reserved_keys = {original_key for original_key, filtered_key, _ in filtered_keys if original_key == filtered_key}
-				for original_key, filtered_key, item in filtered_keys:
+				reserved_keys = {original_key for original_key, _, is_sensitive, _ in filtered_keys if not is_sensitive}
+				for original_key, filtered_key, is_sensitive, item in filtered_keys:
 					unique_key = original_key
-					if filtered_key != original_key:
-						unique_key = filtered_key
-						suffix = 2
-						while unique_key in reserved_keys:
-							unique_key = f'{filtered_key}#{suffix}'
+					if is_sensitive:
+						generated_key = filtered_key
+						suffix = 1
+						while generated_key in reserved_keys:
 							suffix += 1
+							generated_key = f'{filtered_key}#{suffix}'
+						unique_key = filter_generated_string(generated_key, reserved_keys)
 						reserved_keys.add(unique_key)
 					children.append((item, unique_key))
 				stack.append(('exit', (container_id, False), parent, key))

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -633,6 +633,7 @@ class AgentHistory(BaseModel):
 							suffix += 1
 							generated_key = f'{filtered_key}#{suffix}'
 						unique_key = filter_generated_string(generated_key, reserved_keys | reserved_value_fallbacks)
+						reserved_value_fallbacks.add(unique_key)
 						reserved_keys.add(unique_key)
 					children.append((item, unique_key))
 				stack.append(('exit', (container_id, False), parent, key))

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -529,7 +529,7 @@ class AgentHistory(BaseModel):
 		"""Filter nested sensitive data without relying on the Python recursion stack."""
 		root: list[Any] = [None]
 		active_containers: set[int] = set()
-		stack: list[tuple[str, Any, list[Any] | dict[str, Any], int | str]] = [('visit', value, root, 0)]
+		stack: list[tuple[str, Any, Any, Any]] = [('visit', value, root, 0)]
 
 		while stack:
 			operation, current, parent, key = stack.pop()

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -521,26 +521,77 @@ class AgentHistory(BaseModel):
 
 		return redact_sensitive_string(value, sensitive_values)
 
-	def _filter_sensitive_data_from_value(self, value: Any, sensitive_data: dict[str, str | dict[str, str]] | None) -> Any:
-		"""Recursively filter sensitive data from any supported container or string value"""
-		if isinstance(value, str):
-			return self._filter_sensitive_data_from_string(value, sensitive_data)
-		if isinstance(value, dict):
-			return {key: self._filter_sensitive_data_from_value(item, sensitive_data) for key, item in value.items()}
-		if isinstance(value, list):
-			return [self._filter_sensitive_data_from_value(item, sensitive_data) for item in value]
-		if isinstance(value, tuple):
-			return tuple(self._filter_sensitive_data_from_value(item, sensitive_data) for item in value)
-		return value
+	def _filter_sensitive_data_from_value(
+		self,
+		value: Any,
+		sensitive_data: dict[str, str | dict[str, str]] | None,
+	) -> Any:
+		"""Filter nested sensitive data without relying on the Python recursion stack."""
+		root: list[Any] = [None]
+		active_containers: set[int] = set()
+		stack: list[tuple[str, Any, list[Any] | dict[str, Any], int | str]] = [('visit', value, root, 0)]
+
+		while stack:
+			operation, current, parent, key = stack.pop()
+			if operation == 'exit':
+				container_id, is_tuple = current
+				if is_tuple:
+					parent[key] = tuple(parent[key])
+				active_containers.remove(container_id)
+				continue
+
+			if isinstance(current, str):
+				parent[key] = self._filter_sensitive_data_from_string(current, sensitive_data)
+				continue
+			if not isinstance(current, (dict, list, tuple)):
+				parent[key] = current
+				continue
+
+			container_id = id(current)
+			if container_id in active_containers:
+				parent[key] = '<circular container reference>'
+				continue
+			active_containers.add(container_id)
+
+			if isinstance(current, dict):
+				filtered_dict: dict[str, Any] = {}
+				parent[key] = filtered_dict
+				children: list[tuple[Any, str]] = []
+				filtered_keys = [
+					(original_key, self._filter_sensitive_data_from_string(original_key, sensitive_data), item)
+					for original_key, item in current.items()
+				]
+				reserved_keys = {original_key for original_key, filtered_key, _ in filtered_keys if original_key == filtered_key}
+				for original_key, filtered_key, item in filtered_keys:
+					unique_key = original_key
+					if filtered_key != original_key:
+						unique_key = filtered_key
+						suffix = 2
+						while unique_key in reserved_keys:
+							unique_key = f'{filtered_key}#{suffix}'
+							suffix += 1
+						reserved_keys.add(unique_key)
+					children.append((item, unique_key))
+				stack.append(('exit', (container_id, False), parent, key))
+				stack.extend(('visit', item, filtered_dict, child_key) for item, child_key in reversed(children))
+			else:
+				filtered_list: list[Any] = [None] * len(current)
+				parent[key] = filtered_list
+				stack.append(('exit', (container_id, isinstance(current, tuple)), parent, key))
+				stack.extend(('visit', item, filtered_list, index) for index, item in reversed(list(enumerate(current))))
+
+		return root[0]
 
 	def _filter_sensitive_data_from_dict(
-		self, data: dict[str, Any], sensitive_data: dict[str, str | dict[str, str]] | None
+		self,
+		data: dict[str, Any],
+		sensitive_data: dict[str, str | dict[str, str]] | None,
 	) -> dict[str, Any]:
 		"""Recursively filter sensitive data from a dictionary"""
 		if not sensitive_data:
 			return data
 
-		return {key: self._filter_sensitive_data_from_value(value, sensitive_data) for key, value in data.items()}
+		return self._filter_sensitive_data_from_value(data, sensitive_data)
 
 	def model_dump(self, sensitive_data: dict[str, str | dict[str, str]] | None = None, **kwargs) -> dict[str, Any]:
 		"""Custom serialization handling circular references and filtering sensitive data"""

--- a/tests/ci/security/test_history_sensitive_data.py
+++ b/tests/ci/security/test_history_sensitive_data.py
@@ -1,0 +1,135 @@
+from pydantic import BaseModel
+
+from browser_use.agent.views import AgentHistory, AgentHistoryList, AgentOutput
+from browser_use.browser.views import BrowserStateHistory
+from browser_use.tools.registry.views import ActionModel
+
+
+class HistorySensitiveParams(BaseModel):
+	rows: list[list[str]]
+	payload: tuple[dict[str, tuple[str, list[str]]], ...]
+	lookup: dict[str, str]
+	unchanged: str
+
+
+class HistorySensitiveAction(ActionModel):
+	input: HistorySensitiveParams
+
+
+def _history(secret: str) -> AgentHistoryList:
+	custom_output = AgentOutput.type_with_custom_actions(HistorySensitiveAction)
+	return AgentHistoryList(
+		history=[
+			AgentHistory(
+				model_output=custom_output(
+					evaluation_previous_goal='ok',
+					memory='ok',
+					next_goal='done',
+					action=[
+						HistorySensitiveAction(
+							input=HistorySensitiveParams(
+								rows=[[secret]],
+								payload=({'credentials': (secret, ['safe', secret])},),
+								lookup={secret: 'secret-key', '<secret>api_key</secret>': 'literal-key'},
+								unchanged='safe',
+							)
+						)
+					],
+				),
+				result=[],
+				state=BrowserStateHistory(
+					url='about:blank',
+					title='Blank',
+					tabs=[],
+					interacted_element=[],
+				),
+			)
+		]
+	)
+
+
+def test_model_dump_redacts_secrets_inside_nested_action_containers():
+	secret = 'token-123'
+
+	dumped = _history(secret).history[0].model_dump(sensitive_data={'api_key': secret})
+	input_data = dumped['model_output']['action'][0]['input']
+
+	assert input_data['rows'] == [['<secret>api_key</secret>']]
+	assert input_data['payload'] == [{'credentials': ['<secret>api_key</secret>', ['safe', '<secret>api_key</secret>']]}]
+	assert input_data['lookup'] == {
+		'<secret>api_key</secret>#2': 'secret-key',
+		'<secret>api_key</secret>': 'literal-key',
+	}
+	assert input_data['unchanged'] == 'safe'
+
+
+def test_save_to_file_redacts_secrets_inside_nested_action_containers(tmp_path):
+	secret = 'token-123'
+	output_path = tmp_path / 'history.json'
+
+	_history(secret).save_to_file(output_path, sensitive_data={'api_key': secret})
+	saved = output_path.read_text(encoding='utf-8')
+
+	assert secret not in saved
+	assert '<secret>api_key</secret>' in saved
+
+
+def test_recursive_filter_preserves_tuple_containers():
+	secret = 'token-123'
+	history = _history(secret).history[0]
+
+	filtered = history._filter_sensitive_data_from_dict(
+		{'payload': ({'credentials': (secret, ['safe', secret])},)},
+		{'api_key': secret},
+	)
+
+	assert filtered == {'payload': ({'credentials': ('<secret>api_key</secret>', ['safe', '<secret>api_key</secret>'])},)}
+	assert isinstance(filtered['payload'], tuple)
+	assert isinstance(filtered['payload'][0]['credentials'], tuple)
+
+
+def test_recursive_filter_preserves_literal_keys_regardless_of_order():
+	secret = 'token-123'
+	history = _history(secret).history[0]
+	expected = {
+		'<secret>api_key</secret>': 'literal-key',
+		'<secret>api_key</secret>#2': 'secret-key',
+	}
+
+	assert history._filter_sensitive_data_from_dict(
+		{secret: 'secret-key', '<secret>api_key</secret>': 'literal-key'}, {'api_key': secret}
+	) == {
+		'<secret>api_key</secret>#2': 'secret-key',
+		'<secret>api_key</secret>': 'literal-key',
+	}
+	assert (
+		history._filter_sensitive_data_from_dict(
+			{'<secret>api_key</secret>': 'literal-key', secret: 'secret-key'}, {'api_key': secret}
+		)
+		== expected
+	)
+
+
+def test_recursive_filter_replaces_circular_containers():
+	secret = 'token-123'
+	history = _history(secret).history[0]
+	circular: list[object] = []
+	circular.append(circular)
+
+	filtered = history._filter_sensitive_data_from_dict({'payload': circular}, {'api_key': secret})
+
+	assert filtered == {'payload': ['<circular container reference>']}
+
+
+def test_recursive_filter_handles_deep_containers_without_recursion():
+	secret = 'token-123'
+	history = _history(secret).history[0]
+	nested: object = secret
+	for _ in range(1100):
+		nested = [nested]
+
+	filtered = history._filter_sensitive_data_from_dict({'payload': nested}, {'api_key': secret})
+	leaf = filtered['payload']
+	for _ in range(1100):
+		leaf = leaf[0]
+	assert leaf == '<secret>api_key</secret>'

--- a/tests/ci/security/test_history_sensitive_data.py
+++ b/tests/ci/security/test_history_sensitive_data.py
@@ -171,7 +171,7 @@ def test_recursive_filter_rechecks_every_changed_key_for_generated_secrets():
 	filtered_key = next(iter(filtered))
 
 	assert len(filtered_key) == 1
-	assert all(secret not in filtered_key for secret in sensitive_data.values())
+	assert all(secret not in filtered_key for secret in sensitive_data.values() if isinstance(secret, str))
 	assert filtered[filtered_key] == 'value'
 
 
@@ -245,7 +245,7 @@ def test_generated_string_filter_uses_an_opaque_fallback_for_replacement_cycles(
 	filtered_key = next(iter(filtered))
 
 	assert len(filtered_key) == 1
-	assert all(secret not in filtered_key for secret in sensitive_data.values())
+	assert all(secret not in filtered_key for secret in sensitive_data.values() if isinstance(secret, str))
 	assert filtered[filtered_key] == 'value'
 
 
@@ -257,7 +257,7 @@ def test_generated_string_filter_bounds_expanding_replacements():
 	filtered_key = next(iter(filtered))
 
 	assert len(filtered_key) == 1
-	assert all(secret not in filtered_key for secret in sensitive_data.values())
+	assert all(secret not in filtered_key for secret in sensitive_data.values() if isinstance(secret, str))
 	assert filtered[filtered_key] == 'value'
 
 

--- a/tests/ci/security/test_history_sensitive_data.py
+++ b/tests/ci/security/test_history_sensitive_data.py
@@ -136,7 +136,7 @@ def test_recursive_filter_redacts_chained_secrets_in_the_circular_marker():
 	history = _history('unused').history[0]
 	circular: list[object] = []
 	circular.append(circular)
-	sensitive_data = {
+	sensitive_data: dict[str, str | dict[str, str]] = {
 		'marker': '<circular container reference>',
 		'generated': '<secret>marker</secret>',
 	}
@@ -165,7 +165,7 @@ def test_recursive_filter_redacts_generated_collision_keys():
 
 def test_recursive_filter_rechecks_every_changed_key_for_generated_secrets():
 	history = _history('unused').history[0]
-	sensitive_data = {'label': 'A', 'other': 'label'}
+	sensitive_data: dict[str, str | dict[str, str]] = {'label': 'A', 'other': 'label'}
 
 	filtered = history._filter_sensitive_data_from_dict({'A': 'value'}, sensitive_data)
 	filtered_key = next(iter(filtered))
@@ -236,7 +236,7 @@ def test_recursive_filter_does_not_reuse_an_unchanged_user_value_for_a_circular_
 
 def test_generated_string_filter_uses_an_opaque_fallback_for_replacement_cycles():
 	history = _history('unused').history[0]
-	sensitive_data = {
+	sensitive_data: dict[str, str | dict[str, str]] = {
 		'a': '<secret>b</secret>',
 		'b': '<secret>a</secret>',
 	}
@@ -251,7 +251,7 @@ def test_generated_string_filter_uses_an_opaque_fallback_for_replacement_cycles(
 
 def test_generated_string_filter_bounds_expanding_replacements():
 	history = _history('unused').history[0]
-	sensitive_data = {'expands': 'x', 'unrelated': 'safe'}
+	sensitive_data: dict[str, str | dict[str, str]] = {'expands': 'x', 'unrelated': 'safe'}
 
 	filtered = history._filter_sensitive_data_from_dict({'x': 'value'}, sensitive_data)
 	filtered_key = next(iter(filtered))
@@ -263,7 +263,9 @@ def test_generated_string_filter_bounds_expanding_replacements():
 
 def test_generated_string_filter_skips_singleton_secrets_across_the_bmp_private_use_range():
 	history = _history('unused').history[0]
-	sensitive_data = {f'pua_{codepoint:x}': chr(codepoint) for codepoint in range(0xE000, 0xF900)}
+	sensitive_data: dict[str, str | dict[str, str]] = {
+		f'pua_{codepoint:x}': chr(codepoint) for codepoint in range(0xE000, 0xF900)
+	}
 	sensitive_data['generated'] = '<secret>pua_e000</secret>'
 
 	filtered = history._filter_sensitive_data_from_dict({chr(0xE000): 'value'}, sensitive_data)

--- a/tests/ci/security/test_history_sensitive_data.py
+++ b/tests/ci/security/test_history_sensitive_data.py
@@ -121,6 +121,160 @@ def test_recursive_filter_replaces_circular_containers():
 	assert filtered == {'payload': ['<circular container reference>']}
 
 
+def test_recursive_filter_redacts_the_circular_marker_when_it_is_sensitive():
+	history = _history('unused').history[0]
+	circular: list[object] = []
+	circular.append(circular)
+
+	filtered = history._filter_sensitive_data_from_dict({'payload': circular}, {'marker': '<circular container reference>'})
+
+	assert len(filtered['payload'][0]) == 1
+	assert '<circular container reference>' not in filtered['payload'][0]
+
+
+def test_recursive_filter_redacts_chained_secrets_in_the_circular_marker():
+	history = _history('unused').history[0]
+	circular: list[object] = []
+	circular.append(circular)
+	sensitive_data = {
+		'marker': '<circular container reference>',
+		'generated': '<secret>marker</secret>',
+	}
+
+	filtered = history._filter_sensitive_data_from_dict({'payload': circular}, sensitive_data)
+
+	assert len(filtered['payload'][0]) == 1
+	assert all(secret not in filtered['payload'][0] for secret in sensitive_data.values())
+
+
+def test_recursive_filter_redacts_generated_collision_keys():
+	secret = 'token-123'
+	history = _history(secret).history[0]
+	generated_key = '<secret>api_key</secret>#2'
+
+	filtered = history._filter_sensitive_data_from_dict(
+		{secret: 'secret-key', '<secret>api_key</secret>': 'literal-key'},
+		{'api_key': secret, 'generated_key': generated_key},
+	)
+
+	assert generated_key not in filtered
+	assert '<secret>api_key</secret>' in filtered
+	assert set(filtered.values()) == {'secret-key', 'literal-key'}
+	assert all(secret not in key for key in filtered for secret in {'token-123', generated_key})
+
+
+def test_recursive_filter_rechecks_every_changed_key_for_generated_secrets():
+	history = _history('unused').history[0]
+	sensitive_data = {'label': 'A', 'other': 'label'}
+
+	filtered = history._filter_sensitive_data_from_dict({'A': 'value'}, sensitive_data)
+	filtered_key = next(iter(filtered))
+
+	assert len(filtered_key) == 1
+	assert all(secret not in filtered_key for secret in sensitive_data.values())
+	assert filtered[filtered_key] == 'value'
+
+
+def test_recursive_filter_replaces_self_identical_secret_placeholders_in_keys_and_values():
+	history = _history('unused').history[0]
+	secret = '<secret>label</secret>'
+
+	filtered = history._filter_sensitive_data_from_dict({secret: secret}, {'label': secret})
+	filtered_key = next(iter(filtered))
+
+	assert filtered_key != secret
+	assert filtered[filtered_key] != secret
+	assert len(filtered_key) == 1
+	assert len(filtered[filtered_key]) == 1
+
+
+def test_recursive_filter_preserves_identity_for_distinct_unsafe_values():
+	history = _history('unused').history[0]
+	secret_a = '<secret>a</secret>'
+	secret_b = '<secret>b</secret>'
+
+	filtered = history._filter_sensitive_data_from_dict(
+		{'values': [secret_a, secret_a, secret_b]},
+		{'a': secret_a, 'b': secret_b},
+	)
+	first_a, second_a, filtered_b = filtered['values']
+
+	assert first_a == second_a
+	assert first_a != filtered_b
+	assert all(len(value) == 1 for value in filtered['values'])
+	assert all(secret not in value for value in filtered['values'] for secret in (secret_a, secret_b))
+
+
+def test_recursive_filter_does_not_reuse_an_unchanged_user_value_as_a_fallback():
+	history = _history('unused').history[0]
+	secret = '<secret>a</secret>'
+	unchanged = '\ue000'
+
+	filtered = history._filter_sensitive_data_from_dict({'values': [secret, unchanged]}, {'a': secret})
+	filtered_secret, filtered_unchanged = filtered['values']
+
+	assert filtered_unchanged == unchanged
+	assert filtered_secret != filtered_unchanged
+	assert secret not in filtered_secret
+
+
+def test_recursive_filter_does_not_reuse_an_unchanged_user_value_for_a_circular_marker():
+	history = _history('unused').history[0]
+	unchanged = '\ue000'
+	circular: list[object] = []
+	circular.append(circular)
+
+	filtered = history._filter_sensitive_data_from_dict(
+		{'values': [circular, unchanged]}, {'marker': '<circular container reference>'}
+	)
+	filtered_circular, filtered_unchanged = filtered['values']
+
+	assert filtered_unchanged == unchanged
+	assert filtered_circular[0] != filtered_unchanged
+	assert '<circular container reference>' not in filtered_circular[0]
+
+
+def test_generated_string_filter_uses_an_opaque_fallback_for_replacement_cycles():
+	history = _history('unused').history[0]
+	sensitive_data = {
+		'a': '<secret>b</secret>',
+		'b': '<secret>a</secret>',
+	}
+
+	filtered = history._filter_sensitive_data_from_dict({'<secret>a</secret>': 'value'}, sensitive_data)
+	filtered_key = next(iter(filtered))
+
+	assert len(filtered_key) == 1
+	assert all(secret not in filtered_key for secret in sensitive_data.values())
+	assert filtered[filtered_key] == 'value'
+
+
+def test_generated_string_filter_bounds_expanding_replacements():
+	history = _history('unused').history[0]
+	sensitive_data = {'expands': 'x', 'unrelated': 'safe'}
+
+	filtered = history._filter_sensitive_data_from_dict({'x': 'value'}, sensitive_data)
+	filtered_key = next(iter(filtered))
+
+	assert len(filtered_key) == 1
+	assert all(secret not in filtered_key for secret in sensitive_data.values())
+	assert filtered[filtered_key] == 'value'
+
+
+def test_generated_string_filter_skips_singleton_secrets_across_the_bmp_private_use_range():
+	history = _history('unused').history[0]
+	sensitive_data = {f'pua_{codepoint:x}': chr(codepoint) for codepoint in range(0xE000, 0xF900)}
+	sensitive_data['generated'] = '<secret>pua_e000</secret>'
+
+	filtered = history._filter_sensitive_data_from_dict({chr(0xE000): 'value'}, sensitive_data)
+	filtered_key = next(iter(filtered))
+
+	assert len(filtered_key) == 1
+	assert filtered_key not in sensitive_data.values()
+	assert ord(filtered_key) >= 0xF0000
+	assert filtered[filtered_key] == 'value'
+
+
 def test_recursive_filter_handles_deep_containers_without_recursion():
 	secret = 'token-123'
 	history = _history(secret).history[0]

--- a/tests/ci/security/test_history_sensitive_data.py
+++ b/tests/ci/security/test_history_sensitive_data.py
@@ -266,12 +266,19 @@ def test_generated_string_filter_uses_an_opaque_fallback_for_replacement_cycles(
 		'b': '<secret>a</secret>',
 	}
 
-	filtered = history._filter_sensitive_data_from_dict({'<secret>a</secret>': 'value'}, sensitive_data)
+	filtered = history._filter_sensitive_data_from_dict({'<secret>a</secret>': '<secret>b</secret>'}, sensitive_data)
 	filtered_key = next(iter(filtered))
+	filtered_value = filtered[filtered_key]
 
 	assert len(filtered_key) == 1
-	assert all(secret not in filtered_key for secret in sensitive_data.values() if isinstance(secret, str))
-	assert filtered[filtered_key] == 'value'
+	assert len(filtered_value) == 1
+	assert filtered_key != filtered_value
+	assert all(
+		secret not in output
+		for output in (filtered_key, filtered_value)
+		for secret in sensitive_data.values()
+		if isinstance(secret, str)
+	)
 
 
 def test_generated_string_filter_bounds_expanding_replacements():

--- a/tests/ci/security/test_history_sensitive_data.py
+++ b/tests/ci/security/test_history_sensitive_data.py
@@ -1,3 +1,5 @@
+import json
+
 from pydantic import BaseModel
 
 from browser_use.agent.views import AgentHistory, AgentHistoryList, AgentOutput
@@ -16,7 +18,7 @@ class HistorySensitiveAction(ActionModel):
 	input: HistorySensitiveParams
 
 
-def _history(secret: str) -> AgentHistoryList:
+def _history(secret: str, lookup: dict[str, str] | None = None) -> AgentHistoryList:
 	custom_output = AgentOutput.type_with_custom_actions(HistorySensitiveAction)
 	return AgentHistoryList(
 		history=[
@@ -30,7 +32,9 @@ def _history(secret: str) -> AgentHistoryList:
 							input=HistorySensitiveParams(
 								rows=[[secret]],
 								payload=({'credentials': (secret, ['safe', secret])},),
-								lookup={secret: 'secret-key', '<secret>api_key</secret>': 'literal-key'},
+								lookup=lookup
+								if lookup is not None
+								else {secret: 'secret-key', '<secret>api_key</secret>': 'literal-key'},
 								unchanged='safe',
 							)
 						)
@@ -216,6 +220,27 @@ def test_recursive_filter_does_not_reuse_an_unchanged_user_value_as_a_fallback()
 	assert filtered_unchanged == unchanged
 	assert filtered_secret != filtered_unchanged
 	assert secret not in filtered_secret
+
+
+def test_save_to_file_does_not_reuse_an_unchanged_user_value_as_a_generated_key(tmp_path):
+	secret = 'token-123'
+	unchanged = '<secret>api_key</secret>'
+	output_path = tmp_path / 'history.json'
+
+	_history(secret, lookup={secret: unchanged, 'literal-key': 'kept'}).save_to_file(
+		output_path, sensitive_data={'api_key': secret}
+	)
+	saved = json.loads(output_path.read_text(encoding='utf-8'))
+	lookup = saved['history'][0]['model_output']['action'][0]['input']['lookup']
+	generated_keys = set(lookup) - {'literal-key'}
+	filtered_key = next(iter(generated_keys))
+
+	assert len(lookup) == 2
+	assert len(generated_keys) == 1
+	assert lookup['literal-key'] == 'kept'
+	assert lookup[filtered_key] == unchanged
+	assert filtered_key != unchanged
+	assert secret not in output_path.read_text(encoding='utf-8')
 
 
 def test_recursive_filter_does_not_reuse_an_unchanged_user_value_for_a_circular_marker():


### PR DESCRIPTION
## Summary

Current main already filters ordinary nested values (63d13371, closing #5623), but leaves mapping keys untouched. A configured secret used as a key still appears in `AgentHistory.model_dump()` and persisted history. This PR now builds on that upstream fix and protects the remaining mapping-key boundary.

- Redact mapping keys, preserve literal keys, and retain collisions with stable suffixes.
- Keep generated replacements free of configured secrets without confusing them with unchanged user values.
- Traverse dict/list/tuple containers iteratively; replace circular branches with a non-sensitive marker.

Filtering still applies to action input under the existing serialization contract. This does not broaden filtering to every action or `ActionResult`, which is separate from the work in #5680 and #5709. Pydantic serialization can still reject malformed raw models before this filter runs.

## Validation

Rebased onto current main `50f205533fe10ba35b553d2a3689c77b87bd5d0a`.

- `ANONYMIZED_TELEMETRY=false python -m pytest tests/ci/security/test_history_sensitive_data.py tests/ci/security/test_sensitive_data.py -q`: **35 passed** on CPython 3.13.15.
- The mapping-key `model_dump` regression fails with the exact current-main `views.py`: `token-123` remains as a key. Both saved-file regressions also fail on current main with `token-123` in the JSON. The patched tests exercise real Pydantic action models and saved history files, with collision, generated-replacement, circular-container and deep-container cases.
- All configured pre-commit hooks passed for both changed files, including Ruff and Pyright. `git diff --check` passed.

Related: #5623 (ordinary nested values already fixed upstream).
