### PR TITLE
fix(llm): keep Google system instruction when assistant precedes first user

### DIFF
--- a/browser_use/llm/google/serializer.py
+++ b/browser_use/llm/google/serializer.py
@@ -69,7 +69,9 @@ class GoogleMessageSerializer:
 			# Initialize message parts
 			message_parts: list[Part] = []
 
-			# If this is the first user message and we have system parts, prepend them
+			# Prepend pending system parts to the first user message, even if a
+			# model turn was already serialized. Clearing system_parts prevents
+			# later user messages from receiving the same prefix.
 			system_text = None
 			# Merge into the *first* user message. An earlier assistant turn must not disqualify it,
 			# but a user message that has already been serialized must: the merge target is gone, so

--- a/tests/ci/models/test_llm_google.py
+++ b/tests/ci/models/test_llm_google.py
@@ -243,3 +243,142 @@ def test_include_system_in_user_keeps_the_agent_state_message(tmp_path):
 	text, images = _describe(contents)
 	assert 'Buy a red stapler' in text, 'the task never reached the model'
 	assert images == 1, 'the screenshot never reached the model'
+
+
+def test_include_system_in_user_prepends_after_an_assistant_turn():
+	"""System text must still reach the first user message after a prior model turn.
+
+	include_system_in_user is documented as prepending to the first user message, not
+	the first formatted message. If an assistant turn is serialized first, the system
+	text must not be dropped.
+	"""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import AssistantMessage, SystemMessage, UserMessage
+
+	messages = [
+		SystemMessage(content='Follow the system rule.'),
+		AssistantMessage(content='Earlier assistant turn.'),
+		UserMessage(content='Continue the task.'),
+	]
+
+	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+
+	assert system_instruction is None
+	assert len(contents) == 2
+	assert contents[0].role == 'model'
+	assert contents[1].role == 'user'
+	assert contents[1].parts is not None
+	assert contents[1].parts[0].text == 'Follow the system rule.\n\nContinue the task.'
+
+
+def test_include_system_in_user_prepends_after_multiple_assistant_turns():
+	"""Two model turns before the first user message must not drop the system text."""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import AssistantMessage, SystemMessage, UserMessage
+
+	messages = [
+		SystemMessage(content='Follow the system rule.'),
+		AssistantMessage(content='First assistant turn.'),
+		AssistantMessage(content='Second assistant turn.'),
+		UserMessage(content='Continue the task.'),
+	]
+
+	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+
+	assert system_instruction is None
+	assert [content.role for content in contents] == ['model', 'model', 'user']
+	assert contents[-1].parts is not None
+	assert contents[-1].parts[0].text == 'Follow the system rule.\n\nContinue the task.'
+
+
+def test_include_system_in_user_prepends_only_to_the_first_user_message():
+	"""Later user messages must not receive a second copy of the system text."""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import AssistantMessage, SystemMessage, UserMessage
+
+	messages = [
+		SystemMessage(content='Follow the system rule.'),
+		AssistantMessage(content='Earlier assistant turn.'),
+		UserMessage(content='First user turn.'),
+		UserMessage(content='Second user turn.'),
+	]
+
+	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+
+	assert system_instruction is None
+	assert [content.role for content in contents] == ['model', 'user', 'user']
+	assert contents[1].parts is not None
+	assert contents[1].parts[0].text == 'Follow the system rule.\n\nFirst user turn.'
+	assert contents[2].parts is not None
+	assert contents[2].parts[0].text == 'Second user turn.'
+
+
+def test_include_system_in_user_keeps_list_content_after_an_assistant_turn():
+	"""List user content after a model turn must keep system text, user text, and images."""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import (
+		AssistantMessage,
+		ContentPartImageParam,
+		ContentPartTextParam,
+		ImageURL,
+		SystemMessage,
+		UserMessage,
+	)
+
+	messages = [
+		SystemMessage(content='You are a browser agent.'),
+		AssistantMessage(content='Earlier assistant turn.'),
+		UserMessage(
+			content=[
+				ContentPartTextParam(text='<browser_state>the page and the task live here</browser_state>'),
+				ContentPartImageParam(image_url=ImageURL(url=f'data:image/png;base64,{_PNG_1PX}', media_type='image/png')),
+			]
+		),
+	]
+
+	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+
+	assert system_instruction is None
+	assert contents[0].role == 'model'
+	assert contents[1].role == 'user'
+	text, images = _describe(contents)
+	assert 'You are a browser agent.' in text
+	assert '<browser_state>the page and the task live here</browser_state>' in text
+	assert images == 1
+
+
+def test_include_system_in_user_false_returns_system_instruction():
+	"""Default path still extracts system text separately and leaves user content alone."""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import AssistantMessage, SystemMessage, UserMessage
+
+	messages = [
+		SystemMessage(content='Follow the system rule.'),
+		AssistantMessage(content='Earlier assistant turn.'),
+		UserMessage(content='Continue the task.'),
+	]
+
+	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=False)
+
+	assert system_instruction == 'Follow the system rule.'
+	assert [content.role for content in contents] == ['model', 'user']
+	assert contents[1].parts is not None
+	assert contents[1].parts[0].text == 'Continue the task.'
+
+
+def test_include_system_in_user_with_no_system_message():
+	"""A conversation without a system message is serialized unchanged."""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import AssistantMessage, UserMessage
+
+	messages = [
+		AssistantMessage(content='Earlier assistant turn.'),
+		UserMessage(content='Continue the task.'),
+	]
+
+	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+
+	assert system_instruction is None
+	assert [content.role for content in contents] == ['model', 'user']
+	assert contents[1].parts is not None
+	assert contents[1].parts[0].text == 'Continue the task.'

--- a/tests/ci/models/test_llm_google.py
+++ b/tests/ci/models/test_llm_google.py
@@ -138,6 +138,11 @@ def _flatten(contents) -> list:
 	return [part for content in contents for part in (content.parts or [])]
 
 
+def _turns(contents) -> list:
+	"""Materialise ContentListUnion as a list so tests can index roles and parts."""
+	return list(contents)
+
+
 def _describe(contents) -> tuple[str, int]:
 	"""Summarise serialized Google contents as (all text, number of inline images)."""
 	parts = _flatten(contents)
@@ -262,13 +267,14 @@ def test_include_system_in_user_prepends_after_an_assistant_turn():
 	]
 
 	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+	turns = _turns(contents)
 
 	assert system_instruction is None
-	assert len(contents) == 2
-	assert contents[0].role == 'model'
-	assert contents[1].role == 'user'
-	assert contents[1].parts is not None
-	assert contents[1].parts[0].text == 'Follow the system rule.\n\nContinue the task.'
+	assert len(turns) == 2
+	assert turns[0].role == 'model'
+	assert turns[1].role == 'user'
+	assert turns[1].parts is not None
+	assert turns[1].parts[0].text == 'Follow the system rule.\n\nContinue the task.'
 
 
 def test_include_system_in_user_prepends_after_multiple_assistant_turns():
@@ -284,11 +290,12 @@ def test_include_system_in_user_prepends_after_multiple_assistant_turns():
 	]
 
 	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+	turns = _turns(contents)
 
 	assert system_instruction is None
-	assert [content.role for content in contents] == ['model', 'model', 'user']
-	assert contents[-1].parts is not None
-	assert contents[-1].parts[0].text == 'Follow the system rule.\n\nContinue the task.'
+	assert [turn.role for turn in turns] == ['model', 'model', 'user']
+	assert turns[-1].parts is not None
+	assert turns[-1].parts[0].text == 'Follow the system rule.\n\nContinue the task.'
 
 
 def test_include_system_in_user_prepends_only_to_the_first_user_message():
@@ -304,13 +311,14 @@ def test_include_system_in_user_prepends_only_to_the_first_user_message():
 	]
 
 	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+	turns = _turns(contents)
 
 	assert system_instruction is None
-	assert [content.role for content in contents] == ['model', 'user', 'user']
-	assert contents[1].parts is not None
-	assert contents[1].parts[0].text == 'Follow the system rule.\n\nFirst user turn.'
-	assert contents[2].parts is not None
-	assert contents[2].parts[0].text == 'Second user turn.'
+	assert [turn.role for turn in turns] == ['model', 'user', 'user']
+	assert turns[1].parts is not None
+	assert turns[1].parts[0].text == 'Follow the system rule.\n\nFirst user turn.'
+	assert turns[2].parts is not None
+	assert turns[2].parts[0].text == 'Second user turn.'
 
 
 def test_include_system_in_user_keeps_list_content_after_an_assistant_turn():
@@ -337,10 +345,11 @@ def test_include_system_in_user_keeps_list_content_after_an_assistant_turn():
 	]
 
 	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+	turns = _turns(contents)
 
 	assert system_instruction is None
-	assert contents[0].role == 'model'
-	assert contents[1].role == 'user'
+	assert turns[0].role == 'model'
+	assert turns[1].role == 'user'
 	text, images = _describe(contents)
 	assert 'You are a browser agent.' in text
 	assert '<browser_state>the page and the task live here</browser_state>' in text
@@ -359,11 +368,12 @@ def test_include_system_in_user_false_returns_system_instruction():
 	]
 
 	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=False)
+	turns = _turns(contents)
 
 	assert system_instruction == 'Follow the system rule.'
-	assert [content.role for content in contents] == ['model', 'user']
-	assert contents[1].parts is not None
-	assert contents[1].parts[0].text == 'Continue the task.'
+	assert [turn.role for turn in turns] == ['model', 'user']
+	assert turns[1].parts is not None
+	assert turns[1].parts[0].text == 'Continue the task.'
 
 
 def test_include_system_in_user_with_no_system_message():
@@ -377,8 +387,9 @@ def test_include_system_in_user_with_no_system_message():
 	]
 
 	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages, include_system_in_user=True)
+	turns = _turns(contents)
 
 	assert system_instruction is None
-	assert [content.role for content in contents] == ['model', 'user']
-	assert contents[1].parts is not None
-	assert contents[1].parts[0].text == 'Continue the task.'
+	assert [turn.role for turn in turns] == ['model', 'user']
+	assert turns[1].parts is not None
+	assert turns[1].parts[0].text == 'Continue the task.'


### PR DESCRIPTION
Fixes #5624

## Problem

`GoogleMessageSerializer.serialize_messages(..., include_system_in_user=True)` is documented as prepending system/developer text to the first user message. That only happened when the first user message was also the first formatted non-system message.

For `system -> assistant -> user`, the system text was neither returned as `system_instruction` nor copied into the user turn. Gemini therefore received the conversation without the configured rules.

This is a different failure from #5596 / #5597, which kept list/image user parts once the prepend branch ran. Those PRs still left the prepend itself gated on an empty `formatted_messages` list.

## Cause

System text is accumulated into `system_parts` when `include_system_in_user=True`. The prepend then required:

```python
include_system_in_user and system_parts and role == "user" and not formatted_messages
```

Serializing an assistant/model turn first makes `formatted_messages` non-empty. The later first user message never consumes `system_parts`. Because the flag is on, that text is also not assigned to the separate `system_instruction` return value, so it is dropped.

## Fix

Drop the `not formatted_messages` guard. The first user message still consumes pending `system_parts`, and the list is cleared so later user messages are not prepended again.

`include_system_in_user=False` is unchanged: system text is still returned separately as `system_instruction`.

## Tests

Added cases in `tests/ci/models/test_llm_google.py`:

- system -> assistant -> user (the issue reproduction)
- system -> assistant -> assistant -> user
- later user messages do not receive a second copy
- list + image user content after an assistant turn
- `include_system_in_user=False` still returns `system_instruction`
- no system message

Existing coverage for `system -> user`, string content, list content, and image parts is unchanged.

Verification:

- `uv run pytest tests/ci/models/test_llm_google.py` — 14 passed, 1 skipped (live Gemini, no API key)
- `pre-commit run --files browser_use/llm/google/serializer.py tests/ci/models/test_llm_google.py` — all hooks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5624: Google serializer no longer drops the system instruction when an assistant message precedes the first user message. Previously the prepend only ran when `formatted_messages` was empty, so system text was neither prepended nor returned separately. Now the first user message always consumes pending system parts, and those parts are cleared to prevent duplicate prepends later.

- Keeps `include_system_in_user=False` behavior, which still returns system text as `system_instruction`.
- Adds tests for assistant-first conversations, multiple assistant turns, no double prepend, list/image content, and the flag-disabled path.

<sup>Written for commit d14f582588d6a80a56c2da4d52a468a8bb7a9188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

