### PR TITLE
fix(google): preserve multiple system messages

### DIFF
--- a/browser_use/llm/google/serializer.py
+++ b/browser_use/llm/google/serializer.py
@@ -47,10 +47,7 @@ class GoogleMessageSerializer:
 			if isinstance(message, SystemMessage) or role in ['system', 'developer']:
 				# Extract system message content as string
 				if isinstance(message.content, str):
-					if include_system_in_user:
-						system_parts.append(message.content)
-					else:
-						system_message = message.content
+					system_parts.append(message.content)
 				elif message.content is not None:
 					# Handle Iterable of content parts
 					parts = []
@@ -58,10 +55,7 @@ class GoogleMessageSerializer:
 						if part.type == 'text':
 							parts.append(part.text)
 					combined_text = '\n'.join(parts)
-					if include_system_in_user:
-						system_parts.append(combined_text)
-					else:
-						system_message = combined_text
+					system_parts.append(combined_text)
 				continue
 
 			# Determine the role for non-system messages
@@ -120,5 +114,8 @@ class GoogleMessageSerializer:
 				final_message = Content(role=role, parts=message_parts)
 				# for some reason, the type checker is not able to infer the type of formatted_messages
 				formatted_messages.append(final_message)  # type: ignore
+
+		if not include_system_in_user and system_parts:
+			system_message = '\n\n'.join(system_parts)
 
 		return formatted_messages, system_message

--- a/tests/ci/models/test_llm_google.py
+++ b/tests/ci/models/test_llm_google.py
@@ -209,9 +209,7 @@ def test_multiple_system_messages_are_preserved_when_extracted():
 
 	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages)
 
-	assert system_instruction == (
-		'Follow the base system rule.\n\nAlso follow the additional system rule.'
-	)
+	assert system_instruction == ('Follow the base system rule.\n\nAlso follow the additional system rule.')
 	text, images = _describe(contents)
 	assert text == 'Continue the task.'
 	assert images == 0

--- a/tests/ci/models/test_llm_google.py
+++ b/tests/ci/models/test_llm_google.py
@@ -196,6 +196,27 @@ def test_include_system_in_user_string_content_is_merged_into_one_part():
 	assert parts[0].text == 'You are a browser agent.\n\nBuy a red stapler'
 
 
+def test_multiple_system_messages_are_preserved_when_extracted():
+	"""Extracted system instructions retain every message in their original order."""
+	from browser_use.llm.google.serializer import GoogleMessageSerializer
+	from browser_use.llm.messages import SystemMessage, UserMessage
+
+	messages = [
+		SystemMessage(content='Follow the base system rule.'),
+		SystemMessage(content='Also follow the additional system rule.'),
+		UserMessage(content='Continue the task.'),
+	]
+
+	contents, system_instruction = GoogleMessageSerializer.serialize_messages(messages)
+
+	assert system_instruction == (
+		'Follow the base system rule.\n\nAlso follow the additional system rule.'
+	)
+	text, images = _describe(contents)
+	assert text == 'Continue the task.'
+	assert images == 0
+
+
 def test_include_system_in_user_keeps_the_agent_state_message(tmp_path):
 	"""End-to-end shape: what the agent actually builds with vision on must survive serialization."""
 	from browser_use.agent.prompts import AgentMessagePrompt, SystemPrompt


### PR DESCRIPTION
## Problem
`GoogleMessageSerializer.serialize_messages` drops earlier system messages when multiple system messages are provided with the default `include_system_in_user=False` behavior. The resulting Gemini request contains only the final instruction.

## Root Cause
The serializer overwrites `system_message` for each system message instead of preserving the ordered sequence. The existing `system_parts` accumulator is only used for the `include_system_in_user=True` path.

## Solution
Accumulate extracted system text for both modes and join it once with the existing double-newline separator when returning a separate system instruction.

## Changes
- Preserve string and iterable-text system messages in their original order.
- Add a regression test covering two extracted system messages and the unchanged user content.

## Testing
- Baseline on `origin/main`: the issue reproducer failed because only the last system message was returned.
- `\.venv\Scripts\python.exe -m pytest -o addopts='' --basetemp=.pytest-tmp-5628 tests/ci/models/test_llm_google.py -q`: 9 passed, 1 skipped.
- Ruff check on the changed files: passed.
- Pyright on the changed source and test with the repository environment: 0 errors.
- `git diff --check`: passed.
- `pre-commit` was attempted but could not initialize its Python 3.11 hook environment because Python 3.11 is unavailable on this Windows host.
- Ruff format check was attempted; it reports existing repository-wide CRLF/formatter differences in these files, with no unrelated formatting rewrite applied.

## Compatibility/Risk
This only changes the default extracted system-instruction value from the last system message to the ordered concatenation of all system messages. Single-system-message behavior and the `include_system_in_user=True` path remain unchanged. No provider request or API key is required by the regression test.

## Notes for Reviewer
The fix is intentionally limited to the serializer and its focused test. The baseline reproducer and final suite use the same message order and verify that the user turn remains unchanged.

## Linked Issue
Fixes #5628

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GoogleMessageSerializer.serialize_messages` so Gemini requests keep every system message instead of only the last one: with `include_system_in_user=False`, only the final instruction was extracted; now all system messages are concatenated in order with a double newline. Single-system-message behavior and the `include_system_in_user=True` path are unchanged. Fixes #5628.

**Bug Fixes**
- Adds a regression test covering two extracted system messages and unchanged user content.

<sup>Written for commit 579458ce0f6dab09fac8c67964d3bf600c1a7f92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

