### PR TITLE
fix(dom): preserve visible code with ordinary IDs

### DIFF
--- a/browser_use/dom/serializer/html_serializer.py
+++ b/browser_use/dom/serializer/html_serializer.py
@@ -81,7 +81,7 @@ class HTMLSerializer:
 				element_id = node.attributes.get('id', '')
 				element_id_lower = element_id.lower()
 				if 'bpr-guid' in element_id or (
-					not node.is_visible and ('data' in element_id_lower or 'state' in element_id_lower)
+					node.is_visible is False and ('data' in element_id_lower or 'state' in element_id_lower)
 				):
 					return ''
 

--- a/browser_use/dom/serializer/html_serializer.py
+++ b/browser_use/dom/serializer/html_serializer.py
@@ -78,7 +78,7 @@ class HTMLSerializer:
 					return ''
 				# Also check for bpr-guid IDs (LinkedIn's JSON data pattern)
 				element_id = node.attributes.get('id', '')
-				if 'bpr-guid' in element_id or 'data' in element_id or 'state' in element_id:
+				if 'bpr-guid' in element_id:
 					return ''
 
 			# Skip base64 inline images - these are usually placeholders or tracking pixels

--- a/browser_use/dom/serializer/html_serializer.py
+++ b/browser_use/dom/serializer/html_serializer.py
@@ -77,9 +77,12 @@ class HTMLSerializer:
 				normalized_style = ''.join(style.lower().split())
 				if 'display:none' in normalized_style:
 					return ''
-				# Also check for bpr-guid IDs (LinkedIn's JSON data pattern)
+				# Preserve visible code examples, but filter hidden application state.
 				element_id = node.attributes.get('id', '')
-				if 'bpr-guid' in element_id:
+				element_id_lower = element_id.lower()
+				if 'bpr-guid' in element_id or (
+					not node.is_visible and ('data' in element_id_lower or 'state' in element_id_lower)
+				):
 					return ''
 
 			# Skip base64 inline images - these are usually placeholders or tracking pixels

--- a/tests/ci/test_html_serializer.py
+++ b/tests/ci/test_html_serializer.py
@@ -14,7 +14,7 @@ def _make_node(
 	node_value: str = '',
 	attributes: dict[str, str] | None = None,
 	children: list[EnhancedDOMTreeNode] | None = None,
-	is_visible: bool = True,
+	is_visible: bool | None = True,
 ) -> EnhancedDOMTreeNode:
 	node = EnhancedDOMTreeNode(
 		node_id=1,
@@ -44,7 +44,7 @@ def _make_node(
 	return node
 
 
-def _serialize_code(element_id: str, *, style: str = 'display: inline', is_visible: bool = True) -> tuple[str, str]:
+def _serialize_code(element_id: str, *, style: str = 'display: inline', is_visible: bool | None = True) -> tuple[str, str]:
 	text = _make_node(NodeType.TEXT_NODE, '#text', node_value='visible code content')
 	code = _make_node(
 		NodeType.ELEMENT_NODE,
@@ -60,9 +60,10 @@ def _serialize_code(element_id: str, *, style: str = 'display: inline', is_visib
 	return html, markdown
 
 
-@pytest.mark.parametrize('element_id', ['user-data', 'workflow-state', 'snippet-1'])
-def test_visible_code_with_ordinary_id_is_preserved(element_id: str):
-	html, markdown = _serialize_code(element_id)
+@pytest.mark.parametrize('element_id', ['user-data', 'workflow-state', 'snippet-1', 'metadata', 'database', 'estate'])
+@pytest.mark.parametrize('is_visible', [True, None])
+def test_visible_or_unknown_code_with_ordinary_id_is_preserved(element_id: str, is_visible: bool | None):
+	html, markdown = _serialize_code(element_id, is_visible=is_visible)
 
 	assert 'visible code content' in html
 	assert 'visible code content' in markdown
@@ -75,8 +76,9 @@ def test_code_with_display_none_is_filtered():
 	assert markdown == ''
 
 
-def test_hidden_data_or_state_code_remains_filtered():
-	html, markdown = _serialize_code('workflow-state', style='', is_visible=False)
+@pytest.mark.parametrize('element_id', ['workflow-state', 'metadata', 'database', 'estate'])
+def test_hidden_data_or_state_code_remains_filtered(element_id: str):
+	html, markdown = _serialize_code(element_id, style='', is_visible=False)
 
 	assert html == ''
 	assert markdown == ''

--- a/tests/ci/test_html_serializer.py
+++ b/tests/ci/test_html_serializer.py
@@ -1,0 +1,80 @@
+"""Regression tests for enhanced DOM HTML serialization."""
+
+import pytest
+
+from browser_use.dom.markdown_extractor import convert_html_to_markdown
+from browser_use.dom.serializer.html_serializer import HTMLSerializer
+from browser_use.dom.views import EnhancedDOMTreeNode, NodeType
+
+
+def _make_node(
+	node_type: NodeType,
+	node_name: str,
+	*,
+	node_value: str = '',
+	attributes: dict[str, str] | None = None,
+	children: list[EnhancedDOMTreeNode] | None = None,
+) -> EnhancedDOMTreeNode:
+	node = EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=node_type,
+		node_name=node_name,
+		node_value=node_value,
+		attributes=attributes or {},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=children,
+		ax_node=None,
+		snapshot_node=None,
+	)
+
+	for child in children or []:
+		child.parent_node = node
+
+	return node
+
+
+def _serialize_code(element_id: str, *, style: str = 'display: inline') -> tuple[str, str]:
+	text = _make_node(NodeType.TEXT_NODE, '#text', node_value='visible code content')
+	code = _make_node(
+		NodeType.ELEMENT_NODE,
+		'CODE',
+		attributes={'id': element_id, 'style': style},
+		children=[text],
+	)
+	document = _make_node(NodeType.DOCUMENT_NODE, '#document', children=[code])
+
+	html = HTMLSerializer().serialize(document)
+	markdown, _, _ = convert_html_to_markdown(html)
+	return html, markdown
+
+
+@pytest.mark.parametrize('element_id', ['user-data', 'workflow-state', 'snippet-1'])
+def test_visible_code_with_ordinary_id_is_preserved(element_id: str):
+	html, markdown = _serialize_code(element_id)
+
+	assert 'visible code content' in html
+	assert 'visible code content' in markdown
+
+
+def test_code_with_display_none_is_filtered():
+	html, markdown = _serialize_code('user-data', style='display: none')
+
+	assert html == ''
+	assert markdown == ''
+
+
+def test_linkedin_application_state_code_is_filtered():
+	html, markdown = _serialize_code('bpr-guid-123')
+
+	assert html == ''
+	assert markdown == ''

--- a/tests/ci/test_html_serializer.py
+++ b/tests/ci/test_html_serializer.py
@@ -14,6 +14,7 @@ def _make_node(
 	node_value: str = '',
 	attributes: dict[str, str] | None = None,
 	children: list[EnhancedDOMTreeNode] | None = None,
+	is_visible: bool = True,
 ) -> EnhancedDOMTreeNode:
 	node = EnhancedDOMTreeNode(
 		node_id=1,
@@ -23,7 +24,7 @@ def _make_node(
 		node_value=node_value,
 		attributes=attributes or {},
 		is_scrollable=None,
-		is_visible=True,
+		is_visible=is_visible,
 		absolute_position=None,
 		target_id='target-1',
 		frame_id=None,
@@ -43,13 +44,14 @@ def _make_node(
 	return node
 
 
-def _serialize_code(element_id: str, *, style: str = 'display: inline') -> tuple[str, str]:
+def _serialize_code(element_id: str, *, style: str = 'display: inline', is_visible: bool = True) -> tuple[str, str]:
 	text = _make_node(NodeType.TEXT_NODE, '#text', node_value='visible code content')
 	code = _make_node(
 		NodeType.ELEMENT_NODE,
 		'CODE',
 		attributes={'id': element_id, 'style': style},
 		children=[text],
+		is_visible=is_visible,
 	)
 	document = _make_node(NodeType.DOCUMENT_NODE, '#document', children=[code])
 
@@ -68,6 +70,13 @@ def test_visible_code_with_ordinary_id_is_preserved(element_id: str):
 
 def test_code_with_display_none_is_filtered():
 	html, markdown = _serialize_code('user-data', style='display: none')
+
+	assert html == ''
+	assert markdown == ''
+
+
+def test_hidden_data_or_state_code_remains_filtered():
+	html, markdown = _serialize_code('workflow-state', style='', is_visible=False)
 
 	assert html == ''
 	assert markdown == ''


### PR DESCRIPTION
## Summary

- preserve visible `<code>` elements whose ordinary IDs contain `data` or `state`
- keep filtering hidden code and LinkedIn `bpr-guid` application-state blocks
- add regression coverage for both HTML serialization and downstream Markdown conversion

## Testing

- `uv run pytest tests/ci/test_html_serializer.py tests/ci/test_markdown_extractor.py tests/ci/test_markdown_chunking.py -q` (43 passed)
- `uv run pre-commit run --files browser_use/dom/serializer/html_serializer.py tests/ci/test_html_serializer.py`

Closes #5629

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the DOM serializer so visible or unknown-visibility `<code>` elements with IDs containing `data` or `state` are no longer dropped, while hidden elements and LinkedIn's `bpr-guid` IDs are still filtered. Adds regression tests covering HTML serialization and Markdown conversion for these cases. Closes #5629.

<sup>Written for commit a3bb2a9cae848bcfc86d56f282a0dca0317475a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

