### PR TITLE
fix(anthropic): treat data URL scheme and media type case-insensitively

### DIFF
--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -29,20 +29,30 @@ class AnthropicMessageSerializer:
 
 	@staticmethod
 	def _is_base64_image(url: str) -> bool:
-		"""Check if the URL is a base64 encoded image."""
-		return url.startswith('data:image/')
+		"""Check if the URL is a base64 encoded image.
+
+		URI scheme names are case-insensitive (RFC 3986). MIME type/subtype
+		names are case-insensitive (RFC 2045). Compare the lowered scheme and
+		media type so DATA:image/PNG;base64,... is still treated as a data URL.
+		"""
+		scheme, sep, remainder = url.partition(':')
+		if not sep or scheme.lower() != 'data':
+			return False
+		media_type = remainder.split(',', 1)[0].split(';', 1)[0].lower()
+		return media_type.startswith('image/')
 
 	@staticmethod
 	def _parse_base64_url(url: str) -> tuple[SupportedImageMediaType, str]:
 		"""Parse a base64 data URL to extract media type and data."""
-		# Format: data:image/jpeg;base64,<data>
-		if not url.startswith('data:'):
+		# Format: data:image/jpeg;base64,<data> (scheme and media type case-insensitive)
+		scheme, sep, remainder = url.partition(':')
+		if not sep or scheme.lower() != 'data':
 			raise ValueError(f'Invalid base64 URL: {url}')
 
-		header, data = url.split(',', 1)
-		media_type = header.split(';')[0].replace('data:', '')
+		header, data = remainder.split(',', 1)
+		media_type = header.split(';', 1)[0].lower()
 
-		# Ensure it's a supported media type
+		# Ensure it's a supported media type (canonical lowercase for Anthropic)
 		supported_types = ['image/jpeg', 'image/png', 'image/gif', 'image/webp']
 		if media_type not in supported_types:
 			# Default to jpeg if not recognized

--- a/tests/ci/models/test_anthropic_data_url_case.py
+++ b/tests/ci/models/test_anthropic_data_url_case.py
@@ -1,4 +1,5 @@
 import pytest
+from anthropic.types import ImageBlockParam
 
 from browser_use.llm.anthropic.serializer import AnthropicMessageSerializer
 from browser_use.llm.messages import ContentPartImageParam, ImageURL, UserMessage
@@ -10,11 +11,16 @@ WEBP_DATA = 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA'
 HTTPS_URL = 'https://example.com/cat.png'
 
 
-def serialize_image(url: str):
+def serialize_image(url: str) -> ImageBlockParam:
 	message = UserMessage(content=[ContentPartImageParam(image_url=ImageURL(url=url))])
 	serialized = AnthropicMessageSerializer.serialize(message)
-	assert isinstance(serialized['content'], list)
-	return serialized['content'][0]
+	content = serialized['content']
+	assert isinstance(content, list)
+	block = content[0]
+	# Narrow the ContentBlockParam union down to an image block before indexing into it.
+	assert isinstance(block, dict)
+	assert block['type'] == 'image'
+	return block
 
 
 @pytest.mark.parametrize(

--- a/tests/ci/models/test_anthropic_data_url_case.py
+++ b/tests/ci/models/test_anthropic_data_url_case.py
@@ -1,0 +1,58 @@
+import pytest
+
+from browser_use.llm.anthropic.serializer import AnthropicMessageSerializer
+from browser_use.llm.messages import ContentPartImageParam, ImageURL, UserMessage
+
+PNG_DATA = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+JPEG_DATA = '/9j/4AAQSkZJRgABAQAAAQABAAD/2wAAA=='
+GIF_DATA = 'R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=='
+WEBP_DATA = 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA'
+HTTPS_URL = 'https://example.com/cat.png'
+
+
+def serialize_image(url: str):
+	message = UserMessage(content=[ContentPartImageParam(image_url=ImageURL(url=url))])
+	serialized = AnthropicMessageSerializer.serialize(message)
+	assert isinstance(serialized['content'], list)
+	return serialized['content'][0]
+
+
+@pytest.mark.parametrize(
+	'url',
+	[
+		f'data:image/png;base64,{PNG_DATA}',
+		f'data:image/PNG;base64,{PNG_DATA}',
+		f'DATA:image/png;base64,{PNG_DATA}',
+		f'Data:Image/Png;base64,{PNG_DATA}',
+	],
+)
+def test_data_url_case_variants_remain_png_base64_images(url):
+	block = serialize_image(url)
+	assert block['source'] == {
+		'type': 'base64',
+		'media_type': 'image/png',
+		'data': PNG_DATA,
+	}
+
+
+@pytest.mark.parametrize(
+	'media_type,data',
+	[
+		('image/jpeg', JPEG_DATA),
+		('image/png', PNG_DATA),
+		('image/gif', GIF_DATA),
+		('image/webp', WEBP_DATA),
+	],
+)
+def test_supported_media_types_keep_canonical_lowercase(media_type, data):
+	block = serialize_image(f'data:{media_type.upper()};base64,{data}')
+	assert block['source'] == {
+		'type': 'base64',
+		'media_type': media_type,
+		'data': data,
+	}
+
+
+def test_remote_https_image_stays_a_url_source():
+	block = serialize_image(HTTPS_URL)
+	assert block['source'] == {'type': 'url', 'url': HTTPS_URL}


### PR DESCRIPTION
Fixes #5632

`AnthropicMessageSerializer` compared data URL schemes and image media types case-sensitively. `data:image/PNG;base64,...` kept the PNG bytes but labeled them `image/jpeg`; `DATA:image/png;base64,...` was treated as a remote URL source.

Scheme names (RFC 3986) and MIME type/subtype names (RFC 2045) are case-insensitive. The parser now lowercases those for matching and emits the canonical lowercase media types Anthropic expects, without changing the base64 payload.

Verified with `uv run pytest tests/ci/models/test_anthropic_data_url_case.py` (9 passed) and `ruff check` on the touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5632 by treating data URL schemes and media types case-insensitively in `AnthropicMessageSerializer`. `data:image/PNG;base64,...` previously relabeled PNG bytes as `image/jpeg`, and `DATA:image/png;base64,...` was treated as a remote URL; now both are parsed as base64 images with canonical lowercase media types, leaving the base64 payload unchanged.

- Adds tests for case variants, canonical media type output, and remote URL handling.

<sup>Written for commit 72fc5d2a7db4a505579d8c60607b042d13dedfd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

