### PR TITLE
fix: surface failed tab switches as errors

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -1007,25 +1007,23 @@ class Tools(Generic[Context]):
 			terminates_sequence=True,
 		)
 		async def switch(params: SwitchTabAction, browser_session: BrowserSession):
-			# Simple switch tab logic
 			try:
 				target_id = await browser_session.get_target_id_from_tab_id(params.tab_id)
 
 				event = browser_session.event_bus.dispatch(SwitchTabEvent(target_id=target_id))
 				await event
-				new_target_id = await event.event_result(raise_if_any=False, raise_if_none=False)  # Don't raise on errors
+				new_target_id = await event.event_result(raise_if_any=True, raise_if_none=False)
 
-				if new_target_id:
-					memory = f'Switched to tab #{new_target_id[-4:]}'
-				else:
-					memory = f'Switched to tab #{params.tab_id}'
+				if not new_target_id:
+					return ActionResult(error=f'Failed to switch to tab #{params.tab_id}: no target was returned')
 
+				memory = f'Switched to tab #{new_target_id[-4:]}'
 				logger.info(f'🔄  {memory}')
 				return ActionResult(extracted_content=memory, long_term_memory=memory)
 			except Exception as e:
-				logger.warning(f'Tab switch may have failed: {e}')
-				memory = f'Attempted to switch to tab #{params.tab_id}'
-				return ActionResult(extracted_content=memory, long_term_memory=memory)
+				error = f'Failed to switch to tab #{params.tab_id}: {e}'
+				logger.warning(error)
+				return ActionResult(error=error)
 
 		@self.registry.action(
 			'Close a tab by tab_id. Tab IDs are shown in browser state tabs list (last 4 chars of target_id). Use to clean up tabs you no longer need.',

--- a/tests/ci/test_tools.py
+++ b/tests/ci/test_tools.py
@@ -3,6 +3,8 @@ import json
 import os
 import tempfile
 import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import anyio
 import pytest
@@ -14,6 +16,24 @@ from browser_use.browser import BrowserSession
 from browser_use.browser.profile import BrowserProfile
 from browser_use.filesystem.file_system import FileSystem
 from browser_use.tools.service import Tools
+
+
+class SwitchEvent:
+	"""Awaitable event stub for tab-switch failure tests."""
+
+	def __init__(self, result: str | None):
+		self.result = result
+		self.result_kwargs: dict[str, object] | None = None
+
+	def __await__(self):
+		return self._wait().__await__()
+
+	async def _wait(self):
+		return self
+
+	async def event_result(self, **_kwargs):
+		self.result_kwargs = _kwargs
+		return self.result
 
 
 @pytest.fixture(scope='session')
@@ -84,6 +104,37 @@ async def browser_session():
 def tools():
 	"""Create and provide a Tools instance."""
 	return Tools()
+
+
+class TestSwitchActionFailures:
+	"""Verify failed tab switches are visible to the agent loop."""
+
+	async def test_switch_returns_error_for_unknown_tab(self, tools):
+		browser_session = SimpleNamespace(
+			get_target_id_from_tab_id=AsyncMock(side_effect=ValueError('No TargetID found ending in tab_id=...gone')),
+			get_current_page_url=AsyncMock(return_value='about:blank'),
+			cdp_client=None,
+		)
+
+		result = await tools.switch(tab_id='gone', browser_session=browser_session)
+
+		assert result.error == 'Failed to switch to tab #gone: No TargetID found ending in tab_id=...gone'
+		assert result.long_term_memory is None
+
+	async def test_switch_returns_error_when_event_has_no_result(self, tools):
+		event = SwitchEvent(result=None)
+		browser_session = SimpleNamespace(
+			get_target_id_from_tab_id=AsyncMock(return_value='target-id'),
+			get_current_page_url=AsyncMock(return_value='about:blank'),
+			cdp_client=None,
+			event_bus=SimpleNamespace(dispatch=MagicMock(return_value=event)),
+		)
+
+		result = await tools.switch(tab_id='gone', browser_session=browser_session)
+
+		assert result.error == 'Failed to switch to tab #gone: no target was returned'
+		assert result.long_term_memory is None
+		assert event.result_kwargs == {'raise_if_any': True, 'raise_if_none': False}
 
 
 class TestToolsIntegration:


### PR DESCRIPTION
  ## Summary

  Fixes #5486.

  Failed `switch` actions now return `ActionResult.error` instead of a success-shaped result that writes a false tab-
  switch claim into agent memory.

  ## Changes

  - Surface unknown or closed tab IDs as action errors.
  - Treat a missing switch event result as a failure.
  - Add regression coverage for both failure paths.

  ## Validation

  - `uv run pytest tests/ci/test_tools.py -k SwitchActionFailures -v`
  - `ruff check` and `ruff format --check`
  - `pyright browser_use/tools/service.py tests/ci/test_tools.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Failed tab switches now return `ActionResult.error` instead of a success-shaped result that wrote a false "switched to tab" claim into agent memory. Fixes #5486.

- Unknown or closed tab IDs now surface as error results.
- A missing switch event target is treated as a failure.
- Added regression tests for both failure paths.

<sup>Written for commit 3800d34fc9bc6528af2ea553acef1e608ac94259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

