### PR TITLE
fix(tools): report go back with empty history as an error

### DIFF
--- a/browser_use/browser/events.py
+++ b/browser_use/browser/events.py
@@ -210,7 +210,7 @@ class BrowserStateRequestEvent(BaseEvent[BrowserStateSummary]):
 # 	state: Literal['attached', 'detached', 'visible', 'hidden'] | None = None
 
 
-class GoBackEvent(BaseEvent[None]):
+class GoBackEvent(BaseEvent[bool]):
 	"""Navigate back in browser history."""
 
 	event_timeout: float | None = Field(default_factory=lambda: _get_timeout('TIMEOUT_GoBackEvent', 15.0))  # seconds

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2367,7 +2367,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 		cdp_session = await self.browser_session.get_or_create_cdp_session()
 		return cdp_session.session_id
 
-	async def on_GoBackEvent(self, event: GoBackEvent) -> None:
+	async def on_GoBackEvent(self, event: GoBackEvent) -> bool:
 		"""Handle navigate back request with CDP."""
 		cdp_session = await self.browser_session.get_or_create_cdp_session()
 		try:
@@ -2381,7 +2381,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 			# Check if we can go back
 			if current_index <= 0:
 				self.logger.warning('⚠️ Cannot go back - no previous entry in history')
-				return
+				return False
 
 			# Navigate to the previous entry
 			previous_entry_id = entries[current_index - 1]['id']
@@ -2394,6 +2394,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 			# Navigation is handled by BrowserSession via events
 
 			self.logger.info(f'🔙 Navigated back to {entries[current_index - 1]["url"]}')
+			return True
 		except Exception as e:
 			raise
 

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -1054,7 +1054,9 @@ class BrowserUseServer:
 		from browser_use.browser.events import GoBackEvent
 
 		event = self.browser_session.event_bus.dispatch(GoBackEvent())
-		await event
+		did_navigate = await event.event_result(raise_if_any=True, raise_if_none=True)
+		if not did_navigate:
+			return 'Error: Cannot go back - no previous entry in history'
 		return 'Navigated back'
 
 	async def _close_browser(self) -> str:

--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -584,7 +584,9 @@ class Tools(Generic[Context]):
 		async def go_back(_: NoParamsAction, browser_session: BrowserSession):
 			try:
 				event = browser_session.event_bus.dispatch(GoBackEvent())
-				await event
+				did_navigate = await event.event_result(raise_if_any=True, raise_if_none=True)
+				if not did_navigate:
+					return ActionResult(error='Cannot go back - no previous entry in history')
 				memory = 'Navigated back'
 				msg = f'🔙  {memory}'
 				logger.info(msg)

--- a/tests/ci/test_go_back_no_history.py
+++ b/tests/ci/test_go_back_no_history.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+from browser_use.browser import BrowserSession
+from browser_use.browser.events import GoBackEvent
+from browser_use.browser.watchdogs.default_action_watchdog import DefaultActionWatchdog
+from browser_use.mcp.server import BrowserUseServer
+from browser_use.tools.service import Tools
+
+
+class CompletedGoBackEvent:
+	def __init__(self, did_navigate: bool):
+		self.did_navigate = did_navigate
+
+	async def event_result(self, **kwargs):
+		return self.did_navigate
+
+
+async def test_go_back_handler_reports_no_history():
+	cdp_session = MagicMock()
+	cdp_session.cdp_client.send.Page.getNavigationHistory = AsyncMock(return_value={'currentIndex': 0, 'entries': []})
+	browser_session = MagicMock(spec=BrowserSession)
+	browser_session.get_or_create_cdp_session = AsyncMock(return_value=cdp_session)
+
+	watchdog = DefaultActionWatchdog.model_construct(event_bus=MagicMock(), browser_session=browser_session)
+
+	assert await watchdog.on_GoBackEvent(GoBackEvent()) is False
+
+
+async def test_go_back_tool_returns_error_when_history_is_empty():
+	event = CompletedGoBackEvent(did_navigate=False)
+	browser_session = SimpleNamespace(cdp_client=None, event_bus=SimpleNamespace(dispatch=lambda _: event))
+
+	result = await Tools().go_back(browser_session=browser_session)
+
+	assert result.error == 'Cannot go back - no previous entry in history'
+	assert result.extracted_content is None
+
+
+async def test_go_back_mcp_returns_error_when_history_is_empty():
+	event = CompletedGoBackEvent(did_navigate=False)
+	server = cast(
+		BrowserUseServer,
+		SimpleNamespace(browser_session=SimpleNamespace(event_bus=SimpleNamespace(dispatch=lambda _: event))),
+	)
+
+	result = await BrowserUseServer._go_back(server)
+
+	assert result == 'Error: Cannot go back - no previous entry in history'


### PR DESCRIPTION
## Summary

- make `GoBackEvent` report whether navigation occurred
- return an error from the tools and MCP interfaces when browser history is empty
- add regression coverage for the event handler, tool action, and MCP command

## Why

The go-back handler currently returns normally when the browser has no previous history entry. Both callers then report `Navigated back`, even though the URL did not change. This gives the agent a false success result.

A real headless Chromium reproduction showed the first go-back navigating from `about:blank` to `chrome://newtab/`. The next two attempts logged `Cannot go back - no previous entry in history`, kept the same URL, but still returned `error=None` and `Navigated back`.

## Testing

- `pytest -q tests/ci/test_go_back_no_history.py tests/ci/test_tools.py::TestToolsIntegration::test_go_back_action` (4 passed)
- project pre-commit hooks on all changed files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the go-back action so it reports an error when browser history is empty, instead of falsely reporting success. The handler now returns a boolean indicating whether navigation occurred, and both the tools and MCP interfaces return an error when history is empty.

<sup>Written for commit 4d6d0e4e229c3b5553127c1b70919c4e21f1ca0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

