### PR TITLE
fix(variable_detector): detect company_name and organization_name as company variables

### DIFF
--- a/browser_use/agent/variable_detector.py
+++ b/browser_use/agent/variable_detector.py
@@ -173,6 +173,10 @@ def _detect_from_attributes(attributes: dict[str, str]) -> tuple[str, str | None
 	if any(keyword in combined_text for keyword in ['phone', 'tel', 'mobile', 'cell']):
 		return ('phone', 'phone')
 
+	# Company detection (check before generic name, so company_name / organization_name map to company)
+	if 'company' in combined_text or 'organization' in combined_text:
+		return ('company', None)
+
 	# Name detection (order matters - check specific before general)
 	if 'first' in combined_text and 'name' in combined_text:
 		return ('first_name', None)
@@ -202,10 +206,6 @@ def _detect_from_attributes(attributes: dict[str, str]) -> tuple[str, str | None
 	# Zip code detection
 	if any(keyword in combined_text for keyword in ['zip', 'postal', 'postcode']):
 		return ('zip_code', 'postal_code')
-
-	# Company detection
-	if 'company' in combined_text or 'organization' in combined_text:
-		return ('company', None)
 
 	return None
 

--- a/tests/ci/test_variable_detection.py
+++ b/tests/ci/test_variable_detection.py
@@ -406,3 +406,8 @@ def test_detect_variables_multiple_types():
 	assert result['email'].original_value == 'test@example.com'
 	assert result['first_name'].original_value == 'John'
 	assert result['date'].original_value == '1990-01-01'
+
+def test_detect_company_name_and_organization_name_from_attributes():
+	assert _detect_from_attributes({'name': 'company_name'}) == ('company', None)
+	assert _detect_from_attributes({'name': 'organization_name'}) == ('company', None)
+	assert _detect_from_attributes({'id': 'company_name_input'}) == ('company', None)


### PR DESCRIPTION
## Problem
When input fields use attributes such as `name="company_name"` or `name="organization_name"`, `detect_variables_in_history` detects them as generic `name` variables instead of `company` variables. This prevents subsequent `load_and_rerun` calls with `variables={"company": "..."}` from finding and substituting the company value.

## Root Cause
In `browser_use/agent/variable_detector.py`, `_detect_from_attributes` evaluated generic `'name' in combined_text` before `'company' in combined_text or 'organization' in combined_text`. Because `company_name` and `organization_name` contain the substring `name`, the generic name branch matched first.

## Fix
Check company and organization keywords before the generic name fallback in `_detect_from_attributes`, preserving specific personal name checks (`first_name`, `last_name`, `full_name`).

## Testing
Added `test_detect_company_name_and_organization_name_from_attributes` in `tests/ci/test_variable_detection.py` and verified with pytest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes variable detection so that `company_name` and `organization_name` attributes are recognized as `company` variables, allowing subsequent `load_and_rerun` calls with `variables={"company": ...}` to substitute the correct value. Previously, these attributes were detected as generic `name` variables because the `name` check ran first.

Moves the company/organization check before the generic `name` branch in `_detect_from_attributes`, while keeping specific personal name checks (e.g., `first_name`) intact. Adds tests covering `name` and `id` attributes with `company_name` and `organization_name`. Closes the issue behind this fix.

<sup>Written for commit b1e132f8ed61b4a121f97c0b1fb67a753a85a48a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

