### PR TITLE
fix(gif): decode unicode escapes without latin1 encoding failure on existing unicode chars

### DIFF
--- a/browser_use/agent/gif.py
+++ b/browser_use/agent/gif.py
@@ -5,6 +5,7 @@ import io
 import logging
 import os
 import platform
+import re
 from typing import TYPE_CHECKING
 
 from browser_use.agent.views import AgentHistoryList
@@ -20,16 +21,18 @@ logger = logging.getLogger(__name__)
 def decode_unicode_escapes_to_utf8(text: str) -> str:
 	"""Handle decoding any unicode escape sequences embedded in a string (needed to render non-ASCII languages like chinese or arabic in the GIF overlay text)"""
 
-	if r'\u' not in text:
-		# doesn't have any escape sequences that need to be decoded
+	if r'\u' not in text and r'\U' not in text:
 		return text
 
-	try:
-		# Try to decode Unicode escape sequences
-		return text.encode('latin1').decode('unicode_escape')
-	except (UnicodeEncodeError, UnicodeDecodeError):
-		# logger.debug(f"Failed to decode unicode escape sequences while generating gif text: {text}")
-		return text
+	def replace_match(match: re.Match) -> str:
+		try:
+			hex_val = match.group(1) or match.group(2)
+			return chr(int(hex_val, 16))
+		except Exception:
+			return match.group(0)
+
+	pattern = r'\\u([0-9a-fA-F]{4})|\\U([0-9a-fA-F]{8})'
+	return re.sub(pattern, replace_match, text)
 
 
 def create_history_gif(

--- a/tests/ci/test_gif.py
+++ b/tests/ci/test_gif.py
@@ -1,0 +1,36 @@
+import pytest
+
+from browser_use.agent.gif import decode_unicode_escapes_to_utf8
+
+
+@pytest.mark.parametrize(
+	('text', 'expected'),
+	[
+		(
+			r'Next: open \u4f60',
+			'Next: open 你',
+		),
+		(
+			r'Next: open \u4f60 😀',
+			'Next: open 你 😀',
+		),
+		(
+			r'已完成; next: \u963f',
+			'已完成; next: 阿',
+		),
+		(
+			r'Next: \U0001f600',
+			'Next: 😀',
+		),
+		(
+			'Plain text without escapes',
+			'Plain text without escapes',
+		),
+		(
+			r'Invalid escape \u123z remains',
+			r'Invalid escape \u123z remains',
+		),
+	],
+)
+def test_gif_text_decodes_embedded_unicode_escapes(text, expected):
+	assert decode_unicode_escapes_to_utf8(text) == expected


### PR DESCRIPTION
## Problem
When generating GIF overlays, `decode_unicode_escapes_to_utf8` fails to decode `\uXXXX` or `\UXXXXXXXX` escape sequences if the string already contains non-Latin-1 characters (such as emoji or CJK characters), leaving the literal escape sequences in the rendered text.

## Root Cause
In `browser_use/agent/gif.py`, `decode_unicode_escapes_to_utf8` attempted to encode the entire string via `text.encode('latin1').decode('unicode_escape')`. Characters outside Latin-1 raise `UnicodeEncodeError`, causing the exception handler to return the original unescaped string.

## Fix
Use regex pattern replacement to convert matched Unicode escape hex codes directly to code points with `chr(int(..., 16))`, preserving all existing Unicode characters without whole-string Latin-1 encoding roundtrips.

## Testing
Added `tests/ci/test_gif.py` covering ASCII, mixed emoji/CJK with Unicode escapes, plain text, and invalid escapes; verified with pytest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GIF overlay text decoding so `\uXXXX` and `\UXXXXXXXX` escape sequences render correctly even when the string already contains emoji or CJK characters. Previously, the whole string was encoded as Latin-1, which failed on any character outside that range and returned the literal escape sequence instead. Fixes #5638.

**Bug Fixes**
- Replaces escape sequences with a regex that maps hex codes straight to code points, avoiding a whole-string encoding roundtrip.
- Adds `tests/ci/test_gif.py` covering ASCII-only, mixed emoji/CJK, plain text, and invalid escape cases.

<sup>Written for commit 7a364172cbbdfedb1f692af1096802708d17b81e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

