### PR TITLE
feat(agent): add atomic agent state checkpoints

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3937,19 +3937,43 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		checkpoint_state.last_model_output = None
 		checkpoint_state.last_result = None
 
+		history_data = self.history.model_dump(sensitive_data=self.sensitive_data)
+		if self.history.usage is not None:
+			history_data['usage'] = self.history.usage.model_dump(mode='json')
+
 		checkpoint = {
 			'state': checkpoint_state.model_dump(mode='json'),
-			'history': self.history.model_dump(),
+			'history': history_data,
 		}
 
-		# Atomic write: write to a temp file in the same directory, then rename.
+		# Atomic write: write to a unique temp file in the same directory, then rename.
 		# This prevents a partially-written checkpoint from being read after a crash.
-		tmp_path = path.with_name(path.name + '.tmp')
-		with open(tmp_path, 'w', encoding='utf-8') as f:
-			json.dump(checkpoint, f, indent=2, ensure_ascii=False)
-			f.flush()
-			os.fsync(f.fileno())
-		tmp_path.replace(path)
+		tmp_path = None
+		try:
+			with tempfile.NamedTemporaryFile(
+				mode='w',
+				encoding='utf-8',
+				dir=path.parent,
+				prefix=f'.{path.name}.',
+				suffix='.tmp',
+				delete=False,
+			) as f:
+				tmp_path = Path(f.name)
+				json.dump(checkpoint, f, indent=2, ensure_ascii=False)
+				f.flush()
+				os.fsync(f.fileno())
+			for attempt in range(5):
+				try:
+					tmp_path.replace(path)
+					break
+				except PermissionError:
+					if attempt == 4:
+						raise
+					time.sleep(0.01)
+		except Exception:
+			if tmp_path is not None:
+				tmp_path.unlink(missing_ok=True)
+			raise
 
 		self.logger.info(f'💾 Checkpoint saved to {_log_pretty_path(path)}')
 		return path
@@ -3972,6 +3996,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 		self.state = state
 		self.history = history
+		if self.state.file_system_state is not None:
+			self.file_system = FileSystem.from_state(self.state.file_system_state)
+			self.file_system_path = str(self.file_system.base_dir)
+		self._message_manager.state = self.state.message_manager_state
+		self._message_manager.file_system = self.file_system
 
 		self.logger.info(f'💾 Checkpoint loaded from {_log_pretty_path(path)}')
 		return state, history

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3,6 +3,7 @@ import gc
 import inspect
 import json
 import logging
+import os
 import re
 import tempfile
 import time
@@ -3913,6 +3914,67 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		if not file_path:
 			file_path = 'AgentHistory.json'
 		self.history.save_to_file(file_path, sensitive_data=self.sensitive_data)
+
+	def save_checkpoint(self, path: str | Path | None = None) -> Path:
+		"""Save the agent's full state (AgentState + history) to a JSON checkpoint file atomically.
+
+		Persists a serializable boundary of the agent's state so it can be restored
+		after a crash via load_checkpoint(). Transient per-step state (last_model_output,
+		last_result) is omitted from the serialized copy: it is recreated every step,
+		is already captured in AgentHistory, and holds dynamically-created ActionModel
+		subclasses that cannot be safely round-tripped through JSON.
+		"""
+		if path is None:
+			path = f'agent_checkpoint_{self.id}.json'
+		path = Path(path)
+		path.parent.mkdir(parents=True, exist_ok=True)
+
+		# Clear transient per-step state on a copy before serializing. These fields
+		# are recreated each step and are already captured in AgentHistory; they
+		# hold dynamically-created ActionModel subclasses that cannot be safely
+		# deserialized. Do not mutate the live state while taking a checkpoint.
+		checkpoint_state = self.state.model_copy(deep=True)
+		checkpoint_state.last_model_output = None
+		checkpoint_state.last_result = None
+
+		checkpoint = {
+			'state': checkpoint_state.model_dump(mode='json'),
+			'history': self.history.model_dump(),
+		}
+
+		# Atomic write: write to a temp file in the same directory, then rename.
+		# This prevents a partially-written checkpoint from being read after a crash.
+		tmp_path = path.with_name(path.name + '.tmp')
+		with open(tmp_path, 'w', encoding='utf-8') as f:
+			json.dump(checkpoint, f, indent=2, ensure_ascii=False)
+			f.flush()
+			os.fsync(f.fileno())
+		tmp_path.replace(path)
+
+		self.logger.info(f'💾 Checkpoint saved to {_log_pretty_path(path)}')
+		return path
+
+	def load_checkpoint(self, path: str | Path) -> tuple[AgentState, AgentHistoryList]:
+		"""Load a checkpoint file and restore the agent's state and history.
+
+		Args:
+			path: Path to the checkpoint file created by save_checkpoint().
+
+		Returns:
+			The restored (AgentState, AgentHistoryList).
+		"""
+		path = Path(path)
+		with open(path, encoding='utf-8') as f:
+			data = json.load(f)
+
+		state = AgentState.model_validate(data['state'])
+		history = AgentHistoryList.load_from_dict(data['history'], self.AgentOutput)
+
+		self.state = state
+		self.history = history
+
+		self.logger.info(f'💾 Checkpoint loaded from {_log_pretty_path(path)}')
+		return state, history
 
 	def pause(self) -> None:
 		"""Pause the agent before the next step"""

--- a/tests/ci/test_agent_checkpoint.py
+++ b/tests/ci/test_agent_checkpoint.py
@@ -1,0 +1,202 @@
+"""Regression tests for agent checkpoint save/load (crash recovery boundary).
+
+These tests verify that Agent.save_checkpoint() / load_checkpoint() provide a
+serializable, atomically-persisted boundary of agent state that survives a
+process restart, and that transient per-step state is excluded from the
+checkpoint because it cannot be safely round-tripped through JSON.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+from browser_use import Agent
+from browser_use.agent.message_manager.views import HistoryItem
+from browser_use.agent.views import AgentOutput, PlanItem
+from browser_use.filesystem.file_system import FileSystemState
+from tests.ci.conftest import create_mock_llm
+
+
+def _make_agent(task: str = 'Test task') -> Agent:
+	"""Create an agent with a mock LLM and no running browser."""
+	return Agent(task=task, llm=create_mock_llm(actions=None))
+
+
+def test_save_checkpoint_creates_atomic_file():
+	"""save_checkpoint() should write a JSON file and leave no temp file behind."""
+	agent = _make_agent()
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		path = Path(tmpdir) / 'checkpoint.json'
+		returned = agent.save_checkpoint(path)
+
+		assert returned == path
+		assert path.exists()
+		# Atomic write: the .tmp sibling must be gone after the rename.
+		assert not path.with_name(path.name + '.tmp').exists()
+
+		# The file must be valid JSON with the expected top-level shape.
+		data = json.loads(path.read_text(encoding='utf-8'))
+		assert set(data.keys()) == {'state', 'history'}
+		assert isinstance(data['state'], dict)
+		assert isinstance(data['history'], dict)
+
+
+def test_checkpoint_round_trips_agent_state():
+	"""State mutations before save should be observable after load."""
+	agent = _make_agent()
+	agent.state.n_steps = 42
+	agent.state.consecutive_failures = 3
+	agent.state.follow_up_task = True
+	agent.state.paused = True
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		path = Path(tmpdir) / 'checkpoint.json'
+		agent.save_checkpoint(path)
+
+		# Load into a fresh agent instance.
+		restored_agent = _make_agent()
+		state, history = restored_agent.load_checkpoint(path)
+
+		assert state is restored_agent.state
+		assert history is restored_agent.history
+		assert state.n_steps == 42
+		assert state.consecutive_failures == 3
+		assert state.follow_up_task is True
+		assert state.paused is True
+		# The in-memory agent must reflect the loaded state.
+		assert restored_agent.state.n_steps == 42
+
+
+def test_checkpoint_excludes_transient_step_state():
+	"""last_model_output / last_result must not survive the checkpoint round-trip.
+
+	These fields hold dynamically-created ActionModel subclasses that cannot be
+	deserialized from JSON, and they are recreated every step anyway (their content
+	is already captured in AgentHistory). save_checkpoint() clears them.
+	"""
+	agent = _make_agent()
+
+	# Populate transient per-step state with a valid AgentOutput + ActionResult.
+	output = AgentOutput.model_construct(evaluation_previous_goal='prev', memory='mem', next_goal='next', action=[])
+	agent.state.last_model_output = output
+	agent.state.last_result = []
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		path = Path(tmpdir) / 'checkpoint.json'
+		agent.save_checkpoint(path)
+
+		# The serialized checkpoint must not carry the transient fields.
+		data = json.loads(path.read_text(encoding='utf-8'))
+		assert data['state']['last_model_output'] is None
+		assert data['state']['last_result'] is None
+
+		# Taking a checkpoint must not mutate the live state.
+		assert agent.state.last_model_output is output
+		assert agent.state.last_result == []
+
+		# Reloading must succeed (no leftover transient data to break validation).
+		restored_agent = _make_agent()
+		restored_agent.load_checkpoint(path)
+		assert restored_agent.state.last_model_output is None
+		assert restored_agent.state.last_result is None
+
+
+def test_checkpoint_persists_file_system_state():
+	"""file_system_state should round-trip through the checkpoint."""
+	agent = _make_agent()
+	# Populate file system state directly (avoids async file I/O in a sync test).
+	agent.state.file_system_state = FileSystemState(
+		files={'notes.md': {'content': '# hello\n'}},
+		base_dir='/tmp/fs_test',
+		extracted_content_count=1,
+	)
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		path = Path(tmpdir) / 'checkpoint.json'
+		agent.save_checkpoint(path)
+
+		restored_agent = _make_agent()
+		restored_agent.load_checkpoint(path)
+
+		assert restored_agent.state.file_system_state is not None
+		assert 'notes.md' in restored_agent.state.file_system_state.files
+		assert restored_agent.state.file_system_state.extracted_content_count == 1
+
+
+def test_checkpoint_persists_loop_detector_state():
+	"""ActionLoopDetector state should round-trip through the checkpoint."""
+	agent = _make_agent()
+	agent.state.loop_detector.record_action('click', {'index': 5})
+	agent.state.loop_detector.record_page_state('https://example.com', 'dom text', 10)
+	assert agent.state.loop_detector.max_repetition_count >= 1
+	assert len(agent.state.loop_detector.recent_page_fingerprints) >= 1
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		path = Path(tmpdir) / 'checkpoint.json'
+		agent.save_checkpoint(path)
+
+		restored_agent = _make_agent()
+		restored_agent.load_checkpoint(path)
+
+		assert restored_agent.state.loop_detector.max_repetition_count == agent.state.loop_detector.max_repetition_count
+		assert len(restored_agent.state.loop_detector.recent_page_fingerprints) == len(
+			agent.state.loop_detector.recent_page_fingerprints
+		)
+
+
+def test_checkpoint_default_path_uses_agent_id():
+	"""save_checkpoint() with no path should derive one from the agent id."""
+	agent = _make_agent()
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		original_cwd = Path.cwd()
+		try:
+			os.chdir(tmpdir)
+			returned = agent.save_checkpoint()
+			assert returned.name == f'agent_checkpoint_{agent.id}.json'
+			assert returned.exists()
+		finally:
+			os.chdir(original_cwd)
+
+
+def test_checkpoint_round_trips_message_manager_state():
+	"""message_manager_state (including message history) should round-trip."""
+	agent = _make_agent()
+	# Directly mutate message manager state to avoid EventBus side effects
+	# from add_new_task() on a fresh (not-yet-running) agent.
+	agent.state.follow_up_task = True
+	agent.state.message_manager_state.tool_id = 7
+	agent.state.message_manager_state.read_state_description = 'page loaded'
+	agent.state.message_manager_state.agent_history_items.append(HistoryItem(step_number=1, system_message='follow up on this'))
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		path = Path(tmpdir) / 'checkpoint.json'
+		agent.save_checkpoint(path)
+
+		restored_agent = _make_agent()
+		restored_agent.load_checkpoint(path)
+
+		assert restored_agent.state.message_manager_state.tool_id == 7
+		assert restored_agent.state.message_manager_state.read_state_description == 'page loaded'
+		assert len(restored_agent.state.message_manager_state.agent_history_items) >= 2
+		# The follow-up task marker should survive.
+		assert restored_agent.state.follow_up_task is True
+
+
+def test_checkpoint_survives_json_round_trip():
+	"""The checkpoint file must be valid JSON that can be loaded by json.load."""
+	agent = _make_agent()
+	agent.state.n_steps = 10
+	agent.state.plan = [PlanItem(text='step 1', status='current'), PlanItem(text='step 2', status='pending')]
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		path = Path(tmpdir) / 'checkpoint.json'
+		agent.save_checkpoint(path)
+
+		# Must be parseable by plain json.load (no pydantic needed).
+		data = json.loads(path.read_text(encoding='utf-8'))
+		assert data['state']['n_steps'] == 10
+		assert data['state']['plan'][0]['text'] == 'step 1'
+		assert data['state']['plan'][0]['status'] == 'current'

--- a/tests/ci/test_agent_checkpoint.py
+++ b/tests/ci/test_agent_checkpoint.py
@@ -9,12 +9,15 @@ checkpoint because it cannot be safely round-tripped through JSON.
 import json
 import os
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import cast
 
 from browser_use import Agent
 from browser_use.agent.message_manager.views import HistoryItem
-from browser_use.agent.views import AgentOutput, PlanItem
-from browser_use.filesystem.file_system import FileSystemState
+from browser_use.agent.views import AgentHistory, AgentOutput, PlanItem
+from browser_use.browser.views import BrowserStateHistory
+from browser_use.tokens.views import UsageSummary
 from tests.ci.conftest import create_mock_llm
 
 
@@ -106,12 +109,14 @@ def test_checkpoint_excludes_transient_step_state():
 def test_checkpoint_persists_file_system_state():
 	"""file_system_state should round-trip through the checkpoint."""
 	agent = _make_agent()
-	# Populate file system state directly (avoids async file I/O in a sync test).
-	agent.state.file_system_state = FileSystemState(
-		files={'notes.md': {'content': '# hello\n'}},
-		base_dir='/tmp/fs_test',
-		extracted_content_count=1,
-	)
+	# Populate a valid serializable file system state directly (avoids async file I/O).
+	file_system_state = agent.file_system.get_state()
+	file_system_state.files['notes.md'] = {
+		'type': 'MarkdownFile',
+		'data': {'name': 'notes', 'content': '# hello\n'},
+	}
+	file_system_state.extracted_content_count = 1
+	agent.state.file_system_state = file_system_state
 
 	with tempfile.TemporaryDirectory() as tmpdir:
 		path = Path(tmpdir) / 'checkpoint.json'
@@ -180,7 +185,7 @@ def test_checkpoint_round_trips_message_manager_state():
 
 		assert restored_agent.state.message_manager_state.tool_id == 7
 		assert restored_agent.state.message_manager_state.read_state_description == 'page loaded'
-		assert len(restored_agent.state.message_manager_state.agent_history_items) >= 2
+		assert restored_agent.state.message_manager_state.agent_history_items[-1].system_message == 'follow up on this'
 		# The follow-up task marker should survive.
 		assert restored_agent.state.follow_up_task is True
 
@@ -200,3 +205,55 @@ def test_checkpoint_survives_json_round_trip():
 		assert data['state']['n_steps'] == 10
 		assert data['state']['plan'][0]['text'] == 'step 1'
 		assert data['state']['plan'][0]['status'] == 'current'
+
+
+def test_checkpoint_preserves_usage_and_redacts_sensitive_data():
+	"""Checkpoint history keeps usage totals without writing credential values."""
+	agent = _make_agent()
+	agent.sensitive_data = cast(dict[str, str | dict[str, str]], {'password': {'value': 'super-secret'}})
+	agent.history.usage = UsageSummary(
+		total_prompt_tokens=1,
+		total_prompt_cost=0.1,
+		total_prompt_cached_tokens=2,
+		total_prompt_cached_cost=0.2,
+		total_completion_tokens=3,
+		total_completion_cost=0.3,
+		total_tokens=6,
+		total_cost=0.6,
+		entry_count=1,
+		by_model={},
+	)
+	input_action = agent.ActionModel.model_validate({'input': {'index': 0, 'text': 'super-secret'}})
+	output = AgentOutput.model_construct(
+		evaluation_previous_goal='prev',
+		memory='mem',
+		next_goal='next',
+		action=[input_action],
+	)
+	agent.history.history.append(
+		AgentHistory.model_construct(
+			model_output=output, result=[], state=BrowserStateHistory(url='', title='', tabs=[], interacted_element=[])
+		)
+	)
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		path = Path(tmpdir) / 'checkpoint.json'
+		agent.save_checkpoint(path)
+		serialized = path.read_text(encoding='utf-8')
+		assert 'super-secret' not in serialized
+
+		restored_agent = _make_agent()
+		restored_agent.load_checkpoint(path)
+		assert restored_agent.history.usage is not None
+		assert restored_agent.history.usage.total_cost == 0.6
+
+
+def test_checkpoint_saves_to_same_path_concurrently():
+	"""Concurrent writers use independent temporary files and do not collide."""
+	agent = _make_agent()
+
+	with tempfile.TemporaryDirectory() as tmpdir:
+		path = Path(tmpdir) / 'checkpoint.json'
+		with ThreadPoolExecutor(max_workers=2) as executor:
+			list(executor.map(agent.save_checkpoint, [path, path]))
+		assert json.loads(path.read_text(encoding='utf-8'))['state']['agent_id'] == agent.state.agent_id


### PR DESCRIPTION
## Summary

Add a small, explicit checkpoint boundary for long-running agent executions. The existing `AgentState` is designed to be serializable for checkpointing and `injected_agent_state` provides a restore hook, but there was no public way to persist or load that state after a process crash.

## What changed

- Add `Agent.save_checkpoint(path=None)` to persist `AgentState` and `AgentHistoryList` as JSON.
- Use an atomic same-directory temporary file plus flush/fsync/replace so readers never observe a partial checkpoint.
- Omit transient dynamic action state from a deep-copied state while leaving the live agent untouched.
- Add `Agent.load_checkpoint(path)` to validate and restore state and history through the existing dynamic action model.
- Add focused tests for atomic persistence, state/history round-tripping, filesystem and loop-detector state, message-manager state, plan state, default paths, and transient-state handling.

## Validation

- `uv run --dev pytest tests/ci/test_agent_checkpoint.py -q` (8 passed)
- `uv run --dev ruff check browser_use/agent/service.py tests/ci/test_agent_checkpoint.py`
- `uv run --dev ruff format browser_use/agent/service.py tests/ci/test_agent_checkpoint.py --check`
- `uv run --dev pre-commit run --files browser_use/agent/service.py tests/ci/test_agent_checkpoint.py`
- `git diff --check`

This is intentionally the persistence boundary only; browser-session reconstruction and automatic crash-triggered resume can build on it without changing the existing full-history replay API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds checkpoint save/load to `Agent` so long-running executions can persist their full state and restore it after a crash. Previously there was no public way to persist or load agent state; `save_checkpoint()` and `load_checkpoint()` now provide that boundary without changing the existing replay API.

- `save_checkpoint()` writes `AgentState` and history to JSON atomically via a same-directory temp file with fsync and rename; it defaults to `agent_checkpoint_{agent_id}.json`.
- Transient per-step fields are omitted from the serialized copy; the live agent is left untouched.
- `load_checkpoint()` restores state and history through the existing dynamic action model and re-syncs `file_system` and `_message_manager`.
- Regression tests cover atomic and concurrent writes, state/history round-tripping, and sensitive-data redaction.

<sup>Written for commit e8f4da2d9b8a2f2da5a80b75aaadbc454f7dbd8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

