### PR TITLE
docs: correct grammar in browser configuration guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,7 +567,7 @@ async def main():
   * **Performance**: Lists with 100+ domains are automatically optimized to sets for O(1) lookup (same as `allowed_domains`)
 * `enable_default_extensions` (default: `True`): Load automation extensions (uBlock Origin, cookie handlers, ClearURLs)
 * `cross_origin_iframes` (default: `False`): Enable cross-origin iframe support (may cause complexity)
-* `is_local` (default: `True`): Whether this is a local browser instance. Set to `False` for remote browsers. If we have a `executable_path` set, it will be automatically set to `True`. This can effect your download behavior.
+* `is_local` (default: `True`): Whether this is a local browser instance. Set to `False` for remote browsers. If we have a `executable_path` set, it will be automatically set to `True`. This can affect your download behavior.
 
 ## User Data & Profiles
 


### PR DESCRIPTION
## Summary
Correct the grammar in the `is_local` browser configuration guidance.

## Validation
- Ran `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects a grammar mistake in the `AGENTS.md` browser configuration guidance, changing "effect" to "affect".

<sup>Written for commit 902c8c3e5c60e7f5e14dac3d82c253d590126e04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

