### PR TITLE
fix(agent): preserve company variable classification

### DIFF
--- a/browser_use/agent/variable_detector.py
+++ b/browser_use/agent/variable_detector.py
@@ -173,15 +173,13 @@ def _detect_from_attributes(attributes: dict[str, str]) -> tuple[str, str | None
 	if any(keyword in combined_text for keyword in ['phone', 'tel', 'mobile', 'cell']):
 		return ('phone', 'phone')
 
-	# Name detection (order matters - check specific before general)
+	# Specific personal-name fields take precedence over other semantic matches.
 	if 'first' in combined_text and 'name' in combined_text:
 		return ('first_name', None)
 	elif 'last' in combined_text and 'name' in combined_text:
 		return ('last_name', None)
 	elif 'full' in combined_text and 'name' in combined_text:
 		return ('full_name', None)
-	elif 'name' in combined_text:
-		return ('name', None)
 
 	# Date detection
 	if any(keyword in combined_text for keyword in ['date', 'dob', 'birth']):
@@ -203,9 +201,13 @@ def _detect_from_attributes(attributes: dict[str, str]) -> tuple[str, str | None
 	if any(keyword in combined_text for keyword in ['zip', 'postal', 'postcode']):
 		return ('zip_code', 'postal_code')
 
-	# Company detection
+	# Company detection (after more specific fields, before generic name)
 	if 'company' in combined_text or 'organization' in combined_text:
 		return ('company', None)
+
+	# Generic name detection
+	if 'name' in combined_text:
+		return ('name', None)
 
 	return None
 

--- a/tests/ci/test_variable_detection.py
+++ b/tests/ci/test_variable_detection.py
@@ -215,13 +215,50 @@ def test_detect_zip_code_from_attributes():
 
 def test_detect_company_from_attributes():
 	"""Test company detection from element attributes"""
-	attributes = {'name': 'company', 'id': 'company-input'}
+	attributes = {'name': 'company_name', 'id': 'company-input'}
 	result = _detect_from_attributes(attributes)
 
 	assert result is not None
 	var_name, var_format = result
 	assert var_name == 'company'
 	assert var_format is None
+
+
+def test_detect_organization_name_from_attributes():
+	"""Test organization_name is detected as a company variable"""
+	result = _detect_from_attributes({'name': 'organization_name'})
+
+	assert result == ('company', None)
+
+
+def test_company_fields_preserve_more_specific_semantics():
+	"""Test company keywords do not override more specific field types"""
+	expected_by_name = {
+		'company_city': ('city', None),
+		'company_state': ('state', None),
+		'company_date': ('date', 'date'),
+		'organization_country': ('country', None),
+		'organization_zip': ('zip_code', 'postal_code'),
+	}
+
+	for field_name, expected in expected_by_name.items():
+		assert _detect_from_attributes({'name': field_name}) == expected
+
+
+def test_detect_company_name_in_history():
+	"""Test company_name stays reusable as the company variable in history"""
+	history = create_mock_history(
+		[
+			(
+				{'input': {'index': 1, 'text': 'Acme Corp'}},
+				create_test_element(attributes={'name': 'company_name'}),
+			)
+		]
+	)
+
+	result = detect_variables_in_history(history)  # type: ignore[arg-type]
+
+	assert result['company'].original_value == 'Acme Corp'
 
 
 def test_detect_number_from_pattern():


### PR DESCRIPTION
## Summary

- classify company and organization fields before the generic name fallback
- preserve the existing first, last, and full-name precedence
- cover both attribute detection and history variable extraction

## Testing

- `python -m pytest -q tests/ci/test_variable_detection.py tests/ci/test_variable_substitution.py` (43 passed)
- `python -m ruff check browser_use/agent/variable_detector.py tests/ci/test_variable_detection.py`
- `python -m pyright browser_use/agent/variable_detector.py tests/ci/test_variable_detection.py`

Fixes #5635

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes company and organization fields that include `name`, like `company_name` and `organization_name`, being classified as generic `name` variables instead of `company`. Moves company detection before the generic `name` fallback so both attribute and history extraction paths classify these fields as `company`.

**Bug Fixes**
- Keeps first, last, and full-name detection ahead of company matching.
- Adds test coverage for `organization_name`, `company_name` in history, and compound fields like `company_city` and `company_state`.

Fixes #5635

<sup>Written for commit 06b2fcde347ac5fbe1cacb1c6671954a31fe304e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


