### PR TITLE
docs: add PZERO OpenAI-compatible provider example (#5579)

### DIFF
--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -275,5 +275,17 @@ llm = ChatOpenAI(model="deepseek/deepseek-r1", base_url="https://api.novita.ai/v
 ```
 **Env:** `NOVITA_API_KEY`
 
+### PZERO
+```python
+llm = ChatOpenAI(
+    model="deepseek-v4-flash",
+    base_url="https://api.pzero.studio/v1",
+    api_key="pzero_YOUR_KEY",
+)
+```
+**Env:** `PZERO_API_KEY` — get a key at https://pzero.studio/agents
+
+Use the `/v1` base URL (not `/v1/chat/completions`). Pass catalog model ids as-is (no `openai/` prefix). The default `deepseek-v4-flash` model is text-only — set `use_vision=False` on the agent unless you pick a vision-capable model from the [catalog](https://api.pzero.studio/v1/models).
+
 ### LangChain
 See example at [examples/models/langchain](https://github.com/browser-use/browser-use/tree/main/examples/models/langchain).

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -277,10 +277,12 @@ llm = ChatOpenAI(model="deepseek/deepseek-r1", base_url="https://api.novita.ai/v
 
 ### PZERO
 ```python
+import os
+
 llm = ChatOpenAI(
     model="deepseek-v4-flash",
     base_url="https://api.pzero.studio/v1",
-    api_key="pzero_YOUR_KEY",
+    api_key=os.environ["PZERO_API_KEY"],
 )
 ```
 **Env:** `PZERO_API_KEY` — get a key at https://pzero.studio/agents

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -282,12 +282,12 @@ import os
 llm = ChatOpenAI(
     model="deepseek-v4-flash",
     base_url="https://api.pzero.studio/v1",
-    api_key=os.environ["PZERO_API_KEY"],
+    api_key=os.getenv("PZERO_API_KEY"),
 )
 ```
 **Env:** `PZERO_API_KEY` — get a key at https://pzero.studio/agents
 
-Use the `/v1` base URL (not `/v1/chat/completions`). Pass catalog model ids as-is (no `openai/` prefix). The default `deepseek-v4-flash` model is text-only — set `use_vision=False` on the agent unless you pick a vision-capable model from the [catalog](https://api.pzero.studio/v1/models).
+Use the `/v1` base URL (not `/v1/chat/completions`). Pass catalog model ids as-is (no `openai/` prefix). The default `deepseek-v4-flash` model is text-only — set `use_vision=False` on the agent unless you pick a vision-capable model. List available models with `GET https://api.pzero.studio/v1/models` (no auth required).
 
 ### LangChain
 See example at [examples/models/langchain](https://github.com/browser-use/browser-use/tree/main/examples/models/langchain).


### PR DESCRIPTION
## Why

The supported-models docs already document OpenAI-compatible providers such as Qwen, ModelScope, and Novita via `ChatOpenAI` + `base_url`.

However, PZERO users currently have to infer the API host, environment variable, and model ID conventions themselves.

Fixes #5579.

## What changed

Added a **PZERO** section under **OpenAI-Compatible APIs** in `skills/open-source/references/models.md`.

The documentation includes:

- `ChatOpenAI` configuration with the PZERO `/v1` base URL
- `PZERO_API_KEY` environment variable and link to the PZERO agents page
- Default model: `deepseek-v4-flash`
- Notes on using `/v1` rather than `/v1/chat/completions`
- PZERO catalog model IDs without the `openai/` prefix
- `use_vision=False` for the text-only default model
- Link to the public PZERO model catalog

No provider implementation or code changes are required; this is a documentation-only change.

## Testing

- [ ] Verified the new PZERO section matches the existing Novita/ModelScope documentation format
- [ ] Optional: Tested the example with a valid `PZERO_API_KEY`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PZERO section under OpenAI-Compatible APIs in `skills/open-source/references/models.md` so PZERO users no longer have to infer the base URL, env var, and model ID conventions. Fixes #5579.

- Documents `ChatOpenAI` with `base_url="https://api.pzero.studio/v1"` and `api_key` read from `os.environ["PZERO_API_KEY"]`, so the key must be set explicitly; links to the PZERO agents page for keys.
- Shows `deepseek-v4-flash` as the default model and notes that catalog model IDs are passed without the `openai/` prefix.
- Notes the `/v1` base URL (not `/v1/chat/completions`) and the model list endpoint at `GET https://api.pzero.studio/v1/models` (no auth required).
- Warns that the default model is text-only, so set `use_vision=False` unless selecting a vision-capable model.
- Docs-only change; no code changes required.

<sup>Written for commit 4b328e99c66ec19e17e87db2a6a14c4eb704c10f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

