### PR TITLE
fix(gmail): write gmail_token.json with owner-only permissions

### DIFF
--- a/browser_use/integrations/gmail/service.py
+++ b/browser_use/integrations/gmail/service.py
@@ -22,6 +22,33 @@ from browser_use.config import CONFIG
 logger = logging.getLogger(__name__)
 
 
+async def _write_secret_file(path: Path, content: str) -> None:
+	"""Write a credential file readable only by the current user.
+
+	`gmail_token.json` holds a long-lived OAuth ``refresh_token`` and the OAuth
+	client's ``client_secret``, so it must never be left at the process umask
+	(0644 on a default Linux install). The file is created with 0600 *before*
+	any content is written, so the secret is never briefly present in a
+	world-readable file, and an existing file from an earlier version has its
+	mode corrected too (the mode argument to os.open is ignored when the file
+	already exists).
+
+	Mirrors the protection `browser_use/sync/auth.py` already applies to
+	`cloud_auth.json`.
+	"""
+	# O_CREAT|O_TRUNC with an explicit mode, then an unconditional chmod for
+	# the pre-existing-file case.
+	fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+	os.close(fd)
+	try:
+		os.chmod(path, 0o600)
+	except OSError:
+		# Some filesystems and platforms (notably Windows) do not support
+		# POSIX modes; the write below still needs to happen.
+		pass
+	await anyio.Path(path).write_text(content)
+
+
 class GmailService:
 	"""
 	Gmail API service for email reading.
@@ -123,7 +150,7 @@ class GmailService:
 					self.creds = flow.run_local_server(port=8080, open_browser=True)
 
 				# Save tokens for next time
-				await anyio.Path(self.token_file).write_text(self.creds.to_json())
+				await _write_secret_file(Path(self.token_file), self.creds.to_json())
 				logger.info(f'💾 Tokens saved to {self.token_file}')
 
 			# Build Gmail service

--- a/tests/ci/test_gmail_token_permissions.py
+++ b/tests/ci/test_gmail_token_permissions.py
@@ -1,0 +1,54 @@
+"""The Gmail OAuth token file must not be readable by other local users.
+
+`gmail_token.json` stores a long-lived `refresh_token` and the OAuth client's
+`client_secret` (see `google.oauth2.credentials.Credentials.to_json`), so a
+default-umask write would leave a live Gmail credential at mode 0644.
+"""
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from browser_use.integrations.gmail.service import _write_secret_file
+
+pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='POSIX file modes')
+
+
+def _mode(path: Path) -> int:
+	return path.stat().st_mode & 0o777
+
+
+async def test_secret_file_is_owner_only(tmp_path: Path):
+	"""A newly created token file is 0600, not the 0644 the default umask gives."""
+	token = tmp_path / 'gmail_token.json'
+	await _write_secret_file(token, '{"refresh_token": "x", "client_secret": "y"}')
+
+	assert _mode(token) == 0o600
+	assert not _mode(token) & stat.S_IROTH, 'token file is world-readable'
+	assert not _mode(token) & stat.S_IRGRP, 'token file is group-readable'
+	assert token.read_text() == '{"refresh_token": "x", "client_secret": "y"}'
+
+
+async def test_existing_world_readable_file_is_corrected(tmp_path: Path):
+	"""A token left at 0644 by an older version is tightened on the next write."""
+	token = tmp_path / 'gmail_token.json'
+	token.write_text('{"refresh_token": "old"}')
+	os.chmod(token, 0o644)
+	assert _mode(token) == 0o644
+
+	await _write_secret_file(token, '{"refresh_token": "new"}')
+
+	assert _mode(token) == 0o600
+	assert token.read_text() == '{"refresh_token": "new"}'
+
+
+async def test_write_is_truncating(tmp_path: Path):
+	"""A shorter payload must not leave a tail of the previous credential behind."""
+	token = tmp_path / 'gmail_token.json'
+	await _write_secret_file(token, 'a' * 200)
+	await _write_secret_file(token, 'b')
+
+	assert token.read_text() == 'b'


### PR DESCRIPTION
## What

`gmail_token.json` is written with the process umask. On a default Linux install that is mode 0644, so the file is readable by every other local account that can traverse the home directory.

The file is not low-value: `Credentials.to_json()` serialises `token`, **`refresh_token`**, `client_id` and **`client_secret`**, and the token carries the `gmail.readonly` scope. Anyone who reads it can mint API calls against the user's mailbox, which includes OTP and password-reset mail for unrelated services.

`browser_use/sync/auth.py` already chmods `cloud_auth.json` to 0600. This applies the same protection to the Gmail token.

## Before / after

```
gmail_token.json  0644   <- world-readable
cloud_auth.json   0600   <- sibling, already protected
```

```
gmail_token.json  0600
```

## The change

A small `_write_secret_file()` helper in `browser_use/integrations/gmail/service.py`, used at the one write site:

- creates the file with `O_CREAT|O_TRUNC` and mode 0600 **before** any content is written, so the credential is never briefly present in a world-readable file;
- follows with an unconditional `chmod`, because `os.open`'s mode argument is ignored when the file already exists, which fixes tokens left at 0644 by an earlier version;
- tolerates `OSError` from `chmod` so Windows and filesystems without POSIX modes still write normally.

## Scope of the fix

Only the token file. A 0600 file is unreadable by other users regardless of the directory mode, so this closes the exposure on its own and no shared config code is touched.

Worth noting separately: nothing in the tree sets a mode on the config directory itself. `browser_use/config.py` `_ensure_dirs()`, `gmail/service.py`, and `sync/auth.py` all call `mkdir(parents=True, exist_ok=True)` with no `mode=`, so it lands at 0755. That is out of scope here, but a `mode=0o700` there would be defence in depth. Happy to follow up if you want it.

## Tests

`tests/ci/test_gmail_token_permissions.py`, three cases: a new file is 0600 and not group/world readable; a pre-existing 0644 file is corrected on the next write; the write truncates so a shorter payload leaves no tail of the previous credential.

I checked the tests fail without the fix rather than only passing with it: reverting the helper to the plain `write_text` makes `test_secret_file_is_owner_only` fail with the file at the umask default.

## Affected users

This needs a local account on the same machine, and the Gmail integration is opt-in: `register_gmail_actions` is not called anywhere inside `browser_use/`, so a user must wire it up themselves and supply their own Google Cloud OAuth client. Exposure also depends on the home directory mode, which browser-use does not control: live where homes are 0755 (Debian 12, older Ubuntu, many shared and CI hosts), inert on Ubuntu 22.04+ where `HOME_MODE` is 0750.

Low severity, and I am reporting it as a normal PR rather than through the advisory process for that reason. Happy to route it differently if you would prefer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes `gmail_token.json` with owner-only permissions (0600) instead of the default umask 0644, so the Gmail OAuth refresh token and client secret are no longer readable by other local users.

- Creates the file at 0600 before writing any content, so credentials are never briefly world-readable.
- Corrects token files left at 0644 by earlier versions on the next write.
- Tolerates `chmod` failures on Windows and filesystems without POSIX modes.
- Adds tests covering new files, pre-existing 0644 files, and truncating writes.

<sup>Written for commit 73794d835350205e3f3a7811fc2879893912ffea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

