### PR TITLE
Show the live value of pre-filled inputs to the agent

### DIFF
--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -91,6 +91,18 @@ def build_snapshot_lookup(
 		has_clickable_data = 'isClickable' in nodes
 		is_clickable_set: set[int] = set(nodes['isClickable']['index']) if has_clickable_data else set()
 
+		# Live form values live in the snapshot, not in the DOM attributes. Map
+		# snapshot index -> string once so each node lookup stays O(1).
+		input_value_by_index: dict[int, str] = {}
+		for key in ('inputValue', 'textValue'):
+			rare = nodes.get(key)
+			if rare:
+				for idx, string_index in zip(rare.get('index', []), rare.get('value', [])):
+					if 0 <= string_index < len(strings):
+						input_value_by_index[idx] = strings[string_index]
+		input_checked_set: set[int] = set(nodes['inputChecked']['index']) if 'inputChecked' in nodes else set()
+		has_checked_data = 'inputChecked' in nodes
+
 		# Build snapshot lookup for each backend node id
 		for backend_node_id, snapshot_index in backend_node_to_snapshot_index.items():
 			is_clickable = None
@@ -173,6 +185,8 @@ def build_snapshot_lookup(
 				computed_styles=computed_styles if computed_styles else None,
 				paint_order=paint_order,
 				stacking_contexts=stacking_contexts,
+				input_value=input_value_by_index.get(snapshot_index),
+				input_checked=(snapshot_index in input_checked_set) if has_checked_data else None,
 			)
 
 	# Count how many have bounds (are actually visible/laid out)

--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -43,6 +43,30 @@ def _parse_computed_styles(strings: list[str], style_indices: list[int]) -> dict
 	return styles
 
 
+# Live values of these fields never leave the snapshot: they would otherwise be
+# serialized by EnhancedDOMTreeNode.__json__ and could reach logs or the LLM.
+_SENSITIVE_INPUT_TYPES = frozenset({'password', 'file', 'hidden'})
+_SENSITIVE_AUTOCOMPLETE_PREFIXES = ('cc-', 'one-time-code')
+
+
+def _is_sensitive_input(strings: list[str], nodes: NodeTreeSnapshot, snapshot_index: int) -> bool:
+	"""True for password/file/hidden inputs and payment or one-time-code autocomplete fields."""
+	attribute_lists = nodes.get('attributes')
+	if not attribute_lists or snapshot_index >= len(attribute_lists):
+		return False
+	indices = attribute_lists[snapshot_index]
+	for name_index, value_index in zip(indices[0::2], indices[1::2]):
+		if not (0 <= name_index < len(strings) and 0 <= value_index < len(strings)):
+			continue
+		name = strings[name_index].lower()
+		value = strings[value_index].lower()
+		if name == 'type' and value in _SENSITIVE_INPUT_TYPES:
+			return True
+		if name == 'autocomplete' and value.startswith(_SENSITIVE_AUTOCOMPLETE_PREFIXES):
+			return True
+	return False
+
+
 def build_snapshot_lookup(
 	snapshot: CaptureSnapshotReturns,
 	device_pixel_ratio: float = 1.0,
@@ -98,7 +122,7 @@ def build_snapshot_lookup(
 			rare = nodes.get(key)
 			if rare:
 				for idx, string_index in zip(rare.get('index', []), rare.get('value', [])):
-					if 0 <= string_index < len(strings):
+					if 0 <= string_index < len(strings) and not _is_sensitive_input(strings, nodes, idx):
 						input_value_by_index[idx] = strings[string_index]
 		input_checked_set: set[int] = set(nodes['inputChecked']['index']) if 'inputChecked' in nodes else set()
 		has_checked_data = 'inputChecked' in nodes

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -814,11 +814,16 @@ class DomService:
 			# Show the value a field currently holds, not only the static attribute.
 			# JS, autofill, and framework bindings set the property without touching
 			# the attribute, so the agent used to see pre-filled fields as empty (#5647).
-			if snapshot_data and snapshot_data.input_value is not None and node['nodeName'].upper() in ('INPUT', 'TEXTAREA'):
-				input_type = (attributes or {}).get('type', '').lower()
-				if input_type not in ('password', 'file', 'hidden'):
+			if snapshot_data and node['nodeName'].upper() in ('INPUT', 'TEXTAREA'):
+				if snapshot_data.input_value is not None:
 					attributes = dict(attributes or {})
 					attributes['value'] = snapshot_data.input_value
+				if snapshot_data.input_checked is not None:
+					attributes = dict(attributes or {})
+					if snapshot_data.input_checked:
+						attributes['checked'] = 'true'
+					else:
+						attributes.pop('checked', None)
 
 			# DIAGNOSTIC: Log when interactive elements don't have snapshot data
 			if not snapshot_data and node['nodeName'].upper() in ['INPUT', 'BUTTON', 'SELECT', 'TEXTAREA', 'A']:

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -811,6 +811,15 @@ class DomService:
 			# Get snapshot data and calculate absolute position
 			snapshot_data = snapshot_lookup.get(node['backendNodeId'], None)
 
+			# Show the value a field currently holds, not only the static attribute.
+			# JS, autofill, and framework bindings set the property without touching
+			# the attribute, so the agent used to see pre-filled fields as empty (#5647).
+			if snapshot_data and snapshot_data.input_value is not None and node['nodeName'].upper() in ('INPUT', 'TEXTAREA'):
+				input_type = (attributes or {}).get('type', '').lower()
+				if input_type not in ('password', 'file', 'hidden'):
+					attributes = dict(attributes or {})
+					attributes['value'] = snapshot_data.input_value
+
 			# DIAGNOSTIC: Log when interactive elements don't have snapshot data
 			if not snapshot_data and node['nodeName'].upper() in ['INPUT', 'BUTTON', 'SELECT', 'TEXTAREA', 'A']:
 				parent_has_shadow = False

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -353,6 +353,10 @@ class EnhancedSnapshotNode:
 	"""Paint order from the layout tree"""
 	stacking_contexts: int | None
 	"""Stacking contexts from the layout tree"""
+	input_value: str | None = None
+	"""Live value of an <input> or <textarea> (DOMSnapshot inputValue/textValue), which the value attribute misses when JS, autofill, or a framework set it."""
+	input_checked: bool | None = None
+	"""Live checked state of a checkbox or radio input (DOMSnapshot inputChecked)."""
 
 
 # @dataclass(slots=True)

--- a/tests/ci/test_dom_live_input_value.py
+++ b/tests/ci/test_dom_live_input_value.py
@@ -1,0 +1,53 @@
+"""The DOM the agent sees must show the value a form field currently holds.
+
+Regression test for #5647: values set by JavaScript, autofill, or a framework
+live in the element's `value` property, not in the `value` attribute, so the
+agent used to see pre-filled fields as empty.
+"""
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from browser_use.browser.events import NavigateToUrlEvent
+
+PAGE = """<!DOCTYPE html>
+<html><head><title>Prefilled form</title></head>
+<body>
+	<label for="name">Name</label>
+	<input id="name" type="text" placeholder="Your name">
+	<label for="notes">Notes</label>
+	<textarea id="notes"></textarea>
+	<input id="secret" type="password">
+	<script>
+		document.getElementById('name').value = 'Ada Lovelace';
+		document.getElementById('notes').value = 'call back tuesday';
+		document.getElementById('secret').value = 'hunter2';
+	</script>
+</body></html>"""
+
+
+@pytest.fixture(scope='module')
+def http_server():
+	server = HTTPServer()
+	server.start()
+	server.expect_request('/prefilled').respond_with_data(PAGE, content_type='text/html')
+	yield server
+	server.stop()
+
+
+async def test_live_input_values_reach_the_agent(browser_session, http_server):
+	event = browser_session.event_bus.dispatch(NavigateToUrlEvent(url=http_server.url_for('/prefilled')))
+	await event
+	await event.event_result(raise_if_any=True, raise_if_none=False)
+
+	state = await browser_session.get_browser_state_summary()
+	by_id = {node.attributes.get('id'): node for node in state.dom_state.selector_map.values() if node.attributes}
+
+	assert by_id['name'].attributes.get('value') == 'Ada Lovelace'
+	assert by_id['notes'].attributes.get('value') == 'call back tuesday'
+	assert by_id['secret'].attributes.get('value') is None, 'password values must not be exposed'
+
+	llm_view = state.dom_state.llm_representation()
+	assert 'Ada Lovelace' in llm_view
+	assert 'call back tuesday' in llm_view
+	assert 'hunter2' not in llm_view

--- a/tests/ci/test_dom_live_input_value.py
+++ b/tests/ci/test_dom_live_input_value.py
@@ -18,10 +18,18 @@ PAGE = """<!DOCTYPE html>
 	<label for="notes">Notes</label>
 	<textarea id="notes"></textarea>
 	<input id="secret" type="password">
+	<input id="otp" type="text" autocomplete="one-time-code">
+	<input id="card" type="text" autocomplete="cc-number">
+	<input id="agree" type="checkbox" checked>
+	<input id="news" type="checkbox">
 	<script>
 		document.getElementById('name').value = 'Ada Lovelace';
 		document.getElementById('notes').value = 'call back tuesday';
 		document.getElementById('secret').value = 'hunter2';
+		document.getElementById('otp').value = '493021';
+		document.getElementById('card').value = '4242424242424242';
+		document.getElementById('agree').checked = false;
+		document.getElementById('news').checked = true;
 	</script>
 </body></html>"""
 
@@ -46,8 +54,15 @@ async def test_live_input_values_reach_the_agent(browser_session, http_server):
 	assert by_id['name'].attributes.get('value') == 'Ada Lovelace'
 	assert by_id['notes'].attributes.get('value') == 'call back tuesday'
 	assert by_id['secret'].attributes.get('value') is None, 'password values must not be exposed'
+	assert by_id['otp'].attributes.get('value') is None, 'one-time codes must not be exposed'
+	assert by_id['card'].attributes.get('value') is None, 'card numbers must not be exposed'
+	assert by_id['secret'].snapshot_node is not None and by_id['secret'].snapshot_node.input_value is None
+	assert by_id['agree'].attributes.get('checked') is None, 'live unchecked state wins over the checked attribute'
+	assert by_id['news'].attributes.get('checked') == 'true'
 
 	llm_view = state.dom_state.llm_representation()
 	assert 'Ada Lovelace' in llm_view
 	assert 'call back tuesday' in llm_view
 	assert 'hunter2' not in llm_view
+	assert '493021' not in llm_view
+	assert '4242424242424242' not in llm_view


### PR DESCRIPTION
## Problem

Fixes #5647. The DOM the agent sees only carried the static `value` attribute. When JavaScript, autofill, or a framework binding fills a field, the value lives in the element property, so pre-filled inputs looked empty and the agent retyped over them or skipped them. Form filling is one of the most common tasks, so this shows up a lot.

## Fix

`DOMSnapshot.captureSnapshot` already returns `inputValue`, `textValue`, and `inputChecked`. This reads them once per document, keeps them on `EnhancedSnapshotNode`, and surfaces the live value as the `value` attribute for `input` and `textarea` nodes so the serializer and `get_meaningful_text_for_llm` pick it up without further changes. Password, file, and hidden inputs are skipped.

## Proof

`tests/ci/test_dom_live_input_value.py` loads a page whose fields are filled by script and asserts the values reach `selector_map` and the LLM representation, and that a password value does not.

- on `main`: `AssertionError: assert None == 'Ada Lovelace'`
- with this change: passes; `test_dom_visibility.py` and `test_ax_name_matching.py` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UV3AvcViJQzAV75u67XZCF

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5647 by showing the live value of pre-filled inputs to the agent. The DOM snapshot only carried the static `value` attribute, so fields filled by JavaScript, autofill, or framework bindings looked empty; now the live value is surfaced for `input` and `textarea` nodes, and checkboxes/radios show their live checked state. Password, file, hidden, payment (`cc-*`), and one-time-code fields never expose their live value.

**Details**
- Reads `inputValue`, `textValue`, and `inputChecked` from `DOMSnapshot.captureSnapshot` and stores them on `EnhancedSnapshotNode`.
- Adds a regression test covering script-filled values, sensitive exclusions, and checked state.

<sup>Written for commit 3b12a946ccd4cf132dd8ffb51d503d05cc0f2245. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

