### PR TITLE
fix(llm/google): retry SDK-raised errors with retryable status codes

### DIFF
--- a/browser_use/llm/google/chat.py
+++ b/browser_use/llm/google/chat.py
@@ -571,6 +571,18 @@ class ChatGoogle(BaseChatModel):
 				):
 					status_code = 503
 
+				# SDK errors (google.genai ClientError/ServerError) also land here: give them
+				# the same backoff as the ModelProviderError branch above
+				if status_code is not None and status_code in self.retryable_status_codes and attempt < self.max_retries - 1:
+					delay = min(self.retry_base_delay * (2**attempt), self.retry_max_delay)
+					jitter = random.uniform(0, delay * 0.1)  # 10% jitter
+					total_delay = delay + jitter
+					self.logger.warning(
+						f'⚠️ Got {status_code} error, retrying in {total_delay:.1f}s... (attempt {attempt + 1}/{self.max_retries})'
+					)
+					await asyncio.sleep(total_delay)
+					continue
+
 				raise ModelProviderError(
 					message=error_message,
 					status_code=status_code or 502,

--- a/tests/ci/test_llm_retries.py
+++ b/tests/ci/test_llm_retries.py
@@ -299,6 +299,85 @@ class TestChatGoogleRetries:
 		assert attempt_count == 2
 		assert result.completion == 'Success after rate limit!'
 
+	@pytest.mark.asyncio
+	async def test_retries_on_sdk_error_with_retryable_status(self, mock_env):
+		"""Test that SDK-raised ClientError with a retryable status code is retried."""
+		from types import SimpleNamespace
+
+		from google.genai.errors import ClientError
+
+		from browser_use.llm.google.chat import ChatGoogle
+		from browser_use.llm.messages import UserMessage
+
+		attempt_count = 0
+
+		with patch('browser_use.llm.google.chat.genai') as mock_genai:
+			mock_client = MagicMock()
+			mock_genai.Client.return_value = mock_client
+
+			async def mock_generate(*args, **kwargs):
+				nonlocal attempt_count
+				attempt_count += 1
+
+				if attempt_count < 3:
+					raise ClientError(
+						code=429,
+						response_json={'error': {'message': 'RESOURCE_EXHAUSTED: quota exceeded'}},
+						response=SimpleNamespace(status_code=429),
+					)
+				else:
+					mock_response = MagicMock()
+					mock_response.text = 'Success after SDK error!'
+					mock_response.usage_metadata = MagicMock(
+						prompt_token_count=10, candidates_token_count=5, total_token_count=15, cached_content_token_count=0
+					)
+					mock_response.candidates = [MagicMock(content=MagicMock(parts=[MagicMock(text='Success after SDK error!')]))]
+					return mock_response
+
+			mock_client.aio.models.generate_content = mock_generate
+
+			client = ChatGoogle(model='gemini-2.0-flash', api_key='test', retry_base_delay=0.01)
+			result = await client.ainvoke([UserMessage(content='test')])
+
+		assert attempt_count == 3
+		assert result.completion == 'Success after SDK error!'
+
+	@pytest.mark.asyncio
+	async def test_no_retry_on_sdk_error_with_non_retryable_status(self, mock_env):
+		"""Test that SDK-raised ClientError with a non-retryable status code fails without retry."""
+		from types import SimpleNamespace
+
+		from google.genai.errors import ClientError
+
+		from browser_use.llm.exceptions import ModelProviderError
+		from browser_use.llm.google.chat import ChatGoogle
+		from browser_use.llm.messages import UserMessage
+
+		attempt_count = 0
+
+		with patch('browser_use.llm.google.chat.genai') as mock_genai:
+			mock_client = MagicMock()
+			mock_genai.Client.return_value = mock_client
+
+			async def mock_generate(*args, **kwargs):
+				nonlocal attempt_count
+				attempt_count += 1
+				raise ClientError(
+					code=400,
+					response_json={'error': {'message': 'API key not valid'}},
+					response=SimpleNamespace(status_code=400),
+				)
+
+			mock_client.aio.models.generate_content = mock_generate
+
+			client = ChatGoogle(model='gemini-2.0-flash', api_key='test', retry_base_delay=0.01)
+
+			with pytest.raises(ModelProviderError) as exc_info:
+				await client.ainvoke([UserMessage(content='test')])
+
+		assert attempt_count == 1
+		assert exc_info.value.status_code == 400
+
 
 if __name__ == '__main__':
 	pytest.main([__file__, '-v'])


### PR DESCRIPTION
Ran into this while running longer Gemini tasks: one rate-limit hit aborts the step, because the retry loop in ChatGoogle only ever retried ModelProviderError. Real errors raised by google-genai (ClientError/ServerError for 429 RESOURCE_EXHAUSTED, 503, etc.) fall into the generic `except Exception` branch, where the code already goes to the trouble of pulling out a status code from `e.response.status_code` or the message text, and then raises without ever consulting `retryable_status_codes`.

So `max_retries`/`retryable_status_codes` only applied to errors we raise ourselves (e.g. the JSON-parse 500), which is backwards.

This runs the extracted status code through the same backoff check the ModelProviderError branch uses - nothing else changes. Errors without a recognizable status (or with a non-retryable one like 400) still fail exactly as before, and ChatBrowserUse already retries real transport errors the same way.

Tests: added two cases to TestChatGoogleRetries that raise actual `google.genai.errors.ClientError` instead of ModelProviderError - one 429 that now succeeds on the third attempt, one 400 that still fails after a single attempt. `uv run pytest tests/ci/test_llm_retries.py tests/ci/models/test_llm_google.py` passes locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries SDK-raised errors from `google-genai` (429, 503, etc.) so a single rate-limit hit no longer aborts a Gemini step. Previously the retry loop only handled `ModelProviderError`; SDK errors fell into the generic exception branch and failed immediately despite the status code already being extracted. Now that status code is checked against `retryable_status_codes` and gets the same backoff before failing.

- Non-retryable statuses like 400 still fail on the first attempt, unchanged.
- Adds tests covering a 429 that succeeds on the third attempt and a 400 that fails immediately.

<sup>Written for commit b0ba09eb483cbbc0e16d45d7de8348d21c10937a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

