### PR TITLE
fix(dom): handle case-insensitive display:none in hidden code filtering

### DIFF
--- a/browser_use/dom/serializer/html_serializer.py
+++ b/browser_use/dom/serializer/html_serializer.py
@@ -74,7 +74,7 @@ class HTMLSerializer:
 			if tag_name == 'code' and node.attributes:
 				style = node.attributes.get('style', '')
 				# Check if element is hidden (display:none) - likely JSON data
-				if 'display:none' in style.replace(' ', '') or 'display: none' in style:
+				if 'display:none' in ''.join(style.lower().split()):
 					return ''
 				# Also check for bpr-guid IDs (LinkedIn's JSON data pattern)
 				element_id = node.attributes.get('id', '')

--- a/tests/ci/test_html_serializer_hidden_code_style_case.py
+++ b/tests/ci/test_html_serializer_hidden_code_style_case.py
@@ -1,0 +1,147 @@
+import pytest
+
+from browser_use.dom.serializer.html_serializer import HTMLSerializer
+from browser_use.dom.views import EnhancedDOMTreeNode, NodeType
+
+
+def _create_element_node(
+	tag_name: str, attributes: dict[str, str] | None = None, children: list[EnhancedDOMTreeNode] | None = None
+) -> EnhancedDOMTreeNode:
+	node = EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name=tag_name.upper(),
+		node_value='',
+		attributes=attributes or {},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=children or [],
+		ax_node=None,
+		snapshot_node=None,
+	)
+	for child in node.children:
+		child.parent_node = node
+	return node
+
+
+def _create_text_node(text: str) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=2,
+		backend_node_id=2,
+		node_type=NodeType.TEXT_NODE,
+		node_name='#text',
+		node_value=text,
+		attributes={},
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=[],
+		ax_node=None,
+		snapshot_node=None,
+	)
+
+
+def test_html_serializer_filters_hidden_code_case_insensitively():
+	serializer = HTMLSerializer()
+
+	hidden_styles = [
+		'display: none',
+		'display:none',
+		'Display: None',
+		'DISPLAY:NONE',
+		'Display: none;',
+		'display : none ;',
+		'display:\nnone',
+		'display:\t none;',
+		'color: red; display: none; font-size: 12px;',
+		'COLOR: BLUE; DISPLAY: NONE;',
+	]
+
+	for style in hidden_styles:
+		code_node = _create_element_node(
+			tag_name='code',
+			attributes={'style': style},
+			children=[_create_text_node('hidden payload')],
+		)
+		result = serializer.serialize(code_node)
+		assert result == '', f'Expected empty string for hidden code with style {style!r}, got: {result!r}'
+
+
+def test_html_serializer_preserves_visible_code_elements():
+	serializer = HTMLSerializer()
+
+	visible_styles = [
+		'display: block',
+		'display: inline',
+		'display: inline-block',
+		'color: green;',
+		'',
+	]
+
+	for style in visible_styles:
+		attrs = {'style': style} if style else {}
+		code_node = _create_element_node(
+			tag_name='code',
+			attributes=attrs,
+			children=[_create_text_node('visible code content')],
+		)
+		result = serializer.serialize(code_node)
+		assert 'visible code content' in result, f'Expected visible code content for style {style!r}, got: {result!r}'
+		assert '<code' in result
+
+
+from urllib.parse import quote
+
+from browser_use import Browser, BrowserProfile
+from browser_use.dom.markdown_extractor import extract_clean_markdown
+
+
+@pytest.mark.asyncio
+async def test_hidden_code_style_matching_is_case_insensitive_end_to_end():
+	browser = Browser(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=False,
+		)
+	)
+
+	try:
+		await browser.start()
+		observed = {}
+
+		for style in ('display: none', 'Display: None'):
+			html = f'<main>visible control</main><code id="snippet" style="{style}">hidden state payload</code>'
+			await browser.navigate_to('data:text/html,' + quote(html))
+
+			page = await browser.get_current_page()
+			assert page is not None
+
+			attribute = await page.evaluate("() => document.querySelector('#snippet').getAttribute('style')")
+			computed = await page.evaluate("() => getComputedStyle(document.querySelector('#snippet')).display")
+			markdown, _ = await extract_clean_markdown(browser_session=browser)
+			observed[style] = markdown
+
+			assert attribute == style
+			assert computed == 'none'
+
+		assert 'hidden state payload' not in observed['display: none']
+		assert 'hidden state payload' not in observed['Display: None']
+	finally:
+		await browser.stop()


### PR DESCRIPTION
## Summary
Fixes #5637

`HTMLSerializer` filters out hidden `<code>` blocks that commonly contain SPA serialized state or metadata. However, the existing check evaluated `style` attributes case-sensitively (`"display:none" in style.replace(" ", "") or "display: none" in style`). When inline styles use mixed casing or whitespace (e.g. `style="Display: None"` or `style="display : none;"`), the filter failed to identify them, allowing hidden state payloads to be included in extracted markdown.

This PR normalizes inline style string casing and whitespace (`''.join(style.lower().split())`) so that all valid CSS casing and whitespace variations of `display:none` are accurately filtered while keeping visible code blocks intact.

## Changes
- **`browser_use/dom/serializer/html_serializer.py`**: Normalize casing and whitespace when checking `display:none` on `<code>` tags.
- **`tests/ci/test_html_serializer_hidden_code_style_case.py`**: Added unit tests and end-to-end extraction tests covering various casing, whitespace, and compound CSS style variations.

## Testing
- `pytest tests/ci/test_html_serializer_hidden_code_style_case.py` passed (3/3 tests)
- Regression test suites in `tests/ci/` passed
- Code formatted and checked with `ruff`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5637 by normalizing inline `style` casing and whitespace when filtering hidden `<code>` blocks, so SPA state payloads with mixed-case styles like `Display: None` or `display : none;` no longer leak into extracted markdown.

**Bug Fixes**
- Replaces the two case/whitespace-specific checks with a single normalized match for `display:none`.
- Adds unit and end-to-end tests covering casing, whitespace, newline/tab variations, and compound styles.

<sup>Written for commit 49ba72f11353e1d70f6879bfb4430879e98906fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

