### PR TITLE
fix(watchdogs): hold a reference to the HAR body fetch task

### DIFF
--- a/browser_use/browser/watchdogs/har_recording_watchdog.py
+++ b/browser_use/browser/watchdogs/har_recording_watchdog.py
@@ -7,6 +7,7 @@ and `record_har_mode` (full/minimal).
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import json
@@ -152,6 +153,7 @@ class HarRecordingWatchdog(BaseWatchdog):
 		super().__init__(*args, **kwargs)
 		self._enabled: bool = False
 		self._entries: dict[str, _HarEntryBuilder] = {}
+		self._fetch_tasks: set[asyncio.Task] = set()
 		self._top_level_pages: dict[
 			str, dict
 		] = {}  # frameId -> {url, title, startedDateTime, monotonic_start, onContentLoad, onLoad}
@@ -410,10 +412,12 @@ class HarRecordingWatchdog(BaseWatchdog):
 					pass
 
 			# Always schedule the response body fetch task
-			create_task_with_error_handling(
+			task = create_task_with_error_handling(
 				_fetch_body(self, request_id, session_id),
 				name=f'har-fetch-{request_id}',
 			)
+			self._fetch_tasks.add(task)
+			task.add_done_callback(self._fetch_tasks.discard)
 
 			encoded_length = (
 				params.get('encodedDataLength') if hasattr(params, 'get') else getattr(params, 'encodedDataLength', None)

--- a/browser_use/browser/watchdogs/har_recording_watchdog.py
+++ b/browser_use/browser/watchdogs/har_recording_watchdog.py
@@ -27,6 +27,7 @@ from cdp_use.cdp.page.events import FrameNavigatedEvent, LifecycleEventEvent
 
 from browser_use.browser.events import BrowserConnectedEvent, BrowserStopEvent
 from browser_use.browser.watchdog_base import BaseWatchdog
+from browser_use.utils import create_task_with_error_handling
 
 
 @dataclass
@@ -386,7 +387,6 @@ class HarRecordingWatchdog(BaseWatchdog):
 			entry = self._entries[request_id]
 			entry.ts_finished = params.get('timestamp')
 			# Fetch response body via CDP as dataReceived may be incomplete
-			import asyncio as _asyncio
 
 			async def _fetch_body(self_ref, req_id, sess_id):
 				try:
@@ -410,7 +410,10 @@ class HarRecordingWatchdog(BaseWatchdog):
 					pass
 
 			# Always schedule the response body fetch task
-			_asyncio.create_task(_fetch_body(self, request_id, session_id))
+			create_task_with_error_handling(
+				_fetch_body(self, request_id, session_id),
+				name=f'har-fetch-{request_id}',
+			)
 
 			encoded_length = (
 				params.get('encodedDataLength') if hasattr(params, 'get') else getattr(params, 'encodedDataLength', None)

--- a/browser_use/browser/watchdogs/har_recording_watchdog.py
+++ b/browser_use/browser/watchdogs/har_recording_watchdog.py
@@ -226,7 +226,14 @@ class HarRecordingWatchdog(BaseWatchdog):
 		"""
 		pending = [t for t in self._fetch_tasks if not t.done()]
 		if pending:
-			await asyncio.wait(pending, timeout=FETCH_DRAIN_TIMEOUT_SECONDS)
+			_, still_pending = await asyncio.wait(pending, timeout=FETCH_DRAIN_TIMEOUT_SECONDS)
+			# Cancel fetches that outlived the window: they hold CDP/entry
+			# references after the HAR is written and would surface as
+			# "Task was destroyed but it is pending" at loop shutdown. Safe
+			# because the wrapper's done-callback treats CancelledError as
+			# normal, and the discard callback still fires so the set cleans up.
+			for task in still_pending:
+				task.cancel()
 
 	# =============== CDP Event Handlers (sync) ==================
 	def _on_request_will_be_sent(self, params: RequestWillBeSentEvent, session_id: str | None) -> None:

--- a/browser_use/browser/watchdogs/har_recording_watchdog.py
+++ b/browser_use/browser/watchdogs/har_recording_watchdog.py
@@ -31,6 +31,12 @@ from browser_use.browser.watchdog_base import BaseWatchdog
 from browser_use.utils import create_task_with_error_handling
 
 
+# Grace window for in-flight response-body fetches when the browser stops.
+# A fetch that outlives the window is written without its body, which matches
+# the pre-existing behavior for that entry instead of stalling shutdown.
+FETCH_DRAIN_TIMEOUT_SECONDS = 10.0
+
+
 @dataclass
 class _HarContent:
 	mime_type: str | None = None
@@ -204,10 +210,23 @@ class HarRecordingWatchdog(BaseWatchdog):
 		if not self._enabled:
 			return
 		try:
+			await self._drain_fetch_tasks()
 			await self._write_har()
 			self.logger.info(f'📊 HAR file saved: {self._har_path}')
 		except Exception as e:
 			self.logger.warning(f'Failed to write HAR: {e}')
+
+	async def _drain_fetch_tasks(self) -> None:
+		"""Wait for in-flight body fetches so the HAR includes their bodies.
+
+		Bounded on purpose: a fetch that never completes must not stall
+		shutdown, so after the grace window the HAR is written with whatever
+		completed — the same outcome the entry had before this watchdog
+		tracked fetch tasks at all.
+		"""
+		pending = [t for t in self._fetch_tasks if not t.done()]
+		if pending:
+			await asyncio.wait(pending, timeout=FETCH_DRAIN_TIMEOUT_SECONDS)
 
 	# =============== CDP Event Handlers (sync) ==================
 	def _on_request_will_be_sent(self, params: RequestWillBeSentEvent, session_id: str | None) -> None:


### PR DESCRIPTION
Why

`_on_loading_finished` in `browser_use/browser/watchdogs/har_recording_watchdog.py` schedules the response-body fetch with a bare `asyncio.create_task(...)` and drops the returned Task handle. Every other watchdog in this directory goes through `create_task_with_error_handling`. This is the only bare create_task in the whole watchdogs set.

`asyncio.create_task` docs are explicit that the caller should save a reference to avoid the task disappearing mid-execution. Here the coroutine awaits a CDP `Network.getResponseBody` round-trip; if the task is garbage-collected during that await, the coroutine is cancelled and `entry.response_body` never gets written, so the HAR entry ends up without its body. The handler is a synchronous CDP callback fired once per `Network.loadingFinished` event, so on a page with many requests there are many of these short-lived tasks in flight.

Honest caveat: whether a dropped task actually gets collected depends on timing and load, so I can't point at a deterministic reproduction where a body is missing. The code path is still the only one in this directory that violates the documented create_task contract and the directory's own pattern.

What changed

1. `6d9852b` switches the call to `create_task_with_error_handling` with a per-request task name, matching the rest of the watchdogs. The function-local `import asyncio as _asyncio` is removed.

2. `ef3bcdf` actually keeps the task alive. A bare `create_task_with_error_handling(...)` that drops the return value still leaves the task with no external reference; its done-callback is a plain function taking the task as an argument and does not form a closure back to it, so the task is still collected once it suspends on the CDP round-trip. The follow-up stores each fetch task in `self._fetch_tasks` (initialized in `__init__`) and registers `task.add_done_callback(self._fetch_tasks.discard)` so the set holds a strong reference until the task finishes.

The set only ever holds in-flight tasks — the done callback drops each entry as it fires — so there is no leak of completed tasks.

Note on supersedes

This is the second attempt at the same fix. The previous PR (#5653) was accidentally closed after a force-push that rewrote the author email on history; the branch is no longer re-openable, so this is a clean replacement against the latest main with the same final content.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the HAR recording watchdog so response-body fetch tasks are kept alive and drained before the HAR is written, preventing entries from missing their bodies.

- Schedules the fetch via `create_task_with_error_handling` with a per-request task name, matching the other watchdogs.
- Stores each task in `self._fetch_tasks` until it finishes; a done callback discards completed tasks.
- On browser stop, awaits pending fetches (with a 10s grace window) before serializing, so completed bodies are included.
- Cancels fetches that outlive the grace window so they don't die as "Task was destroyed but it is pending" at loop shutdown.

<sup>Written for commit 8a2113c63335ba8e7480dcfa9f254a0ac7bc423d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

