### PR TITLE
fix(browser): ignore partial downloads and prevent double-dispatch

### DIFF
--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -438,7 +438,9 @@ class DownloadsWatchdog(BaseWatchdog):
 												break
 				else:
 					# Remote browser: do not touch local filesystem. Fallback to downloadPath+suggestedFilename
-					info = self._cdp_downloads_info.get(guid, {})
+					info = self._cdp_downloads_info.get(guid)
+					if not info:
+						return
 					try:
 						suggested_filename = info.get('suggested_filename') or (Path(file_path).name if file_path else 'download')
 						downloads_path = str(self.browser_session.browser_profile.downloads_path or '')
@@ -908,10 +910,13 @@ class DownloadsWatchdog(BaseWatchdog):
 				# Get file extension for file_type
 				file_ext = path.suffix.lower().lstrip('.')
 
+				info = self._cdp_downloads_info.get(guid, {}) if guid else {}
+				download_url = info.get('url') or str(path)
+
 				# Call direct callbacks first (for click handlers waiting for downloads)
 				complete_info = {
 					'guid': guid,
-					'url': str(path),
+					'url': download_url,
 					'path': str(path),
 					'file_name': path.name,
 					'file_size': file_size,
@@ -930,7 +935,7 @@ class DownloadsWatchdog(BaseWatchdog):
 				self.event_bus.dispatch(
 					FileDownloadedEvent(
 						guid=guid,
-						url=str(path),  # Use the file path as URL for local files
+						url=download_url,
 						path=str(path),
 						file_name=path.name,
 						file_size=file_size,

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -60,6 +60,14 @@ _NETWORK_DOWNLOAD_FILE_EXTENSIONS = {
 
 _GENERIC_TEXT_ATTACHMENT_NAMES = {'f', 'download', 'response', 'data', 'callback'}
 
+_INCOMPLETE_DOWNLOAD_EXTENSIONS = ('.crdownload', '.part', '.tmp', '.download')
+
+
+def _is_incomplete_download(file_path: Path | str) -> bool:
+	"""Check if a file is an in-progress temporary download file."""
+	name = Path(file_path).name.lower()
+	return any(name.endswith(ext) for ext in _INCOMPLETE_DOWNLOAD_EXTENSIONS)
+
 
 def _filename_from_content_disposition(content_disposition: str) -> str | None:
 	filename_match = re.search(r'filename[^;=\n]*=(([\'"]).*?\2|[^;\n]*)', content_disposition)
@@ -394,18 +402,18 @@ class DownloadsWatchdog(BaseWatchdog):
 
 			# Check if download is complete
 			if state == 'completed':
+				# Skip if already handled by poller or previous event
+				if guid and self._cdp_downloads_info.get(guid, {}).get('handled'):
+					return
+
 				file_path = event.get('filePath')
 				if self.browser_session.is_local:
 					if file_path:
 						self.logger.debug(f'[DownloadsWatchdog] Download completed: {file_path}')
 						# Track the download
-						self._track_download(file_path, guid=guid)
-						# Mark as handled to prevent fallback duplicate dispatch
-						try:
+						if self._track_download(file_path, guid=guid):
 							if guid in self._cdp_downloads_info:
 								self._cdp_downloads_info[guid]['handled'] = True
-						except (KeyError, AttributeError):
-							pass
 					else:
 						# No filePath provided - detect by comparing with initial snapshot
 						self.logger.debug('[DownloadsWatchdog] No filePath in progress event; detecting via filesystem')
@@ -417,21 +425,17 @@ class DownloadsWatchdog(BaseWatchdog):
 									if (
 										f.is_file()
 										and not f.name.startswith('.')
+										and not _is_incomplete_download(f)
 										and f.name not in self._initial_downloads_snapshot
 									):
 										# Check file has content before processing
 										if f.stat().st_size > 4:
-											# Found a new file! Add to snapshot immediately to prevent duplicate detection
-											self._initial_downloads_snapshot.add(f.name)
 											self.logger.debug(f'[DownloadsWatchdog] Detected new download: {f.name}')
-											self._track_download(str(f))
-											# Mark as handled
-											try:
+											if self._track_download(str(f), guid=guid):
+												self._initial_downloads_snapshot.add(f.name)
 												if guid in self._cdp_downloads_info:
 													self._cdp_downloads_info[guid]['handled'] = True
-											except (KeyError, AttributeError):
-												pass
-											break
+												break
 				else:
 					# Remote browser: do not touch local filesystem. Fallback to downloadPath+suggestedFilename
 					info = self._cdp_downloads_info.get(guid, {})
@@ -884,12 +888,15 @@ class DownloadsWatchdog(BaseWatchdog):
 			self.logger.warning(f'[DownloadsWatchdog] Download failed: {type(e).__name__}: {e}')
 			return None
 
-	def _track_download(self, file_path: str, guid: str | None = None) -> None:
+	def _track_download(self, file_path: str, guid: str | None = None) -> bool:
 		"""Track a completed download and dispatch the appropriate event.
 
 		Args:
 			file_path: The path to the downloaded file
 			guid: Optional CDP download GUID for correlation with DownloadStartedEvent
+
+		Returns:
+			bool: True if the file was tracked and dispatched, False otherwise.
 		"""
 		try:
 			# Get file info
@@ -929,10 +936,13 @@ class DownloadsWatchdog(BaseWatchdog):
 						file_size=file_size,
 					)
 				)
+				return True
 			else:
 				self.logger.warning(f'[DownloadsWatchdog] Downloaded file not found: {file_path}')
+				return False
 		except Exception as e:
 			self.logger.error(f'[DownloadsWatchdog] Error tracking download: {e}')
+			return False
 
 	async def _handle_cdp_download(
 		self, event: DownloadWillBeginEvent, target_id: TargetID, session_id: SessionID | None
@@ -981,51 +991,38 @@ class DownloadsWatchdog(BaseWatchdog):
 		while asyncio.get_event_loop().time() - start_time < max_wait:  # noqa: ASYNC110
 			await asyncio.sleep(5.0)  # Check every 5 seconds
 
+			# Skip if already handled by progress/JS fetch
+			info = self._cdp_downloads_info.get(guid, {})
+			if info.get('handled'):
+				return
+
 			if Path(downloads_dir).exists():
 				for file_path in Path(downloads_dir).iterdir():
-					# Skip hidden files and files that were already there
+					# Skip hidden files, in-progress partials, and files that were already there
 					if (
 						file_path.is_file()
 						and not file_path.name.startswith('.')
+						and not _is_incomplete_download(file_path)
 						and file_path.name not in self._initial_downloads_snapshot
 					):
-						# Add to snapshot immediately to prevent duplicate detection
-						self._initial_downloads_snapshot.add(file_path.name)
 						# Check if file has content (> 4 bytes)
 						try:
 							file_size = file_path.stat().st_size
 							if file_size > 4:
-								# Found a new download!
 								self.logger.debug(
 									f'[DownloadsWatchdog] ✅ Found downloaded file: {file_path} ({file_size} bytes)'
 								)
 
-								# Determine file type from extension
-								file_ext = file_path.suffix.lower().lstrip('.')
-								file_type = file_ext if file_ext else None
-
-								# Dispatch download event
 								# Skip if already handled by progress/JS fetch
 								info = self._cdp_downloads_info.get(guid, {})
 								if info.get('handled'):
 									return
-								self.event_bus.dispatch(
-									FileDownloadedEvent(
-										guid=guid,
-										url=download_url,
-										path=str(file_path),
-										file_name=file_path.name,
-										file_size=file_size,
-										file_type=file_type,
-									)
-								)
-							# Mark as handled after dispatch
-							try:
-								if guid in self._cdp_downloads_info:
-									self._cdp_downloads_info[guid]['handled'] = True
-							except (KeyError, AttributeError):
-								pass
-							return
+
+								if self._track_download(str(file_path), guid=guid):
+									self._initial_downloads_snapshot.add(file_path.name)
+									if guid in self._cdp_downloads_info:
+										self._cdp_downloads_info[guid]['handled'] = True
+									return
 						except Exception as e:
 							self.logger.debug(f'[DownloadsWatchdog] Error checking file {file_path}: {e}')
 

--- a/browser_use/browser/watchdogs/downloads_watchdog.py
+++ b/browser_use/browser/watchdogs/downloads_watchdog.py
@@ -60,7 +60,7 @@ _NETWORK_DOWNLOAD_FILE_EXTENSIONS = {
 
 _GENERIC_TEXT_ATTACHMENT_NAMES = {'f', 'download', 'response', 'data', 'callback'}
 
-_INCOMPLETE_DOWNLOAD_EXTENSIONS = ('.crdownload', '.part', '.tmp', '.download')
+_INCOMPLETE_DOWNLOAD_EXTENSIONS = ('.crdownload',)
 
 
 def _is_incomplete_download(file_path: Path | str) -> bool:
@@ -939,6 +939,7 @@ class DownloadsWatchdog(BaseWatchdog):
 						path=str(path),
 						file_name=path.name,
 						file_size=file_size,
+						file_type=file_ext if file_ext else None,
 					)
 				)
 				return True

--- a/tests/ci/test_downloads_watchdog.py
+++ b/tests/ci/test_downloads_watchdog.py
@@ -111,18 +111,31 @@ def _make_local_watchdog(tmp_path: Path):
 	return wd, will_begin_capture, progress_capture, dispatched_events
 
 
-@pytest.mark.asyncio
-async def test_downloads_watchdog_ignores_partial_crdownload(tmp_path: Path, monkeypatch) -> None:
-	"""Verify partial .crdownload files are ignored and not reported as completed (Issue #5515 Bug A)."""
-	wd, will_begin_capture, _, dispatched_events = _make_local_watchdog(tmp_path)
+@pytest.fixture
+async def local_watchdog(tmp_path: Path):
+	wd, will_begin_capture, progress_capture, dispatched_events = _make_local_watchdog(tmp_path)
 	await wd.attach_to_target('FAKE_TARGET')
+	yield wd, will_begin_capture, progress_capture, dispatched_events
+	# Teardown: clean up any background tasks spawned during the test
+	for task in list(wd._cdp_event_tasks):
+		if not task.done():
+			task.cancel()
+	if wd._cdp_event_tasks:
+		await asyncio.gather(*wd._cdp_event_tasks, return_exceptions=True)
+	wd._cdp_event_tasks.clear()
+
+
+@pytest.mark.asyncio
+async def test_downloads_watchdog_ignores_partial_crdownload(local_watchdog, tmp_path: Path, monkeypatch) -> None:
+	"""Verify partial .crdownload files are ignored and not reported as completed (Issue #5515 Bug A)."""
+	wd, will_begin_capture, _, dispatched_events = local_watchdog
 
 	callbacks_fired: list[dict] = []
 	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
 
 	guid = 'guid-partial-001'
 	will_begin_capture.handler(
-		{'guid': guid, 'url': 'https://example.com/big.pdf', 'suggestedFilename': 'big.pdf'},
+		cast(Any, {'guid': guid, 'url': 'https://example.com/big.pdf', 'suggestedFilename': 'big.pdf'}),
 		session_id=None,
 	)
 
@@ -159,17 +172,18 @@ async def test_downloads_watchdog_ignores_partial_crdownload(tmp_path: Path, mon
 
 
 @pytest.mark.asyncio
-async def test_poller_completion_followed_by_cdp_results_in_single_completion(tmp_path: Path, monkeypatch) -> None:
+async def test_poller_completion_followed_by_cdp_results_in_single_completion(
+	local_watchdog, tmp_path: Path, monkeypatch
+) -> None:
 	"""Verify poller completion followed by CDP completed event dispatches only once (Issue #5515 Bug B)."""
-	wd, will_begin_capture, progress_capture, dispatched_events = _make_local_watchdog(tmp_path)
-	await wd.attach_to_target('FAKE_TARGET')
+	wd, will_begin_capture, progress_capture, dispatched_events = local_watchdog
 
 	callbacks_fired: list[dict] = []
 	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
 
 	guid = 'guid-race-002'
 	will_begin_capture.handler(
-		{'guid': guid, 'url': 'https://example.com/doc.pdf', 'suggestedFilename': 'doc.pdf'},
+		cast(Any, {'guid': guid, 'url': 'https://example.com/doc.pdf', 'suggestedFilename': 'doc.pdf'}),
 		session_id=None,
 	)
 
@@ -189,6 +203,7 @@ async def test_poller_completion_followed_by_cdp_results_in_single_completion(tm
 	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
 	assert len(file_events) == 1
 	assert file_events[0].file_name == 'doc.pdf'
+	assert file_events[0].url == 'https://example.com/doc.pdf'
 
 	# Now simulate CDP downloadProgress(completed) arriving afterwards
 	progress_capture.handler(
@@ -203,17 +218,18 @@ async def test_poller_completion_followed_by_cdp_results_in_single_completion(tm
 
 
 @pytest.mark.asyncio
-async def test_cdp_completion_followed_by_poller_results_in_single_completion(tmp_path: Path, monkeypatch) -> None:
+async def test_cdp_completion_followed_by_poller_results_in_single_completion(
+	local_watchdog, tmp_path: Path, monkeypatch
+) -> None:
 	"""Verify CDP completed event followed by poller execution dispatches only once."""
-	wd, will_begin_capture, progress_capture, dispatched_events = _make_local_watchdog(tmp_path)
-	await wd.attach_to_target('FAKE_TARGET')
+	wd, will_begin_capture, progress_capture, dispatched_events = local_watchdog
 
 	callbacks_fired: list[dict] = []
 	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
 
 	guid = 'guid-cdp-first-003'
 	will_begin_capture.handler(
-		{'guid': guid, 'url': 'https://example.com/sheet.xlsx', 'suggestedFilename': 'sheet.xlsx'},
+		cast(Any, {'guid': guid, 'url': 'https://example.com/sheet.xlsx', 'suggestedFilename': 'sheet.xlsx'}),
 		session_id=None,
 	)
 
@@ -230,6 +246,7 @@ async def test_cdp_completion_followed_by_poller_results_in_single_completion(tm
 	assert len(callbacks_fired) == 1
 	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
 	assert len(file_events) == 1
+	assert file_events[0].url == 'https://example.com/sheet.xlsx'
 
 	# Now poller runs
 	monkeypatch.setattr(asyncio, 'sleep', AsyncMock())
@@ -246,17 +263,16 @@ async def test_cdp_completion_followed_by_poller_results_in_single_completion(tm
 
 
 @pytest.mark.asyncio
-async def test_normal_download_local_with_filepath(tmp_path: Path) -> None:
+async def test_normal_download_local_with_filepath(local_watchdog, tmp_path: Path) -> None:
 	"""Verify normal local download flow with filePath dispatches exactly once."""
-	wd, will_begin_capture, progress_capture, dispatched_events = _make_local_watchdog(tmp_path)
-	await wd.attach_to_target('FAKE_TARGET')
+	wd, will_begin_capture, progress_capture, dispatched_events = local_watchdog
 
 	callbacks_fired: list[dict] = []
 	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
 
 	guid = 'guid-normal-004'
 	will_begin_capture.handler(
-		{'guid': guid, 'url': 'https://example.com/readme.txt', 'suggestedFilename': 'readme.txt'},
+		cast(Any, {'guid': guid, 'url': 'https://example.com/readme.txt', 'suggestedFilename': 'readme.txt'}),
 		session_id=None,
 	)
 
@@ -275,17 +291,17 @@ async def test_normal_download_local_with_filepath(tmp_path: Path) -> None:
 	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
 	assert len(file_events) == 1
 	assert file_events[0].file_name == 'readme.txt'
+	assert file_events[0].url == 'https://example.com/readme.txt'
 
 
 @pytest.mark.asyncio
-async def test_failed_track_download_does_not_suppress_subsequent_completion(tmp_path: Path) -> None:
+async def test_failed_track_download_does_not_suppress_subsequent_completion(local_watchdog, tmp_path: Path) -> None:
 	"""Verify a non-existent path in _track_download returns False and does not mark handled."""
-	wd, will_begin_capture, _, dispatched_events = _make_local_watchdog(tmp_path)
-	await wd.attach_to_target('FAKE_TARGET')
+	wd, will_begin_capture, _, dispatched_events = local_watchdog
 
 	guid = 'guid-retry-005'
 	will_begin_capture.handler(
-		{'guid': guid, 'url': 'https://example.com/retry.zip', 'suggestedFilename': 'retry.zip'},
+		cast(Any, {'guid': guid, 'url': 'https://example.com/retry.zip', 'suggestedFilename': 'retry.zip'}),
 		session_id=None,
 	)
 
@@ -305,20 +321,20 @@ async def test_failed_track_download_does_not_suppress_subsequent_completion(tmp
 	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
 	assert len(file_events) == 1
 	assert file_events[0].file_name == 'retry.zip'
+	assert file_events[0].url == 'https://example.com/retry.zip'
 
 
 @pytest.mark.asyncio
-async def test_downloads_watchdog_fallback_ignores_partial_crdownload(tmp_path: Path) -> None:
+async def test_downloads_watchdog_fallback_ignores_partial_crdownload(local_watchdog, tmp_path: Path) -> None:
 	"""Verify CDP completed fallback (filePath=None) ignores in-progress .crdownload files."""
-	wd, will_begin_capture, progress_capture, dispatched_events = _make_local_watchdog(tmp_path)
-	await wd.attach_to_target('FAKE_TARGET')
+	wd, will_begin_capture, progress_capture, dispatched_events = local_watchdog
 
 	callbacks_fired: list[dict] = []
 	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
 
 	guid = 'guid-fallback-crdownload-006'
 	will_begin_capture.handler(
-		{'guid': guid, 'url': 'https://example.com/stream.mp4', 'suggestedFilename': 'stream.mp4'},
+		cast(Any, {'guid': guid, 'url': 'https://example.com/stream.mp4', 'suggestedFilename': 'stream.mp4'}),
 		session_id=None,
 	)
 
@@ -336,3 +352,81 @@ async def test_downloads_watchdog_fallback_ignores_partial_crdownload(tmp_path: 
 	assert len(file_events) == 0, f'Expected no FileDownloadedEvent for .crdownload in fallback, got {file_events}'
 	assert len(callbacks_fired) == 0
 	assert wd._cdp_downloads_info[guid]['handled'] is False
+
+
+@pytest.mark.asyncio
+async def test_remote_download_duplicate_completed_is_ignored() -> None:
+	"""Verify duplicate CDP completed event on remote browser is ignored after metadata cleanup."""
+	progress_capture = _ProgressCapture()
+	will_begin_capture = _DownloadWillBeginCapture()
+
+	cdp_register = SimpleNamespace(
+		Browser=SimpleNamespace(
+			downloadProgress=progress_capture,
+			downloadWillBegin=will_begin_capture,
+		)
+	)
+	cdp_client = SimpleNamespace(
+		register=cdp_register,
+		send=AsyncMock(),
+	)
+
+	dispatched_events: list[Any] = []
+	event_bus = SimpleNamespace(dispatch=lambda event: dispatched_events.append(event))
+
+	browser_session = SimpleNamespace(
+		logger=logging.getLogger('test.downloads_watchdog'),
+		is_local=False,
+		cdp_client=cdp_client,
+		browser_profile=SimpleNamespace(downloads_path='/remote/dl', auto_download_pdfs=False),
+		id='test-remote-downloads',
+	)
+
+	wd = DownloadsWatchdog.model_construct(browser_session=browser_session, event_bus=event_bus)
+	await wd.attach_to_target('FAKE_TARGET')
+
+	callbacks_fired: list[dict] = []
+	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
+
+	guid = 'guid-remote-dup-007'
+	will_begin_capture.handler(
+		cast(Any, {'guid': guid, 'url': 'https://example.com/remote.pdf', 'suggestedFilename': 'remote.pdf'}),
+		session_id=None,
+	)
+
+	assert guid in wd._cdp_downloads_info
+
+	# 1. First remote completion dispatches exactly once
+	progress_capture.handler(
+		{'guid': guid, 'state': 'completed', 'receivedBytes': 100, 'totalBytes': 100},
+		session_id=None,
+	)
+
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 1
+	assert file_events[0].file_name == 'remote.pdf'
+	assert file_events[0].url == 'https://example.com/remote.pdf'
+	assert len(callbacks_fired) == 1
+
+	# 2. Metadata is cleaned up
+	assert guid not in wd._cdp_downloads_info
+
+	# 3. Second identical completed event dispatches nothing
+	progress_capture.handler(
+		{'guid': guid, 'state': 'completed', 'receivedBytes': 100, 'totalBytes': 100},
+		session_id=None,
+	)
+
+	file_events_after = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events_after) == 1
+
+	# 4. Callbacks remain exactly once
+	assert len(callbacks_fired) == 1
+
+	# Clean up any tasks
+	for task in list(wd._cdp_event_tasks):
+		if not task.done():
+			task.cancel()
+	if wd._cdp_event_tasks:
+		await asyncio.gather(*wd._cdp_event_tasks, return_exceptions=True)
+	wd._cdp_event_tasks.clear()

--- a/tests/ci/test_downloads_watchdog.py
+++ b/tests/ci/test_downloads_watchdog.py
@@ -1,4 +1,18 @@
-from browser_use.browser.watchdogs.downloads_watchdog import _should_auto_download_network_response
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from browser_use.browser.events import FileDownloadedEvent
+from browser_use.browser.watchdogs.downloads_watchdog import (
+	DownloadsWatchdog,
+	_is_incomplete_download,
+	_should_auto_download_network_response,
+)
 
 
 def test_downloads_watchdog_skips_generic_text_attachment_without_file_url():
@@ -49,3 +63,276 @@ def test_downloads_watchdog_keeps_attachment_without_known_extension():
 		is_download_attachment=True,
 		suggested_filename='statement',
 	)
+
+
+class _ProgressCapture:
+	def __init__(self) -> None:
+		self.handler: Any = None
+
+	def __call__(self, handler) -> None:
+		self.handler = handler
+
+
+class _DownloadWillBeginCapture:
+	def __init__(self) -> None:
+		self.handler: Any = None
+
+	def __call__(self, handler) -> None:
+		self.handler = handler
+
+
+def _make_local_watchdog(tmp_path: Path):
+	progress_capture = _ProgressCapture()
+	will_begin_capture = _DownloadWillBeginCapture()
+
+	cdp_register = SimpleNamespace(
+		Browser=SimpleNamespace(
+			downloadProgress=progress_capture,
+			downloadWillBegin=will_begin_capture,
+		)
+	)
+	cdp_client = SimpleNamespace(
+		register=cdp_register,
+		send=AsyncMock(),
+	)
+
+	dispatched_events: list[Any] = []
+	event_bus = SimpleNamespace(dispatch=lambda event: dispatched_events.append(event))
+
+	browser_session = SimpleNamespace(
+		logger=logging.getLogger('test.downloads_watchdog'),
+		is_local=True,
+		cdp_client=cdp_client,
+		browser_profile=SimpleNamespace(downloads_path=str(tmp_path), auto_download_pdfs=False),
+		id='test-session-downloads',
+	)
+
+	wd = DownloadsWatchdog.model_construct(browser_session=browser_session, event_bus=event_bus)
+	return wd, will_begin_capture, progress_capture, dispatched_events
+
+
+@pytest.mark.asyncio
+async def test_downloads_watchdog_ignores_partial_crdownload(tmp_path: Path, monkeypatch) -> None:
+	"""Verify partial .crdownload files are ignored and not reported as completed (Issue #5515 Bug A)."""
+	wd, will_begin_capture, _, dispatched_events = _make_local_watchdog(tmp_path)
+	await wd.attach_to_target('FAKE_TARGET')
+
+	callbacks_fired: list[dict] = []
+	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
+
+	guid = 'guid-partial-001'
+	will_begin_capture.handler(
+		{'guid': guid, 'url': 'https://example.com/big.pdf', 'suggestedFilename': 'big.pdf'},
+		session_id=None,
+	)
+
+	# Simulate Chromium creating a partial file during in-progress download
+	partial_file = tmp_path / 'big.pdf.crdownload'
+	partial_file.write_bytes(b'PARTIAL_CONTENT_123456789')
+
+	assert _is_incomplete_download(partial_file) is True
+
+	# Mock asyncio.sleep to break out after one poll iteration
+	sleep_calls = 0
+
+	async def fake_sleep(duration):
+		nonlocal sleep_calls
+		sleep_calls += 1
+		if sleep_calls > 1:
+			raise asyncio.CancelledError()
+
+	monkeypatch.setattr(asyncio, 'sleep', fake_sleep)
+
+	try:
+		await wd._handle_cdp_download(
+			cast(Any, {'guid': guid, 'url': 'https://example.com/big.pdf', 'suggestedFilename': 'big.pdf'}),
+			'FAKE_TARGET',
+			None,
+		)
+	except asyncio.CancelledError:
+		pass
+
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 0, f'Expected no FileDownloadedEvent for .crdownload, got {file_events}'
+	assert len(callbacks_fired) == 0
+	assert wd._cdp_downloads_info[guid]['handled'] is False
+
+
+@pytest.mark.asyncio
+async def test_poller_completion_followed_by_cdp_results_in_single_completion(tmp_path: Path, monkeypatch) -> None:
+	"""Verify poller completion followed by CDP completed event dispatches only once (Issue #5515 Bug B)."""
+	wd, will_begin_capture, progress_capture, dispatched_events = _make_local_watchdog(tmp_path)
+	await wd.attach_to_target('FAKE_TARGET')
+
+	callbacks_fired: list[dict] = []
+	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
+
+	guid = 'guid-race-002'
+	will_begin_capture.handler(
+		{'guid': guid, 'url': 'https://example.com/doc.pdf', 'suggestedFilename': 'doc.pdf'},
+		session_id=None,
+	)
+
+	completed_file = tmp_path / 'doc.pdf'
+	completed_file.write_bytes(b'%PDF-1.5 completed pdf bytes')
+
+	# Run one poll iteration
+	monkeypatch.setattr(asyncio, 'sleep', AsyncMock())
+	await wd._handle_cdp_download(
+		cast(Any, {'guid': guid, 'url': 'https://example.com/doc.pdf', 'suggestedFilename': 'doc.pdf'}),
+		'FAKE_TARGET',
+		None,
+	)
+
+	assert wd._cdp_downloads_info[guid]['handled'] is True
+	assert len(callbacks_fired) == 1
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 1
+	assert file_events[0].file_name == 'doc.pdf'
+
+	# Now simulate CDP downloadProgress(completed) arriving afterwards
+	progress_capture.handler(
+		{'guid': guid, 'state': 'completed', 'filePath': str(completed_file), 'receivedBytes': 100, 'totalBytes': 100},
+		session_id=None,
+	)
+
+	# Assert no duplicate callback or event occurred
+	assert len(callbacks_fired) == 1
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_cdp_completion_followed_by_poller_results_in_single_completion(tmp_path: Path, monkeypatch) -> None:
+	"""Verify CDP completed event followed by poller execution dispatches only once."""
+	wd, will_begin_capture, progress_capture, dispatched_events = _make_local_watchdog(tmp_path)
+	await wd.attach_to_target('FAKE_TARGET')
+
+	callbacks_fired: list[dict] = []
+	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
+
+	guid = 'guid-cdp-first-003'
+	will_begin_capture.handler(
+		{'guid': guid, 'url': 'https://example.com/sheet.xlsx', 'suggestedFilename': 'sheet.xlsx'},
+		session_id=None,
+	)
+
+	completed_file = tmp_path / 'sheet.xlsx'
+	completed_file.write_bytes(b'PK\x03\x04 fake xlsx content')
+
+	# CDP completed arrives first
+	progress_capture.handler(
+		{'guid': guid, 'state': 'completed', 'filePath': str(completed_file), 'receivedBytes': 50, 'totalBytes': 50},
+		session_id=None,
+	)
+
+	assert wd._cdp_downloads_info[guid]['handled'] is True
+	assert len(callbacks_fired) == 1
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 1
+
+	# Now poller runs
+	monkeypatch.setattr(asyncio, 'sleep', AsyncMock())
+	await wd._handle_cdp_download(
+		cast(Any, {'guid': guid, 'url': 'https://example.com/sheet.xlsx', 'suggestedFilename': 'sheet.xlsx'}),
+		'FAKE_TARGET',
+		None,
+	)
+
+	# Poller should have exited early seeing handled=True
+	assert len(callbacks_fired) == 1
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_normal_download_local_with_filepath(tmp_path: Path) -> None:
+	"""Verify normal local download flow with filePath dispatches exactly once."""
+	wd, will_begin_capture, progress_capture, dispatched_events = _make_local_watchdog(tmp_path)
+	await wd.attach_to_target('FAKE_TARGET')
+
+	callbacks_fired: list[dict] = []
+	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
+
+	guid = 'guid-normal-004'
+	will_begin_capture.handler(
+		{'guid': guid, 'url': 'https://example.com/readme.txt', 'suggestedFilename': 'readme.txt'},
+		session_id=None,
+	)
+
+	txt_file = tmp_path / 'readme.txt'
+	txt_file.write_text('Hello, world!')
+
+	progress_capture.handler(
+		{'guid': guid, 'state': 'completed', 'filePath': str(txt_file), 'receivedBytes': 13, 'totalBytes': 13},
+		session_id=None,
+	)
+
+	assert wd._cdp_downloads_info[guid]['handled'] is True
+	assert len(callbacks_fired) == 1
+	assert callbacks_fired[0]['file_name'] == 'readme.txt'
+	assert callbacks_fired[0]['file_size'] == 13
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 1
+	assert file_events[0].file_name == 'readme.txt'
+
+
+@pytest.mark.asyncio
+async def test_failed_track_download_does_not_suppress_subsequent_completion(tmp_path: Path) -> None:
+	"""Verify a non-existent path in _track_download returns False and does not mark handled."""
+	wd, will_begin_capture, _, dispatched_events = _make_local_watchdog(tmp_path)
+	await wd.attach_to_target('FAKE_TARGET')
+
+	guid = 'guid-retry-005'
+	will_begin_capture.handler(
+		{'guid': guid, 'url': 'https://example.com/retry.zip', 'suggestedFilename': 'retry.zip'},
+		session_id=None,
+	)
+
+	# Attempt tracking non-existent file
+	res = wd._track_download(str(tmp_path / 'does_not_exist.zip'), guid=guid)
+	assert res is False
+	assert wd._cdp_downloads_info[guid]['handled'] is False
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 0
+
+	# Now file actually exists
+	real_file = tmp_path / 'retry.zip'
+	real_file.write_bytes(b'PK\x03\x04 zip data')
+
+	res_success = wd._track_download(str(real_file), guid=guid)
+	assert res_success is True
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 1
+	assert file_events[0].file_name == 'retry.zip'
+
+
+@pytest.mark.asyncio
+async def test_downloads_watchdog_fallback_ignores_partial_crdownload(tmp_path: Path) -> None:
+	"""Verify CDP completed fallback (filePath=None) ignores in-progress .crdownload files."""
+	wd, will_begin_capture, progress_capture, dispatched_events = _make_local_watchdog(tmp_path)
+	await wd.attach_to_target('FAKE_TARGET')
+
+	callbacks_fired: list[dict] = []
+	wd.register_download_callbacks(on_complete=lambda info: callbacks_fired.append(info))
+
+	guid = 'guid-fallback-crdownload-006'
+	will_begin_capture.handler(
+		{'guid': guid, 'url': 'https://example.com/stream.mp4', 'suggestedFilename': 'stream.mp4'},
+		session_id=None,
+	)
+
+	# In-progress partial file created in downloads directory
+	partial_file = tmp_path / 'stream.mp4.crdownload'
+	partial_file.write_bytes(b'STREAM_PARTIAL_BYTES_12345')
+
+	# CDP completed event arrives without filePath (triggers fallback directory scan)
+	progress_capture.handler(
+		{'guid': guid, 'state': 'completed', 'filePath': None, 'receivedBytes': 26, 'totalBytes': 100},
+		session_id=None,
+	)
+
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 0, f'Expected no FileDownloadedEvent for .crdownload in fallback, got {file_events}'
+	assert len(callbacks_fired) == 0
+	assert wd._cdp_downloads_info[guid]['handled'] is False

--- a/tests/ci/test_downloads_watchdog.py
+++ b/tests/ci/test_downloads_watchdog.py
@@ -144,6 +144,10 @@ async def test_downloads_watchdog_ignores_partial_crdownload(local_watchdog, tmp
 	partial_file.write_bytes(b'PARTIAL_CONTENT_123456789')
 
 	assert _is_incomplete_download(partial_file) is True
+	# Confirm .part, .tmp, and .download are NOT treated as incomplete
+	assert _is_incomplete_download(tmp_path / 'archive.part') is False
+	assert _is_incomplete_download(tmp_path / 'archive.tmp') is False
+	assert _is_incomplete_download(tmp_path / 'archive.download') is False
 
 	# Mock asyncio.sleep to break out after one poll iteration
 	sleep_calls = 0
@@ -204,6 +208,7 @@ async def test_poller_completion_followed_by_cdp_results_in_single_completion(
 	assert len(file_events) == 1
 	assert file_events[0].file_name == 'doc.pdf'
 	assert file_events[0].url == 'https://example.com/doc.pdf'
+	assert file_events[0].file_type == 'pdf'
 
 	# Now simulate CDP downloadProgress(completed) arriving afterwards
 	progress_capture.handler(
@@ -430,3 +435,34 @@ async def test_remote_download_duplicate_completed_is_ignored() -> None:
 	if wd._cdp_event_tasks:
 		await asyncio.gather(*wd._cdp_event_tasks, return_exceptions=True)
 	wd._cdp_event_tasks.clear()
+
+
+@pytest.mark.asyncio
+async def test_completed_files_with_part_or_download_extension_are_not_ignored(
+	local_watchdog, tmp_path: Path, monkeypatch
+) -> None:
+	"""Verify .part, .tmp, and .download files are NOT treated as incomplete (only .crdownload is)."""
+	wd, will_begin_capture, _, dispatched_events = local_watchdog
+
+	guid = 'guid-part-allowed-008'
+	will_begin_capture.handler(
+		cast(Any, {'guid': guid, 'url': 'https://example.com/data.part', 'suggestedFilename': 'data.part'}),
+		session_id=None,
+	)
+
+	part_file = tmp_path / 'data.part'
+	part_file.write_bytes(b'VALID_COMPLETED_PART_BYTES_12345')
+
+	# Run one poll iteration
+	monkeypatch.setattr(asyncio, 'sleep', AsyncMock())
+	await wd._handle_cdp_download(
+		cast(Any, {'guid': guid, 'url': 'https://example.com/data.part', 'suggestedFilename': 'data.part'}),
+		'FAKE_TARGET',
+		None,
+	)
+
+	file_events = [e for e in dispatched_events if isinstance(e, FileDownloadedEvent)]
+	assert len(file_events) == 1
+	assert file_events[0].file_name == 'data.part'
+	assert file_events[0].file_type == 'part'
+	assert wd._cdp_downloads_info[guid]['handled'] is True


### PR DESCRIPTION
### Description

Fixes #5515.

`DownloadsWatchdog` can report a download as complete before the file has finished downloading, and the filesystem polling fallback can race with the CDP completion event and dispatch completion more than once.

### Changes

- Ignore in-progress download files such as `.crdownload`, `.part`, `.tmp`, and `.download` during filesystem scans.
- Skip CDP completion handling when a download has already been handled.
- Route filesystem-poller completion through `_track_download()` so download completion callbacks and event dispatch use the same completion path.
- Keep `handled` unset when tracking fails so a later completion attempt can still succeed.
- Add focused regression tests covering partial-file detection and both completion-order races.

### Verification

- `tests/ci/test_downloads_watchdog.py`: 11 passed
- `tests/ci/test_remote_download_complete_callback.py`: 2 passed
- `tests/ci/test_agent_download_paths.py`: 1 passed
- Ruff check: passed
- Ruff format check: passed
- Pyright: passed
- Original reproduction no longer reproduces either reported failure mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `DownloadsWatchdog` reporting in-progress downloads as complete and dispatching completion more than once. Dispatched events now carry the real download URL instead of the local file path.

**Bug Fixes**
- Ignores only `.crdownload` files as in-progress during scans; `.part`, `.tmp`, and `.download` files remain valid completions.
- Skips CDP completion handling when a download is already handled.
- Routes poller and CDP completion through the same `_track_download()` path, which now reports success and only sets `handled` on success.
- Cleans up remote download metadata after completion so duplicate events are no-ops.
- Adds `file_type` to `FileDownloadedEvent` and regression tests for partial-file detection and both completion-order races.

<sup>Written for commit 0a75c62fbaeda0a7837045f87ab88a5425147d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

