### PR TITLE
Bump browser-harness to 0.1.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "markdownify==1.2.2",
     "python-docx==1.2.0",
     "browser-use-sdk==3.4.2",
-    "browser-harness==0.1.10",
+    "browser-harness==0.1.11",
 ]
 # google-api-core: only used for Google LLM APIs
 # pyperclip: only used for examples that use copy/paste


### PR DESCRIPTION
## Change
Pin `browser-harness==0.1.10` -> `0.1.11`.

## Why
browser-harness v0.1.11 is on PyPI (https://github.com/browser-use/browser-harness/releases/tag/v0.1.11). It carries the tab-management prompt guidance in SKILL.md plus the fixes merged since v0.1.10. The `browser-use` CLI wraps that skill, so users only get it once this pin moves and a new `browser-use` release is cut.

## Proof
Published wheel checked: `browser_harness/SKILL.md` contains the new tab guidance. CI on this PR installs the pinned version via `uv sync`.

## Risk / rollout / rollback
- Pin-only diff. Takes effect for users at the next `browser-use` release.
- Rollback: revert the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY3ATYZkSS6g2RoGiStQip

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `browser-harness` from 0.1.10 to 0.1.11 so `browser-use` picks up the new tab-management prompt guidance and fixes merged since 0.1.10.

This is a pin-only change; it takes effect for users at the next `browser-use` release, and rollback is just reverting the pin.

<sup>Written for commit 76849d492145027d8c5d77c0e4ead75fb27bb8e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

