### PR TITLE
fix(agent): redact sensitive data nested below list boundaries in saved history

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -521,6 +521,18 @@ class AgentHistory(BaseModel):
 
 		return redact_sensitive_string(value, sensitive_values)
 
+	def _filter_sensitive_data_from_value(self, value: Any, sensitive_data: dict[str, str | dict[str, str]] | None) -> Any:
+		"""Recursively filter sensitive data from any supported container or string value"""
+		if isinstance(value, str):
+			return self._filter_sensitive_data_from_string(value, sensitive_data)
+		if isinstance(value, dict):
+			return {key: self._filter_sensitive_data_from_value(item, sensitive_data) for key, item in value.items()}
+		if isinstance(value, list):
+			return [self._filter_sensitive_data_from_value(item, sensitive_data) for item in value]
+		if isinstance(value, tuple):
+			return tuple(self._filter_sensitive_data_from_value(item, sensitive_data) for item in value)
+		return value
+
 	def _filter_sensitive_data_from_dict(
 		self, data: dict[str, Any], sensitive_data: dict[str, str | dict[str, str]] | None
 	) -> dict[str, Any]:
@@ -528,24 +540,7 @@ class AgentHistory(BaseModel):
 		if not sensitive_data:
 			return data
 
-		filtered_data = {}
-		for key, value in data.items():
-			if isinstance(value, str):
-				filtered_data[key] = self._filter_sensitive_data_from_string(value, sensitive_data)
-			elif isinstance(value, dict):
-				filtered_data[key] = self._filter_sensitive_data_from_dict(value, sensitive_data)
-			elif isinstance(value, list):
-				filtered_data[key] = [
-					self._filter_sensitive_data_from_string(item, sensitive_data)
-					if isinstance(item, str)
-					else self._filter_sensitive_data_from_dict(item, sensitive_data)
-					if isinstance(item, dict)
-					else item
-					for item in value
-				]
-			else:
-				filtered_data[key] = value
-		return filtered_data
+		return {key: self._filter_sensitive_data_from_value(value, sensitive_data) for key, value in data.items()}
 
 	def model_dump(self, sensitive_data: dict[str, str | dict[str, str]] | None = None, **kwargs) -> dict[str, Any]:
 		"""Custom serialization handling circular references and filtering sensitive data"""

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -623,3 +623,47 @@ def test_password_field_without_type_attribute():
 	attrs_str = DOMTreeSerializer._build_attributes_string(node, list(DEFAULT_INCLUDE_ATTRIBUTES), '')
 
 	assert value in attrs_str, 'Input without type attribute should preserve its value'
+
+
+def test_history_filters_sensitive_data_inside_nested_lists(tmp_path):
+	"""
+	Saved history must not leak sensitive values that sit below a nested-list
+	boundary in an action parameter (e.g. a list of rows, each row a list).
+	"""
+	from typing import Any
+
+	from pydantic import create_model
+
+	from browser_use.agent.views import AgentHistory, AgentHistoryList, AgentOutput
+	from browser_use.browser.views import BrowserStateHistory
+	from browser_use.tools.registry.views import ActionModel
+
+	class NestedInputAction(BaseModel):
+		rows: list[list[str]]
+		lookup: dict[str, list[dict[str, str]]]
+
+	InputActionModel = create_model('InputActionModel', __base__=ActionModel, input=(NestedInputAction | None, None))
+	OutputModel = AgentOutput.type_with_custom_actions(InputActionModel)
+
+	action = InputActionModel(
+		input=NestedInputAction(
+			rows=[['token-123']],
+			lookup={'headers': [{'authorization': 'token-123'}]},
+		)
+	)
+	history = AgentHistoryList[Any](
+		history=[
+			AgentHistory(
+				model_output=OutputModel(memory='', action=[action]),
+				result=[],
+				state=BrowserStateHistory(url='https://example.test', title='t', tabs=[], interacted_element=[None]),
+			)
+		]
+	)
+
+	filepath = tmp_path / 'history.json'
+	history.save_to_file(filepath, sensitive_data={'api_key': 'token-123'})
+	saved = filepath.read_text(encoding='utf-8')
+
+	assert 'token-123' not in saved, 'Sensitive value leaked into the saved history file'
+	assert saved.count('<secret>api_key</secret>') == 2

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -645,11 +645,14 @@ def test_history_filters_sensitive_data_inside_nested_lists(tmp_path):
 	InputActionModel = create_model('InputActionModel', __base__=ActionModel, input=(NestedInputAction | None, None))
 	OutputModel = AgentOutput.type_with_custom_actions(InputActionModel)
 
-	action = InputActionModel(
-		input=NestedInputAction(
-			rows=[['token-123']],
-			lookup={'headers': [{'authorization': 'token-123'}]},
-		)
+	# built via model_validate because create_model's field is invisible to static analysis
+	action = InputActionModel.model_validate(
+		{
+			'input': {
+				'rows': [['token-123']],
+				'lookup': {'headers': [{'authorization': 'token-123'}]},
+			}
+		}
 	)
 	history = AgentHistoryList[Any](
 		history=[


### PR DESCRIPTION
Fixes #5623

### Problem

`AgentHistory._filter_sensitive_data_from_dict` walked only one level into lists. A `str` or `dict` sitting directly inside a list was filtered, but anything deeper — a list inside a list, or a dict inside that list — fell through to the `else item` branch and was returned unchanged.

So an action parameter shaped like this:

```python
{"input": {"rows": [["token-123"]]}}
```

was written to the history file with `token-123` intact, even though `save_to_file` was given `sensitive_data={"api_key": "token-123"}`.

The injection side of the same feature, `Registry._replace_sensitive_data`, already recurses properly over `str` / `dict` / `list` / `tuple`. The two halves disagreed about which container shapes exist, and the redaction half was the lenient one.

### Fix

Replaced the hand-rolled one-level walk with a single recursive value dispatcher, `_filter_sensitive_data_from_value`, that handles `str` / `dict` / `list` / `tuple` — mirroring the injection path so both directions now cover identical shapes. `_filter_sensitive_data_from_dict` keeps its signature and collapses to a one-line comprehension, so nothing calling it needs to change.

### Tests

Added `test_history_filters_sensitive_data_inside_nested_lists` in `tests/ci/security/test_sensitive_data.py`. It builds a real `AgentHistoryList` with an action holding both a `list[list[str]]` and a `dict[str, list[dict[str, str]]]`, saves it, and asserts the raw secret is absent and both occurrences became `<secret>api_key</secret>`.

### Evidence

On `main` (fix reverted, new test present):

```
tests/ci/security/test_sensitive_data.py::test_history_filters_sensitive_data_inside_nested_lists FAILED
E   AssertionError: Sensitive value leaked into the saved history file
E   assert 'token-123' not in '{\n  "histo...   }\n  ]\n}'
1 failed in 0.80s
```

With this branch:

```
tests/ci/security/test_sensitive_data.py::test_history_filters_sensitive_data_inside_nested_lists PASSED
1 passed in 0.15s
```

`tests/ci/security/` passes (102 tests), along with `ruff check`, `ruff format`, and `pyright`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5623 so sensitive data nested below list boundaries is redacted when saving agent history. Previously `_filter_sensitive_data_from_dict` only walked one level into lists, so `{"input": {"rows": [["token-123"]]}}` leaked the secret into the saved file; now redaction recurses through `str` / `dict` / `list` / `tuple`, matching the injection path in `Registry._replace_sensitive_data`.

- Replaced the hand-rolled one-level walk with a single recursive dispatcher; `_filter_sensitive_data_from_dict` keeps its signature, so callers are unaffected.
- Added a regression test covering a list-in-list and a dict-in-list action parameter, building the dynamic action via `model_validate` for static analysis.

<sup>Written for commit ff97910088a1419b7c0de31aefac8a4953b31c84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

