### PR TITLE
fix(llm): keep every system message in the Anthropic request

### DIFF
--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -312,11 +312,11 @@ class AnthropicMessageSerializer:
 
 		# Separate system messages from normal messages
 		normal_messages: list[NonSystemMessage] = []
-		system_message: SystemMessage | None = None
+		system_messages: list[SystemMessage] = []
 
 		for message in messages:
 			if isinstance(message, SystemMessage):
-				system_message = message
+				system_messages.append(message)
 			else:
 				normal_messages.append(message)
 
@@ -328,11 +328,23 @@ class AnthropicMessageSerializer:
 		for message in normal_messages:
 			serialized_messages.append(AnthropicMessageSerializer.serialize(message))
 
-		# Serialize system message
+		# Serialize system messages, keeping every one of them in the order they were given
 		serialized_system_message: list[TextBlockParam] | str | None = None
-		if system_message:
+		if len(system_messages) == 1:
 			serialized_system_message = AnthropicMessageSerializer._serialize_content_to_str(
-				system_message.content, use_cache=system_message.cache
+				system_messages[0].content, use_cache=system_messages[0].cache
 			)
+		elif system_messages:
+			# Multiple system messages become separate text blocks so each keeps its own cache control
+			system_blocks: list[TextBlockParam] = []
+			for system_message in system_messages:
+				serialized = AnthropicMessageSerializer._serialize_content_to_str(
+					system_message.content, use_cache=system_message.cache
+				)
+				if isinstance(serialized, str):
+					system_blocks.append(TextBlockParam(text=serialized, type='text', cache_control=None))
+				else:
+					system_blocks.extend(serialized)
+			serialized_system_message = system_blocks
 
 		return serialized_messages, serialized_system_message

--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -1,5 +1,5 @@
 import json
-from typing import overload
+from typing import TypeVar, overload
 
 from anthropic.types import (
 	Base64ImageSourceParam,
@@ -22,6 +22,8 @@ from browser_use.llm.messages import (
 )
 
 NonSystemMessage = UserMessage | AssistantMessage
+
+CacheableMessage = TypeVar('CacheableMessage', bound=BaseMessage)
 
 
 class AnthropicMessageSerializer:
@@ -266,11 +268,13 @@ class AnthropicMessageSerializer:
 			raise ValueError(f'Unknown message type: {type(message)}')
 
 	@staticmethod
-	def _clean_cache_messages(messages: list[NonSystemMessage]) -> list[NonSystemMessage]:
+	def _clean_cache_messages(messages: list[CacheableMessage]) -> list[CacheableMessage]:
 		"""Clean cache settings so only the last cache=True message remains cached.
 
-		Because of how Claude caching works, only the last cache message matters.
+		Because of how Claude caching works, only the last cache message matters: a breakpoint
+		caches everything before it, and Anthropic accepts at most four of them per request.
 		This method automatically removes cache=True from all messages except the last one.
+		It applies to system messages as well as to the conversation messages.
 
 		Args:
 			messages: List of non-system messages to clean
@@ -320,8 +324,10 @@ class AnthropicMessageSerializer:
 			else:
 				normal_messages.append(message)
 
-		# Clean cache messages so only the last cache=True message remains cached
+		# Clean cache messages so only the last cache=True message remains cached. System messages
+		# are normalized separately so the two groups contribute one breakpoint each at most.
 		normal_messages = AnthropicMessageSerializer._clean_cache_messages(normal_messages)
+		system_messages = AnthropicMessageSerializer._clean_cache_messages(system_messages)
 
 		# Serialize normal messages
 		serialized_messages: list[MessageParam] = []

--- a/tests/ci/models/test_anthropic_serializer.py
+++ b/tests/ci/models/test_anthropic_serializer.py
@@ -42,5 +42,5 @@ def test_cache_control_is_kept_per_system_message():
 	)
 
 	assert isinstance(system, list)
-	assert system[0]['cache_control'] == {'type': 'ephemeral'}
-	assert system[1]['cache_control'] is None
+	assert system[0].get('cache_control') == {'type': 'ephemeral'}
+	assert system[1].get('cache_control') is None

--- a/tests/ci/models/test_anthropic_serializer.py
+++ b/tests/ci/models/test_anthropic_serializer.py
@@ -1,7 +1,7 @@
 """Regression tests for AnthropicMessageSerializer's handling of system messages."""
 
 from browser_use.llm.anthropic.serializer import AnthropicMessageSerializer
-from browser_use.llm.messages import SystemMessage, UserMessage
+from browser_use.llm.messages import BaseMessage, SystemMessage, UserMessage
 
 
 def test_single_system_message_is_returned_as_plain_string():
@@ -31,8 +31,8 @@ def test_all_system_messages_are_preserved_in_order():
 	assert len(messages) == 1
 
 
-def test_cache_control_is_kept_per_system_message():
-	"""A cached system message keeps its cache_control when combined with an uncached one."""
+def test_cache_control_marks_the_last_cached_system_message():
+	"""The breakpoint lands on the last *cached* message, not simply the last one."""
 	_, system = AnthropicMessageSerializer.serialize_messages(
 		[
 			SystemMessage(content='Follow the base system rule.', cache=True),
@@ -44,3 +44,15 @@ def test_cache_control_is_kept_per_system_message():
 	assert isinstance(system, list)
 	assert system[0].get('cache_control') == {'type': 'ephemeral'}
 	assert system[1].get('cache_control') is None
+
+
+def test_only_the_last_cached_system_message_keeps_a_breakpoint():
+	"""Anthropic allows four cache_control breakpoints per request, and a breakpoint caches
+	everything before it, so several cached system messages must collapse to a single marker."""
+	messages: list[BaseMessage] = [SystemMessage(content=f'Rule {index}.', cache=True) for index in range(5)]
+	messages.append(UserMessage(content='Continue the task.'))
+
+	_, system = AnthropicMessageSerializer.serialize_messages(messages)
+
+	assert isinstance(system, list)
+	assert [block.get('cache_control') is not None for block in system] == [False, False, False, False, True]

--- a/tests/ci/models/test_anthropic_serializer.py
+++ b/tests/ci/models/test_anthropic_serializer.py
@@ -1,0 +1,46 @@
+"""Regression tests for AnthropicMessageSerializer's handling of system messages."""
+
+from browser_use.llm.anthropic.serializer import AnthropicMessageSerializer
+from browser_use.llm.messages import SystemMessage, UserMessage
+
+
+def test_single_system_message_is_returned_as_plain_string():
+	"""The common case must keep returning a bare string, not a block list."""
+	_, system = AnthropicMessageSerializer.serialize_messages(
+		[SystemMessage(content='Follow the base system rule.'), UserMessage(content='Continue the task.')]
+	)
+
+	assert system == 'Follow the base system rule.'
+
+
+def test_all_system_messages_are_preserved_in_order():
+	"""Every SystemMessage must reach the request, in the order it was supplied."""
+	messages, system = AnthropicMessageSerializer.serialize_messages(
+		[
+			SystemMessage(content='Follow the base system rule.'),
+			SystemMessage(content='Also follow the additional system rule.'),
+			UserMessage(content='Continue the task.'),
+		]
+	)
+
+	assert isinstance(system, list)
+	assert [block['text'] for block in system] == [
+		'Follow the base system rule.',
+		'Also follow the additional system rule.',
+	]
+	assert len(messages) == 1
+
+
+def test_cache_control_is_kept_per_system_message():
+	"""A cached system message keeps its cache_control when combined with an uncached one."""
+	_, system = AnthropicMessageSerializer.serialize_messages(
+		[
+			SystemMessage(content='Follow the base system rule.', cache=True),
+			SystemMessage(content='Also follow the additional system rule.'),
+			UserMessage(content='Continue the task.'),
+		]
+	)
+
+	assert isinstance(system, list)
+	assert system[0]['cache_control'] == {'type': 'ephemeral'}
+	assert system[1]['cache_control'] is None


### PR DESCRIPTION
Fixes #5633

### Problem

`AnthropicMessageSerializer.serialize_messages()` accumulated the extracted system message into a single `system_message` variable:

```python
for message in messages:
    if isinstance(message, SystemMessage):
        system_message = message   # overwrites the previous one
```

Every `SystemMessage` after the first therefore clobbered its predecessor, and only the last one reached the request. Anyone layering an extra instruction on top of a base system prompt silently lost the base prompt — no warning, no error, just a model running without the rules it was given.

### Fix

Collect the system messages into a list and serialize all of them.

- **One system message** — unchanged: still returns the same plain string (or single cached block), so nothing downstream shifts for the overwhelmingly common case.
- **Two or more** — returns an ordered list of `TextBlockParam`. Anthropic's `system` parameter accepts a block list, which preserves order and lets each message keep its own `cache_control` rather than forcing one flag across a concatenated blob.

### Tests

New `tests/ci/models/test_anthropic_serializer.py` covering all three behaviours: the single-message string shape is unchanged, both messages survive in order, and per-message cache control is preserved when one is cached and the other is not.

### Evidence

On `main` (fix reverted, new tests present):

```
test_single_system_message_is_returned_as_plain_string PASSED
test_all_system_messages_are_preserved_in_order       FAILED
test_cache_control_is_kept_per_system_message         FAILED
2 failed, 1 passed in 1.96s
```

With this branch:

```
test_single_system_message_is_returned_as_plain_string PASSED
test_all_system_messages_are_preserved_in_order       PASSED
test_cache_control_is_kept_per_system_message         PASSED
3 passed
```

`tests/ci/models` and `tests/ci/security` pass (212 tests), along with `ruff check`, `ruff format`, and `pyright`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5633 by keeping every `SystemMessage` in Anthropic requests. Previously, `AnthropicMessageSerializer.serialize_messages()` stored the extracted system message in a single variable, so each `SystemMessage` overwrote the previous one and only the last reached the request.

- One system message still serializes to the same plain string as before.
- Multiple serialize to an ordered list of `TextBlockParam`, separated by exactly one blank line (trailing newlines are normalized) so instructions don't run together.
- Empty system messages alongside real ones are dropped (a lone empty one is unchanged); cache breakpoints are normalized so only the last cached message keeps `cache_control`.
- Adds regression tests covering single, multiple, empty, and cache normalization cases.

<sup>Written for commit 4f4407ed8961afe02afa314652b72675549deb71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

