### PR TITLE
fix(config): use timezone-aware UTC timestamps

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cache
 from pathlib import Path
 from typing import Any
@@ -248,7 +248,7 @@ class DBStyleEntry(BaseModel):
 
 	id: str = Field(default_factory=lambda: str(uuid4()))
 	default: bool = Field(default=False)
-	created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+	created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
 
 class BrowserProfileEntry(DBStyleEntry):

--- a/tests/ci/test_config.py
+++ b/tests/ci/test_config.py
@@ -1,0 +1,12 @@
+from datetime import datetime, timezone
+
+from browser_use.config import BrowserProfileEntry
+
+
+def test_db_style_entry_created_at_is_timezone_aware_utc():
+	entry = BrowserProfileEntry()
+
+	created_at = datetime.fromisoformat(entry.created_at)
+
+	assert created_at.tzinfo is not None
+	assert created_at.utcoffset() == timezone.utc.utcoffset(created_at)


### PR DESCRIPTION
## Problem

`DBStyleEntry.created_at` currently uses `datetime.utcnow().isoformat()`, which creates a naive datetime string even though the value represents UTC. That makes the persisted config metadata ambiguous for consumers that parse the timestamp later.

## Before / after

Before this change, new DB-style config entries had timestamps like `2026-09-04T00:53:57.363541` with no timezone offset.

After this change, they use `datetime.now(timezone.utc).isoformat()`, producing timezone-aware UTC timestamps such as `2026-09-04T00:53:57.363541+00:00`.

## Verification

- `python -m py_compile browser_use/config.py tests/ci/test_config.py`
- direct smoke check importing `BrowserProfileEntry` and parsing `created_at` as timezone-aware UTC
- `git diff --check`

I also attempted `python -m pytest tests/ci/test_config.py -q -o addopts=''`, but collection in this bare checkout requires the missing test dependency `pytest_httpserver` from `tests/ci/conftest.py`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes `DBStyleEntry.created_at` to use timezone-aware UTC timestamps, so persisted config metadata no longer carries ambiguous naive timestamps.

- Replaces `datetime.utcnow().isoformat()` with `datetime.now(timezone.utc).isoformat()`, producing values like `2026-09-04T00:53:57.363541+00:00`.
- Adds a test in `tests/ci/test_config.py` verifying the timestamp is timezone-aware UTC.

<sup>Written for commit f40281eacab6a19f8c1d39df7cec3e695bee7482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

