### PR TITLE
chore: pin publish workflow toolchain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,6 +110,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
         with:
+          version: "0.12.9"
           enable-cache: true
           activate-environment: true
       - run: uv sync

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.create_tag
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Create pre-release tag
         run: |
           git fetch --tags
@@ -107,8 +107,8 @@ jobs:
             exit 1
           fi
           echo "::notice::Environment '${ENV_NAME}' is protected with prevent_self_review. OK."
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
         with:
           version: "0.12.9"
           enable-cache: true


### PR DESCRIPTION
## Summary

Pin the publish workflow's uv binary to 0.12.9 instead of resolving the latest uv release at publish time.

This is split from #5667 so the Browser Use runtime dependency release can proceed while this workflow-only supply-chain hardening receives the required workflow-guardians review.

## Verification

- workflow diff is one exact version pin
- Browser Use 0.13.10 was locally built successfully using uv 0.12.9
- repository workflow checks will validate YAML and release setup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the publish workflow's `uv` binary to 0.12.9 and pins `actions/checkout` and `astral-sh/setup-uv` to commit SHAs instead of mutable version tags. This prevents unexpected `uv` or action updates from affecting releases.

<sup>Written for commit 68f9a0992d9674e685498a6a3b82c12dcfb3d6a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

