### PR TITLE
fix(dom): keep prefixed payment and OTP autocomplete values out of agent context

### DIFF
--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -46,7 +46,8 @@ def _parse_computed_styles(strings: list[str], style_indices: list[int]) -> dict
 # Live values of these fields never leave the snapshot: they would otherwise be
 # serialized by EnhancedDOMTreeNode.__json__ and could reach logs or the LLM.
 _SENSITIVE_INPUT_TYPES = frozenset({'password', 'file', 'hidden'})
-_SENSITIVE_AUTOCOMPLETE_PREFIXES = ('cc-', 'one-time-code')
+_SENSITIVE_AUTOCOMPLETE_TOKEN = 'one-time-code'
+_SENSITIVE_AUTOCOMPLETE_PREFIX = 'cc-'
 
 
 def _is_sensitive_input(strings: list[str], nodes: NodeTreeSnapshot, snapshot_index: int) -> bool:
@@ -62,7 +63,10 @@ def _is_sensitive_input(strings: list[str], nodes: NodeTreeSnapshot, snapshot_in
 		value = strings[value_index].lower()
 		if name == 'type' and value in _SENSITIVE_INPUT_TYPES:
 			return True
-		if name == 'autocomplete' and value.startswith(_SENSITIVE_AUTOCOMPLETE_PREFIXES):
+		if name == 'autocomplete' and any(
+			token == _SENSITIVE_AUTOCOMPLETE_TOKEN or token.startswith(_SENSITIVE_AUTOCOMPLETE_PREFIX)
+			for token in value.split()
+		):
 			return True
 	return False
 

--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -64,8 +64,7 @@ def _is_sensitive_input(strings: list[str], nodes: NodeTreeSnapshot, snapshot_in
 		if name == 'type' and value in _SENSITIVE_INPUT_TYPES:
 			return True
 		if name == 'autocomplete' and any(
-			token == _SENSITIVE_AUTOCOMPLETE_TOKEN or token.startswith(_SENSITIVE_AUTOCOMPLETE_PREFIX)
-			for token in value.split()
+			token == _SENSITIVE_AUTOCOMPLETE_TOKEN or token.startswith(_SENSITIVE_AUTOCOMPLETE_PREFIX) for token in value.split()
 		):
 			return True
 	return False

--- a/tests/ci/test_dom_live_input_value.py
+++ b/tests/ci/test_dom_live_input_value.py
@@ -18,8 +18,9 @@ PAGE = """<!DOCTYPE html>
 	<label for="notes">Notes</label>
 	<textarea id="notes"></textarea>
 	<input id="secret" type="password">
-	<input id="otp" type="text" autocomplete="one-time-code">
-	<input id="card" type="text" autocomplete="cc-number">
+	<input id="otp" type="text" autocomplete="section-login one-time-code">
+	<input id="card" type="text" autocomplete="section-checkout billing cc-number">
+	<input id="address" type="text" autocomplete="section-checkout shipping street-address">
 	<input id="agree" type="checkbox" checked>
 	<input id="news" type="checkbox">
 	<script>
@@ -28,6 +29,7 @@ PAGE = """<!DOCTYPE html>
 		document.getElementById('secret').value = 'hunter2';
 		document.getElementById('otp').value = '493021';
 		document.getElementById('card').value = '4242424242424242';
+		document.getElementById('address').value = '12 Analytical Engine Way';
 		document.getElementById('agree').checked = false;
 		document.getElementById('news').checked = true;
 	</script>
@@ -56,13 +58,19 @@ async def test_live_input_values_reach_the_agent(browser_session, http_server):
 	assert by_id['secret'].attributes.get('value') is None, 'password values must not be exposed'
 	assert by_id['otp'].attributes.get('value') is None, 'one-time codes must not be exposed'
 	assert by_id['card'].attributes.get('value') is None, 'card numbers must not be exposed'
+	assert by_id['address'].attributes.get('value') == '12 Analytical Engine Way'
 	assert by_id['secret'].snapshot_node is not None and by_id['secret'].snapshot_node.input_value is None
+	assert by_id['otp'].snapshot_node is not None and by_id['otp'].snapshot_node.input_value is None
+	assert by_id['card'].snapshot_node is not None and by_id['card'].snapshot_node.input_value is None
+	assert by_id['address'].snapshot_node is not None
+	assert by_id['address'].snapshot_node.input_value == '12 Analytical Engine Way'
 	assert by_id['agree'].attributes.get('checked') is None, 'live unchecked state wins over the checked attribute'
 	assert by_id['news'].attributes.get('checked') == 'true'
 
 	llm_view = state.dom_state.llm_representation()
 	assert 'Ada Lovelace' in llm_view
 	assert 'call back tuesday' in llm_view
+	assert '12 Analytical Engine Way' in llm_view
 	assert 'hunter2' not in llm_view
 	assert '493021' not in llm_view
 	assert '4242424242424242' not in llm_view


### PR DESCRIPTION
## Summary

- parse `autocomplete` as a token list before deciding whether a live input value is safe to expose
- keep section-prefixed payment and one-time-code fields out of the enhanced snapshot and LLM representation
- retain ordinary multi-token autofill values, such as a shipping street address

## Why

#5650 deliberately excludes card and OTP fields from the new live-value path, but its prefix check applies to the whole attribute. Valid values such as `section-checkout billing cc-number` and `section-login one-time-code` therefore bypass the guard and expose their live values to agent context.

This change recognizes `one-time-code` as an exact token and every `cc-*` payment token, without broadening the filter to unrelated autocomplete fields.

## Validation

- Python AST parse for both changed files
- Ruff check for both changed files (ignoring the pre-existing `F841` in `enhanced_snapshot.py`)
- direct semantic matrix covering prefixed card, prefixed OTP, ordinary multi-token address, and a non-token lookalike
- regression extends the existing browser test across selector attributes, `EnhancedSnapshotNode.input_value`, and `llm_representation()`

Follow-up to #5650.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes prefixed payment and OTP autocomplete fields leaking live values into agent context.

Previously the sensitive-autocomplete check only matched the whole attribute value, so prefixed values like `section-checkout billing cc-number` bypassed the guard from #5650. Now the attribute is parsed as a token list, and any token matching `one-time-code` or starting with `cc-` keeps the live value out of the enhanced snapshot and LLM representation. Ordinary multi-token autofill values like shipping street addresses still pass through.

**Bug Fixes**
- Tokenizes the `autocomplete` attribute before applying the sensitive-field check.
- Extends the regression test to cover prefixed card, prefixed OTP, and multi-token address fields.

<sup>Written for commit a649275f1f807d1dfd16bd0b474b6a9729dc9127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

