### PR TITLE
fix(llm): resolve DeepSeek and Cerebras API keys explicitly

### DIFF
--- a/browser_use/llm/cerebras/chat.py
+++ b/browser_use/llm/cerebras/chat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
@@ -47,8 +48,16 @@ class ChatCerebras(BaseChatModel):
 		return 'cerebras'
 
 	def _client(self) -> AsyncOpenAI:
+		api_key = self.api_key or os.getenv('CEREBRAS_API_KEY')
+		if not api_key:
+			raise ModelProviderError(
+				message='Missing Cerebras API key. Set CEREBRAS_API_KEY or pass api_key.',
+				status_code=401,
+				model=self.name,
+			)
+
 		return AsyncOpenAI(
-			api_key=self.api_key,
+			api_key=api_key,
 			base_url=self.base_url,
 			timeout=self.timeout,
 			**(self.client_params or {}),

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
@@ -50,8 +51,16 @@ class ChatDeepSeek(BaseChatModel):
 		return 'deepseek'
 
 	def _client(self) -> AsyncOpenAI:
+		api_key = self.api_key or os.getenv('DEEPSEEK_API_KEY')
+		if not api_key:
+			raise ModelProviderError(
+				message='Missing DeepSeek API key. Set DEEPSEEK_API_KEY or pass api_key.',
+				status_code=401,
+				model=self.name,
+			)
+
 		return AsyncOpenAI(
-			api_key=self.api_key,
+			api_key=api_key,
 			base_url=self.base_url,
 			timeout=self.timeout,
 			**(self.client_params or {}),

--- a/tests/ci/models/test_llm_cerebras.py
+++ b/tests/ci/models/test_llm_cerebras.py
@@ -1,0 +1,22 @@
+"""Regression tests for Cerebras client setup."""
+
+import pytest
+
+from browser_use.llm.cerebras.chat import ChatCerebras
+from browser_use.llm.exceptions import ModelProviderError
+
+
+def test_provider_key_does_not_fall_back_to_openai_key(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('OPENAI_API_KEY', 'wrong-provider-key')
+	monkeypatch.setenv('CEREBRAS_API_KEY', 'cerebras-key')
+	assert ChatCerebras(model='llama3.3-70b')._client().api_key == 'cerebras-key'
+
+	monkeypatch.delenv('CEREBRAS_API_KEY')
+	with pytest.raises(ModelProviderError, match='Missing Cerebras API key') as exc_info:
+		ChatCerebras(model='llama3.3-70b')._client()
+	assert exc_info.value.status_code == 401
+
+
+def test_explicit_api_key_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('CEREBRAS_API_KEY', 'env-key')
+	assert ChatCerebras(model='llama3.3-70b', api_key='explicit-key')._client().api_key == 'explicit-key'

--- a/tests/ci/models/test_llm_deepseek.py
+++ b/tests/ci/models/test_llm_deepseek.py
@@ -1,0 +1,22 @@
+"""Regression tests for DeepSeek client setup."""
+
+import pytest
+
+from browser_use.llm.deepseek.chat import ChatDeepSeek
+from browser_use.llm.exceptions import ModelProviderError
+
+
+def test_provider_key_does_not_fall_back_to_openai_key(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('OPENAI_API_KEY', 'wrong-provider-key')
+	monkeypatch.setenv('DEEPSEEK_API_KEY', 'deepseek-key')
+	assert ChatDeepSeek(model='deepseek-v4-flash')._client().api_key == 'deepseek-key'
+
+	monkeypatch.delenv('DEEPSEEK_API_KEY')
+	with pytest.raises(ModelProviderError, match='Missing DeepSeek API key') as exc_info:
+		ChatDeepSeek(model='deepseek-v4-flash')._client()
+	assert exc_info.value.status_code == 401
+
+
+def test_explicit_api_key_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('DEEPSEEK_API_KEY', 'env-key')
+	assert ChatDeepSeek(model='deepseek-v4-flash', api_key='explicit-key')._client().api_key == 'explicit-key'


### PR DESCRIPTION
## Summary
- resolve `DEEPSEEK_API_KEY` and `CEREBRAS_API_KEY` explicitly instead of letting `AsyncOpenAI` fall back to `OPENAI_API_KEY`
- raise a 401 `ModelProviderError` when neither an explicit `api_key` nor the provider's env var is set
- extends the fix from #5599 to the two remaining adapters with the same defect

## Details

`ChatDeepSeek` and `ChatCerebras` pass `api_key=self.api_key` into `AsyncOpenAI` while pointing `base_url` at `api.deepseek.com` and `api.cerebras.ai`. When `api_key` is `None`, the SDK resolves `OPENAI_API_KEY` and authenticates those third-party endpoints with it.

This is the same defect described in item 2 of #5598 and fixed for `ChatOpenRouter` and `ChatVercel` in #5599. `ChatOrcaRouter` already guards against it, and states the hazard in an inline comment:

> `AsyncOpenAI` falls back to `OPENAI_API_KEY` when `api_key` is unset, which would send an unrelated provider's key to the OrcaRouter endpoint.

`skills/open-source/references/models.md` already documents `DEEPSEEK_API_KEY` (line 15) and `CEREBRAS_API_KEY` (line 18) as these providers' env vars, and `config.py` exposes a `DEEPSEEK_API_KEY` property — neither adapter read them. No docs change is needed; this makes the code match what was already documented.

## Scope

I audited the nine adapters that authenticate with an API key at construction time, using a script that sets `OPENAI_API_KEY` to a canary, unsets every provider-specific variable, and inspects the resolved key and `base_url` on the constructed client.

Five adapters point an OpenAI-SDK client at a non-OpenAI `base_url`. Three already guard (`ChatOpenRouter`, `ChatVercel`, `ChatOrcaRouter`); these two did not.

Verified unaffected and deliberately unchanged: `ChatGroq` and `ChatAnthropic` use their own vendor SDKs and never resolved the canary. `ChatOpenAI` resolves `OPENAI_API_KEY` while pointed at `api.openai.com`, which is correct.

Before / after, with all other rows byte-identical:

```
 LEAK  the canary to a foreign endpoint : ['ChatDeepSeek', 'ChatCerebras']
 LEAK  the canary to a foreign endpoint : none
```
## Tests
- `uv run pytest -q tests/ci/models/test_llm_deepseek.py tests/ci/models/test_llm_cerebras.py`
- `uv run pre-commit run --files browser_use/llm/deepseek/chat.py browser_use/llm/cerebras/chat.py tests/ci/models/test_llm_deepseek.py tests/ci/models/test_llm_cerebras.py`

The new tests fail on `main` and pass with this change:

    tests/ci/models/test_llm_deepseek.py::test_provider_key_does_not_fall_back_to_openai_key FAILED
    AssertionError: assert 'wrong-provider-key' == 'deepseek-key'

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DeepSeek and Cerebras clients sending `OPENAI_API_KEY` to their endpoints when no explicit key is provided. Each adapter now uses `DEEPSEEK_API_KEY` or `CEREBRAS_API_KEY` when no `api_key` is passed, and raises a 401 `ModelProviderError` if neither is set.

- Explicit `api_key` takes precedence over the provider env var.
- Setups relying on `OPENAI_API_KEY` for these providers must switch to the provider-specific env var.
- Adds regression tests for fallback prevention and explicit key precedence.

<sup>Written for commit 24f60f71bb1d843a8ffa0bf351061e8d4c8baba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

