### PR TITLE
fix(llm): remap retired Mistral pixtral-large alias

### DIFF
--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -108,7 +108,8 @@ def get_llm_by_name(model_name: str):
 		'mistral_medium': 'mistral-medium-latest',
 		'mistral_small': 'mistral-small-latest',
 		'codestral': 'codestral-latest',
-		'pixtral_large': 'pixtral-large-latest',
+		# Pixtral Large was retired; Mistral names Mistral Medium 3.5 as the replacement
+		'pixtral_large': 'mistral-medium-latest',
 	}
 	if model_name in mistral_aliases:
 		api_key = os.getenv('MISTRAL_API_KEY')
@@ -195,7 +196,7 @@ def get_llm_by_name(model_name: str):
 			'medium': 'mistral-medium-latest',
 			'small': 'mistral-small-latest',
 			'codestral': 'codestral-latest',
-			'pixtral-large': 'pixtral-large-latest',
+			'pixtral-large': 'mistral-medium-latest',
 		}
 		normalized_model_part = model_part.replace('_', '-')
 		resolved_model = mistral_map.get(normalized_model_part, model.replace('_', '-'))

--- a/tests/ci/models/test_llm_model_factory.py
+++ b/tests/ci/models/test_llm_model_factory.py
@@ -1,3 +1,5 @@
+import pytest
+
 from browser_use.llm.anthropic.chat import ChatAnthropic
 from browser_use.llm.cerebras.chat import ChatCerebras
 from browser_use.llm.models import get_llm_by_name
@@ -21,3 +23,19 @@ def test_get_llm_by_name_preserves_cerebras_zai_glm_version_separator(monkeypatc
 	assert isinstance(llm, ChatCerebras)
 	assert llm.model == 'zai-glm-4.7'
 	assert llm.api_key == 'cerebras-test-key'
+
+
+def test_get_llm_by_name_remaps_retired_pixtral_alias(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('MISTRAL_API_KEY', 'mistral-key')
+	# 'pixtral_large' has no provider prefix and hits the top-level alias table
+	assert get_llm_by_name('pixtral_large').model == 'mistral-medium-latest'
+	# 'mistral_pixtral-large' is provider-prefixed and hits the mistral_map branch
+	assert get_llm_by_name('mistral_pixtral-large').model == 'mistral-medium-latest'
+
+
+def test_get_llm_by_name_preserves_served_mistral_aliases(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('MISTRAL_API_KEY', 'mistral-key')
+	assert get_llm_by_name('mistral_large').model == 'mistral-large-latest'
+	assert get_llm_by_name('mistral_medium').model == 'mistral-medium-latest'
+	assert get_llm_by_name('mistral_small').model == 'mistral-small-latest'
+	assert get_llm_by_name('codestral').model == 'codestral-latest'


### PR DESCRIPTION
## Summary
- `pixtral_large` and `mistral_pixtral-large` resolved to `pixtral-large-latest`, which Mistral no longer accepts
- remap both to `mistral-medium-latest`, the replacement named on Mistral's model card
- add factory tests covering all five Mistral aliases

## Details

`get_llm_by_name` maps Pixtral Large in two places — `mistral_aliases` for the unprefixed form and `mistral_map` for the provider-prefixed form. Both pointed at `pixtral-large-latest`. Mistral lists Pixtral Large (`pixtral-large-2411`) in its deprecated and retired models table, and the identifier is no longer accepted.

Verified against `api.mistral.ai` on 2026-09-04, paid tier, identical request shape for all five:

    mistral-medium-latest   HTTP 200
    mistral-small-latest    HTTP 200
    codestral-latest        HTTP 200
    mistral-large-latest    HTTP 200
    pixtral-large-latest    HTTP 400
      {"type":"invalid_model","message":"Invalid model: pixtral-large-latest"}

The four passing controls rule out a credentials or tier issue: the same key succeeds on every other alias in the map. Only `pixtral-large-latest` is rejected, and Mistral reports it as an invalid identifier rather than a gated one.

Pixtral Large's model card names Mistral Medium 3.5 as its replacement, so both entries now resolve to `mistral-medium-latest`. Mistral Medium 3.5 is multimodal, so image support is preserved. Removing the aliases outright was the alternative,
but that would surface the same failure as an opaque API error rather than resolving to a working model — happy to change it if you'd rather they be dropped.

The other four aliases were checked and left unchanged.

## Tests
- `uv run pytest -q tests/ci/models/test_llm_model_factory.py`
- `uv run pre-commit run --files browser_use/llm/models.py tests/ci/models/test_llm_model_factory.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remaps both Mistral Pixtral Large aliases (`pixtral_large` and `mistral_pixtral-large`) from the retired `pixtral-large-latest` to `mistral-medium-latest`, which Mistral's model card lists as the replacement, so requests no longer fail with an invalid model error.

- Mistral rejects `pixtral-large-latest` with HTTP 400; the other four Mistral aliases still return HTTP 200.
- Mistral Medium 3.5 is multimodal, so image support is preserved.
- Adds tests covering all five Mistral aliases.

<sup>Written for commit 10729fbd688e7c70298433ecb174a0be72bbe8ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

