### PR TITLE
fix(filesystem): preserve state on failed writes

### DIFF
--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -159,12 +159,22 @@ class BaseFile(BaseModel, ABC):
 			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content, encoding='utf-8'))
 
 	async def write(self, content: str, path: Path) -> None:
+		previous_content = self.content
 		self.write_file_content(content)
-		await self.sync_to_disk(path)
+		try:
+			await self.sync_to_disk(path)
+		except (Exception, asyncio.CancelledError):
+			self.content = previous_content
+			raise
 
 	async def append(self, content: str, path: Path) -> None:
+		previous_content = self.content
 		self.append_file_content(content)
-		await self.sync_to_disk(path)
+		try:
+			await self.sync_to_disk(path)
+		except (Exception, asyncio.CancelledError):
+			self.content = previous_content
+			raise
 
 	def read(self) -> str:
 		return self.content

--- a/browser_use/filesystem/file_system.py
+++ b/browser_use/filesystem/file_system.py
@@ -123,6 +123,12 @@ class FileSystemError(Exception):
 	pass
 
 
+class _DiskSyncCompletedDuringCancellation(asyncio.CancelledError):
+	"""Raised when disk sync succeeds after the caller has cancelled the operation."""
+
+	pass
+
+
 class BaseFile(BaseModel, ABC):
 	"""Base class for all file types"""
 
@@ -158,23 +164,40 @@ class BaseFile(BaseModel, ABC):
 		with ThreadPoolExecutor() as executor:
 			await asyncio.get_event_loop().run_in_executor(executor, lambda: file_path.write_text(self.content, encoding='utf-8'))
 
+	async def _sync_to_disk_after_mutation(self, path: Path, previous_content: str) -> None:
+		sync_task = asyncio.create_task(self.sync_to_disk(path))
+		try:
+			await asyncio.shield(sync_task)
+		except asyncio.CancelledError as exc:
+			while not sync_task.done():
+				try:
+					await asyncio.shield(sync_task)
+				except asyncio.CancelledError:
+					continue
+				except Exception:
+					break
+
+			try:
+				sync_task.result()
+			except (Exception, asyncio.CancelledError) as sync_error:
+				self.content = previous_content
+				if sync_error is exc:
+					raise
+				raise exc from sync_error
+			raise _DiskSyncCompletedDuringCancellation from exc
+		except Exception:
+			self.content = previous_content
+			raise
+
 	async def write(self, content: str, path: Path) -> None:
 		previous_content = self.content
 		self.write_file_content(content)
-		try:
-			await self.sync_to_disk(path)
-		except (Exception, asyncio.CancelledError):
-			self.content = previous_content
-			raise
+		await self._sync_to_disk_after_mutation(path, previous_content)
 
 	async def append(self, content: str, path: Path) -> None:
 		previous_content = self.content
 		self.append_file_content(content)
-		try:
-			await self.sync_to_disk(path)
-		except (Exception, asyncio.CancelledError):
-			self.content = previous_content
-			raise
+		await self._sync_to_disk_after_mutation(path, previous_content)
 
 	def read(self) -> str:
 		return self.content
@@ -906,7 +929,12 @@ class FileSystem:
 			file_obj = self.files[full_filename] if not is_new else file_class(name=name_without_ext)
 
 			# Use file-specific write method
-			await file_obj.write(content, self.data_dir)
+			try:
+				await file_obj.write(content, self.data_dir)
+			except _DiskSyncCompletedDuringCancellation:
+				if is_new:
+					self.files[full_filename] = file_obj
+				raise
 			if is_new:
 				self.files[full_filename] = file_obj
 			sanitize_note = f" (auto-corrected from '{original_filename}')" if was_sanitized else ''
@@ -974,7 +1002,12 @@ class FileSystem:
 		initial_filename = f'extracted_content_{self.extracted_content_count}'
 		extracted_filename = f'{initial_filename}.md'
 		file_obj = MarkdownFile(name=initial_filename)
-		await file_obj.write(content, self.data_dir)
+		try:
+			await file_obj.write(content, self.data_dir)
+		except _DiskSyncCompletedDuringCancellation:
+			self.files[extracted_filename] = file_obj
+			self.extracted_content_count += 1
+			raise
 		self.files[extracted_filename] = file_obj
 		self.extracted_content_count += 1
 		return extracted_filename

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -183,6 +183,42 @@ class TestBaseFile:
 			assert file_path.read_text() == expected_content
 			assert file_obj.content == expected_content
 
+	async def test_write_and_append_roll_back_content_on_sync_failure(self, monkeypatch):
+		"""Failed disk sync must not leave changed content in memory."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			file_obj = TxtFile(name='notes', content='persisted')
+
+			async def fail_sync(_self, _path):
+				raise OSError('disk unavailable')
+
+			monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
+
+			with pytest.raises(OSError, match='disk unavailable'):
+				await file_obj.write('phantom update', Path(tmp_dir))
+			assert file_obj.content == 'persisted'
+
+			with pytest.raises(OSError, match='disk unavailable'):
+				await file_obj.append(' phantom append', Path(tmp_dir))
+			assert file_obj.content == 'persisted'
+
+	async def test_write_and_append_roll_back_content_on_sync_cancellation(self, monkeypatch):
+		"""Cancelled disk sync must restore content before propagating."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			file_obj = TxtFile(name='notes', content='persisted')
+
+			async def cancel_sync(_self, _path):
+				raise asyncio.CancelledError
+
+			monkeypatch.setattr(TxtFile, 'sync_to_disk', cancel_sync)
+
+			with pytest.raises(asyncio.CancelledError):
+				await file_obj.write('phantom update', Path(tmp_dir))
+			assert file_obj.content == 'persisted'
+
+			with pytest.raises(asyncio.CancelledError):
+				await file_obj.append(' phantom append', Path(tmp_dir))
+			assert file_obj.content == 'persisted'
+
 	async def test_json_file_disk_operations(self):
 		"""Test JSON file sync to disk operations."""
 		with tempfile.TemporaryDirectory() as tmp_dir:
@@ -582,6 +618,30 @@ class TestFileSystem:
 		# Write with unsupported extension - gives specific error
 		result = await fs.write_file('test.doc', 'content')
 		assert 'Unsupported file extension' in result
+
+	async def test_write_and_append_file_preserve_state_on_failed_persist(self, empty_filesystem, monkeypatch):
+		"""Failed writes must not create phantom files or corrupt existing ones."""
+		fs = empty_filesystem
+		await fs.write_file('existing.txt', 'persisted')
+
+		async def fail_sync(_self, _path):
+			raise OSError('disk unavailable')
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_sync)
+
+		result = await fs.write_file('ghost.txt', 'phantom file')
+		assert 'disk unavailable' in result
+		assert 'ghost.txt' not in fs.files
+
+		result = await fs.write_file('existing.txt', 'phantom update')
+		assert 'disk unavailable' in result
+		assert fs.get_file('existing.txt').content == 'persisted'
+		assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
+
+		result = await fs.append_file('existing.txt', ' phantom append')
+		assert 'disk unavailable' in result
+		assert fs.get_file('existing.txt').content == 'persisted'
+		assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
 
 	async def test_write_json_file(self, temp_filesystem):
 		"""Test writing JSON files."""

--- a/tests/ci/infrastructure/test_filesystem.py
+++ b/tests/ci/infrastructure/test_filesystem.py
@@ -219,6 +219,58 @@ class TestBaseFile:
 				await file_obj.append(' phantom append', Path(tmp_dir))
 			assert file_obj.content == 'persisted'
 
+	async def test_write_and_append_wait_for_sync_on_outer_cancellation(self, monkeypatch):
+		"""Caller cancellation must not roll back a disk write that completes successfully."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			tmp_path = Path(tmp_dir)
+			file_obj = TxtFile(name='notes', content='persisted')
+			file_path = tmp_path / 'notes.txt'
+
+			async def run_cancelled_operation(operation, expected_content):
+				started = asyncio.Event()
+				release = asyncio.Event()
+
+				async def slow_sync(self, path):
+					started.set()
+					await release.wait()
+					self.sync_to_disk_sync(path)
+
+				monkeypatch.setattr(TxtFile, 'sync_to_disk', slow_sync)
+				task = asyncio.create_task(operation())
+				await started.wait()
+				task.cancel()
+				release.set()
+
+				with pytest.raises(asyncio.CancelledError):
+					await task
+				assert file_obj.content == expected_content
+				assert file_path.read_text(encoding='utf-8') == expected_content
+
+			await run_cancelled_operation(lambda: file_obj.write('committed', tmp_path), 'committed')
+			await run_cancelled_operation(lambda: file_obj.append(' append', tmp_path), 'committed append')
+
+	async def test_write_rolls_back_if_sync_fails_after_outer_cancellation(self, monkeypatch):
+		"""Caller cancellation should still roll back if the disk sync eventually fails."""
+		with tempfile.TemporaryDirectory() as tmp_dir:
+			file_obj = TxtFile(name='notes', content='persisted')
+			started = asyncio.Event()
+			release = asyncio.Event()
+
+			async def fail_after_cancel(_self, _path):
+				started.set()
+				await release.wait()
+				raise OSError('disk unavailable')
+
+			monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_after_cancel)
+			task = asyncio.create_task(file_obj.write('phantom update', Path(tmp_dir)))
+			await started.wait()
+			task.cancel()
+			release.set()
+
+			with pytest.raises(asyncio.CancelledError):
+				await task
+			assert file_obj.content == 'persisted'
+
 	async def test_json_file_disk_operations(self):
 		"""Test JSON file sync to disk operations."""
 		with tempfile.TemporaryDirectory() as tmp_dir:
@@ -642,6 +694,64 @@ class TestFileSystem:
 		assert 'disk unavailable' in result
 		assert fs.get_file('existing.txt').content == 'persisted'
 		assert (fs.data_dir / 'existing.txt').read_text(encoding='utf-8') == 'persisted'
+
+	async def test_write_file_does_not_register_when_sync_is_cancelled(self, empty_filesystem, monkeypatch):
+		"""A cancelled disk sync must not leave a phantom file in the registry."""
+		fs = empty_filesystem
+
+		async def cancel_sync(_self, _path):
+			raise asyncio.CancelledError
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', cancel_sync)
+
+		with pytest.raises(asyncio.CancelledError):
+			await fs.write_file('ghost.txt', 'phantom file')
+		assert 'ghost.txt' not in fs.files
+
+	async def test_write_file_registers_after_successful_sync_despite_outer_cancellation(self, empty_filesystem, monkeypatch):
+		"""If disk sync completes after caller cancellation, memory must match disk."""
+		fs = empty_filesystem
+		started = asyncio.Event()
+		release = asyncio.Event()
+
+		async def slow_sync(self, path):
+			started.set()
+			await release.wait()
+			self.sync_to_disk_sync(path)
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', slow_sync)
+		task = asyncio.create_task(fs.write_file('committed.txt', 'committed'))
+		await started.wait()
+		task.cancel()
+		release.set()
+
+		with pytest.raises(asyncio.CancelledError):
+			await task
+		file_obj = fs.get_file('committed.txt')
+		assert file_obj is not None
+		assert file_obj.content == 'committed'
+		assert (fs.data_dir / 'committed.txt').read_text(encoding='utf-8') == 'committed'
+
+	async def test_write_file_does_not_register_when_sync_fails_after_outer_cancellation(self, empty_filesystem, monkeypatch):
+		"""A delayed sync failure after caller cancellation must not register a new file."""
+		fs = empty_filesystem
+		started = asyncio.Event()
+		release = asyncio.Event()
+
+		async def fail_after_cancel(_self, _path):
+			started.set()
+			await release.wait()
+			raise OSError('disk unavailable')
+
+		monkeypatch.setattr(TxtFile, 'sync_to_disk', fail_after_cancel)
+		task = asyncio.create_task(fs.write_file('ghost.txt', 'phantom file'))
+		await started.wait()
+		task.cancel()
+		release.set()
+
+		with pytest.raises(asyncio.CancelledError):
+			await task
+		assert 'ghost.txt' not in fs.files
 
 	async def test_write_json_file(self, temp_filesystem):
 		"""Test writing JSON files."""


### PR DESCRIPTION
## Summary
- roll back in-memory file content when disk sync fails during write or append
- only register newly-created files after their first successful disk write
- add regression coverage for disk failures, cancellations, and phantom file registration

Fixes #5527.

## Tests
- uv run pytest tests/ci/infrastructure/test_filesystem.py -q -k "roll_back_content_on_sync_failure or roll_back_content_on_sync_cancellation or preserve_state_on_failed_persist"
- uv run pytest tests/ci/infrastructure/test_filesystem.py -q
- uv run pytest tests/ci/test_file_system_docx.py tests/ci/test_file_system_images.py -q
- uv run pytest tests/ci/test_file_system_llm_integration.py -q
- uv run pytest tests/ci/test_tools.py -q -k "structured_output_done"
- uv run ruff check browser_use/filesystem/file_system.py tests/ci/infrastructure/test_filesystem.py
- uv run ruff format --check browser_use/filesystem/file_system.py tests/ci/infrastructure/test_filesystem.py
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the filesystem so a failed disk write rolls back in-memory content and doesn't register phantom files. If a write is cancelled but the disk sync still completes, the content is kept and the file is registered so memory matches disk. Fixes #5527.

- Write and append restore previous content only when the disk sync actually fails, including when the failure happens after a cancellation.
- New files are registered after their first successful disk write, even if the caller cancelled the operation.

<sup>Written for commit 517de3744563329441e4d3a0e06219788fc43319. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

