### PR TITLE
fix: preserve multiple Anthropic system messages

### DIFF
--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -1,5 +1,5 @@
 import json
-from typing import overload
+from typing import TypeVar, overload
 
 from anthropic.types import (
 	Base64ImageSourceParam,
@@ -22,6 +22,7 @@ from browser_use.llm.messages import (
 )
 
 NonSystemMessage = UserMessage | AssistantMessage
+CacheableMessage = TypeVar('CacheableMessage', bound=BaseMessage)
 
 
 class AnthropicMessageSerializer:
@@ -256,14 +257,14 @@ class AnthropicMessageSerializer:
 			raise ValueError(f'Unknown message type: {type(message)}')
 
 	@staticmethod
-	def _clean_cache_messages(messages: list[NonSystemMessage]) -> list[NonSystemMessage]:
+	def _clean_cache_messages_by_last_cache(messages: list[CacheableMessage]) -> list[CacheableMessage]:
 		"""Clean cache settings so only the last cache=True message remains cached.
 
 		Because of how Claude caching works, only the last cache message matters.
 		This method automatically removes cache=True from all messages except the last one.
 
 		Args:
-			messages: List of non-system messages to clean
+			messages: List of messages to clean
 
 		Returns:
 			List of messages with cleaned cache settings
@@ -291,25 +292,14 @@ class AnthropicMessageSerializer:
 		return cleaned_messages
 
 	@staticmethod
+	def _clean_cache_messages(messages: list[NonSystemMessage]) -> list[NonSystemMessage]:
+		"""Clean non-system cache settings so only the last cache=True message remains cached."""
+		return AnthropicMessageSerializer._clean_cache_messages_by_last_cache(messages)
+
+	@staticmethod
 	def _clean_cache_system_messages(messages: list[SystemMessage]) -> list[SystemMessage]:
 		"""Clean system cache settings so only the last cache=True system message remains cached."""
-		if not messages:
-			return messages
-
-		cleaned_messages = [msg.model_copy(deep=True) for msg in messages]
-
-		last_cache_index = -1
-		for i in range(len(cleaned_messages) - 1, -1, -1):
-			if cleaned_messages[i].cache:
-				last_cache_index = i
-				break
-
-		if last_cache_index != -1:
-			for i, msg in enumerate(cleaned_messages):
-				if i != last_cache_index and msg.cache:
-					msg.cache = False
-
-		return cleaned_messages
+		return AnthropicMessageSerializer._clean_cache_messages_by_last_cache(messages)
 
 	@staticmethod
 	def _serialize_system_messages(messages: list[SystemMessage]) -> list[TextBlockParam] | str | None:

--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -291,6 +291,36 @@ class AnthropicMessageSerializer:
 		return cleaned_messages
 
 	@staticmethod
+	def _serialize_system_messages(messages: list[SystemMessage]) -> list[TextBlockParam] | str | None:
+		"""Serialize all system messages without dropping earlier prompts."""
+		if not messages:
+			return None
+
+		if len(messages) == 1:
+			message = messages[0]
+			return AnthropicMessageSerializer._serialize_content_to_str(message.content, use_cache=message.cache)
+
+		serialized_blocks: list[TextBlockParam] = []
+		for message_index, message in enumerate(messages):
+			serialized = AnthropicMessageSerializer._serialize_content_to_str(message.content, use_cache=message.cache)
+			if isinstance(serialized, str):
+				serialized_blocks.append(
+					TextBlockParam(
+						text=serialized,
+						type='text',
+						cache_control=AnthropicMessageSerializer._serialize_cache_control(message.cache),
+					)
+				)
+			else:
+				serialized_blocks.extend(serialized)
+
+			# Keep adjacent string/list system messages distinct while preserving order.
+			if message_index != len(messages) - 1:
+				serialized_blocks.append(TextBlockParam(text='\n\n', type='text'))
+
+		return serialized_blocks
+
+	@staticmethod
 	def serialize_messages(messages: list[BaseMessage]) -> tuple[list[MessageParam], list[TextBlockParam] | str | None]:
 		"""Serialize a list of messages, extracting any system message.
 
@@ -302,11 +332,11 @@ class AnthropicMessageSerializer:
 
 		# Separate system messages from normal messages
 		normal_messages: list[NonSystemMessage] = []
-		system_message: SystemMessage | None = None
+		system_messages: list[SystemMessage] = []
 
 		for message in messages:
 			if isinstance(message, SystemMessage):
-				system_message = message
+				system_messages.append(message)
 			else:
 				normal_messages.append(message)
 
@@ -318,11 +348,7 @@ class AnthropicMessageSerializer:
 		for message in normal_messages:
 			serialized_messages.append(AnthropicMessageSerializer.serialize(message))
 
-		# Serialize system message
-		serialized_system_message: list[TextBlockParam] | str | None = None
-		if system_message:
-			serialized_system_message = AnthropicMessageSerializer._serialize_content_to_str(
-				system_message.content, use_cache=system_message.cache
-			)
+		# Serialize system messages
+		serialized_system_message = AnthropicMessageSerializer._serialize_system_messages(system_messages)
 
 		return serialized_messages, serialized_system_message

--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -291,10 +291,33 @@ class AnthropicMessageSerializer:
 		return cleaned_messages
 
 	@staticmethod
+	def _clean_cache_system_messages(messages: list[SystemMessage]) -> list[SystemMessage]:
+		"""Clean system cache settings so only the last cache=True system message remains cached."""
+		if not messages:
+			return messages
+
+		cleaned_messages = [msg.model_copy(deep=True) for msg in messages]
+
+		last_cache_index = -1
+		for i in range(len(cleaned_messages) - 1, -1, -1):
+			if cleaned_messages[i].cache:
+				last_cache_index = i
+				break
+
+		if last_cache_index != -1:
+			for i, msg in enumerate(cleaned_messages):
+				if i != last_cache_index and msg.cache:
+					msg.cache = False
+
+		return cleaned_messages
+
+	@staticmethod
 	def _serialize_system_messages(messages: list[SystemMessage]) -> list[TextBlockParam] | str | None:
 		"""Serialize all system messages without dropping earlier prompts."""
 		if not messages:
 			return None
+
+		messages = AnthropicMessageSerializer._clean_cache_system_messages(messages)
 
 		if len(messages) == 1:
 			message = messages[0]

--- a/browser_use/llm/tests/test_anthropic_cache.py
+++ b/browser_use/llm/tests/test_anthropic_cache.py
@@ -320,6 +320,24 @@ class TestAnthropicCache:
 		assert content_blocks[0].get('cache_control') is None  # type: ignore[attr-defined]
 		assert content_blocks[1].get('cache_control') is None  # type: ignore[attr-defined]
 
+	def test_multiple_system_messages_are_preserved(self):
+		"""Test that multiple SystemMessages are serialized in order."""
+		messages: list[BaseMessage] = [
+			SystemMessage(content='First system instruction'),
+			UserMessage(content='User message'),
+			SystemMessage(content='Second system instruction'),
+		]
+
+		serialized_messages, system_message = AnthropicMessageSerializer.serialize_messages(messages)
+
+		assert len(serialized_messages) == 1
+		assert isinstance(system_message, list)
+		assert [block['text'] for block in system_message] == [
+			'First system instruction',
+			'\n\n',
+			'Second system instruction',
+		]
+
 	def test_cache_assistant_with_content_and_tools(self):
 		"""Test AssistantMessage with both content and tool calls - only last tool gets cache."""
 		tool_call = ToolCall(id='test_id', function=Function(name='test_function', arguments='{"arg": "value"}'))

--- a/browser_use/llm/tests/test_anthropic_cache.py
+++ b/browser_use/llm/tests/test_anthropic_cache.py
@@ -338,6 +338,30 @@ class TestAnthropicCache:
 			'Second system instruction',
 		]
 
+	def test_multiple_cached_system_messages_only_cache_last(self):
+		"""Test that multiple cached SystemMessages preserve text but only cache the last one."""
+		messages: list[BaseMessage] = [
+			SystemMessage(content='First cached system instruction', cache=True),
+			SystemMessage(content='Second cached system instruction', cache=True),
+			SystemMessage(content='Third uncached system instruction', cache=False),
+			SystemMessage(content='Fourth cached system instruction', cache=True),
+		]
+
+		_, system_message = AnthropicMessageSerializer.serialize_messages(messages)
+
+		assert isinstance(system_message, list)
+		assert [block['text'] for block in system_message] == [
+			'First cached system instruction',
+			'\n\n',
+			'Second cached system instruction',
+			'\n\n',
+			'Third uncached system instruction',
+			'\n\n',
+			'Fourth cached system instruction',
+		]
+		assert sum(1 for block in system_message if block.get('cache_control') is not None) == 1
+		assert system_message[-1].get('cache_control') is not None
+
 	def test_cache_assistant_with_content_and_tools(self):
 		"""Test AssistantMessage with both content and tool calls - only last tool gets cache."""
 		tool_call = ToolCall(id='test_id', function=Function(name='test_function', arguments='{"arg": "value"}'))
@@ -383,5 +407,7 @@ if __name__ == '__main__':
 	test_instance.test_max_4_cache_blocks()
 	test_instance.test_cache_only_last_block_in_message()
 	test_instance.test_cache_only_last_tool_call()
+	test_instance.test_multiple_system_messages_are_preserved()
+	test_instance.test_multiple_cached_system_messages_only_cache_last()
 	test_instance.test_cache_assistant_with_content_and_tools()
 	print('All cache tests passed!')


### PR DESCRIPTION
## Summary
- preserve every `SystemMessage` when serializing Anthropic requests instead of overwriting earlier system prompts
- keep existing single-system-message behavior unchanged
- add regression coverage for multiple system messages interleaved with normal messages

Fixes #5633.

## Validation
```console
uv run pytest browser_use/llm/tests/test_anthropic_cache.py -q
# 17 passed in 5.86s

uv run ruff check browser_use/llm/anthropic/serializer.py browser_use/llm/tests/test_anthropic_cache.py
# All checks passed!

uv run pre-commit run --files browser_use/llm/anthropic/serializer.py browser_use/llm/tests/test_anthropic_cache.py
# all hooks passed

git diff --check
# no output
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic request serialization so multiple `SystemMessage`s are preserved in order instead of overwritten by the last one. Also limits cache blocks so only the final `cache=True` system message is cached, keeping the single-system-message behavior unchanged.

**Bug Fixes**
- Serializes all system messages as separate text blocks with `\n\n` separators.
- Shares the cache-cleaning logic between system and non-system messages.
- Adds regression coverage for multiple system messages and cache-block limiting.

<sup>Written for commit d2c572835815d7d00e6303b1468e97765093996f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

