### PR TITLE
fix(aws): support query strings in Bedrock image URLs

### DIFF
--- a/browser_use/llm/aws/serializer.py
+++ b/browser_use/llm/aws/serializer.py
@@ -2,6 +2,7 @@ import base64
 import json
 import re
 from typing import Any, overload
+from urllib.parse import urlsplit
 
 from browser_use.llm.messages import (
 	AssistantMessage,
@@ -26,8 +27,17 @@ class AWSBedrockMessageSerializer:
 	@staticmethod
 	def _is_url_image(url: str) -> bool:
 		"""Check if the URL is a regular HTTP/HTTPS image URL."""
-		return url.startswith(('http://', 'https://')) and any(
-			url.lower().endswith(ext) for ext in ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp']
+		try:
+			parsed_url = urlsplit(url)
+			has_valid_authority = bool(parsed_url.hostname)
+			_ = parsed_url.port
+		except ValueError:
+			return False
+
+		return (
+			parsed_url.scheme.lower() in {'http', 'https'}
+			and has_valid_authority
+			and parsed_url.path.lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.webp'))
 		)
 
 	@staticmethod
@@ -71,13 +81,22 @@ class AWSBedrockMessageSerializer:
 
 			# Detect format from content type or URL
 			content_type = response.headers.get('content-type', '').lower()
-			if 'jpeg' in content_type or url.lower().endswith(('.jpg', '.jpeg')):
+			url_path = urlsplit(url).path.lower()
+			if 'jpeg' in content_type:
 				image_format = 'jpeg'
-			elif 'png' in content_type or url.lower().endswith('.png'):
+			elif 'png' in content_type:
 				image_format = 'png'
-			elif 'gif' in content_type or url.lower().endswith('.gif'):
+			elif 'gif' in content_type:
 				image_format = 'gif'
-			elif 'webp' in content_type or url.lower().endswith('.webp'):
+			elif 'webp' in content_type:
+				image_format = 'webp'
+			elif url_path.endswith(('.jpg', '.jpeg')):
+				image_format = 'jpeg'
+			elif url_path.endswith('.png'):
+				image_format = 'png'
+			elif url_path.endswith('.gif'):
+				image_format = 'gif'
+			elif url_path.endswith('.webp'):
 				image_format = 'webp'
 			else:
 				image_format = 'jpeg'  # Default format

--- a/tests/ci/models/test_aws_bedrock_serializer.py
+++ b/tests/ci/models/test_aws_bedrock_serializer.py
@@ -1,0 +1,85 @@
+import pytest
+from pytest_httpserver import HTTPServer
+from werkzeug import Response
+
+from browser_use.llm.aws.serializer import AWSBedrockMessageSerializer
+from browser_use.llm.messages import ContentPartImageParam, ImageURL
+
+
+@pytest.mark.parametrize(
+	'url',
+	[
+		'https://cdn.example.com/photo.jpg',
+		'https://cdn.example.com/photo.jpg?width=800',
+		'https://cdn.example.com/photo.jpg#preview',
+		'https://cdn.example.com/photo.jpg?width=800#preview',
+		'HTTPS://cdn.example.com/photo.jpg',
+		'https://cdn.example.com/photo.PNG?width=800',
+	],
+)
+def test_is_url_image_accepts_supported_http_urls(url: str) -> None:
+	assert AWSBedrockMessageSerializer._is_url_image(url)
+
+
+@pytest.mark.parametrize(
+	'url',
+	[
+		'ftp://cdn.example.com/photo.jpg',
+		'data:image/png;base64,aGVsbG8=',
+		'https://cdn.example.com/photo.svg',
+		'https://cdn.example.com/photo.bmp',
+		'https://cdn.example.com/photo.bmp?signature=example',
+		'https://cdn.example.com/photo?format=.jpg',
+		'https:photo.jpg',
+		'https:///photo.jpg',
+		'https://[::1/photo.jpg',
+		'https://[not-an-ipv6-address]/photo.jpg',
+		'https://cdn.example.com:invalid/photo.jpg',
+	],
+)
+def test_is_url_image_rejects_unsupported_urls(url: str) -> None:
+	assert not AWSBedrockMessageSerializer._is_url_image(url)
+
+
+def test_serialize_content_part_prefers_response_content_type(httpserver: HTTPServer) -> None:
+	image_bytes = b'image-bytes'
+	httpserver.expect_request('/photo.jpg').respond_with_data(
+		image_bytes,
+		content_type='image/png',
+	)
+	url = httpserver.url_for('/photo.jpg')
+
+	result = AWSBedrockMessageSerializer._serialize_content_part_image(ContentPartImageParam(image_url=ImageURL(url=url)))
+
+	assert result == {
+		'image': {
+			'format': 'png',
+			'source': {
+				'bytes': image_bytes,
+			},
+		}
+	}
+
+
+@pytest.mark.parametrize('content_type', ['application/octet-stream', None])
+def test_serialize_content_part_uses_url_path_when_content_type_is_unavailable(
+	httpserver: HTTPServer,
+	content_type: str | None,
+) -> None:
+	image_bytes = b'image-bytes'
+	response = Response(image_bytes, content_type=content_type)
+	if content_type is None:
+		response.headers.pop('Content-Type', None)
+	httpserver.expect_request('/photo.png', query_string='signature=example').respond_with_response(response)
+	url = f'{httpserver.url_for("/photo.png")}?signature=example'.replace('http://', 'HTTP://', 1)
+
+	result = AWSBedrockMessageSerializer._serialize_content_part_image(ContentPartImageParam(image_url=ImageURL(url=url)))
+
+	assert result == {
+		'image': {
+			'format': 'png',
+			'source': {
+				'bytes': image_bytes,
+			},
+		}
+	}


### PR DESCRIPTION
## Why

`AWSBedrockMessageSerializer._is_url_image()` checked the raw URL suffix, so otherwise supported image URLs were rejected when they contained a query string or fragment. The same check was case-sensitive for the HTTP scheme.

That prevents common signed/CDN image URLs from reaching the existing Bedrock download path.

## What changed

- Parse URLs with `urlsplit()` and classify supported extensions from the path, independent of query strings and fragments.
- Accept HTTP(S) schemes case-insensitively while rejecting missing or malformed authorities without leaking parser exceptions.
- Prefer a recognized response `Content-Type`, then use the parsed path extension when the server returns a generic or missing content type.
- Reject BMP URLs at the classifier because Bedrock Converse supports JPEG, PNG, GIF, and WebP—not BMP.
- Add real local HTTP-server coverage for signed query preservation, uppercase schemes, content-type precedence, generic/missing MIME fallback, and malformed URLs.

## Verification

- `uv run pytest tests/ci/models/test_aws_bedrock_serializer.py tests/ci/models/test_chat_anthropic_bedrock_client_config.py tests/ci/models/test_chat_anthropic_bedrock_empty_content.py` — 22 passed
- `uv run pre-commit run --all-files` — all hooks passed, including Ruff and Pyright
- `./bin/test.sh` — 1,157 passed, 34 skipped
- `git diff --check origin/main..HEAD` — clean

The regression was also reproduced against `origin/main`: a queried PNG was rejected before the change. The HTTP tests use a real local server rather than mocked download calls.

Fixes #5658

Developed with AI assistance; I reviewed the final diff and validation results.
