### PR TITLE
fix: accept Bedrock image URLs with query strings

### DIFF
--- a/browser_use/llm/aws/serializer.py
+++ b/browser_use/llm/aws/serializer.py
@@ -2,6 +2,7 @@ import base64
 import json
 import re
 from typing import Any, overload
+from urllib.parse import urlsplit
 
 from browser_use.llm.messages import (
 	AssistantMessage,
@@ -26,8 +27,9 @@ class AWSBedrockMessageSerializer:
 	@staticmethod
 	def _is_url_image(url: str) -> bool:
 		"""Check if the URL is a regular HTTP/HTTPS image URL."""
-		return url.startswith(('http://', 'https://')) and any(
-			url.lower().endswith(ext) for ext in ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp']
+		parsed_url = urlsplit(url)
+		return parsed_url.scheme.lower() in {'http', 'https'} and parsed_url.path.lower().endswith(
+			('.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp')
 		)
 
 	@staticmethod

--- a/tests/ci/models/test_aws_bedrock_serializer.py
+++ b/tests/ci/models/test_aws_bedrock_serializer.py
@@ -1,0 +1,28 @@
+import pytest
+
+from browser_use.llm.aws.serializer import AWSBedrockMessageSerializer
+
+
+@pytest.mark.parametrize(
+	'url',
+	[
+		'https://cdn.example.com/photo.jpg?width=800',
+		'https://cdn.example.com/photo.png#preview',
+		'https://cdn.example.com/photo.webp?width=800#preview',
+		'HTTPS://cdn.example.com/photo.JPEG',
+	],
+)
+def test_is_url_image_accepts_query_fragments_and_mixed_case(url: str) -> None:
+	assert AWSBedrockMessageSerializer._is_url_image(url) is True
+
+
+@pytest.mark.parametrize(
+	'url',
+	[
+		'https://cdn.example.com/photo.jpg.exe?format=jpg',
+		'https://cdn.example.com/photo?format=jpg',
+		'ftp://cdn.example.com/photo.jpg',
+	],
+)
+def test_is_url_image_rejects_non_image_paths_and_unsupported_schemes(url: str) -> None:
+	assert AWSBedrockMessageSerializer._is_url_image(url) is False


### PR DESCRIPTION
Fixes #5658.

Bedrock image detection checked the raw URL suffix, so query strings, fragments, and uppercase schemes were rejected before download. This parses the URL and checks the path extension instead.

Tests cover CDN transforms, fragments, mixed-case schemes/extensions, misleading query parameters, and unsupported schemes.

Validation:
- `uv run pytest -q tests/ci/models/test_aws_bedrock_serializer.py` — 7 passed
- `uv run pre-commit run --files browser_use/llm/aws/serializer.py tests/ci/models/test_aws_bedrock_serializer.py` — passed
- `uv run pytest -q tests/ci/models` — 72 passed, 6 skipped; stopped on an existing live OpenAI test because the configured API key returns 401

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5658. Bedrock image detection now parses the URL and checks the path extension, so image URLs with query strings, fragments, or mixed-case schemes are accepted instead of being rejected before download.

**Tests**
- Adds parametrized tests covering query strings, fragments, mixed-case schemes/extensions, misleading query parameters, and unsupported schemes.

<sup>Written for commit a9e3a542e586a415abb31c3f9dc35ef5ba6eebdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

