### PR TITLE
feat(mcp): support Streamable HTTP client connections

### DIFF
--- a/browser_use/mcp/client.py
+++ b/browser_use/mcp/client.py
@@ -16,6 +16,13 @@ Example usage:
         args=["@mycompany/mcp-server@latest"]
     )
 
+    # Or connect to a remote Streamable HTTP server
+    mcp_client = MCPClient(
+        server_name="remote-server",
+        url="https://mcp.example.com/mcp",
+        headers={"Authorization": "Bearer YOUR_TOKEN"},
+    )
+
     # Register all MCP tools as browser-use actions
     await mcp_client.register_to_tools(tools)
 
@@ -25,7 +32,9 @@ Example usage:
 import asyncio
 import logging
 import time
+from contextlib import AsyncExitStack
 from typing import Any
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, ConfigDict, Field, create_model
 
@@ -40,6 +49,8 @@ logger = logging.getLogger(__name__)
 # Import MCP SDK
 from mcp import ClientSession, StdioServerParameters, types
 from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 
 MCP_AVAILABLE = True
 
@@ -50,9 +61,12 @@ class MCPClient:
 	def __init__(
 		self,
 		server_name: str,
-		command: str,
+		command: str | None = None,
 		args: list[str] | None = None,
 		env: dict[str, str] | None = None,
+		*,
+		url: str | None = None,
+		headers: dict[str, str] | None = None,
 	):
 		"""Initialize MCP client.
 
@@ -61,14 +75,29 @@ class MCPClient:
 			command: Command to start the MCP server (e.g., "npx", "python")
 			args: Arguments for the command (e.g., ["@playwright/mcp@latest"])
 			env: Environment variables for the server process
+			url: Streamable HTTP endpoint, instead of a stdio command
+			headers: HTTP request headers, such as an Authorization header (HTTP only)
 		"""
+		if (command is None) == (url is None):
+			raise ValueError('Provide exactly one of command or url')
+		if url is not None:
+			parsed_url = urlsplit(url)
+			if parsed_url.scheme not in {'http', 'https'} or not parsed_url.hostname:
+				raise ValueError('url must be an HTTP or HTTPS endpoint')
+			if args is not None or env is not None:
+				raise ValueError('args and env are only supported with a stdio command')
+		elif headers is not None:
+			raise ValueError('headers are only supported with an HTTP url')
+
 		self.server_name = server_name
 		self.command = command
 		self.args = args or []
 		self.env = env
+		self.url = url
+		self.headers = dict(headers) if headers is not None else None
 
 		self.session: ClientSession | None = None
-		self._stdio_task = None
+		self._connection_task: asyncio.Task[None] | None = None
 		self._read_stream = None
 		self._write_stream = None
 		self._tools: dict[str, types.Tool] = {}
@@ -85,17 +114,17 @@ class MCPClient:
 
 		start_time = time.time()
 		error_msg = None
+		connection_task: asyncio.Task[None] | None = None
 
 		try:
-			logger.info(f"🔌 Connecting to MCP server '{self.server_name}': {self.command} {' '.join(self.args)}")
+			if self.url is not None:
+				logger.info(f"🔌 Connecting to MCP server '{self.server_name}' via Streamable HTTP")
+			else:
+				logger.info(f"🔌 Connecting to MCP server '{self.server_name}': {self.command} {' '.join(self.args)}")
 
-			# Create server parameters
-			server_params = StdioServerParameters(command=self.command, args=self.args, env=self.env)
-
-			# Start stdio client in background task
-			self._stdio_task = create_task_with_error_handling(
-				self._run_stdio_client(server_params), name='mcp_stdio_client', suppress_exceptions=True
-			)
+			# Keep transport and session contexts in the same background task.
+			connection_task = create_task_with_error_handling(self._run_client(), name='mcp_client', suppress_exceptions=True)
+			self._connection_task = connection_task
 
 			# Wait for connection to be established
 			retries = 0
@@ -110,8 +139,11 @@ class MCPClient:
 
 			logger.info(f"📦 Discovered {len(self._tools)} tools from '{self.server_name}': {list(self._tools.keys())}")
 
-		except Exception as e:
+		except (Exception, asyncio.CancelledError) as e:
 			error_msg = str(e)
+			if connection_task is not None:
+				connection_task.cancel()
+				await asyncio.gather(connection_task, return_exceptions=True)
 			raise
 		finally:
 			# Capture telemetry for connect action
@@ -119,7 +151,7 @@ class MCPClient:
 			self._telemetry.capture(
 				MCPClientTelemetryEvent(
 					server_name=self.server_name,
-					command=self.command,
+					command=self.command or 'streamable-http',
 					tools_discovered=len(self._tools),
 					version=get_browser_use_version(),
 					action='connect',
@@ -128,10 +160,20 @@ class MCPClient:
 				)
 			)
 
-	async def _run_stdio_client(self, server_params: StdioServerParameters):
-		"""Run the stdio client connection in a background task."""
+	async def _run_client(self) -> None:
+		"""Own the transport and session until disconnect is requested."""
 		try:
-			async with stdio_client(server_params) as (read_stream, write_stream):
+			async with AsyncExitStack() as stack:
+				if self.url is not None:
+					http_client = await stack.enter_async_context(create_mcp_http_client(headers=self.headers))
+					read_stream, write_stream = await stack.enter_async_context(
+						streamable_http_client(self.url, http_client=http_client)
+					)
+				else:
+					assert self.command is not None
+					server_params = StdioServerParameters(command=self.command, args=self.args, env=self.env)
+					read_stream, write_stream = await stack.enter_async_context(stdio_client(server_params))
+
 				self._read_stream = read_stream
 				self._write_stream = write_stream
 
@@ -175,15 +217,15 @@ class MCPClient:
 			self._connected = False
 			self._disconnect_event.set()
 
-			# Wait for stdio task to finish
-			if self._stdio_task:
+			# Wait for the transport task to finish
+			if self._connection_task:
 				try:
-					await asyncio.wait_for(self._stdio_task, timeout=2.0)
+					await asyncio.wait_for(self._connection_task, timeout=2.0)
 				except TimeoutError:
 					logger.warning(f"Timeout waiting for MCP server '{self.server_name}' to disconnect")
-					self._stdio_task.cancel()
+					self._connection_task.cancel()
 					try:
-						await self._stdio_task
+						await self._connection_task
 					except asyncio.CancelledError:
 						pass
 
@@ -199,7 +241,7 @@ class MCPClient:
 			self._telemetry.capture(
 				MCPClientTelemetryEvent(
 					server_name=self.server_name,
-					command=self.command,
+					command=self.command or 'streamable-http',
 					tools_discovered=0,  # Tools cleared on disconnect
 					version=get_browser_use_version(),
 					action='disconnect',
@@ -346,7 +388,7 @@ class MCPClient:
 					self._telemetry.capture(
 						MCPClientTelemetryEvent(
 							server_name=self.server_name,
-							command=self.command,
+							command=self.command or 'streamable-http',
 							tools_discovered=len(self._tools),
 							version=get_browser_use_version(),
 							action='tool_call',
@@ -394,7 +436,7 @@ class MCPClient:
 					self._telemetry.capture(
 						MCPClientTelemetryEvent(
 							server_name=self.server_name,
-							command=self.command,
+							command=self.command or 'streamable-http',
 							tools_discovered=len(self._tools),
 							version=get_browser_use_version(),
 							action='tool_call',

--- a/tests/ci/test_mcp_client_http.py
+++ b/tests/ci/test_mcp_client_http.py
@@ -29,8 +29,13 @@ class LocalMCPServer:
 	request_started: threading.Event = field(default_factory=threading.Event)
 
 
-@pytest.fixture(params=[True, False], ids=['json', 'sse'])
-async def local_mcp_server(request: pytest.FixtureRequest) -> AsyncIterator[LocalMCPServer]:
+@pytest.fixture
+def mcp_json_response() -> bool:
+	return True
+
+
+@pytest.fixture
+async def local_mcp_server(mcp_json_response: bool) -> AsyncIterator[LocalMCPServer]:
 	mcp = MCPServer('local-http')
 	state = LocalMCPServer(url='')
 	state.allow_requests.set()
@@ -41,7 +46,7 @@ async def local_mcp_server(request: pytest.FixtureRequest) -> AsyncIterator[Loca
 		state.calls.append(value)
 		return value * 2
 
-	app = mcp.streamable_http_app(json_response=request.param)
+	app = mcp.streamable_http_app(json_response=mcp_json_response)
 
 	async def authenticated_app(scope: Scope, receive: Receive, send: Send) -> None:
 		if scope['type'] == 'http':
@@ -83,6 +88,7 @@ async def local_mcp_server(request: pytest.FixtureRequest) -> AsyncIterator[Loca
 					os.environ['NO_PROXY'] = original_no_proxy
 
 
+@pytest.mark.parametrize('mcp_json_response', [True, False], ids=['json', 'sse'])
 async def test_http_tools_register_call_and_disconnect(
 	local_mcp_server: LocalMCPServer, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/ci/test_mcp_client_http.py
+++ b/tests/ci/test_mcp_client_http.py
@@ -1,0 +1,203 @@
+"""Exercise MCP clients against real local HTTP and stdio servers."""
+
+import asyncio
+import os
+import socket
+import sys
+import threading
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+import uvicorn
+from mcp.server.mcpserver import MCPServer
+from starlette.datastructures import Headers
+from starlette.responses import Response
+from starlette.types import Receive, Scope, Send
+
+from browser_use import Tools
+from browser_use.mcp.client import MCPClient
+
+
+@dataclass
+class LocalMCPServer:
+	url: str
+	request_auth: list[str | None] = field(default_factory=list)
+	calls: list[int] = field(default_factory=list)
+	allow_requests: threading.Event = field(default_factory=threading.Event)
+	request_started: threading.Event = field(default_factory=threading.Event)
+
+
+@pytest.fixture(params=[True, False], ids=['json', 'sse'])
+async def local_mcp_server(request: pytest.FixtureRequest) -> AsyncIterator[LocalMCPServer]:
+	mcp = MCPServer('local-http')
+	state = LocalMCPServer(url='')
+	state.allow_requests.set()
+
+	@mcp.tool()
+	def double(value: int) -> int:
+		"""Double a number."""
+		state.calls.append(value)
+		return value * 2
+
+	app = mcp.streamable_http_app(json_response=request.param)
+
+	async def authenticated_app(scope: Scope, receive: Receive, send: Send) -> None:
+		if scope['type'] == 'http':
+			authorization = Headers(scope=scope).get('authorization')
+			state.request_auth.append(authorization)
+			state.request_started.set()
+			await asyncio.to_thread(state.allow_requests.wait)
+			if authorization != 'Bearer local-test-token':
+				await Response(status_code=401)(scope, receive, send)
+				return
+		await app(scope, receive, send)
+
+	original_no_proxy = os.environ.get('NO_PROXY')
+	os.environ['NO_PROXY'] = '127.0.0.1,localhost'
+	with socket.socket() as listener:
+		listener.bind(('127.0.0.1', 0))
+		listener.listen()
+		state.url = f'http://127.0.0.1:{listener.getsockname()[1]}/mcp'
+		server = uvicorn.Server(uvicorn.Config(authenticated_app, log_level='error', lifespan='on'))
+		serving = threading.Thread(target=server.run, kwargs={'sockets': [listener]}, daemon=True)
+		serving.start()
+		try:
+			async with asyncio.timeout(10):
+				while not server.started:
+					if not serving.is_alive():
+						raise RuntimeError('Local MCP server exited before startup')
+					await asyncio.sleep(0.01)
+			yield state
+		finally:
+			state.allow_requests.set()
+			server.should_exit = True
+			try:
+				await asyncio.to_thread(serving.join, 10)
+				assert not serving.is_alive()
+			finally:
+				if original_no_proxy is None:
+					os.environ.pop('NO_PROXY', None)
+				else:
+					os.environ['NO_PROXY'] = original_no_proxy
+
+
+async def test_http_tools_register_call_and_disconnect(
+	local_mcp_server: LocalMCPServer, caplog: pytest.LogCaptureFixture
+) -> None:
+	client = MCPClient(
+		server_name='remote-tools',
+		url=local_mcp_server.url,
+		headers={'Authorization': 'Bearer local-test-token'},
+	)
+	tools = Tools()
+	try:
+		await client.register_to_tools(tools, prefix='remote_')
+		assert client.session is not None
+		result = await tools.registry.execute_action('remote_double', {'value': 7})
+		assert result.error is None
+		assert result.extracted_content == '14'
+		assert local_mcp_server.calls == [7]
+	finally:
+		await client.disconnect()
+
+	assert client.session is None
+	assert not client._connected
+	assert client._connection_task is not None and client._connection_task.done()
+	assert local_mcp_server.request_auth
+	assert set(local_mcp_server.request_auth) == {'Bearer local-test-token'}
+	assert 'local-test-token' not in caplog.text
+
+
+@pytest.mark.parametrize(
+	'options',
+	[
+		{},
+		{'command': 'python', 'url': 'http://127.0.0.1/mcp'},
+		{'url': 'http://127.0.0.1/mcp', 'args': ['server.py']},
+		{'url': 'http://127.0.0.1/mcp', 'env': {'TEST': 'value'}},
+		{'command': 'python', 'headers': {'Authorization': 'test'}},
+		{'url': 'file:///tmp/mcp'},
+		{'url': 'http:///mcp'},
+	],
+)
+def test_invalid_transport_configuration(options: dict[str, Any]) -> None:
+	with pytest.raises(ValueError):
+		MCPClient(server_name='invalid', **options)
+
+
+async def test_stdio_client_still_registers_and_calls_tools() -> None:
+	server_code = """
+from mcp.server.mcpserver import MCPServer
+server = MCPServer('local-stdio')
+@server.tool()
+def greet(name: str) -> str:
+	return f'Hello {name}'
+server.run()
+"""
+	client = MCPClient('stdio-tools', sys.executable, ['-c', server_code])
+	tools = Tools()
+	try:
+		await client.register_to_tools(tools)
+		result = await tools.registry.execute_action('greet', {'name': 'Ada'})
+		assert result.error is None
+		assert result.extracted_content == 'Hello Ada'
+	finally:
+		await client.disconnect()
+	assert client.session is None
+
+
+@pytest.mark.parametrize('failure_mode', ['unauthorized', 'timeout'])
+async def test_http_transport_failure_exits_session(local_mcp_server: LocalMCPServer, failure_mode: str) -> None:
+	if failure_mode == 'timeout':
+		local_mcp_server.allow_requests.clear()
+	client = MCPClient(server_name='connection-failure', url=local_mcp_server.url)
+	try:
+		with pytest.raises(RuntimeError, match='Failed to connect'):
+			await client.connect()
+	finally:
+		local_mcp_server.allow_requests.set()
+	assert client._connection_task is not None and client._connection_task.done()
+	assert local_mcp_server.request_auth
+	assert client.session is None
+	assert not client._connected
+
+
+async def test_http_transport_cancellation_exits_session(local_mcp_server: LocalMCPServer) -> None:
+	client = MCPClient(
+		server_name='cancelled',
+		url=local_mcp_server.url,
+		headers={'Authorization': 'Bearer local-test-token'},
+	)
+	await client.connect()
+	connection_task = client._connection_task
+	assert connection_task is not None
+	connection_task.cancel()
+	with pytest.raises(asyncio.CancelledError):
+		await connection_task
+	assert client.session is None
+	assert not client._connected
+
+
+async def test_cancel_connect_drains_http_initialization(local_mcp_server: LocalMCPServer) -> None:
+	local_mcp_server.allow_requests.clear()
+	client = MCPClient(
+		server_name='cancel-initialization',
+		url=local_mcp_server.url,
+		headers={'Authorization': 'Bearer local-test-token'},
+	)
+	connecting = asyncio.create_task(client.connect())
+	try:
+		assert await asyncio.to_thread(local_mcp_server.request_started.wait, 5)
+		connecting.cancel()
+		with pytest.raises(asyncio.CancelledError):
+			await connecting
+		assert client._connection_task is not None and client._connection_task.done()
+		assert client.session is None
+		assert not client._connected
+	finally:
+		local_mcp_server.allow_requests.set()
+		if client._connection_task is not None and not client._connection_task.done():
+			client._connection_task.cancel()
+			await asyncio.gather(client._connection_task, return_exceptions=True)


### PR DESCRIPTION
`MCPClient` currently launches only stdio subprocesses. This adds Streamable HTTP connections so remote MCP services can register their tools with a browser-use agent. The positional stdio API stays compatible; `url` and `headers` are keyword-only and reject conflicting process configuration. No dependency changes are needed.

```python
from browser_use import Tools
from browser_use.mcp.client import MCPClient

tools = Tools()
client = MCPClient(
    server_name="remote-tools",
    url="https://mcp.example.com/mcp",
    headers={"Authorization": "Bearer YOUR_TOKEN"},
)
try:
    await client.register_to_tools(tools, prefix="remote_")
    # Pass tools to the agent while this connection is open.
finally:
    await client.disconnect()
```

The transport uses the pinned MCP SDK's HTTP client factory and owns its HTTP client, transport, and `ClientSession` in one background task. Failed or cancelled `connect()` calls cancel and await that task so HTTP initialization cannot outlive its caller. The broader reconnect and concurrent lifecycle changes in #5286 remain separate. The HTTP URL and headers are not added to application connection logs or the telemetry command field.

Validation:

- Focused MCP tests on the current revision: 17 passed in 23.06s, including 14 new cases against real local SDK servers. JSON/SSE parameterization covers successful initialization, registration, tool calls, and disconnect; protocol-independent failure/cancellation cases use one format. This removes four redundant cases and about 20 seconds from the earlier 21-case run without losing behavior coverage. New configuration and public-connect cancellation tests were confirmed failing before implementation.
- `uv run pyright`: 0 errors, warnings, or information messages.
- `uv run pre-commit run --all-files`: passed, including the new test file and hook pyright.
- `uv run pytest -vxs tests/ci`: 544 passed, 33 skipped, then stopped on an existing beta Agent class-identity failure. On untouched base `cfe10a23585e3fa56486ae0db983522674a20712`, running `test_malformed_env_timeout_does_not_break_import` before `test_beta_agent_constructor_type_hints_match_browser_use_core_params` reproduces the identical failure: reloading `browser_use.tools.service` creates a different `Tools` class object. The beta case passes alone. Neither existing test was changed.
- The remaining 634 collected cases (including that beta case), run in a fresh process: 633 passed, 1 skipped. Thus every collected case was exercised; the original single-process failure above remains disclosed.

Generated with Codex. Automated implementation and review were used; no human review is claimed.

Review follow-up: narrowed JSON/SSE parameterization to successful protocol exchanges, addressing the redundant timeout-case review. Focused tests and all pre-commit hooks for the changed test file passed; production code is unchanged.
