### PR TITLE
fix(history): redact sensitive data from input_text actions

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -554,10 +554,7 @@ class AgentHistory(BaseModel):
 			# {action_name: params}, so checking for a literal "input" key misses built-in
 			# actions like input_text and any custom action with a different name.
 			if sensitive_data:
-				action_dump = [
-					self._filter_sensitive_data_from_dict(action, sensitive_data)
-					for action in action_dump
-				]
+				action_dump = [self._filter_sensitive_data_from_dict(action, sensitive_data) for action in action_dump]
 
 			model_output_dump = {
 				'evaluation_previous_goal': self.model_output.evaluation_previous_goal,

--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -550,10 +550,12 @@ class AgentHistory(BaseModel):
 		if self.model_output:
 			action_dump = [action.model_dump(exclude_none=True, mode='json') for action in self.model_output.action]
 
-			# Filter sensitive data only from input action parameters if sensitive_data is provided
+			# Filter sensitive data from every action parameter payload. The dumped shape is
+			# {action_name: params}, so checking for a literal "input" key misses built-in
+			# actions like input_text and any custom action with a different name.
 			if sensitive_data:
 				action_dump = [
-					self._filter_sensitive_data_from_dict(action, sensitive_data) if 'input' in action else action
+					self._filter_sensitive_data_from_dict(action, sensitive_data)
 					for action in action_dump
 				]
 

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -670,3 +670,36 @@ def test_history_filters_sensitive_data_inside_nested_lists(tmp_path):
 
 	assert 'token-123' not in saved, 'Sensitive value leaked into the saved history file'
 	assert saved.count('<secret>api_key</secret>') == 2
+
+
+def test_history_filters_sensitive_data_from_input_text_action(tmp_path):
+	"""Saved history must redact sensitive values typed by the built-in input_text action."""
+	from pathlib import Path
+	from typing import Any
+
+	from pydantic import create_model
+
+	from browser_use.agent.views import AgentHistory, AgentHistoryList, AgentOutput
+	from browser_use.browser.views import BrowserStateHistory
+	from browser_use.tools.registry.views import ActionModel
+	from browser_use.tools.views import InputTextAction
+
+	InputTextActionModel = create_model('InputTextActionModel', __base__=ActionModel, input_text=(InputTextAction | None, None))
+	OutputModel = AgentOutput.type_with_custom_actions(InputTextActionModel)
+	action = InputTextActionModel.model_validate({'input_text': {'index': 1, 'text': 'token-123'}})
+	history = AgentHistoryList[Any](
+		history=[
+			AgentHistory(
+				model_output=OutputModel(memory='', action=[action]),
+				result=[],
+				state=BrowserStateHistory(url='https://example.test', title='t', tabs=[], interacted_element=[None]),
+			)
+		]
+	)
+
+	filepath = Path(tmp_path) / 'history.json'
+	history.save_to_file(filepath, sensitive_data={'api_key': 'token-123'})
+	saved = filepath.read_text(encoding='utf-8')
+
+	assert 'token-123' not in saved, 'input_text leaked sensitive value into saved history'
+	assert '<secret>api_key</secret>' in saved


### PR DESCRIPTION
## Summary
- fix saved history redaction for built-in `input_text` actions by applying the existing sensitive-data filter to all action payloads
- add a regression test matching the `input_text` leak reported in #5679

Fixes #5679.

## Test plan
```console
uv run pytest tests/ci/security/test_sensitive_data.py::test_history_filters_sensitive_data_from_input_text_action tests/ci/security/test_sensitive_data.py::test_history_filters_sensitive_data_inside_nested_lists -q
# 2 passed in 0.09s

uv run ruff check browser_use/agent/views.py tests/ci/security/test_sensitive_data.py
# All checks passed!

git diff --check
# no output
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes saved history leaking sensitive data from built-in `input_text` actions by applying the redaction filter to all action payloads, not just those with an `'input'` key. Adds a regression test for the reported issue (#5679).

<sup>Written for commit 4294b08c3c634c8ea2450896b6bc1cc787724afb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

