### PR TITLE
fix(llm): keep every system message in the Bedrock request

### DIFF
--- a/browser_use/llm/aws/serializer.py
+++ b/browser_use/llm/aws/serializer.py
@@ -255,22 +255,23 @@ class AWSBedrockMessageSerializer:
 	@staticmethod
 	def serialize_messages(messages: list[BaseMessage]) -> tuple[list[dict[str, Any]], list[dict[str, Any]] | None]:
 		"""
-		Serialize a list of messages, extracting any system message.
+		Serialize a list of messages, extracting the system messages.
 
 		Returns:
-			Tuple of (bedrock_messages, system_message) where system_message is extracted
-			from any SystemMessage in the list.
+			Tuple of (bedrock_messages, system_blocks) where system_blocks holds the content
+			blocks of every SystemMessage in the list, in order, or None if there were none.
 		"""
 		bedrock_messages: list[dict[str, Any]] = []
-		system_message: list[dict[str, Any]] | None = None
+		system_blocks: list[dict[str, Any]] = []
 
 		for message in messages:
 			if isinstance(message, SystemMessage):
-				# Extract system message content
-				system_message = AWSBedrockMessageSerializer._serialize_system_content(message.content)
+				# Converse takes `system` as a list of content blocks, so collect every system
+				# message instead of letting the last one replace the ones before it
+				system_blocks.extend(AWSBedrockMessageSerializer._serialize_system_content(message.content))
 			else:
 				# Serialize and add to regular messages
 				serialized = AWSBedrockMessageSerializer.serialize(message)
 				bedrock_messages.append(serialized)
 
-		return bedrock_messages, system_message
+		return bedrock_messages, system_blocks or None

--- a/tests/ci/models/test_aws_bedrock_serializer.py
+++ b/tests/ci/models/test_aws_bedrock_serializer.py
@@ -3,7 +3,14 @@ from pytest_httpserver import HTTPServer
 from werkzeug import Response
 
 from browser_use.llm.aws.serializer import AWSBedrockMessageSerializer
-from browser_use.llm.messages import ContentPartImageParam, ImageURL
+from browser_use.llm.messages import (
+	BaseMessage,
+	ContentPartImageParam,
+	ContentPartTextParam,
+	ImageURL,
+	SystemMessage,
+	UserMessage,
+)
 
 
 @pytest.mark.parametrize(
@@ -83,3 +90,67 @@ def test_serialize_content_part_uses_url_path_when_content_type_is_unavailable(
 			},
 		}
 	}
+
+
+def test_single_system_message_is_serialized_as_one_block() -> None:
+	"""A lone system message must still produce the single-block list the Converse API expects."""
+	messages: list[BaseMessage] = [SystemMessage(content='Only rule.'), UserMessage(content='Go.')]
+
+	_, system = AWSBedrockMessageSerializer.serialize_messages(messages)
+
+	assert system == [{'text': 'Only rule.'}]
+
+
+def test_all_system_messages_are_preserved_in_order() -> None:
+	"""Bedrock takes `system` as a list of content blocks, so every system message must survive.
+
+	The agent builds its prompt from several system messages, and dropping all but the last one
+	silently discards instructions the caller supplied.
+	"""
+	messages: list[BaseMessage] = [
+		SystemMessage(content='First rule.'),
+		SystemMessage(content='Second rule.'),
+		SystemMessage(content='Third rule.'),
+		UserMessage(content='Go.'),
+	]
+
+	_, system = AWSBedrockMessageSerializer.serialize_messages(messages)
+
+	assert system == [{'text': 'First rule.'}, {'text': 'Second rule.'}, {'text': 'Third rule.'}]
+
+
+def test_multi_part_system_messages_keep_every_text_block() -> None:
+	"""A system message carrying several text parts contributes all of them, still in order."""
+	messages: list[BaseMessage] = [
+		SystemMessage(content=[ContentPartTextParam(text='Part one.'), ContentPartTextParam(text='Part two.')]),
+		SystemMessage(content='Part three.'),
+		UserMessage(content='Go.'),
+	]
+
+	_, system = AWSBedrockMessageSerializer.serialize_messages(messages)
+
+	assert system == [{'text': 'Part one.'}, {'text': 'Part two.'}, {'text': 'Part three.'}]
+
+
+def test_system_messages_do_not_reach_the_conversation() -> None:
+	"""System text belongs in the `system` field only; it must not leak into the message list."""
+	messages: list[BaseMessage] = [
+		SystemMessage(content='First rule.'),
+		UserMessage(content='Go.'),
+		SystemMessage(content='Late rule.'),
+	]
+
+	bedrock_messages, system = AWSBedrockMessageSerializer.serialize_messages(messages)
+
+	assert system == [{'text': 'First rule.'}, {'text': 'Late rule.'}]
+	assert [message['role'] for message in bedrock_messages] == ['user']
+
+
+def test_conversation_without_system_messages_has_no_system_field() -> None:
+	"""Without any system message the serializer returns None so the request omits `system`."""
+	messages: list[BaseMessage] = [UserMessage(content='Go.')]
+
+	bedrock_messages, system = AWSBedrockMessageSerializer.serialize_messages(messages)
+
+	assert system is None
+	assert len(bedrock_messages) == 1


### PR DESCRIPTION
## Summary

`AWSBedrockMessageSerializer.serialize_messages` assigns `system_message` on every
`SystemMessage` it encounters, so each one overwrites the last and only the final
system message reaches the model:

```python
for message in messages:
    if isinstance(message, SystemMessage):
        system_message = AWSBedrockMessageSerializer._serialize_system_content(message.content)
```

`chat_bedrock.py` passes that value straight through as `body['system']`, so any
instruction in an earlier system message is silently discarded before the request is
built. Nothing raises and nothing logs — the model just never sees it.

## Fix

The Converse API takes `system` as a **list** of content blocks, so the blocks can
simply be accumulated in order rather than replaced:

```python
system_blocks.extend(AWSBedrockMessageSerializer._serialize_system_content(message.content))
...
return bedrock_messages, system_blocks or None
```

`system_blocks or None` preserves the existing behaviour for a conversation with no
system messages, so `system` stays out of the request body exactly as before. A single
system message still serializes to the same one-block list it did previously, so this
is additive for every existing caller.

## Verifying the tests catch the bug

**Step 1 — new tests against the unmodified serializer:**

```console
$ uv run pytest tests/ci/models/test_aws_bedrock_serializer.py -q --maxfail=10
FAILED test_all_system_messages_are_preserved_in_order
FAILED test_multi_part_system_messages_keep_every_text_block
FAILED test_system_messages_do_not_reach_the_conversation
3 failed, 22 passed
```

with

```
AssertionError: assert [{'text': 'Third rule.'}] == [{'text': 'First rule.'}, ...]
  At index 0 diff: {'text': 'Third rule.'} != {'text': 'First rule.'}
  Right contains 2 more items, first extra item: {'text': 'Second rule.'}
```

**Step 2 — the same tests after the fix:**

```console
$ uv run pytest tests/ci/models/test_aws_bedrock_serializer.py -q
25 passed
```

The two tests that pass in both steps are deliberate regression guards: a single system
message must still produce one block, and a conversation with no system message must
still return `None`.

Wider run:

```console
$ uv run pytest tests/ci/models tests/ci/security -q
220 passed, 7 skipped
$ uv run ruff check --no-fix --select PLE browser_use/ tests/
All checks passed!
$ uv run pyright browser_use/llm/aws/serializer.py tests/ci/models/test_aws_bedrock_serializer.py
0 errors, 0 warnings, 0 informations
```

(The three errors in `tests/ci/security/test_mcp_allowed_domains.py` on my machine are a
local `mcp` version mismatch and reproduce on unmodified `main`.)

## Note

This is the same defect class as #5624/#5628 in the Gemini serializer, fixed in #5664,
and #5633 in the Anthropic serializer. I went looking for it across the remaining
providers after those: the OpenAI-compatible ones (`openai`, `groq`, `ollama`,
`deepseek`, `cerebras`, `openrouter`, `orcarouter`, `vercel`, `litellm`) keep system
messages inline in the message list and are unaffected. Bedrock is the last provider
with a separate system field, and it had the same bug. No issue was filed for it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Bedrock serializer so every system message reaches the model instead of only the last one. Previously each `SystemMessage` overwrote the previous one, silently dropping earlier instructions from the request.

- Accumulates all system message content blocks in order to match the Converse API's `system` list format.
- Drops empty system messages (Converse rejects empty text blocks) and separates remaining blocks with exactly one blank line, normalizing trailing newlines so the gap doesn't depend on caller input.
- Returns `None` when no system message remains, keeping `system` out of the request as before.
- Adds regression tests for single, multiple, mixed-part, late, empty, and no-system cases.
- No breaking change for existing callers: a single system message still serializes to one block.

<sup>Written for commit 7e4da60aaa69e13a45f292bdef2c1a556ba4d326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

