### PR TITLE
fix(dom): stop classifying preview/next-steps widgets as pagination (#5514)

### DIFF
--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -1167,17 +1167,35 @@ class DomService:
 
 	# Decorative glyphs often wrap pagination labels ("Next >", "‹ Previous").
 	_PAGINATION_DECORATION_RE = re.compile(r'^[\s<>«»←→⇤⇥›‹.]+|[\s<>«»←→⇤⇥›‹.]+$')
+	_PAGINATION_GO_PREFIX = r'(?:go to|ir a|aller(?:\s+à)?|zur|naar)\s+'
+	_PAGINATION_PAGE_WORD = r'(?:page|página|pagina|seite)'
 
 	@staticmethod
 	def _normalized_pagination_label(value: str) -> str:
 		return DomService._PAGINATION_DECORATION_RE.sub('', value).strip()
 
 	@staticmethod
+	def _matches_word_pagination_pattern(normalized: str, pattern: str) -> bool:
+		"""Accept bare/localized page labels without matching 'Next steps'."""
+		return bool(
+			re.fullmatch(
+				rf'(?:{DomService._PAGINATION_GO_PREFIX})?{re.escape(pattern)}(?:\s+{DomService._PAGINATION_PAGE_WORD})?',
+				normalized,
+			)
+		)
+
+	@staticmethod
+	def _matches_symbol_pagination_pattern(value: str, normalized: str, pattern: str) -> bool:
+		compact = ''.join(value.split())
+		return value == pattern or normalized == pattern or bool(pattern) and bool(compact) and set(compact) == {pattern}
+
+	@staticmethod
 	def _matches_pagination_pattern(sources: tuple[str, ...], patterns: list[str]) -> bool:
 		"""Match user-facing labels, not CSS class substrings or incidental words.
 
-		Alphabetic patterns must be the whole label (optionally plus "page"), after
-		stripping decorative arrows. Symbol patterns must be the entire label.
+		Alphabetic patterns must be the whole label, optionally with a go-to prefix
+		and a page word (including localized forms), after stripping decorative
+		arrows. Symbol patterns must be the entire label or a repeated copy of it.
 		"""
 		for raw in sources:
 			value = raw.strip()
@@ -1186,11 +1204,25 @@ class DomService:
 			normalized = DomService._normalized_pagination_label(value)
 			for pattern in patterns:
 				if any(ch.isalpha() for ch in pattern):
-					if normalized == pattern or normalized == f'{pattern} page':
+					if DomService._matches_word_pagination_pattern(normalized, pattern):
 						return True
-				elif value == pattern or normalized == pattern:
+				elif DomService._matches_symbol_pagination_pattern(value, normalized, pattern):
 					return True
 		return False
+
+	@staticmethod
+	def _pagination_peer_key(node: EnhancedDOMTreeNode) -> object:
+		"""Group numbered controls that share a pager container or the same parent."""
+		current = node.parent_node
+		while current is not None:
+			attributes = current.attributes or {}
+			role = attributes.get('role', '').lower()
+			class_name = attributes.get('class', '').lower()
+			element_id = attributes.get('id', '').lower()
+			if current.tag_name == 'nav' or role == 'navigation' or 'paginat' in class_name or 'paginat' in element_id:
+				return current
+			current = current.parent_node
+		return node.parent_node if node.parent_node is not None else node
 
 	@staticmethod
 	def detect_pagination_buttons(selector_map: dict[int, EnhancedDOMTreeNode]) -> list[dict[str, str | int | bool]]:
@@ -1209,6 +1241,7 @@ class DomService:
 			- is_disabled: Whether the button appears disabled
 		"""
 		pagination_buttons: list[dict[str, str | int | bool]] = []
+		page_number_nodes: list[tuple[dict[str, str | int | bool], EnhancedDOMTreeNode]] = []
 
 		# Common pagination patterns to look for
 		# `«` and `»` are ambiguous across sites, so treat them only as prev/next
@@ -1255,19 +1288,24 @@ class DomService:
 				button_type = 'page_number'
 
 			if button_type:
-				pagination_buttons.append(
-					{
-						'button_type': button_type,
-						'backend_node_id': node.backend_node_id,
-						'selector_index': index,
-						'text': node.get_all_children_text().strip() or aria_label or title,
-						'selector': node.xpath,
-						'is_disabled': is_disabled,
-					}
-				)
+				button = {
+					'button_type': button_type,
+					'backend_node_id': node.backend_node_id,
+					'selector_index': index,
+					'text': node.get_all_children_text().strip() or aria_label or title,
+					'selector': node.xpath,
+					'is_disabled': is_disabled,
+				}
+				pagination_buttons.append(button)
+				if button_type == 'page_number':
+					page_number_nodes.append((button, node))
 
-		page_numbers = [button for button in pagination_buttons if button['button_type'] == 'page_number']
-		if len(page_numbers) < 2:
-			pagination_buttons = [button for button in pagination_buttons if button['button_type'] != 'page_number']
+		peer_groups: dict[object, list[dict[str, str | int | bool]]] = {}
+		for button, page_node in page_number_nodes:
+			peer_groups.setdefault(DomService._pagination_peer_key(page_node), []).append(button)
+		keep_page_numbers = {id(button) for members in peer_groups.values() if len(members) >= 2 for button in members}
+		pagination_buttons = [
+			button for button in pagination_buttons if button['button_type'] != 'page_number' or id(button) in keep_page_numbers
+		]
 
 		return pagination_buttons

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -1164,6 +1165,33 @@ class DomService:
 
 		return serialized_dom_state, enhanced_dom_tree, timing_info
 
+	# Decorative glyphs often wrap pagination labels ("Next >", "‹ Previous").
+	_PAGINATION_DECORATION_RE = re.compile(r'^[\s<>«»←→⇤⇥›‹.]+|[\s<>«»←→⇤⇥›‹.]+$')
+
+	@staticmethod
+	def _normalized_pagination_label(value: str) -> str:
+		return DomService._PAGINATION_DECORATION_RE.sub('', value).strip()
+
+	@staticmethod
+	def _matches_pagination_pattern(sources: tuple[str, ...], patterns: list[str]) -> bool:
+		"""Match user-facing labels, not CSS class substrings or incidental words.
+
+		Alphabetic patterns must be the whole label (optionally plus "page"), after
+		stripping decorative arrows. Symbol patterns must be the entire label.
+		"""
+		for raw in sources:
+			value = raw.strip()
+			if not value:
+				continue
+			normalized = DomService._normalized_pagination_label(value)
+			for pattern in patterns:
+				if any(ch.isalpha() for ch in pattern):
+					if normalized == pattern or normalized == f'{pattern} page':
+						return True
+				elif value == pattern or normalized == pattern:
+					return True
+		return False
+
 	@staticmethod
 	def detect_pagination_buttons(selector_map: dict[int, EnhancedDOMTreeNode]) -> list[dict[str, str | int | bool]]:
 		"""Detect pagination buttons from the selector map.
@@ -1201,9 +1229,7 @@ class DomService:
 			title = node.attributes.get('title', '').lower()
 			class_name = node.attributes.get('class', '').lower()
 			role = node.attributes.get('role', '').lower()
-
-			# Combine all text sources for pattern matching
-			all_text = f'{text} {aria_label} {title} {class_name}'.strip()
+			label_sources = (text, aria_label, title)
 
 			# Check if it's disabled
 			is_disabled = (
@@ -1215,19 +1241,17 @@ class DomService:
 			button_type: str | None = None
 
 			# Match specific first/last semantics before generic prev/next fallbacks.
-			if any(pattern in all_text for pattern in first_patterns):
+			if DomService._matches_pagination_pattern(label_sources, first_patterns):
 				button_type = 'first'
-			# Check for last button
-			elif any(pattern in all_text for pattern in last_patterns):
+			elif DomService._matches_pagination_pattern(label_sources, last_patterns):
 				button_type = 'last'
-			# Check for next button
-			elif any(pattern in all_text for pattern in next_patterns):
+			elif DomService._matches_pagination_pattern(label_sources, next_patterns):
 				button_type = 'next'
-			# Check for previous button
-			elif any(pattern in all_text for pattern in prev_patterns):
+			elif DomService._matches_pagination_pattern(label_sources, prev_patterns):
 				button_type = 'prev'
-			# Check for numeric page buttons (single or double digit)
-			elif text.isdigit() and len(text) <= 2 and role in ['button', 'link', '']:
+			elif text.isdigit() and len(text) <= 2 and (role in {'button', 'link'} or node.tag_name in {'a', 'button'}):
+				# Lone numeric widgets (ratings, qty steppers) are not pagination.
+				# A real pager almost always exposes 2+ numbered controls together.
 				button_type = 'page_number'
 
 			if button_type:
@@ -1241,5 +1265,9 @@ class DomService:
 						'is_disabled': is_disabled,
 					}
 				)
+
+		page_numbers = [button for button in pagination_buttons if button['button_type'] == 'page_number']
+		if len(page_numbers) < 2:
+			pagination_buttons = [button for button in pagination_buttons if button['button_type'] != 'page_number']
 
 		return pagination_buttons

--- a/browser_use/dom/service.py
+++ b/browser_use/dom/service.py
@@ -1210,9 +1210,12 @@ class DomService:
 					return True
 		return False
 
+	# Single-item wrappers around page links (li/td/th) are not pager peers themselves.
+	_PAGINATION_PEER_WRAPPER_TAGS = frozenset({'li', 'td', 'th'})
+
 	@staticmethod
 	def _pagination_peer_key(node: EnhancedDOMTreeNode) -> object:
-		"""Group numbered controls that share a pager container or the same parent."""
+		"""Group numbered controls that share a pager container or list/table row."""
 		current = node.parent_node
 		while current is not None:
 			attributes = current.attributes or {}
@@ -1222,7 +1225,13 @@ class DomService:
 			if current.tag_name == 'nav' or role == 'navigation' or 'paginat' in class_name or 'paginat' in element_id:
 				return current
 			current = current.parent_node
-		return node.parent_node if node.parent_node is not None else node
+
+		# Plain <ul><li><a>1</a></li><li><a>2</a></li></ul> has no nav marker; peer by
+		# the shared list/table ancestor instead of each lone wrapper element.
+		fallback = node.parent_node
+		while fallback is not None and fallback.tag_name in DomService._PAGINATION_PEER_WRAPPER_TAGS:
+			fallback = fallback.parent_node
+		return fallback if fallback is not None else node
 
 	@staticmethod
 	def detect_pagination_buttons(selector_map: dict[int, EnhancedDOMTreeNode]) -> list[dict[str, str | int | bool]]:

--- a/tests/ci/test_pagination_detection.py
+++ b/tests/ci/test_pagination_detection.py
@@ -157,3 +157,18 @@ def test_pagination_rejects_unrelated_numeric_controls():
 	buttons = DomService.detect_pagination_buttons({1: rating, 2: quantity})
 
 	assert buttons == []
+
+
+def test_pagination_keeps_page_numbers_in_plain_list_items():
+	page_one = _clickable('a', '1', node_id=1)
+	page_two = _clickable('a', '2', node_id=2)
+	list_container = _clickable('ul', '', node_id=90)
+	item_one = _clickable('li', '', node_id=91)
+	item_two = _clickable('li', '', node_id=92)
+	_attach(item_one, page_one)
+	_attach(item_two, page_two)
+	_attach(list_container, item_one, item_two)
+
+	buttons = DomService.detect_pagination_buttons({1: page_one, 2: page_two})
+
+	assert _types(buttons) == [('1', 'page_number'), ('2', 'page_number')]

--- a/tests/ci/test_pagination_detection.py
+++ b/tests/ci/test_pagination_detection.py
@@ -71,6 +71,12 @@ def _clickable(
 	return node
 
 
+def _attach(parent: EnhancedDOMTreeNode, *children: EnhancedDOMTreeNode) -> None:
+	parent.children_nodes = list(children)
+	for child in children:
+		child.parent_node = parent
+
+
 def _types(buttons: list[dict[str, str | int | bool]]) -> list[tuple[str, str]]:
 	return [(str(button['text']), str(button['button_type'])) for button in buttons]
 
@@ -91,16 +97,25 @@ def test_pagination_ignores_css_class_and_substring_false_positives():
 
 
 def test_pagination_keeps_real_controls_and_decorated_labels():
+	page_one = _clickable('a', '1', node_id=4)
+	page_two = _clickable('a', '2', node_id=5)
+	_attach(_clickable('nav', '', node_id=90), page_one, page_two)
+
 	buttons = DomService.detect_pagination_buttons(
 		{
 			1: _clickable('a', 'Next', node_id=1, role='button'),
 			2: _clickable('a', '‹ Previous', node_id=2),
 			3: _clickable('button', 'Next page', node_id=3),
-			4: _clickable('a', '1', node_id=4),
-			5: _clickable('a', '2', node_id=5),
+			4: page_one,
+			5: page_two,
 			6: _clickable('button', 'First', node_id=6),
 			7: _clickable('button', 'Last', node_id=7),
 			8: _clickable('button', '>', node_id=8),
+			9: _clickable('button', '>>', node_id=9),
+			10: _clickable('button', '<<', node_id=10),
+			11: _clickable('a', 'Go to next page', node_id=11),
+			12: _clickable('a', 'Siguiente página', node_id=12),
+			13: _clickable('a', 'Volgende pagina', node_id=13),
 		}
 	)
 
@@ -113,6 +128,11 @@ def test_pagination_keeps_real_controls_and_decorated_labels():
 		('First', 'first'),
 		('Last', 'last'),
 		('>', 'next'),
+		('>>', 'next'),
+		('<<', 'prev'),
+		('Go to next page', 'next'),
+		('Siguiente página', 'next'),
+		('Volgende pagina', 'next'),
 	]
 
 
@@ -124,5 +144,16 @@ def test_pagination_rejects_lone_numeric_widgets():
 			3: _clickable('div', '10', node_id=3, role=''),
 		}
 	)
+
+	assert buttons == []
+
+
+def test_pagination_rejects_unrelated_numeric_controls():
+	rating = _clickable('button', '5', node_id=1, role='button')
+	quantity = _clickable('button', '10', node_id=2, role='button')
+	_attach(_clickable('div', '', node_id=90, class_name='star-rating'), rating)
+	_attach(_clickable('div', '', node_id=91, class_name='qty-stepper'), quantity)
+
+	buttons = DomService.detect_pagination_buttons({1: rating, 2: quantity})
 
 	assert buttons == []

--- a/tests/ci/test_pagination_detection.py
+++ b/tests/ci/test_pagination_detection.py
@@ -1,0 +1,128 @@
+"""Regression coverage for pagination button classification (#5514)."""
+
+from browser_use.dom.service import DomService
+from browser_use.dom.views import DOMRect, EnhancedDOMTreeNode, EnhancedSnapshotNode, NodeType
+
+
+def _clickable(
+	tag_name: str,
+	text: str,
+	*,
+	node_id: int,
+	role: str = '',
+	class_name: str = '',
+	aria_label: str = '',
+	title: str = '',
+) -> EnhancedDOMTreeNode:
+	bounds = DOMRect(x=0, y=0, width=80, height=28)
+	node = EnhancedDOMTreeNode(
+		node_id=node_id,
+		backend_node_id=node_id,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name=tag_name.upper(),
+		node_value='',
+		attributes={'role': role, 'class': class_name, 'aria-label': aria_label, 'title': title},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=bounds,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=[],
+		ax_node=None,
+		snapshot_node=EnhancedSnapshotNode(
+			is_clickable=True,
+			cursor_style='pointer',
+			bounds=bounds,
+			clientRects=bounds,
+			scrollRects=None,
+			computed_styles={},
+			paint_order=None,
+			stacking_contexts=None,
+		),
+	)
+	if text:
+		text_node = EnhancedDOMTreeNode(
+			node_id=node_id + 1000,
+			backend_node_id=node_id + 1000,
+			node_type=NodeType.TEXT_NODE,
+			node_name='#text',
+			node_value=text,
+			attributes={},
+			is_scrollable=False,
+			is_visible=True,
+			absolute_position=bounds,
+			target_id='target-1',
+			frame_id=None,
+			session_id=None,
+			content_document=None,
+			shadow_root_type=None,
+			shadow_roots=None,
+			parent_node=node,
+			children_nodes=None,
+			ax_node=None,
+			snapshot_node=None,
+		)
+		node.children_nodes = [text_node]
+	return node
+
+
+def _types(buttons: list[dict[str, str | int | bool]]) -> list[tuple[str, str]]:
+	return [(str(button['text']), str(button['button_type'])) for button in buttons]
+
+
+def test_pagination_ignores_css_class_and_substring_false_positives():
+	buttons = DomService.detect_pagination_buttons(
+		{
+			1: _clickable('a', 'Preview', node_id=1, class_name='preview-link'),
+			2: _clickable('button', 'Continue', node_id=2, class_name='pagination-next'),
+			3: _clickable('button', 'Last name', node_id=3),
+			4: _clickable('button', 'Last modified', node_id=4),
+			5: _clickable('button', 'Next steps', node_id=5),
+			6: _clickable('button', '', node_id=6, aria_label='price < 100'),
+		}
+	)
+
+	assert buttons == []
+
+
+def test_pagination_keeps_real_controls_and_decorated_labels():
+	buttons = DomService.detect_pagination_buttons(
+		{
+			1: _clickable('a', 'Next', node_id=1, role='button'),
+			2: _clickable('a', '‹ Previous', node_id=2),
+			3: _clickable('button', 'Next page', node_id=3),
+			4: _clickable('a', '1', node_id=4),
+			5: _clickable('a', '2', node_id=5),
+			6: _clickable('button', 'First', node_id=6),
+			7: _clickable('button', 'Last', node_id=7),
+			8: _clickable('button', '>', node_id=8),
+		}
+	)
+
+	assert _types(buttons) == [
+		('Next', 'next'),
+		('‹ Previous', 'prev'),
+		('Next page', 'next'),
+		('1', 'page_number'),
+		('2', 'page_number'),
+		('First', 'first'),
+		('Last', 'last'),
+		('>', 'next'),
+	]
+
+
+def test_pagination_rejects_lone_numeric_widgets():
+	buttons = DomService.detect_pagination_buttons(
+		{
+			1: _clickable('button', '5', node_id=1, role='button'),
+			2: _clickable('span', '3', node_id=2),
+			3: _clickable('div', '10', node_id=3, role=''),
+		}
+	)
+
+	assert buttons == []


### PR DESCRIPTION
## Why

`detect_pagination_buttons` used unanchored substring matching over text + aria-label + title + **CSS class**. That classified ordinary widgets as pager controls and fed them to the LLM through `BrowserStateSummary`.

Examples on current `main`:

- `Preview` / `class="preview-link"` → `prev` (`'prev' in 'preview'`)
- `Last name` / `Last modified` → `last`
- `Next steps` → `next`
- `aria-label="price < 100"` → `prev`
- any 1–2 digit clickable (`5` star rating, `3` cart badge) → `page_number`

## What changed

- Match **user-facing labels only** (text, aria-label, title). CSS classes are ignored for type detection.
- Alphabetic patterns must be the whole label, optionally plus `" page"`, after stripping decorative arrows (`Next >`, `‹ Previous`).
- Symbol patterns (`<`, `>`) must be the entire label, so `price < 100` is not prev.
- Numeric page buttons require a native `a`/`button` (or explicit `role`) **and** at least two numbered peers. A lone rating/qty control is dropped.

## How to test

```bash
uv run pytest -q \
  tests/ci/test_pagination_detection.py \
  tests/ci/browser/test_dom_selector_index_collisions.py::test_pagination_metadata_separates_selector_and_backend_ids
```

4 passed. Pre-commit (ruff + pyright) passed on the touched files.

Fixes #5514

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pagination detection flagging ordinary widgets like "Preview", "Last name", "Next steps", and lone numeric buttons as page controls. Now matches only user-facing labels (text, aria-label, title) and accepts localized page labels.

- Alphabetic patterns must be the whole label, optionally with a go-to prefix and page word, after stripping decorative arrows.
- Symbol patterns like `<`, `>`, `<<`, and `>>` must be the entire label.
- Numeric page buttons need an `a`/`button` element and at least two numbered peers sharing a pager container or a list/table ancestor, so lone wrappers like `li` are skipped.
- CSS classes are no longer used for type detection.

Fixes #5514.

<sup>Written for commit 525964c648e202d4a89c8bdb7873b5646a2af907. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

