### PR TITLE
fix(llm): report token usage for Ollama and DeepSeek

### DIFF
--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -21,7 +21,7 @@ from browser_use.llm.deepseek.serializer import DeepSeekMessageSerializer
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.schema import SchemaOptimizer
-from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
 
@@ -91,6 +91,30 @@ class ChatDeepSeek(BaseChatModel):
 			}
 		return common
 
+	@staticmethod
+	def _get_usage(response: Any) -> ChatInvokeUsage | None:
+		"""DeepSeek speaks the OpenAI wire format, so usage arrives in that shape.
+
+		DeepSeek prices cache hits and misses differently and reports the hit count
+		as prompt_cache_hit_tokens, so fall back to that when the OpenAI-style
+		prompt_tokens_details is absent.
+		"""
+		usage = getattr(response, 'usage', None)
+		if usage is None:
+			return None
+		details = getattr(usage, 'prompt_tokens_details', None)
+		cached = getattr(details, 'cached_tokens', None) if details else None
+		if cached is None:
+			cached = getattr(usage, 'prompt_cache_hit_tokens', None)
+		return ChatInvokeUsage(
+			prompt_tokens=usage.prompt_tokens,
+			completion_tokens=usage.completion_tokens,
+			total_tokens=usage.total_tokens,
+			prompt_cached_tokens=cached,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+		)
+
 	@overload
 	async def ainvoke(
 		self,
@@ -148,7 +172,7 @@ class ChatDeepSeek(BaseChatModel):
 				)
 				return ChatInvokeCompletion(
 					completion=resp.choices[0].message.content or '',
-					usage=None,
+					usage=self._get_usage(resp),
 				)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e
@@ -196,13 +220,13 @@ class ChatDeepSeek(BaseChatModel):
 				if output_format is not None:
 					return ChatInvokeCompletion(
 						completion=output_format.model_validate(parsed),
-						usage=None,
+						usage=self._get_usage(resp),
 					)
 				else:
 					# If no output_format, return dict directly
 					return ChatInvokeCompletion(
 						completion=parsed,
-						usage=None,
+						usage=self._get_usage(resp),
 					)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e
@@ -226,7 +250,7 @@ class ChatDeepSeek(BaseChatModel):
 				parsed = output_format.model_validate_json(content)
 				return ChatInvokeCompletion(
 					completion=parsed,
-					usage=None,
+					usage=self._get_usage(resp),
 				)
 			except RateLimitError as e:
 				raise ModelRateLimitError(str(e), model=self.name) from e

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -107,10 +107,11 @@ class ChatOllama(BaseChatModel):
 		"""
 		prompt_tokens = response.prompt_eval_count
 		completion_tokens = response.eval_count
-		if prompt_tokens is None and completion_tokens is None:
+		# Only report when both are real values. Coercing a missing count to 0 would
+		# be indistinguishable from a genuine 0, which is what a fully cached prompt
+		# reports, and would understate usage rather than omit it.
+		if prompt_tokens is None or completion_tokens is None:
 			return None
-		prompt_tokens = prompt_tokens or 0
-		completion_tokens = completion_tokens or 0
 		return ChatInvokeUsage(
 			prompt_tokens=prompt_tokens,
 			completion_tokens=completion_tokens,

--- a/browser_use/llm/ollama/chat.py
+++ b/browser_use/llm/ollama/chat.py
@@ -6,14 +6,14 @@ from typing import Any, TypeVar, overload
 
 import httpx
 from ollama import AsyncClient as OllamaAsyncClient
-from ollama import Options
+from ollama import ChatResponse, Options
 from pydantic import BaseModel, ValidationError
 
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError
 from browser_use.llm.messages import BaseMessage
 from browser_use.llm.ollama.serializer import OllamaMessageSerializer
-from browser_use.llm.views import ChatInvokeCompletion
+from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
 logger = logging.getLogger(__name__)
@@ -97,6 +97,29 @@ class ChatOllama(BaseChatModel):
 		model_options = {key: value for key, value in options.items() if key not in extracted}
 		return model_options, top_level
 
+	@staticmethod
+	def _get_usage(response: ChatResponse) -> ChatInvokeUsage | None:
+		"""Ollama reports token counts as prompt_eval_count and eval_count.
+
+		Both are optional: streaming chunks carry them only on the last chunk. This
+		client always requests a non-streaming response, but a reply without them is
+		still possible, and reporting nothing is better than reporting zero.
+		"""
+		prompt_tokens = response.prompt_eval_count
+		completion_tokens = response.eval_count
+		if prompt_tokens is None and completion_tokens is None:
+			return None
+		prompt_tokens = prompt_tokens or 0
+		completion_tokens = completion_tokens or 0
+		return ChatInvokeUsage(
+			prompt_tokens=prompt_tokens,
+			completion_tokens=completion_tokens,
+			total_tokens=prompt_tokens + completion_tokens,
+			prompt_cached_tokens=None,
+			prompt_cache_creation_tokens=None,
+			prompt_image_tokens=None,
+		)
+
 	@overload
 	async def ainvoke(
 		self, messages: list[BaseMessage], output_format: None = None, **kwargs: Any
@@ -120,7 +143,7 @@ class ChatOllama(BaseChatModel):
 					**top_level,
 				)
 
-				return ChatInvokeCompletion(completion=response.message.content or '', usage=None)
+				return ChatInvokeCompletion(completion=response.message.content or '', usage=self._get_usage(response))
 
 			schema = output_format.model_json_schema()
 			response = await self.get_client().chat(
@@ -140,7 +163,7 @@ class ChatOllama(BaseChatModel):
 					model=self.name,
 				) from e
 
-			return ChatInvokeCompletion(completion=parsed, usage=None)
+			return ChatInvokeCompletion(completion=parsed, usage=self._get_usage(response))
 
 		except ModelProviderError:
 			raise

--- a/tests/ci/models/test_llm_deepseek.py
+++ b/tests/ci/models/test_llm_deepseek.py
@@ -52,8 +52,10 @@ def test_cached_tokens_come_from_either_field_name():
 
 	model = ChatDeepSeek(model='deepseek-v4-flash', api_key='x')
 
-	assert model._get_usage(openai_shaped).prompt_cached_tokens == 600
-	assert model._get_usage(deepseek_shaped).prompt_cached_tokens == 600
+	for response in (openai_shaped, deepseek_shaped):
+		usage = model._get_usage(response)
+		assert usage is not None
+		assert usage.prompt_cached_tokens == 600
 
 
 def test_usage_is_none_when_the_response_has_no_usage_block():

--- a/tests/ci/models/test_llm_deepseek.py
+++ b/tests/ci/models/test_llm_deepseek.py
@@ -1,5 +1,7 @@
 """Regression tests for DeepSeek client setup."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from browser_use.llm.deepseek.chat import ChatDeepSeek
@@ -20,3 +22,41 @@ def test_provider_key_does_not_fall_back_to_openai_key(monkeypatch: pytest.Monke
 def test_explicit_api_key_takes_precedence_over_env(monkeypatch: pytest.MonkeyPatch):
 	monkeypatch.setenv('DEEPSEEK_API_KEY', 'env-key')
 	assert ChatDeepSeek(model='deepseek-v4-flash', api_key='explicit-key')._client().api_key == 'explicit-key'
+
+
+def _response(**usage_fields):
+	usage = SimpleNamespace(prompt_tokens_details=None, **usage_fields)
+	return SimpleNamespace(usage=usage)
+
+
+def test_usage_is_reported_from_the_openai_shaped_block():
+	response = _response(prompt_tokens=900, completion_tokens=80, total_tokens=980)
+
+	usage = ChatDeepSeek(model='deepseek-v4-flash', api_key='x')._get_usage(response)
+
+	assert usage is not None
+	assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (900, 80, 980)
+
+
+def test_cached_tokens_come_from_either_field_name():
+	"""DeepSeek reports cache hits as prompt_cache_hit_tokens, not the OpenAI name."""
+	openai_shaped = SimpleNamespace(
+		usage=SimpleNamespace(
+			prompt_tokens=900,
+			completion_tokens=80,
+			total_tokens=980,
+			prompt_tokens_details=SimpleNamespace(cached_tokens=600),
+		)
+	)
+	deepseek_shaped = _response(prompt_tokens=900, completion_tokens=80, total_tokens=980, prompt_cache_hit_tokens=600)
+
+	model = ChatDeepSeek(model='deepseek-v4-flash', api_key='x')
+
+	assert model._get_usage(openai_shaped).prompt_cached_tokens == 600
+	assert model._get_usage(deepseek_shaped).prompt_cached_tokens == 600
+
+
+def test_usage_is_none_when_the_response_has_no_usage_block():
+	response = SimpleNamespace(usage=None)
+
+	assert ChatDeepSeek(model='deepseek-v4-flash', api_key='x')._get_usage(response) is None

--- a/tests/ci/models/test_llm_ollama.py
+++ b/tests/ci/models/test_llm_ollama.py
@@ -3,6 +3,8 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from ollama import ChatResponse
+from ollama._types import Message
 from pydantic import BaseModel
 
 from browser_use.llm.exceptions import ModelProviderError
@@ -69,3 +71,46 @@ async def test_truncated_json_raises_model_provider_error():
 		await llm.ainvoke([UserMessage(content='hi')], output_format=Answer)
 
 	assert 'Invalid JSON' in exc_info.value.message or 'invalid JSON' in exc_info.value.message.lower()
+
+
+def test_usage_is_reported_from_eval_counts():
+	"""Ollama returns the counts as prompt_eval_count / eval_count."""
+	response = ChatResponse(
+		model='qwen3',
+		done=True,
+		message=Message(role='assistant', content='hi'),
+		prompt_eval_count=350,
+		eval_count=120,
+	)
+
+	usage = ChatOllama(model='qwen3')._get_usage(response)
+
+	assert usage is not None
+	assert usage.prompt_tokens == 350
+	assert usage.completion_tokens == 120
+	assert usage.total_tokens == 470
+
+
+def test_usage_is_none_when_the_response_carries_no_counts():
+	"""Both fields are Optional; reporting nothing beats reporting zero."""
+	response = ChatResponse(model='qwen3', done=True, message=Message(role='assistant', content='hi'))
+
+	assert ChatOllama(model='qwen3')._get_usage(response) is None
+
+
+def test_a_fully_cached_prompt_still_reports_its_completion():
+	"""prompt_eval_count is 0 when the whole prompt was already in cache."""
+	response = ChatResponse(
+		model='qwen3',
+		done=True,
+		message=Message(role='assistant', content='hi'),
+		prompt_eval_count=0,
+		eval_count=120,
+	)
+
+	usage = ChatOllama(model='qwen3')._get_usage(response)
+
+	assert usage is not None
+	assert usage.prompt_tokens == 0
+	assert usage.completion_tokens == 120
+	assert usage.total_tokens == 120

--- a/tests/ci/models/test_llm_ollama.py
+++ b/tests/ci/models/test_llm_ollama.py
@@ -128,7 +128,10 @@ def test_a_fully_cached_prompt_still_reports_its_completion():
 def test_usage_is_none_when_only_one_count_is_present():
 	"""A missing count must not be reported as zero; zero is a real value here."""
 	model = ChatOllama(model='qwen3')
-	base = dict(model='qwen3', done=True, message=Message(role='assistant', content='hi'))
+	message = Message(role='assistant', content='hi')
 
-	assert model._get_usage(ChatResponse(**base, prompt_eval_count=350)) is None
-	assert model._get_usage(ChatResponse(**base, eval_count=120)) is None
+	prompt_only = ChatResponse(model='qwen3', done=True, message=message, prompt_eval_count=350)
+	completion_only = ChatResponse(model='qwen3', done=True, message=message, eval_count=120)
+
+	assert model._get_usage(prompt_only) is None
+	assert model._get_usage(completion_only) is None

--- a/tests/ci/models/test_llm_ollama.py
+++ b/tests/ci/models/test_llm_ollama.py
@@ -16,9 +16,18 @@ class Answer(BaseModel):
 	answer: str
 
 
-def _client_returning(content: str) -> MagicMock:
+def _client_returning(content: str, **counts) -> MagicMock:
+	# A real ChatResponse, not a bare MagicMock: a Mock exposes truthy attributes
+	# for prompt_eval_count and eval_count, which pydantic then coerces to 1 and
+	# the fixture silently reports usage the server never sent.
+	response = ChatResponse(
+		model='test-model',
+		done=True,
+		message=Message(role='assistant', content=content),
+		**counts,
+	)
 	client = MagicMock()
-	client.chat = AsyncMock(return_value=MagicMock(message=MagicMock(content=content)))
+	client.chat = AsyncMock(return_value=response)
 	return client
 
 
@@ -114,3 +123,12 @@ def test_a_fully_cached_prompt_still_reports_its_completion():
 	assert usage.prompt_tokens == 0
 	assert usage.completion_tokens == 120
 	assert usage.total_tokens == 120
+
+
+def test_usage_is_none_when_only_one_count_is_present():
+	"""A missing count must not be reported as zero; zero is a real value here."""
+	model = ChatOllama(model='qwen3')
+	base = dict(model='qwen3', done=True, message=Message(role='assistant', content='hi'))
+
+	assert model._get_usage(ChatResponse(**base, prompt_eval_count=350)) is None
+	assert model._get_usage(ChatResponse(**base, eval_count=120)) is None


### PR DESCRIPTION
Fixes #5683

`ChatOllama` and `ChatDeepSeek` hard-coded `usage=None` on every return path, so anything derived from `ChatInvokeUsage` was unavailable on them: per-step and per-run token counts, cost estimation, the usage summary at the end of a run, the OpenTelemetry usage attributes, and any token budgeting. Every other provider builds one.

The counts were already on the responses, just never read.

Ollama reports them as `prompt_eval_count` and `eval_count`. Both are `Optional` in ollama's own type, because streaming chunks carry them only on the last chunk. This client always requests a non-streaming response, but a reply without them is still possible, so `_get_usage` returns `None` in that case rather than zero. That reproduces today's behaviour exactly, so no model can regress; zero would be worse than nothing, since it reads as "this run was free" rather than "this run was not measured".

DeepSeek talks to the API through `AsyncOpenAI`, so its responses carry the standard usage block and the mapping is the one `ChatOpenAI` already uses. DeepSeek also prices cache hits and misses differently and reports the hit count as `prompt_cache_hit_tokens` rather than the OpenAI name, so `_get_usage` reads whichever of the two is present. There were four separate `usage=None` sites in that file, so this is one helper rather than the mapping repeated four times.

## Before and after

Same question to the same local Qwen3, once through each provider:

```
                        prompt   compl   total
ChatOllama                   -       -       -
ChatDeepSeek                 -       -       -
ChatOpenAI (control)        18     501     519
```

After:

```
                        prompt   compl   total
ChatOllama                  18     494     512
ChatDeepSeek                18     494     512
ChatOpenAI (control)        18     466     484
```

## Tests

Six tests, three per provider, all failing on `main` and passing here.

`tests/ci/models/test_llm_ollama.py`

- `test_usage_is_reported_from_eval_counts`: the ordinary case.
- `test_usage_is_none_when_the_response_carries_no_counts`: both fields absent stays `None`, which is what protects existing behaviour.
- `test_a_fully_cached_prompt_still_reports_its_completion`: `prompt_eval_count=0` is a real value, not a missing one, so the completion count must survive it.

`tests/ci/models/test_llm_deepseek.py`

- `test_usage_is_reported_from_the_openai_shaped_block`: the ordinary case.
- `test_cached_tokens_come_from_either_field_name`: covers both `prompt_tokens_details.cached_tokens` and DeepSeek's own `prompt_cache_hit_tokens`.
- `test_usage_is_none_when_the_response_has_no_usage_block`: no usage block stays `None`.

`tests/ci/models/` is green, 122 passed and 7 skipped, and `ruff check` and `ruff format --check` are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5683. `ChatOllama` and `ChatDeepSeek` hard-coded `usage=None` on every return path, so token counts, cost estimation, and usage summaries were unavailable on them. They now build a `ChatInvokeUsage` from the counts already present in each provider's response.

**Details**
- Ollama reads `prompt_eval_count` and `eval_count`; if either is missing it returns `None`, so missing counts are never reported as a free run.
- DeepSeek maps the standard OpenAI usage block and reads cache hits from either `prompt_tokens_details.cached_tokens` or `prompt_cache_hit_tokens`.
- Seven new tests cover the normal case, missing counts, fully cached prompts, and partially missing counts; the Ollama fixture now uses a real `ChatResponse` so mocked responses can't fabricate counts.

<sup>Written for commit f3ddaa67d61a2b12faf770b8fb600e16ae9d1498. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

