### PR TITLE
fix(llm/anthropic): count cache reads in total_tokens

### DIFF
--- a/browser_use/llm/anthropic/chat.py
+++ b/browser_use/llm/anthropic/chat.py
@@ -214,7 +214,12 @@ class ChatAnthropic(BaseChatModel):
 				response.usage.cache_read_input_tokens or 0
 			),  # Total tokens in Anthropic are a bit fucked, you have to add cached tokens to the prompt tokens
 			completion_tokens=response.usage.output_tokens,
-			total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+			# Mirrors prompt_tokens above, which counts cache reads. Anthropic reports
+			# input_tokens excluding them, so leaving this as input + output makes
+			# total disagree with prompt + completion whenever caching is active.
+			total_tokens=response.usage.input_tokens
+			+ (response.usage.cache_read_input_tokens or 0)
+			+ response.usage.output_tokens,
 			prompt_cached_tokens=response.usage.cache_read_input_tokens,
 			prompt_cache_creation_tokens=response.usage.cache_creation_input_tokens,
 			prompt_cache_creation_5m_tokens=cache_creation_5m_tokens,

--- a/tests/ci/models/test_llm_anthropic.py
+++ b/tests/ci/models/test_llm_anthropic.py
@@ -1,3 +1,7 @@
+from types import SimpleNamespace
+
+import pytest
+
 """Test Anthropic model button click."""
 
 from browser_use.llm.anthropic.chat import ChatAnthropic
@@ -13,3 +17,39 @@ async def test_anthropic_claude_sonnet_4_6(httpserver):
 		extra_kwargs={},
 		httpserver=httpserver,
 	)
+
+
+def _response(input_tokens, output_tokens, cache_read=0, cache_creation=0):
+	return SimpleNamespace(
+		usage=SimpleNamespace(
+			input_tokens=input_tokens,
+			output_tokens=output_tokens,
+			cache_read_input_tokens=cache_read,
+			cache_creation_input_tokens=cache_creation,
+			cache_creation=None,
+		)
+	)
+
+
+def test_total_tokens_counts_cache_reads_like_prompt_tokens_does():
+	"""Anthropic reports input_tokens excluding cache reads, so both must add them."""
+	model = ChatAnthropic(model='claude-sonnet-4-5-20250929', api_key='x')
+
+	usage = model._get_usage(_response(input_tokens=1000, output_tokens=200, cache_read=5000))
+
+	assert usage.prompt_tokens == 6000
+	assert usage.completion_tokens == 200
+	assert usage.total_tokens == 6200
+
+
+@pytest.mark.parametrize(
+	'input_tokens,output_tokens,cache_read',
+	[(1000, 200, 0), (1000, 200, 5000), (0, 50, 900)],
+)
+def test_total_tokens_always_equals_prompt_plus_completion(input_tokens, output_tokens, cache_read):
+	"""The invariant every other provider satisfies, with and without caching."""
+	model = ChatAnthropic(model='claude-sonnet-4-5-20250929', api_key='x')
+
+	usage = model._get_usage(_response(input_tokens, output_tokens, cache_read))
+
+	assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens

--- a/tests/ci/models/test_llm_anthropic.py
+++ b/tests/ci/models/test_llm_anthropic.py
@@ -37,6 +37,7 @@ def test_total_tokens_counts_cache_reads_like_prompt_tokens_does():
 
 	usage = model._get_usage(_response(input_tokens=1000, output_tokens=200, cache_read=5000))
 
+	assert usage is not None
 	assert usage.prompt_tokens == 6000
 	assert usage.completion_tokens == 200
 	assert usage.total_tokens == 6200
@@ -52,4 +53,5 @@ def test_total_tokens_always_equals_prompt_plus_completion(input_tokens, output_
 
 	usage = model._get_usage(_response(input_tokens, output_tokens, cache_read))
 
+	assert usage is not None
 	assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens


### PR DESCRIPTION
Fixes #5685

`prompt_tokens` adds `cache_read_input_tokens` because Anthropic reports `input_tokens` without them. `total_tokens` on the line below was left as `input + output`, so with prompt caching active it disagreed with `prompt_tokens + completion_tokens` by exactly the cache-read count. Every other provider satisfies that identity.

The gap is largest on the shape an agent actually sends, a big mostly-cached prompt followed by a short answer:

| | prompt | completion | total_tokens | prompt+completion |
|---|---|---|---|---|
| before | 994 | 40 | 239 | 1034 |
| after | 994 | 40 | 1034 | 1034 |

The two lines agreed until cache support landed. `7a10ae0c96` wrote both, and `2ee526d903` ("updated pricing for cached tokens support") changed `prompt_tokens` the next day without touching the line below it.

Cost is unaffected either way, since `calculate_cost` prices cached and uncached tokens separately and never reads `total_tokens`, and the usage summary recomputes the total itself at `tokens/service.py:469`. What this fixes is `beta/service.py:3241` and the `gen_ai.usage.total_tokens` OpenTelemetry attribute, both of which read the field directly and so under-counted Anthropic traffic.

Worth flagging: if a dashboard has been calibrated against the current under-count, this makes historical numbers step upward. Happy to hold it if that matters.

## Tests

In `tests/ci/models/test_llm_anthropic.py`:

- `test_total_tokens_counts_cache_reads_like_prompt_tokens_does` — the reported case. Fails on `main`.
- `test_total_tokens_always_equals_prompt_plus_completion` — parametrised over no caching, a large cache read, and an all-cached prompt. The no-caching case passes on `main` already and is there as a guard that this change does not alter the uncached path; the other two fail on `main`.

`tests/ci/models/` is green, 120 passed and 7 skipped, `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5685 so Anthropic's `total_tokens` now includes cache reads, matching `prompt_tokens + completion_tokens` when prompt caching is active. Previously `total_tokens` under-counted by the cache-read amount.

**Side effects**
- Dashboards calibrated against the old under-count will see historical totals step upward.
- Cost calculations are unaffected since `calculate_cost` reads separate fields.

<sup>Written for commit c3d4722fbf901fad5f903f1d5f1227e699a2f233. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

