### PR TITLE
fix(llm/openai): name the endpoint when structured output comes back as prose

### DIFF
--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -9,7 +9,7 @@ from openai.types.chat.chat_completion import ChatCompletion
 from openai.types.shared.chat_model import ChatModel
 from openai.types.shared_params.reasoning_effort import ReasoningEffort
 from openai.types.shared_params.response_format_json_schema import JSONSchema, ResponseFormatJSONSchema
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from browser_use.llm.base import BaseChatModel, is_reasoning_model
 from browser_use.llm.exceptions import ModelOutputTruncatedError, ModelProviderError, ModelRateLimitError
@@ -19,6 +19,11 @@ from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
+
+
+def _looks_like_json(text: str) -> bool:
+	"""Did the endpoint attempt JSON at all, or is this prose?"""
+	return (text or '').strip().startswith(('{', '['))
 
 
 @dataclass
@@ -298,7 +303,25 @@ class ChatOpenAI(BaseChatModel):
 
 				usage = self._get_usage(response)
 
-				parsed = output_format.model_validate_json(choice.message.content)
+				try:
+					parsed = output_format.model_validate_json(choice.message.content)
+				except ValidationError as e:
+					# A custom endpoint may accept response_format and ignore it, replying in
+					# prose. Pydantic then only reports that the JSON is invalid, which points
+					# at the model rather than at the endpoint that dropped the schema.
+					if self.base_url and not _looks_like_json(choice.message.content):
+						raise ModelProviderError(
+							message=(
+								'Requested structured output but the response was not JSON. The '
+								f'endpoint at {self.base_url} may not support '
+								'response_format=json_schema; many OpenAI-compatible servers accept '
+								'the field and ignore it. Try '
+								'ChatOpenAI(..., add_schema_to_system_prompt=True). '
+								f'Response began: {choice.message.content.strip()[:120]!r}'
+							),
+							model=self.name,
+						) from e
+					raise
 
 				return ChatInvokeCompletion(
 					completion=parsed,

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal, TypeVar, overload
@@ -22,8 +23,23 @@ T = TypeVar('T', bound=BaseModel)
 
 
 def _looks_like_json(text: str) -> bool:
-	"""Did the endpoint attempt JSON at all, or is this prose?"""
-	return (text or '').strip().startswith(('{', '['))
+	"""Did the endpoint attempt JSON at all, or is this prose?
+
+	Two ways to count as an attempt: it opens an object or array, so the model was
+	producing JSON even if the reply is truncated, or it parses as a bare scalar
+	such as `123` or `"text"`, which is valid JSON in the wrong shape. Both are the
+	model's problem rather than the endpoint's, and must keep the original error.
+	"""
+	stripped = (text or '').strip()
+	if not stripped:
+		return False
+	if stripped.startswith(('{', '[')):
+		return True  # an attempt, even if truncated or malformed
+	try:
+		json.loads(stripped)
+	except ValueError:
+		return False
+	return True  # a bare scalar is valid JSON, just the wrong shape
 
 
 @dataclass
@@ -316,7 +332,8 @@ class ChatOpenAI(BaseChatModel):
 								f'endpoint at {self.base_url} may not support '
 								'response_format=json_schema; many OpenAI-compatible servers accept '
 								'the field and ignore it. Try '
-								'ChatOpenAI(..., add_schema_to_system_prompt=True). '
+								'ChatOpenAI(..., add_schema_to_system_prompt=True), or '
+								'dont_force_structured_output=True to parse the reply yourself. '
 								f'Response began: {choice.message.content.strip()[:120]!r}'
 							),
 							model=self.name,

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -332,8 +332,7 @@ class ChatOpenAI(BaseChatModel):
 								f'endpoint at {self.base_url} may not support '
 								'response_format=json_schema; many OpenAI-compatible servers accept '
 								'the field and ignore it. Try '
-								'ChatOpenAI(..., add_schema_to_system_prompt=True), or '
-								'dont_force_structured_output=True to parse the reply yourself. '
+								'ChatOpenAI(..., add_schema_to_system_prompt=True). '
 								f'Response began: {choice.message.content.strip()[:120]!r}'
 							),
 							model=self.name,

--- a/tests/ci/models/test_openai_structured_output_hint.py
+++ b/tests/ci/models/test_openai_structured_output_hint.py
@@ -47,11 +47,15 @@ async def test_prose_from_a_custom_endpoint_names_the_endpoint():
 
 @pytest.mark.parametrize(
 	'content',
-	['{"headline": "Cats are', '{"title": "Cats"}', '[]'],
-	ids=['truncated', 'wrong-shape', 'wrong-type'],
+	['{"headline": "Cats are', '{"title": "Cats"}', '[]', '123', '"not an object"', 'true', 'null'],
+	ids=['truncated', 'wrong-shape', 'wrong-type', 'int', 'string', 'bool', 'null'],
 )
 async def test_broken_json_keeps_the_original_error(content):
-	"""The model tried to produce JSON and failed, which is the model's problem."""
+	"""The endpoint produced JSON that does not match the schema.
+
+	Includes bare scalars, which are valid JSON and so are the model's problem
+	rather than evidence that the endpoint dropped the schema.
+	"""
 	with pytest.raises(ModelProviderError) as exc:
 		await _invoke(content, base_url='http://localhost:9/v1')
 

--- a/tests/ci/models/test_openai_structured_output_hint.py
+++ b/tests/ci/models/test_openai_structured_output_hint.py
@@ -1,0 +1,66 @@
+"""The error a user gets when an endpoint ignores response_format."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.messages import UserMessage
+from browser_use.llm.openai.chat import ChatOpenAI
+
+HINT = 'may not support response_format=json_schema'
+
+
+class Headline(BaseModel):
+	headline: str
+
+
+def _response(content: str):
+	return SimpleNamespace(
+		choices=[
+			SimpleNamespace(
+				message=SimpleNamespace(content=content, refusal=None),
+				finish_reason='stop',
+			)
+		],
+		usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15, prompt_tokens_details=None),
+	)
+
+
+async def _invoke(content: str, **kwargs):
+	llm = ChatOpenAI(model='gpt-4o', api_key='x', **kwargs)
+	client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=AsyncMock(return_value=_response(content)))))
+	with patch.object(type(llm), 'get_client', return_value=client):
+		return await llm.ainvoke([UserMessage(content='hi')], output_format=Headline)
+
+
+async def test_prose_from_a_custom_endpoint_names_the_endpoint():
+	with pytest.raises(ModelProviderError) as exc:
+		await _invoke('**Cats: The Enigma**', base_url='http://localhost:9/v1')
+
+	assert HINT in str(exc.value)
+	assert 'http://localhost:9/v1' in str(exc.value)
+	assert 'add_schema_to_system_prompt' in str(exc.value)
+
+
+@pytest.mark.parametrize(
+	'content',
+	['{"headline": "Cats are', '{"title": "Cats"}', '[]'],
+	ids=['truncated', 'wrong-shape', 'wrong-type'],
+)
+async def test_broken_json_keeps_the_original_error(content):
+	"""The model tried to produce JSON and failed, which is the model's problem."""
+	with pytest.raises(ModelProviderError) as exc:
+		await _invoke(content, base_url='http://localhost:9/v1')
+
+	assert HINT not in str(exc.value)
+
+
+async def test_prose_from_a_first_party_endpoint_keeps_the_original_error():
+	"""Without a base_url there is no custom endpoint to blame."""
+	with pytest.raises(ModelProviderError) as exc:
+		await _invoke('**Cats: The Enigma**')
+
+	assert HINT not in str(exc.value)


### PR DESCRIPTION
Fixes #5687

Many OpenAI-compatible servers accept `response_format={"type": "json_schema", ...}`, return 200, and ignore it. The model answers in prose, and the user gets:

```
ModelProviderError: 1 validation error for Headline
Invalid JSON: expected value at line 3 column 1
```

which reads as "your model produced bad JSON" when the actual cause is that the endpoint dropped the schema. It also says nothing about `add_schema_to_system_prompt`, which browser-use already ships for exactly this case, alongside `dont_force_structured_output`, `remove_min_items_from_schema` and `remove_defaults_from_schema`. A user hitting the quirk has no way to learn any of them exist.

Now:

```
Requested structured output but the response was not JSON. The endpoint at
http://127.0.0.1:8110/v1 may not support response_format=json_schema; many
OpenAI-compatible servers accept the field and ignore it. Try
ChatOpenAI(..., add_schema_to_system_prompt=True). Response began:
'**"Cats: The Independent Enigma"**'
```

No logic changes, only the message, and only on a path that already raised.

## Not misfiring

The risk is telling someone their endpoint is broken when their model simply produced bad JSON. Two conditions guard it: `base_url` is set, and the reply does not start with `{` or `[`.

| reply | endpoint | message |
|---|---|---|
| prose | custom `base_url` | new hint |
| `{"headline": "Cats are` (truncated) | custom `base_url` | original parse error |
| `{"title": "Cats"}` (wrong shape) | custom `base_url` | original parse error |
| `[]` (wrong type) | custom `base_url` | original parse error |
| prose | first-party, no `base_url` | original parse error |

A model that attempted JSON and failed keeps the message that is correct for it.

## Tests

`tests/ci/models/test_openai_structured_output_hint.py`, five cases matching the table.

Only `test_prose_from_a_custom_endpoint_names_the_endpoint` fails on `main`; the other four pass there already and are the regression guards for the paths this must not change.

`tests/ci/models/` is green, 121 passed and 7 skipped, `ruff check` and `ruff format --check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5687. When a custom OpenAI-compatible endpoint ignores `response_format` and answers in prose, the old error blamed the model with "Invalid JSON". The new error names the endpoint and suggests `add_schema_to_system_prompt`, and now only fires on prose — broken JSON, wrong-shaped JSON, and bare scalars like `123` keep the original error. First-party endpoints are never affected.

- Adds tests covering prose from custom endpoints, broken JSON (including scalars), wrong shape/type, and first-party prose.

<sup>Written for commit 93f2b1e19d5021a3c945831df00bd2083aefc380. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

