### PR TITLE
fix(mcp): discover paginated tool catalogs

### DIFF
--- a/browser_use/mcp/client.py
+++ b/browser_use/mcp/client.py
@@ -85,6 +85,7 @@ class MCPClient:
 
 		start_time = time.time()
 		error_msg = None
+		connection_task: asyncio.Task[None] | None = None
 
 		try:
 			logger.info(f"🔌 Connecting to MCP server '{self.server_name}': {self.command} {' '.join(self.args)}")
@@ -93,14 +94,18 @@ class MCPClient:
 			server_params = StdioServerParameters(command=self.command, args=self.args, env=self.env)
 
 			# Start stdio client in background task
-			self._stdio_task = create_task_with_error_handling(
+			connection_task = create_task_with_error_handling(
 				self._run_stdio_client(server_params), name='mcp_stdio_client', suppress_exceptions=True
 			)
+			self._stdio_task = connection_task
 
 			# Wait for connection to be established
 			retries = 0
 			max_retries = 100  # 10 second timeout (increased for parallel test execution)
 			while not self._connected and retries < max_retries:
+				if connection_task.done():
+					await connection_task
+					break
 				await asyncio.sleep(0.1)
 				retries += 1
 
@@ -110,8 +115,11 @@ class MCPClient:
 
 			logger.info(f"📦 Discovered {len(self._tools)} tools from '{self.server_name}': {list(self._tools.keys())}")
 
-		except Exception as e:
+		except (Exception, asyncio.CancelledError) as e:
 			error_msg = str(e)
+			if connection_task is not None:
+				connection_task.cancel()
+				await asyncio.gather(connection_task, return_exceptions=True)
 			raise
 		finally:
 			# Capture telemetry for connect action
@@ -142,9 +150,21 @@ class MCPClient:
 					# Initialize the connection
 					await session.initialize()
 
-					# Discover available tools
-					tools_response = await session.list_tools()
-					self._tools = {tool.name: tool for tool in tools_response.tools}
+					# Discover the complete catalog before exposing any tools.
+					discovered_tools: dict[str, types.Tool] = {}
+					cursor: str | None = None
+					seen_cursors: set[str] = set()
+					while True:
+						params = types.PaginatedRequestParams(cursor=cursor) if cursor is not None else None
+						tools_response = await session.list_tools(params=params)
+						discovered_tools.update((tool.name, tool) for tool in tools_response.tools)
+						cursor = tools_response.next_cursor
+						if cursor is None:
+							break
+						if cursor in seen_cursors:
+							raise RuntimeError(f"MCP server '{self.server_name}' returned a repeated tools/list cursor")
+						seen_cursors.add(cursor)
+					self._tools = discovered_tools
 
 					# Mark as connected
 					self._connected = True

--- a/tests/ci/test_mcp_client_pagination.py
+++ b/tests/ci/test_mcp_client_pagination.py
@@ -1,0 +1,234 @@
+"""Discover complete MCP catalogs through real stdio sessions and action execution."""
+
+import asyncio
+import json
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import psutil
+import pytest
+
+from browser_use import BrowserSession, Tools
+from browser_use.mcp.client import MCPClient
+
+SERVER = dedent("""
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+
+from mcp import types
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+config = json.loads(Path(sys.argv[1]).read_text())
+events = Path(sys.argv[2])
+page_index = 0
+
+def record(event):
+    with events.open('a') as output:
+        output.write(json.dumps(event) + '\\n')
+
+async def list_tools(ctx, params):
+    global page_index
+    cursor = params.cursor if params else None
+    record({'cursor': cursor})
+    if config.get('endless'):
+        await asyncio.sleep(0.02)
+        page_index += 1
+        return types.ListToolsResult(tools=[], next_cursor=str(page_index))
+    page = config['pages'][page_index]
+    page_index += 1
+    assert cursor == page.get('cursor'), (cursor, page.get('cursor'))
+    if page.get('error'):
+        raise ValueError('second page unavailable')
+    if page.get('wait'):
+        await asyncio.Event().wait()
+    tools = [types.Tool(name=name, description=name,
+                       input_schema={'type': 'object', 'properties': {}})
+             for name in page.get('tools', [])]
+    return types.ListToolsResult(tools=tools, next_cursor=page.get('next_cursor'))
+
+async def call_tool(ctx, params):
+    record({'call': params.name})
+    return types.CallToolResult(content=[types.TextContent(type='text', text='called ' + params.name)])
+
+async def main():
+    record({'pid': os.getpid()})
+    server = Server('paginated-tools', on_list_tools=list_tools, on_call_tool=call_tool)
+    async with stdio_server() as (read, write):
+        await server.run(read, write, server.create_initialization_options())
+
+asyncio.run(main())
+""")
+
+
+@dataclass
+class CatalogServer:
+	client: MCPClient
+	events_path: Path
+
+	def events(self) -> list[dict[str, Any]]:
+		if not self.events_path.exists():
+			return []
+		return [json.loads(line) for line in self.events_path.read_text().splitlines()]
+
+	async def cleanup(self) -> None:
+		await self.client.disconnect()
+		if self.client._stdio_task is not None and not self.client._stdio_task.done():
+			self.client._stdio_task.cancel()
+			await asyncio.gather(self.client._stdio_task, return_exceptions=True)
+
+	def assert_closed(self) -> None:
+		assert self.client.session is None
+		assert not self.client._connected
+		assert self.client._stdio_task is not None and self.client._stdio_task.done()
+		pid = next(event['pid'] for event in self.events() if 'pid' in event)
+		assert not psutil.pid_exists(pid)
+
+
+@pytest.fixture
+def catalog_server(tmp_path: Path) -> Callable[..., CatalogServer]:
+	def create(pages: list[dict[str, Any]], *, endless: bool = False) -> CatalogServer:
+		server = tmp_path / 'server.py'
+		server.write_text(SERVER)
+		config = tmp_path / 'config.json'
+		config.write_text(json.dumps({'pages': pages, 'endless': endless}))
+		events = tmp_path / 'events.jsonl'
+		client = MCPClient('paginated-tools', sys.executable, [str(server), str(config), str(events)])
+		return CatalogServer(client, events)
+
+	return create
+
+
+@pytest.fixture(scope='module')
+async def mcp_browser(tmp_path_factory):
+	browser = BrowserSession(
+		user_data_dir=str(tmp_path_factory.mktemp('mcp-browser-profile')),
+		headless=True,
+		enable_default_extensions=False,
+	)
+	await browser.start()
+	try:
+		yield browser
+	finally:
+		await browser.kill()
+		await browser.event_bus.stop(clear=True, timeout=5)
+
+
+@pytest.mark.parametrize(
+	('pages', 'tool_filter', 'expected'),
+	[
+		([{'tools': ['first']}], None, ['first']),
+		(
+			[{'tools': ['first'], 'next_cursor': 'opaque/+=='}, {'cursor': 'opaque/+==', 'tools': ['second']}],
+			None,
+			['first', 'second'],
+		),
+		(
+			[{'tools': ['first'], 'next_cursor': 'opaque/+=='}, {'cursor': 'opaque/+==', 'tools': ['second']}],
+			['second'],
+			['second'],
+		),
+		(
+			[
+				{'tools': ['first'], 'next_cursor': ''},
+				{'cursor': '', 'tools': [], 'next_cursor': 'opaque-next'},
+				{'cursor': 'opaque-next', 'tools': ['second']},
+			],
+			None,
+			['first', 'second'],
+		),
+	],
+	ids=['single-page', 'all-pages', 'filter-second-page', 'empty-cursor-and-page'],
+)
+async def test_catalog_tools_register_and_execute(catalog_server, mcp_browser, pages, tool_filter, expected):
+	server = catalog_server(pages)
+	tools = Tools()
+	try:
+		await server.client.register_to_tools(tools, tool_filter=tool_filter, prefix='catalog_')
+		registered = [name for name in tools.registry.registry.actions if name.startswith('catalog_')]
+		assert registered == [f'catalog_{name}' for name in expected]
+		assert [event['cursor'] for event in server.events() if 'cursor' in event] == [page.get('cursor') for page in pages]
+		action_name = f'catalog_{expected[-1]}'
+		action = tools.registry.create_action_model()(**{action_name: {}})
+		result = await tools.act(action, browser_session=mcp_browser)
+		assert result.error is None
+		assert result.extracted_content == f'called {expected[-1]}'
+		assert [event['call'] for event in server.events() if 'call' in event] == [expected[-1]]
+	finally:
+		await server.cleanup()
+	server.assert_closed()
+
+
+def exception_messages(error: BaseException) -> str:
+	if isinstance(error, BaseExceptionGroup):
+		return '\n'.join(exception_messages(child) for child in error.exceptions)
+	return str(error)
+
+
+@pytest.mark.parametrize(
+	('following_pages', 'message'),
+	[
+		([{'cursor': 'next', 'tools': ['second'], 'next_cursor': 'next'}], 'repeated tools/list cursor'),
+		(
+			[
+				{'cursor': 'next', 'tools': ['second'], 'next_cursor': 'later'},
+				{'cursor': 'later', 'tools': [], 'next_cursor': 'next'},
+			],
+			'repeated tools/list cursor',
+		),
+		([{'cursor': 'next', 'error': True}], 'second page unavailable'),
+	],
+	ids=['repeated-cursor', 'cursor-cycle', 'second-page-error'],
+)
+async def test_invalid_catalog_is_not_partially_registered(catalog_server, following_pages, message):
+	server = catalog_server([{'tools': ['first'], 'next_cursor': 'next'}, *following_pages])
+	tools = Tools()
+	try:
+		with pytest.raises(Exception) as caught:
+			await server.client.register_to_tools(tools, prefix='catalog_')
+		assert message in exception_messages(caught.value)
+		assert not any(name.startswith('catalog_') for name in tools.registry.registry.actions)
+		assert not server.client._tools
+		server.assert_closed()
+	finally:
+		await server.cleanup()
+
+
+async def test_cancelled_discovery_closes_session_and_server(catalog_server):
+	server = catalog_server([{'tools': ['first'], 'next_cursor': 'next'}, {'cursor': 'next', 'wait': True}])
+	tools = Tools()
+	registration = asyncio.create_task(server.client.register_to_tools(tools, prefix='catalog_'))
+	try:
+		async with asyncio.timeout(5):
+			# Readiness is reported by a separate stdio subprocess, not an in-loop event.
+			while len([event for event in server.events() if 'cursor' in event]) < 2:  # noqa: ASYNC110
+				await asyncio.sleep(0.01)
+		registration.cancel()
+		with pytest.raises(asyncio.CancelledError):
+			await registration
+		assert not any(name.startswith('catalog_') for name in tools.registry.registry.actions)
+		assert not server.client._tools
+		server.assert_closed()
+	finally:
+		registration.cancel()
+		await asyncio.gather(registration, return_exceptions=True)
+		await server.cleanup()
+
+
+async def test_existing_connection_deadline_bounds_endless_new_cursors(catalog_server):
+	server = catalog_server([], endless=True)
+	try:
+		with pytest.raises(RuntimeError, match='Failed to connect'):
+			await server.client.connect()
+		assert len([event for event in server.events() if 'cursor' in event]) > 1
+		assert not server.client._tools
+		server.assert_closed()
+	finally:
+		await server.cleanup()

--- a/tests/ci/test_mcp_client_pagination.py
+++ b/tests/ci/test_mcp_client_pagination.py
@@ -206,10 +206,12 @@ async def test_cancelled_discovery_closes_session_and_server(catalog_server):
 	tools = Tools()
 	registration = asyncio.create_task(server.client.register_to_tools(tools, prefix='catalog_'))
 	try:
-		async with asyncio.timeout(5):
-			# Readiness is reported by a separate stdio subprocess, not an in-loop event.
-			while len([event for event in server.events() if 'cursor' in event]) < 2:  # noqa: ASYNC110
-				await asyncio.sleep(0.01)
+		# Readiness follows the connection's own deadline, including subprocess startup.
+		while len([event for event in server.events() if 'cursor' in event]) < 2:
+			if registration.done():
+				await registration
+				pytest.fail('Registration completed before requesting the second page')
+			await asyncio.sleep(0.01)
 		registration.cancel()
 		with pytest.raises(asyncio.CancelledError):
 			await registration


### PR DESCRIPTION
`MCPClient.register_to_tools()` currently treats the first `tools/list` response as the complete catalog. A server can legitimately return `nextCursor`, leaving subsequent tools silently absent from the action registry—even when `tool_filter` explicitly selects a tool on the next page.

Follow opaque cursors until the server omits `nextCursor`, and publish the collected tools only after discovery succeeds. Empty cursors and empty intermediate pages are supported. Repeated cursors fail before another request. The existing 10-second connection budget includes process startup, initialization, and all catalog pages. A slow finite catalog can still hit that budget; this PR does not promise arbitrary-size catalogs or unbounded discovery, and does not introduce a separate page-count limit. Discovery failures propagate from the owning background task, and cancellation/timeout cancel and await that task so its stdio process and session close.

The real stdio regression demonstrates the behavior through `Tools.act()` and a local browser:

```text
tools/list                         -> [first], nextCursor="opaque/+=="
tools/list(cursor="opaque/+==")     -> [second]
before: registered [catalog_first]
after:  registered [catalog_first, catalog_second]
tool_filter=["second"] -> catalog_second -> "called second"
```

This implements the existing [MCP pagination contract](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination); the pinned SDK does not paginate `ClientSession.list_tools()` automatically. It is based directly on current main and works with the existing stdio transport. #5678 separately adds Streamable HTTP; there is no dependency on that PR, although the shared connection code can need a mechanical merge resolution. The broader reconnect/concurrent lifecycle work in #5286 and #5227 stays separate.

Validation:

- Before implementation, the real two-page regression failed because only `catalog_first` was registered.
- Current focused verification: **14 passed in 66.50s**. This includes all 12 MCP cases (9 new real-server cases plus 3 existing tool-error cases) and both existing tests that failed in the complete run below. Coverage includes second-page filtering and real `Tools.act()` execution, single-page compatibility, opaque/empty cursors and empty intermediate pages, cursor cycles, later-page errors, cancellation, and endless-catalog timeout. Cleanup checks the session and the test's own subprocess exit. The cancellation readiness poll now observes the connection task's lifetime instead of imposing a separate 5-second startup window.
- The first complete local run finished **1,193 passed, 34 skipped, 4 failed, 1 deselected**. The deselected known baseline type-hints test passed separately, so every collected case was exercised; the first complete run is not claimed green. Its four failures were investigated as follows:
  - Repeated-cursor and cursor-cycle tests hit the existing connection timeout **before any `tools/list` request reached the server**. The first fixture had no startup event; the second recorded only its PID. These were not observed failures of the cursor guard or cleanup assertions. Both passed in a separate three-case invalid-catalog rerun and in the final 14-case run; the production timeout was not increased.
  - `test_beta_agent_initializes_tools_and_action_models` failed its `Tools` class-identity assertion. On exact main `d5453ae8`, an independent minimal ordering (import the Python Agent, run the timeout test that reloads the Tools module, then run this beta test) reproduced the same failure: 2 passed / 1 failed. The beta test passed alone on both main and this branch. No Tools/beta code or existing test was changed.
  - `test_datalist_field_no_delay` measured 1.029s against its existing 0.4s threshold. It passed once in isolation on exact main and in the final branch rerun. The cause of the original timing failure remains unconfirmed; no threshold or related production code was changed.
- The separately run `test_beta_agent_constructor_type_hints_match_browser_use_core_params` passed. Its pre-existing Tools-module reload identity issue was independently reproduced on unchanged base `cfe10a2`; the involved files are unchanged on current main.
- `uv run pyright`: 0 errors, 0 warnings, 0 information messages.
- `uv run pre-commit run --all-files`: passed, including the new test and hook pyright. All changed-file hooks passed again after the readiness-test follow-up; production code is unchanged by that follow-up.

Generated with Codex. Implementation and cross-review were performed by automated coding agents; no human review is claimed. No dependency changes.
