### PR TITLE
Add current Astra, Luna, and Opus model defaults and examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ See [Supported Models](https://docs.browser-use.com/supported-models#supported-m
   load_dotenv()
 
   async def main():
-      llm = ChatOpenAI(model="gpt-4.1-mini")
+      llm = ChatOpenAI(model="gpt-5.6-luna")
       task = "Find the number 1 post on Show HN"
       agent = Agent(task=task, llm=llm)
       await agent.run()
@@ -160,7 +160,7 @@ See [Supported Models](https://docs.browser-use.com/supported-models#supported-m
   load_dotenv()
 
   async def main():
-      llm = ChatAnthropic(model='claude-sonnet-4-0', temperature=0.0)
+      llm = ChatAnthropic(model='claude-opus-5')
       task = "Find the number 1 post on Show HN"
       agent = Agent(task=task, llm=llm)
       await agent.run()
@@ -658,7 +658,7 @@ browser = Browser(
 agent = Agent(
     task='Visit https://duckduckgo.com and search for "browser-use founders"',
     browser=browser,
-    llm=ChatOpenAI(model='gpt-4.1-mini'),
+    llm=ChatOpenAI(model='gpt-5.6-luna'),
 )
 async def main():
 	await agent.run()

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ uv add browser-use
 ```bash
 # .env
 BROWSER_USE_API_KEY=your-key
+# OPENAI_API_KEY=your-key
 # GOOGLE_API_KEY=your-key
 # ANTHROPIC_API_KEY=your-key
 ```
@@ -99,15 +100,16 @@ BROWSER_USE_API_KEY=your-key
 ```python
 import asyncio
 
-from browser_use import Agent, ChatBrowserUse
+from browser_use import Agent, ChatAnthropic, ChatBrowserUse, ChatOpenAI
 
 async def main():
     agent = Agent(
         task="Find the number of stars of the browser-use repo",
         llm=ChatBrowserUse(model='openai/gpt-5.5'),
         # llm=ChatBrowserUse(model='bu-2-0-mini-preview'),  # Browser Use's optimized model
-        # llm=ChatOpenAI(model='gpt-5.5'),
-        # llm=ChatAnthropic(model='claude-opus-4-8'),  # Sonnet also works well
+        # llm=ChatOpenAI(model='gpt-5.6-luna'),  # Lower-cost OpenAI option
+        # llm=ChatOpenAI(model='gpt-6-astra'),  # Higher-capability OpenAI option
+        # llm=ChatAnthropic(model='claude-opus-5'),
     )
     history = await agent.run()
 

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -303,7 +303,7 @@ def create_default_config() -> DBStyleConfigJSON:
 	new_config.browser_profile[profile_id] = BrowserProfileEntry(id=profile_id, default=True, headless=False, user_data_dir=None)
 
 	# Create default LLM entry
-	new_config.llm[llm_id] = LLMEntry(id=llm_id, default=True, model='gpt-4.1-mini', api_key='your-openai-api-key-here')
+	new_config.llm[llm_id] = LLMEntry(id=llm_id, default=True, model='gpt-5.6-luna', api_key='your-openai-api-key-here')
 
 	# Create default agent entry
 	new_config.agent[agent_id] = AgentEntry(id=agent_id, default=True)

--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -47,6 +47,8 @@ openai_o4_mini: 'BaseChatModel'
 openai_gpt_5: 'BaseChatModel'
 openai_gpt_5_mini: 'BaseChatModel'
 openai_gpt_5_nano: 'BaseChatModel'
+openai_gpt_6_astra: 'BaseChatModel'
+openai_gpt_5_6_luna: 'BaseChatModel'
 
 azure_gpt_4o: 'BaseChatModel'
 azure_gpt_4o_mini: 'BaseChatModel'
@@ -73,6 +75,7 @@ pixtral_large: 'BaseChatModel'
 
 anthropic_claude_sonnet_4_0: 'BaseChatModel'
 anthropic_claude_fable_5: 'BaseChatModel'
+anthropic_claude_opus_5: 'BaseChatModel'
 anthropic_claude_3_5_sonnet_latest: 'BaseChatModel'
 anthropic_claude_3_5_haiku_latest: 'BaseChatModel'
 
@@ -125,7 +128,9 @@ def get_llm_by_name(model_name: str):
 	model_part = parts[1]
 
 	# Convert underscores back to dots/dashes for actual model names
-	if 'gpt_4_1_mini' in model_part:
+	if provider == 'openai' and model_part == 'gpt_5_6_luna':
+		model = 'gpt-5.6-luna'
+	elif 'gpt_4_1_mini' in model_part:
 		model = model_part.replace('gpt_4_1_mini', 'gpt-4.1-mini')
 	elif 'gpt_4o_mini' in model_part:
 		model = model_part.replace('gpt_4o_mini', 'gpt-4o-mini')
@@ -284,6 +289,8 @@ __all__ += [
 	'openai_gpt_5',
 	'openai_gpt_5_mini',
 	'openai_gpt_5_nano',
+	'openai_gpt_6_astra',
+	'openai_gpt_5_6_luna',
 	# Azure instances - created on demand
 	'azure_gpt_4o',
 	'azure_gpt_4o_mini',
@@ -305,6 +312,7 @@ __all__ += [
 	# Anthropic instances - created on demand
 	'anthropic_claude_sonnet_4_0',
 	'anthropic_claude_fable_5',
+	'anthropic_claude_opus_5',
 	'anthropic_claude_3_5_sonnet_latest',
 	'anthropic_claude_3_5_haiku_latest',
 	# Mistral instances - created on demand

--- a/browser_use/llm/openai/chat.py
+++ b/browser_use/llm/openai/chat.py
@@ -73,6 +73,7 @@ class ChatOpenAI(BaseChatModel):
 			'gpt-5',
 			'gpt-5-mini',
 			'gpt-5-nano',
+			'gpt-6-astra',
 		]
 	)
 
@@ -190,6 +191,8 @@ class ChatOpenAI(BaseChatModel):
 				model_params['reasoning_effort'] = self.reasoning_effort
 				model_params.pop('temperature', None)
 				model_params.pop('frequency_penalty', None)
+				if 'gpt-6-astra' in str(self.model).lower():
+					model_params.pop('top_p', None)
 
 			if output_format is None:
 				# Return string response

--- a/browser_use/mcp/server.py
+++ b/browser_use/mcp/server.py
@@ -636,7 +636,7 @@ class BrowserUseServer:
 			kwargs['base_url'] = base_url
 		if api_key := llm_config.get('api_key'):
 			self.llm = ChatOpenAI(
-				model=llm_config.get('model', 'gpt-o4-mini'),
+				model=llm_config.get('model', 'gpt-5.6-luna'),
 				api_key=api_key,
 				temperature=llm_config.get('temperature', 0.7),
 				**kwargs,
@@ -683,7 +683,7 @@ class BrowserUseServer:
 				return 'Error: OPENAI_API_KEY not set in config or environment'
 
 			# Use explicit model from tool call, otherwise fall back to configured default
-			llm_model = model or llm_config.get('model', 'gpt-4o')
+			llm_model = model or llm_config.get('model', 'gpt-5.6-luna')
 
 			base_url = llm_config.get('base_url', None)
 			kwargs = {}

--- a/examples/models/claude-opus-5.py
+++ b/examples/models/claude-opus-5.py
@@ -1,0 +1,27 @@
+"""
+Read a public page with Claude Opus 5.
+
+@dev Add ANTHROPIC_API_KEY to your environment or .env file.
+"""
+
+import asyncio
+
+from dotenv import load_dotenv
+
+from browser_use import Agent, ChatAnthropic
+
+load_dotenv()
+
+llm = ChatAnthropic(model='claude-opus-5')
+
+agent = Agent(
+	task='Visit https://quotes.toscrape.com/ and list the first three quotes with their authors.',
+	llm=llm,
+)
+
+
+async def main():
+	await agent.run(max_steps=10)
+
+
+asyncio.run(main())

--- a/examples/models/gpt-5.6-luna.py
+++ b/examples/models/gpt-5.6-luna.py
@@ -1,0 +1,28 @@
+"""
+Run a browser task with GPT-5.6 Luna or GPT-6 Astra.
+
+@dev You need to add OPENAI_API_KEY to your environment variables.
+Set OPENAI_MODEL=gpt-6-astra to run the same task with Astra.
+"""
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+
+from browser_use import Agent, ChatOpenAI
+
+load_dotenv()
+
+llm = ChatOpenAI(model=os.getenv('OPENAI_MODEL', 'gpt-5.6-luna'))
+agent = Agent(
+	llm=llm,
+	task='Visit https://quotes.toscrape.com/ and list the first three quotes with their authors.',
+)
+
+
+async def main():
+	await agent.run(max_steps=20)
+
+
+asyncio.run(main())

--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -2,7 +2,15 @@
 
 import os
 
-from browser_use.config import CONFIG
+from browser_use.config import CONFIG, create_default_config
+
+
+def test_new_config_uses_current_low_cost_openai_model():
+	config = create_default_config()
+	assert len(config.llm) == 1
+	llm = next(iter(config.llm.values()))
+	assert llm.default is True
+	assert llm.model == 'gpt-5.6-luna'
 
 
 class TestLazyConfig:

--- a/tests/ci/models/model_test_helper.py
+++ b/tests/ci/models/model_test_helper.py
@@ -83,11 +83,10 @@ async def run_model_button_click_test(
 			task=f'{test_url} - Click the button',
 			llm=llm,
 			browser_session=browser,
-			max_steps=2,  # Max 2 steps as per requirements
 		)
 
 		# Run the agent
-		result = await agent.run()
+		result = await agent.run(max_steps=2)
 
 		# Verify task completed
 		assert result is not None

--- a/tests/ci/models/test_llm_anthropic.py
+++ b/tests/ci/models/test_llm_anthropic.py
@@ -13,3 +13,14 @@ async def test_anthropic_claude_sonnet_4_6(httpserver):
 		extra_kwargs={},
 		httpserver=httpserver,
 	)
+
+
+async def test_anthropic_claude_opus_5(httpserver):
+	"""Exercise Opus 5 with the adapter's default thinking and tool choice."""
+	await run_model_button_click_test(
+		model_class=ChatAnthropic,
+		model_name='claude-opus-5',
+		api_key_env='ANTHROPIC_API_KEY',
+		extra_kwargs={},
+		httpserver=httpserver,
+	)

--- a/tests/ci/models/test_llm_model_factory.py
+++ b/tests/ci/models/test_llm_model_factory.py
@@ -5,6 +5,18 @@ from browser_use.llm.cerebras.chat import ChatCerebras
 from browser_use.llm.models import get_llm_by_name
 
 
+@pytest.mark.parametrize(
+	('alias', 'model'),
+	[
+		('openai_gpt_6_astra', 'gpt-6-astra'),
+		('openai_gpt_5_6_luna', 'gpt-5.6-luna'),
+		('anthropic_claude_opus_5', 'claude-opus-5'),
+	],
+)
+def test_current_model_aliases_preserve_provider_ids(alias, model):
+	assert get_llm_by_name(alias).model == model
+
+
 def test_get_llm_by_name_resolves_anthropic_from_env(monkeypatch):
 	monkeypatch.setenv('ANTHROPIC_API_KEY', 'anthropic-test-key')
 

--- a/tests/ci/models/test_llm_openai.py
+++ b/tests/ci/models/test_llm_openai.py
@@ -2,12 +2,53 @@
 
 from types import SimpleNamespace
 
+import httpx
 import pytest
+from pydantic import BaseModel
 
 from browser_use.llm.base import is_reasoning_model
 from browser_use.llm.messages import UserMessage
 from browser_use.llm.openai.chat import ChatOpenAI
 from tests.ci.models.model_test_helper import run_model_button_click_test
+
+
+@pytest.mark.parametrize('model', ['gpt-6-astra', 'gpt-5.6-luna'])
+@pytest.mark.parametrize('structured', [False, True])
+async def test_current_openai_models_send_compatible_requests(model, structured):
+	"""Exercise SDK serialization for plain and schema-constrained responses."""
+
+	class Answer(BaseModel):
+		answer: str
+
+	requests = []
+
+	def respond(request):
+		import json
+
+		requests.append(json.loads(request.content))
+		return httpx.Response(
+			200,
+			json={
+				'id': 'chatcmpl-test',
+				'object': 'chat.completion',
+				'created': 0,
+				'model': model,
+				'choices': [
+					{'index': 0, 'finish_reason': 'stop', 'message': {'role': 'assistant', 'content': '{"answer":"ok"}'}}
+				],
+			},
+		)
+
+	async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+		llm = ChatOpenAI(model=model, api_key='test-key', http_client=client, top_p=0.9 if model == 'gpt-6-astra' else None)
+		result = await llm.ainvoke([UserMessage(content='Answer ok.')], output_format=Answer if structured else None)
+
+	assert result.completion == (Answer(answer='ok') if structured else '{"answer":"ok"}')
+	assert len(requests) == 1
+	assert requests[0]['model'] == model
+	assert requests[0]['reasoning_effort'] == 'low'
+	assert not {'temperature', 'frequency_penalty', 'top_p'} & requests[0].keys()
+	assert ('response_format' in requests[0]) is structured
 
 
 @pytest.mark.parametrize(
@@ -30,6 +71,17 @@ async def test_openai_gpt_4_1_mini(httpserver):
 	await run_model_button_click_test(
 		model_class=ChatOpenAI,
 		model_name='gpt-4.1-mini',
+		api_key_env='OPENAI_API_KEY',
+		extra_kwargs={},
+		httpserver=httpserver,
+	)
+
+
+@pytest.mark.parametrize('model', ['gpt-5.6-luna', 'gpt-6-astra'])
+async def test_current_openai_models_click_button(httpserver, model):
+	await run_model_button_click_test(
+		model_class=ChatOpenAI,
+		model_name=model,
 		api_key_env='OPENAI_API_KEY',
 		extra_kwargs={},
 		httpserver=httpserver,

--- a/tests/ci/test_mcp_default_models.py
+++ b/tests/ci/test_mcp_default_models.py
@@ -1,0 +1,64 @@
+"""MCP OpenAI fallbacks and configured-model precedence."""
+
+import pytest
+
+from browser_use.mcp import server as server_module
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(tmp_path / 'config'))
+	monkeypatch.delenv('MODEL_PROVIDER', raising=False)
+	instance = server_module.BrowserUseServer()
+	instance.config = {
+		'llm': {'api_key': 'test-key'},
+		'browser_profile': {
+			'headless': True,
+			'user_data_dir': None,
+			'keep_alive': False,
+			'downloads_path': str(tmp_path / 'downloads'),
+			'file_system_path': str(tmp_path / 'files'),
+		},
+	}
+	return instance
+
+
+@pytest.mark.parametrize('configured', [None, 'gpt-4.1-mini'])
+async def test_extraction_model_default_and_configured_override(server, configured):
+	if configured:
+		server.config['llm']['model'] = configured
+	try:
+		await server._init_browser_session()
+		assert server.llm is not None
+		assert server.llm.model == (configured or 'gpt-5.6-luna')
+	finally:
+		if server.browser_session:
+			await server.browser_session.kill()
+
+
+@pytest.mark.parametrize(
+	('configured', 'explicit', 'expected'),
+	[
+		(None, None, 'gpt-5.6-luna'),
+		('gpt-4.1-mini', None, 'gpt-4.1-mini'),
+		('gpt-4.1-mini', 'gpt-6-astra', 'gpt-6-astra'),
+	],
+)
+async def test_agent_model_default_and_override_precedence(server, monkeypatch, configured, explicit, expected):
+	if configured:
+		server.config['llm']['model'] = configured
+	captured = {}
+
+	class ModelSelected(Exception):
+		pass
+
+	def capture_llm(**kwargs):
+		captured.update(kwargs)
+		raise ModelSelected
+
+	# Stop at the LLM constructor: no provider call or agent execution is needed
+	# to verify which model the MCP runner selects.
+	monkeypatch.setattr(server_module, 'ChatOpenAI', capture_llm)
+	with pytest.raises(ModelSelected):
+		await server._retry_with_browser_use_agent(task='No external task', model=explicit)
+	assert captured['model'] == expected


### PR DESCRIPTION
## Summary

Add current direct-provider examples and model aliases for `gpt-6-astra`, `gpt-5.6-luna`, and `claude-opus-5`.

- Fix Astra requests: treat it as a reasoning model and omit unsupported sampling parameters. Unchanged main returns HTTP400 for temperature 0.2; the patched adapter succeeds on the same input.
- Preserve Luna's decimal in the lazy alias factory. Use Luna for newly generated OpenAI config and both MCP OpenAI fallbacks; explicit and saved model choices still take precedence.
- Update README alternatives and AGENTS snippets. Keep Agent's Browser Use default and the README's active Browser Use gateway route unchanged.
- Add two runnable public-page examples: Luna with an Astra environment override, and Opus5. Keep named older examples intact.

No Anthropic adapter change is needed: its current structured-tool path works with Opus5. No dependencies, prices, deployment IDs, gateway behavior, releases or provider routing change.

## Verification

Each named model passed two real browser smoke checks with isolated headless Chrome: click a local button and observe the page change to SUCCESS; run the new public-page example and return the first three quote/author pairs. The final outputs matched an independent fetch of the public page. No fallback provider was configured or observed. These are smoke tests, not comparative benchmarks.

- `gpt-5.6-luna`: button and actual example passed.
- `gpt-6-astra`: button and actual example passed; live same-input failure on unchanged main is fixed.
- `claude-opus-5`: button and actual example passed with the existing Anthropic adapter.
- Focused credential-free regression suite: 30 passed, 5 skipped. The new live-model tests were run separately with credentials.
- All applicable pre-commit hooks passed, including Ruff and Pyright.
- Final full CI: 1202 passed, 37 skipped, 1 failed. `test_user_data_dir_not_allowed_to_corrupt_default_profile` fails during its CDP HTTP startup, before a model call. The same isolated test fails on unchanged base e3251d87 using the same runtime/dependencies. No browser-startup code or user profile was changed to make it pass.

The shared live-model helper previously passed max_steps to Agent's constructor, where it was ignored. It now calls agent.run(max_steps=2), enforcing the intended bound without weakening the observed page-state assertion.

## Scope limits

This does not claim all provider examples are current. Google examples need a separately live-tested update; the old Gemini3Pro preview is shut down. Azure/Bedrock/gateway-specific IDs, saved configs, historical examples and eval fixtures are preserved. The init default/advanced/tools templates already use ChatBrowserUse().

Model references: [Astra](https://developers.openai.com/api/docs/models/gpt-6-astra), [Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna), [Opus5 migration](https://platform.claude.com/docs/en/models/opus-5/migration-guide), [Anthropic tool-choice semantics](https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds current model aliases, tests, and runnable examples for `gpt-6-astra`, `gpt-5.6-luna`, and `claude-opus-5`.

- Astra is now treated as a reasoning model; unsupported `top_p` is omitted, fixing the HTTP 400 that the old code returned.
- The Luna alias preserves its decimal (`gpt-5.6-luna`) when resolved lazily.
- Newly generated OpenAI configs and both MCP OpenAI fallbacks default to `gpt-5.6-luna`; explicit and saved model choices still win.
- README and AGENTS snippets now reference the current models; the Browser Use gateway route is unchanged.
- Two new public-page examples are runnable: Luna with an optional Astra env override, and Opus 5. Named older examples stay intact.
- No Anthropic adapter change is needed; the existing structured-tool path works with Opus 5.

<sup>Written for commit 6dbadf55f98e072512fa7a9faa91bcdc2fca8478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

