### PR TITLE
docs(cloud): fix dead python-framework-agents anchor in subagent guide

### DIFF
--- a/skills/cloud/references/guides/subagent.md
+++ b/skills/cloud/references/guides/subagent.md
@@ -32,7 +32,7 @@ Your system has an orchestrator — some agent, pipeline, or workflow engine tha
 | Your agent type | Best approach |
 |----------------|---------------|
 | CLI coding agent in sandbox (Claude Code, Codex, OpenCode, Cline, Windsurf, Cursor bg, Hermes, OpenClaw) | [CLI cloud passthrough](#shell-command-agents-cli) |
-| Python framework (LangChain, CrewAI, AutoGen, PydanticAI, custom) | [Python Agent wrapper](#python-framework-agents) |
+| Python framework (LangChain, CrewAI, AutoGen, PydanticAI, custom) | [Python Agent wrapper](#python-agents-cloud-sdk) |
 | TypeScript/JS (Vercel AI SDK, LangChain.js, custom) | [Cloud SDK](#typescriptjs-agents) |
 | MCP client (Claude Desktop, Cursor with MCP) | [MCP browser_task tool](#mcp-native-agents) |
 | Workflow engine (n8n, Make, Zapier, Temporal) or any HTTP client | [Cloud REST API](#http--workflow-engines) |


### PR DESCRIPTION
The integration-picker table in `skills/cloud/references/guides/subagent.md` linked `#python-framework-agents`, which matches no heading in the file; the intended target is `## Python Agents (Cloud SDK)` → `#python-agents-cloud-sdk` (the file's own TOC already links it correctly). One-line anchor fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dead `#python-framework-agents` anchor in the subagent guide's integration table so the Python Agent wrapper link now points to the correct `#python-agents-cloud-sdk` heading.

<sup>Written for commit 0b8eb753a8f4bba0c455cc0ca5928a86645fe24b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

