### PR TITLE
docs(llm): restore the contiguous supported-LLM list broken by a merge

### DIFF
--- a/browser_use/llm/README.md
+++ b/browser_use/llm/README.md
@@ -8,15 +8,12 @@ We officially support the following LLMs:
 - Groq
 - Ollama
 - DeepSeek
-
 - Mistral
+- Cerebras
 
 ## Mistral specifics
 
 Use `ChatMistral` with `MISTRAL_API_KEY` (and optional `MISTRAL_BASE_URL`). Structured outputs automatically strip unsupported JSON schema keywords (`minLength`, `maxLength`, `pattern`, `format`), and generation uses `max_tokens` plus the optional `safe_prompt` flag.
-
-- Cerebras
-
 
 ## Migrating from LangChain
 


### PR DESCRIPTION
Merge 0b82aa73 scrambled `browser_use/llm/README.md`: a blank line split the supported-LLM list after DeepSeek, `Cerebras` ended up stranded as a stray bullet under the `## Mistral specifics` section, and the section itself moved above the list. Restored the intended layout (one contiguous list — OpenAI/Anthropic/Google/Groq/Ollama/DeepSeek/Mistral/Cerebras — followed by the Mistral specifics section), matching the pre-merge blob 5de9b995.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the supported-LLM list in `browser_use/llm/README.md` that a merge had scrambled: a blank line split the list after DeepSeek, `Cerebras` was stranded under `## Mistral specifics`, and that section appeared above the list. Restores the contiguous list followed by the Mistral specifics section.

<sup>Written for commit ea5c7f8c23af6a26c1e6cd48f866dd2737358631. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

