### PR TITLE
fix(tools): remove unreachable duplicated file_system elif arms

### DIFF
--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -219,8 +219,6 @@ class Registry(Generic[Context]):
 								raise ValueError(f'Action {func.__name__} requires page but none provided.')
 							elif param.name == 'available_file_paths':
 								raise ValueError(f'Action {func.__name__} requires available_file_paths but none provided.')
-							elif param.name == 'file_system':
-								raise ValueError(f'Action {func.__name__} requires file_system but none provided.')
 							else:
 								raise ValueError(f"{func.__name__}() missing required special parameter '{param.name}'")
 						call_args.append(value)
@@ -238,8 +236,6 @@ class Registry(Generic[Context]):
 							raise ValueError(f'Action {func.__name__} requires page but none provided.')
 						elif param.name == 'available_file_paths':
 							raise ValueError(f'Action {func.__name__} requires available_file_paths but none provided.')
-						elif param.name == 'file_system':
-							raise ValueError(f'Action {func.__name__} requires file_system but none provided.')
 						else:
 							raise ValueError(f"{func.__name__}() missing required special parameter '{param.name}'")
 				else:


### PR DESCRIPTION
In `browser_use/tools/registry/service.py` (`normalized_wrapper`), both error branches had a second `elif param.name == 'file_system':` arm raising the same error — unreachable, because the identical condition earlier in the chain catches it first (copy-paste duplication; an AST scan shows these are the only duplicated if/elif conditions in the package). Removed both dead arms; no behavior change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes two unreachable `elif param.name == 'file_system'` arms in `normalized_wrapper` that duplicated identical conditions earlier in the chain, so error handling behavior is unchanged.

<sup>Written for commit 1f84df2a57ec4eccee487f50a5156b20911039a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

