### PR TITLE
fix: honor MCP disable security environment setting

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -230,6 +230,7 @@ class FlatEnvConfig(BaseSettings):
 	# MCP-specific env vars
 	BROWSER_USE_CONFIG_PATH: str | None = Field(default=None)
 	BROWSER_USE_HEADLESS: bool | None = Field(default=None)
+	BROWSER_USE_DISABLE_SECURITY: bool | None = Field(default=None)
 	BROWSER_USE_ALLOWED_DOMAINS: str | None = Field(default=None)
 	BROWSER_USE_LLM_MODEL: str | None = Field(default=None)
 
@@ -471,6 +472,9 @@ class Config:
 		# Apply MCP-specific env var overrides
 		if env_config.BROWSER_USE_HEADLESS is not None:
 			config['browser_profile']['headless'] = env_config.BROWSER_USE_HEADLESS
+
+		if env_config.BROWSER_USE_DISABLE_SECURITY is not None:
+			config['browser_profile']['disable_security'] = env_config.BROWSER_USE_DISABLE_SECURITY
 
 		if env_config.BROWSER_USE_ALLOWED_DOMAINS:
 			domains = [d.strip() for d in env_config.BROWSER_USE_ALLOWED_DOMAINS.split(',') if d.strip()]

--- a/tests/ci/test_extension_config.py
+++ b/tests/ci/test_extension_config.py
@@ -144,7 +144,8 @@ class TestConfigEnvVars:
 		load_browser_use_config()
 		stored = json.loads(config_path.read_text())
 		if persisted is not None:
-			next(iter(stored['browser_profile'].values()))['disable_security'] = persisted
+			default_profile = next(profile for profile in stored['browser_profile'].values() if profile.get('default'))
+			default_profile['disable_security'] = persisted
 			config_path.write_text(json.dumps(stored))
 		if env_value is not None:
 			monkeypatch.setenv('BROWSER_USE_DISABLE_SECURITY', env_value)

--- a/tests/ci/test_extension_config.py
+++ b/tests/ci/test_extension_config.py
@@ -1,5 +1,8 @@
 """Tests for browser configuration environment variables."""
 
+import json
+from pathlib import Path
+
 import pytest
 
 from browser_use.browser import BrowserSession
@@ -8,6 +11,7 @@ from browser_use.browser.profile import (
 	_get_enable_default_extensions_default,
 	_get_headless_default,
 )
+from browser_use.config import load_browser_use_config
 
 TRUTHY_STRINGS = ['true', 'True', 'TRUE', '1', 'yes', 'on']
 FALSY_STRINGS = ['false', 'False', 'FALSE', '0', 'no', 'off', '']
@@ -114,3 +118,40 @@ class TestConfigEnvVars:
 		monkeypatch.setenv(env_var, env_val)
 		profile = BrowserProfile(**explicit_arg)
 		assert getattr(profile, attr_name) is expected
+
+	@pytest.mark.parametrize('value,expected', [('true', True), ('false', False)])
+	def test_mcp_disable_security_env_var(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, value: str, expected: bool):
+		"""The documented MCP env var must reach the resolved browser profile."""
+		monkeypatch.setenv('BROWSER_USE_CONFIG_PATH', str(tmp_path / 'config.json'))
+		monkeypatch.setenv('BROWSER_USE_DISABLE_SECURITY', value)
+
+		config = load_browser_use_config()
+
+		assert config['browser_profile']['disable_security'] is expected
+		assert BrowserProfile(**config['browser_profile']).disable_security is expected
+
+	@pytest.mark.parametrize(
+		'env_value,persisted,expected',
+		[(None, None, False), (None, True, True), (None, False, False), ('false', True, False), ('true', False, True)],
+	)
+	def test_mcp_disable_security_precedence(
+		self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, env_value: str | None, persisted: bool | None, expected: bool
+	):
+		"""Unset preserves stored policy; an explicit env value overrides it."""
+		config_path = tmp_path / 'config.json'
+		monkeypatch.setenv('BROWSER_USE_CONFIG_PATH', str(config_path))
+		monkeypatch.delenv('BROWSER_USE_DISABLE_SECURITY', raising=False)
+		load_browser_use_config()
+		stored = json.loads(config_path.read_text())
+		if persisted is not None:
+			next(iter(stored['browser_profile'].values()))['disable_security'] = persisted
+			config_path.write_text(json.dumps(stored))
+		if env_value is not None:
+			monkeypatch.setenv('BROWSER_USE_DISABLE_SECURITY', env_value)
+
+		resolved = load_browser_use_config()['browser_profile']
+
+		assert BrowserProfile(**resolved).disable_security is expected
+		if env_value is None and persisted is None:
+			assert 'disable_security' not in resolved
+		assert json.loads(config_path.read_text()) == stored


### PR DESCRIPTION
## Fix

Read the documented `BROWSER_USE_DISABLE_SECURITY` setting when resolving local MCP browser configuration.

The default remains secure. An unset variable leaves the stored profile unchanged; explicit `true` or `false` overrides it without rewriting the config file. Existing explicit browser-session parameters still take priority.

Only the config declaration/mapping and its regression tests change. This does not add a tool-controlled security switch or alter the normal BrowserProfile default.

## Verification

- Before the mapping fix: four new regression cases failed; fourteen passed.
- After: all eighteen focused config tests pass, including unset, persisted true/false and explicit environment overrides.
- The related profile arguments, extension-security and lazy-config checks also pass: twenty-seven local cases in total.
- All applicable pre-commit hooks pass.
- Four fresh owned headless Chrome sessions exercised the actual MCP browser initialization and two synthetic loopback origins. Unset and false kept cross-origin fetch blocked with no `--disable-web-security` flag. True enabled the flag and allowed the synthetic response. An explicit false session override restored the block even with the environment set to true.
- CI's hosted task evaluation reports 2/2, but both tasks log that they skipped because `BROWSER_USE_API_KEY` is absent. Those are not counted as agent or provider validation.

The local proof used no provider calls, shared browser profile or production request. No release or deployment was performed. The explicit true setting intentionally disables browser web-security checks, as already documented.
