### PR TITLE
fix(anthropic): preserve all system instructions in order

### DIFF
--- a/browser_use/llm/anthropic/serializer.py
+++ b/browser_use/llm/anthropic/serializer.py
@@ -302,21 +302,21 @@ class AnthropicMessageSerializer:
 
 	@staticmethod
 	def serialize_messages(messages: list[BaseMessage]) -> tuple[list[MessageParam], list[TextBlockParam] | str | None]:
-		"""Serialize a list of messages, extracting any system message.
+		"""Serialize a list of messages, preserving all system instructions in order.
 
 		Returns:
 		    A tuple of (messages, system_message) where system_message is extracted
-		    from any SystemMessage in the list.
+		    from all SystemMessage instances in the list.
 		"""
 		messages = [m.model_copy(deep=True) for m in messages]
 
 		# Separate system messages from normal messages
 		normal_messages: list[NonSystemMessage] = []
-		system_message: SystemMessage | None = None
+		system_messages: list[SystemMessage] = []
 
 		for message in messages:
 			if isinstance(message, SystemMessage):
-				system_message = message
+				system_messages.append(message)
 			else:
 				normal_messages.append(message)
 
@@ -328,11 +328,25 @@ class AnthropicMessageSerializer:
 		for message in normal_messages:
 			serialized_messages.append(AnthropicMessageSerializer.serialize(message))
 
-		# Serialize system message
+		# Preserve the existing representation for a single system message.
 		serialized_system_message: list[TextBlockParam] | str | None = None
-		if system_message:
+		if len(system_messages) == 1:
+			system_message = system_messages[0]
 			serialized_system_message = AnthropicMessageSerializer._serialize_content_to_str(
 				system_message.content, use_cache=system_message.cache
 			)
+		elif system_messages:
+			# As with normal messages, keep only the last requested cache boundary.
+			last_cache_index = next((i for i in range(len(system_messages) - 1, -1, -1) if system_messages[i].cache), -1)
+			system_blocks: list[TextBlockParam] = []
+			for i, system_message in enumerate(system_messages):
+				content = AnthropicMessageSerializer._serialize_content_to_str(
+					system_message.content, use_cache=i == last_cache_index
+				)
+				if isinstance(content, str):
+					system_blocks.append(TextBlockParam(type='text', text=content))
+				else:
+					system_blocks.extend(content)
+			serialized_system_message = system_blocks
 
 		return serialized_messages, serialized_system_message

--- a/browser_use/llm/tests/test_anthropic_system_messages.py
+++ b/browser_use/llm/tests/test_anthropic_system_messages.py
@@ -1,0 +1,71 @@
+"""Regression coverage for preserving Anthropic system instructions."""
+
+import pytest
+
+from browser_use.llm.anthropic.serializer import AnthropicMessageSerializer
+from browser_use.llm.messages import AssistantMessage, BaseMessage, ContentPartTextParam, SystemMessage, UserMessage
+
+
+@pytest.mark.parametrize('use_blocks', [False, True])
+def test_multiple_system_messages_preserve_order(use_blocks: bool):
+	"""Keep every instruction, including system messages interleaved with conversation."""
+	first = [ContentPartTextParam(text='Base rule'), ContentPartTextParam(text='Extra rule')] if use_blocks else 'Base rule'
+	messages: list[BaseMessage] = [
+		SystemMessage(content=first),
+		UserMessage(content='Question'),
+		SystemMessage(content='Final rule'),
+		AssistantMessage(content='Answer'),
+	]
+	original = [message.model_dump() for message in messages]
+
+	conversation, system = AnthropicMessageSerializer.serialize_messages(messages)
+
+	assert conversation == [{'role': 'user', 'content': 'Question'}, {'role': 'assistant', 'content': 'Answer'}]
+	assert isinstance(system, list)
+	assert [block['text'] for block in system] == (
+		['Base rule', 'Extra rule', 'Final rule'] if use_blocks else ['Base rule', 'Final rule']
+	)
+	assert all(not block.get('cache_control') for block in system)
+	assert [message.model_dump() for message in messages] == original
+
+
+@pytest.mark.parametrize('cached', [False, True])
+@pytest.mark.parametrize('use_blocks', [False, True])
+def test_single_system_message_shape_is_unchanged(cached: bool, use_blocks: bool):
+	"""Retain the existing string and text-block representations for one instruction."""
+	content = [ContentPartTextParam(text='Rule')] if use_blocks else 'Rule'
+	_, system = AnthropicMessageSerializer.serialize_messages([SystemMessage(content=content, cache=cached)])
+	if use_blocks or cached:
+		assert system == [{'type': 'text', 'text': 'Rule', 'cache_control': {'type': 'ephemeral'} if cached else None}]
+	else:
+		assert system == 'Rule'
+
+
+def test_no_system_messages():
+	"""Keep the absent system instruction represented by None."""
+	assert AnthropicMessageSerializer.serialize_messages([]) == ([], None)
+	assert AnthropicMessageSerializer.serialize_messages([UserMessage(content='Hello')]) == (
+		[{'role': 'user', 'content': 'Hello'}],
+		None,
+	)
+
+
+def test_only_last_cached_system_message_has_breakpoint():
+	"""Bound cache breakpoints while preserving the boundary before uncached instructions."""
+	messages: list[BaseMessage] = [SystemMessage(content=f'Rule {i}', cache=True) for i in range(5)]
+	messages.extend(
+		[
+			SystemMessage(content=[ContentPartTextParam(text='Part one'), ContentPartTextParam(text='Part two')], cache=True),
+			SystemMessage(content='Uncached suffix'),
+			UserMessage(content='Question', cache=True),
+		]
+	)
+	original = [message.model_dump() for message in messages]
+	conversation, system = AnthropicMessageSerializer.serialize_messages(messages)
+	assert isinstance(system, list)
+	assert [block['text'] for block in system] == [*(f'Rule {i}' for i in range(5)), 'Part one', 'Part two', 'Uncached suffix']
+	assert [i for i, block in enumerate(system) if block.get('cache_control')] == [6]
+	assert conversation == [
+		{'role': 'user', 'content': [{'type': 'text', 'text': 'Question', 'cache_control': {'type': 'ephemeral'}}]}
+	]
+	assert [message.model_dump() for message in messages] == original


### PR DESCRIPTION
Multiple `SystemMessage` instances currently overwrite one another, so only the last instruction reaches Anthropic. This change preserves every instruction in order, including mixed string and text-block content, while keeping the existing single-message representation.

Only the last cached system message receives a cache breakpoint, independently of conversation caching. Input messages remain unchanged.

Fixes #5633.

This draft overlaps with #5634 and #5663. It is an alternative implementation with regression coverage for interleaved system messages, mixed content, input immutability, and cache normalization; please consider that overlap before review or merge.

Validation:
- New regression tests against the original code: 3 failed, 5 passed.
- Regression tests and existing Anthropic cache suite with the fix: 24 passed.
- All applicable pre-commit hooks passed, including Ruff and Pyright.
- No live model request was required.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves all Anthropic system instructions in order, including mixed string and text-block content, so multiple `SystemMessage` instances no longer overwrite each other. Fixes #5633.

- Only the last cached system message receives a cache breakpoint, independently of conversation caching.
- Input messages remain unchanged.

<sup>Written for commit 9033f8fbff363a473d4e99a7719624fe3bc475cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

