### PR TITLE
fix(browser): catch corrupt-EOCD OSError in _extract_extension so the CRX fallback runs

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1212,13 +1212,14 @@ async function initialize(checkInitialized, magic) {{
 			if not (extract_dir / 'manifest.json').exists():
 				raise Exception('No manifest.json found in extension')
 
-		except (zipfile.BadZipFile, OSError) as e:
+		except (zipfile.BadZipFile, OSError, ValueError) as e:
 			# CRX files have a header before the ZIP data
 			# Skip the CRX header and extract the ZIP part
-			# A corrupt EOCD offset makes zipfile seek to an invalid position,
-			# which surfaces as OSError [Errno 22] (#5506). Other OSErrors are
-			# genuine I/O failures and must propagate instead of being reported
-			# as a format error by the fallback below.
+			# A corrupt EOCD offset makes zipfile seek to an invalid position:
+			# OSError [Errno 22] on real files, ValueError on BytesIO-backed
+			# ones (#5506). Non-EINVAL OSErrors are genuine I/O failures and
+			# must propagate instead of being reported as a format error by
+			# the fallback below.
 			if isinstance(e, OSError) and e.errno != errno.EINVAL:
 				raise
 			with open(crx_path, 'rb') as f:

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1192,7 +1192,7 @@ async function initialize(checkInitialized, magic) {{
 
 	def _extract_extension(self, crx_path: Path, extract_dir: Path) -> None:
 		"""Extract .crx file to directory."""
-		import os
+		import errno
 		import zipfile
 
 		# Remove existing directory
@@ -1212,9 +1212,15 @@ async function initialize(checkInitialized, magic) {{
 			if not (extract_dir / 'manifest.json').exists():
 				raise Exception('No manifest.json found in extension')
 
-		except (zipfile.BadZipFile, OSError, ValueError):
+		except (zipfile.BadZipFile, OSError) as e:
 			# CRX files have a header before the ZIP data
 			# Skip the CRX header and extract the ZIP part
+			# A corrupt EOCD offset makes zipfile seek to an invalid position,
+			# which surfaces as OSError [Errno 22] (#5506). Other OSErrors are
+			# genuine I/O failures and must propagate instead of being reported
+			# as a format error by the fallback below.
+			if isinstance(e, OSError) and e.errno != errno.EINVAL:
+				raise
 			with open(crx_path, 'rb') as f:
 				# Read CRX header to find ZIP start
 				magic = f.read(4)
@@ -1233,16 +1239,29 @@ async function initialize(checkInitialized, magic) {{
 				# Extract ZIP data
 				zip_data = f.read()
 
-			# Write ZIP data to temp file and extract
+			# Write ZIP data to temp file and extract.
+			# The temp file is created with delete=False, so cleanup is ours on
+			# every path: a corrupt payload makes extractall() raise, and the
+			# .zip would otherwise survive in the system temp dir. The handle is
+			# closed before unlinking since Windows refuses to remove files that
+			# still have an open handle.
+			temp_zip_path = None
+			try:
+				with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
+					temp_zip_path = Path(temp_zip.name)
+					temp_zip.write(zip_data)
+					temp_zip.flush()
 
-			with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
-				temp_zip.write(zip_data)
-				temp_zip.flush()
-
-				with zipfile.ZipFile(temp_zip.name, 'r') as zip_ref:
+				with zipfile.ZipFile(temp_zip_path, 'r') as zip_ref:
 					zip_ref.extractall(extract_dir)
-
-				os.unlink(temp_zip.name)
+			finally:
+				if temp_zip_path is not None:
+					try:
+						temp_zip_path.unlink(missing_ok=True)
+					except OSError as cleanup_error:
+						# Never let a cleanup failure replace the extraction
+						# error that is already propagating.
+						logger.warning(f'Failed to remove temp file {_log_pretty_path(temp_zip_path)}: {cleanup_error}')
 
 	def detect_display_configuration(self) -> None:
 		"""

--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -1212,7 +1212,7 @@ async function initialize(checkInitialized, magic) {{
 			if not (extract_dir / 'manifest.json').exists():
 				raise Exception('No manifest.json found in extension')
 
-		except zipfile.BadZipFile:
+		except (zipfile.BadZipFile, OSError, ValueError):
 			# CRX files have a header before the ZIP data
 			# Skip the CRX header and extract the ZIP part
 			with open(crx_path, 'rb') as f:

--- a/tests/ci/test_extract_extension.py
+++ b/tests/ci/test_extract_extension.py
@@ -96,3 +96,18 @@ class TestExtractExtension:
 
 		with pytest.raises(PermissionError):
 			BrowserProfile()._extract_extension(crx, tmp_path / 'out')
+
+	def test_valueerror_from_zipfile_reaches_fallback(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+		"""A ValueError from the first attempt — what a corrupt seek raises on
+		BytesIO-backed files, per #5506 — still routes to the fallback."""
+
+		def failing_extractall(self, path):
+			raise ValueError('negative seek value')
+
+		monkeypatch.setattr(zipfile.ZipFile, 'extractall', failing_extractall)
+
+		crx = tmp_path / 'plain.zip'
+		crx.write_bytes(_zip_payload(corrupt_eocd_offset=False))
+
+		with pytest.raises(Exception, match='Invalid CRX file format'):
+			BrowserProfile()._extract_extension(crx, tmp_path / 'out')

--- a/tests/ci/test_extract_extension.py
+++ b/tests/ci/test_extract_extension.py
@@ -1,0 +1,78 @@
+"""Tests for BrowserProfile._extract_extension corruption handling.
+
+Regression coverage for issue #5506: a .crx whose zip payload has a corrupt
+end-of-central-directory *offset* field makes ``zipfile`` raise
+``OSError: [Errno 22] Invalid argument`` (real files) instead of
+``BadZipFile``, which escaped the old ``except zipfile.BadZipFile`` guard and
+skipped the CRX-header fallback entirely.
+"""
+
+import io
+import struct
+import tempfile
+import zipfile
+
+import pytest
+
+from browser_use.browser.profile import BrowserProfile
+
+CRX3_HEADER = b'crx3-header-placeholder'
+
+
+def _make_crx(payload: bytes) -> bytes:
+	return b'Cr24' + struct.pack('<I', 3) + struct.pack('<I', len(CRX3_HEADER)) + CRX3_HEADER + payload
+
+
+def _zip_payload(corrupt_eocd_offset: bool) -> bytes:
+	buf = io.BytesIO()
+	with zipfile.ZipFile(buf, 'w') as z:
+		z.writestr('manifest.json', '{"manifest_version": 3}')
+	payload = bytearray(buf.getvalue())
+	if corrupt_eocd_offset:
+		eocd = len(payload) - 22
+		payload[eocd + 16 : eocd + 20] = struct.pack('<I', 0xDEADBEEF)
+	return bytes(payload)
+
+
+class TestExtractExtension:
+	def test_extracts_intact_crx_via_header_fallback(self, tmp_path):
+		"""A standard Cr24-wrapped zip extracts through the header fallback."""
+		crx = tmp_path / 'ext.crx'
+		crx.write_bytes(_make_crx(_zip_payload(corrupt_eocd_offset=False)))
+		out = tmp_path / 'out'
+
+		BrowserProfile()._extract_extension(crx, out)
+
+		assert (out / 'manifest.json').exists()
+
+	def test_corrupt_eocd_zip_without_crx_magic_reports_clear_error(self, tmp_path):
+		"""Corrupt-EOCD zip without Cr24 magic raises the clear format error
+		instead of a bare ``OSError: [Errno 22]`` (the issue #5506 improvement)."""
+		crx = tmp_path / 'ext.crx'
+		crx.write_bytes(_zip_payload(corrupt_eocd_offset=True))
+		out = tmp_path / 'out'
+
+		with pytest.raises(Exception, match='Invalid CRX file format'):
+			BrowserProfile()._extract_extension(crx, out)
+
+	def test_corrupt_eocd_crx_reaches_header_fallback(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+		"""Issue #5506 repro: the corrupt-EOCD OSError must be caught by the
+		widened guard so the header fallback runs (and then reports its own
+		failure for the corrupt payload) instead of escaping at first attempt."""
+		calls = []
+		real_named_temporary_file = tempfile.NamedTemporaryFile
+
+		def spy(*args, **kwargs):
+			calls.append(1)
+			return real_named_temporary_file(*args, **kwargs)
+
+		monkeypatch.setattr(tempfile, 'NamedTemporaryFile', spy)
+
+		crx = tmp_path / 'corrupt_eocd.crx'
+		crx.write_bytes(_make_crx(_zip_payload(corrupt_eocd_offset=True)))
+		out = tmp_path / 'out'
+
+		with pytest.raises(Exception):
+			BrowserProfile()._extract_extension(crx, out)
+
+		assert calls, 'CRX-header fallback was not reached'

--- a/tests/ci/test_extract_extension.py
+++ b/tests/ci/test_extract_extension.py
@@ -11,6 +11,7 @@ import io
 import struct
 import tempfile
 import zipfile
+from pathlib import Path
 
 import pytest
 
@@ -59,12 +60,13 @@ class TestExtractExtension:
 		"""Issue #5506 repro: the corrupt-EOCD OSError must be caught by the
 		widened guard so the header fallback runs (and then reports its own
 		failure for the corrupt payload) instead of escaping at first attempt."""
-		calls = []
+		temp_paths = []
 		real_named_temporary_file = tempfile.NamedTemporaryFile
 
 		def spy(*args, **kwargs):
-			calls.append(1)
-			return real_named_temporary_file(*args, **kwargs)
+			handle = real_named_temporary_file(*args, **kwargs)
+			temp_paths.append(handle.name)
+			return handle
 
 		monkeypatch.setattr(tempfile, 'NamedTemporaryFile', spy)
 
@@ -75,4 +77,22 @@ class TestExtractExtension:
 		with pytest.raises(Exception):
 			BrowserProfile()._extract_extension(crx, out)
 
-		assert calls, 'CRX-header fallback was not reached'
+		assert temp_paths, 'CRX-header fallback was not reached'
+		# The widened guard routes this corrupt payload into the fallback, whose
+		# extractall() then fails — the temp .zip must still be cleaned up.
+		assert not Path(temp_paths[0]).exists(), 'temp .zip leaked'
+
+	def test_genuine_io_error_is_not_masked_as_format_error(self, tmp_path, monkeypatch: pytest.MonkeyPatch):
+		"""Non-EINVAL OSErrors from the first attempt propagate instead of
+		triggering the fallback, which would misreport them as a format error."""
+
+		def failing_extractall(self, path):
+			raise PermissionError(13, 'permission denied')
+
+		monkeypatch.setattr(zipfile.ZipFile, 'extractall', failing_extractall)
+
+		crx = tmp_path / 'plain.zip'
+		crx.write_bytes(_zip_payload(corrupt_eocd_offset=False))
+
+		with pytest.raises(PermissionError):
+			BrowserProfile()._extract_extension(crx, tmp_path / 'out')


### PR DESCRIPTION
## Fix

`BrowserProfile._extract_extension()` guarded its first extraction attempt with `except zipfile.BadZipFile`. A `.crx` whose zip payload has a corrupt end-of-central-directory *offset* field makes `zipfile` raise `OSError: [Errno 22] Invalid argument` from its member seeks (`ValueError` on `BytesIO`-backed files). Neither is a `BadZipFile`, so the error escaped `_extract_extension()` unchanged, the CRX-header fallback never ran, and callers saw an unrelated-looking bare `OSError` with no mention of the extension or the file (#5506).

- Widen the first-attempt guard to `except (zipfile.BadZipFile, OSError, ValueError)` — the shape suggested in #5506 — so the header-skipping fallback is reached and its existing `Invalid CRX file format` / `No manifest.json found in extension` messages report the failure. Non-EINVAL `OSError`s re-raise unchanged, so genuine I/O failures (disk full, permission denied) still propagate instead of being misreported as a format error; the intact-CRX fallback path is unchanged.
- Clean up the fallback's temp `.zip` in a `finally` block: with the widened guard, corrupt payloads now reach the fallback and its failing `extractall()` previously left the temp file behind (`delete=False`). Cleanup failures are logged, never replacing the extraction error already propagating. (PR #5504 does a broader cleanup of the same block — if it lands first, this hunk can be dropped.)
- Add `tests/ci/test_extract_extension.py` — no test previously covered `_extract_extension`.

## Verification

- `uv run pytest tests/ci/test_extract_extension.py` — 5 passed:
  - intact CRX still extracts through the header fallback;
  - corrupt-EOCD data without CRX magic now raises the clear `Invalid CRX file format` error instead of bare `OSError`;
  - the issue's exact repro reaches the fallback (asserted via the fallback's temp-file usage) instead of escaping at the first attempt, and the temp `.zip` is cleaned up afterwards;
  - genuine I/O errors (`PermissionError`) propagate instead of being masked as a format error;
  - a `ValueError` from the first attempt still routes to the fallback (the `BytesIO`-backed seek case noted in #5506).
- Manual repro from #5506 (real temp files, CPython 3.12): before → `OSError: [Errno 22] Invalid argument` escaped `_extract_extension()`; after → the fallback runs and reports its clear error.

Refs #5506
