### PR TITLE
fix(llm): preserve Mistral schema field names

### DIFF
--- a/browser_use/llm/mistral/schema.py
+++ b/browser_use/llm/mistral/schema.py
@@ -24,10 +24,15 @@ class MistralSchemaOptimizer:
 		return cls._strip_unsupported_keywords(base_schema)
 
 	@classmethod
-	def _strip_unsupported_keywords(cls, obj: Any) -> Any:
+	def _strip_unsupported_keywords(cls, obj: Any, *, in_properties: bool = False) -> Any:
 		if isinstance(obj, dict):
+			# Keys directly inside `properties` are model field names, not schema keywords.
+			if in_properties:
+				return {key: cls._strip_unsupported_keywords(value) for key, value in obj.items()}
 			return {
-				key: cls._strip_unsupported_keywords(value) for key, value in obj.items() if key not in cls.UNSUPPORTED_KEYWORDS
+				key: cls._strip_unsupported_keywords(value, in_properties=key == 'properties')
+				for key, value in obj.items()
+				if key not in cls.UNSUPPORTED_KEYWORDS
 			}
 		if isinstance(obj, list):
 			return [cls._strip_unsupported_keywords(item) for item in obj]

--- a/tests/ci/models/test_llm_schema_optimizer.py
+++ b/tests/ci/models/test_llm_schema_optimizer.py
@@ -6,6 +6,7 @@ optimizes the schemas for agent actions without losing information.
 from pydantic import BaseModel, Field
 
 from browser_use.agent.views import AgentOutput
+from browser_use.llm.mistral.schema import MistralSchemaOptimizer
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.tools.service import Tools
 
@@ -95,3 +96,38 @@ def test_optimizer_treats_property_names_as_data_not_schema_keywords():
 		field_schema = schema['properties'][field_name]
 		assert '$ref' not in field_schema
 		assert field_schema['properties']['summary']['type'] == 'string'
+
+
+def test_mistral_schema_preserves_property_names_matching_unsupported_keywords():
+	"""Mistral sanitization must distinguish model fields from schema constraints."""
+
+	class KeywordFields(BaseModel):
+		pattern: str
+		format: str
+		minimum_length: str = Field(alias='minLength')
+		maximum_length: str = Field(alias='maxLength')
+		code: str = Field(min_length=2, max_length=4, pattern='[A-Z]+')
+		email: str = Field(json_schema_extra={'format': 'email'})
+
+	class NestedModel(BaseModel):
+		properties: KeywordFields
+
+	schema = MistralSchemaOptimizer.create_mistral_compatible_schema(NestedModel)
+	keyword_schema = schema['properties']['properties']
+
+	assert MistralSchemaOptimizer.UNSUPPORTED_KEYWORDS.issubset(keyword_schema['properties'])
+	assert MistralSchemaOptimizer.UNSUPPORTED_KEYWORDS.issubset(keyword_schema['required'])
+	assert 'minLength' not in keyword_schema['properties']['code']
+	assert 'maxLength' not in keyword_schema['properties']['code']
+	assert 'pattern' not in keyword_schema['properties']['code']
+	assert 'format' not in keyword_schema['properties']['email']
+
+
+def test_mistral_schema_preserves_search_page_pattern_parameter():
+	"""The default search action must remain callable by Mistral models."""
+	from browser_use.tools.views import SearchPageAction
+
+	schema = MistralSchemaOptimizer.create_mistral_compatible_schema(SearchPageAction)
+
+	assert 'pattern' in schema['properties']
+	assert 'pattern' in schema['required']


### PR DESCRIPTION
## Summary

- Preserve model field names that match Mistral's unsupported schema keywords.
- Continue removing actual unsupported constraints such as `pattern`, `format`, `minLength`, and `maxLength` from field schemas.
- Add regressions for nested keyword-named properties and the built-in `SearchPageAction.pattern` parameter.

## Details

The Mistral schema sanitizer previously filtered every dictionary key without distinguishing JSON Schema keywords from keys inside a `properties` map. A valid field named `pattern` was therefore removed from `properties` while remaining in `required`, producing an invalid tool schema for the built-in search-page action.

The recursive sanitizer now treats direct children of `properties` as model field names, then resumes normal keyword filtering inside each field's schema.

## Tests

- `uv run pytest -q tests/ci/models` (118 passed, 7 skipped)
- `uv run pre-commit run --all-files`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Mistral schema sanitizer so model fields named after unsupported schema keywords (like `pattern`) survive, preventing invalid tool schemas for the built-in search action.

- Now treats keys directly under `properties` as model field names, resuming keyword filtering only inside each field's schema.
- Still strips unsupported constraints (`pattern`, `format`, `minLength`, `maxLength`) from field schema definitions.
- Adds regression tests for nested keyword-named properties and the `SearchPageAction.pattern` parameter.

<sup>Written for commit f272841b564b3daaa7672fd70863777e5813b316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

