### PR TITLE
fix(llm): add DeepSeek, Groq, Ollama, and OpenRouter to model factory

### DIFF
--- a/browser_use/llm/models.py
+++ b/browser_use/llm/models.py
@@ -12,14 +12,18 @@ Usage:
 """
 
 import os
+import re
 from typing import TYPE_CHECKING
 
 from browser_use.llm.azure.chat import ChatAzureOpenAI
 from browser_use.llm.browser_use.chat import ChatBrowserUse
 from browser_use.llm.cerebras.chat import ChatCerebras
+from browser_use.llm.deepseek.chat import ChatDeepSeek
 from browser_use.llm.google.chat import ChatGoogle
+from browser_use.llm.groq.chat import ChatGroq
 from browser_use.llm.mistral.chat import ChatMistral
 from browser_use.llm.openai.chat import ChatOpenAI
+from browser_use.llm.openrouter.chat import ChatOpenRouter
 
 # Optional OCI import
 try:
@@ -29,6 +33,14 @@ try:
 except ImportError:
 	ChatOCIRaw = None
 	OCI_AVAILABLE = False
+
+# Optional Ollama import
+try:
+	from browser_use.llm.ollama.chat import ChatOllama
+
+	OLLAMA_AVAILABLE = True
+except ImportError:
+	OLLAMA_AVAILABLE = False
 
 if TYPE_CHECKING:
 	from browser_use.llm.base import BaseChatModel
@@ -79,6 +91,18 @@ anthropic_claude_3_5_haiku_latest: 'BaseChatModel'
 cerebras_gpt_oss_120b: 'BaseChatModel'
 cerebras_zai_glm_4_7: 'BaseChatModel'
 cerebras_gemma_4_31b: 'BaseChatModel'
+
+deepseek_chat: 'BaseChatModel'
+deepseek_reasoner: 'BaseChatModel'
+
+groq_llama_3_3_70b: 'BaseChatModel'
+groq_llama_4_scout: 'BaseChatModel'
+groq_llama_4_maverick: 'BaseChatModel'
+
+ollama_llama3: 'BaseChatModel'
+ollama_llama3_2: 'BaseChatModel'
+
+openrouter_anthropic_claude_3_5_sonnet: 'BaseChatModel'
 
 bu_latest: 'BaseChatModel'
 bu_1_0: 'BaseChatModel'
@@ -135,10 +159,10 @@ def get_llm_by_name(model_name: str):
 		model = model_part.replace('gemini_2_0', 'gemini-2.0').replace('_', '-')
 	elif 'gemini_2_5' in model_part:
 		model = model_part.replace('gemini_2_5', 'gemini-2.5').replace('_', '-')
-	elif 'llama3_1' in model_part:
-		model = model_part.replace('llama3_1', 'llama3.1').replace('_', '-')
-	elif 'llama3_3' in model_part:
-		model = model_part.replace('llama3_3', 'llama-3.3').replace('_', '-')
+	elif 'llama3_1' in model_part or 'llama_3_1' in model_part:
+		model = model_part.replace('llama3_1', 'llama3.1').replace('llama_3_1', 'llama3.1').replace('_', '-')
+	elif 'llama3_3' in model_part or 'llama_3_3' in model_part:
+		model = model_part.replace('llama3_3', 'llama-3.3').replace('llama_3_3', 'llama-3.3').replace('_', '-')
 	elif 'llama_4_scout' in model_part:
 		model = model_part.replace('llama_4_scout', 'llama-4-scout').replace('_', '-')
 	elif 'llama_4_maverick' in model_part:
@@ -213,6 +237,73 @@ def get_llm_by_name(model_name: str):
 		api_key = os.getenv('CEREBRAS_API_KEY')
 		return ChatCerebras(model=model, api_key=api_key)
 
+	# DeepSeek Models
+	elif provider == 'deepseek':
+		api_key = os.getenv('DEEPSEEK_API_KEY')
+		base_url = os.getenv('DEEPSEEK_BASE_URL', 'https://api.deepseek.com/v1')
+		deepseek_map = {
+			'chat': 'deepseek-chat',
+			'reasoner': 'deepseek-reasoner',
+		}
+		normalized_model_part = model_part.replace('_', '-')
+		resolved_model = deepseek_map.get(normalized_model_part, model)
+		if not resolved_model.startswith('deepseek-'):
+			resolved_model = f'deepseek-{resolved_model}'
+		return ChatDeepSeek(model=resolved_model, api_key=api_key, base_url=base_url)
+
+	# Groq Models
+	elif provider == 'groq':
+		api_key = os.getenv('GROQ_API_KEY')
+		base_url = os.getenv('GROQ_BASE_URL')
+		groq_map = {
+			'llama-3.3-70b': 'llama-3.3-70b-versatile',
+			'llama-3.3-70b-versatile': 'llama-3.3-70b-versatile',
+			'llama-4-scout': 'meta-llama/llama-4-scout-17b-16e-instruct',
+			'llama-4-maverick': 'meta-llama/llama-4-maverick-17b-128e-instruct',
+		}
+		normalized_model_part = model_part.replace('_', '-')
+		resolved_model = groq_map.get(normalized_model_part, groq_map.get(model, model))
+		return ChatGroq(model=resolved_model, api_key=api_key, base_url=base_url)
+
+	# Ollama Models
+	elif provider == 'ollama':
+		if not OLLAMA_AVAILABLE:
+			raise ImportError('Ollama integration not available. Install with: pip install ollama')
+		ollama_map = {
+			'llama3_1': 'llama3.1',
+			'llama3-1': 'llama3.1',
+			'llama3_2': 'llama3.2',
+			'llama3-2': 'llama3.2',
+			'llama3_3': 'llama3.3',
+			'llama3-3': 'llama3.3',
+			'llama_3_1': 'llama3.1',
+			'llama_3_2': 'llama3.2',
+			'llama_3_3': 'llama3.3',
+			'qwen2_5': 'qwen2.5',
+			'qwen2-5': 'qwen2.5',
+			'deepseek_r1': 'deepseek-r1',
+		}
+		if model_part in ollama_map:
+			resolved_model = ollama_map[model_part]
+		elif model in ollama_map:
+			resolved_model = ollama_map[model]
+		else:
+			resolved_model = re.sub(r'(\d+)[_-](\d+)(?![a-zA-Z\d])', r'\1.\2', model_part)
+			resolved_model = resolved_model.replace('_', '-')
+		host = os.getenv('OLLAMA_HOST')
+		return ChatOllama(model=resolved_model, host=host)
+
+	# OpenRouter Models
+	elif provider == 'openrouter':
+		api_key = os.getenv('OPENROUTER_API_KEY')
+		base_url = os.getenv('OPENROUTER_BASE_URL', 'https://openrouter.ai/api/v1')
+		openrouter_map = {
+			'anthropic_claude_3_5_sonnet': 'anthropic/claude-3.5-sonnet',
+			'anthropic-claude-3-5-sonnet': 'anthropic/claude-3.5-sonnet',
+		}
+		resolved_model = openrouter_map.get(model_part, openrouter_map.get(model, model))
+		return ChatOpenRouter(model=resolved_model, api_key=api_key, base_url=base_url)
+
 	# Browser Use Models
 	elif provider == 'bu':
 		# Handle bu_latest -> bu-latest conversion (need to prepend 'bu-' back)
@@ -221,7 +312,20 @@ def get_llm_by_name(model_name: str):
 		return ChatBrowserUse(model=model, api_key=api_key)
 
 	else:
-		available_providers = ['openai', 'azure', 'google', 'anthropic', 'mistral', 'oci', 'cerebras', 'bu']
+		available_providers = [
+			'openai',
+			'azure',
+			'google',
+			'anthropic',
+			'mistral',
+			'oci',
+			'cerebras',
+			'deepseek',
+			'groq',
+			'ollama',
+			'openrouter',
+			'bu',
+		]
 		raise ValueError(f"Unknown provider: '{provider}'. Available providers: {', '.join(available_providers)}")
 
 
@@ -245,6 +349,16 @@ def __getattr__(name: str) -> 'BaseChatModel':
 		return ChatOCIRaw  # type: ignore
 	elif name == 'ChatCerebras':
 		return ChatCerebras  # type: ignore
+	elif name == 'ChatDeepSeek':
+		return ChatDeepSeek  # type: ignore
+	elif name == 'ChatGroq':
+		return ChatGroq  # type: ignore
+	elif name == 'ChatOllama':
+		if not OLLAMA_AVAILABLE:
+			raise ImportError('Ollama integration not available. Install with: pip install ollama')
+		return ChatOllama  # type: ignore
+	elif name == 'ChatOpenRouter':
+		return ChatOpenRouter  # type: ignore
 	elif name == 'ChatBrowserUse':
 		return ChatBrowserUse  # type: ignore
 
@@ -263,10 +377,15 @@ __all__ = [
 	'ChatMistral',
 	'ChatCerebras',
 	'ChatBrowserUse',
+	'ChatDeepSeek',
+	'ChatGroq',
+	'ChatOpenRouter',
 ]
 
 if OCI_AVAILABLE:
 	__all__.append('ChatOCIRaw')
+if OLLAMA_AVAILABLE:
+	__all__.append('ChatOllama')
 
 __all__ += [
 	'get_llm_by_name',
@@ -317,6 +436,18 @@ __all__ += [
 	'cerebras_gpt_oss_120b',
 	'cerebras_zai_glm_4_7',
 	'cerebras_gemma_4_31b',
+	# DeepSeek instances - created on demand
+	'deepseek_chat',
+	'deepseek_reasoner',
+	# Groq instances - created on demand
+	'groq_llama_3_3_70b',
+	'groq_llama_4_scout',
+	'groq_llama_4_maverick',
+	# Ollama instances - created on demand
+	'ollama_llama3',
+	'ollama_llama3_2',
+	# OpenRouter instances - created on demand
+	'openrouter_anthropic_claude_3_5_sonnet',
 	# Browser Use instances - created on demand
 	'bu_latest',
 	'bu_1_0',

--- a/tests/ci/models/test_llm_model_factory.py
+++ b/tests/ci/models/test_llm_model_factory.py
@@ -1,8 +1,17 @@
 import pytest
 
+from browser_use.llm import models
 from browser_use.llm.anthropic.chat import ChatAnthropic
 from browser_use.llm.cerebras.chat import ChatCerebras
+from browser_use.llm.deepseek.chat import ChatDeepSeek
+from browser_use.llm.groq.chat import ChatGroq
 from browser_use.llm.models import get_llm_by_name
+from browser_use.llm.openrouter.chat import ChatOpenRouter
+
+try:
+	from browser_use.llm.ollama.chat import ChatOllama
+except ImportError:
+	ChatOllama = None  # type: ignore
 
 
 def test_get_llm_by_name_resolves_anthropic_from_env(monkeypatch):
@@ -39,3 +48,97 @@ def test_get_llm_by_name_preserves_served_mistral_aliases(monkeypatch: pytest.Mo
 	assert get_llm_by_name('mistral_medium').model == 'mistral-medium-latest'
 	assert get_llm_by_name('mistral_small').model == 'mistral-small-latest'
 	assert get_llm_by_name('codestral').model == 'codestral-latest'
+
+
+def test_get_llm_by_name_resolves_deepseek_from_env(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('DEEPSEEK_API_KEY', 'deepseek-test-key')
+
+	llm = get_llm_by_name('deepseek_chat')
+	assert isinstance(llm, ChatDeepSeek)
+	assert llm.model == 'deepseek-chat'
+	assert llm.api_key == 'deepseek-test-key'
+	assert llm.base_url == 'https://api.deepseek.com/v1'
+
+	llm_reasoner = get_llm_by_name('deepseek_reasoner')
+	assert isinstance(llm_reasoner, ChatDeepSeek)
+	assert llm_reasoner.model == 'deepseek-reasoner'
+
+
+def test_get_llm_by_name_resolves_groq_from_env(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('GROQ_API_KEY', 'groq-test-key')
+
+	llm = get_llm_by_name('groq_llama_4_scout')
+	assert isinstance(llm, ChatGroq)
+	assert llm.model == 'meta-llama/llama-4-scout-17b-16e-instruct'
+	assert llm.api_key == 'groq-test-key'
+
+	llm_33 = get_llm_by_name('groq_llama_3_3_70b')
+	assert isinstance(llm_33, ChatGroq)
+	assert llm_33.model == 'llama-3.3-70b-versatile'
+
+
+@pytest.mark.skipif(not models.OLLAMA_AVAILABLE, reason='ollama not installed')
+def test_get_llm_by_name_resolves_ollama_from_env(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('OLLAMA_HOST', 'http://localhost:11434')
+
+	llm = get_llm_by_name('ollama_llama3')
+	assert isinstance(llm, ChatOllama)
+	assert llm.model == 'llama3'
+	assert llm.host == 'http://localhost:11434'
+
+	# Dotted model normalization
+	llm_dotted = get_llm_by_name('ollama_llama3_2')
+	assert isinstance(llm_dotted, ChatOllama)
+	assert llm_dotted.model == 'llama3.2'
+
+	llm_qwen = get_llm_by_name('ollama_qwen2_5')
+	assert isinstance(llm_qwen, ChatOllama)
+	assert llm_qwen.model == 'qwen2.5'
+
+	# Multi-digit minor versions are normalized to dot
+	llm_multi_digit = get_llm_by_name('ollama_v2_10')
+	assert isinstance(llm_multi_digit, ChatOllama)
+	assert llm_multi_digit.model == 'v2.10'
+
+	# Parameter size suffixes preserved without dot conversion
+	llm_size = get_llm_by_name('ollama_qwen3_32b')
+	assert isinstance(llm_size, ChatOllama)
+	assert llm_size.model == 'qwen3-32b'
+
+	llm_r1_size = get_llm_by_name('ollama_deepseek_r1_7b')
+	assert isinstance(llm_r1_size, ChatOllama)
+	assert llm_r1_size.model == 'deepseek-r1-7b'
+
+
+def test_ollama_unavailable_raises_import_error(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setattr(models, 'OLLAMA_AVAILABLE', False)
+	with pytest.raises(ImportError, match='Ollama integration not available'):
+		get_llm_by_name('ollama_llama3')
+
+	with pytest.raises(ImportError, match='Ollama integration not available'):
+		models.__getattr__('ChatOllama')
+
+
+def test_get_llm_by_name_resolves_openrouter_from_env(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('OPENROUTER_API_KEY', 'openrouter-test-key')
+
+	llm = get_llm_by_name('openrouter_anthropic_claude_3_5_sonnet')
+	assert isinstance(llm, ChatOpenRouter)
+	assert llm.model == 'anthropic/claude-3.5-sonnet'
+	assert llm.api_key == 'openrouter-test-key'
+	assert llm.base_url == 'https://openrouter.ai/api/v1'
+
+
+def test_models_lazy_attributes_and_exports(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.setenv('DEEPSEEK_API_KEY', 'deepseek-key')
+	monkeypatch.setenv('GROQ_API_KEY', 'groq-key')
+
+	assert models.ChatDeepSeek is ChatDeepSeek
+	assert models.ChatGroq is ChatGroq
+	if models.OLLAMA_AVAILABLE:
+		assert models.ChatOllama is ChatOllama
+	assert models.ChatOpenRouter is ChatOpenRouter
+
+	deepseek_model = models.deepseek_chat
+	assert isinstance(deepseek_model, ChatDeepSeek)
+	assert deepseek_model.model == 'deepseek-chat'


### PR DESCRIPTION
## Summary

- Add DeepSeek, Groq, Ollama, and OpenRouter model resolution to `browser_use.llm.models.get_llm_by_name()`.
- Add module exports and lazy resolution for `ChatDeepSeek`, `ChatGroq`, `ChatOllama`, `ChatOpenRouter` and preconfigured model instances via `__getattr__`.
- Safely handle optional `ollama` dependency so `models` module imports cleanly in environments without it installed.
- Add comprehensive regression tests in `tests/ci/models/test_llm_model_factory.py`.

## Details

`browser_use.llm.models` acts as the central model resolution factory for CLI defaults and agent instantiation (`get_llm_by_name()`), as well as providing convenient lazy module attributes (e.g. `from browser_use.llm import models; models.deepseek_chat`).

Although `ChatDeepSeek`, `ChatGroq`, `ChatOllama`, and `ChatOpenRouter` adapters exist in `browser_use/llm/`, requesting them through `get_llm_by_name()` failed with `ValueError: Unknown provider: 'deepseek'` (or groq/ollama/openrouter) because provider handling was missing from the dispatch table.

This change:
1. Wires provider handling for `deepseek`, `groq`, `ollama`, and `openrouter` with their standard environment variable configurations (`DEEPSEEK_API_KEY`, `GROQ_API_KEY`, `OLLAMA_HOST`, `OPENROUTER_API_KEY`).
2. Normalizes model IDs (e.g. mapping `deepseek_chat` -> `deepseek-chat`, `groq_llama_4_scout` -> `meta-llama/llama-4-scout-17b-16e-instruct`, `openrouter_anthropic_claude_3_5_sonnet` -> `anthropic/claude-3.5-sonnet`).
3. Supports lazy instantiation via `__getattr__` and adds type stubs for autocomplete.
4. Protects `ollama` behind a try/except guard matching `ChatOCIRaw`.

## Tests

- `pytest tests/ci/models/test_llm_model_factory.py` (9 passed)
- `ruff check browser_use/llm/models.py tests/ci/models/test_llm_model_factory.py`
- `ruff format --check browser_use/llm/models.py tests/ci/models/test_llm_model_factory.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DeepSeek, Groq, Ollama, and OpenRouter to the LLM model factory. `get_llm_by_name()` now resolves these providers using their standard environment variables; before it raised `ValueError: Unknown provider` for them.

**Notes**
- Model names normalize to provider aliases, e.g. `groq_llama_4_scout` maps to `meta-llama/llama-4-scout-17b-16e-instruct`, and dotless names like `ollama_qwen2_5` become `qwen2.5`.
- Ollama stays optional: without the `ollama` package installed, the module imports cleanly but use raises `ImportError`.
- Adds lazy module attributes and type stubs for `ChatDeepSeek`, `ChatGroq`, `ChatOllama`, and `ChatOpenRouter`.

<sup>Written for commit d017a43c25b1cbf4a970754dc1407cb8672c37dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

