### PR TITLE
ci: run the platform-sensitive tests on Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -181,6 +181,62 @@ jobs:
           retry_on: error
           command: pytest "tests/ci/${{ matrix.test_filename }}.py"
 
+  windows-tests:
+    # The suite otherwise only ever runs on Linux, so the Windows branches in
+    # chrome discovery, profile locking, process teardown and path handling are
+    # never exercised. This job covers the platform-sensitive, non-UI tests.
+    runs-on: windows-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    env:
+      # Deliberately no IN_DOCKER here: it disables the Chromium sandbox, and a
+      # Windows runner is not a container.
+      ANONYMIZED_TELEMETRY: 'false'
+      BROWSER_USE_CLOUD_SYNC: 'false'
+      BROWSER_USE_LOGGING_LEVEL: 'DEBUG'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          activate-environment: true
+
+      - name: Cache uv packages and venv
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/AppData/Local/uv/cache
+            .venv
+          key: ${{ runner.os }}-uv-venv-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-venv-
+
+      - run: uv sync --dev --all-extras --refresh-package browser-use-core
+
+      - name: Get week number for cache key
+        id: week
+        run: echo "number=$(date +%Y-W%U)" >> $GITHUB_OUTPUT
+
+      - name: Cache chromium binaries
+        id: cache-chromium
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/AppData/Local/ms-playwright
+          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ steps.week.outputs.number }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-chromium-
+
+      - name: Install Chromium browser if not cached
+        if: steps.cache-chromium.outputs.cache-hit != 'true'
+        # --with-deps installs Linux system packages and is not supported here
+        run: uvx playwright install chromium --no-shell
+
+      - name: Run platform-sensitive tests
+        run: pytest tests/ci/infrastructure tests/ci/models tests/ci/security
+
   evaluate-tasks:
     needs: setup-chromium
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -191,11 +191,14 @@ jobs:
       run:
         shell: bash
     env:
-      # Deliberately no IN_DOCKER here: it disables the Chromium sandbox, and a
-      # Windows runner is not a container.
+      # IN_DOCKER is intentionally left unset: setting it would turn the Chromium
+      # sandbox off, and a Windows runner is not a container.
       ANONYMIZED_TELEMETRY: 'false'
       BROWSER_USE_CLOUD_SYNC: 'false'
       BROWSER_USE_LOGGING_LEVEL: 'DEBUG'
+      # Redirected stdout defaults to the ANSI code page on Windows, and addopts
+      # carries -s, so non-ASCII test output would depend on the runner locale.
+      PYTHONIOENCODING: 'utf-8'
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -218,27 +218,11 @@ jobs:
 
       - run: uv sync --dev --all-extras --refresh-package browser-use-core
 
-      - name: Get week number for cache key
-        id: week
-        run: echo "number=$(date +%Y-W%U)" >> $GITHUB_OUTPUT
-
-      - name: Cache chromium binaries
-        id: cache-chromium
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/AppData/Local/ms-playwright
-          key: ${{ runner.os }}-${{ runner.arch }}-chromium-${{ steps.week.outputs.number }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-chromium-
-
-      - name: Install Chromium browser if not cached
-        if: steps.cache-chromium.outputs.cache-hit != 'true'
-        # --with-deps installs Linux system packages and is not supported here
-        run: uvx playwright install chromium --no-shell
-
       - name: Run platform-sensitive tests
-        run: pytest tests/ci/infrastructure tests/ci/models tests/ci/security
+        # The two registry files drive a real browser, and starting/tearing down
+        # Chrome repeatedly hangs on the Windows runner rather than failing, which
+        # eats the whole job budget. Excluded until that is fixed separately.
+        run: pytest tests/ci/infrastructure tests/ci/models tests/ci/security --ignore=tests/ci/infrastructure/test_registry_core.py --ignore=tests/ci/infrastructure/test_registry_action_parameter_injection.py
 
   evaluate-tasks:
     needs: setup-chromium

--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -84,7 +84,11 @@ class TestLazyConfig:
 
 			# Test default path expansion
 			os.environ.pop('XDG_CACHE_HOME', None)
-			assert '/.cache' in str(CONFIG.XDG_CACHE_HOME)
+			# Compare path components instead of a substring: str(Path) uses the platform
+			# separator, so a hardcoded '/.cache' never matches on Windows
+			default_cache = CONFIG.XDG_CACHE_HOME
+			assert default_cache.name == '.cache'
+			assert default_cache.parent == Path.home().resolve()
 		finally:
 			if original_value:
 				os.environ['XDG_CACHE_HOME'] = original_value

--- a/tests/ci/infrastructure/test_registry_core.py
+++ b/tests/ci/infrastructure/test_registry_core.py
@@ -9,6 +9,7 @@ Tests cover:
 5. Registry execution edge cases
 """
 
+import asyncio
 import logging
 
 import pytest
@@ -110,7 +111,7 @@ async def browser_session(base_url):
 	# dispatch swallows handler exceptions, so check the result to surface a failed
 	# navigation here rather than as a confusing assertion later in the test.
 	event = browser_session.event_bus.dispatch(NavigateToUrlEvent(url=f'{base_url}/test'))
-	await event
+	await asyncio.wait_for(event, timeout=15)
 	await event.event_result(raise_if_any=True, raise_if_none=False)
 	yield browser_session
 	await browser_session.kill()

--- a/tests/ci/infrastructure/test_registry_core.py
+++ b/tests/ci/infrastructure/test_registry_core.py
@@ -106,9 +106,12 @@ async def browser_session(base_url):
 	from browser_use.browser.events import NavigateToUrlEvent
 
 	# Await the event instead of sleeping: a fixed delay is not long enough for a
-	# cold browser start on a slower runner, which leaves the page on about:blank
+	# cold browser start on a slower runner, which leaves the page on about:blank.
+	# dispatch swallows handler exceptions, so check the result to surface a failed
+	# navigation here rather than as a confusing assertion later in the test.
 	event = browser_session.event_bus.dispatch(NavigateToUrlEvent(url=f'{base_url}/test'))
 	await event
+	await event.event_result(raise_if_any=True, raise_if_none=False)
 	yield browser_session
 	await browser_session.kill()
 

--- a/tests/ci/infrastructure/test_registry_core.py
+++ b/tests/ci/infrastructure/test_registry_core.py
@@ -9,7 +9,6 @@ Tests cover:
 5. Registry execution edge cases
 """
 
-import asyncio
 import logging
 
 import pytest
@@ -106,8 +105,10 @@ async def browser_session(base_url):
 	await browser_session.start()
 	from browser_use.browser.events import NavigateToUrlEvent
 
-	browser_session.event_bus.dispatch(NavigateToUrlEvent(url=f'{base_url}/test'))
-	await asyncio.sleep(0.5)  # Wait for navigation
+	# Await the event instead of sleeping: a fixed delay is not long enough for a
+	# cold browser start on a slower runner, which leaves the page on about:blank
+	event = browser_session.event_bus.dispatch(NavigateToUrlEvent(url=f'{base_url}/test'))
+	await event
 	yield browser_session
 	await browser_session.kill()
 


### PR DESCRIPTION
## Summary

Every job in `test.yaml` runs on `ubuntu-latest`. The Windows branches in the codebase are therefore never executed by CI, and there is no way to confirm a Windows fix works short of owning a Windows machine.

That shows up in the PR history: of the Windows-related PRs opened against this repo, roughly 7 have merged and 58 were closed unmerged, most by the stale bot rather than on review. That reads less like disagreement and more like nothing being able to verify the change.

This adds one `windows-latest` job, and fixes the two test bugs it uncovered.

## What the job covers

`tests/ci/infrastructure`, `tests/ci/models` and `tests/ci/security`, minus the two files that drive a real browser. That is **335 passed, 7 skipped, 0 failed**, and the job completes in **1m24s** against a 20 minute cap.

Between them those directories cover config and path handling, the filesystem layer, the LLM serializers, and the security and domain rules, all of which sit on top of the path, encoding and process code that differs on Windows.

## What it deliberately does not cover, and why

`test_registry_core.py` and `test_registry_action_parameter_injection.py` start a real `BrowserSession`. Repeatedly starting and killing Chrome **hangs** on a Windows runner rather than failing: an earlier revision of this PR sat on the full 20 minute cap partway through the registry tests, and pytest's own `timeout = 300` never fired.

So this job does not currently exercise Chrome discovery or browser process teardown on Windows. That is the more interesting half and I would rather report it separately than hold up coverage for everything else. It is reproducible on demand in CI, which is more than the existing Windows CDP reports (#5048, #5051, #4571) have had to work with.

## Design notes

**A separate job, not an `os:` matrix on `tests`.** That job fans out one runner per test file, currently 121 of them, so an OS axis would mean 242 jobs per run at the higher Windows rate. One job keeps this in the noise.

**No Chromium install or cache steps.** Nothing in the scoped run needs a browser, so installing one would just cost time.

**`IN_DOCKER` is left unset.** `chromium_sandbox` defaults to `not CONFIG.IN_DOCKER`, so leaving it unset keeps the sandbox enabled, which is what Windows users actually run. Setting it would turn the sandbox off, and a Windows runner is not a container.

**`PYTHONIOENCODING` is pinned to `utf-8`.** Redirected stdout defaults to the ANSI code page on Windows and `addopts` carries `-s`, so otherwise non-ASCII test output depends on the runner locale.

**uv cache path follows the platform**: `~/AppData/Local/uv/cache`, keyed on `runner.os` so the Linux and Windows caches do not collide.

## The two test fixes

**A POSIX-only assertion.** `test_path_configuration` asserted `'/.cache' in str(CONFIG.XDG_CACHE_HOME)`. `str(Path)` renders the platform separator, so on Windows that compares against `C:\Users\<user>\.cache` and the forward slash can never match. The production property is already correct on every platform; only the assertion was not. It now checks that the default cache directory is named `.cache` and sits under the user's home, which is what the test is actually about.

**A timing-dependent navigation wait.** The `browser_session` fixture dispatched `NavigateToUrlEvent` without awaiting it and slept a fixed 0.5s. That is enough on a warm local machine but not for a cold browser start on a slower runner, where the page is still `about:blank` when the test reads it:

```
assert '/test' in result.extracted_content
AssertionError: assert '/test' in 'No params action executed on about:blank'
```

It now awaits the event with a 15s bound and checks the event result, matching what `BrowserSession.start()`, `BrowserSession._navigate()` and `test_navigation_slow_pages.py` already do. The bound matters: awaiting with no timeout turns a stuck navigation into a hang instead of a failure, and the event bus swallows handler exceptions unless the result is checked.

## Validation

- The job's exact command on Windows 11: 335 passed, 7 skipped
- `tests/ci/infrastructure/test_registry_core.py` on Windows 11: 18 passed
- `ruff check --no-fix --select PLE`, `ruff check`, `ruff format --check`
- `pyright`  0 errors
- `pre-commit run --files .github/workflows/test.yaml tests/ci/infrastructure/test_config.py tests/ci/infrastructure/test_registry_core.py`  all passed, including `check yaml`
