### PR TITLE
fix(agent): redact sensitive_data from every action in saved history

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -550,12 +550,11 @@ class AgentHistory(BaseModel):
 		if self.model_output:
 			action_dump = [action.model_dump(exclude_none=True, mode='json') for action in self.model_output.action]
 
-			# Filter sensitive data only from input action parameters if sensitive_data is provided
+			# Filter sensitive data from every action's parameters if sensitive_data is provided.
+			# Redaction is cheap, and keying it on a hardcoded action name silently skips the
+			# built-in `input_text` action, which is the most common way a secret reaches history.
 			if sensitive_data:
-				action_dump = [
-					self._filter_sensitive_data_from_dict(action, sensitive_data) if 'input' in action else action
-					for action in action_dump
-				]
+				action_dump = [self._filter_sensitive_data_from_dict(action, sensitive_data) for action in action_dump]
 
 			model_output_dump = {
 				'evaluation_previous_goal': self.model_output.evaluation_previous_goal,

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -670,3 +670,79 @@ def test_history_filters_sensitive_data_inside_nested_lists(tmp_path):
 
 	assert 'token-123' not in saved, 'Sensitive value leaked into the saved history file'
 	assert saved.count('<secret>api_key</secret>') == 2
+
+
+def test_history_filters_sensitive_data_from_input_text_action(tmp_path):
+	"""Regression test for the built-in `input_text` action leaking secrets into saved history.
+
+	The name-based guard used to be `if 'input' in action`, which is a dict-key lookup on
+	`{'input_text': ...}` and therefore always False for the built-in action.
+	"""
+	from typing import Any
+
+	from pydantic import create_model
+
+	from browser_use.agent.views import AgentHistory, AgentHistoryList, AgentOutput
+	from browser_use.browser.views import BrowserStateHistory
+	from browser_use.tools.registry.views import ActionModel
+	from browser_use.tools.views import InputTextAction
+
+	InputTextActionModel = create_model('InputTextActionModel', __base__=ActionModel, input_text=(InputTextAction | None, None))
+	OutputModel = AgentOutput.type_with_custom_actions(InputTextActionModel)
+
+	# built via model_validate because create_model's field is invisible to static analysis
+	action = InputTextActionModel.model_validate({'input_text': {'index': 1, 'text': 'token-123', 'clear': True}})
+	history = AgentHistoryList[Any](
+		history=[
+			AgentHistory(
+				model_output=OutputModel(memory='', action=[action]),
+				result=[],
+				state=BrowserStateHistory(url='https://example.test', title='t', tabs=[], interacted_element=[None]),
+			)
+		]
+	)
+
+	filepath = tmp_path / 'history.json'
+	history.save_to_file(filepath, sensitive_data={'api_key': 'token-123'})
+	saved = filepath.read_text(encoding='utf-8')
+
+	assert 'token-123' not in saved, 'Sensitive value leaked into the saved history file'
+	assert '<secret>api_key</secret>' in saved
+
+
+def test_history_filters_sensitive_data_from_actions_without_input_in_the_name(tmp_path):
+	"""Redaction must not depend on the action name containing 'input'.
+
+	A custom action can carry a secret too, so every action's parameters are filtered.
+	"""
+	from typing import Any
+
+	from pydantic import BaseModel, create_model
+
+	from browser_use.agent.views import AgentHistory, AgentHistoryList, AgentOutput
+	from browser_use.browser.views import BrowserStateHistory
+	from browser_use.tools.registry.views import ActionModel
+
+	class SearchParams(BaseModel):
+		query: str
+
+	SearchActionModel = create_model('SearchActionModel', __base__=ActionModel, search=(SearchParams | None, None))
+	OutputModel = AgentOutput.type_with_custom_actions(SearchActionModel)
+
+	action = SearchActionModel.model_validate({'search': {'query': 'token-123'}})
+	history = AgentHistoryList[Any](
+		history=[
+			AgentHistory(
+				model_output=OutputModel(memory='', action=[action]),
+				result=[],
+				state=BrowserStateHistory(url='https://example.test', title='t', tabs=[], interacted_element=[None]),
+			)
+		]
+	)
+
+	filepath = tmp_path / 'history.json'
+	history.save_to_file(filepath, sensitive_data={'api_key': 'token-123'})
+	saved = filepath.read_text(encoding='utf-8')
+
+	assert 'token-123' not in saved, 'Sensitive value leaked into the saved history file'
+	assert '<secret>api_key</secret>' in saved


### PR DESCRIPTION
## Summary

`sensitive_data` is never redacted from the built-in `input_text` action, so a typed password or API key is written to the history file in plaintext.

`AgentHistory.model_dump` decides which actions to filter with this guard (`browser_use/agent/views.py`):

```python
action_dump = [
    self._filter_sensitive_data_from_dict(action, sensitive_data) if 'input' in action else action
    for action in action_dump
]
```

`action` here is the dumped action, shaped `{action_name: params}`. So `'input' in action` is a **dict key lookup, not a substring test**. For the built-in input action the key is `input_text`, and `'input' in {'input_text': ...}` is `False` — the filter is skipped entirely. The guard only ever fires for an action literally named `input`, which no built-in action is.

Reproduced on `main` (`e25ab65e6`) with the script from #5679:

```
dumped action dict: {'input_text': {'index': 1, 'text': 'token-123', 'clear': True}}
guard `'input' in action` evaluates to: False
secret still present in saved history: True
placeholder present: False
```

After this change:

```
secret still present in saved history: False
placeholder present: True
```

## Fix

Drop the name-based guard and filter every action's parameters:

```python
if sensitive_data:
    action_dump = [self._filter_sensitive_data_from_dict(action, sensitive_data) for action in action_dump]
```

Redaction is cheap, and an allowlist keyed on one hardcoded action name keeps missing cases as new actions are added. A custom action can carry a secret just as easily as `input_text` can. #5662 already made the recursion complete, so actually invoking the filter is now enough to close the gap end to end — this is the "better fix" mentioned in #5679.

## Scope

This covers `model_output.action` parameters only. `thinking`, `memory` and `ActionResult` payloads are still written unfiltered, matching the existing behaviour (the code already documents `ActionResult` as deliberately unfiltered). Happy to extend to those in a follow-up if maintainers want it.

## Test plan

- `pytest tests/ci/security/test_sensitive_data.py` — 19 passed (2 new)
  - `test_history_filters_sensitive_data_from_input_text_action` — the exact #5679 case; fails on `main`
  - `test_history_filters_sensitive_data_from_actions_without_input_in_the_name` — pins that redaction no longer depends on the action name
- Both new tests were verified to fail with the guard restored and pass with it removed.
- `ruff check` clean on both changed files.

Fixes #5679


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sensitive data leaking into saved history files when an agent types credentials. The old filter only matched an action literally named `input`, so the built-in `input_text` action—the most common path for typed secrets—was never redacted.

Redaction now applies to every action's parameters, including custom actions. Scope is limited to `model_output.action`; `thinking`, `memory`, and `ActionResult` payloads remain unfiltered, matching existing behavior.

Fixes #5679.

<sup>Written for commit 25b473018749920fd4beb2996d0cbaab2ebd31b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

