### PR TITLE
fix(browser): only wait for navigation when Enter was actually sent

### DIFF
--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -2509,6 +2509,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 			is_combination = False
 			modifiers = []
 			main_key = None
+			sent_enter = False
 			if '+' in keys and keys != '+':
 				if keys.endswith('++'):
 					prefix = keys[:-2]
@@ -2543,6 +2544,9 @@ class DefaultActionWatchdog(BaseWatchdog):
 				await self._dispatch_key_event(cdp_session, 'keyDown', main_key, modifier_value)
 
 				await self._dispatch_key_event(cdp_session, 'keyUp', main_key, modifier_value)
+
+				if main_key == 'Enter':
+					sent_enter = True
 
 				# Release modifier keys
 				for mod in reversed(modifiers):
@@ -2597,6 +2601,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 							},
 							session_id=cdp_session.session_id,
 						)
+						sent_enter = True
 					await self._dispatch_key_event(cdp_session, 'keyUp', normalized_keys)
 				else:
 					# It's text (single character or string) - send each character as text input
@@ -2631,6 +2636,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 								},
 								session_id=cdp_session.session_id,
 							)
+							sent_enter = True
 							continue
 
 						# Get proper modifiers and key info for the character
@@ -2678,7 +2684,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 
 			# Note: We don't clear cached state on Enter; multi_act will detect DOM changes
 			# and rebuild explicitly. We still wait briefly for potential navigation.
-			if 'enter' in event.keys.lower() or 'return' in event.keys.lower():
+			if sent_enter:
 				await asyncio.sleep(0.1)
 		except Exception as e:
 			raise

--- a/tests/ci/browser/test_send_keys_enter_delay.py
+++ b/tests/ci/browser/test_send_keys_enter_delay.py
@@ -1,0 +1,94 @@
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from browser_use.browser.events import SendKeysEvent
+from browser_use.browser.watchdogs.default_action_watchdog import DefaultActionWatchdog
+
+ENTER_DELAY = 0.1
+CHAR_DELAY = 0.010
+
+
+def make_watchdog(recorded_params, dispatched_keys) -> DefaultActionWatchdog:
+	class Input:
+		async def dispatchKeyEvent(self, params=None, session_id=None):
+			recorded_params.append(params or {})
+
+	cdp_session = SimpleNamespace(
+		cdp_client=SimpleNamespace(send=SimpleNamespace(Input=Input())),
+		session_id='session-1',
+	)
+
+	class BrowserSession:
+		async def get_or_create_cdp_session(self, focus=False):
+			return cdp_session
+
+	async def dispatch_key_event(_session, event_type, key, modifiers=0):
+		dispatched_keys.append((event_type, key, modifiers))
+
+	watchdog = SimpleNamespace(
+		browser_session=BrowserSession(),
+		logger=SimpleNamespace(info=lambda *args, **kwargs: None),
+		_dispatch_key_event=dispatch_key_event,
+	)
+	watchdog._get_char_modifiers_and_vk = DefaultActionWatchdog._get_char_modifiers_and_vk.__get__(watchdog)
+	watchdog._get_key_code_for_char = DefaultActionWatchdog._get_key_code_for_char.__get__(watchdog)
+	return cast(DefaultActionWatchdog, watchdog)
+
+
+def send_keys_and_collect_delays(keys: str, monkeypatch: pytest.MonkeyPatch) -> list[float]:
+	"""Run on_SendKeysEvent with asyncio.sleep stubbed out and return every requested delay."""
+	delays: list[float] = []
+
+	async def fake_sleep(delay, *args, **kwargs):
+		delays.append(delay)
+
+	monkeypatch.setattr(asyncio, 'sleep', fake_sleep)
+
+	recorded_params: list[dict] = []
+	dispatched_keys: list[tuple] = []
+	watchdog = make_watchdog(recorded_params, dispatched_keys)
+	asyncio.run(DefaultActionWatchdog.on_SendKeysEvent(watchdog, SendKeysEvent(keys=keys)))
+	return delays
+
+
+@pytest.mark.parametrize('keys', ['center', 'enterprise', 'returning'])
+def test_plain_text_containing_enter_or_return_gets_no_navigation_delay(monkeypatch, keys):
+	"""'enter'/'return' as substrings of ordinary text must not trigger the Enter delay."""
+	delays = send_keys_and_collect_delays(keys, monkeypatch)
+
+	assert ENTER_DELAY not in delays
+	assert delays == [CHAR_DELAY] * len(keys)
+
+
+@pytest.mark.parametrize('keys', ['Enter', 'Return', 'enter', 'return'])
+def test_enter_key_gets_the_navigation_delay(monkeypatch, keys):
+	delays = send_keys_and_collect_delays(keys, monkeypatch)
+
+	assert ENTER_DELAY in delays
+
+
+def test_newline_inside_text_gets_the_navigation_delay(monkeypatch):
+	delays = send_keys_and_collect_delays('line1\nline2', monkeypatch)
+
+	assert ENTER_DELAY in delays
+
+
+def test_shortcut_whose_main_key_is_enter_gets_the_navigation_delay(monkeypatch):
+	delays = send_keys_and_collect_delays('Control+Enter', monkeypatch)
+
+	assert ENTER_DELAY in delays
+
+
+def test_return_shortcut_gets_the_navigation_delay(monkeypatch):
+	delays = send_keys_and_collect_delays('Control+Return', monkeypatch)
+
+	assert ENTER_DELAY in delays
+
+
+def test_shortcut_whose_main_key_is_not_enter_gets_no_navigation_delay(monkeypatch):
+	delays = send_keys_and_collect_delays('Control+A', monkeypatch)
+
+	assert ENTER_DELAY not in delays


### PR DESCRIPTION
## Summary

`send_keys` pays a 100ms "possible navigation" delay whenever the typed text merely *contains* `enter` or `return`.

`DefaultActionWatchdog.on_SendKeysEvent` gates that delay on:

```python
if 'enter' in event.keys.lower() or 'return' in event.keys.lower():
    await asyncio.sleep(0.1)
```

That is a substring test against the raw input, so `send_keys("center")`, `send_keys("enterprise")` and `send_keys("returning")` all match. The keystrokes themselves are dispatched correctly — only the delay is wrong, but repeated calls add avoidable latency to browser tasks.

## Fix

Track whether an Enter/Return key was *actually dispatched* and gate the delay on that:

- **special-key path** — normalized key resolves to `Enter` (covers both the `enter` and `return` aliases)
- **shortcut path** — the shortcut's main key resolves to `Enter` (e.g. `Control+Enter`, `Control+Return`)
- **text path** — the text contains a newline, which the handler already converts into an Enter dispatch

Everything that really sent Enter keeps the delay. Plain text and shortcuts whose main key isn't Enter no longer pay it.

## Test plan

New `tests/ci/browser/test_send_keys_enter_delay.py` (11 tests) reuses the existing `test_send_keys_literal_plus.py` mock harness and records every `asyncio.sleep` call:

- `center` / `enterprise` / `returning` → no `0.1` delay, only the per-character `0.010`
- `Enter` / `Return` / `enter` / `return` → `0.1` delay present
- `line1\nline2` → `0.1` delay present (newline is dispatched as Enter)
- `Control+Enter` / `Control+Return` → `0.1` delay present
- `Control+A` → no `0.1` delay

Verified the first case fails on `main` (`assert 0.1 not in [0.01, 0.01, ...]`) and passes with this change. The 4 pre-existing tests in `test_send_keys_literal_plus.py` still pass; `ruff check` clean.

Fixes #5573


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `send_keys` paying a 100ms navigation delay for any input whose raw text contains `enter` or `return`, like `center` or `enterprise`. The delay now applies only when an Enter/Return key is actually dispatched, including newlines and shortcuts like `Control+Enter`. Fixes #5573.

<sup>Written for commit 931c65449c9874dac989e41513ed41e92290bd71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

