### PR TITLE
docs: fix a root-relative link and a dead anchor

### DIFF
--- a/browser_use/llm/README.md
+++ b/browser_use/llm/README.md
@@ -22,4 +22,4 @@ Use `ChatMistral` with `MISTRAL_API_KEY` (and optional `MISTRAL_BASE_URL`). Stru
 
 Because of how we implemented the LLMs, we can technically support anything. If you want to use a LangChain model, you can use the `ChatLangchain` (NOT OFFICIALLY SUPPORTED) class.
 
-You can find all the details in the [LangChain example](/examples/models/langchain/example.py). We suggest you grab that code and use it as a reference.
+You can find all the details in the [LangChain example](../../examples/models/langchain/example.py). We suggest you grab that code and use it as a reference.

--- a/skills/cloud/references/guides/subagent.md
+++ b/skills/cloud/references/guides/subagent.md
@@ -32,7 +32,7 @@ Your system has an orchestrator — some agent, pipeline, or workflow engine tha
 | Your agent type | Best approach |
 |----------------|---------------|
 | CLI coding agent in sandbox (Claude Code, Codex, OpenCode, Cline, Windsurf, Cursor bg, Hermes, OpenClaw) | [CLI cloud passthrough](#shell-command-agents-cli) |
-| Python framework (LangChain, CrewAI, AutoGen, PydanticAI, custom) | [Python Agent wrapper](#python-framework-agents) |
+| Python framework (LangChain, CrewAI, AutoGen, PydanticAI, custom) | [Python Agent wrapper](#python-agents-cloud-sdk) |
 | TypeScript/JS (Vercel AI SDK, LangChain.js, custom) | [Cloud SDK](#typescriptjs-agents) |
 | MCP client (Claude Desktop, Cursor with MCP) | [MCP browser_task tool](#mcp-native-agents) |
 | Workflow engine (n8n, Make, Zapier, Temporal) or any HTTP client | [Cloud REST API](#http--workflow-engines) |


### PR DESCRIPTION
- `browser_use/llm/README.md`: the LangChain example link used a leading slash (`/examples/models/langchain/example.py`), which resolves to the GitHub domain root and 404s; now repo-relative (`../../examples/...`, target verified to exist).
- `skills/cloud/references/guides/subagent.md`: the framework table's "Python Agent wrapper" anchor `#python-framework-agents` matches no heading; pointed at the intended `## Python Agents (Cloud SDK)` (slug `#python-agents-cloud-sdk`). The other four links in that table resolve.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two broken documentation links: a root-relative link in `browser_use/llm/README.md` that 404'd, and a dead anchor in `skills/cloud/references/guides/subagent.md` that pointed to a non-existent heading. Both now resolve to the intended targets.

<sup>Written for commit c8edec191fec97db6a48358e6234f5e8464d262d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

