### PR TITLE
Add PKCE account login for OrcaRouter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,12 @@ BROWSER_USE_API_KEY=your_bu_api_key_here
 # DEEPSEEK_API_KEY=
 # GROK_API_KEY=
 # NOVITA_API_KEY=
+# OrcaRouter accepts either an existing key here or `browser-use orcarouter login` (PKCE).
 # ORCAROUTER_API_KEY=
+# Optional self-hosted endpoints. Split overrides take precedence over the shared base.
+# ORCA_BASE_URL=
+# ORCA_AUTH_BASE_URL=
+# ORCA_API_BASE_URL=
 
 # AWS Bedrock Configuration (for AWS Bedrock models)
 # Requires: pip install browser-use[aws]

--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -160,6 +160,8 @@ def _patch_browser_harness_cli_text() -> None:
 	from browser_harness import auth, run, telemetry
 
 	run.HELP = _as_browser_use_cli_text(run.HELP)
+	if 'browser-use orcarouter login' not in run.HELP:
+		run.HELP = f'{run.HELP.rstrip()}\n  browser-use orcarouter login   connect an OrcaRouter account with PKCE\n'
 	run.USAGE = _as_browser_use_cli_text(run.USAGE)
 
 	original_auth_cli = auth.run_auth_cli
@@ -348,6 +350,8 @@ def _command_name(args: list[str]) -> str:
 		return 'init'
 	if args and args[0] == 'skill':
 		return 'skill'
+	if args and args[0] == 'orcarouter':
+		return 'orcarouter'
 	legacy = _legacy_command(args)
 	if legacy is not None:
 		return f'legacy:{legacy}'
@@ -371,6 +375,10 @@ def _dispatch(args: list[str]) -> tuple[int | None, str]:
 		from browser_use.skills.install import handle as handle_skill_command
 
 		return handle_skill_command(args[1:]), 'skill'
+	if args and args[0] == 'orcarouter':
+		from browser_use.llm.orcarouter.cli import handle as handle_orcarouter_command
+
+		return handle_orcarouter_command(args[1:]), 'orcarouter'
 
 	legacy = _legacy_command(args)
 	if legacy is not None:

--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -271,6 +271,13 @@ class LLMEntry(DBStyleEntry):
 	model: str | None = None
 	temperature: float | None = None
 	max_tokens: int | None = None
+	provider: str | None = None
+	auth_method: str | None = None
+	user_id: str | None = None
+	scope: str | None = None
+	authorized_at: str | None = None
+	credential_generation: str | None = None
+	needs_reauth: bool = False
 
 
 class AgentEntry(DBStyleEntry):

--- a/browser_use/llm/README.md
+++ b/browser_use/llm/README.md
@@ -8,6 +8,7 @@ We officially support the following LLMs:
 - Groq
 - Ollama
 - DeepSeek
+- OrcaRouter
 
 - Mistral
 
@@ -16,6 +17,17 @@ We officially support the following LLMs:
 Use `ChatMistral` with `MISTRAL_API_KEY` (and optional `MISTRAL_BASE_URL`). Structured outputs automatically strip unsupported JSON schema keywords (`minLength`, `maxLength`, `pattern`, `format`), and generation uses `max_tokens` plus the optional `safe_prompt` flag.
 
 - Cerebras
+
+## OrcaRouter authentication
+
+OrcaRouter supports an existing API key and account login. Set `ORCAROUTER_API_KEY`, pass `api_key` to `ChatOrcaRouter`, or run:
+
+```bash
+browser-use orcarouter login
+browser-use orcarouter status
+```
+
+PKCE login stores the resulting durable API key in Browser Use's existing local LLM configuration. Run `browser-use orcarouter logout` to remove only that stored PKCE credential. An explicit `api_key` takes priority over the environment variable, which takes priority over the PKCE credential.
 
 
 ## Migrating from LangChain

--- a/browser_use/llm/orcarouter/auth.py
+++ b/browser_use/llm/orcarouter/auth.py
@@ -180,14 +180,8 @@ class OrcaRouterCredentialStore:
 				# The existing migration discards the legacy flat format. Build its replacement
 				# in memory so the caller can persist it through the atomic writer.
 				return create_default_config()
-			if present_sections != required_sections:
-				raise ValueError('Browser Use configuration has incomplete database-style sections')
-			if not all(isinstance(data[section], dict) for section in required_sections):
+			if not all(isinstance(data[section], dict) for section in present_sections):
 				raise ValueError('Browser Use configuration sections must be objects')
-			if not data['browser_profile'] or not all(
-				isinstance(entry, dict) and 'id' in entry for entry in data['browser_profile'].values()
-			):
-				raise ValueError('Browser Use configuration contains invalid browser profiles')
 			return DBStyleConfigJSON.model_validate(data)
 		except Exception as exc:
 			raise OrcaRouterAuthError(f'Could not read Browser Use configuration at {self.path}') from exc

--- a/browser_use/llm/orcarouter/auth.py
+++ b/browser_use/llm/orcarouter/auth.py
@@ -23,7 +23,7 @@ import httpx
 from filelock import FileLock
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from browser_use.config import CONFIG, DBStyleConfigJSON, LLMEntry, create_default_config, load_and_migrate_config
+from browser_use.config import CONFIG, DBStyleConfigJSON, LLMEntry, create_default_config
 
 DEFAULT_ORCAROUTER_AUTH_BASE_URL = 'https://www.orcarouter.ai'
 DEFAULT_ORCAROUTER_API_BASE_URL = 'https://api.orcarouter.ai/v1'
@@ -170,7 +170,25 @@ class OrcaRouterCredentialStore:
 		if not self.path.exists():
 			return create_default_config()
 		try:
-			return load_and_migrate_config(self.path)
+			data = json.loads(self.path.read_text())
+			if not isinstance(data, dict):
+				raise ValueError('Browser Use configuration must be a JSON object')
+
+			required_sections = {'browser_profile', 'llm', 'agent'}
+			present_sections = required_sections.intersection(data)
+			if not present_sections:
+				# The existing migration discards the legacy flat format. Build its replacement
+				# in memory so the caller can persist it through the atomic writer.
+				return create_default_config()
+			if present_sections != required_sections:
+				raise ValueError('Browser Use configuration has incomplete database-style sections')
+			if not all(isinstance(data[section], dict) for section in required_sections):
+				raise ValueError('Browser Use configuration sections must be objects')
+			if not data['browser_profile'] or not all(
+				isinstance(entry, dict) and 'id' in entry for entry in data['browser_profile'].values()
+			):
+				raise ValueError('Browser Use configuration contains invalid browser profiles')
+			return DBStyleConfigJSON.model_validate(data)
 		except Exception as exc:
 			raise OrcaRouterAuthError(f'Could not read Browser Use configuration at {self.path}') from exc
 

--- a/browser_use/llm/orcarouter/auth.py
+++ b/browser_use/llm/orcarouter/auth.py
@@ -1,0 +1,405 @@
+"""Local PKCE authentication for OrcaRouter."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import ipaddress
+import json
+import os
+import secrets
+import tempfile
+import webbrowser
+from collections.abc import Callable
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from browser_use.config import CONFIG, DBStyleConfigJSON, LLMEntry, create_default_config
+
+DEFAULT_ORCAROUTER_AUTH_BASE_URL = 'https://www.orcarouter.ai'
+DEFAULT_ORCAROUTER_API_BASE_URL = 'https://api.orcarouter.ai/v1'
+DEFAULT_ORCAROUTER_APP_NAME = 'Browser Use'
+
+
+class OrcaRouterAuthError(RuntimeError):
+	"""An OrcaRouter authorization or credential-storage failure."""
+
+
+def _validate_api_key(key: str) -> str:
+	if not key.startswith('sk-orca-') or len(key) <= len('sk-orca-'):
+		raise ValueError('OrcaRouter returned an invalid API key')
+	if any(character.isspace() or ord(character) < 32 or ord(character) == 127 for character in key):
+		raise ValueError('OrcaRouter returned an invalid API key')
+	return key
+
+
+class OrcaRouterCredential(BaseModel):
+	"""A durable API key minted by OrcaRouter's PKCE flow."""
+
+	model_config = ConfigDict(frozen=True)
+
+	api_key: str
+	user_id: str
+	scope: str = 'api'
+	authorized_at: datetime
+	generation: str
+	needs_reauth: bool = False
+
+	_validate_key = field_validator('api_key')(_validate_api_key)
+
+
+class _OrcaRouterExchangeResponse(BaseModel):
+	key: str
+	user_id: str
+	scope: str
+
+	_validate_key = field_validator('key')(_validate_api_key)
+
+
+class OrcaRouterCredentialStore:
+	"""Read and atomically update OrcaRouter PKCE data in Browser Use's LLM config."""
+
+	def __init__(self, path: Path | None = None):
+		self.path = path or CONFIG._get_config_path()
+
+	def load(self) -> OrcaRouterCredential | None:
+		if not self.path.exists():
+			return None
+		try:
+			config = DBStyleConfigJSON.model_validate_json(self.path.read_text())
+			entry = next(
+				(
+					candidate
+					for candidate in config.llm.values()
+					if candidate.provider == 'orcarouter' and candidate.auth_method == 'pkce'
+				),
+				None,
+			)
+			if entry is None or not all(
+				(entry.api_key, entry.user_id, entry.scope, entry.authorized_at, entry.credential_generation)
+			):
+				return None
+			return OrcaRouterCredential.model_validate(
+				{
+					'api_key': entry.api_key,
+					'user_id': entry.user_id,
+					'scope': entry.scope,
+					'authorized_at': entry.authorized_at,
+					'generation': entry.credential_generation,
+					'needs_reauth': entry.needs_reauth,
+				}
+			)
+		except Exception as exc:
+			raise OrcaRouterAuthError(f'Could not read the OrcaRouter credential at {self.path}') from exc
+
+	def save(self, *, key: str, user_id: str) -> OrcaRouterCredential:
+		credential = OrcaRouterCredential(
+			api_key=key,
+			user_id=user_id,
+			scope='api',
+			authorized_at=datetime.now(UTC),
+			generation=str(uuid4()),
+		)
+		self._write(credential)
+		return credential
+
+	def mark_needs_reauth(self, generation: str) -> bool:
+		credential = self.load()
+		if credential is None or credential.generation != generation:
+			return False
+		self._write(credential.model_copy(update={'needs_reauth': True}))
+		return True
+
+	def clear(self) -> bool:
+		config = self._load_config()
+		entry_ids = [
+			entry_id for entry_id, entry in config.llm.items() if entry.provider == 'orcarouter' and entry.auth_method == 'pkce'
+		]
+		if not entry_ids:
+			return False
+		for entry_id in entry_ids:
+			del config.llm[entry_id]
+		self._write_config(config)
+		return True
+
+	def _write(self, credential: OrcaRouterCredential) -> None:
+		config = self._load_config()
+		entry_id = next(
+			(
+				candidate_id
+				for candidate_id, candidate in config.llm.items()
+				if candidate.provider == 'orcarouter' and candidate.auth_method == 'pkce'
+			),
+			str(uuid4()),
+		)
+		previous = config.llm.get(entry_id)
+		config.llm[entry_id] = LLMEntry(
+			id=entry_id,
+			default=previous.default if previous else False,
+			created_at=previous.created_at if previous else datetime.now(UTC).isoformat(),
+			api_key=credential.api_key,
+			model=previous.model if previous else 'orcarouter/auto',
+			provider='orcarouter',
+			auth_method='pkce',
+			user_id=credential.user_id,
+			scope=credential.scope,
+			authorized_at=credential.authorized_at.isoformat(),
+			credential_generation=credential.generation,
+			needs_reauth=credential.needs_reauth,
+		)
+		self._write_config(config)
+
+	def _load_config(self) -> DBStyleConfigJSON:
+		if not self.path.exists():
+			return create_default_config()
+		try:
+			return DBStyleConfigJSON.model_validate_json(self.path.read_text())
+		except Exception as exc:
+			raise OrcaRouterAuthError(f'Could not read Browser Use configuration at {self.path}') from exc
+
+	def _write_config(self, config: DBStyleConfigJSON) -> None:
+		self.path.parent.mkdir(parents=True, exist_ok=True)
+		fd, temporary_name = tempfile.mkstemp(prefix=f'.{self.path.name}.', dir=self.path.parent)
+		temporary_path = Path(temporary_name)
+		try:
+			os.chmod(temporary_path, 0o600)
+			with os.fdopen(fd, 'w') as file:
+				json.dump(config.model_dump(mode='json'), file, indent=2)
+				file.write('\n')
+				file.flush()
+				os.fsync(file.fileno())
+			os.replace(temporary_path, self.path)
+			os.chmod(self.path, 0o600)
+		except Exception:
+			try:
+				os.close(fd)
+			except OSError:
+				pass
+			temporary_path.unlink(missing_ok=True)
+			raise
+
+
+def _is_loopback_host(host: str | None) -> bool:
+	if host == 'localhost':
+		return True
+	if host is None:
+		return False
+	try:
+		return ipaddress.ip_address(host).is_loopback
+	except ValueError:
+		return False
+
+
+def _validated_auth_base_url(value: str) -> str:
+	parsed = urlsplit(value)
+	try:
+		parsed.port
+	except ValueError as exc:
+		raise OrcaRouterAuthError('OrcaRouter auth base URL contains an invalid port') from exc
+	if not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+		raise OrcaRouterAuthError('OrcaRouter auth base URL must be an origin without credentials, query, or fragment')
+	if parsed.path not in {'', '/'}:
+		raise OrcaRouterAuthError('OrcaRouter auth base URL must not contain a path')
+	if parsed.scheme != 'https' and not (parsed.scheme == 'http' and _is_loopback_host(parsed.hostname)):
+		raise OrcaRouterAuthError('OrcaRouter auth base URL must use HTTPS (HTTP is allowed only for loopback testing)')
+	return urlunsplit((parsed.scheme, parsed.netloc, '', '', ''))
+
+
+def resolve_orcarouter_auth_base_url(explicit: str | None = None) -> str:
+	"""Resolve split and shared self-hosted endpoint overrides."""
+
+	value = (
+		explicit
+		or os.getenv('ORCAROUTER_AUTH_BASE_URL')
+		or os.getenv('ORCA_AUTH_BASE_URL')
+		or os.getenv('ORCAROUTER_BASE_URL')
+		or os.getenv('ORCA_BASE_URL')
+		or DEFAULT_ORCAROUTER_AUTH_BASE_URL
+	)
+	return _validated_auth_base_url(value)
+
+
+def resolve_orcarouter_api_base_url() -> str:
+	"""Resolve the OpenAI-compatible API base without deriving it from the auth origin."""
+
+	explicit = os.getenv('ORCAROUTER_API_BASE_URL') or os.getenv('ORCA_API_BASE_URL')
+	shared = os.getenv('ORCAROUTER_BASE_URL') or os.getenv('ORCA_BASE_URL')
+	value = explicit or shared or DEFAULT_ORCAROUTER_API_BASE_URL
+	return validate_orcarouter_api_base_url(value, append_version_if_origin=True)
+
+
+def validate_orcarouter_api_base_url(value: str | httpx.URL, *, append_version_if_origin: bool = False) -> str:
+	parsed = urlsplit(str(value))
+	try:
+		parsed.port
+	except ValueError as exc:
+		raise OrcaRouterAuthError('OrcaRouter API base URL contains an invalid port') from exc
+	if not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
+		raise OrcaRouterAuthError('OrcaRouter API base URL must not contain credentials, query, or fragment')
+	if parsed.scheme != 'https' and not (parsed.scheme == 'http' and _is_loopback_host(parsed.hostname)):
+		raise OrcaRouterAuthError('OrcaRouter API base URL must use HTTPS (HTTP is allowed only for loopback testing)')
+	path = parsed.path.rstrip('/')
+	if not path and append_version_if_origin:
+		path = '/v1'
+	return urlunsplit((parsed.scheme, parsed.netloc, path, '', ''))
+
+
+def _pkce_verifier() -> str:
+	# token_urlsafe(64) is URL-safe and produces an 86-character verifier (RFC 7636 permits 43-128).
+	return secrets.token_urlsafe(64)
+
+
+def _pkce_challenge(verifier: str) -> str:
+	return base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b'=').decode()
+
+
+def _html_response(status: int, title: str, message: str) -> bytes:
+	body = (
+		'<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">'
+		f'<title>{title}</title></head><body><main><h1>{title}</h1><p>{message}</p></main></body></html>'
+	).encode()
+	reason = {200: 'OK', 400: 'Bad Request', 404: 'Not Found', 409: 'Conflict'}.get(status, 'Error')
+	headers = (
+		f'HTTP/1.1 {status} {reason}\r\n'
+		f'Content-Length: {len(body)}\r\n'
+		'Content-Type: text/html; charset=utf-8\r\n'
+		'Cache-Control: no-store\r\n'
+		"Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'\r\n"
+		'Connection: close\r\n\r\n'
+	).encode()
+	return headers + body
+
+
+class OrcaRouterPKCEClient:
+	"""Run OrcaRouter's authorization-code + PKCE flow on a loopback callback."""
+
+	def __init__(
+		self,
+		*,
+		auth_base_url: str | None = None,
+		credential_store: OrcaRouterCredentialStore | None = None,
+		http_client: httpx.AsyncClient | None = None,
+		app_name: str = DEFAULT_ORCAROUTER_APP_NAME,
+	):
+		self.auth_base_url = resolve_orcarouter_auth_base_url(auth_base_url)
+		self.credential_store = credential_store or OrcaRouterCredentialStore()
+		self.http_client = http_client
+		self.app_name = app_name
+
+	async def login(
+		self,
+		*,
+		open_browser: bool = True,
+		on_authorization_url: Callable[[str], None] | None = None,
+		timeout: float = 300,
+	) -> OrcaRouterCredential:
+		verifier = _pkce_verifier()
+		challenge = _pkce_challenge(verifier)
+		state = secrets.token_urlsafe(32)
+		loop = asyncio.get_running_loop()
+		callback_result: asyncio.Future[str] = loop.create_future()
+
+		async def handle_callback(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+			try:
+				request_line = (await asyncio.wait_for(reader.readline(), timeout=5)).decode('ascii', errors='replace')
+				parts = request_line.rstrip('\r\n').split(' ')
+				if len(parts) != 3 or parts[0] != 'GET':
+					writer.write(_html_response(400, 'Invalid request', 'Return to the terminal and try again.'))
+					return
+				parsed = urlsplit(parts[1])
+				if parsed.path != '/cb':
+					writer.write(_html_response(404, 'Not found', 'Return to the terminal and try again.'))
+					return
+				query = parse_qs(parsed.query)
+				returned_state = query.get('state', [''])[0]
+				if not hmac.compare_digest(returned_state, state):
+					writer.write(_html_response(400, 'Invalid state', 'The authorization response did not match this login.'))
+					return
+				if callback_result.done():
+					writer.write(_html_response(409, 'Already handled', 'This authorization response was already handled.'))
+					return
+				if query.get('error', [''])[0]:
+					callback_result.set_exception(OrcaRouterAuthError('OrcaRouter authorization was denied'))
+					writer.write(_html_response(400, 'Authorization denied', 'Return to the terminal to try again.'))
+					return
+				code = query.get('code', [''])[0]
+				if not code:
+					callback_result.set_exception(
+						OrcaRouterAuthError('OrcaRouter callback did not include an authorization code')
+					)
+					writer.write(_html_response(400, 'Missing code', 'Return to the terminal and try again.'))
+					return
+				callback_result.set_result(code)
+				writer.write(_html_response(200, 'OrcaRouter connected', 'You can close this tab and return to Browser Use.'))
+			except (TimeoutError, UnicodeError):
+				writer.write(_html_response(400, 'Invalid request', 'Return to the terminal and try again.'))
+			finally:
+				with suppress(ConnectionError):
+					await writer.drain()
+				writer.close()
+				with suppress(ConnectionError):
+					await writer.wait_closed()
+
+		server = await asyncio.start_server(handle_callback, host='127.0.0.1', port=0)
+		socket = server.sockets[0]
+		port = socket.getsockname()[1]
+		callback_url = f'http://127.0.0.1:{port}/cb'
+		authorization_query = urlencode(
+			{
+				'callback_url': callback_url,
+				'code_challenge': challenge,
+				'code_challenge_method': 'S256',
+				'state': state,
+				'app_name': self.app_name,
+				'scope': 'api',
+			}
+		)
+		authorization_url = f'{self.auth_base_url}/auth?{authorization_query}'
+
+		try:
+			if on_authorization_url is not None:
+				on_authorization_url(authorization_url)
+			if open_browser:
+				await asyncio.to_thread(webbrowser.open, authorization_url)
+			try:
+				code = await asyncio.wait_for(callback_result, timeout=timeout)
+			except TimeoutError as exc:
+				raise OrcaRouterAuthError('Timed out waiting for OrcaRouter authorization') from exc
+		finally:
+			server.close()
+			await server.wait_closed()
+
+		response = await self._exchange(code=code, verifier=verifier)
+		if response.scope != 'api':
+			raise OrcaRouterAuthError(f'OrcaRouter granted scope {response.scope!r}; expected api')
+		return self.credential_store.save(key=response.key, user_id=response.user_id)
+
+	async def _exchange(self, *, code: str, verifier: str) -> _OrcaRouterExchangeResponse:
+		payload = {
+			'code': code,
+			'code_verifier': verifier,
+			'code_challenge_method': 'S256',
+		}
+		try:
+			if self.http_client is not None:
+				response = await self.http_client.post(f'{self.auth_base_url}/api/v1/auth/keys', json=payload)
+			else:
+				async with httpx.AsyncClient(timeout=30) as client:
+					response = await client.post(f'{self.auth_base_url}/api/v1/auth/keys', json=payload)
+		except httpx.HTTPError as exc:
+			raise OrcaRouterAuthError('Could not reach the OrcaRouter key exchange endpoint') from exc
+
+		if response.status_code < 200 or response.status_code >= 300:
+			raise OrcaRouterAuthError(f'OrcaRouter key exchange failed (HTTP {response.status_code})')
+		try:
+			return _OrcaRouterExchangeResponse.model_validate(response.json())
+		except Exception as exc:
+			raise OrcaRouterAuthError('OrcaRouter key exchange returned an invalid response') from exc

--- a/browser_use/llm/orcarouter/auth.py
+++ b/browser_use/llm/orcarouter/auth.py
@@ -12,17 +12,18 @@ import os
 import secrets
 import tempfile
 import webbrowser
-from collections.abc import Callable
-from contextlib import suppress
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
 import httpx
+from filelock import FileLock
 from pydantic import BaseModel, ConfigDict, field_validator
 
-from browser_use.config import CONFIG, DBStyleConfigJSON, LLMEntry, create_default_config
+from browser_use.config import CONFIG, DBStyleConfigJSON, LLMEntry, create_default_config, load_and_migrate_config
 
 DEFAULT_ORCAROUTER_AUTH_BASE_URL = 'https://www.orcarouter.ai'
 DEFAULT_ORCAROUTER_API_BASE_URL = 'https://api.orcarouter.ai/v1'
@@ -112,25 +113,33 @@ class OrcaRouterCredentialStore:
 		return credential
 
 	def mark_needs_reauth(self, generation: str) -> bool:
-		credential = self.load()
-		if credential is None or credential.generation != generation:
-			return False
-		self._write(credential.model_copy(update={'needs_reauth': True}))
-		return True
+		with self._locked():
+			credential = self.load()
+			if credential is None or credential.generation != generation:
+				return False
+			self._write_unlocked(credential.model_copy(update={'needs_reauth': True}))
+			return True
 
 	def clear(self) -> bool:
-		config = self._load_config()
-		entry_ids = [
-			entry_id for entry_id, entry in config.llm.items() if entry.provider == 'orcarouter' and entry.auth_method == 'pkce'
-		]
-		if not entry_ids:
-			return False
-		for entry_id in entry_ids:
-			del config.llm[entry_id]
-		self._write_config(config)
-		return True
+		with self._locked():
+			config = self._load_config()
+			entry_ids = [
+				entry_id
+				for entry_id, entry in config.llm.items()
+				if entry.provider == 'orcarouter' and entry.auth_method == 'pkce'
+			]
+			if not entry_ids:
+				return False
+			for entry_id in entry_ids:
+				del config.llm[entry_id]
+			self._write_config(config)
+			return True
 
 	def _write(self, credential: OrcaRouterCredential) -> None:
+		with self._locked():
+			self._write_unlocked(credential)
+
+	def _write_unlocked(self, credential: OrcaRouterCredential) -> None:
 		config = self._load_config()
 		entry_id = next(
 			(
@@ -161,15 +170,30 @@ class OrcaRouterCredentialStore:
 		if not self.path.exists():
 			return create_default_config()
 		try:
-			return DBStyleConfigJSON.model_validate_json(self.path.read_text())
+			return load_and_migrate_config(self.path)
 		except Exception as exc:
 			raise OrcaRouterAuthError(f'Could not read Browser Use configuration at {self.path}') from exc
 
-	def _write_config(self, config: DBStyleConfigJSON) -> None:
-		self.path.parent.mkdir(parents=True, exist_ok=True)
-		fd, temporary_name = tempfile.mkstemp(prefix=f'.{self.path.name}.', dir=self.path.parent)
-		temporary_path = Path(temporary_name)
+	@contextmanager
+	def _locked(self) -> Iterator[None]:
+		"""Serialize credential read-modify-write operations across processes."""
+		lock_path = self.path.with_name(f'.{self.path.name}.lock')
 		try:
+			self.path.parent.mkdir(parents=True, exist_ok=True)
+			with FileLock(lock_path):
+				with suppress(OSError):
+					os.chmod(lock_path, 0o600)
+				yield
+		except OrcaRouterAuthError:
+			raise
+		except Exception as exc:
+			raise OrcaRouterAuthError(f'Could not update Browser Use configuration at {self.path}') from exc
+
+	def _write_config(self, config: DBStyleConfigJSON) -> None:
+		try:
+			self.path.parent.mkdir(parents=True, exist_ok=True)
+			fd, temporary_name = tempfile.mkstemp(prefix=f'.{self.path.name}.', dir=self.path.parent)
+			temporary_path = Path(temporary_name)
 			os.chmod(temporary_path, 0o600)
 			with os.fdopen(fd, 'w') as file:
 				json.dump(config.model_dump(mode='json'), file, indent=2)
@@ -178,13 +202,14 @@ class OrcaRouterCredentialStore:
 				os.fsync(file.fileno())
 			os.replace(temporary_path, self.path)
 			os.chmod(self.path, 0o600)
-		except Exception:
-			try:
-				os.close(fd)
-			except OSError:
-				pass
-			temporary_path.unlink(missing_ok=True)
-			raise
+		except Exception as exc:
+			if 'fd' in locals():
+				with suppress(OSError):
+					os.close(fd)
+			if 'temporary_path' in locals():
+				with suppress(OSError):
+					temporary_path.unlink(missing_ok=True)
+			raise OrcaRouterAuthError(f'Could not write Browser Use configuration at {self.path}') from exc
 
 
 def _is_loopback_host(host: str | None) -> bool:
@@ -199,11 +224,11 @@ def _is_loopback_host(host: str | None) -> bool:
 
 
 def _validated_auth_base_url(value: str) -> str:
-	parsed = urlsplit(value)
 	try:
+		parsed = urlsplit(value)
 		parsed.port
 	except ValueError as exc:
-		raise OrcaRouterAuthError('OrcaRouter auth base URL contains an invalid port') from exc
+		raise OrcaRouterAuthError('OrcaRouter auth base URL is invalid') from exc
 	if not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
 		raise OrcaRouterAuthError('OrcaRouter auth base URL must be an origin without credentials, query, or fragment')
 	if parsed.path not in {'', '/'}:
@@ -237,11 +262,11 @@ def resolve_orcarouter_api_base_url() -> str:
 
 
 def validate_orcarouter_api_base_url(value: str | httpx.URL, *, append_version_if_origin: bool = False) -> str:
-	parsed = urlsplit(str(value))
 	try:
+		parsed = urlsplit(str(value))
 		parsed.port
 	except ValueError as exc:
-		raise OrcaRouterAuthError('OrcaRouter API base URL contains an invalid port') from exc
+		raise OrcaRouterAuthError('OrcaRouter API base URL is invalid') from exc
 	if not parsed.hostname or parsed.username or parsed.password or parsed.query or parsed.fragment:
 		raise OrcaRouterAuthError('OrcaRouter API base URL must not contain credentials, query, or fragment')
 	if parsed.scheme != 'https' and not (parsed.scheme == 'http' and _is_loopback_host(parsed.hostname)):

--- a/browser_use/llm/orcarouter/chat.py
+++ b/browser_use/llm/orcarouter/chat.py
@@ -1,6 +1,6 @@
 import os
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, TypeVar, overload
 
 import httpx
@@ -15,11 +15,21 @@ from pydantic import BaseModel
 from browser_use.llm.base import BaseChatModel
 from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
 from browser_use.llm.messages import BaseMessage
+from browser_use.llm.orcarouter.auth import (
+	OrcaRouterAuthError,
+	OrcaRouterCredentialStore,
+	resolve_orcarouter_api_base_url,
+	validate_orcarouter_api_base_url,
+)
 from browser_use.llm.orcarouter.serializer import OrcaRouterMessageSerializer
 from browser_use.llm.schema import SchemaOptimizer
 from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 T = TypeVar('T', bound=BaseModel)
+
+
+def _default_api_base_url() -> str:
+	return resolve_orcarouter_api_base_url()
 
 
 @dataclass
@@ -41,7 +51,7 @@ class ChatOrcaRouter(BaseChatModel):
 
 	# Client initialization parameters
 	api_key: str | None = None
-	base_url: str | httpx.URL = 'https://api.orcarouter.ai/v1'
+	base_url: str | httpx.URL = field(default_factory=_default_api_base_url)
 	timeout: float | httpx.Timeout | None = None
 	max_retries: int = 10
 	default_headers: Mapping[str, str] | None = None
@@ -58,17 +68,38 @@ class ChatOrcaRouter(BaseChatModel):
 	def _get_api_key(self) -> str:
 		# AsyncOpenAI falls back to OPENAI_API_KEY when api_key is unset, which would send an
 		# unrelated provider's key to the OrcaRouter endpoint.
-		key = self.api_key or os.getenv('ORCAROUTER_API_KEY')
-		if not key:
-			raise ModelProviderError('Missing OrcaRouter API key', status_code=401, model=self.name)
-		return key
+		self._pkce_credential_generation = None
+		if self.api_key:
+			return self.api_key
+		if env_key := os.getenv('ORCAROUTER_API_KEY'):
+			return env_key
+
+		try:
+			credential = OrcaRouterCredentialStore().load()
+		except OrcaRouterAuthError as exc:
+			raise ModelProviderError(str(exc), status_code=401, model=self.name) from exc
+		if credential is not None:
+			if credential.needs_reauth:
+				raise ModelProviderError(
+					'OrcaRouter login needs to be renewed; run `browser-use orcarouter login`',
+					status_code=401,
+					model=self.name,
+				)
+			self._pkce_credential_generation = credential.generation
+			return credential.api_key
+
+		raise ModelProviderError(
+			'Missing OrcaRouter API key; set ORCAROUTER_API_KEY or run `browser-use orcarouter login`',
+			status_code=401,
+			model=self.name,
+		)
 
 	def _get_client_params(self) -> dict[str, Any]:
 		"""Prepare client parameters dictionary."""
 		# Define base client params
 		base_params = {
 			'api_key': self._get_api_key(),
-			'base_url': self.base_url,
+			'base_url': validate_orcarouter_api_base_url(self.base_url),
 			'timeout': self.timeout,
 			'max_retries': self.max_retries,
 			'default_headers': self.default_headers,
@@ -140,6 +171,13 @@ class ChatOrcaRouter(BaseChatModel):
 		Returns:
 		    Either a string response or an instance of output_format
 		"""
+		if getattr(self, '_pkce_needs_reauth', False):
+			raise ModelProviderError(
+				'OrcaRouter login needs to be renewed; run `browser-use orcarouter login`',
+				status_code=401,
+				model=self.name,
+			)
+
 		orcarouter_messages = OrcaRouterMessageSerializer.serialize_messages(messages)
 
 		try:
@@ -240,6 +278,14 @@ class ChatOrcaRouter(BaseChatModel):
 			raise ModelProviderError(message=str(e), model=self.name) from e
 
 		except APIStatusError as e:
+			credential_generation = getattr(self, '_pkce_credential_generation', None)
+			if e.status_code == 401 and isinstance(credential_generation, str):
+				self._pkce_needs_reauth = True
+				try:
+					OrcaRouterCredentialStore().mark_needs_reauth(credential_generation)
+				except OrcaRouterAuthError:
+					# Preserve the upstream authentication error if local status persistence fails.
+					pass
 			raise ModelProviderError(message=e.message, status_code=e.status_code, model=self.name) from e
 
 		except Exception as e:

--- a/browser_use/llm/orcarouter/cli.py
+++ b/browser_use/llm/orcarouter/cli.py
@@ -1,0 +1,97 @@
+"""CLI commands for OrcaRouter authentication."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from browser_use.llm.orcarouter.auth import OrcaRouterAuthError, OrcaRouterCredentialStore, OrcaRouterPKCEClient
+
+
+def _parser() -> argparse.ArgumentParser:
+	parser = argparse.ArgumentParser(
+		prog='browser-use orcarouter',
+		description='Connect Browser Use to OrcaRouter with an existing API key or PKCE login.',
+	)
+	subparsers = parser.add_subparsers(dest='command', required=True)
+
+	login = subparsers.add_parser('login', help='Connect an OrcaRouter account with PKCE')
+	login.add_argument('--no-open', action='store_true', help='Print the authorization URL without opening a browser')
+	login.add_argument('--timeout', type=float, default=300, help='Seconds to wait for browser authorization (default: 300)')
+	login.add_argument('--auth-base-url', help=argparse.SUPPRESS)
+
+	subparsers.add_parser('status', help='Show PKCE connection status without printing the key')
+	subparsers.add_parser('logout', help='Remove the stored PKCE credential')
+	return parser
+
+
+async def _login(args: argparse.Namespace) -> int:
+	if args.timeout <= 0:
+		print('browser-use orcarouter: --timeout must be greater than zero', file=sys.stderr)
+		return 2
+
+	client = OrcaRouterPKCEClient(auth_base_url=args.auth_base_url)
+
+	def show_authorization_url(url: str) -> None:
+		print('Authorize Browser Use with OrcaRouter:')
+		print(url, flush=True)
+		if args.no_open:
+			print('Waiting for authorization in that browser tab...', flush=True)
+
+	try:
+		credential = await client.login(
+			open_browser=not args.no_open,
+			on_authorization_url=show_authorization_url,
+			timeout=args.timeout,
+		)
+	except OrcaRouterAuthError as exc:
+		print(f'OrcaRouter login failed: {exc}', file=sys.stderr)
+		return 1
+
+	print(f'OrcaRouter connected (scope: {credential.scope}).')
+	return 0
+
+
+def _status() -> int:
+	try:
+		credential = OrcaRouterCredentialStore().load()
+	except OrcaRouterAuthError as exc:
+		print(f'OrcaRouter status unavailable: {exc}', file=sys.stderr)
+		return 1
+	if credential is None:
+		print('OrcaRouter PKCE is not connected. Run `browser-use orcarouter login`.')
+		return 1
+	if credential.needs_reauth:
+		print('OrcaRouter PKCE needs reauthorization. Run `browser-use orcarouter login`.')
+		return 1
+	print(f'OrcaRouter PKCE is connected (scope: {credential.scope}).')
+	return 0
+
+
+def _logout() -> int:
+	try:
+		removed = OrcaRouterCredentialStore().clear()
+	except OrcaRouterAuthError as exc:
+		print(f'OrcaRouter logout failed: {exc}', file=sys.stderr)
+		return 1
+	if removed:
+		print('Removed the stored OrcaRouter PKCE credential.')
+	else:
+		print('No stored OrcaRouter PKCE credential was found.')
+	return 0
+
+
+def handle(argv: list[str]) -> int:
+	args = _parser().parse_args(argv)
+	if args.command == 'login':
+		try:
+			return asyncio.run(_login(args))
+		except KeyboardInterrupt:
+			print('\nOrcaRouter login cancelled.', file=sys.stderr)
+			return 130
+	if args.command == 'status':
+		return _status()
+	if args.command == 'logout':
+		return _logout()
+	return 2

--- a/browser_use/llm/orcarouter/cli.py
+++ b/browser_use/llm/orcarouter/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import math
 import sys
 
 from browser_use.llm.orcarouter.auth import OrcaRouterAuthError, OrcaRouterCredentialStore, OrcaRouterPKCEClient
@@ -27,11 +28,9 @@ def _parser() -> argparse.ArgumentParser:
 
 
 async def _login(args: argparse.Namespace) -> int:
-	if args.timeout <= 0:
-		print('browser-use orcarouter: --timeout must be greater than zero', file=sys.stderr)
+	if not math.isfinite(args.timeout) or args.timeout <= 0:
+		print('browser-use orcarouter: --timeout must be a finite number greater than zero', file=sys.stderr)
 		return 2
-
-	client = OrcaRouterPKCEClient(auth_base_url=args.auth_base_url)
 
 	def show_authorization_url(url: str) -> None:
 		print('Authorize Browser Use with OrcaRouter:')
@@ -40,6 +39,7 @@ async def _login(args: argparse.Namespace) -> int:
 			print('Waiting for authorization in that browser tab...', flush=True)
 
 	try:
+		client = OrcaRouterPKCEClient(auth_base_url=args.auth_base_url)
 		credential = await client.login(
 			open_browser=not args.no_open,
 			on_authorization_url=show_authorization_url,

--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -50,20 +50,58 @@ PY
   `current_tab()` and `list_tabs()` and use `switch_tab()` to reuse a matching
   tab. Do not leave duplicate tabs on the same URL or close tabs you did not
   create.
+- At task completion, close tabs created for the task that are no longer needed.
+  Keep a tab open if the user needs to see it, it is needed for a known follow-up,
+  or closing it could discard unsaved work or other important state.
 - `new_tab()` and `switch_tab()` attach and move the horse marker without
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
-  background; call `activate_tab(target)` only when the user explicitly asks
-  or a page demonstrably pauses rendering while hidden.
+  background. Never call `activate_tab(target)` automatically: it brings Chrome
+  to the foreground. Call it only when the user explicitly asks to see or
+  visibly switch to that tab. Do not pair `switch_tab()` with `activate_tab()`.
+- A local daemon is a connection to the whole Chrome instance, not to one site,
+  task, card, or agent. Omit `BU_NAME` and reuse the default daemon for normal
+  sequential local work across websites, tabs, screenshots, and Codex turns.
+  Do not invent per-job names such as `gmail1375` or `slack1371`: every new
+  local daemon opens another browser-level CDP connection and Chrome may show
+  another Allow prompt.
 - Set `BH_TAB_MARKER=0` before starting the daemon to leave page titles unchanged.
   The horse marker remains enabled by default.
-- A timed-out `scroll(...)` on an attached background tab is evidence that the
-  page needs to be visible. Call `activate_tab(current_tab())`, retry the same
-  scroll once, then re-read the scroll position. This visibly switches tabs,
-  so do not use it when the user has forbidden foreground changes. Do not
-  invent a `Runtime.evaluate` scroll replacement or a cross-frame JS walker.
+- A timeout or page that pauses while hidden is not permission to foreground
+  Chrome. Keep using background CDP operations. For a focus-gated page,
+  temporarily call `cdp("Emulation.setFocusEmulationEnabled", enabled=True)`,
+  perform and verify the operation, then disable it in a `finally` block. If
+  background control still cannot work, report that limitation instead of
+  activating the tab. Do not invent a `Runtime.evaluate` scroll replacement or
+  a cross-frame JS walker.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome
+
+The default daemon can keep many tabs and visit many sites; browser-use has
+no per-site, screenshot, or result-count limit that requires a new daemon.
+Chrome memory and page complexity are the practical limits. Reuse matching tabs
+with `list_tabs()` and `switch_tab()`.
+
+One daemon has one mutable attached/current tab. Many agents can share it when
+their browser operations are serialized: treat local Chrome as one shared
+browser lane while non-browser work continues in parallel. Sequential tab
+switching, input, and screenshot capture are safe. Do not create another local
+daemon merely because several agents exist.
+
+Two agents that switch tabs and act simultaneously can race, causing one to act
+on or capture the other's tab. For truly simultaneous interactive work, use
+separate remote browsers when Browser Use Cloud authentication is already
+available. Otherwise serialize browser operations through the default local
+daemon. A named local daemon is a last resort when simultaneous isolation is
+required, remote auth is unavailable or unsuitable, and the extra Chrome
+approval prompt is acceptable. It creates another controller and dedicated tab
+in the same local Chrome profile, not another Chrome profile or process.
+
+If the default daemon becomes stale, use its built-in reattachment/recovery
+first. A command timeout, truncated output, site change, closed tab, or new task
+is not a reason to create another daemon. Run `browser-use --doctor` and
+restart or replace the default daemon only when it is actually dead or cannot
+recover.
 
 If the daemon cannot connect, run diagnostics:
 
@@ -96,9 +134,31 @@ Settings > Privacy & Security > Accessibility, then call `mac-approve` once
 again. This is only for local Chrome; do not call it for `BU_CDP_URL`,
 `BU_CDP_WS`, or Browser Use Cloud.
 
+When the shell tool can yield a still-running process, use a short 3-5 second
+initial yield for the first local command, not a 30-second wait. If the command
+yields with the Allow hint, leave that exact process running, immediately call
+`browser-use mac-approve` in a second tool call, then resume or poll the
+original process. With a named daemon, preserve its exact `BU_NAME` for the
+helper. Never start the browser command again. If the user clicks Allow first,
+the same handshake completes and the original command returning successfully
+is the agent's feedback; `mac-approve` also returns `ready` when the daemon is
+already connected.
+
+`mac-approve` is macOS-only. On Linux or Windows, keep the original browser
+command running and ask the user to click Allow if Chrome presents the approval
+dialog. Their click completes the same handshake, so resume or poll the original
+process for success; do not rerun it or create a replacement daemon. If that
+Chrome build presents no approval dialog, the original command simply connects.
+
 ## Remote Browsers
 
 Use Browser Use cloud for headless servers, parallel sub-agents, or isolated work.
+
+Remote browsers require Browser Use Cloud authentication. Check
+`browser-use auth status` before depending on them. `browser-use auth
+login` stores authentication for later processes, so an API key does not need to
+be passed to every agent process; without stored authentication or an available
+`BROWSER_USE_API_KEY`, serialize work through the default local daemon instead.
 
 Cloud browsers are managed Chrome instances hosted by Browser Use. Each one is a fresh, isolated browser. Proactively suggest one (briefly explain why) when:
 

--- a/browser_use/skills/browser-use/SKILL.md
+++ b/browser_use/skills/browser-use/SKILL.md
@@ -57,7 +57,7 @@ PY
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
   background. Never call `activate_tab(target)` automatically: it brings Chrome
   to the foreground. Call it only when the user explicitly asks to see or
-  visibly switch to that tab. Do not pair `switch_tab()` with `activate_tab()`.
+  visibly switch to that tab. Never add `activate_tab()` after `switch_tab()` unless the user explicitly asked to see or visibly switch to the tab.
 - A local daemon is a connection to the whole Chrome instance, not to one site,
   task, card, or agent. Omit `BU_NAME` and reuse the default daemon for normal
   sequential local work across websites, tabs, screenshots, and Codex turns.
@@ -209,6 +209,9 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.
+  Pass CDP parameters as keywords: `cdp("Input.insertText", text="hello")`.
+  The second positional argument is a session ID, not a parameters dictionary.
+  When targeting an explicit session, use `session_id="..."` alongside the keywords.
 
 ## Recordings and Videos
 

--- a/browser_use/skills/browser_use.py
+++ b/browser_use/skills/browser_use.py
@@ -28,6 +28,11 @@ OPENCLAW_METADATA_LINES = (
 	'  }',
 )
 
+_OLD_ACTIVATE_TAB_GUIDANCE = 'Do not pair `switch_tab()` with `activate_tab()`.'
+_NEW_ACTIVATE_TAB_GUIDANCE = (
+	'Never add `activate_tab()` after `switch_tab()` unless the user explicitly asked to see or visibly switch to the tab.'
+)
+
 
 def as_browser_use_skill(text: str) -> str:
 	"""Expose the Browser Harness skill under the Browser Use skill identity."""
@@ -70,10 +75,11 @@ def as_browser_use_skill(text: str) -> str:
 	# Rebrand every mention except repo URLs (github.com/browser-use/browser-harness/...)
 	body = re.sub(r'(?<!/)browser-harness', 'browser-use', body)
 	body = body.replace('Browser Harness', 'Browser Use')
-	body = body.replace(
-		'Do not pair `switch_tab()` with `activate_tab()`.',
-		'Never add `activate_tab()` after `switch_tab()` unless the user explicitly asked to see or visibly switch to the tab.',
-	)
+	if '`activate_tab(target)`' in body and not any(
+		guidance in body for guidance in (_OLD_ACTIVATE_TAB_GUIDANCE, _NEW_ACTIVATE_TAB_GUIDANCE)
+	):
+		raise ValueError('Upstream activate_tab guidance changed; review the Browser Use foreground-tab policy')
+	body = body.replace(_OLD_ACTIVATE_TAB_GUIDANCE, _NEW_ACTIVATE_TAB_GUIDANCE)
 	frontmatter_text = '\n'.join(lines)
 	return f'---\n{frontmatter_text}\n---\n{body}'
 

--- a/browser_use/skills/browser_use.py
+++ b/browser_use/skills/browser_use.py
@@ -32,6 +32,7 @@ _OLD_ACTIVATE_TAB_GUIDANCE = 'Do not pair `switch_tab()` with `activate_tab()`.'
 _NEW_ACTIVATE_TAB_GUIDANCE = (
 	'Never add `activate_tab()` after `switch_tab()` unless the user explicitly asked to see or visibly switch to the tab.'
 )
+_CURRENT_ACTIVATE_TAB_POLICY_MARKER = 'Never call `activate_tab(target)` automatically:'
 
 
 def as_browser_use_skill(text: str) -> str:
@@ -75,7 +76,7 @@ def as_browser_use_skill(text: str) -> str:
 	# Rebrand every mention except repo URLs (github.com/browser-use/browser-harness/...)
 	body = re.sub(r'(?<!/)browser-harness', 'browser-use', body)
 	body = body.replace('Browser Harness', 'Browser Use')
-	if '`activate_tab(target)`' in body and not any(
+	if _CURRENT_ACTIVATE_TAB_POLICY_MARKER in body and not any(
 		guidance in body for guidance in (_OLD_ACTIVATE_TAB_GUIDANCE, _NEW_ACTIVATE_TAB_GUIDANCE)
 	):
 		raise ValueError('Upstream activate_tab guidance changed; review the Browser Use foreground-tab policy')

--- a/browser_use/skills/browser_use.py
+++ b/browser_use/skills/browser_use.py
@@ -70,6 +70,10 @@ def as_browser_use_skill(text: str) -> str:
 	# Rebrand every mention except repo URLs (github.com/browser-use/browser-harness/...)
 	body = re.sub(r'(?<!/)browser-harness', 'browser-use', body)
 	body = body.replace('Browser Harness', 'Browser Use')
+	body = body.replace(
+		'Do not pair `switch_tab()` with `activate_tab()`.',
+		'Never add `activate_tab()` after `switch_tab()` unless the user explicitly asked to see or visibly switch to the tab.',
+	)
 	frontmatter_text = '\n'.join(lines)
 	return f'---\n{frontmatter_text}\n---\n{body}'
 

--- a/examples/models/orcarouter.py
+++ b/examples/models/orcarouter.py
@@ -1,7 +1,9 @@
 """
 Simple try of the agent with OrcaRouter.
 
-@dev You need to add ORCAROUTER_API_KEY to your environment variables.
+Authenticate first with either `browser-use orcarouter login` (PKCE) or the
+ORCAROUTER_API_KEY environment variable. An explicitly passed `api_key` takes
+priority over both.
 """
 
 import asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pyotp==2.9.0",
     "pillow==12.3.0",
     "cloudpickle==3.1.2",
+    "filelock==3.32.5",
     "markdownify==1.2.2",
     "python-docx==1.2.0",
     "browser-use-sdk==3.4.2",

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -50,20 +50,58 @@ PY
   `current_tab()` and `list_tabs()` and use `switch_tab()` to reuse a matching
   tab. Do not leave duplicate tabs on the same URL or close tabs you did not
   create.
+- At task completion, close tabs created for the task that are no longer needed.
+  Keep a tab open if the user needs to see it, it is needed for a known follow-up,
+  or closing it could discard unsaved work or other important state.
 - `new_tab()` and `switch_tab()` attach and move the horse marker without
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
-  background; call `activate_tab(target)` only when the user explicitly asks
-  or a page demonstrably pauses rendering while hidden.
+  background. Never call `activate_tab(target)` automatically: it brings Chrome
+  to the foreground. Call it only when the user explicitly asks to see or
+  visibly switch to that tab. Do not pair `switch_tab()` with `activate_tab()`.
+- A local daemon is a connection to the whole Chrome instance, not to one site,
+  task, card, or agent. Omit `BU_NAME` and reuse the default daemon for normal
+  sequential local work across websites, tabs, screenshots, and Codex turns.
+  Do not invent per-job names such as `gmail1375` or `slack1371`: every new
+  local daemon opens another browser-level CDP connection and Chrome may show
+  another Allow prompt.
 - Set `BH_TAB_MARKER=0` before starting the daemon to leave page titles unchanged.
   The horse marker remains enabled by default.
-- A timed-out `scroll(...)` on an attached background tab is evidence that the
-  page needs to be visible. Call `activate_tab(current_tab())`, retry the same
-  scroll once, then re-read the scroll position. This visibly switches tabs,
-  so do not use it when the user has forbidden foreground changes. Do not
-  invent a `Runtime.evaluate` scroll replacement or a cross-frame JS walker.
+- A timeout or page that pauses while hidden is not permission to foreground
+  Chrome. Keep using background CDP operations. For a focus-gated page,
+  temporarily call `cdp("Emulation.setFocusEmulationEnabled", enabled=True)`,
+  perform and verify the operation, then disable it in a `finally` block. If
+  background control still cannot work, report that limitation instead of
+  activating the tab. Do not invent a `Runtime.evaluate` scroll replacement or
+  a cross-frame JS walker.
 - The normal local flow attaches to the running Chrome/Chromium CDP endpoint. No browser ids or local profile selection.
 
 ## Local Chrome
+
+The default daemon can keep many tabs and visit many sites; browser-use has
+no per-site, screenshot, or result-count limit that requires a new daemon.
+Chrome memory and page complexity are the practical limits. Reuse matching tabs
+with `list_tabs()` and `switch_tab()`.
+
+One daemon has one mutable attached/current tab. Many agents can share it when
+their browser operations are serialized: treat local Chrome as one shared
+browser lane while non-browser work continues in parallel. Sequential tab
+switching, input, and screenshot capture are safe. Do not create another local
+daemon merely because several agents exist.
+
+Two agents that switch tabs and act simultaneously can race, causing one to act
+on or capture the other's tab. For truly simultaneous interactive work, use
+separate remote browsers when Browser Use Cloud authentication is already
+available. Otherwise serialize browser operations through the default local
+daemon. A named local daemon is a last resort when simultaneous isolation is
+required, remote auth is unavailable or unsuitable, and the extra Chrome
+approval prompt is acceptable. It creates another controller and dedicated tab
+in the same local Chrome profile, not another Chrome profile or process.
+
+If the default daemon becomes stale, use its built-in reattachment/recovery
+first. A command timeout, truncated output, site change, closed tab, or new task
+is not a reason to create another daemon. Run `browser-use --doctor` and
+restart or replace the default daemon only when it is actually dead or cannot
+recover.
 
 If the daemon cannot connect, run diagnostics:
 
@@ -96,9 +134,31 @@ Settings > Privacy & Security > Accessibility, then call `mac-approve` once
 again. This is only for local Chrome; do not call it for `BU_CDP_URL`,
 `BU_CDP_WS`, or Browser Use Cloud.
 
+When the shell tool can yield a still-running process, use a short 3-5 second
+initial yield for the first local command, not a 30-second wait. If the command
+yields with the Allow hint, leave that exact process running, immediately call
+`browser-use mac-approve` in a second tool call, then resume or poll the
+original process. With a named daemon, preserve its exact `BU_NAME` for the
+helper. Never start the browser command again. If the user clicks Allow first,
+the same handshake completes and the original command returning successfully
+is the agent's feedback; `mac-approve` also returns `ready` when the daemon is
+already connected.
+
+`mac-approve` is macOS-only. On Linux or Windows, keep the original browser
+command running and ask the user to click Allow if Chrome presents the approval
+dialog. Their click completes the same handshake, so resume or poll the original
+process for success; do not rerun it or create a replacement daemon. If that
+Chrome build presents no approval dialog, the original command simply connects.
+
 ## Remote Browsers
 
 Use Browser Use cloud for headless servers, parallel sub-agents, or isolated work.
+
+Remote browsers require Browser Use Cloud authentication. Check
+`browser-use auth status` before depending on them. `browser-use auth
+login` stores authentication for later processes, so an API key does not need to
+be passed to every agent process; without stored authentication or an available
+`BROWSER_USE_API_KEY`, serialize work through the default local daemon instead.
 
 Cloud browsers are managed Chrome instances hosted by Browser Use. Each one is a fresh, isolated browser. Proactively suggest one (briefly explain why) when:
 

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -57,7 +57,7 @@ PY
   changing Chrome's visible tab. Screenshots and normal CDP input work in the
   background. Never call `activate_tab(target)` automatically: it brings Chrome
   to the foreground. Call it only when the user explicitly asks to see or
-  visibly switch to that tab. Do not pair `switch_tab()` with `activate_tab()`.
+  visibly switch to that tab. Never add `activate_tab()` after `switch_tab()` unless the user explicitly asked to see or visibly switch to the tab.
 - A local daemon is a connection to the whole Chrome instance, not to one site,
   task, card, or agent. Omit `BU_NAME` and reuse the default daemon for normal
   sequential local work across websites, tabs, screenshots, and Codex turns.
@@ -209,6 +209,9 @@ Cloud profile cookie sync reference: https://github.com/browser-use/browser-harn
 - When entering unusually long text, avoid slow per-character typing: find a faster page-appropriate input method, then verify the page kept the exact value.
 - Login walls: stop and ask. Exception: use available SSO automatically when Chrome is already signed in; still stop for passwords, MFA, consent, or ambiguous account choice.
 - Raw CDP is available with `cdp("Domain.method", ...)`.
+  Pass CDP parameters as keywords: `cdp("Input.insertText", text="hello")`.
+  The second positional argument is a session ID, not a parameters dictionary.
+  When targeting an explicit session, use `session_id="..."` alongside the keywords.
 
 ## Recordings and Videos
 

--- a/tests/ci/test_browser_use_cli.py
+++ b/tests/ci/test_browser_use_cli.py
@@ -6,9 +6,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 
 
-def _run_browser_use_cli(*args: str, module: str = 'browser_use.cli') -> subprocess.CompletedProcess[str]:
+def _run_browser_use_cli(
+	*args: str,
+	module: str = 'browser_use.cli',
+	env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
 	env = os.environ.copy()
 	env['PYTHONPATH'] = os.pathsep.join(part for part in (str(ROOT), env.get('PYTHONPATH', '')) if part)
+	if env_overrides:
+		env.update(env_overrides)
 	return subprocess.run(
 		[sys.executable, '-m', module, *args],
 		cwd=ROOT,
@@ -55,3 +61,39 @@ def test_browser_use_tui_is_deprecated_alias(monkeypatch, capsys):
 
 	assert browser_use_cli.browser_use_tui_main() == 0
 	assert capsys.readouterr().err == 'browser-use-tui is deprecated; use browser-use instead.\n'
+
+
+def test_orcarouter_cli_help_is_available() -> None:
+	result = _run_browser_use_cli('orcarouter', '--help')
+
+	assert result.returncode == 0
+	assert 'login' in result.stdout
+	assert 'status' in result.stdout
+	assert 'logout' in result.stdout
+	assert result.stderr == ''
+
+
+def test_main_cli_help_mentions_orcarouter_login() -> None:
+	result = _run_browser_use_cli('--help')
+
+	assert result.returncode == 0
+	assert 'browser-use orcarouter login' in result.stdout
+
+
+def test_orcarouter_status_and_logout_never_print_the_stored_key(tmp_path: Path) -> None:
+	from browser_use.llm.orcarouter.auth import OrcaRouterCredentialStore
+
+	key = 'sk-orca-' + ('a' * 48)
+	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
+	store.save(key=key, user_id='user-123')
+	env = {'BROWSER_USE_CONFIG_DIR': str(tmp_path)}
+
+	status_result = _run_browser_use_cli('orcarouter', 'status', env_overrides=env)
+	assert status_result.returncode == 0
+	assert 'connected' in status_result.stdout.lower()
+	assert key not in status_result.stdout + status_result.stderr
+
+	logout_result = _run_browser_use_cli('orcarouter', 'logout', env_overrides=env)
+	assert logout_result.returncode == 0
+	assert key not in logout_result.stdout + logout_result.stderr
+	assert store.load() is None

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from browser_use.skills.browser_use import as_browser_use_skill
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -173,6 +175,16 @@ def test_browser_use_skill_allows_an_explicitly_requested_visible_tab_switch():
 		in converted
 	)
 	assert 'Do not pair `switch_tab()` with `activate_tab()`.' not in converted
+
+
+def test_browser_use_skill_rejects_unreviewed_activate_tab_guidance_drift():
+	source = (
+		'---\nname: browser-harness\n---\n\n# Browser Harness\n\n'
+		'Call `activate_tab(target)` only when foreground interaction is useful.\n'
+	)
+
+	with pytest.raises(ValueError, match='activate_tab guidance changed'):
+		as_browser_use_skill(source)
 
 
 def test_browser_use_cli_validates_destination_before_installing_harness(tmp_path):

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -177,10 +177,23 @@ def test_browser_use_skill_allows_an_explicitly_requested_visible_tab_switch():
 	assert 'Do not pair `switch_tab()` with `activate_tab()`.' not in converted
 
 
+def test_browser_use_skill_accepts_pinned_browser_harness_activation_policy():
+	source = (
+		'---\nname: browser-harness\n---\n\n# Browser Harness\n\n'
+		"`new_tab()` and `switch_tab()` attach without changing Chrome's visible tab. "
+		'Call `activate_tab(target)` only when the user explicitly asks or a page pauses while hidden.\n'
+	)
+
+	converted = as_browser_use_skill(source)
+
+	assert 'Call `activate_tab(target)` only when the user explicitly asks or a page pauses while hidden.' in converted
+
+
 def test_browser_use_skill_rejects_unreviewed_activate_tab_guidance_drift():
 	source = (
 		'---\nname: browser-harness\n---\n\n# Browser Harness\n\n'
-		'Call `activate_tab(target)` only when foreground interaction is useful.\n'
+		'Never call `activate_tab(target)` automatically: it brings Chrome to the foreground. '
+		'Call it only when foreground interaction is useful. Avoid pairing `switch_tab()` with `activate_tab()`.\n'
 	)
 
 	with pytest.raises(ValueError, match='activate_tab guidance changed'):

--- a/tests/ci/test_browser_use_skill_install_docs.py
+++ b/tests/ci/test_browser_use_skill_install_docs.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from browser_use.skills.browser_use import as_browser_use_skill
+
 ROOT = Path(__file__).resolve().parents[2]
 BROWSER_USE_REPO_SKILL_URL = 'https://raw.githubusercontent.com/browser-use/browser-use/main/skills/browser-use/SKILL.md'
 EXPECTED_SKILL_INSTALL_PATHS = (
@@ -155,6 +157,22 @@ def test_browser_use_cli_installs_browser_harness_package_skill(tmp_path):
 	)
 	for installed in (home / path for path in EXPECTED_SKILL_INSTALL_PATHS):
 		assert installed.read_text(encoding='utf-8') == expected
+
+
+def test_browser_use_skill_allows_an_explicitly_requested_visible_tab_switch():
+	source = (
+		'---\nname: browser-harness\n---\n\n# Browser Harness\n\n'
+		'Call `activate_tab(target)` only when the user explicitly asks to see or visibly switch to that tab. '
+		'Do not pair `switch_tab()` with `activate_tab()`.\n'
+	)
+
+	converted = as_browser_use_skill(source)
+
+	assert (
+		'Never add `activate_tab()` after `switch_tab()` unless the user explicitly asked to see or visibly switch to the tab.'
+		in converted
+	)
+	assert 'Do not pair `switch_tab()` with `activate_tab()`.' not in converted
 
 
 def test_browser_use_cli_validates_destination_before_installing_harness(tmp_path):

--- a/tests/ci/test_orcarouter.py
+++ b/tests/ci/test_orcarouter.py
@@ -2,6 +2,8 @@ import asyncio
 import base64
 import hashlib
 import os
+import threading
+from argparse import Namespace
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
@@ -18,6 +20,7 @@ from browser_use.llm.orcarouter.auth import (
 	OrcaRouterPKCEClient,
 )
 from browser_use.llm.orcarouter.chat import ChatOrcaRouter
+from browser_use.llm.orcarouter.cli import _login
 from browser_use.llm.orcarouter.serializer import OrcaRouterMessageSerializer
 from browser_use.llm.views import ChatInvokeUsage
 from browser_use.tokens.service import TokenCost
@@ -90,8 +93,9 @@ def test_orcarouter_reads_api_key_from_env(monkeypatch: pytest.MonkeyPatch) -> N
 	assert client.api_key == 'orca-key'
 
 
-def test_orcarouter_never_falls_back_to_the_openai_key(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_orcarouter_never_falls_back_to_the_openai_key(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 	"""An unset OrcaRouter key must fail loudly, not ship OPENAI_API_KEY to the gateway."""
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(tmp_path))
 	monkeypatch.delenv('ORCAROUTER_API_KEY', raising=False)
 	monkeypatch.setenv('OPENAI_API_KEY', 'sk-unrelated-openai-key')
 
@@ -123,7 +127,10 @@ async def test_pkce_login_uses_s256_loopback_callback_and_persists_api_scope(htt
 	client = OrcaRouterPKCEClient(auth_base_url=httpserver.url_for(''), credential_store=store)
 	authorization_url: str | None = None
 
+	callback_task: asyncio.Task[None] | None = None
+
 	def authorize(url: str) -> None:
+		nonlocal callback_task
 		nonlocal authorization_url
 		authorization_url = url
 
@@ -133,9 +140,13 @@ async def test_pkce_login_uses_s256_loopback_callback_and_persists_api_scope(htt
 			async with httpx.AsyncClient() as callback_client:
 				await callback_client.get(callback_url, params={'code': 'one-time-code', 'state': query['state'][0]})
 
-		asyncio.create_task(send_callback())
+		callback_task = asyncio.create_task(send_callback())
 
-	credential = await client.login(open_browser=False, on_authorization_url=authorize, timeout=2)
+	try:
+		credential = await client.login(open_browser=False, on_authorization_url=authorize, timeout=2)
+	finally:
+		if callback_task is not None:
+			await callback_task
 
 	assert authorization_url is not None
 	parsed_url = urlparse(authorization_url)
@@ -170,7 +181,11 @@ async def test_pkce_state_mismatch_is_rejected_before_exchange(httpserver, tmp_p
 	client = OrcaRouterPKCEClient(auth_base_url=httpserver.url_for(''), credential_store=store)
 	mismatch_status: int | None = None
 
+	callback_task: asyncio.Task[None] | None = None
+
 	def authorize(url: str) -> None:
+		nonlocal callback_task
+
 		async def send_callbacks() -> None:
 			nonlocal mismatch_status
 			query = parse_qs(urlparse(url).query)
@@ -180,9 +195,13 @@ async def test_pkce_state_mismatch_is_rejected_before_exchange(httpserver, tmp_p
 				mismatch_status = mismatch.status_code
 				await callback_client.get(callback_url, params={'code': 'real-code', 'state': query['state'][0]})
 
-		asyncio.create_task(send_callbacks())
+		callback_task = asyncio.create_task(send_callbacks())
 
-	credential = await client.login(open_browser=False, on_authorization_url=authorize, timeout=2)
+	try:
+		credential = await client.login(open_browser=False, on_authorization_url=authorize, timeout=2)
+	finally:
+		if callback_task is not None:
+			await callback_task
 
 	assert mismatch_status == 400
 	assert credential.api_key == _fake_orcarouter_key()
@@ -195,7 +214,11 @@ async def test_pkce_rejects_downgraded_scope_and_does_not_persist(httpserver, tm
 	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
 	client = OrcaRouterPKCEClient(auth_base_url=httpserver.url_for(''), credential_store=store)
 
+	callback_task: asyncio.Task[None] | None = None
+
 	def authorize(url: str) -> None:
+		nonlocal callback_task
+
 		async def send_callback() -> None:
 			query = parse_qs(urlparse(url).query)
 			async with httpx.AsyncClient() as callback_client:
@@ -204,10 +227,14 @@ async def test_pkce_rejects_downgraded_scope_and_does_not_persist(httpserver, tm
 					params={'code': 'one-time-code', 'state': query['state'][0]},
 				)
 
-		asyncio.create_task(send_callback())
+		callback_task = asyncio.create_task(send_callback())
 
-	with pytest.raises(OrcaRouterAuthError, match='scope'):
-		await client.login(open_browser=False, on_authorization_url=authorize, timeout=2)
+	try:
+		with pytest.raises(OrcaRouterAuthError, match='scope'):
+			await client.login(open_browser=False, on_authorization_url=authorize, timeout=2)
+	finally:
+		if callback_task is not None:
+			await callback_task
 
 	assert store.load() is None
 
@@ -269,6 +296,29 @@ async def test_stored_pkce_key_401_is_marked_needs_reauth(httpserver, monkeypatc
 		await chat.ainvoke([UserMessage(content='do not retry with the rejected key')])
 
 
+async def test_stored_pkce_key_401_preserves_provider_error_when_status_write_fails(
+	httpserver, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(tmp_path))
+	monkeypatch.delenv('ORCAROUTER_API_KEY', raising=False)
+	store = OrcaRouterCredentialStore()
+	store.save(key=_fake_orcarouter_key(), user_id='user-123')
+	httpserver.expect_request('/v1/chat/completions', method='POST').respond_with_json(
+		{'error': {'message': 'invalid api key', 'type': 'authentication_error'}}, status=401
+	)
+	chat = ChatOrcaRouter(model='orcarouter/auto', base_url=httpserver.url_for('/v1'), max_retries=0)
+
+	def fail_replace(source, destination):
+		raise OSError('read-only filesystem')
+
+	monkeypatch.setattr('browser_use.llm.orcarouter.auth.os.replace', fail_replace)
+	with pytest.raises(ModelProviderError) as exc_info:
+		await chat.ainvoke([UserMessage(content='hello')])
+
+	assert exc_info.value.status_code == 401
+	assert 'invalid api key' in str(exc_info.value)
+
+
 def test_stale_401_cannot_invalidate_a_replacement_key(tmp_path: Path) -> None:
 	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
 	old = store.save(key=_fake_orcarouter_key('o'), user_id='user-old')
@@ -276,6 +326,115 @@ def test_stale_401_cannot_invalidate_a_replacement_key(tmp_path: Path) -> None:
 
 	assert store.mark_needs_reauth(old.generation) is False
 	assert store.load() == new
+
+
+def test_concurrent_stale_401_cannot_overwrite_a_replacement_key(tmp_path: Path) -> None:
+	loaded_old_credential = threading.Event()
+	allow_stale_write = threading.Event()
+	replacement_started = threading.Event()
+	replacement_finished = threading.Event()
+	config_path = tmp_path / 'config.json'
+
+	class PausingStore(OrcaRouterCredentialStore):
+		def load(self):
+			credential = super().load()
+			if threading.current_thread().name == 'stale-marker':
+				loaded_old_credential.set()
+				assert allow_stale_write.wait(timeout=2)
+			return credential
+
+	class ReplacementStore(OrcaRouterCredentialStore):
+		def save(self, *, key: str, user_id: str):
+			replacement_started.set()
+			credential = super().save(key=key, user_id=user_id)
+			replacement_finished.set()
+			return credential
+
+	store = PausingStore(config_path)
+	old = store.save(key=_fake_orcarouter_key('o'), user_id='user-old')
+	replacement_store = ReplacementStore(config_path)
+	marker = threading.Thread(target=store.mark_needs_reauth, args=(old.generation,), name='stale-marker')
+	replacement = threading.Thread(
+		target=replacement_store.save,
+		kwargs={'key': _fake_orcarouter_key('n'), 'user_id': 'user-new'},
+		name='replacement-login',
+	)
+
+	marker.start()
+	assert loaded_old_credential.wait(timeout=2)
+	replacement.start()
+	assert replacement_started.wait(timeout=2)
+	replacement_finished.wait(timeout=0.1)
+	allow_stale_write.set()
+	marker.join(timeout=2)
+	replacement.join(timeout=2)
+
+	assert not marker.is_alive()
+	assert not replacement.is_alive()
+	credential = OrcaRouterCredentialStore(config_path).load()
+	assert credential is not None
+	assert credential.api_key == _fake_orcarouter_key('n')
+	assert credential.needs_reauth is False
+
+
+def test_pkce_save_migrates_legacy_config_before_writing(tmp_path: Path) -> None:
+	config_path = tmp_path / 'config.json'
+	config_path.write_text('{"llm_model":"gpt-4.1-mini"}')
+
+	OrcaRouterCredentialStore(config_path).save(key=_fake_orcarouter_key(), user_id='user-123')
+
+	config = load_and_migrate_config(config_path)
+	assert config.browser_profile
+	assert config.agent
+	assert any(entry.provider == 'orcarouter' for entry in config.llm.values())
+
+
+@pytest.mark.parametrize('operation', ['save', 'clear'])
+def test_pkce_store_wraps_write_path_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, operation: str) -> None:
+	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
+	if operation == 'clear':
+		store.save(key=_fake_orcarouter_key(), user_id='user-123')
+
+	def fail_replace(source, destination):
+		raise OSError('read-only filesystem')
+
+	monkeypatch.setattr('browser_use.llm.orcarouter.auth.os.replace', fail_replace)
+
+	with pytest.raises(OrcaRouterAuthError, match='configuration'):
+		if operation == 'save':
+			store.save(key=_fake_orcarouter_key(), user_id='user-123')
+		else:
+			store.clear()
+
+
+@pytest.mark.parametrize('timeout', [float('nan'), float('inf'), float('-inf'), 0, -1])
+async def test_login_rejects_non_finite_and_non_positive_timeouts(
+	monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], timeout: float
+) -> None:
+	def fail_if_constructed(*args, **kwargs):
+		raise AssertionError('invalid timeout must be rejected before constructing the client')
+
+	monkeypatch.setattr('browser_use.llm.orcarouter.cli.OrcaRouterPKCEClient', fail_if_constructed)
+	result = await _login(Namespace(timeout=timeout, auth_base_url=None, no_open=True))
+
+	assert result == 2
+	assert '--timeout must be a finite number greater than zero' in capsys.readouterr().err
+
+
+async def test_login_handles_invalid_auth_base_url(capsys: pytest.CaptureFixture[str]) -> None:
+	result = await _login(Namespace(timeout=1, auth_base_url='https://[invalid', no_open=True))
+
+	assert result == 1
+	assert 'OrcaRouter login failed:' in capsys.readouterr().err
+
+
+@pytest.mark.parametrize('validator', ['auth', 'api'])
+def test_malformed_url_is_reported_as_auth_error(validator: str) -> None:
+	with pytest.raises(OrcaRouterAuthError):
+		if validator == 'auth':
+			OrcaRouterPKCEClient(auth_base_url='https://[invalid')
+		else:
+			ChatOrcaRouter(model='orcarouter/auto', api_key='test-key', base_url='https://[invalid').get_client()
 
 
 async def test_pkce_attempts_use_fresh_secrets_and_close_listener_on_timeout(tmp_path: Path) -> None:

--- a/tests/ci/test_orcarouter.py
+++ b/tests/ci/test_orcarouter.py
@@ -324,15 +324,18 @@ def test_stale_401_cannot_invalidate_a_replacement_key(tmp_path: Path) -> None:
 	old = store.save(key=_fake_orcarouter_key('o'), user_id='user-old')
 	new = store.save(key=_fake_orcarouter_key('n'), user_id='user-new')
 
-	assert store.mark_needs_reauth(old.generation) is False
+	stale_mark_applied = store.mark_needs_reauth(old.generation)
+
+	assert stale_mark_applied is False
 	assert store.load() == new
 
 
-def test_concurrent_stale_401_cannot_overwrite_a_replacement_key(tmp_path: Path) -> None:
+def test_credential_lock_serializes_mark_and_replacement_save(tmp_path: Path) -> None:
 	loaded_old_credential = threading.Event()
 	allow_stale_write = threading.Event()
 	replacement_started = threading.Event()
 	replacement_finished = threading.Event()
+	mark_results: list[bool] = []
 	config_path = tmp_path / 'config.json'
 
 	class PausingStore(OrcaRouterCredentialStore):
@@ -353,7 +356,10 @@ def test_concurrent_stale_401_cannot_overwrite_a_replacement_key(tmp_path: Path)
 	store = PausingStore(config_path)
 	old = store.save(key=_fake_orcarouter_key('o'), user_id='user-old')
 	replacement_store = ReplacementStore(config_path)
-	marker = threading.Thread(target=store.mark_needs_reauth, args=(old.generation,), name='stale-marker')
+	marker = threading.Thread(
+		target=lambda: mark_results.append(store.mark_needs_reauth(old.generation)),
+		name='stale-marker',
+	)
 	replacement = threading.Thread(
 		target=replacement_store.save,
 		kwargs={'key': _fake_orcarouter_key('n'), 'user_id': 'user-new'},
@@ -371,6 +377,7 @@ def test_concurrent_stale_401_cannot_overwrite_a_replacement_key(tmp_path: Path)
 
 	assert not marker.is_alive()
 	assert not replacement.is_alive()
+	assert mark_results == [True]
 	credential = OrcaRouterCredentialStore(config_path).load()
 	assert credential is not None
 	assert credential.api_key == _fake_orcarouter_key('n')
@@ -387,6 +394,32 @@ def test_pkce_save_migrates_legacy_config_before_writing(tmp_path: Path) -> None
 	assert config.browser_profile
 	assert config.agent
 	assert any(entry.provider == 'orcarouter' for entry in config.llm.values())
+
+
+def test_failed_pkce_save_does_not_modify_legacy_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+	config_path = tmp_path / 'config.json'
+	original = '{"llm_model":"gpt-4.1-mini"}'
+	config_path.write_text(original)
+
+	def fail_replace(source, destination):
+		raise OSError('read-only filesystem')
+
+	monkeypatch.setattr('browser_use.llm.orcarouter.auth.os.replace', fail_replace)
+	with pytest.raises(OrcaRouterAuthError, match='configuration'):
+		OrcaRouterCredentialStore(config_path).save(key=_fake_orcarouter_key(), user_id='user-123')
+
+	assert config_path.read_text() == original
+
+
+def test_pkce_save_rejects_malformed_config_without_modifying_it(tmp_path: Path) -> None:
+	config_path = tmp_path / 'config.json'
+	original = '{"browser_profile":'
+	config_path.write_text(original)
+
+	with pytest.raises(OrcaRouterAuthError, match='read Browser Use configuration'):
+		OrcaRouterCredentialStore(config_path).save(key=_fake_orcarouter_key(), user_id='user-123')
+
+	assert config_path.read_text() == original
 
 
 @pytest.mark.parametrize('operation', ['save', 'clear'])

--- a/tests/ci/test_orcarouter.py
+++ b/tests/ci/test_orcarouter.py
@@ -1,7 +1,22 @@
-import pytest
+import asyncio
+import base64
+import hashlib
+import os
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
+import httpx
+import pytest
+from werkzeug.wrappers import Request, Response
+
+from browser_use.config import load_and_migrate_config
 from browser_use.llm.exceptions import ModelProviderError
 from browser_use.llm.messages import ContentPartTextParam, SystemMessage, UserMessage
+from browser_use.llm.orcarouter.auth import (
+	OrcaRouterAuthError,
+	OrcaRouterCredentialStore,
+	OrcaRouterPKCEClient,
+)
 from browser_use.llm.orcarouter.chat import ChatOrcaRouter
 from browser_use.llm.orcarouter.serializer import OrcaRouterMessageSerializer
 from browser_use.llm.views import ChatInvokeUsage
@@ -85,3 +100,240 @@ def test_orcarouter_never_falls_back_to_the_openai_key(monkeypatch: pytest.Monke
 
 	assert exc_info.value.status_code == 401
 	assert 'sk-unrelated-openai-key' not in str(exc_info.value)
+
+
+def _fake_orcarouter_key(character: str = 'a') -> str:
+	return 'sk-orca-' + (character * 48)
+
+
+async def test_pkce_login_uses_s256_loopback_callback_and_persists_api_scope(httpserver, tmp_path: Path) -> None:
+	exchange_request: dict[str, str] = {}
+	issued_key = _fake_orcarouter_key()
+
+	def exchange(request: Request) -> Response:
+		exchange_request.update(request.get_json())
+		return Response(
+			response=f'{{"key":"{issued_key}","user_id":"user-123","scope":"api"}}',
+			status=200,
+			content_type='application/json',
+		)
+
+	httpserver.expect_request('/api/v1/auth/keys', method='POST').respond_with_handler(exchange)
+	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
+	client = OrcaRouterPKCEClient(auth_base_url=httpserver.url_for(''), credential_store=store)
+	authorization_url: str | None = None
+
+	def authorize(url: str) -> None:
+		nonlocal authorization_url
+		authorization_url = url
+
+		async def send_callback() -> None:
+			query = parse_qs(urlparse(url).query)
+			callback_url = query['callback_url'][0]
+			async with httpx.AsyncClient() as callback_client:
+				await callback_client.get(callback_url, params={'code': 'one-time-code', 'state': query['state'][0]})
+
+		asyncio.create_task(send_callback())
+
+	credential = await client.login(open_browser=False, on_authorization_url=authorize, timeout=2)
+
+	assert authorization_url is not None
+	parsed_url = urlparse(authorization_url)
+	query = parse_qs(parsed_url.query)
+	assert parsed_url.path == '/auth'
+	assert query['code_challenge_method'] == ['S256']
+	assert query['scope'] == ['api']
+	assert query['app_name'] == ['Browser Use']
+	assert 'client_id' not in query
+	assert 'appid' not in query
+	assert 'code_verifier' not in query
+	assert query['callback_url'][0].startswith('http://127.0.0.1:')
+	assert exchange_request['code'] == 'one-time-code'
+	assert exchange_request['code_challenge_method'] == 'S256'
+	expected_challenge = (
+		base64.urlsafe_b64encode(hashlib.sha256(exchange_request['code_verifier'].encode()).digest()).rstrip(b'=').decode()
+	)
+	assert query['code_challenge'] == [expected_challenge]
+	assert exchange_request['code_verifier'] not in authorization_url
+	assert issued_key not in authorization_url
+	assert credential.scope == 'api'
+	assert credential.api_key == issued_key
+	assert store.load() == credential
+	assert os.stat(store.path).st_mode & 0o777 == 0o600
+
+
+async def test_pkce_state_mismatch_is_rejected_before_exchange(httpserver, tmp_path: Path) -> None:
+	httpserver.expect_request('/api/v1/auth/keys', method='POST').respond_with_json(
+		{'key': _fake_orcarouter_key(), 'user_id': 'user-123', 'scope': 'api'}
+	)
+	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
+	client = OrcaRouterPKCEClient(auth_base_url=httpserver.url_for(''), credential_store=store)
+	mismatch_status: int | None = None
+
+	def authorize(url: str) -> None:
+		async def send_callbacks() -> None:
+			nonlocal mismatch_status
+			query = parse_qs(urlparse(url).query)
+			callback_url = query['callback_url'][0]
+			async with httpx.AsyncClient() as callback_client:
+				mismatch = await callback_client.get(callback_url, params={'code': 'attacker-code', 'state': 'wrong-state'})
+				mismatch_status = mismatch.status_code
+				await callback_client.get(callback_url, params={'code': 'real-code', 'state': query['state'][0]})
+
+		asyncio.create_task(send_callbacks())
+
+	credential = await client.login(open_browser=False, on_authorization_url=authorize, timeout=2)
+
+	assert mismatch_status == 400
+	assert credential.api_key == _fake_orcarouter_key()
+
+
+async def test_pkce_rejects_downgraded_scope_and_does_not_persist(httpserver, tmp_path: Path) -> None:
+	httpserver.expect_request('/api/v1/auth/keys', method='POST').respond_with_json(
+		{'key': _fake_orcarouter_key(), 'user_id': 'user-123', 'scope': 'profile'}
+	)
+	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
+	client = OrcaRouterPKCEClient(auth_base_url=httpserver.url_for(''), credential_store=store)
+
+	def authorize(url: str) -> None:
+		async def send_callback() -> None:
+			query = parse_qs(urlparse(url).query)
+			async with httpx.AsyncClient() as callback_client:
+				await callback_client.get(
+					query['callback_url'][0],
+					params={'code': 'one-time-code', 'state': query['state'][0]},
+				)
+
+		asyncio.create_task(send_callback())
+
+	with pytest.raises(OrcaRouterAuthError, match='scope'):
+		await client.login(open_browser=False, on_authorization_url=authorize, timeout=2)
+
+	assert store.load() is None
+
+
+def test_orcarouter_key_priority_is_explicit_then_env_then_pkce(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+	stored_key = _fake_orcarouter_key('s')
+	env_key = _fake_orcarouter_key('e')
+	explicit_key = _fake_orcarouter_key('x')
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(tmp_path))
+	OrcaRouterCredentialStore().save(key=stored_key, user_id='user-123')
+
+	monkeypatch.setenv('ORCAROUTER_API_KEY', env_key)
+	assert ChatOrcaRouter(model='orcarouter/auto', api_key=explicit_key).get_client().api_key == explicit_key
+	assert ChatOrcaRouter(model='orcarouter/auto').get_client().api_key == env_key
+
+	monkeypatch.delenv('ORCAROUTER_API_KEY')
+	assert ChatOrcaRouter(model='orcarouter/auto').get_client().api_key == stored_key
+
+
+def test_needs_reauth_key_is_preserved_but_not_reused(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(tmp_path))
+	store = OrcaRouterCredentialStore()
+	credential = store.save(key=_fake_orcarouter_key(), user_id='user-123')
+	assert store.mark_needs_reauth(credential.generation)
+
+	with pytest.raises(ModelProviderError, match='orcarouter login') as exc_info:
+		ChatOrcaRouter(model='orcarouter/auto').get_client()
+
+	assert exc_info.value.status_code == 401
+	loaded = store.load()
+	assert loaded is not None
+	assert loaded.api_key == credential.api_key
+
+
+async def test_stored_pkce_key_401_is_marked_needs_reauth(httpserver, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+	monkeypatch.setenv('BROWSER_USE_CONFIG_DIR', str(tmp_path))
+	monkeypatch.delenv('ORCAROUTER_API_KEY', raising=False)
+	store = OrcaRouterCredentialStore()
+	credential = store.save(key=_fake_orcarouter_key(), user_id='user-123')
+	httpserver.expect_request('/v1/chat/completions', method='POST').respond_with_json(
+		{'error': {'message': 'invalid api key', 'type': 'authentication_error'}}, status=401
+	)
+	chat = ChatOrcaRouter(
+		model='orcarouter/auto',
+		base_url=httpserver.url_for('/v1'),
+		max_retries=0,
+	)
+
+	with pytest.raises(ModelProviderError) as exc_info:
+		await chat.ainvoke([UserMessage(content='hello')])
+
+	assert exc_info.value.status_code == 401
+	loaded = store.load()
+	assert loaded is not None
+	assert loaded.generation == credential.generation
+	assert loaded.needs_reauth is True
+	assert loaded.api_key == credential.api_key
+	with pytest.raises(ModelProviderError, match='orcarouter login'):
+		await chat.ainvoke([UserMessage(content='do not retry with the rejected key')])
+
+
+def test_stale_401_cannot_invalidate_a_replacement_key(tmp_path: Path) -> None:
+	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
+	old = store.save(key=_fake_orcarouter_key('o'), user_id='user-old')
+	new = store.save(key=_fake_orcarouter_key('n'), user_id='user-new')
+
+	assert store.mark_needs_reauth(old.generation) is False
+	assert store.load() == new
+
+
+async def test_pkce_attempts_use_fresh_secrets_and_close_listener_on_timeout(tmp_path: Path) -> None:
+	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
+	client = OrcaRouterPKCEClient(auth_base_url='http://127.0.0.1:9', credential_store=store)
+	authorization_urls: list[str] = []
+
+	for _ in range(2):
+		with pytest.raises(OrcaRouterAuthError, match='Timed out'):
+			await client.login(
+				open_browser=False,
+				on_authorization_url=authorization_urls.append,
+				timeout=0.01,
+			)
+
+	first = parse_qs(urlparse(authorization_urls[0]).query)
+	second = parse_qs(urlparse(authorization_urls[1]).query)
+	assert first['state'] != second['state']
+	assert first['code_challenge'] != second['code_challenge']
+
+	async with httpx.AsyncClient() as callback_client:
+		with pytest.raises(httpx.ConnectError):
+			await callback_client.get(first['callback_url'][0])
+
+
+def test_split_origins_override_shared_self_hosted_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+	for name in (
+		'ORCAROUTER_AUTH_BASE_URL',
+		'ORCAROUTER_API_BASE_URL',
+		'ORCAROUTER_BASE_URL',
+		'ORCA_AUTH_BASE_URL',
+		'ORCA_API_BASE_URL',
+		'ORCA_BASE_URL',
+	):
+		monkeypatch.delenv(name, raising=False)
+	monkeypatch.setenv('ORCA_BASE_URL', 'https://shared.example')
+	assert OrcaRouterPKCEClient().auth_base_url == 'https://shared.example'
+	assert str(ChatOrcaRouter(model='orcarouter/auto', api_key='test-key').base_url) == 'https://shared.example/v1'
+
+	monkeypatch.setenv('ORCA_AUTH_BASE_URL', 'https://auth.example')
+	monkeypatch.setenv('ORCA_API_BASE_URL', 'https://api.example/custom/v1')
+	assert OrcaRouterPKCEClient().auth_base_url == 'https://auth.example'
+	assert str(ChatOrcaRouter(model='orcarouter/auto', api_key='test-key').base_url) == 'https://api.example/custom/v1'
+
+
+def test_remote_auth_origin_requires_https() -> None:
+	with pytest.raises(OrcaRouterAuthError, match='HTTPS'):
+		OrcaRouterPKCEClient(auth_base_url='http://auth.example')
+	with pytest.raises(OrcaRouterAuthError, match='HTTPS'):
+		ChatOrcaRouter(model='orcarouter/auto', api_key='test-key', base_url='http://api.example/v1').get_client()
+
+
+def test_pkce_credential_uses_native_config_without_breaking_config_loading(tmp_path: Path) -> None:
+	store = OrcaRouterCredentialStore(tmp_path / 'config.json')
+	credential = store.save(key=_fake_orcarouter_key(), user_id='user-123')
+
+	config = load_and_migrate_config(store.path)
+	entry = next(item for item in config.llm.values() if item.provider == 'orcarouter')
+	assert entry.api_key == credential.api_key
+	assert entry.auth_method == 'pkce'
+	assert store.load() == credential

--- a/tests/ci/test_orcarouter.py
+++ b/tests/ci/test_orcarouter.py
@@ -422,6 +422,23 @@ def test_pkce_save_rejects_malformed_config_without_modifying_it(tmp_path: Path)
 	assert config_path.read_text() == original
 
 
+@pytest.mark.parametrize(
+	'config_text',
+	[
+		'{"llm":{}}',
+		'{"browser_profile":{},"llm":{},"agent":{}}',
+	],
+)
+def test_pkce_save_accepts_db_config_with_defaultable_or_empty_sections(tmp_path: Path, config_text: str) -> None:
+	config_path = tmp_path / 'config.json'
+	config_path.write_text(config_text)
+	store = OrcaRouterCredentialStore(config_path)
+
+	credential = store.save(key=_fake_orcarouter_key(), user_id='user-123')
+
+	assert store.load() == credential
+
+
 @pytest.mark.parametrize('operation', ['save', 'clear'])
 def test_pkce_store_wraps_write_path_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, operation: str) -> None:
 	store = OrcaRouterCredentialStore(tmp_path / 'config.json')


### PR DESCRIPTION
## Summary

This is a focused follow-up to #5451. It keeps the existing OrcaRouter API-key integration and adds optional browser-based account login using OrcaRouter's authorization-code + PKCE flow.

## What changed

- add `browser-use orcarouter login`, `status`, and `logout` commands
- use a fresh cryptographic verifier and state for every attempt, with `S256` and a random loopback callback port
- keep authentication on `https://www.orcarouter.ai` and inference on `https://api.orcarouter.ai/v1`
- support shared and split self-hosted endpoint overrides, while rejecting non-loopback HTTP origins
- persist the issued durable API key in Browser Use's existing LLM configuration using atomic writes and owner-only file permissions
- resolve credentials in this order: explicit `api_key`, `ORCAROUTER_API_KEY`, then the stored PKCE credential
- preserve rejected credentials but mark the exact credential generation as `needs_reauth` after an upstream `401`
- document both API-key and PKCE usage

The flow intentionally does not send an `appid`, `client_id`, or client secret; OrcaRouter identifies the integration using the consent-screen `app_name` label.

## Security behavior

- the code verifier and API key are never placed in the authorization URL or CLI status output
- callback state is compared before the authorization code is accepted
- downgraded scopes are rejected before persistence
- listeners close on success, denial, cancellation, and timeout
- a late `401` from an old credential cannot invalidate a replacement credential

## Repository maintenance

The repository's live `browser-use skill sync` check detected that both committed Browser Use skill copies were stale relative to `browser-harness/main`. They were regenerated with the repository-provided `scripts/sync_browser_harness_skill.py` script in a separate commit.

## Validation

- `uv run pytest -q tests/ci/test_orcarouter.py tests/ci/test_browser_use_cli.py` (23 passed)
- `uv run pytest -q tests/ci/test_browser_use_skill_install_docs.py` (5 passed)
- `python3 scripts/sync_browser_harness_skill.py --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright`
- `uv run pre-commit run --all-files`
- `uv build`
- manually opened the real OrcaRouter authorization flow in a browser and confirmed the stored status reports `scope: api`
