### PR TITLE
fix(cli): report Browser Use version and accept JSON doctor flags

### DIFF
--- a/browser_use/cli.py
+++ b/browser_use/cli.py
@@ -191,11 +191,16 @@ def _run_browser_harness() -> int | None:
 	_patch_browser_harness_cli_text()
 	args = sys.argv[1:]
 	if args and args[0] == 'doctor' and args[1:]:
+		rest = args[1:]
+		usage = 'usage: browser-use doctor [--fix-snap|--json [--require-existing-daemon]]'
 		if args[1:] in (['--help'], ['-h']):
-			print('usage: browser-use doctor [--fix-snap]')
+			print(usage)
 			return 0
-		if args[1:] != ['--fix-snap']:
-			print('usage: browser-use doctor [--fix-snap]', file=sys.stderr)
+		json_options = (
+			set(rest).issubset({'--json', '--require-existing-daemon'}) and '--json' in rest and len(rest) == len(set(rest))
+		)
+		if rest != ['--fix-snap'] and not json_options:
+			print(usage, file=sys.stderr)
 			sys.exit(2)
 	_delegated_to_harness = True
 	run.main()
@@ -355,6 +360,9 @@ def _command_name(args: list[str]) -> str:
 
 
 def _dispatch(args: list[str]) -> tuple[int | None, str]:
+	if args == ['--version']:
+		print(_browser_use_version())
+		return 0, 'version'
 	if '--cli-mcp' in args:
 		_run_cli_mcp_server()
 		return 0, 'cli-mcp'

--- a/tests/ci/test_browser_use_cli.py
+++ b/tests/ci/test_browser_use_cli.py
@@ -1,7 +1,11 @@
+import json
 import os
 import subprocess
 import sys
+from importlib.metadata import version
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -23,7 +27,7 @@ def test_browser_use_doctor_help_prints_browser_use_usage():
 	result = _run_browser_use_cli('doctor', '--help')
 
 	assert result.returncode == 0
-	assert result.stdout == 'usage: browser-use doctor [--fix-snap]\n'
+	assert result.stdout == 'usage: browser-use doctor [--fix-snap|--json [--require-existing-daemon]]\n'
 	assert result.stderr == ''
 
 
@@ -55,3 +59,36 @@ def test_browser_use_tui_is_deprecated_alias(monkeypatch, capsys):
 
 	assert browser_use_cli.browser_use_tui_main() == 0
 	assert capsys.readouterr().err == 'browser-use-tui is deprecated; use browser-use instead.\n'
+
+
+def test_browser_use_version_reports_installed_distribution():
+	result = _run_browser_use_cli('--version')
+
+	assert result.returncode == 0
+	assert result.stdout.strip() == version('browser-use')
+	assert result.stderr == ''
+
+
+@pytest.mark.parametrize('args', [('--json', '--require-existing-daemon'), ('--require-existing-daemon', '--json')])
+def test_browser_use_doctor_json_reports_missing_daemon_without_starting_one(monkeypatch, tmp_path, args):
+	monkeypatch.setenv('BH_HOME', str(tmp_path))
+	monkeypatch.delenv('BROWSER_HARNESS_HOME', raising=False)
+	monkeypatch.delenv('BU_NAME', raising=False)
+	result = _run_browser_use_cli('doctor', *args)
+
+	assert result.returncode == 1
+	report = json.loads(result.stdout)
+	assert report['healthy'] is False
+	assert report['require_existing_daemon'] is True
+	assert report['daemon']['alive'] is False
+	assert result.stderr == ''
+	assert not list(tmp_path.rglob('*.sock'))
+
+
+@pytest.mark.parametrize('args', [('--require-existing-daemon',), ('--json', '--json'), ('--json', '--fix-snap'), ('--wat',)])
+def test_browser_use_doctor_still_rejects_invalid_options(args):
+	result = _run_browser_use_cli('doctor', *args)
+
+	assert result.returncode == 2
+	assert result.stdout == ''
+	assert result.stderr == 'usage: browser-use doctor [--fix-snap|--json [--require-existing-daemon]]\n'


### PR DESCRIPTION
## Summary

- Report the installed browser-use distribution for --version instead of the browser-harness dependency version.
- Accept the documented doctor --json [--require-existing-daemon] options while retaining validation for unsupported or duplicate flags.
- Update doctor help and cover the real CLI entrypoint with regression tests.

## Reproduction

An isolated browser-use 0.13.10 installation prints 0.1.13 for --version. Its help advertises doctor --json --require-existing-daemon, but that command exits 2 before reaching the Harness health check.

With this patch, --version prints 0.13.10. The documented health command reaches the existing JSON reporter. With no daemon in an isolated runtime directory, it returns healthy: false and exit 1 without starting a daemon.

## Validation

- Focused CLI subprocess checks cover the version, both JSON flag orders, missing-daemon health, invalid flags, help, module invocation and the deprecated alias.
- Changed-file pre-commit passes, including pyright; git diff --check passes.
- A TypeScript subprocess opened example.com using the published CLI; the published and patched CLI both read its title and URL from the same isolated Chrome target.

## Scope

Only browser_use/cli.py and tests/ci/test_browser_use_cli.py change. No dependency, daemon, browser, authentication or Cloud API behavior is changed. The JSON report retains the Harness schema and runtime-version field. The focused run excluded unrelated integration conftest setup; this is not a full repository suite result. First-time Chrome permission setup was not tested.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI so `--version` reports the installed browser-use distribution and the documented doctor JSON flags work instead of exiting with code 2.

- `--version` now prints the installed browser-use version (e.g., 0.13.10) instead of the browser-harness dependency version (0.1.13).
- `doctor --json [--require-existing-daemon]` now parses in either flag order and reaches the existing JSON reporter, returning `healthy: false` and exit 1 when no daemon is running without starting one.
- Invalid, duplicate, or unsupported doctor flag combinations still print usage and exit 2; doctor help now advertises the supported options.
- Expands CLI regression tests to cover version output, both JSON flag orders, missing-daemon health, invalid flags, help, module invocation, and the deprecated alias.
- No dependency, daemon, browser, authentication, or Cloud API behavior changes.

<sup>Written for commit 2670a6be6171706cbd04bf4a92eb7b37c2fd1f48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

