### PR TITLE
Make config text IO explicit UTF-8

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import cache
 from pathlib import Path
 from typing import Any
@@ -249,7 +249,7 @@ class DBStyleEntry(BaseModel):
 
 	id: str = Field(default_factory=lambda: str(uuid4()))
 	default: bool = Field(default=False)
-	created_at: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+	created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
 
 
 class BrowserProfileEntry(DBStyleEntry):
@@ -318,12 +318,12 @@ def load_and_migrate_config(config_path: Path) -> DBStyleConfigJSON:
 		# Create fresh config with defaults
 		config_path.parent.mkdir(parents=True, exist_ok=True)
 		new_config = create_default_config()
-		with open(config_path, 'w') as f:
+		with open(config_path, 'w', encoding='utf-8') as f:
 			json.dump(new_config.model_dump(), f, indent=2)
 		return new_config
 
 	try:
-		with open(config_path) as f:
+		with open(config_path, encoding='utf-8') as f:
 			data = json.load(f)
 
 		# Check if it's already in DB-style format
@@ -340,7 +340,7 @@ def load_and_migrate_config(config_path: Path) -> DBStyleConfigJSON:
 		new_config = create_default_config()
 
 		# Overwrite with new config
-		with open(config_path, 'w') as f:
+		with open(config_path, 'w', encoding='utf-8') as f:
 			json.dump(new_config.model_dump(), f, indent=2)
 
 		logger.debug(f'Created fresh config.json at {config_path}')
@@ -351,7 +351,7 @@ def load_and_migrate_config(config_path: Path) -> DBStyleConfigJSON:
 		# On any error, create fresh config
 		new_config = create_default_config()
 		try:
-			with open(config_path, 'w') as f:
+			with open(config_path, 'w', encoding='utf-8') as f:
 				json.dump(new_config.model_dump(), f, indent=2)
 		except Exception as write_error:
 			logger.error(f'Failed to write fresh config: {write_error}')

--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -37,12 +37,12 @@ def get_or_create_device_id() -> str:
 def _persisted_device_id() -> str | None:
 	try:
 		if os.path.exists(DEVICE_ID_PATH):
-			with open(DEVICE_ID_PATH) as f:
+			with open(DEVICE_ID_PATH, encoding='utf-8') as f:
 				return f.read().strip() or None
 		os.makedirs(os.path.dirname(DEVICE_ID_PATH), exist_ok=True)
 		new_device_id = uuid7str()
 		tmp_path = f'{DEVICE_ID_PATH}.{os.getpid()}.tmp'
-		with open(tmp_path, 'w') as f:
+		with open(tmp_path, 'w', encoding='utf-8') as f:
 			f.write(new_device_id)
 		os.replace(tmp_path, DEVICE_ID_PATH)
 		return new_device_id

--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -1,8 +1,10 @@
 """Tests for lazy loading configuration system."""
 
+from datetime import datetime, timezone
+import json
 import os
 
-from browser_use.config import CONFIG
+from browser_use.config import CONFIG, BrowserProfileEntry, load_and_migrate_config
 
 
 class TestLazyConfig:
@@ -118,3 +120,23 @@ class TestLazyConfig:
 				os.environ['BROWSER_USE_CLOUD_SYNC'] = sync_original
 			else:
 				os.environ.pop('BROWSER_USE_CLOUD_SYNC', None)
+
+	def test_default_config_timestamps_are_timezone_aware_utc(self):
+		"""Test generated DB-style entries use explicit UTC timestamps."""
+		entry = BrowserProfileEntry()
+
+		created_at = datetime.fromisoformat(entry.created_at)
+
+		assert created_at.tzinfo == timezone.utc
+
+	def test_config_migration_round_trips_utf8(self, tmp_path):
+		"""Test config migration reads and writes UTF-8 text."""
+		config_path = tmp_path / 'config.json'
+		config_path.write_text('{"legacy": "cafe \\u2615"}', encoding='utf-8')
+
+		migrated = load_and_migrate_config(config_path)
+		reloaded = load_and_migrate_config(config_path)
+		written = json.loads(config_path.read_text(encoding='utf-8'))
+
+		assert migrated == reloaded
+		assert set(written) == {'browser_profile', 'llm', 'agent'}

--- a/tests/ci/infrastructure/test_config.py
+++ b/tests/ci/infrastructure/test_config.py
@@ -1,8 +1,8 @@
 """Tests for lazy loading configuration system."""
 
-from datetime import datetime, timezone
 import json
 import os
+from datetime import datetime, timezone
 
 from browser_use.config import CONFIG, BrowserProfileEntry, load_and_migrate_config
 


### PR DESCRIPTION
## Problem

A few config and telemetry text files are read or written without an explicit encoding, which leaves behavior up to the platform default. The DB-style config entry timestamp also uses naive `datetime.utcnow()`.

## Before / after

Before:
- config migration and telemetry device-id persistence used platform-default text encoding
- generated config entries stored a naive UTC timestamp string

After:
- config migration and telemetry device-id reads/writes explicitly use UTF-8
- generated config entries use an explicit timezone-aware UTC timestamp

## Verification

- `uv run pytest tests/ci/infrastructure/test_config.py::TestLazyConfig::test_default_config_timestamps_are_timezone_aware_utc tests/ci/infrastructure/test_config.py::TestLazyConfig::test_config_migration_round_trips_utf8`

I also tried the full `tests/ci/infrastructure/test_config.py` file locally on Windows, but it stops on an existing path-format assertion that expects `/.cache` while Windows resolves to `C:\Users\Administrator\.cache`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes config and telemetry text file reads/writes explicit UTF-8 instead of relying on platform defaults, and generated DB-style config timestamps now use timezone-aware UTC.

- Config migration and telemetry device-id persistence open files with `encoding='utf-8'`.
- Generated `created_at` values now include a UTC offset instead of using naive `datetime.utcnow()`.
- Adds tests for timezone-aware timestamps, UTF-8 migration round-trips, and preservation of multilingual configs under non-UTF-8 system defaults.

<sup>Written for commit 2979f2d2fe400658e3c592b192fc32d98cadf945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

