### PR TITLE
fix: defer change event until input replacement

### DIFF
--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -520,48 +520,51 @@ class Element:
 			# Reconcile a controlled field that restored stale text before notifying
 			# change listeners. This keeps the clear and replacement atomic from the
 			# formatter's perspective, including an intentional empty replacement.
-			if clear:
-				value_verification = await cdp_client.send.Runtime.callFunctionOn(
-					params={
-						'functionDeclaration': 'function() { return this.value !== undefined ? this.value : this.textContent; }',
-						'objectId': object_id,
-						'returnByValue': True,
-					},
-					session_id=session_id,
-				)
-				actual_value = value_verification.get('result', {}).get('value')
-				if actual_value != value:
-					await cdp_client.send.Runtime.callFunctionOn(
+			if clear and not cleared_successfully:
+				try:
+					value_verification = await cdp_client.send.Runtime.callFunctionOn(
 						params={
-							'functionDeclaration': """
-								function(newValue) {
-									const setValue = () => {
-										if (this.value !== undefined) {
-											if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
-												const proto = this instanceof HTMLTextAreaElement
-													? window.HTMLTextAreaElement.prototype
-													: window.HTMLInputElement.prototype;
-												const desc = Object.getOwnPropertyDescriptor(proto, 'value');
-												try { desc.set.call(this, newValue); } catch (e) { this.value = newValue; }
-											} else {
-												this.value = newValue;
-											}
-									} else if (this.isContentEditable) {
-										this.textContent = newValue;
-									}
-								};
-								setValue();
-								this.dispatchEvent(new Event('input', { bubbles: true }));
-								if (newValue === '' && (this.value !== undefined ? this.value : this.textContent) !== newValue) setValue();
-								return this.value !== undefined ? this.value : this.textContent;
-								}
-							""",
-							'arguments': [{'value': value}],
+							'functionDeclaration': 'function() { return this.value !== undefined ? this.value : this.textContent; }',
 							'objectId': object_id,
 							'returnByValue': True,
 						},
 						session_id=session_id,
 					)
+					actual_value = value_verification.get('result', {}).get('value')
+					if actual_value != value:
+						await cdp_client.send.Runtime.callFunctionOn(
+							params={
+								'functionDeclaration': """
+									function(newValue) {
+										const setValue = () => {
+											if (this.value !== undefined) {
+												if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
+													const proto = this instanceof HTMLTextAreaElement
+														? window.HTMLTextAreaElement.prototype
+														: window.HTMLInputElement.prototype;
+													const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+													try { desc.set.call(this, newValue); } catch (e) { this.value = newValue; }
+												} else {
+													this.value = newValue;
+												}
+											} else if (this.isContentEditable) {
+												this.textContent = newValue;
+											}
+										};
+										setValue();
+										this.dispatchEvent(new Event('input', { bubbles: true }));
+										if (newValue === '' && (this.value !== undefined ? this.value : this.textContent) !== newValue) setValue();
+										return this.value !== undefined ? this.value : this.textContent;
+									}
+								""",
+								'arguments': [{'value': value}],
+								'objectId': object_id,
+								'returnByValue': True,
+							},
+							session_id=session_id,
+						)
+				except Exception as e:
+					logger.debug(f'Value reconciliation failed: {e}')
 
 			# Notify change listeners only after the replacement text is complete.
 			await cdp_client.send.Runtime.callFunctionOn(

--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -503,6 +503,15 @@ class Element:
 				# Add 18ms delay between keystrokes
 				await asyncio.sleep(0.018)
 
+			# Notify change listeners only after the replacement text is complete.
+			await cdp_client.send.Runtime.callFunctionOn(
+				params={
+					'functionDeclaration': 'function() { this.dispatchEvent(new Event("change", { bubbles: true })); }',
+					'objectId': object_id,
+				},
+				session_id=session_id,
+			)
+
 		except Exception as e:
 			raise Exception(f'Failed to fill element: {str(e)}')
 
@@ -977,7 +986,6 @@ class Element:
 							this.value = "";
 							// Dispatch events to notify frameworks like React
 							this.dispatchEvent(new Event("input", { bubbles: true }));
-							this.dispatchEvent(new Event("change", { bubbles: true }));
 							return this.value;
 						}
 					""",

--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -418,7 +418,7 @@ class Element:
 				try:
 					clear_verification = await cdp_client.send.Runtime.callFunctionOn(
 						params={
-							'functionDeclaration': 'function() { return this.value !== undefined ? this.value : this.textContent; }',
+							'functionDeclaration': 'function() { return this.isContentEditable ? this.textContent : this.value; }',
 							'objectId': object_id,
 							'returnByValue': True,
 						},
@@ -524,7 +524,7 @@ class Element:
 				try:
 					value_verification = await cdp_client.send.Runtime.callFunctionOn(
 						params={
-							'functionDeclaration': 'function() { return this.value !== undefined ? this.value : this.textContent; }',
+							'functionDeclaration': 'function() { return this.isContentEditable ? this.textContent : this.value; }',
 							'objectId': object_id,
 							'returnByValue': True,
 						},
@@ -537,7 +537,9 @@ class Element:
 								'functionDeclaration': """
 									function(newValue) {
 										const setValue = () => {
-											if (this.value !== undefined) {
+											if (this.isContentEditable) {
+												this.textContent = newValue;
+											} else if (this.value !== undefined) {
 												if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
 													const proto = this instanceof HTMLTextAreaElement
 														? window.HTMLTextAreaElement.prototype
@@ -547,14 +549,12 @@ class Element:
 												} else {
 													this.value = newValue;
 												}
-											} else if (this.isContentEditable) {
-												this.textContent = newValue;
 											}
 										};
 										setValue();
 										this.dispatchEvent(new Event('input', { bubbles: true }));
-										if (newValue === '' && (this.value !== undefined ? this.value : this.textContent) !== newValue) setValue();
-										return this.value !== undefined ? this.value : this.textContent;
+										if (newValue === '' && (this.isContentEditable ? this.textContent : this.value) !== newValue) setValue();
+										return this.isContentEditable ? this.textContent : this.value;
 									}
 								""",
 								'arguments': [{'value': value}],
@@ -1037,6 +1037,13 @@ class Element:
 				params={
 					'functionDeclaration': """
 						function() {
+							if (this.isContentEditable) {
+								this.textContent = '';
+								this.innerHTML = '';
+								this.focus();
+								this.dispatchEvent(new Event('input', { bubbles: true }));
+								return this.textContent;
+							}
 							// Try to select all text first (only works on text-like inputs)
 							// This handles cases where cursor is in the middle of text
 							try {
@@ -1061,7 +1068,7 @@ class Element:
 			# Verify clearing worked by checking the value
 			verify_result = await cdp_client.send.Runtime.callFunctionOn(
 				params={
-					'functionDeclaration': 'function() { return this.value; }',
+					'functionDeclaration': 'function() { return this.isContentEditable ? this.textContent : this.value; }',
 					'objectId': object_id,
 					'returnByValue': True,
 				},

--- a/browser_use/actor/element.py
+++ b/browser_use/actor/element.py
@@ -410,10 +410,24 @@ class Element:
 			)
 
 			# Step 2: Clear existing text if requested
+			cleared_successfully = True
 			if clear:
 				cleared_successfully = await self._clear_text_field(
 					object_id=object_id, cdp_client=cdp_client, session_id=session_id
 				)
+				try:
+					clear_verification = await cdp_client.send.Runtime.callFunctionOn(
+						params={
+							'functionDeclaration': 'function() { return this.value !== undefined ? this.value : this.textContent; }',
+							'objectId': object_id,
+							'returnByValue': True,
+						},
+						session_id=session_id,
+					)
+					cleared_successfully = clear_verification.get('result', {}).get('value') == ''
+				except Exception as e:
+					logger.debug(f'Clear verification failed: {e}')
+					cleared_successfully = False
 				if not cleared_successfully:
 					logger.warning('Text field clearing failed, typing may append to existing text')
 
@@ -502,6 +516,52 @@ class Element:
 
 				# Add 18ms delay between keystrokes
 				await asyncio.sleep(0.018)
+
+			# Reconcile a controlled field that restored stale text before notifying
+			# change listeners. This keeps the clear and replacement atomic from the
+			# formatter's perspective, including an intentional empty replacement.
+			if clear:
+				value_verification = await cdp_client.send.Runtime.callFunctionOn(
+					params={
+						'functionDeclaration': 'function() { return this.value !== undefined ? this.value : this.textContent; }',
+						'objectId': object_id,
+						'returnByValue': True,
+					},
+					session_id=session_id,
+				)
+				actual_value = value_verification.get('result', {}).get('value')
+				if actual_value != value:
+					await cdp_client.send.Runtime.callFunctionOn(
+						params={
+							'functionDeclaration': """
+								function(newValue) {
+									const setValue = () => {
+										if (this.value !== undefined) {
+											if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
+												const proto = this instanceof HTMLTextAreaElement
+													? window.HTMLTextAreaElement.prototype
+													: window.HTMLInputElement.prototype;
+												const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+												try { desc.set.call(this, newValue); } catch (e) { this.value = newValue; }
+											} else {
+												this.value = newValue;
+											}
+									} else if (this.isContentEditable) {
+										this.textContent = newValue;
+									}
+								};
+								setValue();
+								this.dispatchEvent(new Event('input', { bubbles: true }));
+								if (newValue === '' && (this.value !== undefined ? this.value : this.textContent) !== newValue) setValue();
+								return this.value !== undefined ? this.value : this.textContent;
+								}
+							""",
+							'arguments': [{'value': value}],
+							'objectId': object_id,
+							'returnByValue': True,
+						},
+						session_id=session_id,
+					)
 
 			# Notify change listeners only after the replacement text is complete.
 			await cdp_client.send.Runtime.callFunctionOn(
@@ -1006,7 +1066,7 @@ class Element:
 			)
 
 			current_value = verify_result.get('result', {}).get('value', '')
-			if not current_value:
+			if current_value == '':
 				logger.debug('Text field cleared successfully using JavaScript')
 				return True
 			else:

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1849,6 +1849,25 @@ class DefaultActionWatchdog(BaseWatchdog):
 			cleared_successfully = True
 			if clear:
 				cleared_successfully = await self._clear_text_field(object_id=object_id, cdp_session=cdp_session)
+				if cleared_successfully:
+					# Fallback clearing strategies can report success even when a
+					# controlled field immediately restores its old value. Verify the
+					# live DOM value before deciding whether an empty replacement is
+					# already complete; otherwise the concatenation retry is skipped.
+					try:
+						clear_verification = await cdp_session.cdp_client.send.Runtime.callFunctionOn(
+							params={
+								'functionDeclaration': 'function() { return this.value !== undefined ? this.value : this.textContent; }',
+								'objectId': object_id,
+								'returnByValue': True,
+							},
+							session_id=cdp_session.session_id,
+						)
+						clear_value = clear_verification.get('result', {}).get('value')
+						cleared_successfully = isinstance(clear_value, str) and not clear_value.strip()
+					except Exception as e:
+						self.logger.debug(f'Clear verification failed: {e}')
+						cleared_successfully = False
 				if not cleared_successfully:
 					self.logger.warning('⚠️ Text field clearing failed, typing may append to existing text')
 
@@ -2068,6 +2087,24 @@ class DefaultActionWatchdog(BaseWatchdog):
 										}
 										this.dispatchEvent(new Event('input', { bubbles: true }));
 										this.dispatchEvent(new Event('change', { bubbles: true }));
+										// A controlled-field listener may synchronously restore its old
+										// value while handling the events. Reapply the native value so an
+										// empty replacement cannot finish with stale text.
+										if (newValue === '' && (this.value !== undefined ? this.value : this.textContent) !== newValue) {
+											if (this.value !== undefined) {
+												if (desc && desc.set) {
+													try {
+														desc.set.call(this, newValue);
+													} catch (e) {
+														this.value = newValue;
+													}
+												} else {
+													this.value = newValue;
+												}
+										} else if (this.isContentEditable) {
+											this.textContent = newValue;
+										}
+										}
 										return this.value !== undefined ? this.value : this.textContent;
 									}
 								""",

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1373,9 +1373,9 @@ class DefaultActionWatchdog(BaseWatchdog):
 								selection.removeAllRanges();
 								selection.addRange(range);
 
-								// Dispatch events
+								// Dispatch input so frameworks observe the clear. The final
+								// change event is sent after replacement text is typed.
 								this.dispatchEvent(new Event("input", { bubbles: true }));
-								this.dispatchEvent(new Event("change", { bubbles: true }));
 
 								return {cleared: true, method: 'contenteditable', finalText: this.textContent};
 							} else if (this.value !== undefined) {
@@ -1406,7 +1406,6 @@ class DefaultActionWatchdog(BaseWatchdog):
 									this.value = "";
 								}
 								this.dispatchEvent(new Event("input", { bubbles: true }));
-								this.dispatchEvent(new Event("change", { bubbles: true }));
 								return {cleared: true, method: 'value', finalText: this.value};
 							} else {
 								return {cleared: false, method: 'none', error: 'Not a supported input type'};
@@ -1847,6 +1846,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 				return input_coordinates
 
 			# Step 3: Clear existing text if requested (only for regular inputs that support typing)
+			cleared_successfully = True
 			if clear:
 				cleared_successfully = await self._clear_text_field(object_id=object_id, cdp_session=cdp_session)
 				if not cleared_successfully:
@@ -2022,7 +2022,13 @@ class DefaultActionWatchdog(BaseWatchdog):
 			# Step 6: Auto-retry on concatenation mismatch (only when clear was requested)
 			# If we asked to clear but the readback value contains the typed text as a substring
 			# yet is longer, the field had pre-existing text that wasn't cleared. Set directly.
-			if clear and not is_sensitive and input_coordinates and 'actual_value' in input_coordinates:
+			if (
+				clear
+				and not is_sensitive
+				and input_coordinates
+				and 'actual_value' in input_coordinates
+				and (text or not cleared_successfully)
+			):
 				actual_value = input_coordinates['actual_value']
 				if (
 					isinstance(actual_value, str)

--- a/browser_use/browser/watchdogs/default_action_watchdog.py
+++ b/browser_use/browser/watchdogs/default_action_watchdog.py
@@ -1864,7 +1864,7 @@ class DefaultActionWatchdog(BaseWatchdog):
 							session_id=cdp_session.session_id,
 						)
 						clear_value = clear_verification.get('result', {}).get('value')
-						cleared_successfully = isinstance(clear_value, str) and not clear_value.strip()
+						cleared_successfully = clear_value == ''
 					except Exception as e:
 						self.logger.debug(f'Clear verification failed: {e}')
 						cleared_successfully = False
@@ -2013,10 +2013,47 @@ class DefaultActionWatchdog(BaseWatchdog):
 				# Small delay between characters to look human (realistic typing speed)
 				await asyncio.sleep(0.001)
 
-			# Step 4: Trigger framework-aware DOM events after typing completion
-			# Modern JavaScript frameworks (React, Vue, Angular) rely on these events
-			# to update their internal state and trigger re-renders
-			await self._trigger_framework_events(object_id=object_id, cdp_session=cdp_session)
+			# Step 4: Trigger framework-aware DOM events after typing completion.
+			# When an empty replacement follows a failed clear, correct the value and
+			# dispatch the final change only after any synchronous controlled-field
+			# listener has had a chance to restore stale state.
+			if clear and not text and not cleared_successfully:
+				await cdp_session.cdp_client.send.Runtime.callFunctionOn(
+					params={
+						'functionDeclaration': """
+							function() {
+								const setEmpty = () => {
+									if (this.value !== undefined) {
+										if (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement) {
+											const proto = this instanceof HTMLTextAreaElement
+												? window.HTMLTextAreaElement.prototype
+												: window.HTMLInputElement.prototype;
+											const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+											try { desc.set.call(this, ''); } catch (e) { this.value = ''; }
+										} else {
+											this.value = '';
+										}
+									} else if (this.isContentEditable) {
+										this.textContent = '';
+									}
+								};
+								setEmpty();
+								this.dispatchEvent(new Event('input', { bubbles: true }));
+								if ((this.value !== undefined ? this.value : this.textContent) !== '') setEmpty();
+								this.dispatchEvent(new Event('change', { bubbles: true }));
+								this.dispatchEvent(new Event('blur', { bubbles: true }));
+								return this.value !== undefined ? this.value : this.textContent;
+							}
+						""",
+						'objectId': object_id,
+						'returnByValue': True,
+					},
+					session_id=cdp_session.session_id,
+				)
+			else:
+				# Modern JavaScript frameworks (React, Vue, Angular) rely on these
+				# events to update their internal state and trigger re-renders.
+				await self._trigger_framework_events(object_id=object_id, cdp_session=cdp_session)
 
 			# Step 5: Read back actual value for verification (skip for sensitive data)
 			if not is_sensitive:

--- a/tests/ci/interactions/test_autocomplete_interaction.py
+++ b/tests/ci/interactions/test_autocomplete_interaction.py
@@ -13,6 +13,7 @@ Tests cover:
 """
 
 import asyncio
+import json
 
 import pytest
 from pytest_httpserver import HTTPServer
@@ -139,6 +140,42 @@ def http_server():
 						el.value = 'prefix_';
 					}
 				});
+			</script>
+		</body>
+		</html>
+		""",
+		content_type='text/html',
+	)
+
+	# Page 7: Formatter that must not observe an intermediate empty change event.
+	server.expect_request('/clear-change-order').respond_with_data(
+		"""
+		<!DOCTYPE html>
+		<html>
+		<head><title>Clear Change Order Test</title></head>
+		<body>
+			<input id="amount-input" type="text" value="0.00" />
+			<textarea id="amount-textarea">0.00</textarea>
+			<div id="amount-edit" contenteditable="true">0.00</div>
+			<script>
+				window.__fieldEvents = {};
+				for (const field of [
+					document.getElementById('amount-input'),
+					document.getElementById('amount-textarea'),
+					document.getElementById('amount-edit'),
+				]) {
+					window.__fieldEvents[field.id] = [];
+					const currentValue = () => 'value' in field ? field.value : field.textContent;
+					field.addEventListener('input', () => {
+						window.__fieldEvents[field.id].push({type: 'input', value: currentValue()});
+					});
+					field.addEventListener('change', () => {
+						window.__fieldEvents[field.id].push({type: 'change', value: currentValue()});
+						const formatted = (Number(currentValue()) || 0).toFixed(2);
+						if ('value' in field) field.value = formatted;
+						else field.textContent = formatted;
+					});
+				}
 			</script>
 		</body>
 		</html>
@@ -380,3 +417,64 @@ class TestAutocompleteInteraction:
 		# Datalist fields should complete without the 400ms tax.
 		# Normal typing for 3 chars takes well under 400ms.
 		assert duration < 0.4, f'Datalist field got unexpected delay: {duration:.3f}s (should be < 0.4s)'
+
+	@pytest.mark.parametrize('field_id', ['amount-input', 'amount-textarea', 'amount-edit'])
+	async def test_clear_defers_change_until_replacement_is_typed(
+		self, tools: Tools, browser_session: BrowserSession, base_url: str, field_id: str
+	):
+		"""A formatter must see the replacement value, not an intermediate empty value."""
+		await tools.navigate(url=f'{base_url}/clear-change-order', new_tab=False, browser_session=browser_session)
+		await asyncio.sleep(0.3)
+		await browser_session.get_browser_state_summary()
+
+		field_index = await browser_session.get_index_by_id(field_id)
+		assert field_index is not None, f'Could not find {field_id}'
+		result = await tools.input(index=field_index, text='1', browser_session=browser_session)
+		assert isinstance(result, ActionResult)
+		assert result.error is None, f'Input action failed: {result.error}'
+
+		cdp_session = await browser_session.get_or_create_cdp_session()
+		readback = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={
+				'expression': f'JSON.stringify(window.__fieldEvents[{json.dumps(field_id)}])',
+				'returnByValue': True,
+			},
+			session_id=cdp_session.session_id,
+		)
+		events = json.loads(readback.get('result', {}).get('value', '[]'))
+		changes = [event['value'] for event in events if event['type'] == 'change']
+		assert changes, f'Input action did not dispatch a final change event: {events}'
+		assert '' not in changes, f'Formatter saw a premature empty change: {events}'
+		assert changes[-1] == '1', f'Final change should observe the replacement text: {events}'
+
+		value_expression = f'document.getElementById({json.dumps(field_id)}).value'
+		if field_id == 'amount-edit':
+			value_expression = f'document.getElementById({json.dumps(field_id)}).textContent'
+		value = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': value_expression, 'returnByValue': True},
+			session_id=cdp_session.session_id,
+		)
+		assert value.get('result', {}).get('value') == '1.00', f'Formatter did not apply final value: {events}'
+
+	async def test_clear_only_keeps_one_final_change_event(self, tools: Tools, browser_session: BrowserSession, base_url: str):
+		"""An intentional empty replacement still emits its one final change event."""
+		await tools.navigate(url=f'{base_url}/clear-change-order', new_tab=False, browser_session=browser_session)
+		await asyncio.sleep(0.3)
+		await browser_session.get_browser_state_summary()
+
+		field_index = await browser_session.get_index_by_id('amount-input')
+		assert field_index is not None
+		result = await tools.input(index=field_index, text='', browser_session=browser_session)
+		assert isinstance(result, ActionResult)
+		assert result.error is None, f'Input action failed: {result.error}'
+
+		cdp_session = await browser_session.get_or_create_cdp_session()
+		readback = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={
+				'expression': 'JSON.stringify(window.__fieldEvents["amount-input"])',
+				'returnByValue': True,
+			},
+			session_id=cdp_session.session_id,
+		)
+		events = json.loads(readback.get('result', {}).get('value', '[]'))
+		assert [event['value'] for event in events if event['type'] == 'change'] == ['']

--- a/tests/ci/interactions/test_autocomplete_interaction.py
+++ b/tests/ci/interactions/test_autocomplete_interaction.py
@@ -442,6 +442,10 @@ class TestAutocompleteInteraction:
 			session_id=cdp_session.session_id,
 		)
 		events = json.loads(readback.get('result', {}).get('value', '[]'))
+		inputs = [event['value'] for event in events if event['type'] == 'input']
+		assert inputs, f'Input action did not dispatch an input event: {events}'
+		assert inputs[0] == '', f'Clear should notify frameworks before replacement typing: {events}'
+		assert inputs[-1] == '1', f'Final input event should observe the replacement text: {events}'
 		changes = [event['value'] for event in events if event['type'] == 'change']
 		assert changes, f'Input action did not dispatch a final change event: {events}'
 		assert '' not in changes, f'Formatter saw a premature empty change: {events}'
@@ -478,3 +482,24 @@ class TestAutocompleteInteraction:
 		)
 		events = json.loads(readback.get('result', {}).get('value', '[]'))
 		assert [event['value'] for event in events if event['type'] == 'change'] == ['']
+
+	async def test_empty_replacement_recovers_after_fallback_clear(
+		self, tools: Tools, browser_session: BrowserSession, base_url: str
+	):
+		"""A fallback that reports success after stale restoration must still clear an empty replacement."""
+		await tools.navigate(url=f'{base_url}/sticky-input', new_tab=False, browser_session=browser_session)
+		await asyncio.sleep(0.3)
+		await browser_session.get_browser_state_summary()
+
+		field_index = await browser_session.get_index_by_id('sticky')
+		assert field_index is not None
+		result = await tools.input(index=field_index, text='', browser_session=browser_session)
+		assert isinstance(result, ActionResult)
+		assert result.error is None, f'Input action failed: {result.error}'
+
+		cdp_session = await browser_session.get_or_create_cdp_session()
+		value = await cdp_session.cdp_client.send.Runtime.evaluate(
+			params={'expression': 'document.getElementById("sticky").value', 'returnByValue': True},
+			session_id=cdp_session.session_id,
+		)
+		assert value.get('result', {}).get('value') == '', 'Empty replacement retained stale text after fallback clear'


### PR DESCRIPTION
Fixes #5721. Defer change notifications until replacement text is typed while preserving input notifications for controlled fields. Add regression coverage for input, textarea, and contenteditable fields plus intentional empty replacement. Validation: uv run pytest tests/ci/interactions/test_autocomplete_interaction.py -k clear -q (6 passed); pre-commit changed files (passed). The full interaction file latest run was 10 passed, 1 failed due unrelated Chromium/EventBus navigation timeout before field lookup; this is disclosed rather than treated as a product failure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5721 so clearing a field no longer fires a `change` event before replacement text is typed, preventing formatters from seeing an intermediate empty value. Also recovers empty replacements when a fallback clear reports success but a controlled field immediately restores its old value.

- `change` is now deferred until after replacement text is inserted; `input` events still dispatch immediately.
- Intentional empty replacements still dispatch exactly one final `change` event.
- Fallback clears verify the live DOM value; failed clears reapply the value if a listener synchronously reverts it.
- Contenteditable fields are cleared via text content alongside input, textarea, and select fields.
- Adds regression tests covering input, textarea, contenteditable, and the fallback-restore case.

<sup>Written for commit 5a4f5da401738bdc0de93c0004022ad4b894b0f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

