### PR TITLE
fix(agent): stop masking step failures as output format errors

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -375,8 +375,12 @@ class MessageManager:
 					history_item = HistoryItem(step_number=step_number, action_results=action_results)
 					self.state.agent_history_items.append(history_item)
 				elif step_number > 0:
-					# Error case for steps > 0
-					history_item = HistoryItem(step_number=step_number, error='Agent failed to output in the right format.')
+					# Error case for steps > 0: report why the step actually failed (LLM timeout, CDP
+					# error, ...) and only assume a malformed response when no reason was recorded.
+					if action_results:
+						history_item = HistoryItem(step_number=step_number, action_results=action_results)
+					else:
+						history_item = HistoryItem(step_number=step_number, error='Agent failed to output in the right format.')
 					self.state.agent_history_items.append(history_item)
 		else:
 			history_item = HistoryItem(

--- a/tests/ci/test_message_manager_step_error_history.py
+++ b/tests/ci/test_message_manager_step_error_history.py
@@ -1,0 +1,78 @@
+"""Regression test: a failed step must tell the model why it actually failed.
+
+When a step fails before the LLM returns usable output, `Agent._handle_step_error`
+records the reason in `ActionResult.error` and clears `last_model_output`. The next
+prompt is therefore built with `model_output=None`, and
+`MessageManager._update_agent_history_description` used to render the recorded reason
+(the old format was "No model output (parsing failed)" followed by the action results).
+
+A history-formatting change (8c4dc394 "Improve history") dropped the action-results
+interpolation from that branch, so every such failure was reported to the model as
+"Agent failed to output in the right format." regardless of its real cause. An LLM
+timeout, whose error text asks the model to shorten its output, was presented as a
+schema violation instead, pushing the model to fix its JSON rather than shorten.
+"""
+
+import tempfile
+
+from browser_use.agent.message_manager.service import MessageManager
+from browser_use.agent.views import ActionResult, AgentStepInfo
+from browser_use.filesystem.file_system import FileSystem
+from browser_use.llm import SystemMessage
+
+FORMAT_FALLBACK = 'Agent failed to output in the right format.'
+LLM_TIMEOUT_ERROR = 'LLM call timed out after 60 seconds. Keep your thinking and output short.'
+
+
+def _make_manager() -> MessageManager:
+	return MessageManager(
+		task='test task',
+		system_message=SystemMessage(content='system'),
+		file_system=FileSystem(tempfile.mkdtemp()),
+	)
+
+
+def test_failed_step_reports_the_actual_error():
+	"""The recorded error reaches the model instead of the generic format message."""
+	mm = _make_manager()
+
+	mm._update_agent_history_description(
+		model_output=None,
+		result=[ActionResult(error=LLM_TIMEOUT_ERROR)],
+		step_info=AgentStepInfo(step_number=3, max_steps=10),
+	)
+
+	history = mm.agent_history_description
+	assert LLM_TIMEOUT_ERROR in history
+	assert FORMAT_FALLBACK not in history
+
+
+def test_failed_step_without_a_recorded_error_keeps_the_format_message():
+	"""With nothing to report, the original generic message is still the best guess."""
+	mm = _make_manager()
+
+	mm._update_agent_history_description(
+		model_output=None,
+		result=[],
+		step_info=AgentStepInfo(step_number=3, max_steps=10),
+	)
+
+	assert FORMAT_FALLBACK in mm.agent_history_description
+
+
+def test_long_step_error_is_elided_in_the_middle():
+	"""A long error (e.g. a stack trace) is shortened so it cannot flood the prompt."""
+	mm = _make_manager()
+	long_error = 'HEAD' + 'x' * 500 + 'TAIL'
+
+	mm._update_agent_history_description(
+		model_output=None,
+		result=[ActionResult(error=long_error)],
+		step_info=AgentStepInfo(step_number=3, max_steps=10),
+	)
+
+	history = mm.agent_history_description
+	assert long_error not in history
+	assert 'HEAD' in history
+	assert 'TAIL' in history
+	assert '......' in history


### PR DESCRIPTION
When a step fails before the LLM returns usable output, `Agent._handle_step_error` records the reason in `ActionResult.error` and leaves `last_model_output` as `None`. `MessageManager._update_agent_history_description` builds the history entry for that step from that state, and the entry was hardcoded to `Agent failed to output in the right format.` regardless of what had been recorded.

An LLM timeout therefore reached the model as a schema violation. Its error text asks the model to shorten its output, but the model was told to fix its JSON instead. CDP errors, browser-state failures and recovered connection losses were masked the same way.

The interpolation used to be there. The branch rendered `No model output (parsing failed)` followed by the action results until 8c4dc394 changed the history format from `## Step N` to `<step_N>` and dropped it. This restores it: report the recorded results when there are any, and keep the generic message only when nothing was recorded.

What the model sees for a timed-out step:

```diff
-<step>
-Agent failed to output in the right format.
+<step>
+Result
+LLM call timed out after 60 seconds. Keep your thinking and output short.
```

Regression tests cover the recorded reason reaching the history, the fallback when no reason exists, and the existing middle-elision that keeps a long stack trace from flooding the prompt.

Scope is limited to that one branch. `HistoryItem.error` is read only by `HistoryItem.to_string()`, and the hardcoded string had no other reference in the repository, so nothing else depends on the old wording.

Validation:
- Before the fix: the new suite fails on the masked-error assertion.
- After the fix: 3 passed in the new suite; 1207 passed, 34 skipped across `tests/ci`.
- `./bin/lint.sh` passed, including Ruff and Pyright.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes step failures being presented to the model as output format errors. Step history now shows the recorded failure reason (such as an LLM timeout) when one exists, keeping the generic format message only as a fallback.

**Bug Fixes**
- An LLM timeout previously reached the model as a schema violation, telling it to fix its JSON instead of shortening its output.
- CDP errors, browser-state failures, and recovered connection losses were masked the same way.
- Nothing else depends on the old wording, so no migration is needed.
- Regression tests cover the recorded reason, the fallback, and middle-elision of long stack traces.

<sup>Written for commit 1a0293d557c77e54d2e66a97575b2dfddf7bd67b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

