### PR TITLE
fix(dom): expose live selections of visible disabled selects

### DIFF
--- a/browser_use/dom/enhanced_snapshot.py
+++ b/browser_use/dom/enhanced_snapshot.py
@@ -114,6 +114,8 @@ def build_snapshot_lookup(
 		# At 20k elements: 5,925ms (list) → 2ms (set) = 3,000x speedup.
 		has_clickable_data = 'isClickable' in nodes
 		is_clickable_set: set[int] = set(nodes['isClickable']['index']) if has_clickable_data else set()
+		has_option_selected_data = 'optionSelected' in nodes
+		selected_option_indices = set(nodes['optionSelected']['index']) if has_option_selected_data else set()
 
 		# Live form values live in the snapshot, not in the DOM attributes. Map
 		# snapshot index -> string once so each node lookup stays O(1).
@@ -211,6 +213,7 @@ def build_snapshot_lookup(
 				stacking_contexts=stacking_contexts,
 				input_value=input_value_by_index.get(snapshot_index),
 				input_checked=(snapshot_index in input_checked_set) if has_checked_data else None,
+				option_selected=snapshot_index in selected_option_indices if has_option_selected_data else None,
 			)
 
 	# Count how many have bounds (are actually visible/laid out)

--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -450,6 +450,9 @@ class DOMTreeSerializer:
 			return False
 		current: EnhancedDOMTreeNode | None = node
 		while current:
+			# DOMSnapshot has no layout styles for display:contents wrappers. They
+			# generate no box, so their own opacity does not hide painted descendants.
+			# Do not treat missing layout styles as evidence that a select is hidden.
 			styles = current.snapshot_node.computed_styles or {} if current.snapshot_node else {}
 			if styles.get('display', '').lower() == 'none':
 				return False

--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -1,5 +1,7 @@
 # @file purpose: Serializes enhanced DOM trees to string format for LLM consumption
 
+import json
+import re
 from typing import Any
 
 from browser_use.dom.serializer.clickable_elements import ClickableElementDetector
@@ -431,6 +433,43 @@ class DOMTreeSerializer:
 
 		return {'count': len(options), 'first_options': first_options, 'format_hint': format_hint}
 
+	@staticmethod
+	def _serialize_selected_options(select_node: EnhancedDOMTreeNode) -> str:
+		"""Describe live selections without guessing from HTML defaults or the option list."""
+		if not select_node.snapshot_node or select_node.snapshot_node.option_selected is None:
+			return 'unknown'
+
+		selected_options: list[dict[str, str]] = []
+		pending = list(reversed(select_node.children))
+		while pending:
+			option = pending.pop()
+			if option.tag_name != 'option':
+				pending.extend(reversed(option.children))
+				continue
+			if not option.snapshot_node or option.snapshot_node.option_selected is None:
+				return 'unknown'
+			if not option.snapshot_node.option_selected:
+				continue
+
+			# option.text collapses HTML whitespace; label/value may differ from that text.
+			text_parts: list[str] = []
+			text_nodes = list(reversed(option.children))
+			while text_nodes:
+				child = text_nodes.pop()
+				if child.node_type == NodeType.TEXT_NODE:
+					text_parts.append(child.node_value)
+				elif child.tag_name != 'script':
+					text_nodes.extend(reversed(child.children))
+			option_text = re.sub(r'[\t\n\f\r ]+', ' ', ''.join(text_parts)).strip(' ')
+			selected_options.append(
+				{
+					'value': option.attributes.get('value', option_text),
+					'label': option.attributes.get('label') or option_text,
+				}
+			)
+
+		return json.dumps(selected_options, ensure_ascii=False, separators=(',', ':'))
+
 	def _is_interactive_cached(self, node: EnhancedDOMTreeNode) -> bool:
 		"""Cached version of clickable element detection to avoid redundant calls."""
 
@@ -660,6 +699,14 @@ class DOMTreeSerializer:
 	def _assign_interactive_indices_and_mark_new_nodes(self, node: SimplifiedNode | None) -> None:
 		"""Assign interactive indices to clickable elements that are also visible."""
 		if not node:
+			return
+
+		# Disabled selects and their options are readable, but cannot be action targets.
+		original = node.original_node
+		if original.tag_name == 'select' and (
+			'disabled' in original.attributes
+			or (original.ax_node and any(prop.name == 'disabled' and prop.value for prop in original.ax_node.properties or []))
+		):
 			return
 
 		# Skip assigning index to excluded nodes, or ignored by paint order
@@ -1005,6 +1052,13 @@ class DOMTreeSerializer:
 		next_depth = depth
 
 		if node.original_node.node_type == NodeType.ELEMENT_NODE:
+			is_select = node.original_node.tag_name == 'select'
+			if is_select:
+				# Keep the existing indexed shadow-control fallback when CDP has no layout.
+				indexed_without_layout = node.is_interactive and node.original_node.snapshot_node is None
+				if node.ignored_by_paint_order or not (node.original_node.is_visible or indexed_without_layout):
+					return ''
+
 			# Skip displaying nodes marked as should_display=False
 			if not node.should_display:
 				for child in node.children:
@@ -1046,6 +1100,7 @@ class DOMTreeSerializer:
 			if (
 				node.is_interactive
 				or is_any_scrollable
+				or is_select
 				or node.original_node.tag_name.upper() == 'IFRAME'
 				or node.original_node.tag_name.upper() == 'FRAME'
 			):
@@ -1056,6 +1111,9 @@ class DOMTreeSerializer:
 				attributes_html_str = DOMTreeSerializer._build_attributes_string(
 					node.original_node, include_attributes, text_content
 				)
+				if is_select:
+					selection = DOMTreeSerializer._serialize_selected_options(node.original_node)
+					attributes_html_str = f'{attributes_html_str} selected={selection}'.strip()
 				if node.is_interactive:
 					image_context = DOMTreeSerializer._get_child_image_context(node)
 					if image_context:
@@ -1065,7 +1123,7 @@ class DOMTreeSerializer:
 							attributes_html_str = image_context
 
 				# Add compound component information to attributes if present
-				if node.original_node._compound_children:
+				if node.original_node._compound_children and (not is_select or node.is_interactive):
 					compound_info = []
 					for child_info in node.original_node._compound_children:
 						parts = []
@@ -1339,6 +1397,14 @@ class DOMTreeSerializer:
 						if value_str:
 							attributes_to_include['value'] = value_str
 							break
+
+		if node.tag_name == 'select':
+			# Avoid stale or duplicate value summaries alongside the explicit live
+			# selection rendered from the snapshot.
+			for attribute in ('value', 'valuetext', 'selected'):
+				attributes_to_include.pop(attribute, None)
+			if 'disabled' in node.attributes:
+				attributes_to_include['disabled'] = 'true'
 
 		if not attributes_to_include:
 			return ''

--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -434,6 +434,36 @@ class DOMTreeSerializer:
 		return {'count': len(options), 'first_options': first_options, 'format_hint': format_hint}
 
 	@staticmethod
+	def _is_disabled_select(node: EnhancedDOMTreeNode) -> bool:
+		"""Use native and accessibility state, including disabled fieldset inheritance."""
+		return node.tag_name == 'select' and (
+			'disabled' in node.attributes
+			or bool(node.ax_node and any(prop.name == 'disabled' and prop.value for prop in node.ax_node.properties or []))
+		)
+
+	@staticmethod
+	def _has_visible_select_layout(node: EnhancedDOMTreeNode) -> bool:
+		"""Check CSS visibility without treating an offscreen control as hidden."""
+		if not node.snapshot_node or not node.snapshot_node.bounds:
+			return False
+		if (node.snapshot_node.computed_styles or {}).get('visibility', '').lower() in {'hidden', 'collapse'}:
+			return False
+		current: EnhancedDOMTreeNode | None = node
+		while current:
+			styles = current.snapshot_node.computed_styles or {} if current.snapshot_node else {}
+			if styles.get('display', '').lower() == 'none':
+				return False
+			try:
+				if float(styles.get('opacity', '1')) <= 0:
+					return False
+			except (ValueError, TypeError):
+				pass
+			# Ancestor opacity affects the entire subtree. Visibility, in contrast,
+			# can be overridden by a child, so its computed value is checked above.
+			current = current.parent_node
+		return True
+
+	@staticmethod
 	def _serialize_selected_options(select_node: EnhancedDOMTreeNode) -> str:
 		"""Describe live selections without guessing from HTML defaults or the option list."""
 		if not select_node.snapshot_node or select_node.snapshot_node.option_selected is None:
@@ -702,11 +732,7 @@ class DOMTreeSerializer:
 			return
 
 		# Disabled selects and their options are readable, but cannot be action targets.
-		original = node.original_node
-		if original.tag_name == 'select' and (
-			'disabled' in original.attributes
-			or (original.ax_node and any(prop.name == 'disabled' and prop.value for prop in original.ax_node.properties or []))
-		):
+		if self._is_disabled_select(node.original_node):
 			return
 
 		# Skip assigning index to excluded nodes, or ignored by paint order
@@ -1053,10 +1079,17 @@ class DOMTreeSerializer:
 
 		if node.original_node.node_type == NodeType.ELEMENT_NODE:
 			is_select = node.original_node.tag_name == 'select'
+			is_disabled_select = DOMTreeSerializer._is_disabled_select(node.original_node)
 			if is_select:
-				# Keep the existing indexed shadow-control fallback when CDP has no layout.
+				# Read-only selects require viewport visibility. Existing action targets
+				# may be outside that cutoff, but CSS-hidden data must stay excluded.
+				can_display = node.original_node.is_visible or (node.is_interactive and not is_disabled_select)
 				indexed_without_layout = node.is_interactive and node.original_node.snapshot_node is None
-				if node.ignored_by_paint_order or not (node.original_node.is_visible or indexed_without_layout):
+				if (
+					node.ignored_by_paint_order
+					or not can_display
+					or not (indexed_without_layout or DOMTreeSerializer._has_visible_select_layout(node.original_node))
+				):
 					return ''
 
 			# Skip displaying nodes marked as should_display=False
@@ -1198,6 +1231,10 @@ class DOMTreeSerializer:
 						line += f' ({scroll_info_text})'
 
 				formatted_text.append(line)
+				if is_disabled_select:
+					# The live selection already describes this read-only control.
+					# Option/selectedcontent descendants can otherwise repeat its label.
+					return '\n'.join(formatted_text)
 
 		elif node.original_node.node_type == NodeType.DOCUMENT_FRAGMENT_NODE:
 			# Shadow DOM representation - show clearly to LLM

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -357,6 +357,8 @@ class EnhancedSnapshotNode:
 	"""Live value of an <input> or <textarea> (DOMSnapshot inputValue/textValue), which the value attribute misses when JS, autofill, or a framework set it."""
 	input_checked: bool | None = None
 	"""Live checked state of a checkbox or radio input (DOMSnapshot inputChecked)."""
+	option_selected: bool | None = None
+	"""Live option selection from DOMSnapshot; None when that data was not captured."""
 
 
 # @dataclass(slots=True)

--- a/tests/ci/browser/test_disabled_select_serialization.py
+++ b/tests/ci/browser/test_disabled_select_serialization.py
@@ -1,0 +1,256 @@
+"""Expose live values of visible disabled selects without assigning action indices."""
+
+import json
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+from browser_use.browser import BrowserProfile, BrowserSession
+from browser_use.browser.profile import ViewportSize
+from browser_use.dom.views import SerializedDOMState
+from browser_use.tools.service import Tools
+
+
+@pytest.fixture(scope='module')
+async def select_browser() -> AsyncIterator[BrowserSession]:
+	"""Use a real browser without an LLM or optional browser extensions."""
+	browser = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			use_cloud=False,
+			enable_default_extensions=False,
+			window_size=ViewportSize(width=1280, height=1000),
+		)
+	)
+	await browser.start()
+	try:
+		yield browser
+	finally:
+		await browser.kill()
+		await browser.event_bus.stop(clear=True, timeout=5)
+
+
+@pytest.fixture
+def select_server() -> Iterator[HTTPServer]:
+	server = HTTPServer(host='127.0.0.1', threaded=True)
+	server.start()
+	server.expect_request('/favicon.ico').respond_with_data('', status=204)
+	try:
+		yield server
+	finally:
+		server.stop()
+
+
+async def _open_form(browser: BrowserSession, server: HTTPServer, controls: str) -> None:
+	server.expect_request('/form').respond_with_data(
+		f'<!doctype html><html><head><meta charset="utf-8"><title>Form</title></head>'
+		f'<body><h1>Form</h1><button id="save-form" type="button">Save form</button>{controls}</body></html>',
+		content_type='text/html; charset=utf-8',
+	)
+	await browser.navigate_to(server.url_for('/form'))
+
+
+async def _dom_state(browser: BrowserSession) -> SerializedDOMState:
+	state = await browser.get_browser_state_summary(include_screenshot=False, include_recent_events=False, cached=False)
+	assert any(node.attributes.get('id') == 'save-form' for node in state.dom_state.selector_map.values()), (
+		f'The ordinary button must be captured before checking dropdown serialization: {state.dom_state.llm_representation()}'
+	)
+	assert 'Save form' in state.dom_state.llm_representation()
+	return state.dom_state
+
+
+def _reported_selection(state: SerializedDOMState) -> list[dict[str, str]]:
+	serialized = state.llm_representation()
+	select_lines = [line for line in serialized.splitlines() if '<select' in line]
+	assert len(select_lines) == 1, f'The visible select should remain identifiable: {serialized}'
+	select_line = select_lines[0]
+	assert 'selected=' in select_line, f'The current selection must be explicit: {select_line}'
+	selected, _ = json.JSONDecoder().raw_decode(select_line.split('selected=', 1)[1])
+	assert isinstance(selected, list)
+	return selected
+
+
+def _assert_disabled_controls_not_indexed(state: SerializedDOMState) -> None:
+	indexed_controls = [node for node in state.selector_map.values() if node.tag_name.lower() in {'select', 'option', 'optgroup'}]
+	assert not indexed_controls, f'Disabled dropdowns and their options must not be actionable: {state.llm_representation()}'
+	select_line = next(line for line in state.llm_representation().splitlines() if '<select' in line)
+	assert 'disabled' in select_line
+
+
+async def test_disabled_select_reports_implicit_first_option(select_browser: BrowserSession, select_server: HTTPServer):
+	"""The browser selects the first option even when HTML has no selected attribute."""
+	await _open_form(
+		select_browser,
+		select_server,
+		'<select id="status" name="status" disabled><option value="active">Active</option></select>',
+	)
+	session = await select_browser.get_or_create_cdp_session()
+	readback = await session.cdp_client.send.Runtime.evaluate(
+		params={
+			'expression': "({value: document.querySelector('select').value, selectedAttribute: document.querySelector('option').hasAttribute('selected')})",
+			'returnByValue': True,
+		},
+		session_id=session.session_id,
+	)
+	assert readback['result'].get('value') == {'value': 'active', 'selectedAttribute': False}
+	state = await _dom_state(select_browser)
+	assert _reported_selection(state) == [{'value': 'active', 'label': 'Active'}]
+	_assert_disabled_controls_not_indexed(state)
+
+
+@pytest.mark.parametrize(
+	('selected_index', 'expected_selection'),
+	[
+		pytest.param(1, [{'value': 'active', 'label': 'Active'}], id='selection-changed'),
+		pytest.param(-1, [], id='selection-cleared'),
+	],
+)
+async def test_disabled_select_reports_live_selection_after_script_change(
+	select_browser: BrowserSession,
+	select_server: HTTPServer,
+	selected_index: int,
+	expected_selection: list[dict[str, str]],
+):
+	"""HTML defaults remain unchanged when the live selection changes or is cleared."""
+	await _open_form(
+		select_browser,
+		select_server,
+		'<select id="status" name="status" disabled>'
+		'<option value="draft" selected>Draft</option>'
+		'<option value="active">Active</option></select>',
+	)
+	initial_state = await _dom_state(select_browser)
+	assert _reported_selection(initial_state) == [{'value': 'draft', 'label': 'Draft'}]
+	session = await select_browser.get_or_create_cdp_session()
+	mutation = await session.cdp_client.send.Runtime.evaluate(
+		params={
+			'expression': f"document.querySelector('select').selectedIndex = {selected_index}",
+			'returnByValue': True,
+		},
+		session_id=session.session_id,
+	)
+	assert not mutation.get('exceptionDetails'), mutation
+	readback = await session.cdp_client.send.Runtime.evaluate(
+		params={
+			'expression': """(() => {
+				const select = document.querySelector('select');
+				return {
+					selected: Array.from(select.selectedOptions, option => ({value: option.value, label: option.label})),
+					selectedAttributes: Array.from(select.options, option => option.hasAttribute('selected'))
+				};
+			})()""",
+			'returnByValue': True,
+		},
+		session_id=session.session_id,
+	)
+	assert readback['result'].get('value') == {'selected': expected_selection, 'selectedAttributes': [True, False]}
+	updated_state = await _dom_state(select_browser)
+	assert _reported_selection(updated_state) == expected_selection
+	_assert_disabled_controls_not_indexed(updated_state)
+
+
+@pytest.mark.parametrize(
+	('options', 'expected_selection'),
+	[
+		pytest.param(
+			'<optgroup label="Available">'
+			'<option value="active" label="Active" selected>internal-active</option>'
+			'<option value="pending" label="Pending">internal-pending</option>'
+			'</optgroup><optgroup label="Completed">'
+			'<option value="archived" label="Archived" selected>internal-archived</option></optgroup>',
+			[{'value': 'active', 'label': 'Active'}, {'value': 'archived', 'label': 'Archived'}],
+			id='selected-labels-in-optgroups',
+		),
+		pytest.param(
+			'<option value="" label="Choose status" selected>internal-placeholder</option>'
+			'<option label="" selected>Text fallback</option>'
+			'<option value="empty-label" label="" selected>Empty label fallback</option>'
+			'<option value="missing-label" selected>Missing label fallback</option>'
+			'<option value="" label="" selected></option>',
+			[
+				{'value': '', 'label': 'Choose status'},
+				{'value': 'Text fallback', 'label': 'Text fallback'},
+				{'value': 'empty-label', 'label': 'Empty label fallback'},
+				{'value': 'missing-label', 'label': 'Missing label fallback'},
+				{'value': '', 'label': ''},
+			],
+			id='empty-values-and-label-fallbacks',
+		),
+	],
+)
+async def test_disabled_multiple_select_preserves_selected_values_and_labels(
+	select_browser: BrowserSession,
+	select_server: HTTPServer,
+	options: str,
+	expected_selection: list[dict[str, str]],
+):
+	"""Only live selected options contribute, with native value and displayed label semantics."""
+	await _open_form(
+		select_browser,
+		select_server,
+		f'<select id="status" name="status" multiple size="7" disabled>{options}</select>',
+	)
+	session = await select_browser.get_or_create_cdp_session()
+	readback = await session.cdp_client.send.Runtime.evaluate(
+		params={
+			'expression': "Array.from(document.querySelector('select').selectedOptions, option => ({value: option.value, label: option.label || option.text}))",
+			'returnByValue': True,
+		},
+		session_id=session.session_id,
+	)
+	assert readback['result'].get('value') == expected_selection
+	state = await _dom_state(select_browser)
+	assert _reported_selection(state) == expected_selection
+	_assert_disabled_controls_not_indexed(state)
+
+
+async def test_enabled_select_remains_indexed_and_can_change_selection(select_browser: BrowserSession, select_server: HTTPServer):
+	"""Exposing disabled values must preserve the normal dropdown action path."""
+	await _open_form(
+		select_browser,
+		select_server,
+		'<select id="status" name="status">'
+		'<option value="draft" selected>Draft</option>'
+		'<option value="active">Active</option></select>',
+	)
+	state = await _dom_state(select_browser)
+	indices = [index for index, node in state.selector_map.items() if node.attributes.get('id') == 'status']
+	assert len(indices) == 1, state.llm_representation()
+	result = await Tools().select_dropdown(index=indices[0], text='Active', browser_session=select_browser)
+	assert result.error is None, result.error
+	updated_state = await _dom_state(select_browser)
+	assert any(node.attributes.get('id') == 'status' for node in updated_state.selector_map.values())
+	assert _reported_selection(updated_state) == [{'value': 'active', 'label': 'Active'}]
+
+
+@pytest.mark.parametrize(
+	('prefix', 'attributes', 'suffix'),
+	[
+		pytest.param('', 'hidden', '', id='hidden-attribute'),
+		pytest.param('', 'style="display: none"', '', id='display-none'),
+		pytest.param('', 'style="visibility: hidden"', '', id='visibility-hidden'),
+		pytest.param('<div hidden>', '', '</div>', id='hidden-ancestor'),
+	],
+)
+async def test_hidden_disabled_select_does_not_expose_values_or_indices(
+	select_browser: BrowserSession,
+	select_server: HTTPServer,
+	prefix: str,
+	attributes: str,
+	suffix: str,
+):
+	"""The visible-value exception must not leak hidden controls or their option text."""
+	await _open_form(
+		select_browser,
+		select_server,
+		f'{prefix}<select id="hidden-status" name="hidden-status" disabled {attributes}>'
+		'<option value="hidden-choice" label="Hidden selected label">Hidden option text</option>'
+		f'</select>{suffix}',
+	)
+	state = await _dom_state(select_browser)
+	serialized = state.llm_representation()
+	for hidden_content in ('hidden-status', 'hidden-choice', 'Hidden selected label', 'Hidden option text'):
+		assert hidden_content not in serialized, serialized
+	assert all(node.tag_name.lower() not in {'select', 'option', 'optgroup'} for node in state.selector_map.values())

--- a/tests/ci/browser/test_disabled_select_serialization.py
+++ b/tests/ci/browser/test_disabled_select_serialization.py
@@ -75,8 +75,16 @@ def _reported_selection(state: SerializedDOMState) -> list[dict[str, str]]:
 def _assert_disabled_controls_not_indexed(state: SerializedDOMState) -> None:
 	indexed_controls = [node for node in state.selector_map.values() if node.tag_name.lower() in {'select', 'option', 'optgroup'}]
 	assert not indexed_controls, f'Disabled dropdowns and their options must not be actionable: {state.llm_representation()}'
-	select_line = next(line for line in state.llm_representation().splitlines() if '<select' in line)
+	lines = state.llm_representation().splitlines()
+	select_position = next(index for index, line in enumerate(lines) if '<select' in line)
+	select_line = lines[select_position]
 	assert 'disabled' in select_line
+	select_depth = len(select_line) - len(select_line.lstrip('\t'))
+	if select_position + 1 < len(lines):
+		next_line = lines[select_position + 1]
+		assert len(next_line) - len(next_line.lstrip('\t')) <= select_depth, (
+			f'Disabled select state must not be followed by duplicate option/selectedcontent text: {state.llm_representation()}'
+		)
 
 
 async def test_disabled_select_reports_implicit_first_option(select_browser: BrowserSession, select_server: HTTPServer):
@@ -206,6 +214,78 @@ async def test_disabled_multiple_select_preserves_selected_values_and_labels(
 	_assert_disabled_controls_not_indexed(state)
 
 
+@pytest.mark.parametrize('customizable', [False, True], ids=['native', 'customizable'])
+async def test_disabled_select_serializes_only_its_current_selection(
+	select_browser: BrowserSession, select_server: HTTPServer, customizable: bool
+):
+	"""Rendered selectedcontent must not repeat the selection or expose unselected labels."""
+	style = '<style>select, select::picker(select) { appearance: base-select; }</style>' if customizable else ''
+	button = '<button><selectedcontent></selectedcontent></button>' if customizable else ''
+	await _open_form(
+		select_browser,
+		select_server,
+		f'{style}<select id="status" disabled>{button}'
+		'<option value="alpha">Alpha label</option>'
+		'<option value="beta" selected>Beta label</option>'
+		'<option value="gamma">Gamma label</option></select>',
+	)
+	if customizable:
+		session = await select_browser.get_or_create_cdp_session()
+		readback = await session.cdp_client.send.Runtime.evaluate(
+			params={
+				'expression': """(() => {
+					const selected = document.querySelector('selectedcontent');
+					return {appearance: getComputedStyle(document.querySelector('select')).appearance,
+						text: selected.textContent, height: selected.getBoundingClientRect().height};
+				})()""",
+				'returnByValue': True,
+			},
+			session_id=session.session_id,
+		)
+		value = readback['result'].get('value') or {}
+		if value.get('appearance') != 'base-select':
+			pytest.skip('This browser does not support customizable select rendering')
+		assert value['text'] == 'Beta label' and value['height'] > 0
+	state = await _dom_state(select_browser)
+	assert _reported_selection(state) == [{'value': 'beta', 'label': 'Beta label'}]
+	serialized = state.llm_representation()
+	assert serialized.count('Beta label') == 1, serialized
+	assert 'Alpha label' not in serialized and 'Gamma label' not in serialized, serialized
+	_assert_disabled_controls_not_indexed(state)
+
+
+@pytest.mark.parametrize('inside_first_legend', [False, True], ids=['inherited-disabled', 'first-legend-exception'])
+async def test_fieldset_disabled_select_respects_the_first_legend_exception(
+	select_browser: BrowserSession, select_server: HTTPServer, inside_first_legend: bool
+):
+	"""Use the browser's inherited disabled state without disabling the first legend's control."""
+	select = '<select id="status"><option value="draft" selected>Draft</option><option value="active">Active</option></select>'
+	fieldset = (
+		f'<fieldset disabled><legend>Status {select}</legend></fieldset>'
+		if inside_first_legend
+		else f'<fieldset disabled><legend>Status</legend>{select}</fieldset>'
+	)
+	await _open_form(select_browser, select_server, fieldset)
+	session = await select_browser.get_or_create_cdp_session()
+	readback = await session.cdp_client.send.Runtime.evaluate(
+		params={
+			'expression': "document.querySelector('select').matches(':disabled')",
+			'returnByValue': True,
+		},
+		session_id=session.session_id,
+	)
+	assert readback['result'].get('value') is not inside_first_legend
+	state = await _dom_state(select_browser)
+	assert _reported_selection(state) == [{'value': 'draft', 'label': 'Draft'}]
+	if inside_first_legend:
+		index = next(index for index, node in state.selector_map.items() if node.attributes.get('id') == 'status')
+		result = await Tools().select_dropdown(index=index, text='Active', browser_session=select_browser)
+		assert result.error is None, result.error
+		assert _reported_selection(await _dom_state(select_browser)) == [{'value': 'active', 'label': 'Active'}]
+	else:
+		_assert_disabled_controls_not_indexed(state)
+
+
 async def test_enabled_select_remains_indexed_and_can_change_selection(select_browser: BrowserSession, select_server: HTTPServer):
 	"""Exposing disabled values must preserve the normal dropdown action path."""
 	await _open_form(
@@ -254,3 +334,73 @@ async def test_hidden_disabled_select_does_not_expose_values_or_indices(
 	for hidden_content in ('hidden-status', 'hidden-choice', 'Hidden selected label', 'Hidden option text'):
 		assert hidden_content not in serialized, serialized
 	assert all(node.tag_name.lower() not in {'select', 'option', 'optgroup'} for node in state.selector_map.values())
+
+
+async def test_offscreen_enabled_scrollable_select_keeps_its_action_index_in_output(
+	select_browser: BrowserSession, select_server: HTTPServer
+):
+	"""Viewport filtering must not erase an enabled dropdown that was deliberately indexed."""
+	options = ''.join(f'<option value="{index}">Choice {index}</option>' for index in range(20))
+	await _open_form(
+		select_browser,
+		select_server,
+		f'<select id="offscreen-status" size="4" style="position: absolute; top: 3000px">{options}</select>',
+	)
+	state = await _dom_state(select_browser)
+	indexed = [(index, node) for index, node in state.selector_map.items() if node.attributes.get('id') == 'offscreen-status']
+	assert len(indexed) == 1, state.llm_representation()
+	index, original = indexed[0]
+	assert original.snapshot_node is not None
+	assert original.is_visible is False
+	assert original.is_actually_scrollable is True
+	select_lines = [line for line in state.llm_representation().splitlines() if '<select' in line]
+	assert len(select_lines) == 1, state.llm_representation()
+	assert f'[{index}]' in select_lines[0], select_lines[0]
+
+	result = await Tools().select_dropdown(index=index, text='Choice 7', browser_session=select_browser)
+	assert result.error is None, result.error
+	# The action scrolls this control into view, so the top-of-page button may be offscreen.
+	updated_summary = await select_browser.get_browser_state_summary(
+		include_screenshot=False, include_recent_events=False, cached=False
+	)
+	updated_state = updated_summary.dom_state
+	assert _reported_selection(updated_state) == [{'value': '7', 'label': 'Choice 7'}]
+	updated_indices = [
+		index for index, node in updated_state.selector_map.items() if node.attributes.get('id') == 'offscreen-status'
+	]
+	assert len(updated_indices) == 1
+	updated_line = next(line for line in updated_state.llm_representation().splitlines() if '<select' in line)
+	assert f'[{updated_indices[0]}]' in updated_line, updated_line
+
+
+@pytest.mark.parametrize(
+	('prefix', 'attributes', 'suffix'),
+	[
+		pytest.param('', 'style="opacity: 0"', '', id='opacity-zero'),
+		pytest.param('', 'style="visibility: hidden"', '', id='visibility-hidden'),
+		pytest.param('<div hidden>', '', '</div>', id='hidden-ancestor'),
+		pytest.param('<div style="opacity: 0">', '', '</div>', id='opacity-zero-ancestor'),
+	],
+)
+async def test_css_hidden_enabled_scrollable_select_does_not_expose_values(
+	select_browser: BrowserSession,
+	select_server: HTTPServer,
+	prefix: str,
+	attributes: str,
+	suffix: str,
+):
+	"""Preserving indexed scrollable dropdowns must not expose CSS-hidden selection data."""
+	options = ''.join(
+		f'<option value="hidden-choice-{index}" label="Hidden choice {index}"'
+		f'{" selected" if index == 0 else ""}>Hidden internal option {index}</option>'
+		for index in range(20)
+	)
+	await _open_form(
+		select_browser,
+		select_server,
+		f'{prefix}<select id="hidden-scrollable-status" multiple size="4" {attributes}>{options}</select>{suffix}',
+	)
+	state = await _dom_state(select_browser)
+	serialized = state.llm_representation()
+	for hidden_content in ('hidden-scrollable-status', 'hidden-choice-', 'Hidden choice', 'Hidden internal option'):
+		assert hidden_content not in serialized, serialized

--- a/tests/ci/browser/test_disabled_select_serialization.py
+++ b/tests/ci/browser/test_disabled_select_serialization.py
@@ -1,13 +1,17 @@
 """Expose live values of visible disabled selects without assigning action indices."""
 
+import base64
+import io
 import json
 from collections.abc import AsyncIterator, Iterator
 
 import pytest
+from PIL import Image
 from pytest_httpserver import HTTPServer
 
 from browser_use.browser import BrowserProfile, BrowserSession
 from browser_use.browser.profile import ViewportSize
+from browser_use.dom.service import DomService
 from browser_use.dom.views import SerializedDOMState
 from browser_use.tools.service import Tools
 
@@ -404,3 +408,80 @@ async def test_css_hidden_enabled_scrollable_select_does_not_expose_values(
 	serialized = state.llm_representation()
 	for hidden_content in ('hidden-scrollable-status', 'hidden-choice-', 'Hidden choice', 'Hidden internal option'):
 		assert hidden_content not in serialized, serialized
+
+
+@pytest.mark.parametrize('disabled', [False, True], ids=['enabled', 'disabled'])
+@pytest.mark.parametrize('opacity', [0, 1])
+@pytest.mark.parametrize('ancestor_display', ['block', 'contents'])
+async def test_select_visibility_matches_painting_with_layoutless_ancestors(
+	select_browser: BrowserSession,
+	select_server: HTTPServer,
+	disabled: bool,
+	opacity: int,
+	ancestor_display: str,
+):
+	"""A boxless wrapper's opacity must not hide a select that Chromium actually paints."""
+	await _open_form(
+		select_browser,
+		select_server,
+		'<style>body { background: white; } '
+		'#status { width: 300px; height: 60px; background: lime; color: black; font-size: 16px; opacity: 1; }</style>'
+		f'<div id="ancestor" style="display: {ancestor_display}; opacity: {opacity}">'
+		f'<select id="status" {"disabled" if disabled else ""}>'
+		'<option value="active">Active</option></select></div>',
+	)
+	state, tree, _ = await DomService(select_browser).get_serialized_dom_tree()
+	pending = [tree]
+	ancestor = None
+	while pending:
+		node = pending.pop()
+		if node.attributes.get('id') == 'ancestor':
+			ancestor = node
+			break
+		pending.extend(node.children_and_shadow_roots)
+	assert ancestor is not None and ancestor.snapshot_node is not None
+	if ancestor_display == 'contents':
+		assert ancestor.snapshot_node.bounds is None
+		assert ancestor.snapshot_node.computed_styles is None
+	else:
+		assert ancestor.snapshot_node.bounds is not None
+		assert ancestor.snapshot_node.computed_styles is not None
+		assert ancestor.snapshot_node.computed_styles['opacity'] == str(opacity)
+
+	session = await select_browser.get_or_create_cdp_session()
+	readback = await session.cdp_client.send.Runtime.evaluate(
+		params={
+			'expression': """(() => {
+				const ancestor = document.getElementById('ancestor');
+				const rect = document.getElementById('status').getBoundingClientRect();
+				return {opacity: getComputedStyle(ancestor).opacity,
+					clip: {x: rect.x, y: rect.y, width: rect.width, height: rect.height, scale: 1}};
+			})()""",
+			'returnByValue': True,
+		},
+		session_id=session.session_id,
+	)
+	value = readback['result'].get('value')
+	assert isinstance(value, dict) and value['opacity'] == str(opacity)
+	screenshot = await session.cdp_client.send.Page.captureScreenshot(
+		params={'format': 'png', 'clip': value['clip']}, session_id=session.session_id
+	)
+	# checkVisibility({opacityProperty: true}) also sees boxless ancestors and
+	# can disagree with painting. Check a background pixel away from text/arrow.
+	with Image.open(io.BytesIO(base64.b64decode(screenshot['data']))) as screenshot_image:
+		rgb = screenshot_image.convert('RGB')
+		pixel = rgb.getpixel((rgb.width * 3 // 4, rgb.height // 2))
+	assert isinstance(pixel, tuple)
+	is_painted = pixel[1] > pixel[0] + 100 and pixel[1] > pixel[2] + 100
+	expected_visible = ancestor_display == 'contents' or opacity == 1
+	assert is_painted is expected_visible, (ancestor_display, opacity, pixel)
+
+	serialized = state.llm_representation()
+	if expected_visible:
+		assert _reported_selection(state) == [{'value': 'active', 'label': 'Active'}]
+		if disabled:
+			_assert_disabled_controls_not_indexed(state)
+		else:
+			assert any(node.attributes.get('id') == 'status' for node in state.selector_map.values())
+	else:
+		assert '<select' not in serialized and 'Active' not in serialized, serialized

--- a/tests/ci/test_dom_paint_order_serialization.py
+++ b/tests/ci/test_dom_paint_order_serialization.py
@@ -1,4 +1,4 @@
-"""Regression test for DOMTreeSerializer leaking paint-order-occluded text.
+"""Regression coverage for DOM text and native select visibility.
 
 PaintOrderRemover.calculate_paint_order() correctly computes which nodes are
 fully covered by another element painted on top of them (e.g. content
@@ -79,3 +79,77 @@ class TestPaintOrderTextExclusion:
 
 		assert 'TOP LAYER TEXT' in output
 		assert 'HIDDEN BEHIND MODAL' not in output
+
+
+class TestSelectStateVisibility:
+	def test_occluded_scrollable_select_does_not_expose_selected_value(self):
+		"""The scrollable-control rendering path must respect paint-order occlusion."""
+		bounds = DOMRect(x=0, y=0, width=100, height=20)
+		select_snapshot = _make_snapshot(paint_order=1, bounds=bounds)
+		select_snapshot.option_selected = False
+		select = _make_node(NodeType.ELEMENT_NODE, '', select_snapshot)
+		select.node_name = 'SELECT'
+		select.attributes = {'id': 'covered-select', 'disabled': ''}
+		select.is_scrollable = True
+		option_snapshot = _make_snapshot(paint_order=1, bounds=bounds)
+		option_snapshot.option_selected = True
+		option = _make_node(NodeType.ELEMENT_NODE, '', option_snapshot)
+		option.node_name = 'OPTION'
+		option.attributes = {'value': 'covered-status', 'label': 'Status behind the overlay'}
+		select.children_nodes = [option]
+		covered_select = SimplifiedNode(original_node=select, children=[])
+		overlay = SimplifiedNode(
+			original_node=_make_node(NodeType.TEXT_NODE, 'VISIBLE OVERLAY', _make_snapshot(paint_order=2, bounds=bounds)),
+			children=[],
+		)
+		wrapper = SimplifiedNode(
+			original_node=_make_node(NodeType.ELEMENT_NODE, '', None),
+			children=[covered_select, overlay],
+			should_display=False,
+		)
+
+		PaintOrderRemover(wrapper).calculate_paint_order()
+		assert covered_select.ignored_by_paint_order is True
+		assert select.is_actually_scrollable is True
+
+		output = DOMTreeSerializer.serialize_tree(wrapper, ['id', 'disabled'])
+
+		assert 'VISIBLE OVERLAY' in output
+		assert '<select' not in output
+		assert 'covered-status' not in output
+		assert 'Status behind the overlay' not in output
+
+	def test_indexed_shadow_select_without_snapshot_keeps_unknown_selection(self):
+		"""Missing layout must preserve the existing shadow-control action fallback."""
+		bounds = DOMRect(x=0, y=0, width=100, height=20)
+		host = _make_node(NodeType.ELEMENT_NODE, '', _make_snapshot(paint_order=1, bounds=bounds))
+		shadow = _make_node(NodeType.DOCUMENT_FRAGMENT_NODE, '', None)
+		shadow.shadow_root_type = 'open'
+		shadow.parent_node = host
+		host.shadow_roots = [shadow]
+		select = _make_node(NodeType.ELEMENT_NODE, '', None)
+		select.node_name = 'SELECT'
+		select.node_id = 42
+		select.backend_node_id = 42
+		select.attributes = {'id': 'shadow-select', 'aria-label': 'Choose a status'}
+		select.is_visible = False
+		select.parent_node = shadow
+		shadow.children_nodes = [select]
+		option = _make_node(NodeType.ELEMENT_NODE, '', _make_snapshot(paint_order=1, bounds=bounds))
+		option.node_name = 'OPTION'
+		option.node_id = 43
+		option.backend_node_id = 43
+		option.attributes = {'value': 'active'}
+		option.parent_node = select
+		select.children_nodes = [option]
+
+		state = DOMTreeSerializer(host, enable_bbox_filtering=False, paint_order_filtering=False).serialize_accessible_elements()[
+			0
+		]
+		output = state.llm_representation()
+
+		assert state.selector_map[42] is select
+		select_line = next(line for line in output.splitlines() if '[42]<select' in line)
+		assert 'shadow-select' in select_line
+		assert 'selected=unknown' in select_line
+		assert 'selected=[]' not in select_line


### PR DESCRIPTION
A visible disabled native select can disappear from the agent's DOM summary along with its current value, even while adjacent text and buttons are captured. A single-option `<select disabled>` displays `Active` in the browser but currently contributes no selected state to the summary.

Capture `DOMSnapshot.optionSelected` and serialize the live selected values and labels, including implicit defaults and JavaScript updates. Disabled controls, including inherited fieldset disablement, have no action indices and emit their current selection once without repeating option or selectedcontent descendants. Report unknown selection when snapshot data is unavailable.

Preserve existing indexed enabled dropdowns outside the viewport cutoff while retaining CSS visibility and paint-order filtering. Cover inherited disabled state and the first-legend exception through the browser's accessibility state.

Fixes #5727.

Example summary after this change:
```text
<select disabled=true selected=[{"value":"active","label":"Active"}] />
```
The disabled control has no action index.

The [layoutless-ancestor review report](https://github.com/browser-use/browser-use/pull/5728#discussion_r3956049233) is now covered by eight real Chromium cases: block/contents ancestors, opacity 0/1, and enabled/disabled selects. They verify missing snapshot layout/styles, the actual screenshot pixels, and the serialized selection together. A `display: contents; opacity: 0` ancestor has no layout entry, but Chromium still paints its select; an ordinary `display: block; opacity: 0` ancestor hides it and the serializer already excludes it. This is consistent with the [CSS box-generation rule](https://www.w3.org/TR/css-display-3/#box-generation): a contents wrapper generates no box. `checkVisibility({opacityProperty: true})` disagrees with the screenshot in the contents case, so it is not used as the visual oracle. The reported hidden-selection leak was not reproduced by this case; a different minimal HTML reproduction is needed before adding a blanket style fallback.

Validation:
- The original minimal browser regression fails on unmodified upstream because the select is missing.
- Additional review regressions fail on the previous PR commit: 3 failed, 6 passed. Real Chromium reproduced duplicate selectedcontent in a customizable select, an indexed offscreen enabled dropdown missing from the summary, and selection text under an opacity-zero ancestor. Ordinary native selects did not duplicate in these tests.
- `uv run --no-sync python -m pytest tests/ci/browser/test_disabled_select_serialization.py tests/ci/test_dom_paint_order_serialization.py -q`: 30 passed. Tests include real dropdown selection, fieldset/legend behavior, hidden controls, occlusion, and missing-layout shadow controls.
- All applicable pre-commit hooks passed for the five changed files, including Ruff and Pyright.
- The existing live-input test's assertions, including sensitive-value exclusions, passed with a threaded HTTP fixture. Its original non-threaded fixture timed out during Windows teardown in a combined run, so that run is not reported as passing.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes visible disabled selects being omitted from the DOM summary. They now serialize live selected values and labels from `DOMSnapshot.optionSelected` while staying non-actionable; hidden selects remain excluded and enabled dropdown actions are unchanged.

**Details**
- Adds `option_selected` to snapshot nodes from `DOMSnapshot.optionSelected` and renders it as a JSON list of `{value, label}` pairs.
- Disabled selects and their options are excluded from action indices, including fieldset-inherited disabled state.
- Selects must be viewport- and paint-order-visible to be exposed; CSS-hidden or occluded ones stay excluded, offscreen enabled scrollable selects keep their indices, and `display: contents` wrappers' opacity doesn't hide painted selects.
- Reports `selected=unknown` for shadow-DOM selects without snapshot data and strips stale `value`/`selected` attributes.

<sup>Written for commit 83ed25a18869d8482bfad23b74c7121d88945f75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



