### PR TITLE
fix(groq): preserve code fences inside failed-generation JSON

### DIFF
--- a/browser_use/llm/groq/parser.py
+++ b/browser_use/llm/groq/parser.py
@@ -24,9 +24,9 @@ def try_parse_groq_failed_generation(
 		content = error.body['error']['failed_generation']  # type: ignore
 
 		# If content is wrapped in code blocks, extract just the JSON part
-		if '```' in content:
-			# Find the JSON content between code blocks
-			content = content.split('```')[1]
+		if '```' in content and not content.lstrip().startswith(('{', '[')):
+			# Keep backticks inside JSON strings; only remove the outer fence pair.
+			content = content.split('```', 1)[1].rsplit('```', 1)[0]
 			# Remove language identifier if present (e.g., 'json\n')
 			if '\n' in content:
 				content = content.split('\n', 1)[1]

--- a/tests/ci/models/test_groq_parser.py
+++ b/tests/ci/models/test_groq_parser.py
@@ -1,0 +1,28 @@
+"""Regression tests for JSON recovery from Groq failed generations."""
+
+import json
+
+import httpx
+import pytest
+from groq import APIStatusError
+from pydantic import BaseModel
+
+from browser_use.llm.groq.parser import try_parse_groq_failed_generation
+
+
+class ParsedAnswer(BaseModel):
+	answer: str
+
+
+@pytest.mark.parametrize('wrapper', ['{}', '```json\n{}\n```', '```\n{}\n```'])
+@pytest.mark.parametrize('answer', ['plain text', 'Use ``` for code fences', '```python\nprint("hello")\n```'])
+def test_failed_generation_preserves_code_fences_in_json_strings(wrapper: str, answer: str):
+	content = wrapper.format(json.dumps({'answer': answer}))
+	response = httpx.Response(400, request=httpx.Request('POST', 'https://api.groq.com/openai/v1/chat/completions'))
+	error = APIStatusError(
+		'Failed to generate JSON',
+		response=response,
+		body={'error': {'failed_generation': content}},
+	)
+
+	assert try_parse_groq_failed_generation(error, ParsedAnswer) == ParsedAnswer(answer=answer)


### PR DESCRIPTION
Groq failed-generation recovery treats any triple backtick as a surrounding Markdown fence. For example, valid JSON containing an answer such as `Use ``` for code fences` is split inside the string and becomes invalid. Fenced JSON containing embedded code blocks is truncated for the same reason.

Skip fence extraction when the response already begins with JSON, and split only at the first and last fence when unwrapping Markdown. This preserves embedded code fences without changing the subsequent JSON/schema validation.

Validation:
- Added nine cases combining plain text, literal backticks, and multiline code snippets with raw JSON, a labeled outer fence, and an unlabeled outer fence. Six cases fail on the original parser; all nine pass with this change.
- `ANONYMIZED_TELEMETRY=false uv run --frozen --python 3.11 pytest tests/ci/models/test_groq_parser.py tests/ci/models/test_llm_groq.py -q -o addopts=''`: 13 passed.
- `uv run --frozen --python 3.11 pre-commit run --files browser_use/llm/groq/parser.py tests/ci/models/test_groq_parser.py`: all applicable hooks passed, including Ruff and Pyright.
- Tests construct a local Groq error response; no live model calls or browser integration tests were run.

