### PR TITLE
fix(llm): keep API status codes when DeepSeek and Cerebras wrap SDK errors

### DIFF
--- a/browser_use/llm/cerebras/chat.py
+++ b/browser_use/llm/cerebras/chat.py
@@ -5,15 +5,9 @@ from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
 import httpx
-from openai import (
-	APIConnectionError,
-	APIError,
-	APIStatusError,
-	APITimeoutError,
-	AsyncOpenAI,
-	RateLimitError,
-)
+from openai import APIStatusError, AsyncOpenAI, RateLimitError
 from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
 from pydantic import BaseModel
 
 from browser_use.llm.base import BaseChatModel
@@ -81,6 +75,11 @@ class ChatCerebras(BaseChatModel):
 			usage = None
 		return usage
 
+	def _first_choice(self, resp: ChatCompletion) -> Choice:
+		if not resp.choices:
+			raise ModelProviderError('Cerebras returned no choices', model=self.name)
+		return resp.choices[0]
+
 	@overload
 	async def ainvoke(
 		self,
@@ -131,13 +130,15 @@ class ChatCerebras(BaseChatModel):
 				)
 				usage = self._get_usage(resp)
 				return ChatInvokeCompletion(
-					completion=resp.choices[0].message.content or '',
+					completion=self._first_choice(resp).message.content or '',
 					usage=usage,
 				)
 			except RateLimitError as e:
-				raise ModelRateLimitError(str(e), model=self.name) from e
-			except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
-				raise ModelProviderError(str(e), model=self.name) from e
+				raise ModelRateLimitError(e.message, model=self.name) from e
+			except APIStatusError as e:
+				raise ModelProviderError(e.message, status_code=e.status_code, model=self.name) from e
+			except ModelProviderError:
+				raise
 			except Exception as e:
 				raise ModelProviderError(str(e), model=self.name) from e
 
@@ -175,7 +176,7 @@ Your response must be valid JSON only, no other text.
 					messages=cerebras_messages,  # type: ignore
 					**common,
 				)
-				content = resp.choices[0].message.content
+				content = self._first_choice(resp).message.content
 				if not content:
 					raise ModelProviderError('Empty JSON content in Cerebras response', model=self.name)
 
@@ -196,9 +197,11 @@ Your response must be valid JSON only, no other text.
 					usage=usage,
 				)
 			except RateLimitError as e:
-				raise ModelRateLimitError(str(e), model=self.name) from e
-			except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
-				raise ModelProviderError(str(e), model=self.name) from e
+				raise ModelRateLimitError(e.message, model=self.name) from e
+			except APIStatusError as e:
+				raise ModelProviderError(e.message, status_code=e.status_code, model=self.name) from e
+			except ModelProviderError:
+				raise
 			except Exception as e:
 				raise ModelProviderError(str(e), model=self.name) from e
 

--- a/browser_use/llm/deepseek/chat.py
+++ b/browser_use/llm/deepseek/chat.py
@@ -6,14 +6,9 @@ from dataclasses import dataclass
 from typing import Any, TypeVar, overload
 
 import httpx
-from openai import (
-	APIConnectionError,
-	APIError,
-	APIStatusError,
-	APITimeoutError,
-	AsyncOpenAI,
-	RateLimitError,
-)
+from openai import APIStatusError, AsyncOpenAI, RateLimitError
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
 from pydantic import BaseModel
 
 from browser_use.llm.base import BaseChatModel
@@ -91,6 +86,11 @@ class ChatDeepSeek(BaseChatModel):
 			}
 		return common
 
+	def _first_choice(self, resp: ChatCompletion) -> Choice:
+		if not resp.choices:
+			raise ModelProviderError('DeepSeek returned no choices', model=self.name)
+		return resp.choices[0]
+
 	@overload
 	async def ainvoke(
 		self,
@@ -147,13 +147,15 @@ class ChatDeepSeek(BaseChatModel):
 					**common,
 				)
 				return ChatInvokeCompletion(
-					completion=resp.choices[0].message.content or '',
+					completion=self._first_choice(resp).message.content or '',
 					usage=None,
 				)
 			except RateLimitError as e:
-				raise ModelRateLimitError(str(e), model=self.name) from e
-			except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
-				raise ModelProviderError(str(e), model=self.name) from e
+				raise ModelRateLimitError(e.message, model=self.name) from e
+			except APIStatusError as e:
+				raise ModelProviderError(e.message, status_code=e.status_code, model=self.name) from e
+			except ModelProviderError:
+				raise
 			except Exception as e:
 				raise ModelProviderError(str(e), model=self.name) from e
 
@@ -184,10 +186,10 @@ class ChatDeepSeek(BaseChatModel):
 					tool_choice=tool_choice,  # type: ignore
 					**common,
 				)
-				msg = resp.choices[0].message
+				msg = self._first_choice(resp).message
 				if not msg.tool_calls:
 					raise ValueError('Expected tool_calls in response but got none')
-				raw_args = msg.tool_calls[0].function.arguments
+				raw_args = msg.tool_calls[0].function.arguments  # type: ignore[union-attr]
 				if isinstance(raw_args, str):
 					parsed = json.loads(raw_args)
 				else:
@@ -205,9 +207,11 @@ class ChatDeepSeek(BaseChatModel):
 						usage=None,
 					)
 			except RateLimitError as e:
-				raise ModelRateLimitError(str(e), model=self.name) from e
-			except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
-				raise ModelProviderError(str(e), model=self.name) from e
+				raise ModelRateLimitError(e.message, model=self.name) from e
+			except APIStatusError as e:
+				raise ModelProviderError(e.message, status_code=e.status_code, model=self.name) from e
+			except ModelProviderError:
+				raise
 			except Exception as e:
 				raise ModelProviderError(str(e), model=self.name) from e
 
@@ -220,7 +224,7 @@ class ChatDeepSeek(BaseChatModel):
 					response_format={'type': 'json_object'},
 					**common,
 				)
-				content = resp.choices[0].message.content
+				content = self._first_choice(resp).message.content
 				if not content:
 					raise ModelProviderError('Empty JSON content in DeepSeek response', model=self.name)
 				parsed = output_format.model_validate_json(content)
@@ -229,9 +233,11 @@ class ChatDeepSeek(BaseChatModel):
 					usage=None,
 				)
 			except RateLimitError as e:
-				raise ModelRateLimitError(str(e), model=self.name) from e
-			except (APIError, APIConnectionError, APITimeoutError, APIStatusError) as e:
-				raise ModelProviderError(str(e), model=self.name) from e
+				raise ModelRateLimitError(e.message, model=self.name) from e
+			except APIStatusError as e:
+				raise ModelProviderError(e.message, status_code=e.status_code, model=self.name) from e
+			except ModelProviderError:
+				raise
 			except Exception as e:
 				raise ModelProviderError(str(e), model=self.name) from e
 

--- a/tests/ci/models/test_llm_provider_errors.py
+++ b/tests/ci/models/test_llm_provider_errors.py
@@ -1,0 +1,55 @@
+"""DeepSeek and Cerebras must surface the provider's real status code and a clear error for empty responses."""
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from browser_use.llm.cerebras.chat import ChatCerebras
+from browser_use.llm.deepseek.chat import ChatDeepSeek
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import UserMessage
+
+
+class Answer(BaseModel):
+	answer: str
+
+
+def _llm(cls, transport: httpx.MockTransport):
+	client = httpx.AsyncClient(transport=transport)
+	return cls(model='test-model', api_key='test-key', client_params={'http_client': client, 'max_retries': 0})
+
+
+def _error_transport(status: int) -> httpx.MockTransport:
+	return httpx.MockTransport(lambda request: httpx.Response(status, json={'error': {'message': f'upstream said {status}'}}))
+
+
+def _empty_choices_transport() -> httpx.MockTransport:
+	body = {'id': 'x', 'object': 'chat.completion', 'created': 0, 'model': 'test-model', 'choices': []}
+	return httpx.MockTransport(lambda request: httpx.Response(200, json=body))
+
+
+@pytest.mark.parametrize('cls', [ChatDeepSeek, ChatCerebras])
+@pytest.mark.parametrize('status', [400, 401, 402, 500])
+@pytest.mark.parametrize('structured', [False, True])
+async def test_api_status_code_is_preserved(cls, status: int, structured: bool):
+	llm = _llm(cls, _error_transport(status))
+	with pytest.raises(ModelProviderError) as exc_info:
+		await llm.ainvoke([UserMessage(content='hi')], output_format=Answer if structured else None)
+	assert exc_info.value.status_code == status
+	assert f'upstream said {status}' in exc_info.value.message
+
+
+@pytest.mark.parametrize('cls', [ChatDeepSeek, ChatCerebras])
+async def test_rate_limit_maps_to_rate_limit_error(cls):
+	llm = _llm(cls, _error_transport(429))
+	with pytest.raises(ModelRateLimitError) as exc_info:
+		await llm.ainvoke([UserMessage(content='hi')])
+	assert exc_info.value.status_code == 429
+
+
+@pytest.mark.parametrize('cls', [ChatDeepSeek, ChatCerebras])
+@pytest.mark.parametrize('structured', [False, True])
+async def test_empty_choices_is_a_provider_error(cls, structured: bool):
+	llm = _llm(cls, _empty_choices_transport())
+	with pytest.raises(ModelProviderError, match='returned no choices'):
+		await llm.ainvoke([UserMessage(content='hi')], output_format=Answer if structured else None)

--- a/tests/ci/models/test_llm_provider_errors.py
+++ b/tests/ci/models/test_llm_provider_errors.py
@@ -1,5 +1,7 @@
 """DeepSeek and Cerebras must surface the provider's real status code and a clear error for empty responses."""
 
+from contextlib import asynccontextmanager
+
 import httpx
 import pytest
 from pydantic import BaseModel
@@ -14,9 +16,10 @@ class Answer(BaseModel):
 	answer: str
 
 
-def _llm(cls, transport: httpx.MockTransport):
-	client = httpx.AsyncClient(transport=transport)
-	return cls(model='test-model', api_key='test-key', client_params={'http_client': client, 'max_retries': 0})
+@asynccontextmanager
+async def _llm(cls, transport: httpx.MockTransport):
+	async with httpx.AsyncClient(transport=transport) as client:
+		yield cls(model='test-model', api_key='test-key', client_params={'http_client': client, 'max_retries': 0})
 
 
 def _error_transport(status: int) -> httpx.MockTransport:
@@ -32,24 +35,24 @@ def _empty_choices_transport() -> httpx.MockTransport:
 @pytest.mark.parametrize('status', [400, 401, 402, 500])
 @pytest.mark.parametrize('structured', [False, True])
 async def test_api_status_code_is_preserved(cls, status: int, structured: bool):
-	llm = _llm(cls, _error_transport(status))
-	with pytest.raises(ModelProviderError) as exc_info:
-		await llm.ainvoke([UserMessage(content='hi')], output_format=Answer if structured else None)
-	assert exc_info.value.status_code == status
-	assert f'upstream said {status}' in exc_info.value.message
+	async with _llm(cls, _error_transport(status)) as llm:
+		with pytest.raises(ModelProviderError) as exc_info:
+			await llm.ainvoke([UserMessage(content='hi')], output_format=Answer if structured else None)
+		assert exc_info.value.status_code == status
+		assert f'upstream said {status}' in exc_info.value.message
 
 
 @pytest.mark.parametrize('cls', [ChatDeepSeek, ChatCerebras])
 async def test_rate_limit_maps_to_rate_limit_error(cls):
-	llm = _llm(cls, _error_transport(429))
-	with pytest.raises(ModelRateLimitError) as exc_info:
-		await llm.ainvoke([UserMessage(content='hi')])
-	assert exc_info.value.status_code == 429
+	async with _llm(cls, _error_transport(429)) as llm:
+		with pytest.raises(ModelRateLimitError) as exc_info:
+			await llm.ainvoke([UserMessage(content='hi')])
+		assert exc_info.value.status_code == 429
 
 
 @pytest.mark.parametrize('cls', [ChatDeepSeek, ChatCerebras])
 @pytest.mark.parametrize('structured', [False, True])
 async def test_empty_choices_is_a_provider_error(cls, structured: bool):
-	llm = _llm(cls, _empty_choices_transport())
-	with pytest.raises(ModelProviderError, match='returned no choices'):
-		await llm.ainvoke([UserMessage(content='hi')], output_format=Answer if structured else None)
+	async with _llm(cls, _empty_choices_transport()) as llm:
+		with pytest.raises(ModelProviderError, match='returned no choices'):
+			await llm.ainvoke([UserMessage(content='hi')], output_format=Answer if structured else None)


### PR DESCRIPTION
`ChatDeepSeek` and `ChatCerebras` catch `(APIError, APIConnectionError, APITimeoutError, APIStatusError)` and re-raise `ModelProviderError(str(e), model=...)`. That drops the HTTP status, so every API error reaches the agent as the default `502`.

`Agent._should_switch_to_fallback` decides from `status_code`: `{401, 402, 429, 500, 502, 503, 504}` are retryable. A `400` from DeepSeek (bad request, oversized context, rejected schema) therefore looks like a server error and gets retried on the fallback model, where it fails again. The other OpenAI-compatible adapters (`ChatOpenAI`, `ChatAzureOpenAI`, `ChatOpenRouter`, `ChatVercel`) already pass `e.status_code` through; this brings the two remaining ones in line, same shape as #5672 did for API-key resolution.

Changes, both files:
- `except APIStatusError as e` wraps with `e.message` and `status_code=e.status_code`; rate limits keep mapping to `ModelRateLimitError`.
- `except ModelProviderError: raise` so the `Empty JSON content` error raised inside the `try` is no longer re-wrapped by the trailing `except Exception`.
- `_first_choice()` raises `ModelProviderError('<provider> returned no choices')` instead of letting `IndexError: list index out of range` surface as the provider error (same guard `ChatOpenRouter` grew in #5598).
- Dropped the now-unused `APIError`/`APIConnectionError`/`APITimeoutError` imports; those still fall to the generic handler with the 502 default as before.

Tests (`tests/ci/models/test_llm_provider_errors.py`) drive the real SDK through `httpx.MockTransport`, no network: 400/401/402/500 keep their code on both text and structured paths for both providers, 429 maps to `ModelRateLimitError`, and an empty `choices` array raises the clear provider error. 26 tests fail on `main`, pass here.

Validation: `uv run pytest tests/ci/models/test_llm_provider_errors.py tests/ci/models/test_llm_deepseek.py tests/ci/models/test_llm_cerebras.py` (26 passed); `pre-commit run --files ...` (ruff, pyright, codespell all pass).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`ChatDeepSeek` and `ChatCerebras` previously converted every SDK error into `ModelProviderError` with the default `502`, so a permanent bad request like a `400` was retried on the fallback model. They now keep the provider's HTTP status code, so the fallback logic sees the real error and stops retrying `4xx` failures.

- `APIStatusError` is wrapped with its real `status_code` and message; 429 still maps to `ModelRateLimitError`.
- `ModelProviderError` raised inside the request handling (e.g., missing tool calls / empty JSON) is re-raised unchanged instead of re-wrapped.
- Responses with an empty `choices` array now raise a clear `ModelProviderError` ("returned no choices") instead of `IndexError`.
- Added `tests/ci/models/test_llm_provider_errors.py` covering status preservation, rate-limit mapping, and empty responses for both providers on text and structured paths.

<sup>Written for commit 3fe57c919e83dfae8f82ec0ae94ecba5416234ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

