### PR TITLE
fix(azure): pass timeout and max_retries through to the Azure client

### DIFF
--- a/browser_use/llm/azure/chat.py
+++ b/browser_use/llm/azure/chat.py
@@ -84,6 +84,8 @@ class ChatAzureOpenAI(ChatOpenAILike):
 			'azure_ad_token': self.azure_ad_token,
 			'azure_ad_token_provider': self.azure_ad_token_provider,
 			'http_client': self.http_client,
+			'timeout': self.timeout,
+			'max_retries': self.max_retries,
 		}
 		if self.default_headers is not None:
 			_client_params['default_headers'] = self.default_headers

--- a/tests/ci/models/test_llm_azure_client_params.py
+++ b/tests/ci/models/test_llm_azure_client_params.py
@@ -1,0 +1,22 @@
+"""ChatAzureOpenAI must hand timeout and max_retries to the SDK client like ChatOpenAI does."""
+
+from browser_use.llm.azure.chat import ChatAzureOpenAI
+
+
+def _llm(**kwargs) -> ChatAzureOpenAI:
+	return ChatAzureOpenAI(model='gpt-4.1-mini', api_key='test-key', azure_endpoint='https://example.openai.azure.com', **kwargs)
+
+
+def test_timeout_and_max_retries_reach_the_client():
+	client = _llm(timeout=13.0, max_retries=9).get_client()
+	assert client.timeout == 13.0
+	assert client.max_retries == 9
+
+
+def test_default_max_retries_matches_chat_openai():
+	assert _llm().get_client().max_retries == ChatAzureOpenAI.max_retries == 5
+
+
+def test_unset_timeout_keeps_sdk_default():
+	params = _llm()._get_client_params()
+	assert 'timeout' not in params


### PR DESCRIPTION
`ChatAzureOpenAI` subclasses `ChatOpenAI` and so accepts `timeout` and `max_retries`, but its `_get_client_params()` override never put either into the `AsyncAzureOpenAI` kwargs. Whatever the user set, the client got the SDK defaults: 2 retries and a 600s read timeout.

```python
ChatAzureOpenAI(model='gpt-4.1-mini', api_key='k', azure_endpoint='https://x.openai.azure.com', timeout=13, max_retries=9).get_client()
# main: timeout=Timeout(connect=5.0, read=600, write=600, pool=600) max_retries=2
```

Adds the two keys to `params_mapping`; the existing `is not None` filter keeps the SDK default when `timeout` is unset. Note this also means Azure now inherits `ChatOpenAI.max_retries = 5` ("Increase default retries for automation reliability") instead of the SDK's 2, which is what the parent class already intended.

Tests fail on `main`, pass here. `pre-commit` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ChatAzureOpenAI` so `timeout` and `max_retries` are passed through to the Azure SDK client instead of always using the SDK defaults (2 retries, 600s read timeout). Azure now also inherits `ChatOpenAI`'s default `max_retries` of 5, matching the parent class behavior.

<sup>Written for commit e3de8db31c8a6dae869b43cd592d924c798d6c65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

