### PR TITLE
fix(oci): stop structured output from rewriting the caller's system message

### DIFF
--- a/browser_use/llm/oci_raw/chat.py
+++ b/browser_use/llm/oci_raw/chat.py
@@ -370,8 +370,8 @@ IMPORTANT:
 - Use proper JSON syntax with double quotes
 """
 
-				# Clone messages and add system instruction
-				modified_messages = messages.copy()
+				# Deep copy so the schema instruction does not leak into the caller's messages
+				modified_messages = [message.model_copy(deep=True) for message in messages]
 
 				# Add or modify system message
 				from browser_use.llm.messages import SystemMessage

--- a/tests/ci/models/test_llm_oci_raw.py
+++ b/tests/ci/models/test_llm_oci_raw.py
@@ -1,0 +1,39 @@
+"""ChatOCIRaw structured output must not rewrite the caller's messages."""
+
+from types import SimpleNamespace
+
+from pydantic import BaseModel
+
+from browser_use.llm.messages import SystemMessage, UserMessage
+from browser_use.llm.oci_raw.chat import ChatOCIRaw
+
+
+class Answer(BaseModel):
+	answer: str
+
+
+async def test_structured_output_leaves_system_message_untouched():
+	llm = ChatOCIRaw(
+		model_id='ocid1.model.oc1.test', service_endpoint='https://example.test', compartment_id='ocid1.compartment.test'
+	)
+	sent: list[list] = []
+
+	async def fake_request(messages):
+		sent.append(messages)
+		return SimpleNamespace(data=SimpleNamespace(chat_response=SimpleNamespace(text='{"answer": "ok"}')))
+
+	llm._make_request = fake_request  # type: ignore[method-assign]
+
+	system = SystemMessage(content='You are a browser agent.')
+	messages = [system, UserMessage(content='go')]
+
+	for _ in range(3):
+		result = await llm.ainvoke(messages, Answer)
+		assert result.completion == Answer(answer='ok')
+
+	assert system.content == 'You are a browser agent.'
+	assert len(messages) == 2
+	# Every request carried the schema instruction exactly once
+	for request in sent:
+		assert isinstance(request[0].content, str)
+		assert request[0].content.count('You must respond with ONLY a valid JSON object') == 1


### PR DESCRIPTION
`ChatOCIRaw.ainvoke` with an `output_format` appends the JSON schema instruction to `messages[0].content`. It does that on `messages.copy()`, a shallow list copy, so the write lands on the caller's `SystemMessage` object. `MessageManager` keeps one `SystemMessage` for the whole run and passes the same instance every step, so the system prompt grows by a full schema block per step.

Reproduced without network by stubbing `_make_request`: a 24-char system prompt is 493 chars after one call, 962 after two, 1431 after three, with the schema instruction present 3x in the caller's message. With the real `AgentOutput` schema that is thousands of tokens added per step until the context window fills.

`ChatGoogle` and `ChatVercel` do the same prepend and already use `model_copy(deep=True)`; this makes OCI match. The test asserts the caller's message is unchanged after three structured calls and that every outgoing request carried the instruction exactly once.

Test fails on `main`, passes here. `pre-commit` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ChatOCIRaw` structured output mutating the caller's `SystemMessage`, so the system prompt no longer grows by one JSON schema block per step. Previously the schema instruction was appended to the same system message instance reused across the run because `messages.copy()` only copies the list, not the messages inside it. Now messages are deep-copied before the instruction is added, matching `ChatGoogle` and `ChatVercel`. Adds a test asserting the caller's message stays unchanged after three structured calls and that each outgoing request carries the instruction exactly once.

<sup>Written for commit 69326f03da6a9a48361b37c8baa924c516df8127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

