### PR TITLE
fix(llm): raise ModelProviderError for ChatBrowserUse network failures

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -193,9 +193,9 @@ class ChatBrowserUse(BaseChatModel):
 				# Non-retryable HTTP error or exhausted retries
 				self._raise_http_error(e)
 
-			except (httpx.TimeoutException, httpx.ConnectError) as e:
+			except httpx.TransportError as e:
 				last_error = e
-				# Network errors are retryable
+				# Network errors (timeouts, refused/dropped connections, protocol errors) are retryable
 				if attempt < self.max_retries - 1:
 					delay = min(self.retry_base_delay * (2**attempt), self.retry_max_delay)
 					jitter = random.uniform(0, delay * 0.1)
@@ -209,17 +209,27 @@ class ChatBrowserUse(BaseChatModel):
 
 				# Exhausted retries
 				if isinstance(e, httpx.TimeoutException):
-					raise ValueError(f'Request timed out after {self.timeout}s (retried {self.max_retries} times)')
-				raise ValueError(f'Failed to connect to browser-use API after {self.max_retries} attempts: {e}')
+					raise ModelProviderError(
+						message=f'Request timed out after {self.timeout}s (retried {self.max_retries} times)',
+						status_code=504,
+						model=self.name,
+					) from e
+				raise ModelProviderError(
+					message=f'Failed to connect to browser-use API after {self.max_retries} attempts: {e}',
+					status_code=502,
+					model=self.name,
+				) from e
 
 			except Exception as e:
-				raise ValueError(f'Failed to connect to browser-use API: {e}')
+				raise ModelProviderError(message=f'browser-use API request failed: {e}', model=self.name) from e
 		else:
 			# Loop completed without break (all retries exhausted)
 			if last_error is not None:
 				if isinstance(last_error, httpx.HTTPStatusError):
 					self._raise_http_error(last_error)
-				raise ValueError(f'Request failed after {self.max_retries} attempts: {last_error}')
+				raise ModelProviderError(
+					message=f'Request failed after {self.max_retries} attempts: {last_error}', model=self.name
+				) from last_error
 			raise RuntimeError('Retry loop completed without return or exception')
 
 		# Parse response - server returns structured data as dict

--- a/tests/ci/models/test_llm_browseruse_network_errors.py
+++ b/tests/ci/models/test_llm_browseruse_network_errors.py
@@ -1,0 +1,68 @@
+"""Network failures in ChatBrowserUse must surface as ModelProviderError so the agent's fallback_llm can engage."""
+
+import httpx
+import pytest
+
+from browser_use.llm.browser_use.chat import ChatBrowserUse
+from browser_use.llm.exceptions import ModelProviderError
+from browser_use.llm.messages import UserMessage
+
+
+def _llm(max_retries: int) -> ChatBrowserUse:
+	return ChatBrowserUse(api_key='test-key-not-real', max_retries=max_retries, retry_base_delay=0, retry_max_delay=0)
+
+
+@pytest.mark.parametrize(
+	'error, status_code',
+	[
+		(httpx.ReadTimeout('read timed out'), 504),
+		(httpx.ConnectError('connection refused'), 502),
+		(httpx.RemoteProtocolError('server disconnected without sending a response'), 502),
+	],
+)
+async def test_exhausted_network_errors_are_provider_errors(error: httpx.TransportError, status_code: int):
+	llm = _llm(max_retries=2)
+	attempts = 0
+
+	async def failing_request(payload):
+		nonlocal attempts
+		attempts += 1
+		raise error
+
+	llm._make_request = failing_request  # type: ignore[method-assign]
+
+	with pytest.raises(ModelProviderError) as exc_info:
+		await llm.ainvoke([UserMessage(content='hi')])
+	assert exc_info.value.status_code == status_code
+	assert exc_info.value.__cause__ is error
+	assert attempts == 2
+
+
+async def test_dropped_connection_is_retried():
+	llm = _llm(max_retries=3)
+	attempts = 0
+
+	async def flaky_request(payload):
+		nonlocal attempts
+		attempts += 1
+		if attempts == 1:
+			raise httpx.RemoteProtocolError('server disconnected without sending a response')
+		return {'completion': 'ok', 'usage': None}
+
+	llm._make_request = flaky_request  # type: ignore[method-assign]
+
+	result = await llm.ainvoke([UserMessage(content='hi')])
+	assert result.completion == 'ok'
+	assert attempts == 2
+
+
+async def test_unexpected_errors_are_provider_errors():
+	llm = _llm(max_retries=1)
+
+	async def broken_request(payload):
+		raise KeyError('completion')
+
+	llm._make_request = broken_request  # type: ignore[method-assign]
+
+	with pytest.raises(ModelProviderError, match='request failed'):
+		await llm.ainvoke([UserMessage(content='hi')])

--- a/tests/ci/models/test_llm_browseruse_network_errors.py
+++ b/tests/ci/models/test_llm_browseruse_network_errors.py
@@ -18,6 +18,7 @@ def _llm(max_retries: int) -> ChatBrowserUse:
 		(httpx.ReadTimeout('read timed out'), 504),
 		(httpx.ConnectError('connection refused'), 502),
 		(httpx.RemoteProtocolError('server disconnected without sending a response'), 502),
+		(httpx.ReadError('server disconnected'), 502),
 	],
 )
 async def test_exhausted_network_errors_are_provider_errors(error: httpx.TransportError, status_code: int):
@@ -38,7 +39,14 @@ async def test_exhausted_network_errors_are_provider_errors(error: httpx.Transpo
 	assert attempts == 2
 
 
-async def test_dropped_connection_is_retried():
+@pytest.mark.parametrize(
+	'error',
+	[
+		httpx.RemoteProtocolError('server disconnected without sending a response'),
+		httpx.ReadError('server disconnected'),
+	],
+)
+async def test_dropped_connection_is_retried(error: httpx.TransportError):
 	llm = _llm(max_retries=3)
 	attempts = 0
 
@@ -46,7 +54,7 @@ async def test_dropped_connection_is_retried():
 		nonlocal attempts
 		attempts += 1
 		if attempts == 1:
-			raise httpx.RemoteProtocolError('server disconnected without sending a response')
+			raise error
 		return {'completion': 'ok', 'usage': None}
 
 	llm._make_request = flaky_request  # type: ignore[method-assign]


### PR DESCRIPTION
`ChatBrowserUse.ainvoke` re-raised exhausted timeouts and connection errors as `ValueError`. `Agent.get_model_output` only routes `ModelRateLimitError`/`ModelProviderError` into `_try_switch_to_fallback_llm`, so on the default provider a network failure never engaged a configured `fallback_llm`; it just burned a `max_failures` slot with a generic error.

Two related gaps in the same block:
- The retry filter was `(httpx.TimeoutException, httpx.ConnectError)`. `httpx.RemoteProtocolError` ("server disconnected without sending a response") and `httpx.ReadError` fell through to the catch-all, skipped the retry loop and were reported as "Failed to connect".
- The catch-all and the post-loop path also raised `ValueError`.

Changes: retry on `httpx.TransportError` (the shared base), raise `ModelProviderError` with 504 for timeouts and 502 for other transport failures once retries are exhausted, and wrap unexpected errors as `ModelProviderError` too. The HTTP-status path (`_raise_http_error`) already did this correctly and is unchanged.

Tests stub `_make_request` with `retry_base_delay=0`: ReadTimeout/ConnectError/RemoteProtocolError surface as `ModelProviderError` with the right code and `__cause__`, a dropped connection on attempt 1 is retried and succeeds on attempt 2, and a non-network exception is still a `ModelProviderError`. Existing `test_llm_browseruse.py` unit tests still pass.

Tests fail on `main`, pass here. `pre-commit` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ChatBrowserUse` network failures to raise `ModelProviderError` instead of `ValueError`, so a configured `fallback_llm` now engages on the default provider.

**Bug Fixes**

- Previously, network errors surfaced as `ValueError`, which the agent doesn't route to the fallback LLM.
- Retries now catch the shared `httpx.TransportError` base, so `RemoteProtocolError` and `ReadError` no longer skip the retry loop.
- Timeouts raise `ModelProviderError` with 504, other transport failures with 502, and unexpected errors are also wrapped.
- Added tests stubbing `_make_request` with zero retry delays to cover exhausted retries, dropped-connection retries (`RemoteProtocolError` and `ReadError`), and non-network exceptions.

<sup>Written for commit 9e099907ca4a36c38f744d55c46a295318341b2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

