### PR TITLE
fix(tools): actually pass sensitive_data to the input action

### DIFF
--- a/browser_use/tools/registry/service.py
+++ b/browser_use/tools/registry/service.py
@@ -68,6 +68,7 @@ class Registry(Generic[Context]):
 			'page_extraction_llm': BaseChatModel,
 			'available_file_paths': list,
 			'has_sensitive_data': bool,
+			'sensitive_data': None,  # dict[str, str | dict[str, str]] | None, skip type validation
 			'file_system': FileSystem,
 			'extraction_schema': None,  # dict | None, skip type validation
 		}

--- a/browser_use/tools/registry/views.py
+++ b/browser_use/tools/registry/views.py
@@ -179,6 +179,7 @@ class SpecialActionParameters(BaseModel):
 	file_system: FileSystem | None = None
 	available_file_paths: list[str] | None = None
 	has_sensitive_data: bool = False
+	sensitive_data: dict[str, str | dict[str, str]] | None = None
 	extraction_schema: dict | None = None
 
 	@classmethod

--- a/tests/ci/test_input_sensitive_key_name.py
+++ b/tests/ci/test_input_sensitive_key_name.py
@@ -1,0 +1,64 @@
+"""The input action must receive sensitive_data so it can name the key it typed instead of 'Typed sensitive data'."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from browser_use.browser.events import TypeTextEvent
+from browser_use.dom.views import EnhancedDOMTreeNode, NodeType
+from browser_use.tools.service import Tools
+
+
+class _CompletedEvent:
+	def __await__(self):
+		async def _done():
+			return None
+
+		return _done().__await__()
+
+	async def event_result(self, **kwargs):
+		return {}
+
+
+def _password_node() -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='INPUT',
+		node_value='',
+		attributes={'type': 'password'},
+		is_scrollable=False,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=[],
+		ax_node=None,
+		snapshot_node=None,
+	)
+
+
+async def test_input_reports_which_sensitive_key_was_typed():
+	dispatched: list[TypeTextEvent] = []
+	browser_session = MagicMock()
+	browser_session.get_element_by_index = AsyncMock(return_value=_password_node())
+	browser_session.highlight_interaction_element = AsyncMock()
+	browser_session.get_current_page_url = AsyncMock(return_value='https://example.com/login')
+	browser_session.event_bus.dispatch = lambda event: dispatched.append(event) or _CompletedEvent()
+
+	result = await Tools().registry.execute_action(
+		'input',
+		{'index': 1, 'text': 'hunter2'},
+		browser_session=browser_session,
+		sensitive_data={'x_password': 'hunter2'},
+	)
+
+	assert result.extracted_content == 'Typed x_password'
+	assert 'hunter2' not in (result.extracted_content or '')
+	assert len(dispatched) == 1
+	assert dispatched[0].is_sensitive is True
+	assert dispatched[0].sensitive_key_name == 'x_password'


### PR DESCRIPTION
`Registry.execute_action` deliberately injects `special_context['sensitive_data']` for the `input` action, and `input()` declares a `sensitive_data` parameter so it can call `_detect_sensitive_key_name` and report `Typed <key>`. But `sensitive_data` was never listed in `_get_special_param_types()` / `SpecialActionParameters`, so `_normalize_action_function_signature` classified it as an *action* parameter. The wrapper only sources action params from the validated param model, and `InputTextAction` has no such field, so the injected kwarg was silently dropped and `input()` always saw `sensitive_data=None`.

Visible effects on `main` whenever `sensitive_data` is configured:
- every input is recorded in history as the opaque `Typed sensitive data` instead of `Typed x_password`
- `TypeTextEvent.sensitive_key_name` is always `None`, so the `Typed <username>` / `Typed <password>` logging in `default_action_watchdog.py` never fires

An agent filling a login form cannot tell from its own history which field it already filled, which is a classic retry loop.

Fix is the single place all callers route through: register `sensitive_data` as a special parameter (type validation skipped, same as `extraction_schema`). The test drives `registry.execute_action('input', ...)` with a mocked `BrowserSession` and asserts the result text is `Typed x_password`, the secret is not in the result, and the dispatched `TypeTextEvent` carries `sensitive_key_name='x_password'`.

Test fails on `main` (`'Typed sensitive data' == 'Typed x_password'`), passes here. `pre-commit` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `input` action so `sensitive_data` is actually passed through the registry, restoring `Typed <key>` history entries and `sensitive_key_name` on dispatched events. Previously, `sensitive_data` was classified as a regular action parameter and silently dropped, so `input()` always saw `None` — every sensitive input was recorded as the opaque `Typed sensitive data`, and the `Typed <username>` / `Typed <password>` watchdog logging never fired.

**Bug Fixes**
- Register `sensitive_data` as a special parameter in `service.py` and `views.py`, skipping type validation like `extraction_schema`.
- Add a test asserting the result text is `Typed x_password`, the secret is not exposed, and the dispatched `TypeTextEvent` carries `sensitive_key_name='x_password'`.

<sup>Written for commit 9fa0b111757af3947d892354d4785a9d5e56932d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

