### PR TITLE
fix(dom): do not drop an attribute that duplicates itself

### DIFF
--- a/browser_use/dom/serializer/serializer.py
+++ b/browser_use/dom/serializer/serializer.py
@@ -1356,7 +1356,7 @@ class DOMTreeSerializer:
 			for key in ordered_keys:
 				value = attributes_to_include[key]
 				if len(value) > 5:
-					if value in seen_values and key not in protected_attrs:
+					if value in seen_values and seen_values[value] != key and key not in protected_attrs:
 						keys_to_remove.add(key)
 					else:
 						seen_values[value] = key

--- a/browser_use/dom/views.py
+++ b/browser_use/dom/views.py
@@ -58,7 +58,6 @@ DEFAULT_INCLUDE_ATTRIBUTES = [
 	# Webkit shadow DOM identifiers
 	'pseudo',
 	# Accessibility properties from ax_node (ordered by importance for automation)
-	'checked',
 	'selected',
 	'expanded',
 	'pressed',

--- a/tests/ci/test_dom_attribute_dedup.py
+++ b/tests/ci/test_dom_attribute_dedup.py
@@ -1,0 +1,44 @@
+"""Attribute de-duplication must not delete an attribute because it collided with itself."""
+
+from browser_use.dom.serializer.serializer import DOMTreeSerializer
+from browser_use.dom.views import DEFAULT_INCLUDE_ATTRIBUTES, EnhancedDOMTreeNode, NodeType
+
+
+def _node(attributes: dict[str, str]) -> EnhancedDOMTreeNode:
+	return EnhancedDOMTreeNode(
+		node_id=1,
+		backend_node_id=1,
+		node_type=NodeType.ELEMENT_NODE,
+		node_name='MY-TOGGLE',
+		node_value='',
+		attributes=attributes,
+		is_scrollable=None,
+		is_visible=True,
+		absolute_position=None,
+		target_id='target-1',
+		frame_id=None,
+		session_id=None,
+		content_document=None,
+		shadow_root_type=None,
+		shadow_roots=None,
+		parent_node=None,
+		children_nodes=None,
+		ax_node=None,
+		snapshot_node=None,
+	)
+
+
+def test_default_include_attributes_has_no_duplicates():
+	assert len(DEFAULT_INCLUDE_ATTRIBUTES) == len(set(DEFAULT_INCLUDE_ATTRIBUTES))
+
+
+def test_repeated_include_attribute_keeps_the_attribute():
+	node = _node({'name': 'newsletter', 'checked': 'checked'})
+	attrs = DOMTreeSerializer._build_attributes_string(node, ['name', 'checked', 'checked'], '')
+	assert attrs == 'name=newsletter checked=checked'
+
+
+def test_distinct_attributes_with_the_same_value_are_still_deduplicated():
+	node = _node({'id': 'newsletter-optin', 'name': 'newsletter-optin'})
+	attrs = DOMTreeSerializer._build_attributes_string(node, ['id', 'name'], '')
+	assert attrs == 'id=newsletter-optin'


### PR DESCRIPTION
`DEFAULT_INCLUDE_ATTRIBUTES` lists `'checked'` twice (once in the HTML block, once in the AX-property block). `_build_attributes_string` builds `ordered_keys` from that list, so the duplicate-value pass sees `checked` a second time, finds its own value already in `seen_values`, and deletes the attribute. Any value longer than 5 chars triggers it, which is exactly `checked="checked"`. A user-supplied `include_attributes` list with a repeated key hits the same path.

```
checked="checked" -> 'type=checkbox name=newsletter'          (state gone)
checked="true"    -> 'type=checkbox name=newsletter checked=true'
```

Root-cause fix is in the dedup: ignore self-collisions (`seen_values[value] != key`). Also removes the redundant list entry. Tests cover the self-collision, that two *different* attributes with the same value are still deduplicated, and that the default list has no duplicates.

Tests fail on `main`, pass here. `pre-commit` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes attribute de-duplication dropping `checked="checked"` from serialized element lines when the same key appeared twice in the include list.

- Ignores self-collisions in the dedup pass so a repeated key no longer deletes its own attribute.
- Removes the duplicate `'checked'` entry from `DEFAULT_INCLUDE_ATTRIBUTES`.
- Adds tests covering self-collisions, distinct attributes with the same value still being deduplicated, and duplicate-free default list.

<sup>Written for commit 6c570044d68ab46a2c314dcaf65605f8290600cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

