### PR TITLE
fix(security): normalise hostnames and patterns before domain matching

### DIFF
--- a/browser_use/browser/profile.py
+++ b/browser_use/browser/profile.py
@@ -750,18 +750,21 @@ class BrowserProfile(BrowserConnectArgs, BrowserLaunchPersistentContextArgs, Bro
 	@classmethod
 	def optimize_large_domain_lists(cls, v: list[str] | set[str] | None) -> list[str] | set[str] | None:
 		"""Convert large domain lists (>=100 items) to sets for O(1) lookup performance."""
-		if v is None or isinstance(v, set):
+		if v is None:
 			return v
 
-		if len(v) >= DOMAIN_OPTIMIZATION_THRESHOLD:
+		if isinstance(v, list):
+			if len(v) < DOMAIN_OPTIMIZATION_THRESHOLD:
+				return v
 			logger.warning(
 				f'🔧 Optimizing domain list with {len(v)} items to set for O(1) lookup. '
 				f'Note: Pattern matching (*.domain.com, etc.) is not supported for lists >= {DOMAIN_OPTIMIZATION_THRESHOLD} items. '
 				f'Use exact domains only or keep list size < {DOMAIN_OPTIMIZATION_THRESHOLD} for pattern support.'
 			)
-			return set(v)
 
-		return v
+		# Set entries are compared to the parsed hostname directly (lowercase, no trailing
+		# root-label dot), so normalise them the same way once here.
+		return {domain.lower().rstrip('.') for domain in v}
 
 	@model_validator(mode='after')
 	def copy_old_config_names_to_new(self) -> Self:

--- a/browser_use/browser/watchdogs/security_watchdog.py
+++ b/browser_use/browser/watchdogs/security_watchdog.py
@@ -200,8 +200,9 @@ class SecurityWatchdog(BaseWatchdog):
 		if parsed.scheme in ['data', 'blob']:
 			return True
 
-		# Get the actual host (domain)
-		host = parsed.hostname
+		# Get the actual host (domain). Drop a trailing root-label dot: browsers treat
+		# example.com. as the same origin as example.com, so the block/allow lists must too.
+		host = (parsed.hostname or '').rstrip('.')
 		if not host:
 			return False
 
@@ -263,7 +264,7 @@ class SecurityWatchdog(BaseWatchdog):
 			# Check if pattern matches the host
 			if pattern.startswith('*.'):
 				# Pattern like *.example.com should match subdomains and main domain
-				domain_part = pattern[2:]  # Remove *.
+				domain_part = pattern[2:].lower().rstrip('.')  # Remove *.
 				if host == domain_part or host.endswith('.' + domain_part):
 					# Only match http/https URLs for domain-only patterns
 					if scheme in ['http', 'https']:
@@ -276,7 +277,7 @@ class SecurityWatchdog(BaseWatchdog):
 				# Use fnmatch for other glob patterns
 				if fnmatch.fnmatch(
 					full_url_pattern if '://' in pattern else host,
-					pattern,
+					pattern.lower(),
 				):
 					return True
 		else:
@@ -287,10 +288,11 @@ class SecurityWatchdog(BaseWatchdog):
 					return True
 			else:
 				# Domain-only pattern (case-insensitive comparison)
-				if host.lower() == pattern.lower():
+				pattern = pattern.lower().rstrip('.')
+				if host == pattern:
 					return True
 				# If pattern is a root domain, also check www subdomain
-				if self._is_root_domain(pattern) and host.lower() == f'www.{pattern.lower()}':
+				if self._is_root_domain(pattern) and host == f'www.{pattern}':
 					return True
 
 		return False

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -567,3 +567,41 @@ class TestDomainListOptimization:
 		# Should work correctly
 		assert watchdog._is_url_allowed('https://blocked0.com') is False
 		assert watchdog._is_url_allowed('https://example.com') is True
+
+
+class TestHostnameNormalization:
+	"""Pattern case and trailing root-label dots must not change what a domain list matches."""
+
+	@staticmethod
+	def _watchdog(**profile_kwargs):
+		from bubus import EventBus
+
+		from browser_use.browser.watchdogs.security_watchdog import SecurityWatchdog
+
+		browser_profile = BrowserProfile(headless=True, user_data_dir=None, **profile_kwargs)
+		return SecurityWatchdog(browser_session=BrowserSession(browser_profile=browser_profile), event_bus=EventBus())
+
+	def test_glob_patterns_are_case_insensitive(self):
+		prohibited = self._watchdog(prohibited_domains=['*.Example.COM'])
+		assert prohibited._is_url_allowed('https://example.com') is False
+		assert prohibited._is_url_allowed('https://mail.example.com') is False
+		assert prohibited._is_url_allowed('https://other.com') is True
+
+		allowed = self._watchdog(allowed_domains=['*.Example.com', 'HTTP*://Docs.Example.org'])
+		assert allowed._is_url_allowed('https://mail.example.com') is True
+		assert allowed._is_url_allowed('https://docs.example.org') is True
+		assert allowed._is_url_allowed('https://evil.com') is False
+
+	def test_trailing_dot_hostname_cannot_bypass_prohibited_domains(self):
+		for prohibited_domains in (['example.com'], ['*.example.com'], {'example.com'}):
+			watchdog = self._watchdog(prohibited_domains=prohibited_domains)
+			assert watchdog._is_url_allowed('http://example.com/x') is False
+			assert watchdog._is_url_allowed('http://example.com./x') is False, prohibited_domains
+		assert self._watchdog(prohibited_domains=['*.example.com'])._is_url_allowed('http://sub.example.com./x') is False
+
+	def test_trailing_dot_hostname_matches_allowed_domains(self):
+		watchdog = self._watchdog(allowed_domains=['example.com', 'docs.example.org.'])
+		assert watchdog._is_url_allowed('http://example.com./x') is True
+		assert watchdog._is_url_allowed('http://www.example.com./x') is True
+		assert watchdog._is_url_allowed('http://docs.example.org/x') is True
+		assert watchdog._is_url_allowed('http://evil.com./x') is False

--- a/tests/ci/security/test_domain_filtering.py
+++ b/tests/ci/security/test_domain_filtering.py
@@ -605,3 +605,15 @@ class TestHostnameNormalization:
 		assert watchdog._is_url_allowed('http://www.example.com./x') is True
 		assert watchdog._is_url_allowed('http://docs.example.org/x') is True
 		assert watchdog._is_url_allowed('http://evil.com./x') is False
+
+	def test_set_entries_are_normalised(self):
+		watchdog = self._watchdog(prohibited_domains={'Example.COM.', 'other.org'})
+		assert watchdog._is_url_allowed('http://example.com/x') is False
+		assert watchdog._is_url_allowed('http://example.com./x') is False
+		assert watchdog._is_url_allowed('http://safe.com/x') is True
+
+		# Lists at the optimisation threshold are converted to sets and must be normalised on the way in
+		watchdog = self._watchdog(prohibited_domains=[f'blocked{i}.com' for i in range(99)] + ['Example.COM.'])
+		assert isinstance(watchdog.browser_session.browser_profile.prohibited_domains, set)
+		assert watchdog._is_url_allowed('http://example.com/x') is False
+		assert watchdog._is_url_allowed('http://blocked0.com/x') is False


### PR DESCRIPTION
Two ways `allowed_domains` / `prohibited_domains` could disagree with what the browser actually loads:

**Glob patterns were case-sensitive.** `_is_url_match` lowercases both sides only in the exact-match branch. The glob branch compared the raw pattern against the already-lowercased `parsed.hostname`, so:

```
prohibited_domains=['*.Example.COM']  -> blocks nothing
allowed_domains=['*.Example.com']     -> denies every URL
```

`utils.match_url_with_domain_pattern` (used for sensitive-data domain scoping) already lowercases patterns, so the two matchers disagreed too.

**Trailing root-label dot bypassed prohibited_domains.** `parsed.hostname` keeps the DNS root dot, so `http://example.com./x` has host `example.com.`, which equals no pattern and ends with no `.example.com`. Browsers resolve `example.com.` to the same server and origin. One extra character bypassed the list, glob and set (>=100 entries fast path) code paths alike; the reverse also held, `allowed_domains=['example.com']` denied the dotted form.

Fix: strip the trailing dot from `host` once in `_is_url_allowed` (covers all three paths and `_is_ip_address`), and lowercase/strip patterns in the branches that compare against `host`. The `/*` full-URL fnmatch branch is left alone so path case is not touched.

New `TestHostnameNormalization` covers both directions for list, glob and set inputs. All 64 tests in `test_domain_filtering.py` + `test_ip_blocking.py` pass; the new ones fail on `main`. `pre-commit` clean.

Related, not covered here: #5109/#5281 fix the separate `url.startswith(pattern)` prefix bypass in the same function.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes domain matching in the security watchdog so glob patterns are case-insensitive and trailing root-label dots no longer bypass `allowed_domains`/`prohibited_domains`.

- Strips the trailing dot from the host once in `_is_url_allowed`, covering list, glob, and set paths.
- Lowercases patterns in the glob and exact-match branches; the full-URL fnmatch branch stays as-is.
- Normalises set entries (lowercase, strip trailing dot) when the profile validator builds or converts domain lists to sets.
- Adds `TestHostnameNormalization` for case sensitivity and trailing-dot inputs; all 64 tests pass and new ones fail on `main`.

<sup>Written for commit d04648d503c310de8a3ba52eb9a3ae9a4526b0b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

