### PR TITLE
fix(mcp): stop a client's allowed_domains from rewriting the server config

### DIFF
--- a/browser_use/config.py
+++ b/browser_use/config.py
@@ -520,10 +520,14 @@ def load_browser_use_config() -> dict[str, Any]:
 
 
 def get_default_profile(config: dict[str, Any]) -> dict[str, Any]:
-	"""Get default browser profile from config dict."""
-	return config.get('browser_profile', {})
+	"""Get a copy of the default browser profile from config dict.
+
+	A copy so callers can layer per-call overrides on top without editing the
+	loaded config that later calls read.
+	"""
+	return dict(config.get('browser_profile', {}))
 
 
 def get_default_llm(config: dict[str, Any]) -> dict[str, Any]:
-	"""Get default LLM config from config dict."""
-	return config.get('llm', {})
+	"""Get a copy of the default LLM config from config dict."""
+	return dict(config.get('llm', {}))

--- a/tests/ci/security/test_mcp_allowed_domains.py
+++ b/tests/ci/security/test_mcp_allowed_domains.py
@@ -98,3 +98,32 @@ async def test_explicit_empty_list_does_not_override_profile_defaults(server: Br
 
 class _StopAgentSetup(Exception):
 	"""Marker exception used to short-circuit agent construction during testing."""
+
+
+async def test_client_allowed_domains_do_not_persist_into_server_config(server: BrowserUseServer) -> None:
+	"""One client's `allowed_domains` must not replace the admin-configured allowlist for later calls."""
+	from browser_use.mcp import server as server_module
+
+	server.config = {
+		'browser_profile': {'allowed_domains': ['corp.example.com'], 'headless': True, 'user_data_dir': None},
+		'llm': {'api_key': 'test-key', 'model': 'gpt-4o'},
+	}
+	captured: list[Any] = []
+
+	class CapturingBrowserProfile:
+		def __init__(self, **kwargs: Any) -> None:
+			captured.append(kwargs.get('allowed_domains'))
+			raise _StopAgentSetup('captured')
+
+	original_browser_profile = server_module.BrowserProfile
+	server_module.BrowserProfile = CapturingBrowserProfile  # type: ignore[misc]
+	try:
+		with pytest.raises(_StopAgentSetup):
+			await server._retry_with_browser_use_agent(task='noop', allowed_domains=['evil.example.com'])
+		with pytest.raises(_StopAgentSetup):
+			await server._retry_with_browser_use_agent(task='noop')
+	finally:
+		server_module.BrowserProfile = original_browser_profile  # type: ignore[misc]
+
+	assert captured == [['evil.example.com'], ['corp.example.com']]
+	assert server.config['browser_profile']['allowed_domains'] == ['corp.example.com']


### PR DESCRIPTION
Follow-up to the GHSA-vfcm-843v-w6v3 fix. `get_default_profile(self.config)` returns the live nested `browser_profile` dict from the config loaded in `BrowserUseServer.__init__`, and `_retry_with_browser_use_agent` then does `profile_config['allowed_domains'] = allowed_domains` on it. That write persists on the server object for the rest of the process:

```
config before        : ['corp.example.com']
call#1 allowed_domains=['evil.example.com'] -> profile gets ['evil.example.com']
call#2 (no argument)                        -> profile gets ['evil.example.com']   <- should be corp
```

`_init_browser_session` (every `browser_*` tool) reads the same dict, so one tool call replaced the admin-configured allowlist for all later sessions. This is the exact guarantee the existing comment above the override was added to protect.

Fix in `config.py`: `get_default_profile` and `get_default_llm` return `dict(...)` copies, so every caller can layer per-call overrides without editing the loaded config. New test sets a corp allowlist, makes one call with a client override and one without, and asserts the second call sees the admin value and `server.config` is unchanged.

Test fails on `main` (`[['evil.example.com'], ['evil.example.com']]`), passes here. `pre-commit` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MCP server so a client's `allowed_domains` no longer overwrites the admin-configured allowlist for later calls. Previously, one call with a custom domain mutated the server's `browser_profile` dict, and subsequent calls without the argument used that leaked value. Now `get_default_profile` and `get_default_llm` return copies, keeping per-call overrides isolated.

**Bug Fixes**
- Adds a regression test that verifies the server config stays unchanged after a client override and that a later call still sees the admin allowlist.

<sup>Written for commit 6d3b3782aceeb9b9985e24034e82f2f37454ee4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

