### PR TITLE
fix(agent): redact sensitive_data from state_message in saved history

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -580,7 +580,9 @@ class AgentHistory(BaseModel):
 			'result': result_dump,
 			'state': self.state.to_dict(),
 			'metadata': self.metadata.model_dump() if self.metadata else None,
-			'state_message': self.state_message,
+			'state_message': self._filter_sensitive_data_from_string(self.state_message, sensitive_data)
+			if self.state_message
+			else self.state_message,
 		}
 
 

--- a/tests/ci/security/test_sensitive_data.py
+++ b/tests/ci/security/test_sensitive_data.py
@@ -670,3 +670,28 @@ def test_history_filters_sensitive_data_inside_nested_lists(tmp_path):
 
 	assert 'token-123' not in saved, 'Sensitive value leaked into the saved history file'
 	assert saved.count('<secret>api_key</secret>') == 2
+
+
+def test_history_filters_sensitive_data_from_state_message(tmp_path):
+	"""The stored state message is captured before redaction, so save_to_file must redact it itself."""
+	from browser_use.agent.views import AgentHistory, AgentHistoryList, BrowserStateHistory
+
+	history = AgentHistoryList(
+		history=[
+			AgentHistory(
+				model_output=None,
+				result=[],
+				state=BrowserStateHistory(url='https://example.test', title='t', tabs=[], interacted_element=[None]),
+				state_message='<agent_history>\nTyped token-123 into the password field\n</agent_history>',
+			)
+		]
+	)
+
+	filepath = tmp_path / 'history.json'
+	history.save_to_file(filepath, sensitive_data={'api_key': 'token-123'})
+	saved = filepath.read_text(encoding='utf-8')
+
+	assert 'token-123' not in saved, 'Sensitive value leaked into the saved history file via state_message'
+	assert '<secret>api_key</secret>' in saved
+	# Without sensitive_data the message is saved verbatim
+	assert history.history[0].model_dump()['state_message'] == history.history[0].state_message


### PR DESCRIPTION
`MessageManager.create_state_messages()` stores `self.last_state_message_text = state_message.text` *before* `_set_message_with_type(..., 'state')` applies `_filter_sensitive_data()`. `Agent._finalize()` puts that string into `AgentHistory.state_message`, and `AgentHistory.model_dump(sensitive_data=...)` only redacted `action` payloads, returning `state_message` raw.

Net effect: `agent.save_history()` / `AgentHistoryList.save_to_file(..., sensitive_data=...)`, the API that exists precisely to redact, wrote the full unredacted prompt for every step. The prompt includes `agent_history_description` with action results such as `Typed hunter2 into the password field`, which the message manager's own comment says is why state messages need filtering. Verified: the message sent to the LLM was redacted, the saved copy was not.

Fix at the one place all savers route through: run `state_message` through the existing `_filter_sensitive_data_from_string` in `AgentHistory.model_dump`. Without `sensitive_data` it is unchanged. Complements #5709/#5680/#5656 which are about action payloads; none of them touch `state_message`.

Test fails on `main` (`Sensitive value leaked into the saved history file via state_message`), passes here. All 18 tests in `test_sensitive_data.py` pass. `pre-commit` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes saved agent history leaking unredacted sensitive data in `state_message`, so `save_to_file(sensitive_data=...)` now redacts the full prompt instead of only action payloads.

`AgentHistory.model_dump` now runs `state_message` through the same sensitive-data filter used for action payloads; without `sensitive_data` the message is unchanged. Adds a regression test covering both the redacted and unredacted paths.

<sup>Written for commit 6983c785bedc49dddc9ec79442b7201ea996ffde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

