### PR TITLE
fix(agent): only skip start URLs whose path ends with a file extension

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -2396,14 +2396,14 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 				url_lower = url.lower()
 				has_scheme = url_lower.startswith(('http://', 'https://', 'file://'))
 
-				# Check if URL ends with file extension
+				# Check if the URL path ends with a file extension (python.org or texasmonthly.com must not count)
 				should_exclude = False
 				if not url_lower.startswith('file://'):
-					for ext in excluded_extensions:
-						if f'.{ext}' in url_lower:
-							should_exclude = True
-							break
-					if not has_scheme and '.htm' in url_lower:
+					path = urlparse(url_lower if has_scheme else f'//{url_lower}').path
+					suffix = Path(path).suffix.lstrip('.')
+					if suffix in excluded_extensions:
+						should_exclude = True
+					if not has_scheme and suffix.startswith('htm'):
 						should_exclude = True
 
 				if should_exclude:

--- a/tests/ci/test_extract_start_url_extensions.py
+++ b/tests/ci/test_extract_start_url_extensions.py
@@ -1,0 +1,47 @@
+"""_extract_start_url must only skip URLs whose path ends with a file extension, not any URL containing '.py' etc."""
+
+import pytest
+
+from browser_use import Agent
+
+
+class _LLM:
+	model = 'test'
+	provider = 'test'
+	name = 'test'
+	_verified_api_keys = True
+
+	async def ainvoke(self, messages, output_format=None, **kwargs):
+		raise AssertionError('not called')
+
+
+@pytest.fixture
+def agent() -> Agent:
+	return Agent(task='placeholder', llm=_LLM(), directly_open_url=False)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+	'task, expected',
+	[
+		('Go to https://www.python.org and find the download link', 'https://www.python.org'),
+		('Open https://www.texasmonthly.com and summarize the top story', 'https://www.texasmonthly.com'),
+		('Visit https://www.exeter.ac.uk and list the courses', 'https://www.exeter.ac.uk'),
+		('Check https://cdn.jsdelivr.net/npm/foo for the latest build', 'https://cdn.jsdelivr.net/npm/foo'),
+		('Open https://example.com/docs.html?x=1 and read it', 'https://example.com/docs.html?x=1'),
+		('Go to example.com/about', 'https://example.com/about'),
+	],
+)
+def test_sites_whose_names_contain_an_extension_are_kept(agent: Agent, task: str, expected: str):
+	assert agent._extract_start_url(task) == expected
+
+
+@pytest.mark.parametrize(
+	'task',
+	[
+		'Go to https://example.com/report.pdf',
+		'Download https://example.com/build/app.exe now',
+		'Open example.com/index.html',
+	],
+)
+def test_direct_file_links_are_still_skipped(agent: Agent, task: str):
+	assert agent._extract_start_url(task) is None


### PR DESCRIPTION
`_extract_start_url` skips URLs that point at files so the agent does not `navigate` to a PDF. The comment says "Check if URL ends with file extension" but the code did `f'.{ext}' in url_lower`, a substring test over the whole URL including the hostname. With the default `directly_open_url=True` these tasks lost their initial navigate action and started from `about:blank`:

```
Go to https://www.python.org ...        -> None   (.py in "python")
Open https://www.texasmonthly.com ...   -> None   (.tex in "texasmonthly")
Visit https://www.exeter.ac.uk ...      -> None   (.exe in "exeter")
Check https://cdn.jsdelivr.net/npm/foo  -> None   (.js in "jsdelivr")
```

Now the check uses the suffix of the parsed path (`urlparse(...).path`, with a `//` prefix for scheme-less candidates so the host is not treated as path). Real file links (`/report.pdf`, `/app.exe`, scheme-less `example.com/index.html`) are still skipped, and `docs.html?x=1` is kept because `.html` was never in the exclusion list for scheme URLs.

Tests fail on `main`, pass here. Existing URL-extraction tests in `test_beta_agent.py` still pass. `pre-commit` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `_extract_start_url` so it only skips start URLs whose path ends with a file extension, not URLs whose domain or other parts contain those extensions. Previously, sites like `python.org` or `texasmonthly.com` were mistakenly excluded and the agent started from `about:blank` instead of navigating to them. Real file links (e.g., `.pdf`) are still skipped. Adds tests covering both cases.

<sup>Written for commit 8a831de1df9e2d29f29da56fcd41eba1588fac77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

