### PR TITLE
fix(agent): keep URL restoration mapping across LLM retries

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -382,6 +382,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self.directly_open_url = directly_open_url
 		self.include_recent_events = include_recent_events
 		self._url_shortening_limit = _url_shortening_limit
+		# {shortened_url: original_url} for the current model call, reset once per step
+		self._urls_replaced: dict[str, str] = {}
 
 		self.sensitive_data = sensitive_data
 
@@ -1669,6 +1671,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	async def _get_model_output_with_retry(self, input_messages: list[BaseMessage]) -> AgentOutput:
 		"""Get model output with retry logic for empty actions"""
+		# This is a fresh message list, so drop the replacements made for the previous step.
+		self._urls_replaced.clear()
 		model_output = await self.get_model_output(input_messages)
 		self.logger.debug(
 			f'✅ Step {self.state.n_steps}: Got LLM response with {len(model_output.action) if model_output.action else 0} actions'
@@ -1842,7 +1846,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		? @dev edits input_messages in place
 
 		returns:
-			tuple[filtered_input_messages, urls we replaced {shorter_url: original_url}]
+			every replacement made for the current model call {shorter_url: original_url}
 		"""
 		from browser_use.llm.messages import AssistantMessage, UserMessage
 
@@ -1864,7 +1868,11 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 							part.text, replaced_urls = self._replace_urls_in_text(part.text)
 							urls_replaced.update(replaced_urls)
 
-		return urls_replaced
+		# A retry re-sends the same messages, which are already shortened, so a second pass
+		# finds nothing to replace and would otherwise return an empty mapping. Accumulate
+		# instead, so the model's output can still be restored after a retry.
+		self._urls_replaced.update(urls_replaced)
+		return dict(self._urls_replaced)
 
 	@staticmethod
 	def _recursive_process_all_strings_inside_pydantic_model(model: BaseModel, url_replacements: dict[str, str]) -> None:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -382,8 +382,6 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self.directly_open_url = directly_open_url
 		self.include_recent_events = include_recent_events
 		self._url_shortening_limit = _url_shortening_limit
-		# {shortened_url: original_url} for the current model call, reset once per step
-		self._urls_replaced: dict[str, str] = {}
 
 		self.sensitive_data = sensitive_data
 
@@ -1671,9 +1669,10 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	async def _get_model_output_with_retry(self, input_messages: list[BaseMessage]) -> AgentOutput:
 		"""Get model output with retry logic for empty actions"""
-		# This is a fresh message list, so drop the replacements made for the previous step.
-		self._urls_replaced.clear()
-		model_output = await self.get_model_output(input_messages)
+		# The retry below re-sends the same message objects, which get_model_output has already
+		# shortened in place, so both calls have to share one {shortened_url: original_url} mapping.
+		url_replacements: dict[str, str] = {}
+		model_output = await self.get_model_output(input_messages, url_replacements)
 		self.logger.debug(
 			f'✅ Step {self.state.n_steps}: Got LLM response with {len(model_output.action) if model_output.action else 0} actions'
 		)
@@ -1690,7 +1689,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			)
 
 			retry_messages = input_messages + [clarification_message]
-			model_output = await self.get_model_output(retry_messages)
+			model_output = await self.get_model_output(retry_messages, url_replacements)
 
 			if not model_output.action or all(action.model_dump() == {} for action in model_output.action):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
@@ -1846,7 +1845,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		? @dev edits input_messages in place
 
 		returns:
-			every replacement made for the current model call {shorter_url: original_url}
+			urls replaced in this pass {shorter_url: original_url}
 		"""
 		from browser_use.llm.messages import AssistantMessage, UserMessage
 
@@ -1868,11 +1867,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 							part.text, replaced_urls = self._replace_urls_in_text(part.text)
 							urls_replaced.update(replaced_urls)
 
-		# A retry re-sends the same messages, which are already shortened, so a second pass
-		# finds nothing to replace and would otherwise return an empty mapping. Accumulate
-		# instead, so the model's output can still be restored after a retry.
-		self._urls_replaced.update(urls_replaced)
-		return dict(self._urls_replaced)
+		return urls_replaced
 
 	@staticmethod
 	def _recursive_process_all_strings_inside_pydantic_model(model: BaseModel, url_replacements: dict[str, str]) -> None:
@@ -1950,10 +1945,19 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	@time_execution_async('--get_next_action')
 	@observe_debug(ignore_input=True, ignore_output=True, name='get_model_output')
-	async def get_model_output(self, input_messages: list[BaseMessage]) -> AgentOutput:
-		"""Get next action from LLM based on current state"""
+	async def get_model_output(
+		self, input_messages: list[BaseMessage], url_replacements: dict[str, str] | None = None
+	) -> AgentOutput:
+		"""Get next action from LLM based on current state
 
-		urls_replaced = self._process_messsages_and_replace_long_urls_shorter_ones(input_messages)
+		Long URLs in input_messages are shortened in place before the call and restored in the output.
+		A caller that sends the same message objects again (the empty-action retry, the fallback-LLM
+		retry below) must pass the `url_replacements` mapping it got from the earlier call: a second
+		pass finds nothing left to shorten, so on its own it would have nothing to restore either.
+		"""
+
+		urls_replaced = url_replacements if url_replacements is not None else {}
+		urls_replaced.update(self._process_messsages_and_replace_long_urls_shorter_ones(input_messages))
 
 		# Build kwargs for ainvoke
 		# Note: ChatBrowserUse will automatically generate action descriptions from output_format schema
@@ -1985,8 +1989,8 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			if not self._try_switch_to_fallback_llm(e):
 				# No fallback available, re-raise the original error
 				raise
-			# Retry with the fallback LLM
-			return await self.get_model_output(input_messages)
+			# Retry with the fallback LLM, keeping the mapping from this pass: the messages are already shortened
+			return await self.get_model_output(input_messages, urls_replaced)
 
 	def _try_switch_to_fallback_llm(self, error: ModelRateLimitError | ModelProviderError) -> bool:
 		"""

--- a/browser_use/beta/service.py
+++ b/browser_use/beta/service.py
@@ -5694,12 +5694,19 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		await self._force_done_after_failure()
 		return browser_state_summary
 
-	async def get_model_output(self, input_messages: list[BaseMessage]) -> AgentOutput:
-		"""Get next Browser Use action output from the configured Python LLM."""
+	async def get_model_output(
+		self, input_messages: list[BaseMessage], url_replacements: dict[str, str] | None = None
+	) -> AgentOutput:
+		"""Get next Browser Use action output from the configured Python LLM.
+
+		Pass `url_replacements` from an earlier call when re-sending the same message objects: they are
+		already shortened in place, so a second pass alone has nothing to restore.
+		"""
 		if self.llm is None or not hasattr(self.llm, 'ainvoke'):
 			raise ValueError('A Browser Use-compatible llm with ainvoke(...) is required for get_model_output().')
 
-		urls_replaced = self._process_messsages_and_replace_long_urls_shorter_ones(input_messages)
+		urls_replaced = url_replacements if url_replacements is not None else {}
+		urls_replaced.update(self._process_messsages_and_replace_long_urls_shorter_ones(input_messages))
 		response = await self.llm.ainvoke(input_messages, output_format=self.AgentOutput)
 		parsed: AgentOutput = getattr(response, 'completion', response)
 
@@ -5721,7 +5728,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 
 	async def _get_model_output_with_retry(self, input_messages: list[BaseMessage]) -> AgentOutput:
 		"""Get model output, retrying once when the model returns no usable action."""
-		model_output = await self.get_model_output(input_messages)
+		# The retry re-sends the same, already shortened message objects, so both calls share one mapping.
+		url_replacements: dict[str, str] = {}
+		model_output = await self.get_model_output(input_messages, url_replacements)
 		action_count = len(model_output.action) if getattr(model_output, 'action', None) else 0
 		self.logger.debug(f'✅ Step {self.state.n_steps}: Got LLM response with {action_count} actions')
 
@@ -5738,7 +5747,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			clarification_message = UserMessage(
 				content='You forgot to return an action. Please respond with a valid JSON action according to the expected schema with your assessment and next actions.'
 			)
-			model_output = await self.get_model_output(input_messages + [clarification_message])
+			model_output = await self.get_model_output(input_messages + [clarification_message], url_replacements)
 			if has_empty_actions(model_output):
 				self.logger.warning('Model still returned empty after retry. Inserting safe noop action.')
 				try:

--- a/tests/ci/infrastructure/test_url_shortening.py
+++ b/tests/ci/infrastructure/test_url_shortening.py
@@ -159,3 +159,48 @@ class TestUrlShorteningEndToEnd:
 		# Verify original shortened content is no longer present
 		assert shortened_url not in (agent_output.thinking or '')
 		assert shortened_url not in (agent_output.memory or '')
+
+
+class TestUrlShorteningIdempotence:
+	"""Test that re-processing already-shortened messages keeps the restoration mapping."""
+
+	def test_reprocessing_the_same_messages_keeps_the_mapping(self, agent: Agent):
+		"""A second pass finds nothing left to shorten but must not forget the first pass."""
+		messages: list[BaseMessage] = [UserMessage(content=f'Navigate to {SUPER_LONG_URL}')]
+
+		first_pass = agent._process_messsages_and_replace_long_urls_shorter_ones(messages)
+		shortened_url = next(iter(first_pass))
+		content_after_first_pass = messages[0].content
+
+		second_pass = agent._process_messsages_and_replace_long_urls_shorter_ones(messages)
+
+		# The text is already shortened, so the second pass leaves it alone ...
+		assert messages[0].content == content_after_first_pass
+		# ... but the mapping needed to restore it must survive.
+		assert second_pass.get(shortened_url) == SUPER_LONG_URL
+
+	def test_retry_output_still_restores_urls(self, agent: Agent):
+		"""A retry re-sends the same message objects, and its output must still be restorable."""
+		messages: list[BaseMessage] = [UserMessage(content=f'Navigate to {SUPER_LONG_URL}')]
+		agent._process_messsages_and_replace_long_urls_shorter_ones(messages)
+
+		# _get_model_output_with_retry appends a clarification to the messages it already sent
+		retry_messages: list[BaseMessage] = messages + [UserMessage(content='You forgot to return an action.')]
+		url_mappings = agent._process_messsages_and_replace_long_urls_shorter_ones(retry_messages)
+
+		shortened_url: str = agent._replace_urls_in_text(SUPER_LONG_URL)[0]
+		output_json = {
+			'evaluation_previous_goal': 'Retried after an empty action',
+			'memory': 'Target URL captured',
+			'next_goal': 'Open the documentation',
+			'action': [{'navigate': {'url': shortened_url, 'new_tab': False}}],
+		}
+
+		ActionModel = agent.tools.registry.create_action_model()
+		AgentOutputWithActions = AgentOutput.type_with_custom_actions(ActionModel)
+		agent_output = AgentOutputWithActions.model_validate_json(json.dumps(output_json))
+
+		agent._recursive_process_all_strings_inside_pydantic_model(agent_output, url_mappings)
+
+		action_data = agent_output.action[0].model_dump()
+		assert action_data['navigate']['url'] == SUPER_LONG_URL

--- a/tests/ci/infrastructure/test_url_shortening.py
+++ b/tests/ci/infrastructure/test_url_shortening.py
@@ -1,18 +1,23 @@
 """
 Simplified tests for URL shortening functionality in Agent service.
 
-Three focused tests:
+Four focused areas:
 1. Input message processing with URL shortening
 2. Output processing with custom actions and URL restoration
 3. End-to-end pipeline test
+4. Restoration surviving a second LLM call over the same, already shortened messages
 """
 
 import json
+from typing import cast
+from unittest.mock import AsyncMock
 
 import pytest
 
 from browser_use.agent.service import Agent
 from browser_use.agent.views import AgentOutput
+from browser_use.llm.base import BaseChatModel
+from browser_use.llm.exceptions import ModelRateLimitError
 from browser_use.llm.messages import AssistantMessage, BaseMessage, UserMessage
 
 # Super long URL to reuse across tests - much longer than the 25 character limit
@@ -161,46 +166,85 @@ class TestUrlShorteningEndToEnd:
 		assert shortened_url not in (agent_output.memory or '')
 
 
-class TestUrlShorteningIdempotence:
-	"""Test that re-processing already-shortened messages keeps the restoration mapping."""
+class TestUrlShorteningAcrossRepeatedModelCalls:
+	"""URL restoration must survive a second LLM call that re-sends the same, already shortened messages.
 
-	def test_reprocessing_the_same_messages_keeps_the_mapping(self, agent: Agent):
-		"""A second pass finds nothing left to shorten but must not forget the first pass."""
-		messages: list[BaseMessage] = [UserMessage(content=f'Navigate to {SUPER_LONG_URL}')]
+	get_model_output shortens the input messages in place. A second pass over them finds nothing
+	left to shorten, so unless the mapping from the first pass is carried over there is nothing to
+	restore the model's output with. Both production paths that re-send messages are driven here.
+	"""
 
-		first_pass = agent._process_messsages_and_replace_long_urls_shorter_ones(messages)
-		shortened_url = next(iter(first_pass))
-		content_after_first_pass = messages[0].content
+	@staticmethod
+	def _navigate_response(url: str) -> str:
+		return json.dumps(
+			{
+				'evaluation_previous_goal': 'Retried after an empty action',
+				'memory': 'Target URL captured',
+				'next_goal': 'Open the documentation',
+				'action': [{'navigate': {'url': url, 'new_tab': False}}],
+			}
+		)
 
-		second_pass = agent._process_messsages_and_replace_long_urls_shorter_ones(messages)
+	EMPTY_ACTION_RESPONSE = json.dumps(
+		{
+			'evaluation_previous_goal': 'Thinking',
+			'memory': 'Nothing yet',
+			'next_goal': 'Decide what to do',
+			'action': [],
+		}
+	)
 
-		# The text is already shortened, so the second pass leaves it alone ...
-		assert messages[0].content == content_after_first_pass
-		# ... but the mapping needed to restore it must survive.
-		assert second_pass.get(shortened_url) == SUPER_LONG_URL
-
-	def test_retry_output_still_restores_urls(self, agent: Agent):
-		"""A retry re-sends the same message objects, and its output must still be restorable."""
-		messages: list[BaseMessage] = [UserMessage(content=f'Navigate to {SUPER_LONG_URL}')]
-		agent._process_messsages_and_replace_long_urls_shorter_ones(messages)
-
-		# _get_model_output_with_retry appends a clarification to the messages it already sent
-		retry_messages: list[BaseMessage] = messages + [UserMessage(content='You forgot to return an action.')]
-		url_mappings = agent._process_messsages_and_replace_long_urls_shorter_ones(retry_messages)
+	async def test_empty_action_retry_restores_urls_in_the_retried_output(self, agent: Agent):
+		"""_get_model_output_with_retry re-sends input_messages plus a clarification after an empty action."""
+		from tests.ci.conftest import create_mock_llm
 
 		shortened_url: str = agent._replace_urls_in_text(SUPER_LONG_URL)[0]
-		output_json = {
-			'evaluation_previous_goal': 'Retried after an empty action',
-			'memory': 'Target URL captured',
-			'next_goal': 'Open the documentation',
-			'action': [{'navigate': {'url': shortened_url, 'new_tab': False}}],
-		}
+		# First call: no action. Second call (the retry): the model echoes the shortened URL it was shown.
+		agent.llm = create_mock_llm([self.EMPTY_ACTION_RESPONSE, self._navigate_response(shortened_url)])
+		messages: list[BaseMessage] = [UserMessage(content=f'Navigate to {SUPER_LONG_URL}')]
 
-		ActionModel = agent.tools.registry.create_action_model()
-		AgentOutputWithActions = AgentOutput.type_with_custom_actions(ActionModel)
-		agent_output = AgentOutputWithActions.model_validate_json(json.dumps(output_json))
+		model_output = await agent._get_model_output_with_retry(messages)
 
-		agent._recursive_process_all_strings_inside_pydantic_model(agent_output, url_mappings)
+		ainvoke = cast(AsyncMock, agent.llm.ainvoke)
+		assert ainvoke.await_count == 2
+		# The retry sent the already shortened text, not the original ...
+		retry_messages = ainvoke.await_args_list[1].args[0]
+		assert retry_messages[0].content == f'Navigate to {shortened_url}'
+		# ... and the retried output was still restored to the original URL.
+		assert model_output.action[0].model_dump(exclude_unset=True)['navigate']['url'] == SUPER_LONG_URL
 
-		action_data = agent_output.action[0].model_dump()
-		assert action_data['navigate']['url'] == SUPER_LONG_URL
+	async def test_fallback_llm_retry_restores_urls_in_the_fallback_output(self, agent: Agent):
+		"""get_model_output recurses on the same messages after switching to the fallback LLM."""
+		from tests.ci.conftest import create_mock_llm
+
+		shortened_url: str = agent._replace_urls_in_text(SUPER_LONG_URL)[0]
+
+		primary = AsyncMock(spec=BaseChatModel)
+		primary.model = primary.name = primary.model_name = 'primary-model'
+		primary.provider = 'mock'
+		primary._verified_api_keys = True
+		primary.ainvoke.side_effect = ModelRateLimitError(message='Rate limit exceeded', status_code=429, model='primary-model')
+
+		fallback = create_mock_llm([self._navigate_response(shortened_url)])
+		agent.llm = agent._original_llm = primary
+		agent._fallback_llm = fallback
+		messages: list[BaseMessage] = [UserMessage(content=f'Navigate to {SUPER_LONG_URL}')]
+
+		model_output = await agent.get_model_output(messages)
+
+		assert agent.llm is fallback
+		assert model_output.action[0].model_dump(exclude_unset=True)['navigate']['url'] == SUPER_LONG_URL
+
+	async def test_independent_calls_do_not_share_a_mapping(self, agent: Agent):
+		"""Each direct get_model_output call starts from an empty mapping; only an explicit hand-over carries one."""
+		from tests.ci.conftest import create_mock_llm
+
+		shortened_url: str = agent._replace_urls_in_text(SUPER_LONG_URL)[0]
+		agent.llm = create_mock_llm([self._navigate_response(shortened_url), self._navigate_response(shortened_url)])
+
+		first = await agent.get_model_output([UserMessage(content=f'Navigate to {SUPER_LONG_URL}')])
+		assert first.action[0].model_dump(exclude_unset=True)['navigate']['url'] == SUPER_LONG_URL
+
+		# A later, unrelated call never saw the long URL, so nothing carries over and the text stays as the model wrote it.
+		second = await agent.get_model_output([UserMessage(content='Unrelated prompt')])
+		assert second.action[0].model_dump(exclude_unset=True)['navigate']['url'] == shortened_url

--- a/tests/ci/test_beta_agent.py
+++ b/tests/ci/test_beta_agent.py
@@ -7918,3 +7918,24 @@ def test_rust_history_surfaces_terminal_session_interrupted_message():
 	assert history.is_done() is False
 	assert history.errors() == ['Rust terminal session was interrupted: interrupted by send_input']
 	assert history.action_results()[-1].error == 'Rust terminal session was interrupted: interrupted by send_input'
+
+
+async def test_beta_agent_retry_restores_shortened_urls_like_browser_use():
+	from browser_use.beta import Agent
+	from browser_use.llm.messages import UserMessage
+	from tests.ci.conftest import create_mock_llm
+
+	original_url = 'https://example.com/path?abcdefghijklmnopqrstuvwxyz#section'
+	agent = Agent(task='Retry restores URLs.', llm=create_mock_llm(), _url_shortening_limit=8)
+	shortened_url = agent._replace_urls_in_text(original_url)[0]
+
+	def response(action: list[dict[str, Any]]) -> str:
+		return json.dumps({'evaluation_previous_goal': 'e', 'memory': 'm', 'next_goal': 'n', 'action': action})
+
+	# The retry re-sends the same, already shortened message objects; the model echoes the shortened URL.
+	agent.llm = create_mock_llm([response([]), response([{'done': {'text': shortened_url, 'success': True}}])])
+
+	model_output = await agent._get_model_output_with_retry([UserMessage(content=f'Open {original_url} now.')])
+
+	assert agent.llm.ainvoke.await_count == 2
+	assert model_output.action[0].model_dump(exclude_unset=True)['done']['text'] == original_url


### PR DESCRIPTION
`Agent.get_model_output` shortens long URLs in the input messages in place (`base?query...<md5 prefix>`) and returns a `{shortened: original}` mapping that `_recursive_process_all_strings_inside_pydantic_model` uses to restore any shortened URL the model echoes back. The mapping was rebuilt from scratch on every call, so any path that sends the same message objects a second time got an empty mapping:

- `_get_model_output_with_retry` re-sends `input_messages + [clarification]` after the model returns an empty action. The list is new, but the message objects inside it were already shortened by the first pass.
- `get_model_output` recurses on the same list after `_try_switch_to_fallback_llm` swaps in the fallback LLM.

On the second pass `_replace_urls_in_text` finds nothing to replace, `urls_replaced` comes back empty, and `if urls_replaced:` skips restoration entirely. A `navigate` action returned on the retry therefore reached the browser with the truncated URL:

```diff
-https://docs.example.com/api?format=detailed-json&version=3.2.1&timestamp=1699123456789&session_id=abc123...
+https://docs.example.com/api?format=detailed-json&ver...9b7d3f1
```

This only surfaces when a long URL is in the prompt *and* a retry or fallback happens in the same step, which is why it looked intermittent.

The fix accumulates the replacements on the agent for the duration of one model call and returns the accumulated mapping, so the retry and fallback passes can still restore. `_get_model_output_with_retry` resets the accumulator at the start of each step. That reset is safe: the state message is rebuilt from history every step and `context_messages` is cleared in `prepare_state`, so no message shortened in step N is sent in step N+1. The shortening itself is deterministic (md5 of the query/fragment), so a stale entry could never restore to the wrong URL either; the reset only bounds growth over long runs.

Regression tests cover a second pass over already-shortened messages keeping the mapping, and the retry output still restoring the original URL through `_recursive_process_all_strings_inside_pydantic_model`.

Scope is limited to `_process_messsages_and_replace_long_urls_shorter_ones` and its two callers. The return type is unchanged, and the shortened text is unchanged on a second pass (the re-shortened candidate is the same length, so the `len(shortened) < len(original_url)` guard rejects it).

Validation:
- Before the fix: the new suite fails with `assert None == 'https://documentation.example-company.com/...'`.
- After the fix: 6 passed in `tests/ci/infrastructure/test_url_shortening.py`; 1206 passed, 34 skipped across `tests/ci`.
- `./bin/lint.sh` passed, including Ruff and Pyright.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes URL restoration mapping being lost on LLM retries or fallback, so shortened `navigate` URLs are correctly restored instead of reaching the browser truncated.

**Bug Fixes**
- `get_model_output` now takes an optional `url_replacements` mapping that retry and fallback passes share; direct calls still start from an empty one.
- Applies the same fix to the beta agent's retry path.
- Regression tests cover retry, fallback, and independent calls not sharing a mapping.

<sup>Written for commit 0edf932083affac6bf14671fcdbf89e7f9dfcf42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

