### PR TITLE
fix(llm): give ChatMistral an LLM-scale timeout and real retries

### DIFF
--- a/browser_use/llm/mistral/chat.py
+++ b/browser_use/llm/mistral/chat.py
@@ -85,10 +85,8 @@ class ChatMistral(BaseChatModel):
 			return self.http_client
 
 		if not hasattr(self, '_cached_client'):
-			transport = httpx.AsyncHTTPTransport(retries=self.max_retries)
-			client_args: dict[str, Any] = {'transport': transport}
-			client_args['timeout'] = self.timeout if self.timeout is not None else _DEFAULT_TIMEOUT
-			self._cached_client = httpx.AsyncClient(**client_args)
+			timeout = self.timeout if self.timeout is not None else _DEFAULT_TIMEOUT
+			self._cached_client = httpx.AsyncClient(timeout=timeout)
 		return self._cached_client
 
 	def _serialize_messages(self, messages: list[BaseMessage]) -> list[dict[str, Any]]:

--- a/browser_use/llm/mistral/chat.py
+++ b/browser_use/llm/mistral/chat.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
+import random
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar, cast, overload
@@ -19,6 +21,15 @@ from browser_use.llm.views import ChatInvokeCompletion, ChatInvokeUsage
 
 logger = logging.getLogger(__name__)
 T = TypeVar('T', bound=BaseModel)
+
+# Matches the default used by the OpenAI and Anthropic SDKs, which back the other
+# provider adapters. httpx's own default is 5s, which is shorter than a typical
+# agent step.
+_DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=600.0, write=600.0, pool=600.0)
+# Matches ChatBrowserUse, the other adapter that talks to its API over raw httpx.
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+_RETRY_BASE_DELAY = 1.0
+_RETRY_MAX_DELAY = 60.0
 
 
 @dataclass
@@ -76,8 +87,7 @@ class ChatMistral(BaseChatModel):
 		if not hasattr(self, '_cached_client'):
 			transport = httpx.AsyncHTTPTransport(retries=self.max_retries)
 			client_args: dict[str, Any] = {'transport': transport}
-			if self.timeout is not None:
-				client_args['timeout'] = self.timeout
+			client_args['timeout'] = self.timeout if self.timeout is not None else _DEFAULT_TIMEOUT
 			self._cached_client = httpx.AsyncClient(**client_args)
 		return self._cached_client
 
@@ -142,21 +152,47 @@ class ChatMistral(BaseChatModel):
 			pass
 		return response.text
 
+	def _retry_delay(self, attempt: int) -> float:
+		delay = min(_RETRY_BASE_DELAY * (2**attempt), _RETRY_MAX_DELAY)
+		return delay + random.uniform(0, delay * 0.1)
+
 	async def _post(self, payload: dict[str, Any]) -> dict[str, Any]:
 		url = f'{self._get_base_url()}/chat/completions'
 		client = self._client()
-		response = await client.post(url, headers=self._auth_headers(), json=payload, params=self._query_params())
 
-		if response.status_code >= 400:
-			message = self._parse_error(response)
-			if response.status_code == 429:
-				raise ModelRateLimitError(message=message, status_code=response.status_code, model=self.name)
-			raise ModelProviderError(message=message, status_code=response.status_code, model=self.name)
+		attempts = max(1, self.max_retries)
+		for attempt in range(attempts):
+			try:
+				response = await client.post(url, headers=self._auth_headers(), json=payload, params=self._query_params())
+			except (httpx.TimeoutException, httpx.ConnectError) as e:
+				if attempt < attempts - 1:
+					total_delay = self._retry_delay(attempt)
+					error_type = 'timeout' if isinstance(e, httpx.TimeoutException) else 'connection error'
+					logger.warning(f'⚠️ Got {error_type}, retrying in {total_delay:.1f}s... (attempt {attempt + 1}/{attempts})')
+					await asyncio.sleep(total_delay)
+					continue
+				raise ModelProviderError(message=f'Mistral request failed after {attempts} attempts: {e}', model=self.name) from e
 
-		try:
-			return response.json()
-		except Exception as e:
-			raise ModelProviderError(message=f'Failed to parse Mistral response: {e}', model=self.name) from e
+			if response.status_code in _RETRYABLE_STATUS_CODES and attempt < attempts - 1:
+				total_delay = self._retry_delay(attempt)
+				logger.warning(
+					f'⚠️ Got {response.status_code} error, retrying in {total_delay:.1f}s... (attempt {attempt + 1}/{attempts})'
+				)
+				await asyncio.sleep(total_delay)
+				continue
+
+			if response.status_code >= 400:
+				message = self._parse_error(response)
+				if response.status_code == 429:
+					raise ModelRateLimitError(message=message, status_code=response.status_code, model=self.name)
+				raise ModelProviderError(message=message, status_code=response.status_code, model=self.name)
+
+			try:
+				return response.json()
+			except Exception as e:
+				raise ModelProviderError(message=f'Failed to parse Mistral response: {e}', model=self.name) from e
+
+		raise ModelProviderError(message=f'Mistral request failed after {attempts} attempts', model=self.name)
 
 	@overload
 	async def ainvoke(

--- a/tests/ci/models/test_llm_mistral.py
+++ b/tests/ci/models/test_llm_mistral.py
@@ -1,0 +1,87 @@
+"""Regression tests for Mistral client setup and retry behaviour."""
+
+import json
+
+import httpx
+import pytest
+from pytest_httpserver import HTTPServer
+from werkzeug import Request, Response
+
+from browser_use.llm.exceptions import ModelProviderError, ModelRateLimitError
+from browser_use.llm.messages import UserMessage
+from browser_use.llm.mistral.chat import ChatMistral
+
+
+def test_client_uses_llm_scale_timeout_by_default():
+	# httpx's own default is Timeout(5.0), shorter than a typical agent step.
+	# The SDK-backed adapters get read=600 from their vendor SDK.
+	timeout = ChatMistral(model='mistral-medium-latest', api_key='k')._client().timeout
+	assert timeout.read == 600.0
+	assert timeout.connect == 5.0
+
+
+def test_explicit_timeout_takes_precedence():
+	explicit = httpx.Timeout(30.0)
+	assert ChatMistral(model='mistral-medium-latest', api_key='k', timeout=explicit)._client().timeout == explicit
+
+
+def _completion_body() -> dict:
+	return {
+		'choices': [{'message': {'content': 'hi'}}],
+		'usage': {'prompt_tokens': 1, 'completion_tokens': 1, 'total_tokens': 2},
+	}
+
+
+async def test_retries_after_rate_limit_then_succeeds(httpserver: HTTPServer):
+	calls: list[int] = []
+
+	def handler(request: Request) -> Response:
+		calls.append(1)
+		if len(calls) == 1:
+			return Response('{"message": "rate limited"}', status=429, content_type='application/json')
+		return Response(json.dumps(_completion_body()), status=200, content_type='application/json')
+
+	httpserver.expect_request('/chat/completions').respond_with_handler(handler)
+
+	chat = ChatMistral(
+		model='mistral-medium-latest',
+		api_key='k',
+		base_url=httpserver.url_for(''),
+		max_retries=2,
+	)
+	result = await chat.ainvoke([UserMessage(content='hi')])
+
+	assert result.completion == 'hi'
+	assert len(calls) == 2
+
+
+async def test_exhausted_retries_raise_rate_limit_error(httpserver: HTTPServer):
+	calls: list[int] = []
+
+	def handler(request: Request) -> Response:
+		calls.append(1)
+		return Response('{"message": "rate limited"}', status=429, content_type='application/json')
+
+	httpserver.expect_request('/chat/completions').respond_with_handler(handler)
+
+	chat = ChatMistral(model='mistral-medium-latest', api_key='k', base_url=httpserver.url_for(''), max_retries=2)
+	with pytest.raises(ModelRateLimitError):
+		await chat.ainvoke([UserMessage(content='hi')])
+
+	assert len(calls) == 2
+
+
+async def test_client_errors_are_not_retried(httpserver: HTTPServer):
+	calls: list[int] = []
+
+	def handler(request: Request) -> Response:
+		calls.append(1)
+		return Response('{"message": "Invalid model"}', status=400, content_type='application/json')
+
+	httpserver.expect_request('/chat/completions').respond_with_handler(handler)
+
+	chat = ChatMistral(model='bad-model', api_key='k', base_url=httpserver.url_for(''), max_retries=5)
+	with pytest.raises(ModelProviderError):
+		await chat.ainvoke([UserMessage(content='hi')])
+
+	assert len(calls) == 1

--- a/tests/ci/models/test_llm_mistral.py
+++ b/tests/ci/models/test_llm_mistral.py
@@ -12,6 +12,11 @@ from browser_use.llm.messages import UserMessage
 from browser_use.llm.mistral.chat import ChatMistral
 
 
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch):
+	monkeypatch.delenv('MISTRAL_BASE_URL', raising=False)
+
+
 def test_client_uses_llm_scale_timeout_by_default():
 	# httpx's own default is Timeout(5.0), shorter than a typical agent step.
 	# The SDK-backed adapters get read=600 from their vendor SDK.


### PR DESCRIPTION
## Summary
- `ChatMistral` inherited httpx's 5s default timeout, which is shorter than a typical agent step
- `max_retries` was passed to `AsyncHTTPTransport(retries=...)`, which only covers connection establishment — 429s and 5xx were never retried
- add tests for both, plus the first test coverage for this adapter

## Details

`ChatMistral` is the only adapter that talks to its API over raw httpx rather than a vendor SDK. Both defects follow from that.

**Timeout.** `_client()` only set `timeout` when it wasn't `None`, so the default path inherited `httpx.Timeout(5.0)`. The SDK-backed adapters get `connect=5, read=600, write=600, pool=600` from their vendor SDK. This change applies that same shape as the default; an explicit `timeout=` still wins.

**Retries.** `max_retries` went to `httpx.AsyncHTTPTransport(retries=...)`, which per httpcore governs *establishing a connection*. A 429 or 5xx response was raised on the first attempt, so the field promised retry behaviour the code didn't implement.

Every other adapter that declares `max_retries` routes it somewhere that retries HTTP failures:

| adapter | `max_retries` goes to |
|---|---|
| openai, anthropic, openrouter, vercel, orcarouter | SDK client params |
| groq | `AsyncGroq(...)` |
| litellm | `num_retries` |
| **mistral** | **`AsyncHTTPTransport(retries=)`** |

The retry loop follows `ChatBrowserUse`, the other adapter without a vendor SDK: same retryable status codes (`429, 500, 502, 503, 504`), same exponential backoff with jitter, same warning log. Connection-level `retries=` is kept on the transport as well.

`browser_use/llm/mistral/` was last modified 2025-12-15, before these conventions were established across the other adapters.

## On the official SDK

`mistralai` isn't currently a dependency, unlike `openai`, `anthropic`, `groq` and `ollama`. Adopting it would add a hard dependency for a single provider, so I've kept the httpx implementation and aligned its behaviour with the SDK-backed adapters. Happy to migrate instead if you'd prefer to take the dependency.

## Tests

New file — this adapter had no test coverage. On `main`, three of the five fail:

```
FAILED test_client_uses_llm_scale_timeout_by_default
  assert 5.0 == 600.0
   +  where 5.0 = Timeout(timeout=5.0).read

FAILED test_retries_after_rate_limit_then_succeeds
  browser_use.llm.exceptions.ModelRateLimitError: rate limited

FAILED test_exhausted_retries_raise_rate_limit_error
  assert 1 == 2
   +  where 1 = len([1])

3 failed, 2 passed
```

The two that pass on `main` are the explicit-timeout case and `test_client_errors_are_not_retried`, which confirm this change doesn't alter behaviour that was already correct.

With the fix, all five pass against a local server:

```
test_client_uses_llm_scale_timeout_by_default PASSED
test_explicit_timeout_takes_precedence PASSED
test_retries_after_rate_limit_then_succeeds PASSED
  "POST /chat/completions HTTP/1.1" 429
  ⚠️ Got 429 error, retrying in 1.0s... (attempt 1/2)
  "POST /chat/completions HTTP/1.1" 200
test_exhausted_retries_raise_rate_limit_error PASSED
test_client_errors_are_not_retried PASSED

5 passed in 3.01s
```

- `uv run pytest -q tests/ci/models/test_llm_mistral.py`
- `uv run pre-commit run --files browser_use/llm/mistral/chat.py tests/ci/models/test_llm_mistral.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives `ChatMistral` an LLM-scale default timeout and makes `max_retries` retry HTTP failures, timeouts, and connection errors instead of only connection establishment.

- Defaults to `connect=5`, `read=600`, `write=600`, and `pool=600`; an explicit `timeout=` still wins.
- Retries 429, 500, 502, 503, and 504 responses plus timeouts and connection errors with exponential backoff and jitter; non-retryable 4xx responses fail immediately, and the connection-level transport retries are removed since the loop now owns them.
- Adds the first test coverage for this adapter; all five tests pass.

<sup>Written for commit 1f9bd38e3474c7ac97cb39e558c980ec2bc39736. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

