### PR TITLE
docs: number the three paths and simplify README copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,11 @@
 
 Browser Use gives AI agents a browser. Describe a task, and the agent navigates websites, fills forms, and gets the work done.
 
-### Book a driving test
+### Navigate the web like a human does.
 
-Find an available slot, handle the CAPTCHA, and schedule the test with Browser Use V4.
+Find an available slot, pick a date and time, handle the CAPTCHA, and book a driving test.
 
 ![Browser Use V4 booking a driving test](https://github.com/user-attachments/assets/135885e8-1141-4e10-b719-bf690ae7d260)
-
-[Watch Johannes's demo ↗](https://x.com/mathisdittrich/status/2078619618265141560)
 
 [Explore more demos and prompts ↗](https://browser-use.com/showcase)
 
@@ -59,14 +57,26 @@ Find an available slot, handle the CAPTCHA, and schedule the test with Browser U
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="static/readme/which-product-dark.svg">
-  <img alt="Three ways to use Browser Use: fully hosted cloud; your existing agent with Browser Use CLI; or the Python library with the Browser Use agent. The CLI and library each connect to a local or cloud browser." src="static/readme/which-product-light.svg" width="100%">
+  <img alt="Three ways to use Browser Use: fully hosted cloud; your existing agent with Browser Use CLI; or the open source Browser Use agent, available as a Python library. The CLI and library each connect to a local or cloud browser." src="static/readme/which-product-light.svg" width="100%">
 </picture>
 
-- **[CLI](#cli-quickstart):** Give Claude Code, Codex, OpenCode, Pi, or another agent browser access.
-- **[Python library](#python-library):** Run the Browser Use agent locally from your own code.
-- **[Fully hosted cloud](#fully-hosted-cloud):** Send a task through the API; we run the agent and browser.
+- **[Path 1: Fully Hosted Cloud](#path-1-fully-hosted-cloud):** Send a task through the API; we run the agent and browser.
+- **[Path 2: CLI](#path-2-cli):** Give Claude Code, Codex, OpenCode, Pi, or another agent browser access.
+- **[Path 3: Python Library](#path-3-python-library):** Run the open source Browser Use agent locally from your own code.
 
-## CLI quickstart
+# Quickstart
+
+## Path 1: Fully Hosted Cloud
+
+Send a task to our hosted agent. We run the agent, stealth browser, and scalable infrastructure, and handle profiles, recordings, and data policies so you can scale your browser automation.
+
+[Get started with the API ↗](https://docs.browser-use.com/cloud/agent/quickstart)
+
+New Google, GitHub, or Microsoft signups get **$15 cloud credit**.
+
+<br/>
+
+## Path 2: CLI
 
 If you want to use Browser Use in your agent (Claude Code, Codex, OpenCode, Pi, Cursor, Hermes, OpenClaw, etc.), paste this prompt, and it sets everything up itself:
 
@@ -78,7 +88,7 @@ Then tell your agent what you want done.
 
 <br/>
 
-## Python library
+## Path 3: Python Library
 
 Run the Browser Use agent locally from Python, with your choice of model and a local or cloud browser:
 
@@ -121,23 +131,11 @@ if __name__ == "__main__":
 
 <br/>
 
-## Fully hosted cloud
-
-Send a task to our hosted V4 agent. We run the agent, browser, and infrastructure.
-
-[Get started with the API ↗](https://docs.browser-use.com/cloud/agent/quickstart)
-
-New Google, GitHub, or Microsoft signups get **$15 cloud credit**. No card required.
-
-<br/>
-
 # Benchmark
 
 <img alt="Browser Use Benchmark v2 - Mean rubric score by model and cost per task" src="static/hard_benchmark_v2.jpg" width="100%">
 
 This [very hard benchmark](https://github.com/browser-use/benchmark) targets the hardest browser tasks. On easier tasks, even smaller models can achieve very high success rates. Results shown are from a 60-task subset of BU Bench V2.
-
-Browser Use is also **#1 on the [Odysseys leaderboard](https://odysseysbench.com/leaderboard)** with an 87.4% average, ahead of computer-use agents from OpenAI, Anthropic, Google, and Microsoft. Odysseys measures the agent's performance on 200 long-horizon web tasks.
 
 ## Integrations, hosting, custom tools, MCP, and more on our [Docs ↗](https://docs.browser-use.com)
 
@@ -148,7 +146,7 @@ Browser Use is also **#1 on the [Odysseys leaderboard](https://odysseysbench.com
 <details>
 <summary><b>Should I use the CLI vs. the Python library?</b></summary>
 
-**Use the CLI** if you already have an agent (Claude Code, Codex, OpenCode, Pi, Cursor, Hermes, OpenClaw, etc.) that you want to complete browser tasks for you. The agent installs the skill once (see [CLI quickstart](#cli-quickstart)) and can then control the browser. Examples:
+**Use the CLI** if you already have an agent (Claude Code, Codex, OpenCode, Pi, Cursor, Hermes, OpenClaw, etc.) that you want to complete browser tasks for you. The agent installs the skill once (see [CLI quickstart](#path-2-cli)) and can then control the browser. Examples:
 - "Upload this video to YouTube"
 - "Compare these three laptops and give me a table with prices"
 - "Fill in this job application with my resume"

--- a/static/readme/README.md
+++ b/static/readme/README.md
@@ -8,9 +8,10 @@ introduced in [SDK PR #241](https://github.com/browser-use/sdk/pull/241).
 
 The README version shows three paths:
 
-- Fully hosted cloud: OpenCode → Browser Use CLI → cloud browser.
-- CLI: your existing agent → Browser Use CLI → local or cloud browser.
-- Python library: your code → Browser Use agent → local or cloud browser.
+- Path 1, fully hosted cloud: OpenCode → Browser Use CLI → cloud browser.
+- Path 2, CLI: your existing agent → Browser Use CLI → local or cloud browser.
+- Path 3, Python library: the open source Browser Use agent → local or cloud browser.
+  The agent and its Python library are one block, with no CLI step.
 
 Keep the light and dark SVGs structurally identical when changing the diagram.
 The SDK source remains the reference for the hosted stack; this README adds the

--- a/static/readme/which-product-dark.svg
+++ b/static/readme/which-product-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="690" viewBox="0 0 1440 690" role="img" aria-labelledby="title desc">
   <title id="title">Three ways to use Browser Use</title>
-  <desc id="desc">Fully hosted cloud runs our OpenCode agent, Browser Use CLI, and a cloud browser through the V4 API. The CLI connects your existing agent, including Claude Code, Codex, OpenCode, Hermes, or Pi, to a local or cloud browser. The Python library runs the Browser Use agent directly, without the CLI, and also connects to a local or cloud browser.</desc>
+  <desc id="desc">Path 1: fully hosted cloud runs our OpenCode agent, Browser Use CLI, and a cloud browser through the V4 API. Path 2: the CLI connects your existing agent, including Claude Code, Codex, OpenCode, Hermes, or Pi, to a local or cloud browser. Path 3: the open source Browser Use agent is a Python library that connects directly to a local or cloud browser.</desc>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8Z" fill="#92929C"/></marker>
     <marker id="cloud-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8Z" fill="#FFAB66"/></marker>
@@ -12,9 +12,9 @@
     <text x="240" y="55" text-anchor="middle" fill="#FFAB66" font-size="18" font-weight="700">RUN BY BROWSER USE</text>
     <text x="956" y="55" text-anchor="middle" fill="#BDBDC5" font-size="18" font-weight="700">ON YOUR COMPUTER</text>
     <path d="M956 85V650" stroke="#92929C" stroke-opacity="0.35"/>
-    <text x="240" y="109" text-anchor="middle" fill="#FAFAFA" font-size="32" font-weight="750">Fully hosted cloud</text>
-    <text x="720" y="109" text-anchor="middle" fill="#FAFAFA" font-size="32" font-weight="750">CLI</text>
-    <text x="1192" y="109" text-anchor="middle" fill="#FAFAFA" font-size="32" font-weight="750">Python library</text>
+    <text x="240" y="109" text-anchor="middle" fill="#FAFAFA" font-size="30" font-weight="750">1. Fully hosted cloud</text>
+    <text x="720" y="109" text-anchor="middle" fill="#FAFAFA" font-size="30" font-weight="750">2. CLI</text>
+    <text x="1192" y="109" text-anchor="middle" fill="#FAFAFA" font-size="30" font-weight="750">3. Python library</text>
     <text x="240" y="140" text-anchor="middle" fill="#BDBDC5" font-size="20" font-weight="450">Send a task through the API</text>
     <text x="720" y="140" text-anchor="middle" fill="#BDBDC5" font-size="20" font-weight="450">Use your existing agent</text>
     <text x="1192" y="140" text-anchor="middle" fill="#BDBDC5" font-size="20" font-weight="450">Run your own automation</text>
@@ -25,18 +25,16 @@
     <text x="720" y="214" text-anchor="middle" fill="#BDBDC5" font-size="18" font-weight="700">YOUR AGENT</text>
     <text x="720" y="247" text-anchor="middle" fill="#FAFAFA" font-size="24" font-weight="600">Claude Code · Codex</text>
     <text x="720" y="278" text-anchor="middle" fill="#FAFAFA" font-size="24" font-weight="600">OpenCode · Hermes · Pi</text>
-    <rect x="992" y="184" width="400" height="112" rx="16" fill="#29292E" stroke="#92929C" stroke-width="2"/>
-    <text x="1192" y="219" text-anchor="middle" fill="#BDBDC5" font-size="18" font-weight="700">YOUR CODE</text>
-    <text x="1192" y="260" text-anchor="middle" fill="#FAFAFA" font-size="29" font-weight="750">Python library</text>
+    <rect x="992" y="184" width="400" height="244" rx="16" fill="#302419" stroke="#FFAB66" stroke-width="2"/>
+    <text x="1192" y="262" text-anchor="middle" fill="#FFAB66" font-size="20" font-weight="700">OPEN SOURCE</text>
+    <text x="1192" y="313" text-anchor="middle" fill="#FAFAFA" font-size="31" font-weight="750">Browser Use Agent</text>
+    <text x="1192" y="355" text-anchor="middle" fill="#BDBDC5" font-size="24" font-weight="450">Python library</text>
     <path d="M240 296V336" fill="none" stroke="#92929C" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#arrow)"/>
     <path d="M720 296V336" fill="none" stroke="#92929C" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#arrow)"/>
-    <path d="M1192 296V336" fill="none" stroke="#92929C" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#arrow)"/>
     <rect x="64" y="350" width="352" height="78" rx="16" fill="#302419" stroke="#FFAB66" stroke-width="2"/>
     <text x="240.0" y="397" text-anchor="middle" fill="#FAFAFA" font-size="28" font-weight="750">Browser Use CLI</text>
     <rect x="520" y="350" width="400" height="78" rx="16" fill="#302419" stroke="#FFAB66" stroke-width="2"/>
     <text x="720.0" y="397" text-anchor="middle" fill="#FAFAFA" font-size="28" font-weight="750">Browser Use CLI</text>
-    <rect x="992" y="350" width="400" height="78" rx="16" fill="#302419" stroke="#FFAB66" stroke-width="2"/>
-    <text x="1192.0" y="397" text-anchor="middle" fill="#FAFAFA" font-size="28" font-weight="750">Browser Use agent</text>
     <path d="M240 428V498" fill="none" stroke="#FFAB66" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#cloud-arrow)"/>
     <rect x="64" y="512" width="352" height="112" rx="16" fill="#302419" stroke="#FFAB66" stroke-width="2"/>
     <path d="M64 538H416" stroke="#FFAB66" stroke-width="2"/>

--- a/static/readme/which-product-light.svg
+++ b/static/readme/which-product-light.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="690" viewBox="0 0 1440 690" role="img" aria-labelledby="title desc">
   <title id="title">Three ways to use Browser Use</title>
-  <desc id="desc">Fully hosted cloud runs our OpenCode agent, Browser Use CLI, and a cloud browser through the V4 API. The CLI connects your existing agent, including Claude Code, Codex, OpenCode, Hermes, or Pi, to a local or cloud browser. The Python library runs the Browser Use agent directly, without the CLI, and also connects to a local or cloud browser.</desc>
+  <desc id="desc">Path 1: fully hosted cloud runs our OpenCode agent, Browser Use CLI, and a cloud browser through the V4 API. Path 2: the CLI connects your existing agent, including Claude Code, Codex, OpenCode, Hermes, or Pi, to a local or cloud browser. Path 3: the open source Browser Use agent is a Python library that connects directly to a local or cloud browser.</desc>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8Z" fill="#8B8B94"/></marker>
     <marker id="cloud-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8Z" fill="#C94D00"/></marker>
@@ -12,9 +12,9 @@
     <text x="240" y="55" text-anchor="middle" fill="#C94D00" font-size="18" font-weight="700">RUN BY BROWSER USE</text>
     <text x="956" y="55" text-anchor="middle" fill="#606068" font-size="18" font-weight="700">ON YOUR COMPUTER</text>
     <path d="M956 85V650" stroke="#8B8B94" stroke-opacity="0.35"/>
-    <text x="240" y="109" text-anchor="middle" fill="#242428" font-size="32" font-weight="750">Fully hosted cloud</text>
-    <text x="720" y="109" text-anchor="middle" fill="#242428" font-size="32" font-weight="750">CLI</text>
-    <text x="1192" y="109" text-anchor="middle" fill="#242428" font-size="32" font-weight="750">Python library</text>
+    <text x="240" y="109" text-anchor="middle" fill="#242428" font-size="30" font-weight="750">1. Fully hosted cloud</text>
+    <text x="720" y="109" text-anchor="middle" fill="#242428" font-size="30" font-weight="750">2. CLI</text>
+    <text x="1192" y="109" text-anchor="middle" fill="#242428" font-size="30" font-weight="750">3. Python library</text>
     <text x="240" y="140" text-anchor="middle" fill="#606068" font-size="20" font-weight="450">Send a task through the API</text>
     <text x="720" y="140" text-anchor="middle" fill="#606068" font-size="20" font-weight="450">Use your existing agent</text>
     <text x="1192" y="140" text-anchor="middle" fill="#606068" font-size="20" font-weight="450">Run your own automation</text>
@@ -25,18 +25,16 @@
     <text x="720" y="214" text-anchor="middle" fill="#606068" font-size="18" font-weight="700">YOUR AGENT</text>
     <text x="720" y="247" text-anchor="middle" fill="#242428" font-size="24" font-weight="600">Claude Code · Codex</text>
     <text x="720" y="278" text-anchor="middle" fill="#242428" font-size="24" font-weight="600">OpenCode · Hermes · Pi</text>
-    <rect x="992" y="184" width="400" height="112" rx="16" fill="#F4F4F5" stroke="#8B8B94" stroke-width="2"/>
-    <text x="1192" y="219" text-anchor="middle" fill="#606068" font-size="18" font-weight="700">YOUR CODE</text>
-    <text x="1192" y="260" text-anchor="middle" fill="#242428" font-size="29" font-weight="750">Python library</text>
+    <rect x="992" y="184" width="400" height="244" rx="16" fill="#FFF4E8" stroke="#C94D00" stroke-width="2"/>
+    <text x="1192" y="262" text-anchor="middle" fill="#C94D00" font-size="20" font-weight="700">OPEN SOURCE</text>
+    <text x="1192" y="313" text-anchor="middle" fill="#242428" font-size="31" font-weight="750">Browser Use Agent</text>
+    <text x="1192" y="355" text-anchor="middle" fill="#606068" font-size="24" font-weight="450">Python library</text>
     <path d="M240 296V336" fill="none" stroke="#8B8B94" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#arrow)"/>
     <path d="M720 296V336" fill="none" stroke="#8B8B94" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#arrow)"/>
-    <path d="M1192 296V336" fill="none" stroke="#8B8B94" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#arrow)"/>
     <rect x="64" y="350" width="352" height="78" rx="16" fill="#FFF4E8" stroke="#C94D00" stroke-width="2"/>
     <text x="240.0" y="397" text-anchor="middle" fill="#242428" font-size="28" font-weight="750">Browser Use CLI</text>
     <rect x="520" y="350" width="400" height="78" rx="16" fill="#FFF4E8" stroke="#C94D00" stroke-width="2"/>
     <text x="720.0" y="397" text-anchor="middle" fill="#242428" font-size="28" font-weight="750">Browser Use CLI</text>
-    <rect x="992" y="350" width="400" height="78" rx="16" fill="#FFF4E8" stroke="#C94D00" stroke-width="2"/>
-    <text x="1192.0" y="397" text-anchor="middle" fill="#242428" font-size="28" font-weight="750">Browser Use agent</text>
     <path d="M240 428V498" fill="none" stroke="#C94D00" stroke-width="2.5" stroke-linejoin="round" marker-end="url(#cloud-arrow)"/>
     <rect x="64" y="512" width="352" height="112" rx="16" fill="#FFF4E8" stroke="#C94D00" stroke-width="2"/>
     <path d="M64 538H416" stroke="#C94D00" stroke-width="2"/>


### PR DESCRIPTION
Make the three Browser Use paths consistent between the diagram and quickstarts: fully hosted cloud, CLI, and Python library. Combine the open source Browser Use agent and its Python library into one diagram block connected directly to local and cloud browsers.

Rename the demo heading to “Navigate the web like a human does.” and mention choosing a date and time. Keep the inline animation, remove the separate Johannes link, expand the hosted-service description, and remove the no-card text and Odysseys claim.

Validation: pre-commit, whitespace checks, Python snippet parsing, numbered section order and anchors, SVG parsing, and single-block structure in both diagram themes passed. Inspected both diagram themes and the actual GitHub README on desktop and at 390px mobile width. All three quickstart anchors resolve, the inline GIF remains present, and there is no page overflow.
