### PR TITLE
docs: restore branded header and refine README paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,40 @@
 </picture>
 
 <div align="center">
-  <h3>Give AI agents control of the web.</h3>
-  <p>Connect your existing agent, run Browser Use in Python, or send a task to our cloud.</p>
-  <p>
-    <a href="#quickstart">Quickstart</a> ·
-    <a href="#navigate-the-web-like-a-human-does">Demos</a> ·
-    <a href="https://docs.browser-use.com">Docs</a> ·
-    <a href="https://cloud.browser-use.com">Cloud</a>
-  </p>
+    <picture>
+    <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/9955dda9-ede3-4971-8ee0-91cbc3850125">
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/6797d09b-8ac3-4cb9-ba07-b289e080765a">
+    <img alt="The AI browser agent." src="https://github.com/user-attachments/assets/9955dda9-ede3-4971-8ee0-91cbc3850125"  width="400">
+    </picture>
+</div>
+
+<div align="center">
+<a href="https://cloud.browser-use.com?utm_source=github&utm_medium=readme-badge-downloads"><img src="https://media.browser-use.tools/badges/package" height="48" alt="Browser-Use Package Download Statistics"></a>
+</div>
+
+---
+
+<div align="center">
+<a href="#navigate-the-web-like-a-human-does"><img src="https://media.browser-use.tools/badges/demos" alt="Demos"></a>
+<img width="16" height="1" alt="">
+<a href="https://docs.browser-use.com"><img src="https://media.browser-use.tools/badges/docs" alt="Docs"></a>
+<img width="16" height="1" alt="">
+<a href="https://browser-use.com/posts"><img src="https://media.browser-use.tools/badges/blog" alt="Blog"></a>
+<img width="16" height="1" alt="">
+<a href="https://browsermerch.com"><img src="https://media.browser-use.tools/badges/merch" alt="Merch"></a>
+<img width="100" height="1" alt="">
+<a href="https://github.com/browser-use/browser-use"><img src="https://media.browser-use.tools/badges/github" alt="Github Stars"></a>
+<img width="4" height="1" alt="">
+<a href="https://x.com/intent/user?screen_name=browser_use"><img src="https://media.browser-use.tools/badges/twitter" alt="Twitter"></a>
+<img width="4" height="1" alt="">
+<a href="https://link.browser-use.com/discord"><img src="https://media.browser-use.tools/badges/discord" alt="Discord"></a>
+<img width="4" height="1" alt="">
+<a href="https://cloud.browser-use.com?utm_source=github&utm_medium=readme-badge-cloud"><img src="https://media.browser-use.tools/badges/cloud" height="48" alt="Browser-Use Cloud"></a>
+</div>
+
+<br/>
+
+<div align="center">
   <a href="https://browser-use.com">
     <img src="https://browser-use.com/lander/plates/browsers-8dd60aa0.jpg" alt="A person crossing an orange canyon on a giant key-shaped bridge, from the Browser Use website." width="720">
   </a>
@@ -38,15 +64,15 @@ Find an available slot, pick a date and time, handle the CAPTCHA, and book a dri
   <img alt="Three ways to use Browser Use: fully hosted cloud; your existing agent with Browser Use CLI; or the open source Browser Use agent, available as a Python library. The CLI and library each connect to a local or cloud browser." src="static/readme/which-product-light.svg" width="100%">
 </picture>
 
-- **[Path 1: Fully Hosted Cloud](#path-1-fully-hosted-cloud):** Send a task through the API; we run the agent and browser.
-- **[Path 2: CLI](#path-2-cli):** Give Claude Code, Codex, Hermes, OpenClaw, OpenCode, Pi, or another agent browser access.
+- **[Path 1: Fully Hosted Cloud](#path-1-fully-hosted-cloud):** Scale up with a fully hosted agent and browser.
+- **[Path 2: CLI](#path-2-cli):** Automate your own browser tasks.
 - **[Path 3: Python Library](#path-3-python-library):** Run the open source Browser Use agent locally from your own code.
 
 # Quickstart
 
 ## Path 1: Fully Hosted Cloud
 
-Send a task to our hosted agent. We run the agent, stealth browser, and scalable infrastructure, and handle profiles, recordings, and data policies so you can scale your browser automation.
+Scale browser automation with our hosted agent, stealth browsers, and infrastructure for profiles, recordings, and data policies.
 
 [Get started with the API ↗](https://docs.browser-use.com/cloud/agent/quickstart)
 
@@ -56,13 +82,11 @@ New Google, GitHub, or Microsoft signups get **$15 cloud credit**.
 
 ## Path 2: CLI
 
-If you want to use Browser Use in your agent (Claude Code, Codex, Hermes, OpenClaw, OpenCode, Pi, Cursor, etc.), paste this prompt, and it sets everything up itself:
+Paste this setup prompt into your agent to automate your own browser tasks.
 
 ```text
 Install or upgrade browser-use to the latest stable version with uv using Python 3.12, run `browser-use skill install` to register the skill, and connect it to my browser. If setup or connection fails, follow https://github.com/browser-use/browser-harness/blob/main/install.md.
 ```
-
-Then tell your agent what you want done.
 
 <br/>
 
@@ -143,7 +167,7 @@ This [very hard benchmark](https://github.com/browser-use/benchmark) targets the
 <summary><b>Should I use the fully hosted cloud, CLI, or Python library?</b></summary>
 
 - **[Fully Hosted Cloud](#path-1-fully-hosted-cloud):** Send tasks through the API and let Browser Use run the agent, browser, and infrastructure.
-- **[CLI](#path-2-cli):** Give an existing agent (Claude Code, Codex, Hermes, OpenClaw, OpenCode, Pi, Cursor, etc.) browser access. You can use it interactively or in scripts.
+- **[CLI](#path-2-cli):** Give an existing agent (Claude Code, Codex, Hermes, OpenClaw, Pi, Cursor, etc.) browser access. You can use it interactively or in scripts.
 - **[Python Library](#path-3-python-library):** Run the open source agent in your own application, with custom tools, structured output, and your choice of model.
 
 The CLI and Python library can each connect to a local or cloud browser. A cloud browser hosts the browser; the fully hosted API runs the agent as well.
@@ -260,8 +284,11 @@ You can also host the Python library and browsers on your own infrastructure.
 
 | Repository | What it's for |
 | --- | --- |
-| [Browser Harness](https://github.com/browser-use/browser-harness) | Connect your existing AI agent to a real browser. |
+| [Browser Harness](https://github.com/browser-use/browser-harness) | Our CLI for giving AI agents control of your browser. |
+| [Browser Use Pi](https://github.com/browser-use/browser-use-pi) | Run a TypeScript browser agent built on Pi. |
 | [Cloud SDK](https://github.com/browser-use/sdk) | Integrate Browser Use Cloud into your application. |
+| [Video Use](https://github.com/browser-use/video-use) | Edit videos with your coding agent. |
+| [macOS Harness](https://github.com/browser-use/macos-harness) | Give your agent control of Mac apps, browsers, and files. |
 | [Benchmark](https://github.com/browser-use/benchmark) | Explore browser tasks and compare agent performance. |
 
 <br/>
@@ -283,15 +310,6 @@ If you use Browser Use in your research or project, please cite:
 <br/>
 
 <div align="center">
-
-<p>
-  <a href="https://browser-use.com/posts">Blog</a> ·
-  <a href="https://link.browser-use.com/discord">Discord</a> ·
-  <a href="https://x.com/browser_use">X</a> ·
-  <a href="https://browsermerch.com">Merch</a>
-</p>
-
-<a href="https://cloud.browser-use.com?utm_source=github&utm_medium=readme-badge-downloads"><img src="https://media.browser-use.tools/badges/package" height="48" alt="Browser-Use Package Download Statistics"></a>
 
 **Tell your computer what to do, and it gets it done.**
 

--- a/static/readme/README.md
+++ b/static/readme/README.md
@@ -16,7 +16,7 @@ introduced in [SDK PR #241](https://github.com/browser-use/sdk/pull/241).
 
 The README version shows three paths:
 
-- Path 1, fully hosted cloud: OpenCode → Browser Use CLI → cloud browser.
+- Path 1, fully hosted cloud: our hosted agent → Browser Use CLI → cloud browser.
 - Path 2, CLI: your existing agent → Browser Use CLI → local or cloud browser.
 - Path 3, Python library: the open source Browser Use agent → local or cloud browser.
   The agent and its Python library are one block, with no CLI step.

--- a/static/readme/which-product-dark.svg
+++ b/static/readme/which-product-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="690" viewBox="0 0 1440 690" role="img" aria-labelledby="title desc">
   <title id="title">Three ways to use Browser Use</title>
-  <desc id="desc">Path 1: fully hosted cloud runs our OpenCode agent, Browser Use CLI, and a cloud browser through the V4 API. Path 2: the CLI connects your existing agent, including Claude Code, Codex, Hermes, OpenClaw, OpenCode, or Pi, to a local or cloud browser. Path 3: the open source Browser Use agent is a Python library that connects directly to a local or cloud browser.</desc>
+  <desc id="desc">Path 1: fully hosted cloud runs our agent, Browser Use CLI, and a cloud browser through the V4 API. Path 2: the CLI connects your agent, including Claude Code, Codex, Hermes, OpenClaw, or Pi, to a local or cloud browser. Path 3: the open source Browser Use agent is a Python library that can run fully locally or connect to a cloud browser.</desc>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8Z" fill="#92929C"/></marker>
     <marker id="cloud-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8Z" fill="#FFAB66"/></marker>
@@ -15,16 +15,16 @@
     <text x="240" y="109" text-anchor="middle" fill="#FAFAFA" font-size="30" font-weight="750">1. Fully hosted cloud</text>
     <text x="720" y="109" text-anchor="middle" fill="#FAFAFA" font-size="30" font-weight="750">2. CLI</text>
     <text x="1192" y="109" text-anchor="middle" fill="#FAFAFA" font-size="30" font-weight="750">3. Python library</text>
-    <text x="240" y="140" text-anchor="middle" fill="#BDBDC5" font-size="20" font-weight="450">Send a task through the API</text>
-    <text x="720" y="140" text-anchor="middle" fill="#BDBDC5" font-size="20" font-weight="450">Use your existing agent</text>
-    <text x="1192" y="140" text-anchor="middle" fill="#BDBDC5" font-size="20" font-weight="450">Run your own automation</text>
+    <text x="240" y="140" text-anchor="middle" fill="#BDBDC5" font-size="20" font-weight="450">Easiest way to scale up</text>
+    <text x="720" y="140" text-anchor="middle" fill="#BDBDC5" font-size="20" font-weight="450">Automate your own browser tasks</text>
+    <text x="1192" y="140" text-anchor="middle" fill="#BDBDC5" font-size="20" font-weight="450">Run fully local</text>
     <rect x="64" y="184" width="352" height="112" rx="16" fill="#29292E" stroke="#92929C" stroke-width="2"/>
     <text x="240" y="219" text-anchor="middle" fill="#BDBDC5" font-size="18" font-weight="700">OUR AGENT</text>
-    <text x="240" y="260" text-anchor="middle" fill="#FAFAFA" font-size="29" font-weight="750">OpenCode</text>
+    <text x="240" y="260" text-anchor="middle" fill="#FAFAFA" font-size="29" font-weight="750">Browser Use Agent</text>
     <rect x="520" y="184" width="400" height="112" rx="16" fill="#29292E" stroke="#92929C" stroke-width="2"/>
     <text x="720" y="214" text-anchor="middle" fill="#BDBDC5" font-size="18" font-weight="700">YOUR AGENT</text>
     <text x="720" y="247" text-anchor="middle" fill="#FAFAFA" font-size="22" font-weight="600">Claude Code · Codex · Pi</text>
-    <text x="720" y="278" text-anchor="middle" fill="#FAFAFA" font-size="22" font-weight="600">Hermes · OpenClaw · OpenCode</text>
+    <text x="720" y="278" text-anchor="middle" fill="#FAFAFA" font-size="22" font-weight="600">Hermes · OpenClaw</text>
     <rect x="992" y="184" width="400" height="244" rx="16" fill="#302419" stroke="#FFAB66" stroke-width="2"/>
     <text x="1192" y="262" text-anchor="middle" fill="#FFAB66" font-size="20" font-weight="700">OPEN SOURCE</text>
     <text x="1192" y="313" text-anchor="middle" fill="#FAFAFA" font-size="31" font-weight="750">Browser Use Agent</text>

--- a/static/readme/which-product-light.svg
+++ b/static/readme/which-product-light.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1440" height="690" viewBox="0 0 1440 690" role="img" aria-labelledby="title desc">
   <title id="title">Three ways to use Browser Use</title>
-  <desc id="desc">Path 1: fully hosted cloud runs our OpenCode agent, Browser Use CLI, and a cloud browser through the V4 API. Path 2: the CLI connects your existing agent, including Claude Code, Codex, Hermes, OpenClaw, OpenCode, or Pi, to a local or cloud browser. Path 3: the open source Browser Use agent is a Python library that connects directly to a local or cloud browser.</desc>
+  <desc id="desc">Path 1: fully hosted cloud runs our agent, Browser Use CLI, and a cloud browser through the V4 API. Path 2: the CLI connects your agent, including Claude Code, Codex, Hermes, OpenClaw, or Pi, to a local or cloud browser. Path 3: the open source Browser Use agent is a Python library that can run fully locally or connect to a cloud browser.</desc>
   <defs>
     <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8Z" fill="#8B8B94"/></marker>
     <marker id="cloud-arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto"><path d="M0 0L8 4L0 8Z" fill="#C94D00"/></marker>
@@ -15,16 +15,16 @@
     <text x="240" y="109" text-anchor="middle" fill="#242428" font-size="30" font-weight="750">1. Fully hosted cloud</text>
     <text x="720" y="109" text-anchor="middle" fill="#242428" font-size="30" font-weight="750">2. CLI</text>
     <text x="1192" y="109" text-anchor="middle" fill="#242428" font-size="30" font-weight="750">3. Python library</text>
-    <text x="240" y="140" text-anchor="middle" fill="#606068" font-size="20" font-weight="450">Send a task through the API</text>
-    <text x="720" y="140" text-anchor="middle" fill="#606068" font-size="20" font-weight="450">Use your existing agent</text>
-    <text x="1192" y="140" text-anchor="middle" fill="#606068" font-size="20" font-weight="450">Run your own automation</text>
+    <text x="240" y="140" text-anchor="middle" fill="#606068" font-size="20" font-weight="450">Easiest way to scale up</text>
+    <text x="720" y="140" text-anchor="middle" fill="#606068" font-size="20" font-weight="450">Automate your own browser tasks</text>
+    <text x="1192" y="140" text-anchor="middle" fill="#606068" font-size="20" font-weight="450">Run fully local</text>
     <rect x="64" y="184" width="352" height="112" rx="16" fill="#F4F4F5" stroke="#8B8B94" stroke-width="2"/>
     <text x="240" y="219" text-anchor="middle" fill="#606068" font-size="18" font-weight="700">OUR AGENT</text>
-    <text x="240" y="260" text-anchor="middle" fill="#242428" font-size="29" font-weight="750">OpenCode</text>
+    <text x="240" y="260" text-anchor="middle" fill="#242428" font-size="29" font-weight="750">Browser Use Agent</text>
     <rect x="520" y="184" width="400" height="112" rx="16" fill="#F4F4F5" stroke="#8B8B94" stroke-width="2"/>
     <text x="720" y="214" text-anchor="middle" fill="#606068" font-size="18" font-weight="700">YOUR AGENT</text>
     <text x="720" y="247" text-anchor="middle" fill="#242428" font-size="22" font-weight="600">Claude Code · Codex · Pi</text>
-    <text x="720" y="278" text-anchor="middle" fill="#242428" font-size="22" font-weight="600">Hermes · OpenClaw · OpenCode</text>
+    <text x="720" y="278" text-anchor="middle" fill="#242428" font-size="22" font-weight="600">Hermes · OpenClaw</text>
     <rect x="992" y="184" width="400" height="244" rx="16" fill="#FFF4E8" stroke="#C94D00" stroke-width="2"/>
     <text x="1192" y="262" text-anchor="middle" fill="#C94D00" font-size="20" font-weight="700">OPEN SOURCE</text>
     <text x="1192" y="313" text-anchor="middle" fill="#242428" font-size="31" font-weight="750">Browser Use Agent</text>


### PR DESCRIPTION
Restore the original branded README header, including the AI browser agent artwork, downloads, GitHub stars, Discord, and other navigation badges, while retaining the orange bridge painting beneath it.

Shorten the CLI introduction to one sentence and remove OpenCode from the README and diagram. Update the diagram captions to “Easiest way to scale up,” “Automate your own browser tasks,” and “Run fully local.” Identify Browser Harness as our CLI and add Browser Use Pi, Video Use, and macOS Harness to Related Repositories with one-line descriptions verified against their public READMEs.

Validation: pre-commit and git diff checks passed. README anchors resolve; both SVGs parse and contain the requested captions. The Python examples are unchanged. Both diagram themes and the GitHub header were visually inspected; header assets load on desktop and mobile, with no page overflow at 390 pixels.
