### PR TITLE
docs: name agents in CLI setup introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ New Google, GitHub, or Microsoft signups get **$15 cloud credit**.
 
 ## Path 2: CLI
 
-Paste this setup prompt into your agent to automate your own browser tasks.
+Paste this prompt into Claude Code, Codex, Hermes, OpenClaw, or your favorite agent.
 
 ```text
 Install or upgrade browser-use to the latest stable version with uv using Python 3.12, run `browser-use skill install` to register the skill, and connect it to my browser. If setup or connection fails, follow https://github.com/browser-use/browser-harness/blob/main/install.md.


### PR DESCRIPTION
Name Claude Code, Codex, Hermes, and OpenClaw in the CLI quickstart introduction so readers know where to paste the setup prompt.

Validation: pre-commit passed for README.md; git diff --check passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names Claude Code, Codex, Hermes, and OpenClaw in the CLI quickstart so readers know which agents can receive the browser setup prompt.

<sup>Written for commit b752b973d348ae06c018419198c2681514968095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

