### PR TITLE
fix: include full exception details and location in JS error messages

### DIFF
--- a/browser_use/tools/service.py
+++ b/browser_use/tools/service.py
@@ -3,7 +3,8 @@ import json
 import logging
 import math
 import os
-from typing import Generic, TypeVar
+from collections.abc import Mapping
+from typing import Any, Generic, TypeVar
 
 import anyio
 
@@ -436,6 +437,54 @@ def _is_autocomplete_field(node: EnhancedDOMTreeNode) -> bool:
 	if haspopup and haspopup != 'false' and (attrs.get('aria-controls') or attrs.get('aria-owns')):
 		return True
 	return False
+
+
+def _format_js_exception_details(exception_details: Mapping[str, Any]) -> str:
+	"""Format CDP Runtime.evaluate exceptionDetails into a human-readable error string.
+
+	The CDP ``exceptionDetails`` object contains:
+		- ``text``: a short description (often just ``"Uncaught"``)
+		- ``exception.description``: the full exception message (e.g. ``"SyntaxError: Illegal return statement"``)
+		- ``stackTrace.callFrames``: source location info (line/column URL)
+
+	Previous code only used ``text``, dropping the actual error description and location.
+	"""
+	text = exception_details.get('text', 'Unknown error')
+	exception = exception_details.get('exception')
+
+	parts = [text]
+
+	# Prefer exception.description which contains the full error (e.g. "SyntaxError: Illegal return statement")
+	if exception is not None:
+		description = exception.get('description')
+		if description:
+			parts.append(description.strip())
+
+	# Location info: try stack-trace call frames first, then fall back to top-level fields
+	# CDP may provide location as either stackTrace.callFrames[0] OR top-level url/lineNumber/columnNumber
+	location_parts: list[str] = []
+	stack_trace = exception_details.get('stackTrace')
+	call_frames = (stack_trace or {}).get('callFrames') if stack_trace else None
+	if call_frames:
+		frame = call_frames[0]
+		if frame.get('url'):
+			location_parts.append(frame['url'])
+		if frame.get('lineNumber') is not None:
+			location_parts.append(f'line {frame["lineNumber"] + 1}')
+		if frame.get('columnNumber') is not None:
+			location_parts.append(f'column {frame["columnNumber"] + 1}')
+	else:
+		# Fallback: CDP top-level exceptionDetails may carry url/lineNumber/columnNumber directly
+		if exception_details.get('url'):
+			location_parts.append(exception_details['url'])
+		if exception_details.get('lineNumber') is not None:
+			location_parts.append(f'line {exception_details["lineNumber"] + 1}')
+		if exception_details.get('columnNumber') is not None:
+			location_parts.append(f'column {exception_details["columnNumber"] + 1}')
+	if location_parts:
+		parts.append(f'at {", ".join(location_parts)}')
+
+	return ' '.join(parts)
 
 
 class Tools(Generic[Context]):
@@ -1313,7 +1362,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			)
 
 			if result.get('exceptionDetails'):
-				error_text = result['exceptionDetails'].get('text', 'Unknown JS error')
+				error_text = _format_js_exception_details(result['exceptionDetails'])
 				return ActionResult(error=f'search_page failed: {error_text}')
 
 			data = result.get('result', {}).get('value')
@@ -1348,7 +1397,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 			)
 
 			if result.get('exceptionDetails'):
-				error_text = result['exceptionDetails'].get('text', 'Unknown JS error')
+				error_text = _format_js_exception_details(result['exceptionDetails'])
 				return ActionResult(error=f'find_elements failed: {error_text}')
 
 			data = result.get('result', {}).get('value')
@@ -1837,8 +1886,7 @@ You will be given a query and the markdown of a webpage that has been filtered t
 
 				# Check for JavaScript execution errors
 				if result.get('exceptionDetails'):
-					exception = result['exceptionDetails']
-					error_msg = f'JavaScript execution error: {exception.get("text", "Unknown error")}'
+					error_msg = f'JavaScript execution error: {_format_js_exception_details(result["exceptionDetails"])}'
 
 					# Enhanced error message with debugging info
 					enhanced_msg = f"""JavaScript Execution Failed:


### PR DESCRIPTION
## Fix: JavaScript Error Messages Lose Exception Details

### Problem
When `evaluate`, `search_page`, or `find_elements` actions encounter a JavaScript error via CDP's Runtime.evaluate, the error message only includes `exceptionDetails.text` (which often just says "Uncaught"), dropping:
- The actual exception description (e.g., "SyntaxError: Illegal return statement")
- The stack trace location (URL, line, column)

This makes debugging JavaScript errors extremely difficult for users.

### Solution
Added `_format_js_exception_details` helper function that extracts and formats:
1. `exception.description` — the full exception message
2. `stackTrace.callFrames[0]` location — URL, line number, column number

Applied this helper to all three action handlers (`evaluate`, `search_page`, `find_elements`) that process Runtime.evaluate error results.

### Result
Before: `JavaScript execution error: Uncaught`
After: `JavaScript execution error: Uncaught SyntaxError: Illegal return statement at https://example.com/page.js, line 5, column 1`

Fixes #5749

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
JavaScript error messages from `evaluate`, `search_page`, and `find_elements` now include the full exception description and source location instead of just the CDP text (often simply "Uncaught"), making JS debugging far easier.

Adds `_format_js_exception_details`, which extracts the exception description (e.g., "SyntaxError: Illegal return statement") and location from the first stack frame, falling back to top-level `exceptionDetails` fields when no stack frames exist. Fixes #5749.

<sup>Written for commit 7e14229c1ae48c01c434315f152dd69639d7c70c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

