### PR TITLE
fix: add metadata field to message types and fix token count display

### DIFF
--- a/browser_use/agent/message_manager/service.py
+++ b/browser_use/agent/message_manager/service.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal
+import shutil
+from typing import Any, Literal
 
 from browser_use.agent.message_manager.views import (
 	HistoryItem,
@@ -51,6 +52,19 @@ def _log_get_message_emoji(message: BaseMessage) -> str:
 	return emoji_map.get(message.__class__.__name__, '🎮')
 
 
+def _log_extract_message_content(message: BaseMessage, is_last_message: bool, metadata: dict[str, Any]) -> str:
+	"""Extract text content from a message for logging display."""
+	text = getattr(message, 'text', '')
+	if not text:
+		return '[No text content]'
+	if not is_last_message:
+		# Truncate non-final messages for concise logging
+		max_len = 80
+		if len(text) > max_len:
+			return text[: max_len - 3] + '...'
+	return text
+
+
 def _log_format_message_line(message: BaseMessage, content: str, is_last_message: bool, terminal_width: int) -> list[str]:
 	"""Format a single message for logging display"""
 	try:
@@ -58,9 +72,7 @@ def _log_format_message_line(message: BaseMessage, content: str, is_last_message
 
 		# Get emoji and token info
 		emoji = _log_get_message_emoji(message)
-		# token_str = str(message.metadata.tokens).rjust(4)
-		# TODO: fix the token count
-		token_str = '??? (TODO)'
+		token_str = str(message.metadata.get('tokens', '?')).rjust(4)
 		prefix = f'{emoji}[{token_str}]: '
 
 		# Calculate available width (emoji=2 visual cols + [token]: =8 chars)
@@ -434,6 +446,7 @@ class MessageManager:
 		unavailable_skills_info: str | None = None,  # Information about skills that cannot be used yet
 		plan_description: str | None = None,  # Rendered plan for injection into agent state
 		skip_state_update: bool = False,
+		token_count: int | None = None,  # Token count from LLM response for logging
 	) -> None:
 		"""Create single state message with all content"""
 
@@ -504,45 +517,41 @@ class MessageManager:
 		# Store state message text for history
 		self.last_state_message_text = state_message.text
 
+		if token_count is not None:
+			state_message.metadata['tokens'] = token_count
+
 		# Set the state message with caching enabled
 		self._set_message_with_type(state_message, 'state')
 
 	def _log_history_lines(self) -> str:
 		"""Generate a formatted log string of message history for debugging / printing to terminal"""
-		# TODO: fix logging
+		try:
+			total_input_tokens = 0
+			message_lines = []
+			terminal_width = shutil.get_terminal_size((80, 20)).columns
 
-		# try:
-		# 	total_input_tokens = 0
-		# 	message_lines = []
-		# 	terminal_width = shutil.get_terminal_size((80, 20)).columns
+			messages = self.state.history.get_messages()
+			for i, m in enumerate(messages):
+				try:
+					total_input_tokens += m.metadata.get('tokens', 0)
+					is_last_message = i == len(messages) - 1
 
-		# 	for i, m in enumerate(self.state.history.messages):
-		# 		try:
-		# 			total_input_tokens += m.metadata.tokens
-		# 			is_last_message = i == len(self.state.history.messages) - 1
+					# Extract content for logging
+					content = _log_extract_message_content(m, is_last_message, m.metadata)
 
-		# 			# Extract content for logging
-		# 			content = _log_extract_message_content(m.message, is_last_message, m.metadata)
+					# Format the message line(s)
+					lines = _log_format_message_line(m, content, is_last_message, terminal_width)
+					message_lines.extend(lines)
+				except Exception as e:
+					logger.warning(f'Failed to format message {i} for logging: {e}')
+					# Add a fallback line for this message
+					message_lines.append('❓[   ?]: [Error formatting this message]')
 
-		# 			# Format the message line(s)
-		# 			lines = _log_format_message_line(m, content, is_last_message, terminal_width)
-		# 			message_lines.extend(lines)
-		# 		except Exception as e:
-		# 			logger.warning(f'Failed to format message {i} for logging: {e}')
-		# 			# Add a fallback line for this message
-		# 			message_lines.append('❓[   ?]: [Error formatting this message]')
-
-		# 	# Build final log message
-		# 	return (
-		# 		f'📜 LLM Message history ({len(self.state.history.messages)} messages, {total_input_tokens} tokens):\n'
-		# 		+ '\n'.join(message_lines)
-		# 	)
-		# except Exception as e:
-		# 	logger.warning(f'Failed to generate history log: {e}')
-		# 	# Return a minimal fallback message
-		# 	return f'📜 LLM Message history (error generating log: {e})'
-
-		return ''
+			# Build final log message
+			return f'📜 LLM Message history ({len(messages)} messages, {total_input_tokens} tokens):\n' + '\n'.join(message_lines)
+		except Exception as e:
+			logger.warning(f'Failed to generate history log: {e}')
+			return ''
 
 	@time_execution_sync('--get_messages')
 	def get_messages(self) -> list[BaseMessage]:

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -608,6 +608,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		self._external_pause_event = asyncio.Event()
 		self._external_pause_event.set()
 
+		# Save last LLM usage for token count logging
+		self._last_llm_usage: Any = None
+
 	def _enhance_task_with_schema(self, task: str, output_model_schema: type[AgentStructuredOutput] | None) -> str:
 		"""Enhance task description with output schema information if provided."""
 		if output_model_schema is None:
@@ -1148,6 +1151,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 			unavailable_skills_info=unavailable_skills_info,
 			plan_description=plan_description,
 			skip_state_update=True,
+			token_count=getattr(self._last_llm_usage, 'total_tokens', None),
 		)
 
 		await self._inject_budget_warning(step_info)
@@ -1954,6 +1958,7 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 		try:
 			response = await self.llm.ainvoke(input_messages, **kwargs)
 			parsed: AgentOutput = response.completion  # type: ignore[assignment]
+			self._last_llm_usage = response.usage  # type: ignore[assignment]
 
 			# Replace any shortened URLs in the LLM response back to original URLs
 			if urls_replaced:

--- a/browser_use/llm/messages.py
+++ b/browser_use/llm/messages.py
@@ -3,9 +3,9 @@ This implementation is based on the OpenAI types, while removing all the parts t
 """
 
 # region - Content parts
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 def _truncate(text: str, max_length: int = 50) -> str:
@@ -130,6 +130,9 @@ class _MessageBase(BaseModel):
 	cache: bool = False
 	"""Whether to cache this message. This is only applicable when using Anthropic models.
 	"""
+
+	metadata: dict[str, Any] = Field(default_factory=dict)
+	"""Additional metadata for the message (e.g., token counts for logging)."""
 
 
 class UserMessage(_MessageBase):


### PR DESCRIPTION
Adds a `metadata` field to `_MessageBase` so all message types carry a metadata dict, and fixes the token count display in `_log_format_message_line`.

## Changes
1. `browser_use/llm/messages.py`: Added `metadata: dict[str, Any] = Field(default_factory=dict)` to `_MessageBase`
2. `browser_use/agent/message_manager/service.py`: Fixed token count display to use `message.metadata.get('tokens', '?')` instead of hardcoded TODO string

## Why
The original code was commented out with a TODO because `BaseMessage` in `browser_use.llm.messages` did not have a `metadata` attribute. This fix adds the field and uses proper dict access for the token count.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `metadata` field to all message types and restores real token counts in message logs, replacing the `??? (TODO)` placeholder and re-enabling the previously disabled message history log.

- Adds `metadata: dict[str, Any]` with a default empty dict to `_MessageBase`.
- Reads token count from `message.metadata.get('tokens', '?')` in `_log_format_message_line`.
- Re-enables `_log_history_lines`, including truncation of non-final messages.
- Tracks the last LLM response usage and passes its total token count into the state message metadata.

<sup>Written for commit 958da0ea1443d1435898ca73a41e3f140240694c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

