### PR TITLE
fix: preserve remote keep-alive sessions on agent close

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -3984,8 +3984,9 @@ class Agent(Generic[Context, AgentStructuredOutput]):
 					# Kill the browser session - this dispatches BrowserStopEvent,
 					# stops the EventBus with clear=True, and recreates a fresh EventBus
 					await self.browser_session.kill()
-				else:
-					# keep_alive=True sessions shouldn't keep the event loop alive after agent.run()
+				elif self.browser_session.is_local:
+					# Local keep_alive=True sessions shouldn't keep the event loop alive after agent.run().
+					# Remote keep-alive sessions keep their event bus running for reuse.
 					await self.browser_session.event_bus.stop(
 						clear=False,
 						timeout=_get_timeout('TIMEOUT_BrowserSessionEventBusStopOnAgentClose', 1.0),

--- a/tests/ci/test_agent_close_keep_alive.py
+++ b/tests/ci/test_agent_close_keep_alive.py
@@ -1,0 +1,56 @@
+"""Regression tests for Agent.close() keep-alive browser cleanup."""
+
+from typing import Any, cast
+
+from browser_use import Agent
+from browser_use.browser import BrowserProfile, BrowserSession
+
+
+def _make_session(*, keep_alive: bool, is_local: bool, cdp_url: str | None = None) -> tuple[BrowserSession, Any]:
+	session = BrowserSession(
+		browser_profile=BrowserProfile(
+			headless=True,
+			user_data_dir=None,
+			keep_alive=keep_alive,
+			is_local=is_local,
+			cdp_url=cdp_url,
+		),
+		cdp_url=cdp_url,
+	)
+	event_bus = cast(Any, session.event_bus)
+	event_bus._on_idle = object()
+	return session, event_bus
+
+
+async def test_agent_close_preserves_remote_keep_alive_event_bus(mock_llm):
+	session, event_bus = _make_session(keep_alive=True, is_local=False, cdp_url='ws://browser.example/devtools/browser/1')
+	original_event_bus = session.event_bus
+	original_queue = event_bus.event_queue
+	original_on_idle = event_bus._on_idle
+	agent = Agent(task='keep remote browser alive', llm=mock_llm, browser_session=session)
+
+	await agent.close()
+
+	assert session.event_bus is original_event_bus
+	assert event_bus.event_queue is original_queue
+	assert event_bus._on_idle is original_on_idle
+
+
+async def test_agent_close_still_cleans_local_keep_alive_event_bus(mock_llm):
+	session, event_bus = _make_session(keep_alive=True, is_local=True)
+	agent = Agent(task='keep local browser alive', llm=mock_llm, browser_session=session)
+
+	await agent.close()
+
+	assert event_bus.event_queue is None
+	assert event_bus._on_idle is None
+
+
+async def test_agent_close_kills_non_keep_alive_browser_session(mock_llm):
+	session, event_bus = _make_session(keep_alive=False, is_local=False, cdp_url='ws://browser.example/devtools/browser/1')
+	original_event_bus = session.event_bus
+	agent = Agent(task='close browser session', llm=mock_llm, browser_session=session)
+
+	await agent.close()
+
+	assert session.event_bus is not original_event_bus

--- a/tests/ci/test_agent_close_keep_alive.py
+++ b/tests/ci/test_agent_close_keep_alive.py
@@ -1,12 +1,15 @@
 """Regression tests for Agent.close() keep-alive browser cleanup."""
 
+import asyncio
 from typing import Any, cast
 
 from browser_use import Agent
 from browser_use.browser import BrowserProfile, BrowserSession
 
 
-def _make_session(*, keep_alive: bool, is_local: bool, cdp_url: str | None = None) -> tuple[BrowserSession, Any]:
+def _make_session(
+	*, keep_alive: bool, is_local: bool, cdp_url: str | None = None, seed_event_bus: bool = True
+) -> tuple[BrowserSession, Any]:
 	session = BrowserSession(
 		browser_profile=BrowserProfile(
 			headless=True,
@@ -18,7 +21,9 @@ def _make_session(*, keep_alive: bool, is_local: bool, cdp_url: str | None = Non
 		cdp_url=cdp_url,
 	)
 	event_bus = cast(Any, session.event_bus)
-	event_bus._on_idle = object()
+	if seed_event_bus:
+		event_bus.event_queue = asyncio.Queue()
+		event_bus._on_idle = asyncio.Event()
 	return session, event_bus
 
 
@@ -47,7 +52,9 @@ async def test_agent_close_still_cleans_local_keep_alive_event_bus(mock_llm):
 
 
 async def test_agent_close_kills_non_keep_alive_browser_session(mock_llm):
-	session, event_bus = _make_session(keep_alive=False, is_local=False, cdp_url='ws://browser.example/devtools/browser/1')
+	session, event_bus = _make_session(
+		keep_alive=False, is_local=False, cdp_url='ws://browser.example/devtools/browser/1', seed_event_bus=False
+	)
 	original_event_bus = session.event_bus
 	agent = Agent(task='close browser session', llm=mock_llm, browser_session=session)
 


### PR DESCRIPTION
Fixes #4374.

Remote CDP sessions use the WebSocket and event bus as their live browser connection. `Agent.close()` now preserves that path when `keep_alive=True`, while local keep-alive sessions retain the existing event-loop cleanup and non-keep-alive sessions still use the full kill path.

Regression coverage verifies all three lifecycle branches. I ran the focused browser/event-bus tests (9 passed) and the repository pre-commit suite on both changed files; every applicable hook passed.

AI assistance was used for repository scouting and implementation support. I reviewed and verified the change and can explain and maintain it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #4374. `Agent.close()` now keeps remote keep-alive CDP sessions connected by preserving their WebSocket and event bus, while local keep-alive sessions still stop their event bus and non-keep-alive sessions still use the full kill path.

- Adds regression tests covering all three lifecycle branches: remote keep-alive, local keep-alive, and non-keep-alive.

<sup>Written for commit d5b51492744cfeba24ea1709c63e00582d6e6383. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

