### PR TITLE
fix(agent): preserve token usage in AgentHistoryList save/load round-trip

### DIFF
--- a/browser_use/agent/views.py
+++ b/browser_use/agent/views.py
@@ -663,8 +663,11 @@ class AgentHistoryList(BaseModel, Generic[AgentStructuredOutput]):
 
 	def model_dump(self, **kwargs) -> dict[str, Any]:
 		"""Custom serialization that properly uses AgentHistory's model_dump"""
+		# 'sensitive_data' is only understood by AgentHistory.model_dump, not by UsageSummary
+		usage_kwargs = {k: v for k, v in kwargs.items() if k != 'sensitive_data'}
 		return {
 			'history': [h.model_dump(**kwargs) for h in self.history],
+			'usage': self.usage.model_dump(**usage_kwargs) if self.usage else None,
 		}
 
 	@classmethod


### PR DESCRIPTION
Fixes #5767.

`AgentHistoryList.model_dump()` only serialized `history` and dropped the `usage` field, so `save_to_file()` -> `load_from_file()` silently lost the token/cost summary. This includes `usage` in the dump (as `None` when unset). Old history files without the key still load fine.

Verified locally: built a history with `usage` set, saved, reloaded — `usage.total_tokens`/`total_cost` survive; save with `sensitive_data` still works; legacy files without `usage` load with `usage=None`. `ruff check` and `ruff format --check` pass on the touched file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #5767 by including `usage` in `AgentHistoryList.model_dump()`, so token and cost summaries survive a save/load round-trip. Old history files without the `usage` key still load normally.

When `model_dump()` is called with `include` or `exclude`, those filters no longer apply to the usage summary, so it stays complete.

<sup>Written for commit b4f5354adb0ce565d9ee0419ab6ad0fa00b665ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

