### PR TITLE
fix(dom): keep visible code elements whose id contains data/state

### DIFF
--- a/browser_use/dom/serializer/html_serializer.py
+++ b/browser_use/dom/serializer/html_serializer.py
@@ -77,10 +77,14 @@ class HTMLSerializer:
 				normalized_style = ''.join(style.lower().split())
 				if 'display:none' in normalized_style:
 					return ''
-				# Also check for bpr-guid IDs (LinkedIn's JSON data pattern)
-				element_id = node.attributes.get('id', '')
-				if 'bpr-guid' in element_id or 'data' in element_id or 'state' in element_id:
-					return ''
+				# Also check for bpr-guid IDs (LinkedIn's JSON data pattern),
+				# but only for hidden state containers: a visible <code> element
+				# must never be dropped solely because of an ordinary ID
+				# substring like "user-data" or "workflow-state".
+				if node.is_visible is False:
+					element_id = node.attributes.get('id', '')
+					if 'bpr-guid' in element_id or 'data' in element_id or 'state' in element_id:
+						return ''
 
 			# Skip base64 inline images - these are usually placeholders or tracking pixels
 			if tag_name == 'img' and node.attributes:


### PR DESCRIPTION
Visible <code> elements were dropped from extraction when their id contained `data` or `state` (e.g. `user-data`, `workflow-state`), so page content reached the model without those snippets.

The ID-substring check now only applies to hidden nodes (`is_visible is False`). Display:none filtering is unchanged, so real hidden state blocks are still removed.

Repro: serialize a visible `<code id="user-data">visible code content</code>` node — before: `''`; after: full element, and the text survives `convert_html_to_markdown`. Hidden nodes with matching IDs still serialize to `''`.

Fixes #5629

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps visible `<code>` elements whose `id` contains `data` or `state` (e.g. `user-data`, `workflow-state`) from being dropped during extraction, so page content reaches the model intact.

- The ID-substring check now only applies when `is_visible` is False.
- Hidden nodes with matching IDs still serialize to `''`; display:none filtering is unchanged.

Fixes #5629.

<sup>Written for commit 67c1c89a938b0aa26aae1c0182991f3b50abe026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

