### PR TITLE
fix(browser): clean up local browser process trees

### DIFF
--- a/browser_use/browser/session.py
+++ b/browser_use/browser/session.py
@@ -35,6 +35,7 @@ from browser_use.browser.events import (
 	AgentFocusChangedEvent,
 	BrowserConnectedEvent,
 	BrowserErrorEvent,
+	BrowserKillEvent,
 	BrowserLaunchEvent,
 	BrowserLaunchResult,
 	BrowserReconnectedEvent,
@@ -743,7 +744,14 @@ class BrowserSession(BaseModel):
 		await save_event
 
 		# Dispatch stop event to kill the browser
-		await self.event_bus.dispatch(BrowserStopEvent(force=True))
+		stop_event = self.event_bus.dispatch(BrowserStopEvent(force=True))
+		await stop_event
+		await stop_event.event_result(raise_if_any=True, raise_if_none=False)
+		# Awaiting a parent waits for its children, but does not raise their errors.
+		# Do not report a successful kill or discard the watchdog on cleanup failure.
+		for child_event in stop_event.event_children:
+			if isinstance(child_event, BrowserKillEvent):
+				await child_event.event_result(raise_if_any=True, raise_if_none=False)
 		# Stop the event bus
 		await self.event_bus.stop(clear=True, timeout=5)
 		# Reset all state

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -104,6 +104,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				self._subprocess_descendants = list(
 					{process.pid: process for process in [*self._subprocess_descendants, *descendants]}.values()
 				)
+				self._subprocess_descendants_complete = True
 			# Bubus includes child events in parent completion. Keep cleanup queued
 			# so recording/storage stop handlers can finish before process termination.
 			self.event_bus.dispatch(BrowserKillEvent())

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -41,6 +41,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 
 	# Private state for subprocess management
 	_subprocess: psutil.Process | None = PrivateAttr(default=None)
+	_subprocess_descendants: list[psutil.Process] = PrivateAttr(default_factory=list)
 	_owns_browser_resources: bool = PrivateAttr(default=True)
 	_temp_dirs_to_cleanup: list[Path] = PrivateAttr(default_factory=list)
 	_original_user_data_dir: str | None = PrivateAttr(default=None)
@@ -55,6 +56,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			# self.logger.debug('[LocalBrowserWatchdog] Calling _launch_browser...')
 			process, cdp_url = await self._launch_browser()
 			self._subprocess = process
+			self._subprocess_descendants = await self._snapshot_descendants(process) or []
 			# self.logger.debug(f'[LocalBrowserWatchdog] _launch_browser returned: process={process}, cdp_url={cdp_url}')
 
 			return BrowserLaunchResult(cdp_url=cdp_url)
@@ -67,8 +69,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		self.logger.debug('[LocalBrowserWatchdog] Killing local browser process')
 
 		if self._subprocess:
-			await self._cleanup_process(self._subprocess)
+			await self._cleanup_process(self._subprocess, self._subprocess_descendants)
 			self._subprocess = None
+			self._subprocess_descendants = []
 
 		# Clean up temp directories if any were created
 		for temp_dir in self._temp_dirs_to_cleanup:
@@ -83,10 +86,18 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		self.logger.debug('[LocalBrowserWatchdog] Browser cleanup completed')
 
 	async def on_BrowserStopEvent(self, event: BrowserStopEvent) -> None:
-		"""Listen for BrowserStopEvent and dispatch BrowserKillEvent without awaiting it."""
+		"""Queue local process cleanup after the other stop handlers finish."""
+		if self.browser_session.browser_profile.keep_alive and not event.force:
+			return
 		if self.browser_session.is_local and self._subprocess:
 			self.logger.debug('[LocalBrowserWatchdog] BrowserStopEvent received, dispatching BrowserKillEvent')
-			# Dispatch BrowserKillEvent without awaiting so it gets processed after all BrowserStopEvent handlers
+			# Preserve the ownership edge before other stop handlers run. If Chrome's
+			# root exits during teardown, psutil can no longer discover its children.
+			descendants = await self._snapshot_descendants(self._subprocess)
+			if descendants is not None:
+				self._subprocess_descendants = descendants
+			# Bubus includes child events in parent completion. Keep cleanup queued
+			# so recording/storage stop handlers can finish before process termination.
 			self.event_bus.dispatch(BrowserKillEvent())
 
 	@observe_debug(ignore_input=True, ignore_output=True, name='launch_browser_process')
@@ -457,37 +468,59 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		raise TimeoutError(f'Browser did not start within {timeout} seconds')
 
 	@staticmethod
-	async def _cleanup_process(process: psutil.Process) -> None:
-		"""Clean up browser process.
+	async def _snapshot_descendants(process: psutil.Process) -> list[psutil.Process] | None:
+		"""Capture owned descendants while the root/parent relationship still exists."""
 
-		Args:
-			process: psutil.Process to terminate
-		"""
+		def snapshot() -> list[psutil.Process] | None:
+			try:
+				return process.children(recursive=True)
+			except (psutil.NoSuchProcess, psutil.AccessDenied):
+				return None
+
+		return await asyncio.to_thread(snapshot)
+
+	@staticmethod
+	async def _cleanup_process(process: psutil.Process, known_descendants: list[psutil.Process] | None = None) -> None:
+		"""Terminate the owned process tree, then force-kill survivors with bounded waits."""
 		if not process:
 			return
 
-		try:
-			# Try graceful shutdown first
-			process.terminate()
+		def cleanup_tree() -> None:
+			try:
+				# Snapshot descendants before terminating the parent: Windows does not
+				# automatically terminate them, and reparenting loses the ownership edge.
+				current_descendants = process.children(recursive=True)
+			except psutil.NoSuchProcess:
+				current_descendants = []
+			except psutil.AccessDenied:
+				current_descendants = []
 
-			# Use async wait instead of blocking wait
-			for _ in range(50):  # Wait up to 5 seconds (50 * 0.1)
-				if not process.is_running():
-					return
-				await asyncio.sleep(0.1)
+			# Keep both the early snapshot and a last-moment refresh. PID-based
+			# de-duplication avoids signalling the same process object twice.
+			processes_by_pid: dict[int, psutil.Process] = {}
+			for target in [*reversed(current_descendants), *reversed(known_descendants or []), process]:
+				processes_by_pid.setdefault(target.pid, target)
+			processes = list(processes_by_pid.values())
 
-			# If still running after 5 seconds, force kill
-			if process.is_running():
-				process.kill()
-				# Give it a moment to die
-				await asyncio.sleep(0.1)
+			for target in processes:
+				try:
+					target.terminate()
+				except (psutil.NoSuchProcess, psutil.AccessDenied):
+					# Continue cleaning siblings; survivors are escalated and reported below.
+					pass
+			_, alive = psutil.wait_procs(processes, timeout=3)
+			for target in alive:
+				try:
+					target.kill()
+				except (psutil.NoSuchProcess, psutil.AccessDenied):
+					pass
+			_, alive = psutil.wait_procs(alive, timeout=2)
+			if alive:
+				raise RuntimeError(f'Browser processes did not exit after cleanup: {[target.pid for target in alive]}')
 
-		except psutil.NoSuchProcess:
-			# Process already gone
-			pass
-		except Exception:
-			# Ignore any other errors during cleanup
-			pass
+		# psutil's Windows process queries and bounded waits are synchronous. Keep
+		# them off the event loop so CDP teardown and timeout tasks can progress.
+		await asyncio.to_thread(cleanup_tree)
 
 	def _cleanup_temp_dir(self, temp_dir: Path | str) -> None:
 		"""Clean up temporary directory.

--- a/browser_use/browser/watchdogs/local_browser_watchdog.py
+++ b/browser_use/browser/watchdogs/local_browser_watchdog.py
@@ -42,6 +42,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 	# Private state for subprocess management
 	_subprocess: psutil.Process | None = PrivateAttr(default=None)
 	_subprocess_descendants: list[psutil.Process] = PrivateAttr(default_factory=list)
+	_subprocess_descendants_complete: bool = PrivateAttr(default=True)
 	_owns_browser_resources: bool = PrivateAttr(default=True)
 	_temp_dirs_to_cleanup: list[Path] = PrivateAttr(default_factory=list)
 	_original_user_data_dir: str | None = PrivateAttr(default=None)
@@ -56,7 +57,9 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			# self.logger.debug('[LocalBrowserWatchdog] Calling _launch_browser...')
 			process, cdp_url = await self._launch_browser()
 			self._subprocess = process
-			self._subprocess_descendants = await self._snapshot_descendants(process) or []
+			descendants = await self._snapshot_descendants(process)
+			self._subprocess_descendants = descendants or []
+			self._subprocess_descendants_complete = descendants is not None
 			# self.logger.debug(f'[LocalBrowserWatchdog] _launch_browser returned: process={process}, cdp_url={cdp_url}')
 
 			return BrowserLaunchResult(cdp_url=cdp_url)
@@ -69,9 +72,10 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		self.logger.debug('[LocalBrowserWatchdog] Killing local browser process')
 
 		if self._subprocess:
-			await self._cleanup_process(self._subprocess, self._subprocess_descendants)
+			await self._cleanup_process(self._subprocess, self._subprocess_descendants, self._subprocess_descendants_complete)
 			self._subprocess = None
 			self._subprocess_descendants = []
+			self._subprocess_descendants_complete = True
 
 		# Clean up temp directories if any were created
 		for temp_dir in self._temp_dirs_to_cleanup:
@@ -94,8 +98,12 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			# Preserve the ownership edge before other stop handlers run. If Chrome's
 			# root exits during teardown, psutil can no longer discover its children.
 			descendants = await self._snapshot_descendants(self._subprocess)
-			if descendants is not None:
-				self._subprocess_descendants = descendants
+			if descendants is None:
+				self._subprocess_descendants_complete = False
+			else:
+				self._subprocess_descendants = list(
+					{process.pid: process for process in [*self._subprocess_descendants, *descendants]}.values()
+				)
 			# Bubus includes child events in parent completion. Keep cleanup queued
 			# so recording/storage stop handlers can finish before process termination.
 			self.event_bus.dispatch(BrowserKillEvent())
@@ -480,12 +488,17 @@ class LocalBrowserWatchdog(BaseWatchdog):
 		return await asyncio.to_thread(snapshot)
 
 	@staticmethod
-	async def _cleanup_process(process: psutil.Process, known_descendants: list[psutil.Process] | None = None) -> None:
+	async def _cleanup_process(
+		process: psutil.Process,
+		known_descendants: list[psutil.Process] | None = None,
+		descendant_snapshot_complete: bool = True,
+	) -> None:
 		"""Terminate the owned process tree, then force-kill survivors with bounded waits."""
 		if not process:
 			return
 
 		def cleanup_tree() -> None:
+			tree_verified = descendant_snapshot_complete and known_descendants is not None
 			try:
 				# Snapshot descendants before terminating the parent: Windows does not
 				# automatically terminate them, and reparenting loses the ownership edge.
@@ -494,6 +507,7 @@ class LocalBrowserWatchdog(BaseWatchdog):
 				current_descendants = []
 			except psutil.AccessDenied:
 				current_descendants = []
+				tree_verified = False
 
 			# Keep both the early snapshot and a last-moment refresh. PID-based
 			# de-duplication avoids signalling the same process object twice.
@@ -505,18 +519,24 @@ class LocalBrowserWatchdog(BaseWatchdog):
 			for target in processes:
 				try:
 					target.terminate()
-				except (psutil.NoSuchProcess, psutil.AccessDenied):
-					# Continue cleaning siblings; survivors are escalated and reported below.
+				except psutil.NoSuchProcess:
 					pass
+				except psutil.AccessDenied:
+					# Continue cleaning siblings; survivors are escalated and reported below.
+					tree_verified = False
 			_, alive = psutil.wait_procs(processes, timeout=3)
 			for target in alive:
 				try:
 					target.kill()
-				except (psutil.NoSuchProcess, psutil.AccessDenied):
+				except psutil.NoSuchProcess:
 					pass
+				except psutil.AccessDenied:
+					tree_verified = False
 			_, alive = psutil.wait_procs(alive, timeout=2)
 			if alive:
 				raise RuntimeError(f'Browser processes did not exit after cleanup: {[target.pid for target in alive]}')
+			if not tree_verified:
+				raise RuntimeError('Browser process cleanup could not be verified because a descendant snapshot was unavailable')
 
 		# psutil's Windows process queries and bounded waits are synchronous. Keep
 		# them off the event loop so CDP teardown and timeout tasks can progress.

--- a/tests/ci/infrastructure/test_local_browser_teardown.py
+++ b/tests/ci/infrastructure/test_local_browser_teardown.py
@@ -49,6 +49,7 @@ async def test_stop_merges_new_descendants_with_launch_snapshot(monkeypatch, tmp
 	new_child.pid = 43
 	watchdog._subprocess = root
 	watchdog._subprocess_descendants = [orphan]
+	watchdog._subprocess_descendants_complete = False
 	monkeypatch.setattr(session.event_bus, 'dispatch', Mock())
 
 	async def snapshot_descendants(process):

--- a/tests/ci/infrastructure/test_local_browser_teardown.py
+++ b/tests/ci/infrastructure/test_local_browser_teardown.py
@@ -6,15 +6,95 @@ from unittest.mock import Mock
 import psutil
 import pytest
 
-from browser_use.browser.events import BrowserStopEvent
+from browser_use.browser.events import BrowserKillEvent, BrowserLaunchEvent, BrowserStopEvent
 from browser_use.browser.session import BrowserSession, ResilientEventBus
 from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+
+async def test_launch_preserves_unknown_descendant_snapshot(monkeypatch, tmp_path):
+	session = BrowserSession(keep_alive=True, user_data_dir=str(tmp_path))
+	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
+	process = Mock(spec=psutil.Process)
+
+	async def launch_browser():
+		return process, 'http://localhost:9222'
+
+	async def snapshot_descendants(process):
+		return None
+
+	monkeypatch.setattr(watchdog, '_launch_browser', launch_browser)
+	monkeypatch.setattr(watchdog, '_snapshot_descendants', snapshot_descendants)
+	await watchdog.on_BrowserLaunchEvent(BrowserLaunchEvent())
+	assert watchdog._subprocess_descendants == []
+	assert not watchdog._subprocess_descendants_complete
+
+
+async def test_cleanup_reports_unknown_descendant_snapshot(monkeypatch):
+	root = Mock(spec=psutil.Process)
+	root.pid = 41
+	root.children.return_value = []
+	monkeypatch.setattr(psutil, 'wait_procs', Mock(return_value=([root], [])))
+	with pytest.raises(RuntimeError, match='descendant snapshot was unavailable'):
+		await LocalBrowserWatchdog._cleanup_process(root, [], descendant_snapshot_complete=False)
+	root.terminate.assert_called_once()
+
+
+async def test_stop_merges_new_descendants_with_launch_snapshot(monkeypatch, tmp_path):
+	session = BrowserSession(keep_alive=False, user_data_dir=str(tmp_path))
+	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
+	root = Mock(spec=psutil.Process)
+	orphan = Mock(spec=psutil.Process)
+	new_child = Mock(spec=psutil.Process)
+	orphan.pid = 42
+	new_child.pid = 43
+	watchdog._subprocess = root
+	watchdog._subprocess_descendants = [orphan]
+	monkeypatch.setattr(session.event_bus, 'dispatch', Mock())
+
+	async def snapshot_descendants(process):
+		return [new_child]
+
+	monkeypatch.setattr(watchdog, '_snapshot_descendants', snapshot_descendants)
+	await watchdog.on_BrowserStopEvent(BrowserStopEvent(force=True))
+	assert [process.pid for process in watchdog._subprocess_descendants] == [42, 43]
+	assert watchdog._subprocess_descendants_complete
+
+
+async def test_stop_snapshot_failure_still_cleans_known_orphan(monkeypatch, tmp_path):
+	session = BrowserSession(keep_alive=False, user_data_dir=str(tmp_path))
+	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
+	root = Mock(spec=psutil.Process)
+	orphan = Mock(spec=psutil.Process)
+	root.pid = 41
+	orphan.pid = 42
+	root.children.side_effect = psutil.NoSuchProcess(pid=41)
+	root.terminate.side_effect = psutil.NoSuchProcess(pid=41)
+	watchdog._subprocess = root
+	watchdog._subprocess_descendants = [orphan]
+	monkeypatch.setattr(session.event_bus, 'dispatch', Mock())
+
+	async def snapshot_descendants(process):
+		return None
+
+	monkeypatch.setattr(watchdog, '_snapshot_descendants', snapshot_descendants)
+	monkeypatch.setattr(psutil, 'wait_procs', Mock(side_effect=[([root], [orphan]), ([orphan], [])]))
+	await watchdog.on_BrowserStopEvent(BrowserStopEvent(force=True))
+	assert [process.pid for process in watchdog._subprocess_descendants] == [42]
+	assert not watchdog._subprocess_descendants_complete
+	with pytest.raises(RuntimeError, match='descendant snapshot was unavailable'):
+		await watchdog.on_BrowserKillEvent(BrowserKillEvent())
+	orphan.terminate.assert_called_once()
+	orphan.kill.assert_called_once()
+	assert watchdog._subprocess is root
+	assert watchdog._subprocess_descendants == [orphan]
+	assert not watchdog._subprocess_descendants_complete
 
 
 async def test_kill_finishes_local_cleanup_before_stopping_event_bus(monkeypatch, tmp_path):
 	session = BrowserSession(keep_alive=True, user_data_dir=str(tmp_path))
 	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
 	watchdog._subprocess = Mock(spec=psutil.Process)
+	watchdog._subprocess.children.return_value = []
 	watchdog.attach_to_session()
 	cleanup_finished = False
 	cleanup_at_bus_stop = []
@@ -27,7 +107,7 @@ async def test_kill_finishes_local_cleanup_before_stopping_event_bus(monkeypatch
 
 	session.event_bus.on(BrowserStopEvent, later_stop_handler)
 
-	async def cleanup(process, known_descendants=None):
+	async def cleanup(process, known_descendants=None, descendant_snapshot_complete=True):
 		nonlocal cleanup_finished
 		assert stop_handler_finished
 		await asyncio.sleep(0.02)
@@ -65,7 +145,7 @@ async def test_nonforce_stop_preserves_keep_alive_process(monkeypatch, tmp_path)
 	watchdog.attach_to_session()
 	cleaned = []
 
-	async def cleanup(process, known_descendants=None):
+	async def cleanup(process, known_descendants=None, descendant_snapshot_complete=True):
 		cleaned.append(process)
 
 	monkeypatch.setattr(LocalBrowserWatchdog, '_cleanup_process', staticmethod(cleanup))
@@ -81,7 +161,7 @@ async def test_cleanup_escalates_surviving_children(monkeypatch):
 	root.children.return_value = [child]
 	wait = Mock(side_effect=[([root], [child]), ([child], [])])
 	monkeypatch.setattr(psutil, 'wait_procs', wait)
-	await LocalBrowserWatchdog._cleanup_process(root)
+	await LocalBrowserWatchdog._cleanup_process(root, [])
 	child.kill.assert_called_once()
 	root.kill.assert_not_called()
 	assert [call.kwargs['timeout'] for call in wait.call_args_list] == [3, 2]
@@ -96,7 +176,7 @@ async def test_cleanup_reports_survivors_without_skipping_siblings(monkeypatch):
 	child.kill.side_effect = psutil.AccessDenied(pid=42)
 	monkeypatch.setattr(psutil, 'wait_procs', Mock(side_effect=[([root], [child]), ([], [child])]))
 	with pytest.raises(RuntimeError, match='42'):
-		await LocalBrowserWatchdog._cleanup_process(root)
+		await LocalBrowserWatchdog._cleanup_process(root, [])
 	root.terminate.assert_called_once()
 
 
@@ -104,9 +184,10 @@ async def test_kill_propagates_cleanup_failure(monkeypatch, tmp_path):
 	session = BrowserSession(keep_alive=True, user_data_dir=str(tmp_path))
 	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
 	watchdog._subprocess = Mock(spec=psutil.Process)
+	watchdog._subprocess.children.return_value = []
 	watchdog.attach_to_session()
 
-	async def cleanup(process, known_descendants=None):
+	async def cleanup(process, known_descendants=None, descendant_snapshot_complete=True):
 		raise RuntimeError('browser tree still alive')
 
 	monkeypatch.setattr(LocalBrowserWatchdog, '_cleanup_process', staticmethod(cleanup))
@@ -124,7 +205,7 @@ async def test_cleanup_accepts_already_exited_root(monkeypatch):
 	root.children.side_effect = psutil.NoSuchProcess(pid=42)
 	root.terminate.side_effect = psutil.NoSuchProcess(pid=42)
 	monkeypatch.setattr(psutil, 'wait_procs', Mock(return_value=([], [])))
-	await LocalBrowserWatchdog._cleanup_process(root)
+	await LocalBrowserWatchdog._cleanup_process(root, [])
 	root.terminate.assert_called_once()
 
 
@@ -143,9 +224,10 @@ async def test_kill_propagates_cleanup_timeout(monkeypatch, tmp_path):
 	session = BrowserSession(keep_alive=True, user_data_dir=str(tmp_path))
 	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
 	watchdog._subprocess = Mock(spec=psutil.Process)
+	watchdog._subprocess.children.return_value = []
 	watchdog.attach_to_session()
 
-	async def cleanup(process, known_descendants=None):
+	async def cleanup(process, known_descendants=None, descendant_snapshot_complete=True):
 		await asyncio.Event().wait()
 
 	monkeypatch.setattr(LocalBrowserWatchdog, '_cleanup_process', staticmethod(cleanup))

--- a/tests/ci/infrastructure/test_local_browser_teardown.py
+++ b/tests/ci/infrastructure/test_local_browser_teardown.py
@@ -1,0 +1,157 @@
+"""Controlled local teardown regressions that also run without Chromium on Windows CI."""
+
+import asyncio
+from unittest.mock import Mock
+
+import psutil
+import pytest
+
+from browser_use.browser.events import BrowserStopEvent
+from browser_use.browser.session import BrowserSession, ResilientEventBus
+from browser_use.browser.watchdogs.local_browser_watchdog import LocalBrowserWatchdog
+
+
+async def test_kill_finishes_local_cleanup_before_stopping_event_bus(monkeypatch, tmp_path):
+	session = BrowserSession(keep_alive=True, user_data_dir=str(tmp_path))
+	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
+	watchdog._subprocess = Mock(spec=psutil.Process)
+	watchdog.attach_to_session()
+	cleanup_finished = False
+	cleanup_at_bus_stop = []
+	stop_handler_finished = False
+	original_stop = ResilientEventBus.stop
+
+	async def later_stop_handler(event):
+		nonlocal stop_handler_finished
+		stop_handler_finished = True
+
+	session.event_bus.on(BrowserStopEvent, later_stop_handler)
+
+	async def cleanup(process, known_descendants=None):
+		nonlocal cleanup_finished
+		assert stop_handler_finished
+		await asyncio.sleep(0.02)
+		cleanup_finished = True
+
+	async def stop(bus, *args, **kwargs):
+		cleanup_at_bus_stop.append(cleanup_finished)
+		await original_stop(bus, *args, **kwargs)
+
+	monkeypatch.setattr(LocalBrowserWatchdog, '_cleanup_process', staticmethod(cleanup))
+	monkeypatch.setattr(ResilientEventBus, 'stop', stop)
+	await session.kill()
+	assert cleanup_at_bus_stop == [True]
+	assert watchdog._subprocess is None
+
+
+async def test_cleanup_terminates_children_even_when_root_exits_first(monkeypatch):
+	root = Mock(spec=psutil.Process)
+	child = Mock(spec=psutil.Process)
+	root.pid = 41
+	child.pid = 42
+	root.children.side_effect = psutil.NoSuchProcess(pid=41)
+	root.terminate.side_effect = psutil.NoSuchProcess(pid=41)
+	monkeypatch.setattr(psutil, 'wait_procs', Mock(return_value=([root, child], [])))
+	await LocalBrowserWatchdog._cleanup_process(root, [child])
+	root.children.assert_called_once_with(recursive=True)
+	child.terminate.assert_called_once()
+	root.terminate.assert_called_once()
+
+
+async def test_nonforce_stop_preserves_keep_alive_process(monkeypatch, tmp_path):
+	session = BrowserSession(keep_alive=True, user_data_dir=str(tmp_path))
+	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
+	watchdog._subprocess = Mock(spec=psutil.Process)
+	watchdog.attach_to_session()
+	cleaned = []
+
+	async def cleanup(process, known_descendants=None):
+		cleaned.append(process)
+
+	monkeypatch.setattr(LocalBrowserWatchdog, '_cleanup_process', staticmethod(cleanup))
+	event = session.event_bus.dispatch(BrowserStopEvent(force=False))
+	await event
+	await session.event_bus.stop(clear=True, timeout=1)
+	assert cleaned == []
+
+
+async def test_cleanup_escalates_surviving_children(monkeypatch):
+	root = Mock(spec=psutil.Process)
+	child = Mock(spec=psutil.Process)
+	root.children.return_value = [child]
+	wait = Mock(side_effect=[([root], [child]), ([child], [])])
+	monkeypatch.setattr(psutil, 'wait_procs', wait)
+	await LocalBrowserWatchdog._cleanup_process(root)
+	child.kill.assert_called_once()
+	root.kill.assert_not_called()
+	assert [call.kwargs['timeout'] for call in wait.call_args_list] == [3, 2]
+
+
+async def test_cleanup_reports_survivors_without_skipping_siblings(monkeypatch):
+	root = Mock(spec=psutil.Process)
+	child = Mock(spec=psutil.Process)
+	child.pid = 42
+	root.children.return_value = [child]
+	child.terminate.side_effect = psutil.AccessDenied(pid=42)
+	child.kill.side_effect = psutil.AccessDenied(pid=42)
+	monkeypatch.setattr(psutil, 'wait_procs', Mock(side_effect=[([root], [child]), ([], [child])]))
+	with pytest.raises(RuntimeError, match='42'):
+		await LocalBrowserWatchdog._cleanup_process(root)
+	root.terminate.assert_called_once()
+
+
+async def test_kill_propagates_cleanup_failure(monkeypatch, tmp_path):
+	session = BrowserSession(keep_alive=True, user_data_dir=str(tmp_path))
+	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
+	watchdog._subprocess = Mock(spec=psutil.Process)
+	watchdog.attach_to_session()
+
+	async def cleanup(process, known_descendants=None):
+		raise RuntimeError('browser tree still alive')
+
+	monkeypatch.setattr(LocalBrowserWatchdog, '_cleanup_process', staticmethod(cleanup))
+	try:
+		with pytest.raises(RuntimeError, match='browser tree still alive'):
+			await session.kill()
+		assert watchdog._subprocess is not None
+	finally:
+		await session.event_bus.stop(clear=True, timeout=1)
+
+
+async def test_cleanup_accepts_already_exited_root(monkeypatch):
+	root = Mock(spec=psutil.Process)
+	root.pid = 42
+	root.children.side_effect = psutil.NoSuchProcess(pid=42)
+	root.terminate.side_effect = psutil.NoSuchProcess(pid=42)
+	monkeypatch.setattr(psutil, 'wait_procs', Mock(return_value=([], [])))
+	await LocalBrowserWatchdog._cleanup_process(root)
+	root.terminate.assert_called_once()
+
+
+async def test_remote_stop_does_not_touch_local_process(monkeypatch, tmp_path):
+	session = BrowserSession(cdp_url='http://localhost:9222', user_data_dir=str(tmp_path))
+	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
+	process = Mock(spec=psutil.Process)
+	watchdog._subprocess = process
+	await watchdog.on_BrowserStopEvent(BrowserStopEvent(force=True))
+	assert watchdog._subprocess is process
+	process.children.assert_not_called()
+
+
+async def test_kill_propagates_cleanup_timeout(monkeypatch, tmp_path):
+	monkeypatch.setenv('TIMEOUT_BrowserKillEvent', '0.02')
+	session = BrowserSession(keep_alive=True, user_data_dir=str(tmp_path))
+	watchdog = LocalBrowserWatchdog(event_bus=session.event_bus, browser_session=session)
+	watchdog._subprocess = Mock(spec=psutil.Process)
+	watchdog.attach_to_session()
+
+	async def cleanup(process, known_descendants=None):
+		await asyncio.Event().wait()
+
+	monkeypatch.setattr(LocalBrowserWatchdog, '_cleanup_process', staticmethod(cleanup))
+	try:
+		with pytest.raises(TimeoutError):
+			await session.kill()
+		assert watchdog._subprocess is not None
+	finally:
+		await session.event_bus.stop(clear=True, timeout=1)


### PR DESCRIPTION
## Why

Local Chromium launches can leave child processes behind when only the tracked root process is terminated. Cleanup failures were also swallowed, so `BrowserSession.kill()` could return successfully while managed processes remained alive.

This is a focused process-lifecycle hardening change related to the orphan-process evidence in #5770. It does not change remote CDP sessions or non-force `keep_alive` behavior.

## What changed

- snapshot the managed local browser's descendants before terminating the root;
- terminate the process tree, then force-kill survivors with bounded waits;
- run synchronous `psutil` process operations off the event loop;
- preserve the queued stop-handler ordering while propagating completed `BrowserKillEvent` failures to `BrowserSession.kill()`;
- add controlled regressions for descendants, escalation, already-exited roots, access-denied survivors, timeouts, remote sessions, and `keep_alive`.

## Validation

- focused session/event-bus/teardown tests: 15 passed;
- `./bin/test.sh -k local_browser_teardown --numprocesses=0`: 9 passed, 1238 deselected;
- `./bin/lint.sh`: passed, including repository-wide pyright;
- pre-commit on all changed files: passed;
- `git diff --check`: passed.

The implementation and tests were prepared with Codex on behalf of @Dante-dan. The validation results above are from commands that were actually run; no human technical review is being claimed.

Refs #5770

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes local browser teardown so `BrowserSession.kill()` terminates the entire process tree instead of only the tracked root process, addressing the orphaned Chromium processes observed in #5770. Cleanup failures are no longer swallowed—`kill()` now raises instead of returning while managed child processes stay alive.

**Behavior changes**
- Descendants are snapshotted at launch and merged with a refresh at stop, so Windows children are cleaned up even when the root exits first.
- If no descendant snapshot is available, cleanup raises a `RuntimeError` even when processes exit.
- Survivors get a 3-second graceful termination wait, then a force-kill with a 2-second bound; processes still alive raise a `RuntimeError`.
- Synchronous `psutil` operations run off the event loop so CDP teardown can progress.
- Non-force stops with `keep_alive` and remote CDP sessions behave as before.
- Adds controlled regression tests for descendants, escalation, already-exited roots, access-denied survivors, timeouts, remote sessions, and `keep_alive`.

<sup>Written for commit baaf9b9a7192dc3d64a84b1bb18afe1604365a79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

