### PR TITLE
docs: point bu-30b-a3b-preview at self-hosting instead of Cloud

### DIFF
--- a/browser_use/llm/browser_use/chat.py
+++ b/browser_use/llm/browser_use/chat.py
@@ -62,7 +62,9 @@ class ChatBrowserUse(BaseChatModel):
 				- 'bu-2-0-mini-preview': Cheaper and faster per token, opt-in while in preview
 				- 'bu-1-0': Previous generation model, redirected to bu-2-0 at the gateway
 				- 'bu-qa-1': Website QA model (tests a site and scores functionality/aesthetics)
-				- 'browser-use/bu-30b-a3b-preview': Browser Use Open Source Model
+				- 'browser-use/bu-30b-a3b-preview': open weights, self-hosted only. Browser Use
+				  Cloud does not serve it; run it yourself with vLLM and point `ChatOpenAI` at
+				  your own endpoint. See examples/models/bu_oss.py.
 				- Provider-prefixed ids resolved by the gateway, e.g. 'anthropic/claude-sonnet-4-6',
 				  'openai/gpt-5.5', 'google/gemini-3-pro'.
 			api_key: API key for browser-use cloud. Defaults to BROWSER_USE_API_KEY env var.

--- a/examples/models/bu_oss.py
+++ b/examples/models/bu_oss.py
@@ -1,12 +1,23 @@
-"""
+"""Run the open-weights Browser Use model on your own GPU.
+
+`browser-use/bu-30b-a3b-preview` is published under
+https://huggingface.co/browser-use/bu-30b-a3b-preview. It is open weights you host
+yourself, not a model Browser Use Cloud serves for you, so it needs no
+BROWSER_USE_API_KEY and has no per-token price.
+
 Setup:
-1. Get your API key from https://cloud.browser-use.com/new-api-key
-2. Set environment variable: export BROWSER_USE_API_KEY="your-key"
+1. pip install vllm
+2. vllm serve browser-use/bu-30b-a3b-preview --max-model-len 65536 --host 0.0.0.0 --port 8000
+3. python examples/models/bu_oss.py
+
+Point BU_OSS_BASE_URL at the server if it is not on localhost.
 """
+
+import os
 
 from dotenv import load_dotenv
 
-from browser_use import Agent, ChatBrowserUse
+from browser_use import Agent, ChatOpenAI
 
 load_dotenv()
 
@@ -17,9 +28,11 @@ try:
 except ImportError:
 	pass
 
-# Point to local llm-use server for testing
-llm = ChatBrowserUse(
-	model='browser-use/bu-30b-a3b-preview',  # BU Open Source Model!!
+# Any OpenAI-compatible server works; vLLM is what the model card recommends.
+llm = ChatOpenAI(
+	model='browser-use/bu-30b-a3b-preview',
+	base_url=os.getenv('BU_OSS_BASE_URL', 'http://localhost:8000/v1'),
+	api_key=os.getenv('BU_OSS_API_KEY', 'not-needed'),
 )
 
 agent = Agent(

--- a/skills/open-source/references/models.md
+++ b/skills/open-source/references/models.md
@@ -71,7 +71,28 @@ llm = ChatBrowserUse(model='bu-2-0-mini-preview')   # Cheaper per token, opt-in 
 | bu-2-0 (default, premium) | $0.60 | $0.06 | $3.50 |
 | bu-2-0-mini-preview (opt-in) | $0.15 | $0.15 | $1.50 |
 | bu-1-0 (redirects to bu-2-0) | $0.60 | $0.06 | $3.50 |
-| browser-use/bu-30b-a3b-preview (OSS) | — | — | — |
+
+### Open weights (self-hosted)
+
+`bu-30b-a3b-preview` is our open-weights browser model: 30B total, 3B active, 64K context.
+Browser Use Cloud does not route it, so there is no `bu-*` alias and no per-token price.
+Run it yourself and talk to it with `ChatOpenAI`:
+
+```bash
+vllm serve browser-use/bu-30b-a3b-preview --max-model-len 65536 --host 0.0.0.0 --port 8000
+```
+
+```python
+from browser_use import ChatOpenAI
+
+llm = ChatOpenAI(
+    model='browser-use/bu-30b-a3b-preview',
+    base_url='http://localhost:8000/v1',
+    api_key='not-needed',
+)
+```
+
+Weights: https://huggingface.co/browser-use/bu-30b-a3b-preview
 
 ## OpenAI
 


### PR DESCRIPTION
**Option B of two. Do not merge both.** Sibling: #5773, which deletes the mentions instead.

## What is broken

`browser-use/bu-30b-a3b-preview` is still a live route in the Cloud gateway
(`backend/llm_use/gateway/pricing.py` `MODAL_MODELS`, `service.py` `_call_modal`), but
nothing is serving it. The Modal app behind that route, `browser-use-llm-prod` in
`browser-use/deploy-llm` (`deploy.py:18`, 2x H200 `min_containers`), was last deployed on
2025-12-16 and has not been deployed since.

Production, service `browser-use-production-llm-use`, last 90 days: 5 Modal client
initializations and 5 `Modal LLM call failed: Error code: 503`, paired within 14 seconds.
Every observed call failed. The gateway turns that upstream 503 into a generic HTTP 500 for
the caller, which is why it reads as "the model does not exist".

## Why not just delete it

The weights are public and people are using them.
https://huggingface.co/browser-use/bu-30b-a3b-preview is a public repo: 31B, 2.34k downloads
in the last month, 265 likes. The model exists. Only our hosting of it does not.

## What this PR does

Says what the model actually is - open weights you run yourself.

- `examples/models/bu_oss.py` now starts from `vllm serve` and connects with `ChatOpenAI`
  against `http://localhost:8000/v1`. No `BROWSER_USE_API_KEY`, no dependency on the dead
  Cloud route. `BU_OSS_BASE_URL` / `BU_OSS_API_KEY` override the endpoint.
- `browser_use/llm/browser_use/chat.py` - the docstring now says Cloud does not serve it.
- `skills/open-source/references/models.md` - drops the priceless OSS pricing row and adds a
  short self-hosting section with the vLLM command from the model card and the weights URL.

Not touched: the gateway route, and `tests/ci/models/test_llm_browseruse.py:85`.

## Checks

`ruff check`, `ruff format --check` and `git diff --check` clean.
The rewritten example was imported and constructed in this worktree:
`ChatOpenAI(model='browser-use/bu-30b-a3b-preview', base_url='http://localhost:8000/v1', ...)`
resolves to provider `openai` with that base URL. No agent was run, and no GPU was started,
so the end-to-end self-hosted run is not claimed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates docs and the example for `browser-use/bu-30b-a3b-preview` so the model is presented as open weights users host themselves instead of a Browser Use Cloud model.

- `examples/models/bu_oss.py` now uses a vLLM server and connects via `ChatOpenAI`, with optional `BU_OSS_BASE_URL`/`BU_OSS_API_KEY` overrides.
- The `ChatBrowserUse` docstring states the model is self-hosted only and points to the example.
- The skills model table drops the Cloud pricing row and adds the vLLM command and weights URL.

<sup>Written for commit 09dbfcbca919d547b09e7f90c580b4e696ed011c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

