### PR TITLE
docs: point AI agents and crawlers to llms.txt from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Find an available slot, pick a date and time, handle the CAPTCHA, and book a dri
 
 <br/>
 
+> **AI agents and crawlers:** read [browser-use.com/llms.txt](https://browser-use.com/llms.txt) for the product map (open source, Browser Harness, Cloud browsers, Agents API, pricing) and [docs.browser-use.com/llms.txt](https://docs.browser-use.com/llms.txt) for the documentation index. Browser Use is the open-source browser agent (Python and TypeScript), a $0.02 per browser-hour cloud browser with stealth, CAPTCHA solving and residential proxies, and a hosted agent API.
+
 # Which Browser Use do I need?
 
 <picture>


### PR DESCRIPTION
## Why
A neutral audit of ChatGPT, Perplexity, Google AI Mode, Gemini and Claude (50 answers) shows every engine describes Browser Use as "an open-source Python library" and misses the cloud browser, the hosted agent API and Browser Harness. The README is the most-crawled page we have, so it should say what the product is and where the machine-readable map lives.

## Change
One blockquote above "Which Browser Use do I need?" pointing AI agents and crawlers to https://browser-use.com/llms.txt and https://docs.browser-use.com/llms.txt, and naming the three surfaces in one sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rqDxQUeLj81KTgS46m72e


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a blockquote to the README pointing AI agents and crawlers to the product's `llms.txt` files so answer engines stop describing Browser Use as a Python-only library.

The blockquote links to `browser-use.com/llms.txt` and `docs.browser-use.com/llms.txt` and names all three product surfaces: the open-source agent, the cloud browser, and the hosted agent API.

<sup>Written for commit d5b77ab66c1cf2cd385b825b5c8642d6fa03c288. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

