### PR TITLE
ci(publish): add cryptographic supply-chain notarization for PyPI packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,7 +120,7 @@ jobs:
       
       # 🛡️ ProofCore: Cryptographic provenance for PyPI distribution packages (.whl / .tar.gz)
       - name: Notarize Package Artifacts via ProofCore
-        uses: ProofCore-Protocol/proofcore-action@v1
+        uses: ProofCore-Protocol/proofcore-action@bbc4e5b0a2cd1e9bcb08eac5b78d1a09e01d4805
         continue-on-error: true
         with:
           files: "dist/*"  

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,6 +117,13 @@ jobs:
 
       - run: uv run --no-sync ruff check --no-fix --select PLE # quick check for syntax errors to avoid waiting time doing the rest of the build
       - run: uv build
+      
+      # 🛡️ ProofCore: Cryptographic provenance for PyPI distribution packages (.whl / .tar.gz)
+      - name: Notarize Package Artifacts via ProofCore
+        uses: ProofCore-Protocol/proofcore-action@v1
+        continue-on-error: true
+        with:
+          files: "dist/*"  
 
       # - name: Detect installed Playwright version
       #   run: echo "PLAYWRIGHT_VERSION=$(uv pip list --format json | jq -r '.[] | select(.name == "playwright") | .version')" >> $GITHUB_ENV


### PR DESCRIPTION
Hi @gregpr07 @MagMueller and browser-use team! 👋

Because browser-use executes agentic workflows with direct browser and environment access, release supply-chain integrity is of paramount importance to prevent upstream dependency poisoning.

This PR adds automated, non-intrusive cryptographic provenance attestation for compiled release artifacts (dist/*) right after uv build using [ProofCore Action](https://github.com/ProofCore-Protocol/proofcore-action).

How it works:
    Runs immediately after uv build and before PyPI publishing.
    Computes SHA-256 digests of the generated wheel and sdist files locally on the runner without uploading raw binaries (Zero-Storage model).
    Uses your existing id-token: write permission to anchor the build manifest and GitHub OIDC token directly to the blockchain.
    Allows developers and security teams using browser-use in production to verify that their installed PyPI package mathematically matches the exact GitHub Actions workflow run.

Safe by design:
    Configured with continue-on-error: true so external network blips will never block publishing to PyPI.
    Zero credentials or secrets required.

(Note: If your team strictly requires commit-SHA pinning for all actions per your latest security hardening, happy to update @v1 to the full commit hash!)

Thanks for building such an awesome agent framework! 🚀

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cryptographic provenance attestation to the PyPI publish workflow so release artifacts can be verified against the GitHub Actions run that built them.

- Uses `ProofCore-Protocol/proofcore-action` pinned to a full commit SHA, running after `uv build` to notarize files in `dist/*` before publishing.
- Uses `continue-on-error: true`, so a ProofCore failure will not block publishing to PyPI.
- Requires no secrets or new permissions; it uses the existing `id-token: write` permission and anchors to the GitHub OIDC token.

<sup>Written for commit 7dabb731f9210ef09717e0537bc5dc1c22f7a7ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/browser-use/browser-use/pull/5776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

